### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_driver_impl/Cargo.toml
+++ b/compiler/rustc_driver_impl/Cargo.toml
@@ -50,7 +50,7 @@ rustc_trait_selection = { path = "../rustc_trait_selection" }
 rustc_ty_utils = { path = "../rustc_ty_utils" }
 serde_json = "1.0.59"
 shlex = "1.0"
-time = { version = "0.3", default-features = false, features = ["alloc", "formatting"] }
+time = { version = "0.3", default-features = false, features = ["alloc", "formatting", "parsing", "macros"] }
 tracing = { version = "0.1.35" }
 # tidy-alphabetical-end
 

--- a/compiler/rustc_driver_impl/messages.ftl
+++ b/compiler/rustc_driver_impl/messages.ftl
@@ -2,9 +2,9 @@ driver_impl_ice = the compiler unexpectedly panicked. this is a bug.
 driver_impl_ice_bug_report = we would appreciate a bug report: {$bug_report_url}
 driver_impl_ice_bug_report_internal_feature = using internal features is not supported and expected to cause internal compiler errors when used incorrectly
 driver_impl_ice_bug_report_outdated =
-    it seems this '{$version}' is outdated, a newer nightly should have been released in the mean time
+    it seems that this compiler `{$version}` is outdated, a newer nightly should have been released in the mean time
     .update = please consider running `rustup update nightly` to update the nightly channel and check if this problem still persists
-    .url = we would appreciate a bug report: {$bug_report_url}
+    .url = if the problem still persists, we would appreciate a bug report: {$bug_report_url}
 driver_impl_ice_exclude_cargo_defaults = some of the compiler flags provided by cargo are hidden
 
 driver_impl_ice_flags = compiler flags: {$flags}

--- a/compiler/rustc_driver_impl/messages.ftl
+++ b/compiler/rustc_driver_impl/messages.ftl
@@ -1,6 +1,14 @@
 driver_impl_ice = the compiler unexpectedly panicked. this is a bug.
 driver_impl_ice_bug_report = we would appreciate a bug report: {$bug_report_url}
 driver_impl_ice_bug_report_internal_feature = using internal features is not supported and expected to cause internal compiler errors when used incorrectly
+driver_impl_ice_bug_report_internal_feature_outdated =
+    using internal features is not supported and expected to cause internal compiler errors when used incorrectly
+    .outdated = it seems this '{$version}' is outdated, a newer nightly should have been released in the mean time
+    .update = please consider running `rustup update nightly` to update the nightly channel and check if this problem still persists
+driver_impl_ice_bug_report_outdated =
+    it seems this '{$version}' is outdated, a newer nightly should have been released in the mean time
+    .update = please consider running `rustup update nightly` to update the nightly channel and check if this problem still persists
+    .url = we would appreciate a bug report: {$bug_report_url}
 driver_impl_ice_exclude_cargo_defaults = some of the compiler flags provided by cargo are hidden
 
 driver_impl_ice_flags = compiler flags: {$flags}

--- a/compiler/rustc_driver_impl/messages.ftl
+++ b/compiler/rustc_driver_impl/messages.ftl
@@ -1,10 +1,6 @@
 driver_impl_ice = the compiler unexpectedly panicked. this is a bug.
 driver_impl_ice_bug_report = we would appreciate a bug report: {$bug_report_url}
 driver_impl_ice_bug_report_internal_feature = using internal features is not supported and expected to cause internal compiler errors when used incorrectly
-driver_impl_ice_bug_report_internal_feature_outdated =
-    using internal features is not supported and expected to cause internal compiler errors when used incorrectly
-    .outdated = it seems this '{$version}' is outdated, a newer nightly should have been released in the mean time
-    .update = please consider running `rustup update nightly` to update the nightly channel and check if this problem still persists
 driver_impl_ice_bug_report_outdated =
     it seems this '{$version}' is outdated, a newer nightly should have been released in the mean time
     .update = please consider running `rustup update nightly` to update the nightly channel and check if this problem still persists

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -1415,21 +1415,14 @@ fn report_ice(
         && let ver_datetime = OffsetDateTime::new_utc(ver_date, Time::MIDNIGHT)
         && let system_datetime = OffsetDateTime::from(SystemTime::now())
         && system_datetime.checked_sub(36.hours()).is_some_and(|d| d > ver_datetime)
+        && !using_internal_features.load(std::sync::atomic::Ordering::Relaxed)
     {
-        if using_internal_features.load(std::sync::atomic::Ordering::Relaxed) {
-            dcx.emit_note(session_diagnostics::IceBugReportInternalFeatureOutdated {
-                version,
-                note_update: (),
-                note_outdated: (),
-            });
-        } else {
-            dcx.emit_note(session_diagnostics::IceBugReportOutdated {
-                version,
-                bug_report_url,
-                note_update: (),
-                note_url: (),
-            });
-        }
+        dcx.emit_note(session_diagnostics::IceBugReportOutdated {
+            version,
+            bug_report_url,
+            note_update: (),
+            note_url: (),
+        });
     } else {
         if using_internal_features.load(std::sync::atomic::Ordering::Relaxed) {
             dcx.emit_note(session_diagnostics::IceBugReportInternalFeature);

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -57,7 +57,7 @@ use std::str;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::{Instant, SystemTime};
-use time::OffsetDateTime;
+use time::{Date, OffsetDateTime, Time};
 
 #[allow(unused_macros)]
 macro do_not_use_print($($t:tt)*) {
@@ -1370,6 +1370,9 @@ pub fn install_ice_hook(
     using_internal_features
 }
 
+const DATE_FORMAT: &[time::format_description::FormatItem<'static>] =
+    &time::macros::format_description!("[year]-[month]-[day]");
+
 /// Prints the ICE message, including query stack, but without backtrace.
 ///
 /// The message will point the user at `bug_report_url` to report the ICE.
@@ -1398,10 +1401,41 @@ fn report_ice(
         dcx.emit_err(session_diagnostics::Ice);
     }
 
-    if using_internal_features.load(std::sync::atomic::Ordering::Relaxed) {
-        dcx.emit_note(session_diagnostics::IceBugReportInternalFeature);
+    use time::ext::NumericalDuration;
+
+    // Try to hint user to update nightly if applicable when reporting an ICE.
+    // Attempt to calculate when current version was released, and add 12 hours
+    // as buffer. If the current version's release timestamp is older than
+    // the system's current time + 24 hours + 12 hours buffer if we're on
+    // nightly.
+    if let Some("nightly") = option_env!("CFG_RELEASE_CHANNEL")
+        && let Some(version) = option_env!("CFG_VERSION")
+        && let Some(ver_date_str) = option_env!("CFG_VER_DATE")
+        && let Ok(ver_date) = Date::parse(&ver_date_str, DATE_FORMAT)
+        && let ver_datetime = OffsetDateTime::new_utc(ver_date, Time::MIDNIGHT)
+        && let system_datetime = OffsetDateTime::from(SystemTime::now())
+        && system_datetime.checked_sub(36.hours()).is_some_and(|d| d > ver_datetime)
+    {
+        if using_internal_features.load(std::sync::atomic::Ordering::Relaxed) {
+            dcx.emit_note(session_diagnostics::IceBugReportInternalFeatureOutdated {
+                version,
+                note_update: (),
+                note_outdated: (),
+            });
+        } else {
+            dcx.emit_note(session_diagnostics::IceBugReportOutdated {
+                version,
+                bug_report_url,
+                note_update: (),
+                note_url: (),
+            });
+        }
     } else {
-        dcx.emit_note(session_diagnostics::IceBugReport { bug_report_url });
+        if using_internal_features.load(std::sync::atomic::Ordering::Relaxed) {
+            dcx.emit_note(session_diagnostics::IceBugReportInternalFeature);
+        } else {
+            dcx.emit_note(session_diagnostics::IceBugReport { bug_report_url });
+        }
     }
 
     let version = util::version_str!().unwrap_or("unknown_version");

--- a/compiler/rustc_driver_impl/src/session_diagnostics.rs
+++ b/compiler/rustc_driver_impl/src/session_diagnostics.rs
@@ -58,16 +58,6 @@ pub(crate) struct IceBugReportOutdated<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(driver_impl_ice_bug_report_internal_feature_outdated)]
-pub(crate) struct IceBugReportInternalFeatureOutdated<'a> {
-    pub version: &'a str,
-    #[note(driver_impl_outdated)]
-    pub note_outdated: (),
-    #[note(driver_impl_update)]
-    pub note_update: (),
-}
-
-#[derive(Diagnostic)]
 #[diag(driver_impl_ice_version)]
 pub(crate) struct IceVersion<'a> {
     pub version: &'a str,

--- a/compiler/rustc_driver_impl/src/session_diagnostics.rs
+++ b/compiler/rustc_driver_impl/src/session_diagnostics.rs
@@ -47,6 +47,27 @@ pub(crate) struct IceBugReport<'a> {
 pub(crate) struct IceBugReportInternalFeature;
 
 #[derive(Diagnostic)]
+#[diag(driver_impl_ice_bug_report_outdated)]
+pub(crate) struct IceBugReportOutdated<'a> {
+    pub version: &'a str,
+    pub bug_report_url: &'a str,
+    #[note(driver_impl_update)]
+    pub note_update: (),
+    #[note(driver_impl_url)]
+    pub note_url: (),
+}
+
+#[derive(Diagnostic)]
+#[diag(driver_impl_ice_bug_report_internal_feature_outdated)]
+pub(crate) struct IceBugReportInternalFeatureOutdated<'a> {
+    pub version: &'a str,
+    #[note(driver_impl_outdated)]
+    pub note_outdated: (),
+    #[note(driver_impl_update)]
+    pub note_update: (),
+}
+
+#[derive(Diagnostic)]
 #[diag(driver_impl_ice_version)]
 pub(crate) struct IceVersion<'a> {
     pub version: &'a str,

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -63,7 +63,7 @@ use emitter::{is_case_difference, DynEmitter, Emitter};
 use registry::Registry;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_data_structures::stable_hasher::{Hash128, StableHasher};
-use rustc_data_structures::sync::Lock;
+use rustc_data_structures::sync::{Lock, Lrc};
 use rustc_data_structures::AtomicRef;
 use rustc_lint_defs::LintExpectationId;
 use rustc_span::source_map::SourceMap;
@@ -606,29 +606,54 @@ impl DiagCtxt {
     }
 
     pub fn new(emitter: Box<DynEmitter>) -> Self {
-        Self {
-            inner: Lock::new(DiagCtxtInner {
-                flags: DiagCtxtFlags { can_emit_warnings: true, ..Default::default() },
-                err_guars: Vec::new(),
-                lint_err_guars: Vec::new(),
-                delayed_bugs: Vec::new(),
-                deduplicated_err_count: 0,
-                deduplicated_warn_count: 0,
-                emitter,
-                must_produce_diag: false,
-                has_printed: false,
-                suppressed_expected_diag: false,
-                taught_diagnostics: Default::default(),
-                emitted_diagnostic_codes: Default::default(),
-                emitted_diagnostics: Default::default(),
-                stashed_diagnostics: Default::default(),
-                future_breakage_diagnostics: Vec::new(),
-                check_unstable_expect_diagnostics: false,
-                unstable_expect_diagnostics: Vec::new(),
-                fulfilled_expectations: Default::default(),
-                ice_file: None,
-            }),
+        Self { inner: Lock::new(DiagCtxtInner::new(emitter)) }
+    }
+
+    pub fn make_silent(&mut self, fallback_bundle: LazyFallbackBundle, fatal_note: Option<String>) {
+        self.wrap_emitter(|old_dcx| {
+            Box::new(emitter::SilentEmitter {
+                fallback_bundle,
+                fatal_dcx: DiagCtxt { inner: Lock::new(old_dcx) },
+                fatal_note,
+            })
+        });
+    }
+
+    fn wrap_emitter<F>(&mut self, f: F)
+    where
+        F: FnOnce(DiagCtxtInner) -> Box<DynEmitter>,
+    {
+        // A empty type that implements `Emitter` so that a `DiagCtxtInner` can be constructed
+        // to temporarily swap in place of the real one, which will be used in constructing
+        // its replacement.
+        struct FalseEmitter;
+
+        impl Emitter for FalseEmitter {
+            fn emit_diagnostic(&mut self, _: DiagInner) {
+                unimplemented!("false emitter must only used during `wrap_emitter`")
+            }
+
+            fn source_map(&self) -> Option<&Lrc<SourceMap>> {
+                unimplemented!("false emitter must only used during `wrap_emitter`")
+            }
         }
+
+        impl translation::Translate for FalseEmitter {
+            fn fluent_bundle(&self) -> Option<&Lrc<FluentBundle>> {
+                unimplemented!("false emitter must only used during `wrap_emitter`")
+            }
+
+            fn fallback_fluent_bundle(&self) -> &FluentBundle {
+                unimplemented!("false emitter must only used during `wrap_emitter`")
+            }
+        }
+
+        let mut inner = self.inner.borrow_mut();
+        let mut prev_dcx = DiagCtxtInner::new(Box::new(FalseEmitter));
+        std::mem::swap(&mut *inner, &mut prev_dcx);
+        let new_emitter = f(prev_dcx);
+        let mut new_dcx = DiagCtxtInner::new(new_emitter);
+        std::mem::swap(&mut *inner, &mut new_dcx);
     }
 
     /// Translate `message` eagerly with `args` to `SubdiagMessage::Eager`.
@@ -1345,6 +1370,30 @@ impl DiagCtxt {
 // `DiagCtxt::foo()` just borrows `inner` and forwards a call to
 // `DiagCtxtInner::foo`.
 impl DiagCtxtInner {
+    fn new(emitter: Box<DynEmitter>) -> Self {
+        Self {
+            flags: DiagCtxtFlags { can_emit_warnings: true, ..Default::default() },
+            err_guars: Vec::new(),
+            lint_err_guars: Vec::new(),
+            delayed_bugs: Vec::new(),
+            deduplicated_err_count: 0,
+            deduplicated_warn_count: 0,
+            emitter,
+            must_produce_diag: false,
+            has_printed: false,
+            suppressed_expected_diag: false,
+            taught_diagnostics: Default::default(),
+            emitted_diagnostic_codes: Default::default(),
+            emitted_diagnostics: Default::default(),
+            stashed_diagnostics: Default::default(),
+            future_breakage_diagnostics: Vec::new(),
+            check_unstable_expect_diagnostics: false,
+            unstable_expect_diagnostics: Vec::new(),
+            fulfilled_expectations: Default::default(),
+            ice_file: None,
+        }
+    }
+
     /// Emit all stashed diagnostics.
     fn emit_stashed_diagnostics(&mut self) -> Option<ErrorGuaranteed> {
         let mut guar = None;

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -791,7 +791,12 @@ fn convert_enum_variant_types(tcx: TyCtxt<'_>, def_id: DefId) {
 }
 
 fn find_field(tcx: TyCtxt<'_>, (def_id, ident): (DefId, Ident)) -> Option<FieldIdx> {
-    tcx.adt_def(def_id).non_enum_variant().fields.iter_enumerated().find_map(|(idx, field)| {
+    let adt = tcx.adt_def(def_id);
+    if adt.is_enum() {
+        return None;
+    }
+
+    adt.non_enum_variant().fields.iter_enumerated().find_map(|(idx, field)| {
         if field.is_unnamed() {
             let field_ty = tcx.type_of(field.did).instantiate_identity();
             let adt_def = field_ty.ty_adt_def().expect("expect Adt for unnamed field");

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -45,9 +45,10 @@ pub struct Compiler {
 pub(crate) fn parse_cfg(dcx: &DiagCtxt, cfgs: Vec<String>) -> Cfg {
     cfgs.into_iter()
         .map(|s| {
-            let psess = ParseSess::with_silent_emitter(format!(
-                "this error occurred on the command line: `--cfg={s}`"
-            ));
+            let psess = ParseSess::with_silent_emitter(
+                vec![crate::DEFAULT_LOCALE_RESOURCE, rustc_parse::DEFAULT_LOCALE_RESOURCE],
+                format!("this error occurred on the command line: `--cfg={s}`"),
+            );
             let filename = FileName::cfg_spec_source_code(&s);
 
             macro_rules! error {
@@ -107,9 +108,10 @@ pub(crate) fn parse_check_cfg(dcx: &DiagCtxt, specs: Vec<String>) -> CheckCfg {
     let mut check_cfg = CheckCfg { exhaustive_names, exhaustive_values, ..CheckCfg::default() };
 
     for s in specs {
-        let psess = ParseSess::with_silent_emitter(format!(
-            "this error occurred on the command line: `--check-cfg={s}`"
-        ));
+        let psess = ParseSess::with_silent_emitter(
+            vec![crate::DEFAULT_LOCALE_RESOURCE, rustc_parse::DEFAULT_LOCALE_RESOURCE],
+            format!("this error occurred on the command line: `--check-cfg={s}`"),
+        );
         let filename = FileName::cfg_spec_source_code(&s);
 
         macro_rules! error {

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -984,7 +984,14 @@ pub fn transparent_newtype_field<'a, 'tcx>(
 }
 
 /// Is type known to be non-null?
-fn ty_is_known_nonnull<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, mode: CItemKind) -> bool {
+fn ty_is_known_nonnull<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+    ty: Ty<'tcx>,
+    mode: CItemKind,
+) -> bool {
+    let ty = tcx.try_normalize_erasing_regions(param_env, ty).unwrap_or(ty);
+
     match ty.kind() {
         ty::FnPtr(_) => true,
         ty::Ref(..) => true,
@@ -1004,7 +1011,7 @@ fn ty_is_known_nonnull<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, mode: CItemKind) -
             def.variants()
                 .iter()
                 .filter_map(|variant| transparent_newtype_field(tcx, variant))
-                .any(|field| ty_is_known_nonnull(tcx, field.ty(tcx, args), mode))
+                .any(|field| ty_is_known_nonnull(tcx, param_env, field.ty(tcx, args), mode))
         }
         _ => false,
     }
@@ -1012,7 +1019,13 @@ fn ty_is_known_nonnull<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, mode: CItemKind) -
 
 /// Given a non-null scalar (or transparent) type `ty`, return the nullable version of that type.
 /// If the type passed in was not scalar, returns None.
-fn get_nullable_type<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
+fn get_nullable_type<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+    ty: Ty<'tcx>,
+) -> Option<Ty<'tcx>> {
+    let ty = tcx.try_normalize_erasing_regions(param_env, ty).unwrap_or(ty);
+
     Some(match *ty.kind() {
         ty::Adt(field_def, field_args) => {
             let inner_field_ty = {
@@ -1028,22 +1041,19 @@ fn get_nullable_type<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'tcx>> 
                     .expect("No non-zst fields in transparent type.")
                     .ty(tcx, field_args)
             };
-            return get_nullable_type(tcx, inner_field_ty);
+            return get_nullable_type(tcx, param_env, inner_field_ty);
         }
         ty::Int(ty) => Ty::new_int(tcx, ty),
         ty::Uint(ty) => Ty::new_uint(tcx, ty),
         ty::RawPtr(ty_mut) => Ty::new_ptr(tcx, ty_mut),
         // As these types are always non-null, the nullable equivalent of
-        // Option<T> of these types are their raw pointer counterparts.
+        // `Option<T>` of these types are their raw pointer counterparts.
         ty::Ref(_region, ty, mutbl) => Ty::new_ptr(tcx, ty::TypeAndMut { ty, mutbl }),
-        ty::FnPtr(..) => {
-            // There is no nullable equivalent for Rust's function pointers -- you
-            // must use an Option<fn(..) -> _> to represent it.
-            ty
-        }
-
-        // We should only ever reach this case if ty_is_known_nonnull is extended
-        // to other types.
+        // There is no nullable equivalent for Rust's function pointers,
+        // you must use an `Option<fn(..) -> _>` to represent it.
+        ty::FnPtr(..) => ty,
+        // We should only ever reach this case if `ty_is_known_nonnull` is
+        // extended to other types.
         ref unhandled => {
             debug!(
                 "get_nullable_type: Unhandled scalar kind: {:?} while checking {:?}",
@@ -1056,7 +1066,7 @@ fn get_nullable_type<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'tcx>> 
 
 /// Check if this enum can be safely exported based on the "nullable pointer optimization". If it
 /// can, return the type that `ty` can be safely converted to, otherwise return `None`.
-/// Currently restricted to function pointers, boxes, references, `core::num::NonZero*`,
+/// Currently restricted to function pointers, boxes, references, `core::num::NonZero`,
 /// `core::ptr::NonNull`, and `#[repr(transparent)]` newtypes.
 /// FIXME: This duplicates code in codegen.
 pub(crate) fn repr_nullable_ptr<'tcx>(
@@ -1075,7 +1085,7 @@ pub(crate) fn repr_nullable_ptr<'tcx>(
             _ => return None,
         };
 
-        if !ty_is_known_nonnull(tcx, field_ty, ckind) {
+        if !ty_is_known_nonnull(tcx, param_env, field_ty, ckind) {
             return None;
         }
 
@@ -1099,10 +1109,10 @@ pub(crate) fn repr_nullable_ptr<'tcx>(
                 WrappingRange { start: 0, end }
                     if end == field_ty_scalar.size(&tcx).unsigned_int_max() - 1 =>
                 {
-                    return Some(get_nullable_type(tcx, field_ty).unwrap());
+                    return Some(get_nullable_type(tcx, param_env, field_ty).unwrap());
                 }
                 WrappingRange { start: 1, .. } => {
-                    return Some(get_nullable_type(tcx, field_ty).unwrap());
+                    return Some(get_nullable_type(tcx, param_env, field_ty).unwrap());
                 }
                 WrappingRange { start, end } => {
                     unreachable!("Unhandled start and end range: ({}, {})", start, end)

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -1132,7 +1132,13 @@ fn load_dylib(path: &Path, max_attempts: usize) -> Result<libloading::Library, S
             Err(err) => {
                 // Only try to recover from this specific error.
                 if !matches!(err, libloading::Error::LoadLibraryExW { .. }) {
-                    return Err(err.to_string());
+                    let err = format_dlopen_err(&err);
+                    // We include the path of the dylib in the error ourselves, so
+                    // if it's in the error, we strip it.
+                    if let Some(err) = err.strip_prefix(&format!(": {}", path.display())) {
+                        return Err(err.to_string());
+                    }
+                    return Err(err);
                 }
 
                 last_error = Some(err);

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -344,15 +344,6 @@ rustc_queries! {
         }
     }
 
-    query impl_trait_in_assoc_types_defined_by(
-        key: LocalDefId
-    ) -> &'tcx ty::List<LocalDefId> {
-        desc {
-            |tcx| "computing the opaque types defined by `{}`",
-            tcx.def_path_str(key.to_def_id())
-        }
-    }
-
     /// Returns the list of bounds that can be used for
     /// `SelectionCandidate::ProjectionCandidate(_)` and
     /// `ProjectionTyCandidate::TraitDef`.

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1565,6 +1565,8 @@ options! {
         "set options for branch target identification and pointer authentication on AArch64"),
     cf_protection: CFProtection = (CFProtection::None, parse_cfprotection, [TRACKED],
         "instrument control-flow architecture protection"),
+    check_cfg_all_expected: bool = (false, parse_bool, [UNTRACKED],
+        "show all expected values in check-cfg diagnostics (default: no)"),
     codegen_backend: Option<String> = (None, parse_opt_string, [TRACKED],
         "the backend to use"),
     collapse_macro_debuginfo: CollapseMacroDebuginfo = (CollapseMacroDebuginfo::Unspecified,

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -265,14 +265,20 @@ impl ParseSess {
         }
     }
 
-    pub fn with_silent_emitter(fatal_note: String) -> Self {
-        let fallback_bundle = fallback_fluent_bundle(Vec::new(), false);
+    pub fn with_silent_emitter(locale_resources: Vec<&'static str>, fatal_note: String) -> Self {
+        let fallback_bundle = fallback_fluent_bundle(locale_resources, false);
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
-        let emitter =
-            Box::new(HumanEmitter::new(stderr_destination(ColorConfig::Auto), fallback_bundle));
+        let emitter = Box::new(HumanEmitter::new(
+            stderr_destination(ColorConfig::Auto),
+            fallback_bundle.clone(),
+        ));
         let fatal_dcx = DiagCtxt::new(emitter);
-        let dcx =
-            DiagCtxt::new(Box::new(SilentEmitter { fatal_dcx, fatal_note })).disable_warnings();
+        let dcx = DiagCtxt::new(Box::new(SilentEmitter {
+            fallback_bundle,
+            fatal_dcx,
+            fatal_note: Some(fatal_note),
+        }))
+        .disable_warnings();
         ParseSess::with_dcx(dcx, sm)
     }
 

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -34,7 +34,11 @@ enum CollectionMode {
 }
 
 impl<'tcx> OpaqueTypeCollector<'tcx> {
-    fn new(tcx: TyCtxt<'tcx>, item: LocalDefId, mode: CollectionMode) -> Self {
+    fn new(tcx: TyCtxt<'tcx>, item: LocalDefId) -> Self {
+        let mode = match tcx.def_kind(tcx.local_parent(item)) {
+            DefKind::Impl { of_trait: true } => CollectionMode::ImplTraitInAssocTypes,
+            _ => CollectionMode::TypeAliasImplTraitTransition,
+        };
         Self { tcx, opaques: Vec::new(), item, seen: Default::default(), span: None, mode }
     }
 
@@ -287,23 +291,13 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for OpaqueTypeCollector<'tcx> {
     }
 }
 
-fn impl_trait_in_assoc_types_defined_by<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    item: LocalDefId,
-) -> &'tcx ty::List<LocalDefId> {
-    let mut collector = OpaqueTypeCollector::new(tcx, item, CollectionMode::ImplTraitInAssocTypes);
-    super::sig_types::walk_types(tcx, item, &mut collector);
-    tcx.mk_local_def_ids(&collector.opaques)
-}
-
 fn opaque_types_defined_by<'tcx>(
     tcx: TyCtxt<'tcx>,
     item: LocalDefId,
 ) -> &'tcx ty::List<LocalDefId> {
     let kind = tcx.def_kind(item);
     trace!(?kind);
-    let mut collector =
-        OpaqueTypeCollector::new(tcx, item, CollectionMode::TypeAliasImplTraitTransition);
+    let mut collector = OpaqueTypeCollector::new(tcx, item);
     super::sig_types::walk_types(tcx, item, &mut collector);
     match kind {
         DefKind::AssocFn
@@ -346,6 +340,5 @@ fn opaque_types_defined_by<'tcx>(
 }
 
 pub(super) fn provide(providers: &mut Providers) {
-    *providers =
-        Providers { opaque_types_defined_by, impl_trait_in_assoc_types_defined_by, ..*providers };
+    *providers = Providers { opaque_types_defined_by, ..*providers };
 }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -6,6 +6,7 @@ use crate::hash::{Hash, Hasher};
 use crate::intrinsics;
 use crate::marker::StructuralPartialEq;
 use crate::ops::{BitOr, BitOrAssign, Div, Neg, Rem};
+use crate::panic::{RefUnwindSafe, UnwindSafe};
 use crate::ptr;
 use crate::str::FromStr;
 
@@ -128,6 +129,25 @@ impl_nonzero_fmt!(Binary);
 impl_nonzero_fmt!(Octal);
 impl_nonzero_fmt!(LowerHex);
 impl_nonzero_fmt!(UpperHex);
+
+macro_rules! impl_nonzero_auto_trait {
+    (unsafe $Trait:ident) => {
+        #[stable(feature = "nonzero", since = "1.28.0")]
+        unsafe impl<T> $Trait for NonZero<T> where T: ZeroablePrimitive + $Trait {}
+    };
+    ($Trait:ident) => {
+        #[stable(feature = "nonzero", since = "1.28.0")]
+        impl<T> $Trait for NonZero<T> where T: ZeroablePrimitive + $Trait {}
+    };
+}
+
+// Implement auto-traits manually based on `T` to avoid docs exposing
+// the `ZeroablePrimitive::NonZeroInner` implementation detail.
+impl_nonzero_auto_trait!(RefUnwindSafe);
+impl_nonzero_auto_trait!(unsafe Send);
+impl_nonzero_auto_trait!(unsafe Sync);
+impl_nonzero_auto_trait!(Unpin);
+impl_nonzero_auto_trait!(UnwindSafe);
 
 #[stable(feature = "nonzero", since = "1.28.0")]
 impl<T> Clone for NonZero<T>

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -103,6 +103,7 @@ impl_zeroable_primitive!(
 /// ```
 #[unstable(feature = "generic_nonzero", issue = "120257")]
 #[repr(transparent)]
+#[rustc_nonnull_optimization_guaranteed]
 #[rustc_diagnostic_item = "NonZero"]
 pub struct NonZero<T: ZeroablePrimitive>(T::NonZeroInner);
 

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_callee_ret.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_callee_ret.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: constructing invalid value: encountered 0, but expected something greater or equal to 1
+error: Undefined Behavior: constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
   --> $DIR/cast_fn_ptr_invalid_callee_ret.rs:LL:CC
    |
 LL |     f();
-   |     ^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   |     ^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_caller_arg.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_caller_arg.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: constructing invalid value: encountered 0, but expected something greater or equal to 1
+error: Undefined Behavior: constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
   --> $DIR/cast_fn_ptr_invalid_caller_arg.rs:LL:CC
    |
 LL |             Call(_res = f(*ptr), ReturnTo(retblock), UnwindContinue())
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/rustfmt/tests/rustfmt/main.rs
+++ b/src/tools/rustfmt/tests/rustfmt/main.rs
@@ -176,7 +176,7 @@ fn rustfmt_emits_error_on_line_overflow_true() {
 #[test]
 #[allow(non_snake_case)]
 fn dont_emit_ICE() {
-    let files = ["tests/target/issue_5728.rs", "tests/target/issue_5729.rs"];
+    let files = ["tests/target/issue_5728.rs", "tests/target/issue_5729.rs", "tests/target/issue_6082.rs"];
 
     for file in files {
         let args = [file];

--- a/src/tools/rustfmt/tests/target/issue_6082.rs
+++ b/src/tools/rustfmt/tests/target/issue_6082.rs
@@ -1,0 +1,5 @@
+macro_rules! test {
+    ($T:ident, $b:lifetime) => {
+        Box<$T<$b>>
+    };
+}

--- a/tests/ui/check-cfg/mix.rs
+++ b/tests/ui/check-cfg/mix.rs
@@ -74,6 +74,8 @@ fn test_cfg_macro() {
     //~^ WARNING unexpected `cfg` condition value
     //~| WARNING unexpected `cfg` condition value
     //~| WARNING unexpected `cfg` condition value
+    cfg!(target_feature = "zebra");
+    //~^ WARNING unexpected `cfg` condition value
 }
 
 fn main() {}

--- a/tests/ui/check-cfg/mix.stderr
+++ b/tests/ui/check-cfg/mix.stderr
@@ -245,5 +245,14 @@ LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    = help: to expect this configuration use `--check-cfg=cfg(feature, values("zebra"))`
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
-warning: 26 warnings emitted
+warning: unexpected `cfg` condition value: `zebra`
+  --> $DIR/mix.rs:77:10
+   |
+LL |     cfg!(target_feature = "zebra");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `target_feature` are: `10e60`, `2e3`, `3e3r1`, `3e3r2`, `3e3r3`, `3e7`, `7e10`, `a`, `aclass`, `adx`, `aes`, `altivec`, `alu32`, `atomics`, `avx`, `avx2`, `avx512bf16`, `avx512bitalg`, `avx512bw`, `avx512cd`, `avx512dq`, `avx512er`, `avx512f`, `avx512fp16`, `avx512ifma`, `avx512pf`, `avx512vbmi`, `avx512vbmi2`, `avx512vl`, `avx512vnni`, `avx512vp2intersect`, `avx512vpopcntdq`, `bf16`, `bmi1`, `bmi2` and 186 more
+   = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
+
+warning: 27 warnings emitted
 

--- a/tests/ui/check-cfg/well-known-values.rs
+++ b/tests/ui/check-cfg/well-known-values.rs
@@ -6,6 +6,7 @@
 //
 //@ check-pass
 //@ compile-flags: --check-cfg=cfg() -Z unstable-options
+//@ compile-flags: -Zcheck-cfg-all-expected
 
 #![feature(cfg_overflow_checks)]
 #![feature(cfg_relocation_model)]

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:25:5
+  --> $DIR/well-known-values.rs:26:5
    |
 LL |     clippy = "_UNEXPECTED_VALUE",
    |     ^^^^^^----------------------
@@ -11,7 +11,7 @@ LL |     clippy = "_UNEXPECTED_VALUE",
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:27:5
+  --> $DIR/well-known-values.rs:28:5
    |
 LL |     debug_assertions = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^----------------------
@@ -22,7 +22,7 @@ LL |     debug_assertions = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:29:5
+  --> $DIR/well-known-values.rs:30:5
    |
 LL |     doc = "_UNEXPECTED_VALUE",
    |     ^^^----------------------
@@ -33,7 +33,7 @@ LL |     doc = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:31:5
+  --> $DIR/well-known-values.rs:32:5
    |
 LL |     doctest = "_UNEXPECTED_VALUE",
    |     ^^^^^^^----------------------
@@ -44,7 +44,7 @@ LL |     doctest = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:33:5
+  --> $DIR/well-known-values.rs:34:5
    |
 LL |     miri = "_UNEXPECTED_VALUE",
    |     ^^^^----------------------
@@ -55,7 +55,7 @@ LL |     miri = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:35:5
+  --> $DIR/well-known-values.rs:36:5
    |
 LL |     overflow_checks = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^----------------------
@@ -66,7 +66,7 @@ LL |     overflow_checks = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:37:5
+  --> $DIR/well-known-values.rs:38:5
    |
 LL |     panic = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL |     panic = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:39:5
+  --> $DIR/well-known-values.rs:40:5
    |
 LL |     proc_macro = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^----------------------
@@ -86,7 +86,7 @@ LL |     proc_macro = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:41:5
+  --> $DIR/well-known-values.rs:42:5
    |
 LL |     relocation_model = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     relocation_model = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:43:5
+  --> $DIR/well-known-values.rs:44:5
    |
 LL |     sanitize = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,7 +104,7 @@ LL |     sanitize = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:45:5
+  --> $DIR/well-known-values.rs:46:5
    |
 LL |     target_abi = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -113,7 +113,7 @@ LL |     target_abi = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:47:5
+  --> $DIR/well-known-values.rs:48:5
    |
 LL |     target_arch = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -122,7 +122,7 @@ LL |     target_arch = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:49:5
+  --> $DIR/well-known-values.rs:50:5
    |
 LL |     target_endian = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     target_endian = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:51:5
+  --> $DIR/well-known-values.rs:52:5
    |
 LL |     target_env = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -140,7 +140,7 @@ LL |     target_env = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:53:5
+  --> $DIR/well-known-values.rs:54:5
    |
 LL |     target_family = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |     target_family = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:55:5
+  --> $DIR/well-known-values.rs:56:5
    |
 LL |     target_feature = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -158,7 +158,7 @@ LL |     target_feature = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:57:5
+  --> $DIR/well-known-values.rs:58:5
    |
 LL |     target_has_atomic = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -167,7 +167,7 @@ LL |     target_has_atomic = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:59:5
+  --> $DIR/well-known-values.rs:60:5
    |
 LL |     target_has_atomic_equal_alignment = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -176,7 +176,7 @@ LL |     target_has_atomic_equal_alignment = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:61:5
+  --> $DIR/well-known-values.rs:62:5
    |
 LL |     target_has_atomic_load_store = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -185,7 +185,7 @@ LL |     target_has_atomic_load_store = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:63:5
+  --> $DIR/well-known-values.rs:64:5
    |
 LL |     target_os = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -194,7 +194,7 @@ LL |     target_os = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:65:5
+  --> $DIR/well-known-values.rs:66:5
    |
 LL |     target_pointer_width = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -203,7 +203,7 @@ LL |     target_pointer_width = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:67:5
+  --> $DIR/well-known-values.rs:68:5
    |
 LL |     target_thread_local = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^----------------------
@@ -214,7 +214,7 @@ LL |     target_thread_local = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:69:5
+  --> $DIR/well-known-values.rs:70:5
    |
 LL |     target_vendor = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -223,7 +223,7 @@ LL |     target_vendor = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:71:5
+  --> $DIR/well-known-values.rs:72:5
    |
 LL |     test = "_UNEXPECTED_VALUE",
    |     ^^^^----------------------
@@ -234,7 +234,7 @@ LL |     test = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:73:5
+  --> $DIR/well-known-values.rs:74:5
    |
 LL |     unix = "_UNEXPECTED_VALUE",
    |     ^^^^----------------------
@@ -245,7 +245,7 @@ LL |     unix = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:75:5
+  --> $DIR/well-known-values.rs:76:5
    |
 LL |     windows = "_UNEXPECTED_VALUE",
    |     ^^^^^^^----------------------
@@ -256,7 +256,7 @@ LL |     windows = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `linuz`
-  --> $DIR/well-known-values.rs:81:7
+  --> $DIR/well-known-values.rs:82:7
    |
 LL | #[cfg(target_os = "linuz")] // testing that we suggest `linux`
    |       ^^^^^^^^^^^^-------

--- a/tests/ui/codegen/duplicated-path-in-error.rs
+++ b/tests/ui/codegen/duplicated-path-in-error.rs
@@ -1,0 +1,7 @@
+//@ only-linux
+//@ compile-flags: -Zcodegen-backend=/non-existing-one.so
+
+// This test ensures that the error of the "not found dylib" doesn't duplicate
+// the path of the dylib.
+
+fn main() {}

--- a/tests/ui/codegen/duplicated-path-in-error.stderr
+++ b/tests/ui/codegen/duplicated-path-in-error.stderr
@@ -1,0 +1,2 @@
+error: couldn't load codegen backend /non-existing-one.so: cannot open shared object file: No such file or directory
+

--- a/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
@@ -68,7 +68,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/raw-bytes.rs:59:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 1, align: 1) {
@@ -79,7 +79,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/raw-bytes.rs:61:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {

--- a/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
@@ -68,7 +68,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/raw-bytes.rs:59:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 1, align: 1) {
@@ -79,7 +79,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/raw-bytes.rs:61:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {

--- a/tests/ui/consts/const-eval/ub-nonnull.stderr
+++ b/tests/ui/consts/const-eval/ub-nonnull.stderr
@@ -19,7 +19,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-nonnull.rs:24:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
@@ -30,7 +30,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-nonnull.rs:26:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {

--- a/tests/ui/imports/unresolved-seg-after-ambiguous.rs
+++ b/tests/ui/imports/unresolved-seg-after-ambiguous.rs
@@ -1,0 +1,24 @@
+mod a {
+    mod b {
+        mod c {
+            pub struct E;
+        }
+
+        mod d {
+            #[derive(Debug)]
+            pub struct E;
+        }
+
+        pub use self::d::*;
+        pub use self::c::*;
+    }
+
+    pub use self::b::*;
+}
+
+use self::a::E::in_exist;
+//~^ ERROR: unresolved import `self::a::E`
+//~| WARNING: `E` is ambiguous
+//~| WARNING: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+fn main() {}

--- a/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
+++ b/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
@@ -1,0 +1,32 @@
+error[E0432]: unresolved import `self::a::E`
+  --> $DIR/unresolved-seg-after-ambiguous.rs:19:14
+   |
+LL | use self::a::E::in_exist;
+   |              ^ `E` is a struct, not a module
+
+warning: `E` is ambiguous
+  --> $DIR/unresolved-seg-after-ambiguous.rs:19:14
+   |
+LL | use self::a::E::in_exist;
+   |              ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `E` could refer to the struct imported here
+  --> $DIR/unresolved-seg-after-ambiguous.rs:13:17
+   |
+LL |         pub use self::c::*;
+   |                 ^^^^^^^^^^
+   = help: consider adding an explicit import of `E` to disambiguate
+note: `E` could also refer to the struct imported here
+  --> $DIR/unresolved-seg-after-ambiguous.rs:12:17
+   |
+LL |         pub use self::d::*;
+   |                 ^^^^^^^^^^
+   = help: consider adding an explicit import of `E` to disambiguate
+   = note: `#[warn(ambiguous_glob_imports)]` on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/lint/clashing-extern-fn.stderr
+++ b/tests/ui/lint/clashing-extern-fn.stderr
@@ -1,31 +1,3 @@
-warning: `extern` block uses type `Option<NonZero<usize>>`, which is not FFI-safe
-  --> $DIR/clashing-extern-fn.rs:369:43
-   |
-LL |             fn option_non_zero_usize() -> Option<core::num::NonZero<usize>>;
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-   = note: `#[warn(improper_ctypes)]` on by default
-
-warning: `extern` block uses type `Option<NonZero<isize>>`, which is not FFI-safe
-  --> $DIR/clashing-extern-fn.rs:370:43
-   |
-LL |             fn option_non_zero_isize() -> Option<core::num::NonZero<isize>>;
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-warning: `extern` block uses type `Option<Transparent>`, which is not FFI-safe
-  --> $DIR/clashing-extern-fn.rs:428:46
-   |
-LL |             fn hidden_niche_transparent() -> Option<Transparent>;
-   |                                              ^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
 warning: `extern` block uses type `Option<TransparentNoNiche>`, which is not FFI-safe
   --> $DIR/clashing-extern-fn.rs:430:55
    |
@@ -34,6 +6,7 @@ LL |             fn hidden_niche_transparent_no_niche() -> Option<TransparentNoN
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
+   = note: `#[warn(improper_ctypes)]` on by default
 
 warning: `extern` block uses type `Option<UnsafeCell<NonZero<usize>>>`, which is not FFI-safe
   --> $DIR/clashing-extern-fn.rs:434:46
@@ -205,30 +178,6 @@ LL |             fn non_null_ptr() -> *const usize;
    = note: expected `unsafe extern "C" fn() -> NonNull<usize>`
               found `unsafe extern "C" fn() -> *const usize`
 
-warning: `option_non_zero_usize` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:369:13
-   |
-LL |             fn option_non_zero_usize() -> usize;
-   |             ----------------------------------- `option_non_zero_usize` previously declared here
-...
-LL |             fn option_non_zero_usize() -> Option<core::num::NonZero<usize>>;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
-   |
-   = note: expected `unsafe extern "C" fn() -> usize`
-              found `unsafe extern "C" fn() -> Option<NonZero<usize>>`
-
-warning: `option_non_zero_isize` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:370:13
-   |
-LL |             fn option_non_zero_isize() -> isize;
-   |             ----------------------------------- `option_non_zero_isize` previously declared here
-...
-LL |             fn option_non_zero_isize() -> Option<core::num::NonZero<isize>>;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
-   |
-   = note: expected `unsafe extern "C" fn() -> isize`
-              found `unsafe extern "C" fn() -> Option<NonZero<isize>>`
-
 warning: `option_non_zero_usize_incorrect` redeclared with a different signature
   --> $DIR/clashing-extern-fn.rs:374:13
    |
@@ -252,18 +201,6 @@ LL |             fn option_non_null_ptr_incorrect() -> *const isize;
    |
    = note: expected `unsafe extern "C" fn() -> *const usize`
               found `unsafe extern "C" fn() -> *const isize`
-
-warning: `hidden_niche_transparent` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:428:13
-   |
-LL |             fn hidden_niche_transparent() -> usize;
-   |             -------------------------------------- `hidden_niche_transparent` previously declared here
-...
-LL |             fn hidden_niche_transparent() -> Option<Transparent>;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
-   |
-   = note: expected `unsafe extern "C" fn() -> usize`
-              found `unsafe extern "C" fn() -> Option<Transparent>`
 
 warning: `hidden_niche_transparent_no_niche` redeclared with a different signature
   --> $DIR/clashing-extern-fn.rs:430:13
@@ -289,5 +226,5 @@ LL |             fn hidden_niche_unsafe_cell() -> Option<UnsafeCell<NonZero<usiz
    = note: expected `unsafe extern "C" fn() -> usize`
               found `unsafe extern "C" fn() -> Option<UnsafeCell<NonZero<usize>>>`
 
-warning: 25 warnings emitted
+warning: 19 warnings emitted
 

--- a/tests/ui/lint/clashing-extern-fn.stderr
+++ b/tests/ui/lint/clashing-extern-fn.stderr
@@ -1,3 +1,31 @@
+warning: `extern` block uses type `Option<NonZero<usize>>`, which is not FFI-safe
+  --> $DIR/clashing-extern-fn.rs:369:43
+   |
+LL |             fn option_non_zero_usize() -> Option<core::num::NonZero<usize>>;
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+   = note: `#[warn(improper_ctypes)]` on by default
+
+warning: `extern` block uses type `Option<NonZero<isize>>`, which is not FFI-safe
+  --> $DIR/clashing-extern-fn.rs:370:43
+   |
+LL |             fn option_non_zero_isize() -> Option<core::num::NonZero<isize>>;
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+warning: `extern` block uses type `Option<Transparent>`, which is not FFI-safe
+  --> $DIR/clashing-extern-fn.rs:428:46
+   |
+LL |             fn hidden_niche_transparent() -> Option<Transparent>;
+   |                                              ^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
 warning: `extern` block uses type `Option<TransparentNoNiche>`, which is not FFI-safe
   --> $DIR/clashing-extern-fn.rs:430:55
    |
@@ -6,7 +34,6 @@ LL |             fn hidden_niche_transparent_no_niche() -> Option<TransparentNoN
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
-   = note: `#[warn(improper_ctypes)]` on by default
 
 warning: `extern` block uses type `Option<UnsafeCell<NonZero<usize>>>`, which is not FFI-safe
   --> $DIR/clashing-extern-fn.rs:434:46
@@ -178,6 +205,30 @@ LL |             fn non_null_ptr() -> *const usize;
    = note: expected `unsafe extern "C" fn() -> NonNull<usize>`
               found `unsafe extern "C" fn() -> *const usize`
 
+warning: `option_non_zero_usize` redeclared with a different signature
+  --> $DIR/clashing-extern-fn.rs:369:13
+   |
+LL |             fn option_non_zero_usize() -> usize;
+   |             ----------------------------------- `option_non_zero_usize` previously declared here
+...
+LL |             fn option_non_zero_usize() -> Option<core::num::NonZero<usize>>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
+   |
+   = note: expected `unsafe extern "C" fn() -> usize`
+              found `unsafe extern "C" fn() -> Option<NonZero<usize>>`
+
+warning: `option_non_zero_isize` redeclared with a different signature
+  --> $DIR/clashing-extern-fn.rs:370:13
+   |
+LL |             fn option_non_zero_isize() -> isize;
+   |             ----------------------------------- `option_non_zero_isize` previously declared here
+...
+LL |             fn option_non_zero_isize() -> Option<core::num::NonZero<isize>>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
+   |
+   = note: expected `unsafe extern "C" fn() -> isize`
+              found `unsafe extern "C" fn() -> Option<NonZero<isize>>`
+
 warning: `option_non_zero_usize_incorrect` redeclared with a different signature
   --> $DIR/clashing-extern-fn.rs:374:13
    |
@@ -201,6 +252,18 @@ LL |             fn option_non_null_ptr_incorrect() -> *const isize;
    |
    = note: expected `unsafe extern "C" fn() -> *const usize`
               found `unsafe extern "C" fn() -> *const isize`
+
+warning: `hidden_niche_transparent` redeclared with a different signature
+  --> $DIR/clashing-extern-fn.rs:428:13
+   |
+LL |             fn hidden_niche_transparent() -> usize;
+   |             -------------------------------------- `hidden_niche_transparent` previously declared here
+...
+LL |             fn hidden_niche_transparent() -> Option<Transparent>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
+   |
+   = note: expected `unsafe extern "C" fn() -> usize`
+              found `unsafe extern "C" fn() -> Option<Transparent>`
 
 warning: `hidden_niche_transparent_no_niche` redeclared with a different signature
   --> $DIR/clashing-extern-fn.rs:430:13
@@ -226,5 +289,5 @@ LL |             fn hidden_niche_unsafe_cell() -> Option<UnsafeCell<NonZero<usiz
    = note: expected `unsafe extern "C" fn() -> usize`
               found `unsafe extern "C" fn() -> Option<UnsafeCell<NonZero<usize>>>`
 
-warning: 19 warnings emitted
+warning: 25 warnings emitted
 

--- a/tests/ui/lint/invalid_value.stderr
+++ b/tests/ui/lint/invalid_value.stderr
@@ -320,10 +320,7 @@ error: the type `(NonZero<u32>, i32)` does not permit zero-initialization
   --> $DIR/invalid_value.rs:94:41
    |
 LL |         let _val: (NonZero<u32>, i32) = mem::zeroed();
-   |                                         ^^^^^^^^^^^^^
-   |                                         |
-   |                                         this code causes undefined behavior when executed
-   |                                         help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |                                         ^^^^^^^^^^^^^ this code causes undefined behavior when executed
    |
    = note: `std::num::NonZero<u32>` must be non-null
 
@@ -331,13 +328,9 @@ error: the type `(NonZero<u32>, i32)` does not permit being left uninitialized
   --> $DIR/invalid_value.rs:95:41
    |
 LL |         let _val: (NonZero<u32>, i32) = mem::uninitialized();
-   |                                         ^^^^^^^^^^^^^^^^^^^^
-   |                                         |
-   |                                         this code causes undefined behavior when executed
-   |                                         help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |                                         ^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
    |
    = note: `std::num::NonZero<u32>` must be non-null
-   = note: integers must be initialized
 
 error: the type `*const dyn Send` does not permit zero-initialization
   --> $DIR/invalid_value.rs:97:37
@@ -411,10 +404,7 @@ error: the type `OneFruitNonZero` does not permit zero-initialization
   --> $DIR/invalid_value.rs:106:37
    |
 LL |         let _val: OneFruitNonZero = mem::zeroed();
-   |                                     ^^^^^^^^^^^^^
-   |                                     |
-   |                                     this code causes undefined behavior when executed
-   |                                     help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |                                     ^^^^^^^^^^^^^ this code causes undefined behavior when executed
    |
    = note: `OneFruitNonZero` must be non-null
 note: because `std::num::NonZero<u32>` must be non-null (in this field of the only potentially inhabited enum variant)
@@ -427,10 +417,7 @@ error: the type `OneFruitNonZero` does not permit being left uninitialized
   --> $DIR/invalid_value.rs:107:37
    |
 LL |         let _val: OneFruitNonZero = mem::uninitialized();
-   |                                     ^^^^^^^^^^^^^^^^^^^^
-   |                                     |
-   |                                     this code causes undefined behavior when executed
-   |                                     help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |                                     ^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
    |
    = note: `OneFruitNonZero` must be non-null
 note: because `std::num::NonZero<u32>` must be non-null (in this field of the only potentially inhabited enum variant)
@@ -438,7 +425,6 @@ note: because `std::num::NonZero<u32>` must be non-null (in this field of the on
    |
 LL |     Banana(NonZero<u32>),
    |            ^^^^^^^^^^^^
-   = note: integers must be initialized
 
 error: the type `bool` does not permit being left uninitialized
   --> $DIR/invalid_value.rs:111:26
@@ -607,10 +593,7 @@ error: the type `NonZero<u32>` does not permit zero-initialization
   --> $DIR/invalid_value.rs:153:34
    |
 LL |         let _val: NonZero<u32> = mem::transmute(0);
-   |                                  ^^^^^^^^^^^^^^^^^
-   |                                  |
-   |                                  this code causes undefined behavior when executed
-   |                                  help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |                                  ^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
    |
    = note: `std::num::NonZero<u32>` must be non-null
 

--- a/tests/ui/lint/lint-ctypes-enum.stderr
+++ b/tests/ui/lint/lint-ctypes-enum.stderr
@@ -45,131 +45,21 @@ note: the type is defined here
 LL | enum T {
    | ^^^^^^
 
-error: `extern` block uses type `Option<NonZero<u8>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:71:21
-   |
-LL |    fn nonzero_u8(x: Option<num::NonZero<u8>>);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<NonZero<u16>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:72:22
-   |
-LL |    fn nonzero_u16(x: Option<num::NonZero<u16>>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<NonZero<u32>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:73:22
-   |
-LL |    fn nonzero_u32(x: Option<num::NonZero<u32>>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<NonZero<u64>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:74:22
-   |
-LL |    fn nonzero_u64(x: Option<num::NonZero<u64>>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<NonZero<u128>>`, which is not FFI-safe
+error: `extern` block uses type `u128`, which is not FFI-safe
   --> $DIR/lint-ctypes-enum.rs:75:23
    |
 LL |    fn nonzero_u128(x: Option<num::NonZero<u128>>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
+   = note: 128-bit integers don't currently have a known stable ABI
 
-error: `extern` block uses type `Option<NonZero<usize>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:77:24
-   |
-LL |    fn nonzero_usize(x: Option<num::NonZero<usize>>);
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<NonZero<i8>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:78:21
-   |
-LL |    fn nonzero_i8(x: Option<num::NonZero<i8>>);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<NonZero<i16>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:79:22
-   |
-LL |    fn nonzero_i16(x: Option<num::NonZero<i16>>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<NonZero<i32>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:80:22
-   |
-LL |    fn nonzero_i32(x: Option<num::NonZero<i32>>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<NonZero<i64>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:81:22
-   |
-LL |    fn nonzero_i64(x: Option<num::NonZero<i64>>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<NonZero<i128>>`, which is not FFI-safe
+error: `extern` block uses type `i128`, which is not FFI-safe
   --> $DIR/lint-ctypes-enum.rs:82:23
    |
 LL |    fn nonzero_i128(x: Option<num::NonZero<i128>>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<NonZero<isize>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:84:24
-   |
-LL |    fn nonzero_isize(x: Option<num::NonZero<isize>>);
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<TransparentStruct<NonZero<u8>>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:85:29
-   |
-LL |    fn transparent_struct(x: Option<TransparentStruct<num::NonZero<u8>>>);
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
-
-error: `extern` block uses type `Option<TransparentEnum<NonZero<u8>>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:86:27
-   |
-LL |    fn transparent_enum(x: Option<TransparentEnum<num::NonZero<u8>>>);
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
-   |
-   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
-   = note: enum has no representation hint
+   = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `Option<TransparentUnion<NonZero<u8>>>`, which is not FFI-safe
   --> $DIR/lint-ctypes-enum.rs:87:28
@@ -198,5 +88,5 @@ LL |    fn no_result(x: Result<(), num::NonZero<i32>>);
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
 
-error: aborting due to 20 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/lint/lint-ctypes-enum.stderr
+++ b/tests/ui/lint/lint-ctypes-enum.stderr
@@ -45,21 +45,131 @@ note: the type is defined here
 LL | enum T {
    | ^^^^^^
 
-error: `extern` block uses type `u128`, which is not FFI-safe
+error: `extern` block uses type `Option<NonZero<u8>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:71:21
+   |
+LL |    fn nonzero_u8(x: Option<num::NonZero<u8>>);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<NonZero<u16>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:72:22
+   |
+LL |    fn nonzero_u16(x: Option<num::NonZero<u16>>);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<NonZero<u32>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:73:22
+   |
+LL |    fn nonzero_u32(x: Option<num::NonZero<u32>>);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<NonZero<u64>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:74:22
+   |
+LL |    fn nonzero_u64(x: Option<num::NonZero<u64>>);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<NonZero<u128>>`, which is not FFI-safe
   --> $DIR/lint-ctypes-enum.rs:75:23
    |
 LL |    fn nonzero_u128(x: Option<num::NonZero<u128>>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
-   = note: 128-bit integers don't currently have a known stable ABI
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
 
-error: `extern` block uses type `i128`, which is not FFI-safe
+error: `extern` block uses type `Option<NonZero<usize>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:77:24
+   |
+LL |    fn nonzero_usize(x: Option<num::NonZero<usize>>);
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<NonZero<i8>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:78:21
+   |
+LL |    fn nonzero_i8(x: Option<num::NonZero<i8>>);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<NonZero<i16>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:79:22
+   |
+LL |    fn nonzero_i16(x: Option<num::NonZero<i16>>);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<NonZero<i32>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:80:22
+   |
+LL |    fn nonzero_i32(x: Option<num::NonZero<i32>>);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<NonZero<i64>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:81:22
+   |
+LL |    fn nonzero_i64(x: Option<num::NonZero<i64>>);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<NonZero<i128>>`, which is not FFI-safe
   --> $DIR/lint-ctypes-enum.rs:82:23
    |
 LL |    fn nonzero_i128(x: Option<num::NonZero<i128>>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
-   = note: 128-bit integers don't currently have a known stable ABI
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<NonZero<isize>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:84:24
+   |
+LL |    fn nonzero_isize(x: Option<num::NonZero<isize>>);
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<TransparentStruct<NonZero<u8>>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:85:29
+   |
+LL |    fn transparent_struct(x: Option<TransparentStruct<num::NonZero<u8>>>);
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
+
+error: `extern` block uses type `Option<TransparentEnum<NonZero<u8>>>`, which is not FFI-safe
+  --> $DIR/lint-ctypes-enum.rs:86:27
+   |
+LL |    fn transparent_enum(x: Option<TransparentEnum<num::NonZero<u8>>>);
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
+   = note: enum has no representation hint
 
 error: `extern` block uses type `Option<TransparentUnion<NonZero<u8>>>`, which is not FFI-safe
   --> $DIR/lint-ctypes-enum.rs:87:28
@@ -88,5 +198,5 @@ LL |    fn no_result(x: Result<(), num::NonZero<i32>>);
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
 
-error: aborting due to 8 previous errors
+error: aborting due to 20 previous errors
 

--- a/tests/ui/lint/use-redundant/use-redundant-issue-71450.rs
+++ b/tests/ui/lint/use-redundant/use-redundant-issue-71450.rs
@@ -1,0 +1,45 @@
+//@ check-pass
+
+#![warn(unused_imports)]
+
+mod foo {
+    use std::fmt;
+
+    pub struct String;
+
+    impl String {
+        pub fn new() -> String {
+            String{}
+        }
+    }
+
+    impl fmt::Display for String {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "String")
+        }
+    }
+}
+
+fn main() {
+
+    {
+        use std::string::String; //~ WARNING the item `String` is imported redundantly
+        // 'String' from 'std::string::String'.
+        let s = String::new();
+        println!("{}", s);
+    }
+
+    {
+        // 'String' from 'std::string::String'.
+        let s = String::new();
+        println!("{}", s);
+    }
+
+    {
+        use foo::*;
+        // 'String' from 'foo::String'.
+        let s = String::new();
+        println!("{}", s);
+    }
+
+}

--- a/tests/ui/lint/use-redundant/use-redundant-issue-71450.stderr
+++ b/tests/ui/lint/use-redundant/use-redundant-issue-71450.stderr
@@ -1,0 +1,17 @@
+warning: the item `String` is imported redundantly
+  --> $DIR/use-redundant-issue-71450.rs:26:13
+   |
+LL |         use std::string::String;
+   |             ^^^^^^^^^^^^^^^^^^^
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
+   |
+   = note: the item `String` is already defined here
+   |
+note: the lint level is defined here
+  --> $DIR/use-redundant-issue-71450.rs:3:9
+   |
+LL | #![warn(unused_imports)]
+   |         ^^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+

--- a/tests/ui/lint/use-redundant/use-redundant-issue-78894.rs
+++ b/tests/ui/lint/use-redundant/use-redundant-issue-78894.rs
@@ -1,6 +1,15 @@
 //@ check-pass
 //@ edition:2018
+
 #![warn(unused_imports)]
+
+mod foo {
+    macro_rules! foo1 {
+        () => ();
+    }
+
+    pub(crate) use foo1;
+}
 
 fn main ()
 {
@@ -11,4 +20,29 @@ fn main ()
     }
 
     use bar;
+
+    mod m {
+        bar1!();
+
+        macro_rules! bar1 {
+            () => ();
+        }
+
+        use bar1;
+    }
+
+    {
+        foo::foo1!();
+    }
+
+    {
+        use foo::foo1;
+        foo1!();
+    }
+
+    {
+        use foo::foo1; //~ WARNING unused import: `foo::foo1`
+        foo::foo1!();
+    }
+
 }

--- a/tests/ui/lint/use-redundant/use-redundant-issue-78894.rs
+++ b/tests/ui/lint/use-redundant/use-redundant-issue-78894.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+//@ edition:2018
+#![warn(unused_imports)]
+
+fn main ()
+{
+    bar!();
+
+    macro_rules! bar {
+        () => ();
+    }
+
+    use bar;
+}

--- a/tests/ui/lint/use-redundant/use-redundant-issue-78894.stderr
+++ b/tests/ui/lint/use-redundant/use-redundant-issue-78894.stderr
@@ -1,0 +1,14 @@
+warning: unused import: `foo::foo1`
+  --> $DIR/use-redundant-issue-78894.rs:44:13
+   |
+LL |         use foo::foo1;
+   |             ^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/use-redundant-issue-78894.rs:4:9
+   |
+LL | #![warn(unused_imports)]
+   |         ^^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+

--- a/tests/ui/print_type_sizes/niche-filling.stdout
+++ b/tests/ui/print_type_sizes/niche-filling.stdout
@@ -68,6 +68,8 @@ print-type-size type: `Union2<std::num::NonZero<u32>, u32>`: 4 bytes, alignment:
 print-type-size     variant `Union2`: 4 bytes
 print-type-size         field `.a`: 4 bytes
 print-type-size         field `.b`: 4 bytes, offset: 0 bytes, alignment: 4 bytes
+print-type-size type: `core::num::nonzero::private::NonZeroU32Inner`: 4 bytes, alignment: 4 bytes
+print-type-size     field `.0`: 4 bytes
 print-type-size type: `std::num::NonZero<u32>`: 4 bytes, alignment: 4 bytes
 print-type-size     field `.0`: 4 bytes
 print-type-size type: `std::option::Option<std::num::NonZero<u32>>`: 4 bytes, alignment: 4 bytes

--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field2.rs
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field2.rs
@@ -15,7 +15,7 @@ impl Trait for Bar {
     type Assoc = impl std::fmt::Debug;
     fn foo() -> Foo {
         Foo { field: () }
-        //~^ ERROR: item constrains opaque type that is not in its signature
+        //~^ ERROR: mismatched types
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field2.stderr
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field2.stderr
@@ -1,11 +1,15 @@
-error: item constrains opaque type that is not in its signature
+error[E0308]: mismatched types
   --> $DIR/hidden_behind_struct_field2.rs:17:22
    |
+LL |     type Assoc = impl std::fmt::Debug;
+   |                  -------------------- the expected opaque type
+LL |     fn foo() -> Foo {
 LL |         Foo { field: () }
-   |                      ^^
+   |                      ^^ expected opaque type, found `()`
    |
-   = note: this item must mention the opaque type in its signature in order to be able to register hidden types
-note: this item must mention the opaque type in its signature in order to be able to register hidden types
+   = note: expected opaque type `<Bar as Trait>::Assoc`
+                found unit type `()`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
   --> $DIR/hidden_behind_struct_field2.rs:16:8
    |
 LL |     fn foo() -> Foo {
@@ -13,3 +17,4 @@ LL |     fn foo() -> Foo {
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.rs
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.rs
@@ -17,7 +17,7 @@ impl Trait for Bar {
     type Assoc = impl Iterator<Item = Foo>;
     fn foo() -> Self::Assoc {
         vec![Foo { field: () }].into_iter()
-        //~^ ERROR item constrains opaque type that is not in its signature
+        //~^ ERROR mismatched types
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.stderr
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.stderr
@@ -1,11 +1,15 @@
-error: item constrains opaque type that is not in its signature
+error[E0308]: mismatched types
   --> $DIR/hidden_behind_struct_field3.rs:19:27
    |
+LL |     type Assoc2 = impl std::fmt::Debug;
+   |                   -------------------- the expected opaque type
+...
 LL |         vec![Foo { field: () }].into_iter()
-   |                           ^^
+   |                           ^^ expected opaque type, found `()`
    |
-   = note: this item must mention the opaque type in its signature in order to be able to register hidden types
-note: this item must mention the opaque type in its signature in order to be able to register hidden types
+   = note: expected opaque type `<Bar as Trait>::Assoc2`
+                found unit type `()`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
   --> $DIR/hidden_behind_struct_field3.rs:18:8
    |
 LL |     fn foo() -> Self::Assoc {
@@ -13,3 +17,4 @@ LL |     fn foo() -> Self::Assoc {
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/union/unnamed-fields/unnamed-enum-field-issue-121757.rs
+++ b/tests/ui/union/unnamed-fields/unnamed-enum-field-issue-121757.rs
@@ -1,0 +1,25 @@
+type NodeId = u32;
+struct Type<'a>(std::marker::PhantomData::<&'a ()>);
+
+type Ast<'ast> = &'ast AstStructure<'ast>;
+
+struct AstStructure<'ast> {
+//~^ ERROR struct with unnamed fields must have `#[repr(C)]` representation
+    id: NodeId,
+    _: AstKind<'ast>
+//~^ ERROR unnamed fields are not yet fully implemented [E0658]
+//~^^ ERROR unnamed fields can only have struct or union types
+}
+
+enum AstKind<'ast> {
+    ExprInt,
+    ExprLambda(Ast<'ast>),
+}
+
+fn compute_types<'tcx,'ast>(ast: Ast<'ast>) -> Type<'tcx>
+{
+    match ast.kind {}
+//~^ ERROR no field `kind` on type `&'ast AstStructure<'ast>` [E0609]
+}
+
+fn main() {}

--- a/tests/ui/union/unnamed-fields/unnamed-enum-field-issue-121757.stderr
+++ b/tests/ui/union/unnamed-fields/unnamed-enum-field-issue-121757.stderr
@@ -1,0 +1,45 @@
+error[E0658]: unnamed fields are not yet fully implemented
+  --> $DIR/unnamed-enum-field-issue-121757.rs:9:5
+   |
+LL |     _: AstKind<'ast>
+   |     ^
+   |
+   = note: see issue #49804 <https://github.com/rust-lang/rust/issues/49804> for more information
+   = help: add `#![feature(unnamed_fields)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: struct with unnamed fields must have `#[repr(C)]` representation
+  --> $DIR/unnamed-enum-field-issue-121757.rs:6:1
+   |
+LL | struct AstStructure<'ast> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ struct `AstStructure` defined here
+   |
+note: unnamed field defined here
+  --> $DIR/unnamed-enum-field-issue-121757.rs:9:5
+   |
+LL |     _: AstKind<'ast>
+   |     ^^^^^^^^^^^^^^^^
+help: add `#[repr(C)]` to this struct
+   |
+LL + #[repr(C)]
+LL | struct AstStructure<'ast> {
+   |
+
+error: unnamed fields can only have struct or union types
+  --> $DIR/unnamed-enum-field-issue-121757.rs:9:5
+   |
+LL |     _: AstKind<'ast>
+   |     ^^^^^^^^^^^^^^^^
+
+error[E0609]: no field `kind` on type `&'ast AstStructure<'ast>`
+  --> $DIR/unnamed-enum-field-issue-121757.rs:21:15
+   |
+LL |     match ast.kind {}
+   |               ^^^^ unknown field
+   |
+   = note: available fields are: `id`, `_`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0609, E0658.
+For more information about an error, try `rustc --explain E0609`.


### PR DESCRIPTION
Successful merges:

 - #121202 (Limit the number of names and values in check-cfg diagnostics)
 - #121301 (errors: share `SilentEmitter` between rustc and rustfmt)
 - #121658 (Hint user to update nightly on ICEs produced from outdated nightly)
 - #121846 (only compare ambiguity item that have hard error)
 - #121885 (Move generic `NonZero` `rustc_layout_scalar_valid_range_start` attribute to inner type.)
 - #121961 (add test for #78894 #71450)
 - #121975 (hir_analysis: enums return `None` in `find_field`)
 - #121978 (Fix duplicated path in the "not found dylib" error)
 - #121991 (Merge impl_trait_in_assoc_types_defined_by query back into `opaque_types_defined_by`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=121202,121301,121658,121846,121885,121961,121975,121978,121991)
<!-- homu-ignore:end -->