### PR TITLE
Apply the `unused_qualifications` lint to `rustc_hir_typeck`.

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -786,8 +786,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     fn check_ptr_ptr_cast(
         &self,
         fcx: &FnCtxt<'a, 'tcx>,
-        m_expr: ty::TypeAndMut<'tcx>,
-        m_cast: ty::TypeAndMut<'tcx>,
+        m_expr: TypeAndMut<'tcx>,
+        m_cast: TypeAndMut<'tcx>,
     ) -> Result<CastKind, CastError> {
         debug!("check_ptr_ptr_cast m_expr={:?} m_cast={:?}", m_expr, m_cast);
         // ptr-ptr cast. vtables must match.
@@ -826,7 +826,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     fn check_fptr_ptr_cast(
         &self,
         fcx: &FnCtxt<'a, 'tcx>,
-        m_cast: ty::TypeAndMut<'tcx>,
+        m_cast: TypeAndMut<'tcx>,
     ) -> Result<CastKind, CastError> {
         // fptr-ptr cast. must be to thin ptr
 
@@ -840,7 +840,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     fn check_ptr_addr_cast(
         &self,
         fcx: &FnCtxt<'a, 'tcx>,
-        m_expr: ty::TypeAndMut<'tcx>,
+        m_expr: TypeAndMut<'tcx>,
     ) -> Result<CastKind, CastError> {
         // ptr-addr cast. must be from thin ptr
 
@@ -854,8 +854,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     fn check_ref_cast(
         &self,
         fcx: &FnCtxt<'a, 'tcx>,
-        m_expr: ty::TypeAndMut<'tcx>,
-        m_cast: ty::TypeAndMut<'tcx>,
+        m_expr: TypeAndMut<'tcx>,
+        m_cast: TypeAndMut<'tcx>,
     ) -> Result<CastKind, CastError> {
         // array-ptr-cast: allow mut-to-mut, mut-to-const, const-to-const
         if m_expr.mutbl >= m_cast.mutbl {
@@ -904,7 +904,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         }
     }
 
-    fn try_coercion_cast(&self, fcx: &FnCtxt<'a, 'tcx>) -> Result<(), ty::error::TypeError<'tcx>> {
+    fn try_coercion_cast(&self, fcx: &FnCtxt<'a, 'tcx>) -> Result<(), TypeError<'tcx>> {
         match fcx.coerce(self.expr, self.expr_ty, self.cast_ty, AllowTwoPhase::No, None) {
             Ok(_) => Ok(()),
             Err(err) => Err(err),

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -549,7 +549,7 @@ pub enum CastUnknownPointerSub {
     From(Span),
 }
 
-impl rustc_errors::AddToDiagnostic for CastUnknownPointerSub {
+impl AddToDiagnostic for CastUnknownPointerSub {
     fn add_to_diagnostic_with<G: EmissionGuarantee, F: SubdiagMessageOp<G>>(
         self,
         diag: &mut Diag<'_, G>,

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -499,17 +499,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    fn check_lang_item_path(
-        &self,
-        lang_item: hir::LangItem,
-        expr: &'tcx hir::Expr<'tcx>,
-    ) -> Ty<'tcx> {
+    fn check_lang_item_path(&self, lang_item: LangItem, expr: &'tcx hir::Expr<'tcx>) -> Ty<'tcx> {
         self.resolve_lang_item_path(lang_item, expr.span, expr.hir_id).1
     }
 
     pub(crate) fn check_expr_path(
         &self,
-        qpath: &'tcx hir::QPath<'tcx>,
+        qpath: &'tcx QPath<'tcx>,
         expr: &'tcx hir::Expr<'tcx>,
         args: &'tcx [hir::Expr<'tcx>],
         call: Option<&'tcx hir::Expr<'tcx>>,
@@ -2868,7 +2864,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Span,
         base_ty: Ty<'tcx>,
         mod_id: DefId,
-        hir_id: hir::HirId,
+        hir_id: HirId,
     ) -> Vec<(Vec<&'tcx ty::FieldDef>, GenericArgsRef<'tcx>)> {
         debug!("get_field_candidates(span: {:?}, base_t: {:?}", span, base_ty);
 
@@ -3273,7 +3269,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if let Some(ident_2) = fields.get(1)
             && !self.tcx.features().offset_of_nested
         {
-            rustc_session::parse::feature_err(
+            feature_err(
                 &self.tcx.sess,
                 sym::offset_of_nested,
                 ident_2.span,
@@ -3296,7 +3292,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         self.tcx.adjust_ident_and_get_scope(field, container_def.did(), block);
 
                     if !self.tcx.features().offset_of_enum {
-                        rustc_session::parse::feature_err(
+                        feature_err(
                             &self.tcx.sess,
                             sym::offset_of_enum,
                             ident.span,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -335,18 +335,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         ty: Ty<'tcx>,
         span: Span,
-        code: traits::ObligationCauseCode<'tcx>,
+        code: ObligationCauseCode<'tcx>,
         def_id: DefId,
     ) {
         self.register_bound(ty, def_id, traits::ObligationCause::new(span, self.body_id, code));
     }
 
-    pub fn require_type_is_sized(
-        &self,
-        ty: Ty<'tcx>,
-        span: Span,
-        code: traits::ObligationCauseCode<'tcx>,
-    ) {
+    pub fn require_type_is_sized(&self, ty: Ty<'tcx>, span: Span, code: ObligationCauseCode<'tcx>) {
         if !ty.references_error() {
             let lang_item = self.tcx.require_lang_item(LangItem::Sized, None);
             self.require_type_meets(ty, span, code, lang_item);
@@ -357,7 +352,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         ty: Ty<'tcx>,
         span: Span,
-        code: traits::ObligationCauseCode<'tcx>,
+        code: ObligationCauseCode<'tcx>,
     ) {
         if !ty.references_error() {
             self.deferred_sized_obligations.borrow_mut().push((ty, span, code));
@@ -480,7 +475,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         arg: ty::GenericArg<'tcx>,
         span: Span,
-        code: traits::ObligationCauseCode<'tcx>,
+        code: ObligationCauseCode<'tcx>,
     ) {
         // WF obligations never themselves fail, so no real need to give a detailed cause:
         let cause = traits::ObligationCause::new(span, self.body_id, code);
@@ -752,7 +747,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     pub(in super::super) fn resolve_lang_item_path(
         &self,
-        lang_item: hir::LangItem,
+        lang_item: LangItem,
         span: Span,
         hir_id: hir::HirId,
     ) -> (Res, Ty<'tcx>) {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
@@ -338,7 +338,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         struct FindAmbiguousParameter<'a, 'tcx>(&'a FnCtxt<'a, 'tcx>, DefId);
         impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for FindAmbiguousParameter<'_, 'tcx> {
             type BreakTy = ty::GenericArg<'tcx>;
-            fn visit_ty(&mut self, ty: Ty<'tcx>) -> std::ops::ControlFlow<Self::BreakTy> {
+            fn visit_ty(&mut self, ty: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
                 if let Some(origin) = self.0.type_var_origin(ty)
                     && let TypeVariableOriginKind::TypeParameterDefinition(_, def_id) = origin.kind
                     && let generics = self.0.tcx.generics_of(self.1)
@@ -513,7 +513,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     fn blame_specific_expr_if_possible_for_obligation_cause_code(
         &self,
-        obligation_cause_code: &traits::ObligationCauseCode<'tcx>,
+        obligation_cause_code: &ObligationCauseCode<'tcx>,
         expr: &'tcx hir::Expr<'tcx>,
     ) -> Result<&'tcx hir::Expr<'tcx>, &'tcx hir::Expr<'tcx>> {
         match obligation_cause_code {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1857,7 +1857,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// if false { return 0i32; } else { 1u32 }
     /// //                               ^^^^ point at this instead of the whole `if` expression
     /// ```
-    fn get_expr_coercion_span(&self, expr: &hir::Expr<'_>) -> rustc_span::Span {
+    fn get_expr_coercion_span(&self, expr: &hir::Expr<'_>) -> Span {
         let check_in_progress = |elem: &hir::Expr<'_>| {
             self.typeck_results.borrow().node_type_opt(elem.hir_id).filter(|ty| !ty.is_never()).map(
                 |_| match elem.kind {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -67,10 +67,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn suggest_mismatched_types_on_tail(
         &self,
         err: &mut Diag<'_>,
-        expr: &'tcx hir::Expr<'tcx>,
+        expr: &'tcx Expr<'tcx>,
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
-        blk_id: hir::HirId,
+        blk_id: HirId,
     ) -> bool {
         let expr = expr.peel_drop_temps();
         let mut pointing_at_return_type = false;
@@ -98,7 +98,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_fn_call(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         found: Ty<'tcx>,
         can_satisfy: impl FnOnce(Ty<'tcx>) -> bool,
     ) -> bool {
@@ -180,9 +180,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn suggest_two_fn_call(
         &self,
         err: &mut Diag<'_>,
-        lhs_expr: &'tcx hir::Expr<'tcx>,
+        lhs_expr: &'tcx Expr<'tcx>,
         lhs_ty: Ty<'tcx>,
-        rhs_expr: &'tcx hir::Expr<'tcx>,
+        rhs_expr: &'tcx Expr<'tcx>,
         rhs_ty: Ty<'tcx>,
         can_satisfy: impl FnOnce(Ty<'tcx>, Ty<'tcx>) -> bool,
     ) -> bool {
@@ -254,7 +254,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn suggest_remove_last_method_call(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'tcx>,
+        expr: &Expr<'tcx>,
         expected: Ty<'tcx>,
     ) -> bool {
         if let hir::ExprKind::MethodCall(hir::PathSegment { ident: method, .. }, recv_expr, &[], _) =
@@ -267,7 +267,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let span = if let Some(recv_span) = recv_expr.span.find_ancestor_inside(expr.span) {
                 expr.span.with_lo(recv_span.hi())
             } else {
-                expr.span.with_lo(method.span.lo() - rustc_span::BytePos(1))
+                expr.span.with_lo(method.span.lo() - BytePos(1))
             };
             err.span_suggestion_verbose(
                 span,
@@ -283,10 +283,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn suggest_deref_ref_or_into(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'tcx>,
+        expr: &Expr<'tcx>,
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
-        expected_ty_expr: Option<&'tcx hir::Expr<'tcx>>,
+        expected_ty_expr: Option<&'tcx Expr<'tcx>>,
     ) -> bool {
         let expr = expr.peel_blocks();
         let methods = self.get_conversion_methods(expr.span, expected, found, expr.hir_id);
@@ -621,7 +621,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(in super::super) fn suggest_calling_boxed_future_when_appropriate(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
     ) -> bool {
@@ -733,7 +733,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn suggest_missing_semicolon(
         &self,
         err: &mut Diag<'_>,
-        expression: &'tcx hir::Expr<'tcx>,
+        expression: &'tcx Expr<'tcx>,
         expected: Ty<'tcx>,
         needs_block: bool,
     ) {
@@ -796,7 +796,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
         can_suggest: bool,
-        fn_id: hir::HirId,
+        fn_id: HirId,
     ) -> bool {
         let found =
             self.resolve_numeric_literals_with_default(self.resolve_vars_if_possible(found));
@@ -912,7 +912,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         err: &mut Diag<'_>,
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
-        fn_id: hir::HirId,
+        fn_id: HirId,
     ) {
         // Only apply the suggestion if:
         //  - the return type is a generic parameter
@@ -1015,12 +1015,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(in super::super) fn suggest_missing_break_or_return_expr(
         &self,
         err: &mut Diag<'_>,
-        expr: &'tcx hir::Expr<'tcx>,
+        expr: &'tcx Expr<'tcx>,
         fn_decl: &hir::FnDecl<'tcx>,
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
-        id: hir::HirId,
-        fn_id: hir::HirId,
+        id: HirId,
+        fn_id: HirId,
     ) {
         if !expected.is_unit() {
             return;
@@ -1114,7 +1114,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(in super::super) fn suggest_missing_parentheses(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
     ) -> bool {
         let sp = self.tcx.sess.source_map().start_point(expr.span).with_parent(None);
         if let Some(sp) = self.tcx.sess.psess.ambiguous_block_expr_parse.borrow().get(&sp) {
@@ -1132,7 +1132,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_block_to_brackets_peeling_refs(
         &self,
         diag: &mut Diag<'_>,
-        mut expr: &hir::Expr<'_>,
+        mut expr: &Expr<'_>,
         mut expr_ty: Ty<'tcx>,
         mut expected_ty: Ty<'tcx>,
     ) -> bool {
@@ -1159,7 +1159,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_clone_for_ref(
         &self,
         diag: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         expr_ty: Ty<'tcx>,
         expected_ty: Ty<'tcx>,
     ) -> bool {
@@ -1194,7 +1194,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_copied_cloned_or_as_ref(
         &self,
         diag: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         expr_ty: Ty<'tcx>,
         expected_ty: Ty<'tcx>,
     ) -> bool {
@@ -1244,7 +1244,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_into(
         &self,
         diag: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         expr_ty: Ty<'tcx>,
         expected_ty: Ty<'tcx>,
     ) -> bool {
@@ -1307,7 +1307,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_option_to_bool(
         &self,
         diag: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         expr_ty: Ty<'tcx>,
         expected_ty: Ty<'tcx>,
     ) -> bool {
@@ -1324,7 +1324,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let hir = self.tcx.hir();
         let cond_parent = hir.parent_iter(expr.hir_id).find(|(_, node)| {
-            !matches!(node, hir::Node::Expr(hir::Expr { kind: hir::ExprKind::Binary(op, _, _), .. }) if op.node == hir::BinOpKind::And)
+            !matches!(node, hir::Node::Expr(Expr { kind: hir::ExprKind::Binary(op, _, _), .. }) if op.node == hir::BinOpKind::And)
         });
         // Don't suggest:
         //     `let Some(_) = a.is_some() && b`
@@ -1380,15 +1380,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             "to create an array, use square brackets instead of curly braces",
                             vec![
                                 (
-                                    blk.span
-                                        .shrink_to_lo()
-                                        .with_hi(rustc_span::BytePos(blk.span.lo().0 + 1)),
+                                    blk.span.shrink_to_lo().with_hi(BytePos(blk.span.lo().0 + 1)),
                                     "[".to_string(),
                                 ),
                                 (
-                                    blk.span
-                                        .shrink_to_hi()
-                                        .with_lo(rustc_span::BytePos(blk.span.hi().0 - 1)),
+                                    blk.span.shrink_to_hi().with_lo(BytePos(blk.span.hi().0 - 1)),
                                     "]".to_string(),
                                 ),
                             ],
@@ -1404,7 +1400,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_floating_point_literal(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         expected_ty: Ty<'tcx>,
     ) -> bool {
         if !expected_ty.is_floating_point() {
@@ -1475,11 +1471,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_null_ptr_for_literal_zero_given_to_ptr_arg(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         expected_ty: Ty<'tcx>,
     ) -> bool {
         // Expected type needs to be a raw pointer.
-        let ty::RawPtr(ty::TypeAndMut { mutbl, .. }) = expected_ty.kind() else {
+        let ty::RawPtr(TypeAndMut { mutbl, .. }) = expected_ty.kind() else {
             return false;
         };
 
@@ -1513,7 +1509,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_associated_const(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'tcx>,
+        expr: &Expr<'tcx>,
         expected_ty: Ty<'tcx>,
     ) -> bool {
         let Some((DefKind::AssocFn, old_def_id)) =
@@ -1527,10 +1523,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return false;
         }
         let (item, segment) = match expr.kind {
-            hir::ExprKind::Path(QPath::Resolved(
-                Some(ty),
-                hir::Path { segments: [segment], .. },
-            ))
+            hir::ExprKind::Path(QPath::Resolved(Some(ty), Path { segments: [segment], .. }))
             | hir::ExprKind::Path(QPath::TypeRelative(ty, segment)) => {
                 if let Some(self_ty) = self.typeck_results.borrow().node_type_opt(ty.hir_id)
                     && let Ok(pick) = self.probe_for_name(
@@ -1548,10 +1541,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     return false;
                 }
             }
-            hir::ExprKind::Path(QPath::Resolved(
-                None,
-                hir::Path { segments: [.., segment], .. },
-            )) => {
+            hir::ExprKind::Path(QPath::Resolved(None, Path { segments: [.., segment], .. })) => {
                 // we resolved through some path that doesn't end in the item name,
                 // better not do a bad suggestion by accident.
                 if old_item_name != segment.ident.name {
@@ -1592,12 +1582,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    fn is_loop(&self, id: hir::HirId) -> bool {
+    fn is_loop(&self, id: HirId) -> bool {
         let node = self.tcx.hir_node(id);
         matches!(node, Node::Expr(Expr { kind: ExprKind::Loop(..), .. }))
     }
 
-    fn is_local_statement(&self, id: hir::HirId) -> bool {
+    fn is_local_statement(&self, id: HirId) -> bool {
         let node = self.tcx.hir_node(id);
         matches!(node, Node::Stmt(Stmt { kind: StmtKind::Local(..), .. }))
     }
@@ -1609,7 +1599,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         diag: &mut Diag<'_>,
         expected_ty: Ty<'tcx>,
         found_ty: Ty<'tcx>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
     ) {
         // When `expr` is `x` in something like `let x = foo.clone(); x`, need to recurse up to get
         // `foo` and `clone`.
@@ -1716,14 +1706,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// the `expr` as the source of this type mismatch, try to find the method call
     /// as the source of this error and return that instead. Otherwise, return the
     /// original expression.
-    fn note_type_is_not_clone_inner_expr<'b>(
-        &'b self,
-        expr: &'b hir::Expr<'b>,
-    ) -> &'b hir::Expr<'b> {
+    fn note_type_is_not_clone_inner_expr<'b>(&'b self, expr: &'b Expr<'b>) -> &'b Expr<'b> {
         match expr.peel_blocks().kind {
             hir::ExprKind::Path(hir::QPath::Resolved(
                 None,
-                hir::Path { segments: [_], res: crate::Res::Local(binding), .. },
+                Path { segments: [_], res: crate::Res::Local(binding), .. },
             )) => {
                 let hir::Node::Pat(hir::Pat { hir_id, .. }) = self.tcx.hir_node(*binding) else {
                     return expr;
@@ -1771,7 +1758,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             hir::ExprKind::Call(Expr { kind: call_expr_kind, .. }, _) => {
                 if let hir::ExprKind::Path(hir::QPath::Resolved(None, call_expr_path)) =
                     call_expr_kind
-                    && let hir::Path { segments: [_], res: crate::Res::Local(binding), .. } =
+                    && let Path { segments: [_], res: crate::Res::Local(binding), .. } =
                         call_expr_path
                     && let hir::Node::Pat(hir::Pat { hir_id, .. }) = self.tcx.hir_node(*binding)
                     && let hir::Node::Local(hir::Local { init: Some(init), .. }) =
@@ -1813,7 +1800,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_missing_unwrap_expect(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'tcx>,
+        expr: &Expr<'tcx>,
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
     ) -> bool {
@@ -1835,17 +1822,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let is_ctor = matches!(
             expr.kind,
             hir::ExprKind::Call(
-                hir::Expr {
+                Expr {
                     kind: hir::ExprKind::Path(hir::QPath::Resolved(
                         None,
-                        hir::Path { res: Res::Def(hir::def::DefKind::Ctor(_, _), _), .. },
+                        Path { res: Res::Def(hir::def::DefKind::Ctor(_, _), _), .. },
                     )),
                     ..
                 },
                 ..,
             ) | hir::ExprKind::Path(hir::QPath::Resolved(
                 None,
-                hir::Path { res: Res::Def(hir::def::DefKind::Ctor(_, _), _), .. },
+                Path { res: Res::Def(hir::def::DefKind::Ctor(_, _), _), .. },
             )),
         );
 
@@ -1896,14 +1883,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_coercing_result_via_try_operator(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'tcx>,
+        expr: &Expr<'tcx>,
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
     ) -> bool {
         let map = self.tcx.hir();
         let returned = matches!(
             self.tcx.parent_hir_node(expr.hir_id),
-            hir::Node::Expr(hir::Expr { kind: hir::ExprKind::Ret(_), .. })
+            hir::Node::Expr(Expr { kind: hir::ExprKind::Ret(_), .. })
         ) || map.get_return_block(expr.hir_id).is_some();
         if returned
             && let ty::Adt(e, args_e) = expected.kind()
@@ -1943,7 +1930,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_compatible_variants(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         expected: Ty<'tcx>,
         expr_ty: Ty<'tcx>,
     ) -> bool {
@@ -2132,7 +2119,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_non_zero_new_unwrap(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         expected: Ty<'tcx>,
         expr_ty: Ty<'tcx>,
     ) -> bool {
@@ -2205,7 +2192,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// ```ignore (illustrative)
     /// opt.map(|param| { takes_ref(param) });
     /// ```
-    fn can_use_as_ref(&self, expr: &hir::Expr<'_>) -> Option<(Vec<(Span, String)>, &'static str)> {
+    fn can_use_as_ref(&self, expr: &Expr<'_>) -> Option<(Vec<(Span, String)>, &'static str)> {
         let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = expr.kind else {
             return None;
         };
@@ -2220,7 +2207,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return None;
         };
 
-        let Node::Expr(hir::Expr {
+        let Node::Expr(Expr {
             hir_id: expr_hir_id,
             kind: hir::ExprKind::Closure(hir::Closure { fn_decl: closure_fn_decl, .. }),
             ..
@@ -2232,10 +2219,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let hir = self.tcx.parent_hir_node(*expr_hir_id);
         let closure_params_len = closure_fn_decl.inputs.len();
         let (
-            Node::Expr(hir::Expr {
-                kind: hir::ExprKind::MethodCall(method_path, receiver, ..),
-                ..
-            }),
+            Node::Expr(Expr { kind: hir::ExprKind::MethodCall(method_path, receiver, ..), .. }),
             1,
         ) = (hir, closure_params_len)
         else {
@@ -2280,7 +2264,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// `&mut`!".
     pub(crate) fn suggest_deref_or_ref(
         &self,
-        expr: &hir::Expr<'tcx>,
+        expr: &Expr<'tcx>,
         checked_ty: Ty<'tcx>,
         expected: Ty<'tcx>,
     ) -> Option<(
@@ -2410,7 +2394,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         None => String::new(),
                     };
 
-                    if let hir::Node::Expr(hir::Expr { kind: hir::ExprKind::Assign(..), .. }) =
+                    if let hir::Node::Expr(Expr { kind: hir::ExprKind::Assign(..), .. }) =
                         self.tcx.parent_hir_node(expr.hir_id)
                     {
                         if mutability.is_mut() {
@@ -2442,10 +2426,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     };
 
                     // Suggest dereferencing the lhs for expressions such as `&T <= T`
-                    if let hir::Node::Expr(hir::Expr {
-                        kind: hir::ExprKind::Binary(_, lhs, ..),
-                        ..
-                    }) = self.tcx.parent_hir_node(expr.hir_id)
+                    if let hir::Node::Expr(Expr { kind: hir::ExprKind::Binary(_, lhs, ..), .. }) =
+                        self.tcx.parent_hir_node(expr.hir_id)
                         && let &ty::Ref(..) = self.check_expr(lhs).kind()
                     {
                         let (sugg, verbose) = make_sugg(lhs, lhs.span, "*");
@@ -2602,7 +2584,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         // We can always deref a binop that takes its arguments by ref.
                         || matches!(
                             self.tcx.parent_hir_node(expr.hir_id),
-                            hir::Node::Expr(hir::Expr { kind: hir::ExprKind::Binary(op, ..), .. })
+                            hir::Node::Expr(Expr { kind: hir::ExprKind::Binary(op, ..), .. })
                                 if !op.node.is_by_value()
                         )
                     {
@@ -2661,11 +2643,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     /// Returns whether the given expression is an `else if`.
-    fn is_else_if_block(&self, expr: &hir::Expr<'_>) -> bool {
+    fn is_else_if_block(&self, expr: &Expr<'_>) -> bool {
         if let hir::ExprKind::If(..) = expr.kind {
-            if let Node::Expr(hir::Expr {
-                kind: hir::ExprKind::If(_, _, Some(else_expr)), ..
-            }) = self.tcx.parent_hir_node(expr.hir_id)
+            if let Node::Expr(Expr { kind: hir::ExprKind::If(_, _, Some(else_expr)), .. }) =
+                self.tcx.parent_hir_node(expr.hir_id)
             {
                 return else_expr.hir_id == expr.hir_id;
             }
@@ -2676,10 +2657,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_cast(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         checked_ty: Ty<'tcx>,
         expected_ty: Ty<'tcx>,
-        expected_ty_expr: Option<&'tcx hir::Expr<'tcx>>,
+        expected_ty_expr: Option<&'tcx Expr<'tcx>>,
     ) -> bool {
         if self.tcx.sess.source_map().is_imported(expr.span) {
             // Ignore if span is from within a macro.
@@ -2793,11 +2774,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 expected_ty.to_string()
             },
         ));
-        let literal_is_ty_suffixed = |expr: &hir::Expr<'_>| {
+        let literal_is_ty_suffixed = |expr: &Expr<'_>| {
             if let hir::ExprKind::Lit(lit) = &expr.kind { lit.node.is_suffixed() } else { false }
         };
         let is_negative_int =
-            |expr: &hir::Expr<'_>| matches!(expr.kind, hir::ExprKind::Unary(hir::UnOp::Neg, ..));
+            |expr: &Expr<'_>| matches!(expr.kind, hir::ExprKind::Unary(hir::UnOp::Neg, ..));
         let is_uint = |ty: Ty<'_>| matches!(ty.kind(), ty::Uint(..));
 
         let in_const_context = self.tcx.hir().is_inside_const_context(expr.hir_id);
@@ -3040,11 +3021,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_method_call_on_range_literal(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'tcx>,
+        expr: &Expr<'tcx>,
         checked_ty: Ty<'tcx>,
         expected_ty: Ty<'tcx>,
     ) {
-        if !hir::is_range_literal(expr) {
+        if !is_range_literal(expr) {
             return;
         }
         let hir::ExprKind::Struct(hir::QPath::LangItem(LangItem::Range, ..), [start, end], _) =
@@ -3118,7 +3099,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn suggest_return_binding_for_missing_tail_expr(
         &self,
         err: &mut Diag<'_>,
-        expr: &hir::Expr<'_>,
+        expr: &Expr<'_>,
         checked_ty: Ty<'tcx>,
         expected_ty: Ty<'tcx>,
     ) {

--- a/compiler/rustc_hir_typeck/src/inherited.rs
+++ b/compiler/rustc_hir_typeck/src/inherited.rs
@@ -100,7 +100,7 @@ impl<'tcx> Inherited<'tcx> {
     }
 
     #[instrument(level = "debug", skip(self))]
-    pub(super) fn register_predicate(&self, obligation: traits::PredicateObligation<'tcx>) {
+    pub(super) fn register_predicate(&self, obligation: PredicateObligation<'tcx>) {
         if obligation.has_escaping_bound_vars() {
             span_bug!(obligation.cause.span, "escaping bound vars in predicate {:?}", obligation);
         }
@@ -112,7 +112,7 @@ impl<'tcx> Inherited<'tcx> {
 
     pub(super) fn register_predicates<I>(&self, obligations: I)
     where
-        I: IntoIterator<Item = traits::PredicateObligation<'tcx>>,
+        I: IntoIterator<Item = PredicateObligation<'tcx>>,
     {
         for obligation in obligations {
             self.register_predicate(obligation);

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
+#![deny(unused_qualifications)]
 #![feature(if_let_guard)]
 #![feature(let_chains)]
 #![feature(try_blocks)]

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -173,7 +173,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         let Some((ty, n)) = autoderef.nth(pick.autoderefs) else {
             return Ty::new_error_with_message(
                 self.tcx,
-                rustc_span::DUMMY_SP,
+                DUMMY_SP,
                 format!("failed autoderef {}", pick.autoderefs),
             );
         };
@@ -614,7 +614,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                     let span = predicates
                         .iter()
                         .find_map(|(p, span)| if p == pred { Some(span) } else { None })
-                        .unwrap_or(rustc_span::DUMMY_SP);
+                        .unwrap_or(DUMMY_SP);
                     Some((trait_pred, span))
                 }
                 _ => None,

--- a/compiler/rustc_hir_typeck/src/method/prelude2021.rs
+++ b/compiler/rustc_hir_typeck/src/method/prelude2021.rs
@@ -196,7 +196,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         method_name: Ident,
         self_ty: Ty<'tcx>,
         self_ty_span: Span,
-        expr_id: hir::HirId,
+        expr_id: HirId,
         pick: &Pick<'tcx>,
     ) {
         // Rust 2021 and later is already using the new prelude

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -132,7 +132,7 @@ pub(crate) struct Candidate<'tcx> {
     // if `T: Sized`.
     xform_self_ty: Ty<'tcx>,
     xform_ret_ty: Option<Ty<'tcx>>,
-    pub(crate) item: ty::AssocItem,
+    pub(crate) item: AssocItem,
     pub(crate) kind: CandidateKind<'tcx>,
     pub(crate) import_ids: SmallVec<[LocalDefId; 1]>,
 }
@@ -197,7 +197,7 @@ impl AutorefOrPtrAdjustment {
 
 #[derive(Debug, Clone)]
 pub struct Pick<'tcx> {
-    pub item: ty::AssocItem,
+    pub item: AssocItem,
     pub kind: PickKind<'tcx>,
     pub import_ids: SmallVec<[LocalDefId; 1]>,
 
@@ -265,8 +265,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         return_type: Ty<'tcx>,
         self_ty: Ty<'tcx>,
         scope_expr_id: hir::HirId,
-        candidate_filter: impl Fn(&ty::AssocItem) -> bool,
-    ) -> Vec<ty::AssocItem> {
+        candidate_filter: impl Fn(&AssocItem) -> bool,
+    ) -> Vec<AssocItem> {
         let method_names = self
             .probe_op(
                 span,
@@ -882,7 +882,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         bounds: impl Iterator<Item = ty::PolyTraitRef<'tcx>>,
         mut mk_cand: F,
     ) where
-        F: for<'b> FnMut(&mut ProbeContext<'b, 'tcx>, ty::PolyTraitRef<'tcx>, ty::AssocItem),
+        F: for<'b> FnMut(&mut ProbeContext<'b, 'tcx>, ty::PolyTraitRef<'tcx>, AssocItem),
     {
         let tcx = self.tcx;
         for bound_trait_ref in traits::transitive_bounds(tcx, bounds) {
@@ -924,7 +924,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 
     fn matches_return_type(
         &self,
-        method: ty::AssocItem,
+        method: AssocItem,
         self_ty: Option<Ty<'tcx>>,
         expected: Ty<'tcx>,
     ) -> bool {
@@ -1021,10 +1021,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         }
     }
 
-    fn candidate_method_names(
-        &self,
-        candidate_filter: impl Fn(&ty::AssocItem) -> bool,
-    ) -> Vec<Ident> {
+    fn candidate_method_names(&self, candidate_filter: impl Fn(&AssocItem) -> bool) -> Vec<Ident> {
         let mut set = FxHashSet::default();
         let mut names: Vec<_> = self
             .inherent_candidates
@@ -1753,7 +1750,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     /// edit distance based suggestions, we provide at most one such suggestion.
     pub(crate) fn probe_for_similar_candidate(
         &mut self,
-    ) -> Result<Option<ty::AssocItem>, MethodError<'tcx>> {
+    ) -> Result<Option<AssocItem>, MethodError<'tcx>> {
         debug!("probing for method names similar to {:?}", self.method_name);
 
         self.probe(|_| {
@@ -1773,7 +1770,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 
             let method_names = pcx.candidate_method_names(|_| true);
             pcx.allow_similar_names = false;
-            let applicable_close_candidates: Vec<ty::AssocItem> = method_names
+            let applicable_close_candidates: Vec<AssocItem> = method_names
                 .iter()
                 .filter_map(|&method_name| {
                     pcx.reset();
@@ -1813,7 +1810,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 
     ///////////////////////////////////////////////////////////////////////////
     // MISCELLANY
-    fn has_applicable_self(&self, item: &ty::AssocItem) -> bool {
+    fn has_applicable_self(&self, item: &AssocItem) -> bool {
         // "Fast track" -- check for usage of sugar when in method call
         // mode.
         //
@@ -1841,7 +1838,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     #[instrument(level = "debug", skip(self))]
     fn xform_self_ty(
         &self,
-        item: ty::AssocItem,
+        item: AssocItem,
         impl_ty: Ty<'tcx>,
         args: GenericArgsRef<'tcx>,
     ) -> (Ty<'tcx>, Option<Ty<'tcx>>) {
@@ -1996,7 +1993,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     /// `allow_similar_names` is set, find methods with close-matching names.
     // The length of the returned iterator is nearly always 0 or 1 and this
     // method is fairly hot.
-    fn impl_or_trait_item(&self, def_id: DefId) -> SmallVec<[ty::AssocItem; 1]> {
+    fn impl_or_trait_item(&self, def_id: DefId) -> SmallVec<[AssocItem; 1]> {
         if let Some(name) = self.method_name {
             if self.allow_similar_names {
                 let max_dist = max(name.as_str().len(), 3) / 3;

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1826,13 +1826,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         has_unsuggestable_args = true;
                         match arg.unpack() {
                             GenericArgKind::Lifetime(_) => self
-                                .next_region_var(RegionVariableOrigin::MiscVariable(
-                                    rustc_span::DUMMY_SP,
-                                ))
+                                .next_region_var(RegionVariableOrigin::MiscVariable(DUMMY_SP))
                                 .into(),
                             GenericArgKind::Type(_) => self
                                 .next_ty_var(TypeVariableOrigin {
-                                    span: rustc_span::DUMMY_SP,
+                                    span: DUMMY_SP,
                                     kind: TypeVariableOriginKind::MiscVariable,
                                 })
                                 .into(),
@@ -1840,7 +1838,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 .next_const_var(
                                     arg.ty(),
                                     ConstVariableOrigin {
-                                        span: rustc_span::DUMMY_SP,
+                                        span: DUMMY_SP,
                                         kind: ConstVariableOriginKind::MiscVariable,
                                     },
                                 )
@@ -2742,7 +2740,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let SelfSource::QPath(ty) = self_source else {
             return;
         };
-        for (deref_ty, _) in self.autoderef(rustc_span::DUMMY_SP, rcvr_ty).skip(1) {
+        for (deref_ty, _) in self.autoderef(DUMMY_SP, rcvr_ty).skip(1) {
             if let Ok(pick) = self.probe_for_name(
                 Mode::Path,
                 item_name,
@@ -3180,7 +3178,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                                 |param| {
                                                     matches!(
                                                         param.pat.kind,
-                                                        hir::PatKind::Binding(_, _, ident, _)
+                                                        Binding(_, _, ident, _)
                                                             if ident.name == kw::SelfLower
                                                     )
                                                 },
@@ -3491,7 +3489,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         if let Node::Expr(call_expr) = self.tcx.parent_hir_node(expr.hir_id)
             && let hir::ExprKind::MethodCall(
-                hir::PathSegment { ident: method_name, .. },
+                PathSegment { ident: method_name, .. },
                 self_expr,
                 args,
                 ..,

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -261,7 +261,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             Ok(method) => {
                 let by_ref_binop = !op.node.is_by_value();
                 if is_assign == IsAssign::Yes || by_ref_binop {
-                    if let ty::Ref(region, _, mutbl) = method.sig.inputs()[0].kind() {
+                    if let Ref(region, _, mutbl) = method.sig.inputs()[0].kind() {
                         let mutbl = AutoBorrowMutability::new(*mutbl, AllowTwoPhase::Yes);
                         let autoref = Adjustment {
                             kind: Adjust::Borrow(AutoBorrow::Ref(*region, mutbl)),
@@ -271,7 +271,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                 }
                 if by_ref_binop {
-                    if let ty::Ref(region, _, mutbl) = method.sig.inputs()[1].kind() {
+                    if let Ref(region, _, mutbl) = method.sig.inputs()[1].kind() {
                         // Allow two-phase borrows for binops in initial deployment
                         // since they desugar to methods
                         let mutbl = AutoBorrowMutability::new(*mutbl, AllowTwoPhase::Yes);
@@ -1065,7 +1065,7 @@ enum Op {
 /// Dereferences a single level of immutable referencing.
 fn deref_ty_if_possible(ty: Ty<'_>) -> Ty<'_> {
     match ty.kind() {
-        ty::Ref(_, ty, hir::Mutability::Not) => *ty,
+        Ref(_, ty, hir::Mutability::Not) => *ty,
         _ => ty,
     }
 }


### PR DESCRIPTION
This commit removes all the unused qualifications at the use sites. (The alternative would be to remove some of the `use` items.)

r? @ghost