### PR TITLE
Clarify FatalErrorHandler

### DIFF
--- a/tests/ui/linkage-attr/common-linkage-non-zero-init.stderr
+++ b/tests/ui/linkage-attr/common-linkage-non-zero-init.stderr
@@ -1,3 +1,3 @@
 'common' global must have a zero initializer!
 ptr @TEST
-LLVM ERROR: Broken module found, compilation aborted!
+rustc-LLVM ERROR: Broken module found, compilation aborted!


### PR DESCRIPTION
- Identify rustc's LLVM ERRORs by prefixing them
- Comment heavily on its interior, while we are here