### PR TITLE
rust: Ensure cargo executable path is fetched for custom targets when bootstrapping rust compiler

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -975,11 +975,15 @@ class RustBuild(object):
         if "RUSTFLAGS_BOOTSTRAP" in env:
             env["RUSTFLAGS"] += " " + env["RUSTFLAGS_BOOTSTRAP"]
 
-        env["PATH"] = os.path.join(self.bin_root(), "bin") + \
+        cargo_bin_path = os.path.join(self.bin_root(), "bin") + \
             os.pathsep + env["PATH"]
         if not os.path.isfile(self.cargo()):
-            raise Exception("no cargo executable found at `{}`".format(
+            if cargo_bin_path is None:
+                raise Exception("no cargo executable found at `{}`".format(
                 self.cargo()))
+            else:
+                cargo_bin_path = os.getenv("RUST_TARGET_PATH") + "rust-snapshot/bin/cargo"
+                env["PATH"] = os.path.dirname(cargo_bin_path) + os.pathsep + env["PATH"]
         args = [self.cargo(), "build", "--manifest-path",
                 os.path.join(self.rust_root, "src/bootstrap/Cargo.toml")]
         args.extend("--verbose" for _ in range(self.verbose))


### PR DESCRIPTION
When rust compiler is bootstrapped and built in custom sources, for example poky,
the build fails to fetch cargo exe path and gives error as follows.

This PR changes fix the error.
```
====================================
 ERROR: test_cargoflags (bootstrap_test.BuildBootstrap)
-------------------------------------------------------------
  Traceback (most recent call last):
  File "/home/build-st/tmp/work/cortexa57-poky-linux/rust/1.74.1/rustc-1.74.1-src/src/bootstrap/bootstrap_test.py", line 157, in test_cargoflags
     args, _ = self.build_args(env={"CARGOFLAGS": "--timings"})
  File "/home/build-st/tmp/work/cortexa57-poky-linux/rust/1.74.1/rustc-1.74.1-src/src/bootstrap/bootstrap_test.py", line 154, in build_args
     return build.build_bootstrap_cmd(env), env
  File "/home/build-st/tmp/work/cortexa57-poky-linux/rust/1.74.1/rustc-1.74.1-src/src/bootstrap/bootstrap.py", line 960, in build_bootstrap_cmd
    raise Exception("no cargo executable found at `{}`".format(
Exception: no cargo executable found at /home/build-st/tmp/work/cortexa57-poky-linux/rust/1.74.1/rustc-1.74.1-src/build/x86_64-unknown-linux-gnu/stage0/bin/cargo
```