### PR TITLE
Refer to "slice" instead of "vector" in Ord and PartialOrd trait impl of slices

### DIFF
--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -24,7 +24,7 @@ where
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Eq> Eq for [T] {}
 
-/// Implements comparison of vectors [lexicographically](Ord#lexicographical-comparison).
+/// Implements comparison of slices [lexicographically](Ord#lexicographical-comparison).
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord> Ord for [T] {
     fn cmp(&self, other: &[T]) -> Ordering {
@@ -32,7 +32,7 @@ impl<T: Ord> Ord for [T] {
     }
 }
 
-/// Implements comparison of vectors [lexicographically](Ord#lexicographical-comparison).
+/// Implements comparison of slices [lexicographically](Ord#lexicographical-comparison).
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: PartialOrd> PartialOrd for [T] {
     fn partial_cmp(&self, other: &[T]) -> Option<Ordering> {


### PR DESCRIPTION
The trait implementation comments of Ord and PartialOrd for slice incorrectly mention "vectors" instead of "slices". 
This PR fixes those two comments as requested in #122071.