### PR TITLE
Add missing PartialOrd trait implementation doc for array

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -360,6 +360,7 @@ where
     }
 }
 
+/// Implements comparison of arrays [lexicographically](Ord#lexicographical-comparison).
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: PartialOrd, const N: usize> PartialOrd for [T; N] {
     #[inline]


### PR DESCRIPTION
Analogously to vectors and slices, this PR documents the lexicographic sorting of PartialOrd as rustdoc comment on the trait implementation of PartialOrd for arrays.
Associated issue: #122073.