### PR TITLE
Add missing background color for top-level rust documentation page and increase contrast by setting text color to black

### DIFF
--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -5,12 +5,13 @@ body {
 	margin: 0 auto;
 	padding: 0 15px;
 	font-size: 18px;
-	color: #333;
+	color: #000;
 	line-height: 1.428571429;
 
 	-webkit-box-sizing: unset;
 	-moz-box-sizing: unset;
 	box-sizing: unset;
+	background: #fff;
 }
 @media (min-width: 768px) {
 	body {
@@ -39,7 +40,6 @@ h4, h5, h6 {
 	padding: 5px 10px;
 }
 h5, h6 {
-	color: black;
 	text-decoration: underline;
 }
 


### PR DESCRIPTION
Fixes #121954.

r? @notriddle 