### PR TITLE
Add encoding for `f16` and `f128`

### DIFF
--- a/src/doc/rustc/src/symbol-mangling/v0.md
+++ b/src/doc/rustc/src/symbol-mangling/v0.md
@@ -726,10 +726,12 @@ The type encodings based on the initial tag character are:
   * `h` — `u8`
   * `i` — `isize`
   * `j` — `usize`
+  * `k` - `f16`
   * `l` — `i32`
   * `m` — `u32`
   * `n` — `i128`
   * `o` — `u128`
+  * `q` - `f128`
   * `s` — `i16`
   * `t` — `u16`
   * `u` — unit `()`


### PR DESCRIPTION
This establishes new character encodings for the new primitive types tracked at https://github.com/rust-lang/rust/issues/116909:

- `k` for `f16`
- `q` for `f128`

We cannot easily be consistent with Itanium because it uses a multi-character encoding for `_Float16` (`Dh`), which I believe would conflict with `dyn` anyway. We _could_ use Itanium's `g` for `f128`, but `q` is more consistent with `f`=`float`=`f32`, `d`=`double`=`f64`, `q`=`quad`=`f128` (unfortunately `h` for `half`/`f16` is already taken).

Per @michaelwoerister this will need a compiler FCP

See also previous discussion at https://github.com/rust-lang/rustc-demangle/pull/64. Currently, the compiler will just ICE if attempting to v0 mangle these types.

@rustbot label +T-compiler +needs-fcp

Cc @rcvalle @ehuss 