### PR TITLE
compiletest: Add a `//@ needs-threads` directive

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -451,6 +451,15 @@ impl Config {
         self.target_cfg().panic == PanicStrategy::Unwind
     }
 
+    pub fn has_threads(&self) -> bool {
+        // Wasm targets don't have threads unless `-threads` is in the target
+        // name, such as `wasm32-wasip1-threads`.
+        if self.target.starts_with("wasm") {
+            return self.target.contains("threads");
+        }
+        true
+    }
+
     pub fn has_asm_support(&self) -> bool {
         static ASM_SUPPORTED_ARCHS: &[&str] = &[
             "x86", "x86_64", "arm", "aarch64", "riscv32",

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -787,6 +787,7 @@ const DIAGNOSTICS_DIRECTIVE_NAMES: &[&str] = &[
     "needs-sanitizer-shadow-call-stack",
     "needs-sanitizer-support",
     "needs-sanitizer-thread",
+    "needs-threads",
     "needs-unwind",
     "needs-xray",
     "no-prefer-dynamic",

--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -85,6 +85,11 @@ pub(super) fn handle_needs(
             ignore_reason: "ignored when running the resulting test binaries is disabled",
         },
         Need {
+            name: "needs-threads",
+            condition: config.has_threads(),
+            ignore_reason: "ignored on targets without threading support",
+        },
+        Need {
             name: "needs-unwind",
             condition: config.can_unwind(),
             ignore_reason: "ignored on targets without unwinding support",

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -592,3 +592,23 @@ fn ignore_mode() {
         assert!(!check_ignore(&config, &format!("//@ ignore-mode-{other}")));
     }
 }
+
+#[test]
+fn threads_support() {
+    let threads = [
+        ("x86_64-unknown-linux-gnu", true),
+        ("aarch64-apple-darwin", true),
+        ("wasm32-unknown-unknown", false),
+        ("wasm64-unknown-unknown", false),
+        #[cfg(not(bootstrap))]
+        ("wasm32-wasip1", false),
+        #[cfg(not(bootstrap))]
+        ("wasm32-wasip1-threads", true),
+        ("wasm32-wasi-preview1-threads", true),
+    ];
+    for (target, has_threads) in threads {
+        let config = cfg().target(target).build();
+        assert_eq!(config.has_threads(), has_threads);
+        assert_eq!(check_ignore(&config, "//@ needs-threads"), !has_threads)
+    }
+}

--- a/tests/codegen/cffi/c-variadic.rs
+++ b/tests/codegen/cffi/c-variadic.rs
@@ -1,4 +1,4 @@
-//@ ignore-wasm32-bare compiled with panic=abort by default
+//@ needs-unwind
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0
 //
 

--- a/tests/ui/abi/extern/extern-call-deep2.rs
+++ b/tests/ui/abi/extern/extern-call-deep2.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 #![feature(rustc_private)]
 
 extern crate libc;

--- a/tests/ui/abi/extern/extern-call-scrub.rs
+++ b/tests/ui/abi/extern/extern-call-scrub.rs
@@ -4,7 +4,7 @@
 // make sure the stack pointers are maintained properly in both
 // directions
 
-//@ ignore-emscripten no threads support
+//@ needs-threads
 #![feature(rustc_private)]
 
 extern crate libc;

--- a/tests/ui/abi/foreign/foreign-call-no-runtime.rs
+++ b/tests/ui/abi/foreign/foreign-call-no-runtime.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 #![feature(rustc_private)]
 

--- a/tests/ui/box/unit/unique-send-2.rs
+++ b/tests/ui/box/unit/unique-send-2.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::sync::mpsc::{channel, Sender};
 use std::thread;

--- a/tests/ui/codegen/init-large-type.rs
+++ b/tests/ui/codegen/init-large-type.rs
@@ -7,8 +7,7 @@
 // optimisation.
 
 //@ pretty-expanded FIXME #23616
-//@ ignore-emscripten no threads support
-
+//@ needs-threads
 #![feature(intrinsics)]
 
 use std::{mem, thread};

--- a/tests/ui/codegen/issue-28950.rs
+++ b/tests/ui/codegen/issue-28950.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads
+//@ needs-threads
 //@ compile-flags: -O
 
 // Tests that the `vec!` macro does not overflow the stack when it is

--- a/tests/ui/coroutine/smoke.rs
+++ b/tests/ui/coroutine/smoke.rs
@@ -3,7 +3,7 @@
 //@ revisions: default nomiropt
 //@[nomiropt]compile-flags: -Z mir-opt-level=0
 
-//@ ignore-emscripten no threads support
+//@ needs-threads
 //@ compile-flags: --test
 
 #![feature(coroutines, coroutine_trait)]

--- a/tests/ui/cross-crate/cci_capture_clause.rs
+++ b/tests/ui/cross-crate/cci_capture_clause.rs
@@ -5,7 +5,7 @@
 // that use capture clauses.
 
 //@ pretty-expanded FIXME #23616
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 extern crate cci_capture_clause;
 

--- a/tests/ui/hashmap/hashmap-memory.rs
+++ b/tests/ui/hashmap/hashmap-memory.rs
@@ -4,7 +4,7 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 #![allow(unused_mut)]
-//@ ignore-emscripten No support for threads
+//@ needs-threads
 
 /**
    A somewhat reduced test case to expose some Valgrind issues.

--- a/tests/ui/issues/issue-16560.rs
+++ b/tests/ui/issues/issue-16560.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_variables)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 use std::mem;

--- a/tests/ui/issues/issue-21291.rs
+++ b/tests/ui/issues/issue-21291.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 // Regression test for unwrapping the result of `join`, issue #21291
 

--- a/tests/ui/issues/issue-22864-2.rs
+++ b/tests/ui/issues/issue-22864-2.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 pub fn main() {
     let f = || || 0;

--- a/tests/ui/issues/issue-59020.rs
+++ b/tests/ui/issues/issue-59020.rs
@@ -1,6 +1,6 @@
 //@ edition:2018
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 use std::time::Duration;

--- a/tests/ui/logging-only-prints-once.rs
+++ b/tests/ui/logging-only-prints-once.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 //@ ignore-windows
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::cell::Cell;
 use std::fmt;

--- a/tests/ui/lto/lto-still-runs-thread-dtors.rs
+++ b/tests/ui/lto/lto-still-runs-thread-dtors.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ compile-flags: -C lto
 //@ no-prefer-dynamic
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/macros/macro-with-braces-in-expr-position.rs
+++ b/tests/ui/macros/macro-with-braces-in-expr-position.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/moves/moves-based-on-type-capture-clause.rs
+++ b/tests/ui/moves/moves-based-on-type-capture-clause.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/panics/panic-handler-chain.rs
+++ b/tests/ui/panics/panic-handler-chain.rs
@@ -1,8 +1,7 @@
 //@ run-pass
 //@ needs-unwind
+//@ needs-threads
 #![allow(stable_features)]
-
-//@ ignore-emscripten no threads support
 
 #![feature(std_panic)]
 

--- a/tests/ui/panics/panic-task-name-none.rs
+++ b/tests/ui/panics/panic-task-name-none.rs
@@ -1,7 +1,7 @@
 //@ run-fail
 //@ error-pattern:thread '<unnamed>' panicked
 //@ error-pattern:test
-//@ ignore-emscripten Needs threads
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/panics/panic-task-name-owned.rs
+++ b/tests/ui/panics/panic-task-name-owned.rs
@@ -1,7 +1,7 @@
 //@ run-fail
 //@ error-pattern:thread 'owned name' panicked
 //@ error-pattern:test
-//@ ignore-emscripten Needs threads.
+//@ needs-threads
 
 use std::thread::Builder;
 

--- a/tests/ui/process-termination/process-termination-blocking-io.rs
+++ b/tests/ui/process-termination/process-termination-blocking-io.rs
@@ -2,7 +2,7 @@
 // https://github.com/fortanix/rust-sgx/issues/109
 
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::{net::TcpListener, sync::mpsc, thread};
 

--- a/tests/ui/process-termination/process-termination-simple.rs
+++ b/tests/ui/process-termination/process-termination-simple.rs
@@ -1,7 +1,7 @@
 // program should terminate when std::process::exit is called from any thread
 
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::{process, thread};
 

--- a/tests/ui/structs-enums/ivec-tag.rs
+++ b/tests/ui/structs-enums/ivec-tag.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 use std::sync::mpsc::{channel, Sender};

--- a/tests/ui/test-attrs/test-filter-multiple.rs
+++ b/tests/ui/test-attrs/test-filter-multiple.rs
@@ -3,7 +3,7 @@
 //@ run-flags: --test-threads=1 test1 test2
 //@ check-run-results
 //@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 #[test]
 fn test1() {}

--- a/tests/ui/test-attrs/test-type.rs
+++ b/tests/ui/test-attrs/test-type.rs
@@ -2,7 +2,7 @@
 //@ run-flags: --test-threads=1
 //@ check-run-results
 //@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
-//@ ignore-emscripten no threads support
+//@ needs-threads
 //@ run-pass
 
 #[test]

--- a/tests/ui/thread-local/tls.rs
+++ b/tests/ui/thread-local/tls.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 //@ compile-flags: -O
 //@ ignore-nto Doesn't work without emulated TLS enabled (in LLVM)
 

--- a/tests/ui/threads-sendsync/child-outlives-parent.rs
+++ b/tests/ui/threads-sendsync/child-outlives-parent.rs
@@ -2,7 +2,7 @@
 // Reported as issue #126, child leaks the string.
 
 //@ pretty-expanded FIXME #23616
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/clone-with-exterior.rs
+++ b/tests/ui/threads-sendsync/clone-with-exterior.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/comm.rs
+++ b/tests/ui/threads-sendsync/comm.rs
@@ -1,13 +1,13 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 use std::sync::mpsc::{channel, Sender};
 
 pub fn main() {
     let (tx, rx) = channel();
-    let t = thread::spawn(move|| { child(&tx) });
+    let t = thread::spawn(move || { child(&tx) });
     let y = rx.recv().unwrap();
     println!("received");
     println!("{}", y);

--- a/tests/ui/threads-sendsync/eprint-on-tls-drop.rs
+++ b/tests/ui/threads-sendsync/eprint-on-tls-drop.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no processes
+//@ needs-threads
 //@ ignore-sgx no processes
 
 use std::cell::RefCell;

--- a/tests/ui/threads-sendsync/issue-24313.rs
+++ b/tests/ui/threads-sendsync/issue-24313.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads
+//@ needs-threads
 //@ ignore-sgx no processes
 
 use std::thread;

--- a/tests/ui/threads-sendsync/issue-29488.rs
+++ b/tests/ui/threads-sendsync/issue-29488.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/issue-43733-2.rs
+++ b/tests/ui/threads-sendsync/issue-43733-2.rs
@@ -1,4 +1,4 @@
-//@ ignore-wasm32
+//@ needs-threads
 //@ dont-check-compiler-stderr
 #![feature(cfg_target_thread_local, thread_local_internals)]
 

--- a/tests/ui/threads-sendsync/issue-43733.rs
+++ b/tests/ui/threads-sendsync/issue-43733.rs
@@ -1,4 +1,4 @@
-//@ ignore-wasm32
+//@ needs-threads
 #![feature(thread_local)]
 #![feature(cfg_target_thread_local, thread_local_internals)]
 

--- a/tests/ui/threads-sendsync/issue-4446.rs
+++ b/tests/ui/threads-sendsync/issue-4446.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::sync::mpsc::channel;
 use std::thread;

--- a/tests/ui/threads-sendsync/issue-4448.rs
+++ b/tests/ui/threads-sendsync/issue-4448.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::sync::mpsc::channel;
 use std::thread;

--- a/tests/ui/threads-sendsync/issue-8827.rs
+++ b/tests/ui/threads-sendsync/issue-8827.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 use std::sync::mpsc::{channel, Receiver};

--- a/tests/ui/threads-sendsync/issue-9396.rs
+++ b/tests/ui/threads-sendsync/issue-9396.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 #![allow(unused_must_use)]
 #![allow(deprecated)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::sync::mpsc::{TryRecvError, channel};
 use std::thread;

--- a/tests/ui/threads-sendsync/mpsc_stress.rs
+++ b/tests/ui/threads-sendsync/mpsc_stress.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 //@ compile-flags:--test
-//@ ignore-emscripten
+//@ needs-threads
 
 use std::sync::mpsc::channel;
 use std::sync::mpsc::TryRecvError;

--- a/tests/ui/threads-sendsync/send-resource.rs
+++ b/tests/ui/threads-sendsync/send-resource.rs
@@ -4,7 +4,7 @@
 #![allow(non_camel_case_types)]
 
 //@ pretty-expanded FIXME #23616
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 use std::sync::mpsc::channel;

--- a/tests/ui/threads-sendsync/sendfn-spawn-with-fn-arg.rs
+++ b/tests/ui/threads-sendsync/sendfn-spawn-with-fn-arg.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/spawn-fn.rs
+++ b/tests/ui/threads-sendsync/spawn-fn.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/spawn-types.rs
+++ b/tests/ui/threads-sendsync/spawn-types.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 #![allow(non_camel_case_types)]
 
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 /*
   Make sure we can spawn tasks that take different types of

--- a/tests/ui/threads-sendsync/spawn.rs
+++ b/tests/ui/threads-sendsync/spawn.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/spawn2.rs
+++ b/tests/ui/threads-sendsync/spawn2.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/spawning-with-debug.rs
+++ b/tests/ui/threads-sendsync/spawning-with-debug.rs
@@ -3,7 +3,7 @@
 #![allow(unused_mut)]
 //@ ignore-windows
 //@ exec-env:RUST_LOG=debug
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 // regression test for issue #10405, make sure we don't call println! too soon.
 

--- a/tests/ui/threads-sendsync/task-comm-0.rs
+++ b/tests/ui/threads-sendsync/task-comm-0.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 use std::sync::mpsc::{channel, Sender};

--- a/tests/ui/threads-sendsync/task-comm-1.rs
+++ b/tests/ui/threads-sendsync/task-comm-1.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/task-comm-10.rs
+++ b/tests/ui/threads-sendsync/task-comm-10.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 #![allow(unused_must_use)]
 #![allow(unused_mut)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 use std::sync::mpsc::{channel, Sender};

--- a/tests/ui/threads-sendsync/task-comm-11.rs
+++ b/tests/ui/threads-sendsync/task-comm-11.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 #![allow(unused_must_use)]
 //@ pretty-expanded FIXME #23616
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::sync::mpsc::{channel, Sender};
 use std::thread;

--- a/tests/ui/threads-sendsync/task-comm-12.rs
+++ b/tests/ui/threads-sendsync/task-comm-12.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 #![allow(unused_must_use)]
 #![allow(unused_mut)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/task-comm-13.rs
+++ b/tests/ui/threads-sendsync/task-comm-13.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_variables)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::sync::mpsc::{channel, Sender};
 use std::thread;

--- a/tests/ui/threads-sendsync/task-comm-14.rs
+++ b/tests/ui/threads-sendsync/task-comm-14.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_parens)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::sync::mpsc::{channel, Sender};
 use std::thread;

--- a/tests/ui/threads-sendsync/task-comm-15.rs
+++ b/tests/ui/threads-sendsync/task-comm-15.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 //@ pretty-expanded FIXME #23616
 
 use std::sync::mpsc::{channel, Sender};

--- a/tests/ui/threads-sendsync/task-comm-17.rs
+++ b/tests/ui/threads-sendsync/task-comm-17.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 //@ pretty-expanded FIXME #23616
 
 // Issue #922

--- a/tests/ui/threads-sendsync/task-comm-3.rs
+++ b/tests/ui/threads-sendsync/task-comm-3.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 use std::sync::mpsc::{channel, Sender};

--- a/tests/ui/threads-sendsync/task-comm-7.rs
+++ b/tests/ui/threads-sendsync/task-comm-7.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 #![allow(unused_must_use)]
 #![allow(unused_assignments)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::sync::mpsc::{channel, Sender};
 use std::thread;

--- a/tests/ui/threads-sendsync/task-comm-9.rs
+++ b/tests/ui/threads-sendsync/task-comm-9.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 use std::sync::mpsc::{channel, Sender};

--- a/tests/ui/threads-sendsync/task-life-0.rs
+++ b/tests/ui/threads-sendsync/task-life-0.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 //@ pretty-expanded FIXME #23616
 
 use std::thread;

--- a/tests/ui/threads-sendsync/task-spawn-barefn.rs
+++ b/tests/ui/threads-sendsync/task-spawn-barefn.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ error-pattern:Ensure that the child thread runs by panicking
-//@ ignore-emscripten Needs threads.
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/task-spawn-move-and-copy.rs
+++ b/tests/ui/threads-sendsync/task-spawn-move-and-copy.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 use std::sync::mpsc::channel;

--- a/tests/ui/threads-sendsync/task-stderr.rs
+++ b/tests/ui/threads-sendsync/task-stderr.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-emscripten no threads support
+//@ needs-threads
 //@ needs-unwind
 
 #![feature(internal_output_capture)]

--- a/tests/ui/threads-sendsync/tcp-stress.rs
+++ b/tests/ui/threads-sendsync/tcp-stress.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 //@ ignore-android needs extra network permissions
-//@ ignore-emscripten no threads or sockets support
+//@ needs-threads
 //@ ignore-netbsd system ulimit (Too many open files)
 //@ ignore-openbsd system ulimit (Too many open files)
 

--- a/tests/ui/threads-sendsync/test-tasks-invalid-value.rs
+++ b/tests/ui/threads-sendsync/test-tasks-invalid-value.rs
@@ -5,7 +5,7 @@
 //@ error-pattern:should be a positive integer
 //@ compile-flags: --test
 //@ exec-env:RUST_TEST_THREADS=foo
-//@ ignore-emscripten
+//@ needs-threads
 
 #[test]
 fn do_nothing() {}

--- a/tests/ui/threads-sendsync/threads.rs
+++ b/tests/ui/threads-sendsync/threads.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/tls-dtors-are-run-in-a-static-binary.rs
+++ b/tests/ui/threads-sendsync/tls-dtors-are-run-in-a-static-binary.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 //@ no-prefer-dynamic
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 static mut HIT: bool = false;
 

--- a/tests/ui/threads-sendsync/tls-init-on-init.rs
+++ b/tests/ui/threads-sendsync/tls-init-on-init.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 #![allow(stable_features)]
 
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 #![feature(thread_local_try_with)]
 

--- a/tests/ui/threads-sendsync/tls-try-with.rs
+++ b/tests/ui/threads-sendsync/tls-try-with.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 #![allow(stable_features)]
 
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 #![feature(thread_local_try_with)]
 

--- a/tests/ui/threads-sendsync/unwind-resource.rs
+++ b/tests/ui/threads-sendsync/unwind-resource.rs
@@ -2,7 +2,7 @@
 //@ needs-unwind
 
 #![allow(non_camel_case_types)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::sync::mpsc::{channel, Sender};
 use std::thread;

--- a/tests/ui/threads-sendsync/yield.rs
+++ b/tests/ui/threads-sendsync/yield.rs
@@ -2,7 +2,7 @@
 
 #![allow(unused_must_use)]
 #![allow(unused_mut)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/yield1.rs
+++ b/tests/ui/threads-sendsync/yield1.rs
@@ -2,7 +2,7 @@
 
 #![allow(unused_must_use)]
 #![allow(unused_mut)]
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::thread;
 

--- a/tests/ui/traits/bound/in-arc.rs
+++ b/tests/ui/traits/bound/in-arc.rs
@@ -3,7 +3,7 @@
 // Tests that a heterogeneous list of existential `dyn` types can be put inside an Arc
 // and shared between threads as long as all types fulfill Send.
 
-//@ ignore-emscripten no threads support
+//@ needs-threads
 
 use std::sync::Arc;
 use std::sync::mpsc::channel;


### PR DESCRIPTION
This commit is extracted from #122036 and adds a new directive to the `compiletest` test runner, `//@ needs-threads`. This is intended to capture the need that a target must implement threading to execute a specific test, typically one that uses `std::thread`. This is primarily done for WebAssembly targets which currently do not have threads by default. This enables transitioning a lot of `//@ ignore-wasm*`-style ignores into a more self-documenting `//@ needs-threads` directive. Additionally the `wasm32-wasi-preview1-threads` target, for example, does actually have threads, but isn't tested in CI at this time. This change enables running these tests for that target, but not other wasm targets.