### PR TITLE
Make not finding core a fatal error

### DIFF
--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -1077,7 +1077,7 @@ impl CrateError {
                         crate_rejections,
                     });
                 } else {
-                    dcx.emit_err(errors::CannotFindCrate {
+                    let error = errors::CannotFindCrate {
                         span,
                         crate_name,
                         add_info,
@@ -1091,11 +1091,18 @@ impl CrateError {
                         profiler_runtime: Symbol::intern(&sess.opts.unstable_opts.profiler_runtime),
                         locator_triple: locator.triple,
                         is_ui_testing: sess.opts.unstable_opts.ui_testing,
-                    });
+                    };
+                    // The diagnostic for missing core is very good, but it is followed by a lot of
+                    // other diagnostics that do not add information.
+                    if missing_core {
+                        dcx.emit_fatal(error);
+                    } else {
+                        dcx.emit_err(error);
+                    }
                 }
             }
             CrateError::NotFound(crate_name) => {
-                dcx.emit_err(errors::CannotFindCrate {
+                let error = errors::CannotFindCrate {
                     span,
                     crate_name,
                     add_info: String::new(),
@@ -1105,7 +1112,14 @@ impl CrateError {
                     profiler_runtime: Symbol::intern(&sess.opts.unstable_opts.profiler_runtime),
                     locator_triple: sess.opts.target_triple.clone(),
                     is_ui_testing: sess.opts.unstable_opts.ui_testing,
-                });
+                };
+                // The diagnostic for missing core is very good, but it is followed by a lot of
+                // other diagnostics that do not add information.
+                if missing_core {
+                    dcx.emit_fatal(error);
+                } else {
+                    dcx.emit_err(error);
+                }
             }
         }
     }

--- a/tests/ui/crate-loading/missing-std.stderr
+++ b/tests/ui/crate-loading/missing-std.stderr
@@ -8,8 +8,6 @@ LL | extern crate core;
    = help: consider downloading the target with `rustup target add x86_64-unknown-uefi`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`
 
-error: requires `sized` lang_item
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0463`.

--- a/tests/ui/issues/issue-37131.stderr
+++ b/tests/ui/issues/issue-37131.stderr
@@ -4,8 +4,6 @@ error[E0463]: can't find crate for `std`
    = help: consider downloading the target with `rustup target add thumbv6m-none-eabi`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`
 
-error: requires `sized` lang_item
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0463`.

--- a/tests/ui/issues/issue-49851/compiler-builtins-error.rs
+++ b/tests/ui/issues/issue-49851/compiler-builtins-error.rs
@@ -1,5 +1,4 @@
 //~ ERROR can't find crate for `core`
-//~^ ERROR can't find crate for `compiler_builtins`
 
 //@ compile-flags: --target thumbv7em-none-eabihf
 //@ needs-llvm-components: arm
@@ -8,6 +7,5 @@
 #![no_std]
 
 extern crate cortex_m;
-//~^ ERROR can't find crate for `cortex_m`
 
 fn main() {}

--- a/tests/ui/issues/issue-49851/compiler-builtins-error.stderr
+++ b/tests/ui/issues/issue-49851/compiler-builtins-error.stderr
@@ -4,16 +4,6 @@ error[E0463]: can't find crate for `core`
    = help: consider downloading the target with `rustup target add thumbv7em-none-eabihf`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`
 
-error[E0463]: can't find crate for `compiler_builtins`
-
-error[E0463]: can't find crate for `cortex_m`
-  --> $DIR/compiler-builtins-error.rs:10:1
-   |
-LL | extern crate cortex_m;
-   | ^^^^^^^^^^^^^^^^^^^^^^ can't find crate
-
-error: requires `sized` lang_item
-
-error: aborting due to 4 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0463`.


### PR DESCRIPTION
Similar to https://github.com/rust-lang/rust/pull/120472, this prevents terminal spam. In particular, it makes the good diagnostic visible when you try to use a target that's not installed.