### PR TITLE
Silence unecessary !Sized binding error

### DIFF
--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -568,6 +568,11 @@ impl<'a, V> LocalTableInContextMut<'a, V> {
         self.data.get_mut(&id.local_id)
     }
 
+    pub fn get(&mut self, id: hir::HirId) -> Option<&V> {
+        validate_hir_id_for_typeck_results(self.hir_owner, id);
+        self.data.get(&id.local_id)
+    }
+
     pub fn entry(&mut self, id: hir::HirId) -> Entry<'_, hir::ItemLocalId, V> {
         validate_hir_id_for_typeck_results(self.hir_owner, id);
         self.data.entry(id.local_id)

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2954,6 +2954,16 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 }
             }
             ObligationCauseCode::VariableType(hir_id) => {
+                if let Some(typeck_results) = &self.typeck_results
+                    && let Some(ty) = typeck_results.node_type_opt(hir_id)
+                    && let ty::Error(_) = ty.kind()
+                {
+                    err.note(format!(
+                        "`{predicate}` isn't satisfied, but the type of this pattern is \
+                         `{{type error}}`",
+                    ));
+                    err.downgrade_to_delayed_bug();
+                }
                 match tcx.parent_hir_node(hir_id) {
                     Node::Local(hir::Local { ty: Some(ty), .. }) => {
                         err.span_suggestion_verbose(

--- a/tests/ui/sized/expr-type-error-plus-sized-obligation.rs
+++ b/tests/ui/sized/expr-type-error-plus-sized-obligation.rs
@@ -1,0 +1,22 @@
+#![allow(warnings)]
+
+fn issue_117846_repro() {
+    let (a, _) = if true { //~ ERROR E0277
+        produce()
+    } else {
+        (Vec::new(), &[]) //~ ERROR E0308
+    };
+
+    accept(&a);
+}
+
+struct Foo;
+struct Bar;
+
+fn produce() -> (Vec<Foo>, &'static [Bar]) {
+    todo!()
+}
+
+fn accept(c: &[Foo]) {}
+
+fn main() {}

--- a/tests/ui/sized/expr-type-error-plus-sized-obligation.rs
+++ b/tests/ui/sized/expr-type-error-plus-sized-obligation.rs
@@ -1,7 +1,7 @@
 #![allow(warnings)]
 
 fn issue_117846_repro() {
-    let (a, _) = if true { //~ ERROR E0277
+    let (a, _) = if true {
         produce()
     } else {
         (Vec::new(), &[]) //~ ERROR E0308

--- a/tests/ui/sized/expr-type-error-plus-sized-obligation.stderr
+++ b/tests/ui/sized/expr-type-error-plus-sized-obligation.stderr
@@ -14,17 +14,6 @@ LL | |     };
    = note: expected tuple `(Vec<Foo>, &[Bar])`
               found tuple `(Vec<_>, &[_; 0])`
 
-error[E0277]: the size for values of type `[Foo]` cannot be known at compilation time
-  --> $DIR/expr-type-error-plus-sized-obligation.rs:4:10
-   |
-LL |     let (a, _) = if true {
-   |          ^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[Foo]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0277, E0308.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/sized/expr-type-error-plus-sized-obligation.stderr
+++ b/tests/ui/sized/expr-type-error-plus-sized-obligation.stderr
@@ -1,0 +1,30 @@
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/expr-type-error-plus-sized-obligation.rs:7:9
+   |
+LL |       let (a, _) = if true {
+   |  __________________-
+LL | |         produce()
+   | |         --------- expected because of this
+LL | |     } else {
+LL | |         (Vec::new(), &[])
+   | |         ^^^^^^^^^^^^^^^^^ expected `(Vec<Foo>, &[Bar])`, found `(Vec<_>, &[_; 0])`
+LL | |     };
+   | |_____- `if` and `else` have incompatible types
+   |
+   = note: expected tuple `(Vec<Foo>, &[Bar])`
+              found tuple `(Vec<_>, &[_; 0])`
+
+error[E0277]: the size for values of type `[Foo]` cannot be known at compilation time
+  --> $DIR/expr-type-error-plus-sized-obligation.rs:4:10
+   |
+LL |     let (a, _) = if true {
+   |          ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[Foo]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
When gathering locals, we introduce a `Sized` obligation for each
binding in the pattern. *After* doing so, we typecheck the init
expression. If this has a type failure, we store `{type error}`, for
both the expression and the pattern. But later we store an inference
variable for the pattern.

We now avoid any override of an existing type on a hir node when they've
already been marked as `{type error}`, and on E0277, when it comes from
`VariableType` we silence the error in support of the type error.

Fix https://github.com/rust-lang/rust/issues/117846