### PR TITLE
Fix `tidy --bless` on  ̶X̶e̶n̶i̶x̶ Windows

### DIFF
--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -190,7 +190,11 @@ pub fn check(path: &Path, bless: bool, bad: &mut bool) {
         let blessed_issues_path = tidy_src.join("issues_blessed.txt");
         let mut blessed_issues_txt = fs::File::create(&blessed_issues_path).unwrap();
         blessed_issues_txt.write(issues_txt_header.as_bytes()).unwrap();
-        for filename in allowed_issue_names.difference(&remaining_issue_names) {
+        // If we changed paths to use the OS separator, reassert Unix chauvinism for blessing.
+        for filename in allowed_issue_names
+            .difference(&remaining_issue_names)
+            .map(|s| s.replace(std::path::MAIN_SEPARATOR_STR, "/"))
+        {
             write!(blessed_issues_txt, "\"{filename}\",\n").unwrap();
         }
         write!(blessed_issues_txt, "]\n").unwrap();


### PR DESCRIPTION
As reported in https://github.com/rust-lang/rust/pull/120628#issuecomment-1973655740 the requested `tidy --bless` implementation didn't take into account the fact that earlier the linting code canonicalized things to use the OS path separator. This makes it so that the path separator is always rewritten back as '/', which should fix the variance there.

r? @ChrisDenton