### PR TITLE
Set `RustcDocs` to only run on host

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -129,6 +129,7 @@ pub struct RustcDocs {
 impl Step for RustcDocs {
     type Output = Option<GeneratedTarball>;
     const DEFAULT: bool = true;
+    const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;


### PR DESCRIPTION
`./x dist` currently crashes when cross compiling. Add the fix described by @catamorphism in https://github.com/rust-lang/rust/issues/110071.

Fixes #110071