### PR TITLE
Don't pass a break scope to `Builder::break_for_else`

### DIFF
--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -83,7 +83,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                     block,
                                     cond,
                                     Some(condition_scope), // Temp scope
-                                    condition_scope,
                                     source_info,
                                     true, // Declare `let` bindings normally
                                 ));
@@ -156,7 +155,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             block,
                             lhs,
                             Some(condition_scope), // Temp scope
-                            condition_scope,
                             source_info,
                             // This flag controls how inner `let` expressions are lowered,
                             // but either way there shouldn't be any of those in here.


### PR DESCRIPTION
This method would previously take a target scope, and then verify that it was equal to the scope on top of the if-then scope stack.

In practice, this means that callers have to go out of their way to pass around redundant scope information that's already on the if-then stack.

So it's easier to just retrieve the correct scope directly from the if-then stack, and simplify the other code that was passing it around.

---

Both ways of indicating the break target were introduced in #88572. I haven't been able to find any strong indication of whether this was done deliberately, or whether it was just an implementation artifact. But to me it doesn't seem useful to carefully pass around the same scope in two different ways.