### PR TITLE
Record mtime in bootstrap's LLVM linker script

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2046,7 +2046,8 @@ fn install_llvm_file(
             // projects like miri link against librustc_driver.so. We don't use a symlink, as
             // these are not allowed inside rustup components.
             let link = t!(fs::read_link(source));
-            t!(std::fs::write(full_dest, format!("INPUT({})\n", link.display())));
+            let mut linker_script = t!(fs::File::create(full_dest));
+            t!(write!(linker_script, "INPUT({})\n", link.display()));
         }
     } else {
         builder.install(&source, destination, 0o644);

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2048,6 +2048,13 @@ fn install_llvm_file(
             let link = t!(fs::read_link(source));
             let mut linker_script = t!(fs::File::create(full_dest));
             t!(write!(linker_script, "INPUT({})\n", link.display()));
+
+            // We also want the linker script to have the same mtime as the source, otherwise it
+            // can trigger rebuilds.
+            let meta = t!(fs::metadata(source));
+            if let Ok(mtime) = meta.modified() {
+                t!(linker_script.set_modified(mtime));
+            }
         }
     } else {
         builder.install(&source, destination, 0o644);


### PR DESCRIPTION
As discovered in https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/.60ui.60.20tests.20re-running.3F the linker script added in #121967 can trigger rebuilds or new test executions, as it's more recent than some of the existing files themselves.

This PR copies the mtime to the linker script to prevent a second invocation of `./x test tests/ui` from rerunning all of the tests.

