### PR TITLE
Eagerly translate `HelpUseLatestEdition` in parser diagnostics

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -667,7 +667,7 @@ impl<'a> Parser<'a> {
         {
             err.note("you may be trying to write a c-string literal");
             err.note("c-string literals require Rust 2021 or later");
-            HelpUseLatestEdition::new().add_to_diagnostic(&mut err);
+            err.subdiagnostic(self.dcx(), HelpUseLatestEdition::new());
         }
 
         // `pub` may be used for an item or `pub(crate)`

--- a/tests/ui/parser/help-set-edition-ice-122130.rs
+++ b/tests/ui/parser/help-set-edition-ice-122130.rs
@@ -1,0 +1,5 @@
+enum will {
+    s#[c"owned_box"]
+    //~^ERROR expected one of `(`, `,`, `=`, `{`, or `}`, found `#`
+    //~|ERROR expected item, found `"owned_box"`
+}

--- a/tests/ui/parser/help-set-edition-ice-122130.stderr
+++ b/tests/ui/parser/help-set-edition-ice-122130.stderr
@@ -1,0 +1,21 @@
+error: expected one of `(`, `,`, `=`, `{`, or `}`, found `#`
+  --> $DIR/help-set-edition-ice-122130.rs:2:6
+   |
+LL |     s#[c"owned_box"]
+   |      ^ expected one of `(`, `,`, `=`, `{`, or `}`
+   |
+   = note: you may be trying to write a c-string literal
+   = note: c-string literals require Rust 2021 or later
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error: expected item, found `"owned_box"`
+  --> $DIR/help-set-edition-ice-122130.rs:2:9
+   |
+LL |     s#[c"owned_box"]
+   |         ^^^^^^^^^^^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #122130.

This makes me suspicious of these other two usage of  `add_to_diagnostic()`. Would they *also* crash? I haven't attempted to construct test cases for them.

```
compiler/rustc_parse/src/parser/expr.rs
3453:            errors::HelpUseLatestEdition::new().add_to_diagnostic(e);

compiler/rustc_hir_typeck/src/expr.rs
2603:            HelpUseLatestEdition::new().add_to_diagnostic(&mut err);
```

This also seems like a footgun?