### PR TITLE
Don't ICE if we collect no RPITITs unless there are no unification errors

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -520,14 +520,6 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
         )
         .fold_with(&mut collector);
 
-    if !unnormalized_trait_sig.output().references_error() {
-        debug_assert_ne!(
-            collector.types.len(),
-            0,
-            "expect >1 RPITITs in call to `collect_return_position_impl_trait_in_trait_tys`"
-        );
-    }
-
     let trait_sig = ocx.normalize(&misc_cause, param_env, unnormalized_trait_sig);
     trait_sig.error_reported()?;
     let trait_return_ty = trait_sig.output();
@@ -644,6 +636,13 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
             );
             return Err(emitted);
         }
+    }
+
+    if !unnormalized_trait_sig.output().references_error() {
+        debug_assert!(
+            !collector.types.is_empty(),
+            "expect >0 RPITITs in call to `collect_return_position_impl_trait_in_trait_tys`"
+        );
     }
 
     // FIXME: This has the same issue as #108544, but since this isn't breaking

--- a/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.rs
+++ b/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.rs
@@ -1,0 +1,18 @@
+struct Wrapper<'rom>(T);
+//~^ ERROR cannot find type `T` in this scope
+
+trait Foo {
+    fn bar() -> Wrapper<impl Sized>;
+    //~^ ERROR missing lifetime specifier
+    //~| ERROR struct takes 0 generic arguments but 1 generic argument was supplied
+}
+
+impl Foo for () {
+    fn bar() -> i32 {
+        //~^ ERROR method `bar` has an incompatible type for trait
+        //~| ERROR method `bar` has an incompatible return type for trait
+        0
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
+++ b/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
@@ -1,0 +1,67 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/opaque-and-lifetime-mismatch.rs:5:24
+   |
+LL |     fn bar() -> Wrapper<impl Sized>;
+   |                        ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
+   |
+LL |     fn bar() -> Wrapper<'static, impl Sized>;
+   |                         ++++++++
+
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/opaque-and-lifetime-mismatch.rs:1:22
+   |
+LL | struct Wrapper<'rom>(T);
+   |                      ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | struct Wrapper<'rom, T>(T);
+   |                    +++
+
+error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/opaque-and-lifetime-mismatch.rs:5:17
+   |
+LL |     fn bar() -> Wrapper<impl Sized>;
+   |                 ^^^^^^^ ---------- help: remove this generic argument
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: struct defined here, with 0 generic parameters
+  --> $DIR/opaque-and-lifetime-mismatch.rs:1:8
+   |
+LL | struct Wrapper<'rom>(T);
+   |        ^^^^^^^
+
+error[E0053]: method `bar` has an incompatible return type for trait
+  --> $DIR/opaque-and-lifetime-mismatch.rs:11:17
+   |
+LL |     fn bar() -> i32 {
+   |                 ^^^
+   |                 |
+   |                 expected `Wrapper<'static>`, found `i32`
+   |                 return type in trait
+
+error[E0053]: method `bar` has an incompatible type for trait
+  --> $DIR/opaque-and-lifetime-mismatch.rs:11:17
+   |
+LL |     fn bar() -> i32 {
+   |                 ^^^
+   |                 |
+   |                 expected `Wrapper<'static>`, found `i32`
+   |                 help: change the output type to match the trait: `Wrapper<'static>`
+   |
+note: type in trait
+  --> $DIR/opaque-and-lifetime-mismatch.rs:5:17
+   |
+LL |     fn bar() -> Wrapper<impl Sized>;
+   |                 ^^^^^^^^^^^^^^^^^^^
+   = note: expected signature `fn() -> Wrapper<'static>`
+              found signature `fn() -> i32`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0053, E0106, E0107, E0412.
+For more information about an error, try `rustc --explain E0053`.


### PR DESCRIPTION
Move an assertion in `collect_return_position_impl_trait_in_trait_tys` to after the `ObligationCtxt::eq` calls, so that we only assert and ICE if we have unification errors.

Fixes #121468