### PR TITLE
compiler: prefer `b as _` to `if b { 1 } else { 0 }`

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/input_output.rs
+++ b/compiler/rustc_borrowck/src/type_check/input_output.rs
@@ -117,7 +117,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             // In MIR, closure args begin with an implicit `self`.
             // Also, coroutines have a resume type which may be implicitly `()`.
             body.args_iter()
-                .skip(1 + if is_coroutine_with_implicit_resume_ty { 1 } else { 0 })
+                .skip(1 + is_coroutine_with_implicit_resume_ty as usize)
                 .map(|local| &body.local_decls[local]),
         ) {
             self.ascribe_user_type_skip_wf(

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -523,12 +523,11 @@ pub(crate) fn codegen_terminator_call<'tcx>(
             .into_iter()
             .chain(first_arg_override.into_iter())
             .chain(
-                args.into_iter()
-                    .enumerate()
-                    .skip(if first_arg_override.is_some() { 1 } else { 0 })
-                    .flat_map(|(i, arg)| {
+                args.into_iter().enumerate().skip(first_arg_override.is_some() as usize).flat_map(
+                    |(i, arg)| {
                         adjust_arg_for_abi(fx, arg.value, &fn_abi.args[i], arg.is_owned).into_iter()
-                    }),
+                    },
+                ),
             )
             .collect::<Vec<Value>>();
 

--- a/compiler/rustc_codegen_gcc/src/abi.rs
+++ b/compiler/rustc_codegen_gcc/src/abi.rs
@@ -119,7 +119,7 @@ impl<'gcc, 'tcx> FnAbiGccExt<'gcc, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
 
         // This capacity calculation is approximate.
         let mut argument_tys = Vec::with_capacity(
-            self.args.len() + if let PassMode::Indirect { .. } = self.ret.mode { 1 } else { 0 }
+            self.args.len() + matches!(self.ret.mode, PassMode::Indirect { .. }) as usize
         );
 
         let return_type =

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -325,7 +325,7 @@ impl<'ll, 'tcx> FnAbiLlvmExt<'ll, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
 
         // This capacity calculation is approximate.
         let mut llargument_tys = Vec::with_capacity(
-            self.args.len() + if let PassMode::Indirect { .. } = self.ret.mode { 1 } else { 0 },
+            self.args.len() + matches!(self.ret.mode, PassMode::Indirect { .. }) as usize,
         );
 
         let llreturn_ty = match &self.ret.mode {

--- a/compiler/rustc_codegen_ssa/src/assert_module_sources.rs
+++ b/compiler/rustc_codegen_ssa/src/assert_module_sources.rs
@@ -279,7 +279,7 @@ impl CguReuseTracker {
                     };
 
                     if error {
-                        let at_least = if at_least { 1 } else { 0 };
+                        let at_least = at_least as u8;
                         sess.dcx().emit_err(errors::IncorrectCguReuseType {
                             span: *error_span,
                             cgu_user_name,

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1341,8 +1341,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
         // How many LLVM worker threads are running in total. This *includes*
         // any that the main thread is lending a Token to.
         let running_with_any_token = |main_thread_state, running_with_own_token| {
-            running_with_own_token
-                + if main_thread_state == MainThreadState::Lending { 1 } else { 0 }
+            running_with_own_token + (main_thread_state == MainThreadState::Lending) as usize
         };
 
         let mut llvm_start_time: Option<VerboseTimingGuard<'_>> = None;

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -647,7 +647,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     // If `with_caller_location` is set we pretend there is an extra argument (that
                     // we will not pass).
                     assert_eq!(
-                        caller_args.len() + if with_caller_location { 1 } else { 0 },
+                        caller_args.len() + with_caller_location as usize,
                         caller_fn_abi.args.len(),
                         "mismatch between caller ABI and caller arguments",
                     );

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -534,7 +534,7 @@ pub enum Compilation {
 fn handle_explain(early_dcx: &EarlyDiagCtxt, registry: Registry, code: &str, color: ColorConfig) {
     // Allow "E0123" or "0123" form.
     let upper_cased_code = code.to_ascii_uppercase();
-    let start = if upper_cased_code.starts_with('E') { 1 } else { 0 };
+    let start = upper_cased_code.starts_with('E') as usize;
     if let Ok(code) = upper_cased_code[start..].parse::<u32>()
         && let Ok(description) = registry.try_find_description(ErrCode::from_u32(code))
     {

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2535,7 +2535,7 @@ fn num_overlap(
     b_end: usize,
     inclusive: bool,
 ) -> bool {
-    let extra = if inclusive { 1 } else { 0 };
+    let extra = inclusive as usize;
     (b_start..b_end + extra).contains(&a_start) || (a_start..a_end + extra).contains(&b_start)
 }
 

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1570,7 +1570,7 @@ fn check_fn_or_method<'tcx>(
     if sig.abi == Abi::RustCall {
         let span = tcx.def_span(def_id);
         let has_implicit_self = hir_decl.implicit_self != hir::ImplicitSelfKind::None;
-        let mut inputs = sig.inputs().iter().skip(if has_implicit_self { 1 } else { 0 });
+        let mut inputs = sig.inputs().iter().skip(has_implicit_self as usize);
         // Check that the argument is a tuple and is sized
         if let Some(ty) = inputs.next() {
             wfcx.register_bound(

--- a/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
@@ -758,7 +758,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
         let trait_generics = self.tcx.generics_of(trait_);
         let num_trait_generics_except_self =
-            trait_generics.count() - if trait_generics.has_self { 1 } else { 0 };
+            trait_generics.count() - trait_generics.has_self as usize;
 
         let msg = format!(
             "consider moving {these} generic argument{s} to the `{name}` trait, which takes up to {num} argument{s}",

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -1104,9 +1104,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 return;
             }
             let fn_sig = fn_ty.fn_sig(self.tcx).skip_binder();
-            let Some(&arg) = fn_sig
-                .inputs()
-                .get(arg_idx + if matches!(kind, CallableKind::Method) { 1 } else { 0 })
+            let Some(&arg) =
+                fn_sig.inputs().get(arg_idx + matches!(kind, CallableKind::Method) as usize)
             else {
                 return;
             };

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -2152,7 +2152,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .and_then(|node| node.body_id())
                 .into_iter()
                 .flat_map(|id| self.tcx.hir().body(id).params)
-                .skip(if is_method { 1 } else { 0 });
+                .skip(is_method as usize);
 
             for (_, param) in params
                 .into_iter()

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -398,7 +398,7 @@ fn get_type_suggestion(t: Ty<'_>, val: u128, negative: bool) -> Option<&'static 
         ($ty:expr, $val:expr, $negative:expr,
          $($type:ident => [$($utypes:expr),*] => [$($itypes:expr),*]),+) => {
             {
-                let _neg = if negative { 1 } else { 0 };
+                let _neg = negative as u128;
                 match $ty {
                     $($type => {
                         $(if !negative && val <= uint_ty_range($utypes).1 {

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -478,7 +478,7 @@ impl<'a> Parser<'a> {
         } else {
             description = "expected `'}'` but string was terminated".to_owned();
             // point at closing `"`
-            pos = self.input.len() - if self.append_newline { 1 } else { 0 };
+            pos = self.input.len() - self.append_newline as usize;
         }
 
         let pos = self.to_span_index(pos);

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -394,11 +394,10 @@ where
         .min_by_key(|v| {
             let (span, query) = f(v);
             let hash = query.query(query_map).hash;
-            // Prefer entry points which have valid spans for nicer error messages
-            // We add an integer to the tuple ensuring that entry points
-            // with valid spans are picked first
-            let span_cmp = if span == DUMMY_SP { 1 } else { 0 };
-            (span_cmp, hash)
+            // Prefer entry points which have valid spans for nicer error messages.
+            // We add an bool to the tuple ensuring that entry points with valid
+            // spans are picked first.
+            (span.is_dummy(), hash)
         })
         .unwrap()
 }

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -55,7 +55,7 @@ pub trait Encoder {
 
     #[inline]
     fn emit_bool(&mut self, v: bool) {
-        self.emit_u8(if v { 1 } else { 0 });
+        self.emit_u8(v as u8);
     }
 
     #[inline]


### PR DESCRIPTION
This is of course subjective, but I think that's nicer. There are also similar occurrences in tools and libraries, but since different people will review those I don't think it makes sense to cramp everything into the same PR.

`if b { 1 } else { 0 }` could also be written as `!b as _`, but in cases found in the compiler I felt that it would be more confusing than helpful.