### PR TITLE
Downgrade const eval dangling ptr in final to future incompat lint

### DIFF
--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -25,10 +25,13 @@ pub(crate) struct DanglingPtrInFinal {
     pub kind: InternKind,
 }
 
-#[derive(Diagnostic)]
+#[derive(LintDiagnostic)]
 #[diag(const_eval_mutable_ptr_in_final)]
 pub(crate) struct MutablePtrInFinal {
-    #[primary_span]
+    // rust-lang/rust#122153: This was marked as `#[primary_span]` under
+    // `derive(Diagnostic)`. Since we expect we may hard-error in future, we are
+    // keeping the field (and skipping it under `derive(LintDiagnostic)`).
+    #[skip_arg]
     pub span: Span,
     pub kind: InternKind,
 }

--- a/compiler/rustc_const_eval/src/interpret/intern.rs
+++ b/compiler/rustc_const_eval/src/interpret/intern.rs
@@ -21,9 +21,9 @@ use rustc_hir as hir;
 use rustc_middle::mir::interpret::{ConstAllocation, CtfeProvenance, InterpResult};
 use rustc_middle::query::TyCtxtAt;
 use rustc_middle::ty::layout::TyAndLayout;
+use rustc_session::lint;
 use rustc_span::def_id::LocalDefId;
 use rustc_span::sym;
-use rustc_session::lint;
 
 use super::{AllocId, Allocation, InterpCx, MPlaceTy, Machine, MemoryKind, PlaceTy};
 use crate::const_eval;

--- a/compiler/rustc_const_eval/src/interpret/intern.rs
+++ b/compiler/rustc_const_eval/src/interpret/intern.rs
@@ -23,6 +23,7 @@ use rustc_middle::query::TyCtxtAt;
 use rustc_middle::ty::layout::TyAndLayout;
 use rustc_span::def_id::LocalDefId;
 use rustc_span::sym;
+use rustc_session::lint;
 
 use super::{AllocId, Allocation, InterpCx, MPlaceTy, Machine, MemoryKind, PlaceTy};
 use crate::const_eval;
@@ -262,10 +263,13 @@ pub fn intern_const_alloc_recursive<
         })?);
     }
     if found_bad_mutable_pointer {
-        return Err(ecx
-            .tcx
-            .dcx()
-            .emit_err(MutablePtrInFinal { span: ecx.tcx.span, kind: intern_kind }));
+        let err_diag = MutablePtrInFinal { span: ecx.tcx.span, kind: intern_kind };
+        ecx.tcx.emit_node_span_lint(
+            lint::builtin::CONST_EVAL_MUTABLE_PTR_IN_FINAL_VALUE,
+            ecx.best_lint_scope(),
+            err_diag.span,
+            err_diag,
+        )
     }
 
     Ok(())

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2819,10 +2819,18 @@ declare_lint! {
     /// }
     /// ```
     ///
+    /// ### Explanation
+    ///
+    /// In the 1.77 release, the const evaluation machinery adopted some
+    /// stricter rules to reject expressions with values that could
+    /// end up holding mutable references to state stored in static memory
+    /// (which is inherently immutable).
+    ///
     /// This is a [future-incompatible] lint to ease the transition to an error.
     /// See [issue #122153] for more details.
     ///
     /// [issue #122153]: https://github.com/rust-lang/rust/issues/122153
+    /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub CONST_EVAL_MUTABLE_PTR_IN_FINAL_VALUE,
     Warn,
     "detects a mutable pointer that has leaked into final value of a const expression",

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2819,6 +2819,8 @@ declare_lint! {
     /// }
     /// ```
     ///
+    /// {{produces}}
+    ///
     /// ### Explanation
     ///
     /// In the 1.77 release, the const evaluation machinery adopted some

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -30,6 +30,7 @@ declare_lint_pass! {
         CENUM_IMPL_DROP_CAST,
         COHERENCE_LEAK_CHECK,
         CONFLICTING_REPR_HINTS,
+        CONST_EVAL_MUTABLE_PTR_IN_FINAL_VALUE,
         CONST_EVALUATABLE_UNCHECKED,
         CONST_ITEM_MUTATION,
         DEAD_CODE,
@@ -2794,6 +2795,41 @@ declare_lint! {
     Allow,
     "a lossy pointer to integer cast is used",
     @feature_gate = sym::strict_provenance;
+}
+
+declare_lint! {
+    /// The `const_eval_mutable_ptr_in_final_value` lint detects if a mutable pointer
+    /// has leaked into the final value of a const expression.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// pub enum JsValue {
+    ///     Undefined,
+    ///     Object(std::cell::Cell<bool>),
+    /// }
+    ///
+    /// impl ::std::ops::Drop for JsValue {
+    ///     fn drop(&mut self) {}
+    /// }
+    ///
+    /// const UNDEFINED: &JsValue = &JsValue::Undefined;
+    ///
+    /// fn main() {
+    /// }
+    /// ```
+    ///
+    /// This is a [future-incompatible] lint to ease the transition to an error.
+    /// See [issue #122153] for more details.
+    ///
+    /// [issue #122153]: https://github.com/rust-lang/rust/issues/122153
+    pub CONST_EVAL_MUTABLE_PTR_IN_FINAL_VALUE,
+    Warn,
+    "detects a mutable pointer that has leaked into final value of a const expression",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::FutureReleaseErrorReportInDeps,
+        reference: "issue #122153 <https://github.com/rust-lang/rust/issues/122153>",
+    };
 }
 
 declare_lint! {

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_untyped.rs
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_untyped.rs
@@ -1,9 +1,11 @@
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 #![feature(const_mut_refs)]
+#![deny(const_eval_mutable_ptr_in_final_value)]
 use std::intrinsics;
 
 const BAR: *mut i32 = unsafe { intrinsics::const_allocate(4, 4) as *mut i32 };
 //~^ error: mutable pointer in final value of constant
+//~| WARNING this was previously accepted by the compiler
 
 fn main() {}

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_untyped.stderr
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_untyped.stderr
@@ -1,8 +1,31 @@
 error: encountered mutable pointer in final value of constant
-  --> $DIR/alloc_intrinsic_untyped.rs:6:1
+  --> $DIR/alloc_intrinsic_untyped.rs:7:1
    |
 LL | const BAR: *mut i32 = unsafe { intrinsics::const_allocate(4, 4) as *mut i32 };
    | ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/alloc_intrinsic_untyped.rs:4:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: encountered mutable pointer in final value of constant
+  --> $DIR/alloc_intrinsic_untyped.rs:7:1
+   |
+LL | const BAR: *mut i32 = unsafe { intrinsics::const_allocate(4, 4) as *mut i32 };
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/alloc_intrinsic_untyped.rs:4:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/consts/future-incompat-mutable-in-final-value-issue-121610.rs
+++ b/tests/ui/consts/future-incompat-mutable-in-final-value-issue-121610.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+use std::cell::Cell;
+
+pub enum JsValue {
+    Undefined,
+    Object(Cell<bool>),
+}
+
+impl ::std::ops::Drop for JsValue {
+    fn drop(&mut self) {}
+}
+
+const UNDEFINED: &JsValue = &JsValue::Undefined;
+    //~^ WARN encountered mutable pointer in final value of constant
+    //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+fn main() {
+}

--- a/tests/ui/consts/future-incompat-mutable-in-final-value-issue-121610.stderr
+++ b/tests/ui/consts/future-incompat-mutable-in-final-value-issue-121610.stderr
@@ -1,0 +1,23 @@
+warning: encountered mutable pointer in final value of constant
+  --> $DIR/future-incompat-mutable-in-final-value-issue-121610.rs:13:1
+   |
+LL | const UNDEFINED: &JsValue = &JsValue::Undefined;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+   = note: `#[warn(const_eval_mutable_ptr_in_final_value)]` on by default
+
+warning: 1 warning emitted
+
+Future incompatibility report: Future breakage diagnostic:
+warning: encountered mutable pointer in final value of constant
+  --> $DIR/future-incompat-mutable-in-final-value-issue-121610.rs:13:1
+   |
+LL | const UNDEFINED: &JsValue = &JsValue::Undefined;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+   = note: `#[warn(const_eval_mutable_ptr_in_final_value)]` on by default
+

--- a/tests/ui/consts/miri_unleashed/mutable_references.rs
+++ b/tests/ui/consts/miri_unleashed/mutable_references.rs
@@ -10,7 +10,6 @@ use std::cell::UnsafeCell;
 static FOO: &&mut u32 = &&mut 42;
 //~^ ERROR encountered mutable pointer in final value of static
 //~| WARNING this was previously accepted by the compiler
-//~| ERROR it is undefined behavior to use this value
 
 static BAR: &mut () = &mut ();
 //~^ ERROR encountered mutable pointer in final value of static
@@ -29,7 +28,6 @@ unsafe impl Sync for Meh {}
 static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
 //~^ ERROR encountered mutable pointer in final value of static
 //~| WARNING this was previously accepted by the compiler
-//~| ERROR it is undefined behavior to use this value
 
 static OH_YES: &mut i32 = &mut 42;
 //~^ ERROR encountered mutable pointer in final value of static

--- a/tests/ui/consts/miri_unleashed/mutable_references.rs
+++ b/tests/ui/consts/miri_unleashed/mutable_references.rs
@@ -1,4 +1,7 @@
 //@ compile-flags: -Zunleash-the-miri-inside-of-you
+//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+
 #![deny(const_eval_mutable_ptr_in_final_value)]
 use std::cell::UnsafeCell;
 

--- a/tests/ui/consts/miri_unleashed/mutable_references.rs
+++ b/tests/ui/consts/miri_unleashed/mutable_references.rs
@@ -1,19 +1,23 @@
 //@ compile-flags: -Zunleash-the-miri-inside-of-you
-
+#![deny(const_eval_mutable_ptr_in_final_value)]
 use std::cell::UnsafeCell;
 
 // a test demonstrating what things we could allow with a smarter const qualification
 
 static FOO: &&mut u32 = &&mut 42;
 //~^ ERROR encountered mutable pointer in final value of static
+//~| WARNING this was previously accepted by the compiler
+//~| ERROR it is undefined behavior to use this value
 
 static BAR: &mut () = &mut ();
 //~^ ERROR encountered mutable pointer in final value of static
+//~| WARNING this was previously accepted by the compiler
 
 struct Foo<T>(T);
 
 static BOO: &mut Foo<()> = &mut Foo(());
 //~^ ERROR encountered mutable pointer in final value of static
+//~| WARNING this was previously accepted by the compiler
 
 struct Meh {
     x: &'static UnsafeCell<i32>,
@@ -21,9 +25,13 @@ struct Meh {
 unsafe impl Sync for Meh {}
 static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
 //~^ ERROR encountered mutable pointer in final value of static
+//~| WARNING this was previously accepted by the compiler
+//~| ERROR it is undefined behavior to use this value
 
 static OH_YES: &mut i32 = &mut 42;
 //~^ ERROR encountered mutable pointer in final value of static
+//~| WARNING this was previously accepted by the compiler
+//~| ERROR it is undefined behavior to use this value
 
 fn main() {
     unsafe {

--- a/tests/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references.stderr
@@ -3,33 +3,86 @@ error: encountered mutable pointer in final value of static
    |
 LL | static FOO: &&mut u32 = &&mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references.rs:2:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/mutable_references.rs:7:1
+   |
+LL | static FOO: &&mut u32 = &&mut 42;
+   | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>: encountered mutable reference or box pointing to read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               ╾ALLOC0<imm>╼                         │ ╾──────╼
+           }
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:10:1
+  --> $DIR/mutable_references.rs:12:1
    |
 LL | static BAR: &mut () = &mut ();
    | ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:15:1
+  --> $DIR/mutable_references.rs:18:1
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:22:1
+  --> $DIR/mutable_references.rs:26:1
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/mutable_references.rs:26:1
+   |
+LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
+   | ^^^^^^^^^^^^^^^ constructing invalid value at .x.<deref>: encountered `UnsafeCell` in read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               ╾ALLOC1╼                         │ ╾──────╼
+           }
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:25:1
+  --> $DIR/mutable_references.rs:31:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/mutable_references.rs:31:1
+   |
+LL | static OH_YES: &mut i32 = &mut 42;
+   | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               ╾ALLOC2╼                         │ ╾──────╼
+           }
 
 error[E0594]: cannot assign to `*OH_YES`, as `OH_YES` is an immutable static item
-  --> $DIR/mutable_references.rs:32:5
+  --> $DIR/mutable_references.rs:40:5
    |
 LL |     *OH_YES = 99;
    |     ^^^^^^^^^^^^ cannot assign
@@ -42,26 +95,102 @@ help: skipping check that does not even have a feature gate
 LL | static FOO: &&mut u32 = &&mut 42;
    |                          ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:10:23
+  --> $DIR/mutable_references.rs:12:23
    |
 LL | static BAR: &mut () = &mut ();
    |                       ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:15:28
+  --> $DIR/mutable_references.rs:18:28
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    |                            ^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:22:28
+  --> $DIR/mutable_references.rs:26:28
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    |                            ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:25:27
+  --> $DIR/mutable_references.rs:31:27
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    |                           ^^^^^^^
 
-error: aborting due to 6 previous errors; 1 warning emitted
+error: aborting due to 9 previous errors; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0594`.
+Some errors have detailed explanations: E0080, E0594.
+For more information about an error, try `rustc --explain E0080`.
+Future incompatibility report: Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/mutable_references.rs:7:1
+   |
+LL | static FOO: &&mut u32 = &&mut 42;
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references.rs:2:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/mutable_references.rs:12:1
+   |
+LL | static BAR: &mut () = &mut ();
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references.rs:2:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/mutable_references.rs:18:1
+   |
+LL | static BOO: &mut Foo<()> = &mut Foo(());
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references.rs:2:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/mutable_references.rs:26:1
+   |
+LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
+   | ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references.rs:2:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/mutable_references.rs:31:1
+   |
+LL | static OH_YES: &mut i32 = &mut 42;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references.rs:2:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references.stderr
@@ -12,19 +12,8 @@ note: the lint level is defined here
 LL | #![deny(const_eval_mutable_ptr_in_final_value)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:10:1
-   |
-LL | static FOO: &&mut u32 = &&mut 42;
-   | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>: encountered mutable reference or box pointing to read-only memory
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
-
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:15:1
+  --> $DIR/mutable_references.rs:14:1
    |
 LL | static BAR: &mut () = &mut ();
    | ^^^^^^^^^^^^^^^^^^^
@@ -33,7 +22,7 @@ LL | static BAR: &mut () = &mut ();
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:21:1
+  --> $DIR/mutable_references.rs:20:1
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +31,7 @@ LL | static BOO: &mut Foo<()> = &mut Foo(());
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:29:1
+  --> $DIR/mutable_references.rs:28:1
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^
@@ -50,19 +39,8 @@ LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:29:1
-   |
-LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
-   | ^^^^^^^^^^^^^^^ constructing invalid value at .x.<deref>: encountered `UnsafeCell` in read-only memory
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
-
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:34:1
+  --> $DIR/mutable_references.rs:32:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +49,7 @@ LL | static OH_YES: &mut i32 = &mut 42;
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:34:1
+  --> $DIR/mutable_references.rs:32:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
@@ -82,7 +60,7 @@ LL | static OH_YES: &mut i32 = &mut 42;
            }
 
 error[E0594]: cannot assign to `*OH_YES`, as `OH_YES` is an immutable static item
-  --> $DIR/mutable_references.rs:43:5
+  --> $DIR/mutable_references.rs:41:5
    |
 LL |     *OH_YES = 99;
    |     ^^^^^^^^^^^^ cannot assign
@@ -95,27 +73,27 @@ help: skipping check that does not even have a feature gate
 LL | static FOO: &&mut u32 = &&mut 42;
    |                          ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:15:23
+  --> $DIR/mutable_references.rs:14:23
    |
 LL | static BAR: &mut () = &mut ();
    |                       ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:21:28
+  --> $DIR/mutable_references.rs:20:28
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    |                            ^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:29:28
+  --> $DIR/mutable_references.rs:28:28
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    |                            ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:34:27
+  --> $DIR/mutable_references.rs:32:27
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    |                           ^^^^^^^
 
-error: aborting due to 9 previous errors; 1 warning emitted
+error: aborting due to 7 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0080, E0594.
 For more information about an error, try `rustc --explain E0080`.
@@ -136,7 +114,7 @@ LL | #![deny(const_eval_mutable_ptr_in_final_value)]
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:15:1
+  --> $DIR/mutable_references.rs:14:1
    |
 LL | static BAR: &mut () = &mut ();
    | ^^^^^^^^^^^^^^^^^^^
@@ -151,7 +129,7 @@ LL | #![deny(const_eval_mutable_ptr_in_final_value)]
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:21:1
+  --> $DIR/mutable_references.rs:20:1
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -166,7 +144,7 @@ LL | #![deny(const_eval_mutable_ptr_in_final_value)]
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:29:1
+  --> $DIR/mutable_references.rs:28:1
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^
@@ -181,7 +159,7 @@ LL | #![deny(const_eval_mutable_ptr_in_final_value)]
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:34:1
+  --> $DIR/mutable_references.rs:32:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references.stderr
@@ -1,5 +1,5 @@
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:7:1
+  --> $DIR/mutable_references.rs:10:1
    |
 LL | static FOO: &&mut u32 = &&mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -7,24 +7,24 @@ LL | static FOO: &&mut u32 = &&mut 42;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 note: the lint level is defined here
-  --> $DIR/mutable_references.rs:2:9
+  --> $DIR/mutable_references.rs:5:9
    |
 LL | #![deny(const_eval_mutable_ptr_in_final_value)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:7:1
+  --> $DIR/mutable_references.rs:10:1
    |
 LL | static FOO: &&mut u32 = &&mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>: encountered mutable reference or box pointing to read-only memory
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC0<imm>╼                         │ ╾──────╼
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
            }
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:12:1
+  --> $DIR/mutable_references.rs:15:1
    |
 LL | static BAR: &mut () = &mut ();
    | ^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL | static BAR: &mut () = &mut ();
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:18:1
+  --> $DIR/mutable_references.rs:21:1
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +42,7 @@ LL | static BOO: &mut Foo<()> = &mut Foo(());
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:26:1
+  --> $DIR/mutable_references.rs:29:1
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^
@@ -51,18 +51,18 @@ LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:26:1
+  --> $DIR/mutable_references.rs:29:1
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^ constructing invalid value at .x.<deref>: encountered `UnsafeCell` in read-only memory
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC1╼                         │ ╾──────╼
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
            }
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:31:1
+  --> $DIR/mutable_references.rs:34:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,18 +71,18 @@ LL | static OH_YES: &mut i32 = &mut 42;
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:31:1
+  --> $DIR/mutable_references.rs:34:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC2╼                         │ ╾──────╼
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
            }
 
 error[E0594]: cannot assign to `*OH_YES`, as `OH_YES` is an immutable static item
-  --> $DIR/mutable_references.rs:40:5
+  --> $DIR/mutable_references.rs:43:5
    |
 LL |     *OH_YES = 99;
    |     ^^^^^^^^^^^^ cannot assign
@@ -90,27 +90,27 @@ LL |     *OH_YES = 99;
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:7:26
+  --> $DIR/mutable_references.rs:10:26
    |
 LL | static FOO: &&mut u32 = &&mut 42;
    |                          ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:12:23
+  --> $DIR/mutable_references.rs:15:23
    |
 LL | static BAR: &mut () = &mut ();
    |                       ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:18:28
+  --> $DIR/mutable_references.rs:21:28
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    |                            ^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:26:28
+  --> $DIR/mutable_references.rs:29:28
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    |                            ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:31:27
+  --> $DIR/mutable_references.rs:34:27
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    |                           ^^^^^^^
@@ -121,7 +121,7 @@ Some errors have detailed explanations: E0080, E0594.
 For more information about an error, try `rustc --explain E0080`.
 Future incompatibility report: Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:7:1
+  --> $DIR/mutable_references.rs:10:1
    |
 LL | static FOO: &&mut u32 = &&mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -129,14 +129,14 @@ LL | static FOO: &&mut u32 = &&mut 42;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 note: the lint level is defined here
-  --> $DIR/mutable_references.rs:2:9
+  --> $DIR/mutable_references.rs:5:9
    |
 LL | #![deny(const_eval_mutable_ptr_in_final_value)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:12:1
+  --> $DIR/mutable_references.rs:15:1
    |
 LL | static BAR: &mut () = &mut ();
    | ^^^^^^^^^^^^^^^^^^^
@@ -144,14 +144,14 @@ LL | static BAR: &mut () = &mut ();
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 note: the lint level is defined here
-  --> $DIR/mutable_references.rs:2:9
+  --> $DIR/mutable_references.rs:5:9
    |
 LL | #![deny(const_eval_mutable_ptr_in_final_value)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:18:1
+  --> $DIR/mutable_references.rs:21:1
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,14 +159,14 @@ LL | static BOO: &mut Foo<()> = &mut Foo(());
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 note: the lint level is defined here
-  --> $DIR/mutable_references.rs:2:9
+  --> $DIR/mutable_references.rs:5:9
    |
 LL | #![deny(const_eval_mutable_ptr_in_final_value)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:26:1
+  --> $DIR/mutable_references.rs:29:1
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^
@@ -174,14 +174,14 @@ LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 note: the lint level is defined here
-  --> $DIR/mutable_references.rs:2:9
+  --> $DIR/mutable_references.rs:5:9
    |
 LL | #![deny(const_eval_mutable_ptr_in_final_value)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:31:1
+  --> $DIR/mutable_references.rs:34:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -189,7 +189,7 @@ LL | static OH_YES: &mut i32 = &mut 42;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 note: the lint level is defined here
-  --> $DIR/mutable_references.rs:2:9
+  --> $DIR/mutable_references.rs:5:9
    |
 LL | #![deny(const_eval_mutable_ptr_in_final_value)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/miri_unleashed/mutable_references_err.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references_err.stderr
@@ -3,15 +3,48 @@ error: encountered mutable pointer in final value of constant
    |
 LL | const MUH: Meh = Meh {
    | ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references_err.rs:5:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/mutable_references_err.rs:18:1
+   |
+LL | const MUH: Meh = Meh {
+   | ^^^^^^^^^^^^^^ constructing invalid value at .x.<deref>: encountered `UnsafeCell` in read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
+           }
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:29:1
+  --> $DIR/mutable_references_err.rs:31:1
    |
 LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references_err.rs:34:1
+  --> $DIR/mutable_references_err.rs:31:1
+   |
+LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.<dyn-downcast>.x: encountered `UnsafeCell` in read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/mutable_references_err.rs:38:1
    |
 LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`
@@ -22,13 +55,27 @@ LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
            }
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:37:1
+  --> $DIR/mutable_references_err.rs:42:1
    |
 LL | const BLUNT: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/mutable_references_err.rs:42:1
+   |
+LL | const BLUNT: &mut i32 = &mut 42;
+   | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/mutable_references_err.rs:49:1
    |
 LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const _ as *mut _) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
@@ -39,7 +86,7 @@ LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const 
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references_err.rs:49:1
+  --> $DIR/mutable_references_err.rs:56:1
    |
 LL | const POINTS_TO_MUTABLE1: &i32 = unsafe { &MUTABLE };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`
@@ -50,131 +97,284 @@ LL | const POINTS_TO_MUTABLE1: &i32 = unsafe { &MUTABLE };
            }
 
 note: erroneous constant encountered
-  --> $DIR/mutable_references_err.rs:51:34
+  --> $DIR/mutable_references_err.rs:58:34
    |
 LL | const READS_FROM_MUTABLE: i32 = *POINTS_TO_MUTABLE1;
    |                                  ^^^^^^^^^^^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/mutable_references_err.rs:53:43
+  --> $DIR/mutable_references_err.rs:60:43
    |
 LL | const POINTS_TO_MUTABLE2: &i32 = unsafe { &*MUTABLE_REF };
    |                                           ^^^^^^^^^^^^^ constant accesses mutable global memory
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:57:1
+  --> $DIR/mutable_references_err.rs:64:1
    |
 LL | const POINTS_TO_MUTABLE_INNER: *const i32 = &mut 42 as *mut _ as *const _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:59:1
+  --> $DIR/mutable_references_err.rs:68:1
    |
 LL | const POINTS_TO_MUTABLE_INNER2: *const i32 = &mut 42 as *const _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:61:1
+  --> $DIR/mutable_references_err.rs:72:1
    |
 LL | const INTERIOR_MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:73:1
+  --> $DIR/mutable_references_err.rs:85:1
    |
 LL | const RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:75:1
+  --> $DIR/mutable_references_err.rs:89:1
    |
 LL | const RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x: &mut 42 as *mut _ as *const _ };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:77:1
+  --> $DIR/mutable_references_err.rs:93:1
    |
 LL | const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:20:8
+  --> $DIR/mutable_references_err.rs:22:8
    |
 LL |     x: &UnsafeCell::new(42),
    |        ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:29:27
+  --> $DIR/mutable_references_err.rs:31:27
    |
 LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:34:40
+  --> $DIR/mutable_references_err.rs:38:40
    |
 LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
    |                                        ^^^
 help: skipping check for `const_mut_refs` feature
-  --> $DIR/mutable_references_err.rs:34:35
+  --> $DIR/mutable_references_err.rs:38:35
    |
 LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
    |                                   ^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:37:25
+  --> $DIR/mutable_references_err.rs:42:25
    |
 LL | const BLUNT: &mut i32 = &mut 42;
    |                         ^^^^^^^
 help: skipping check for `const_mut_refs` feature
-  --> $DIR/mutable_references_err.rs:42:49
+  --> $DIR/mutable_references_err.rs:49:49
    |
 LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const _ as *mut _) };
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_mut_refs` feature
-  --> $DIR/mutable_references_err.rs:42:49
+  --> $DIR/mutable_references_err.rs:49:49
    |
 LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const _ as *mut _) };
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:49:44
+  --> $DIR/mutable_references_err.rs:56:44
    |
 LL | const POINTS_TO_MUTABLE1: &i32 = unsafe { &MUTABLE };
    |                                            ^^^^^^^
 help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:53:45
+  --> $DIR/mutable_references_err.rs:60:45
    |
 LL | const POINTS_TO_MUTABLE2: &i32 = unsafe { &*MUTABLE_REF };
    |                                             ^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:57:45
+  --> $DIR/mutable_references_err.rs:64:45
    |
 LL | const POINTS_TO_MUTABLE_INNER: *const i32 = &mut 42 as *mut _ as *const _;
    |                                             ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:59:46
+  --> $DIR/mutable_references_err.rs:68:46
    |
 LL | const POINTS_TO_MUTABLE_INNER2: *const i32 = &mut 42 as *const _;
    |                                              ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:61:47
+  --> $DIR/mutable_references_err.rs:72:47
    |
 LL | const INTERIOR_MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    |                                               ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:73:51
+  --> $DIR/mutable_references_err.rs:85:51
    |
 LL | const RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    |                                                   ^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:75:49
+  --> $DIR/mutable_references_err.rs:89:49
    |
 LL | const RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x: &mut 42 as *mut _ as *const _ };
    |                                                 ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:77:51
+  --> $DIR/mutable_references_err.rs:93:51
    |
 LL | const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                   ^^^^^^
 
-error: aborting due to 13 previous errors; 1 warning emitted
+error: aborting due to 16 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.
+Future incompatibility report: Future breakage diagnostic:
+error: encountered mutable pointer in final value of constant
+  --> $DIR/mutable_references_err.rs:18:1
+   |
+LL | const MUH: Meh = Meh {
+   | ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references_err.rs:5:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of constant
+  --> $DIR/mutable_references_err.rs:31:1
+   |
+LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references_err.rs:5:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of constant
+  --> $DIR/mutable_references_err.rs:42:1
+   |
+LL | const BLUNT: &mut i32 = &mut 42;
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references_err.rs:5:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of constant
+  --> $DIR/mutable_references_err.rs:64:1
+   |
+LL | const POINTS_TO_MUTABLE_INNER: *const i32 = &mut 42 as *mut _ as *const _;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references_err.rs:5:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of constant
+  --> $DIR/mutable_references_err.rs:68:1
+   |
+LL | const POINTS_TO_MUTABLE_INNER2: *const i32 = &mut 42 as *const _;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references_err.rs:5:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of constant
+  --> $DIR/mutable_references_err.rs:72:1
+   |
+LL | const INTERIOR_MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references_err.rs:5:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of constant
+  --> $DIR/mutable_references_err.rs:85:1
+   |
+LL | const RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references_err.rs:5:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of constant
+  --> $DIR/mutable_references_err.rs:89:1
+   |
+LL | const RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x: &mut 42 as *mut _ as *const _ };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references_err.rs:5:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of constant
+  --> $DIR/mutable_references_err.rs:93:1
+   |
+LL | const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/mutable_references_err.rs:5:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.32bit.stderr
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.32bit.stderr
@@ -3,42 +3,90 @@ error: encountered mutable pointer in final value of static
    |
 LL | static REF: &AtomicI32 = &AtomicI32::new(42);
    | ^^^^^^^^^^^^^^^^^^^^^^
-
-error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:10:1
    |
-LL | static REFMUT: &mut i32 = &mut 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of static
   --> $DIR/static-no-inner-mut.rs:13:1
    |
-LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
+LL | static REFMUT: &mut i32 = &mut 0;
    | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/static-no-inner-mut.rs:13:1
+   |
+LL | static REFMUT: &mut i32 = &mut 0;
+   | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 4, align: 4) {
+               ╾ALLOC0╼                                     │ ╾──╼
+           }
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:14:1
+  --> $DIR/static-no-inner-mut.rs:19:1
+   |
+LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:23:1
    |
 LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
    | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/static-no-inner-mut.rs:23:1
+   |
+LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 4, align: 4) {
+               ╾ALLOC1╼                                     │ ╾──╼
+           }
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:29:1
+  --> $DIR/static-no-inner-mut.rs:41:1
    |
 LL | static RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:31:1
+  --> $DIR/static-no-inner-mut.rs:45:1
    |
 LL | static RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:33:1
+  --> $DIR/static-no-inner-mut.rs:49:1
    |
 LL | static RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 warning: skipping const checks
    |
@@ -48,35 +96,141 @@ help: skipping check that does not even have a feature gate
 LL | static REF: &AtomicI32 = &AtomicI32::new(42);
    |                          ^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:10:27
+  --> $DIR/static-no-inner-mut.rs:13:27
    |
 LL | static REFMUT: &mut i32 = &mut 0;
    |                           ^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:13:56
+  --> $DIR/static-no-inner-mut.rs:19:56
    |
 LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
    |                                                        ^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:14:44
+  --> $DIR/static-no-inner-mut.rs:23:44
    |
 LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
    |                                            ^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:29:52
+  --> $DIR/static-no-inner-mut.rs:41:52
    |
 LL | static RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    |                                                    ^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:31:51
+  --> $DIR/static-no-inner-mut.rs:45:51
    |
 LL | static RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    |                                                   ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:33:52
+  --> $DIR/static-no-inner-mut.rs:49:52
    |
 LL | static RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                    ^^^^^^
 
-error: aborting due to 7 previous errors; 1 warning emitted
+error: aborting due to 9 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0080`.
+Future incompatibility report: Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:9:1
+   |
+LL | static REF: &AtomicI32 = &AtomicI32::new(42);
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:13:1
+   |
+LL | static REFMUT: &mut i32 = &mut 0;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:19:1
+   |
+LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:23:1
+   |
+LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:41:1
+   |
+LL | static RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:45:1
+   |
+LL | static RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:49:1
+   |
+LL | static RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.64bit.stderr
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.64bit.stderr
@@ -12,11 +12,20 @@ note: the lint level is defined here
 LL | #![deny(const_eval_mutable_ptr_in_final_value)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/static-no-inner-mut.rs:9:1
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:13:1
    |
-LL | static REF: &AtomicI32 = &AtomicI32::new(42);
-   | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.v: encountered `UnsafeCell` in read-only memory
+LL | static REFMUT: &mut i32 = &mut 0;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/static-no-inner-mut.rs:13:1
+   |
+LL | static REFMUT: &mut i32 = &mut 0;
+   | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
@@ -24,27 +33,7 @@ LL | static REF: &AtomicI32 = &AtomicI32::new(42);
            }
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:14:1
-   |
-LL | static REFMUT: &mut i32 = &mut 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
-
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/static-no-inner-mut.rs:14:1
-   |
-LL | static REFMUT: &mut i32 = &mut 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC1╼                         │ ╾──────╼
-           }
-
-error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:20:1
+  --> $DIR/static-no-inner-mut.rs:19:1
    |
 LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,19 +41,8 @@ LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/static-no-inner-mut.rs:20:1
-   |
-LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
-   | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.v: encountered `UnsafeCell` in read-only memory
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC2╼                         │ ╾──────╼
-           }
-
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:25:1
+  --> $DIR/static-no-inner-mut.rs:23:1
    |
 LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,18 +51,18 @@ LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/static-no-inner-mut.rs:25:1
+  --> $DIR/static-no-inner-mut.rs:23:1
    |
 LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
    | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC3╼                         │ ╾──────╼
+               ╾ALLOC1╼                         │ ╾──────╼
            }
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:43:1
+  --> $DIR/static-no-inner-mut.rs:41:1
    |
 LL | static RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,7 +71,7 @@ LL | static RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:47:1
+  --> $DIR/static-no-inner-mut.rs:45:1
    |
 LL | static RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -102,7 +80,7 @@ LL | static RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *con
    = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:51:1
+  --> $DIR/static-no-inner-mut.rs:49:1
    |
 LL | static RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,37 +96,37 @@ help: skipping check that does not even have a feature gate
 LL | static REF: &AtomicI32 = &AtomicI32::new(42);
    |                          ^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:14:27
+  --> $DIR/static-no-inner-mut.rs:13:27
    |
 LL | static REFMUT: &mut i32 = &mut 0;
    |                           ^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:20:56
+  --> $DIR/static-no-inner-mut.rs:19:56
    |
 LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
    |                                                        ^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:25:44
+  --> $DIR/static-no-inner-mut.rs:23:44
    |
 LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
    |                                            ^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:43:52
+  --> $DIR/static-no-inner-mut.rs:41:52
    |
 LL | static RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    |                                                    ^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:47:51
+  --> $DIR/static-no-inner-mut.rs:45:51
    |
 LL | static RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    |                                                   ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:51:52
+  --> $DIR/static-no-inner-mut.rs:49:52
    |
 LL | static RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                    ^^^^^^
 
-error: aborting due to 11 previous errors; 1 warning emitted
+error: aborting due to 9 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.
 Future incompatibility report: Future breakage diagnostic:
@@ -168,7 +146,7 @@ LL | #![deny(const_eval_mutable_ptr_in_final_value)]
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:14:1
+  --> $DIR/static-no-inner-mut.rs:13:1
    |
 LL | static REFMUT: &mut i32 = &mut 0;
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,7 +161,7 @@ LL | #![deny(const_eval_mutable_ptr_in_final_value)]
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:20:1
+  --> $DIR/static-no-inner-mut.rs:19:1
    |
 LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -198,7 +176,7 @@ LL | #![deny(const_eval_mutable_ptr_in_final_value)]
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:25:1
+  --> $DIR/static-no-inner-mut.rs:23:1
    |
 LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -213,7 +191,7 @@ LL | #![deny(const_eval_mutable_ptr_in_final_value)]
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:43:1
+  --> $DIR/static-no-inner-mut.rs:41:1
    |
 LL | static RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -228,7 +206,7 @@ LL | #![deny(const_eval_mutable_ptr_in_final_value)]
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:47:1
+  --> $DIR/static-no-inner-mut.rs:45:1
    |
 LL | static RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -243,7 +221,7 @@ LL | #![deny(const_eval_mutable_ptr_in_final_value)]
 
 Future breakage diagnostic:
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:51:1
+  --> $DIR/static-no-inner-mut.rs:49:1
    |
 LL | static RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.64bit.stderr
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.64bit.stderr
@@ -3,42 +3,112 @@ error: encountered mutable pointer in final value of static
    |
 LL | static REF: &AtomicI32 = &AtomicI32::new(42);
    | ^^^^^^^^^^^^^^^^^^^^^^
-
-error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:10:1
    |
-LL | static REFMUT: &mut i32 = &mut 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-
-error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:13:1
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
    |
-LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/static-no-inner-mut.rs:9:1
+   |
+LL | static REF: &AtomicI32 = &AtomicI32::new(42);
+   | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.v: encountered `UnsafeCell` in read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               ╾ALLOC0╼                         │ ╾──────╼
+           }
 
 error: encountered mutable pointer in final value of static
   --> $DIR/static-no-inner-mut.rs:14:1
    |
-LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | static REFMUT: &mut i32 = &mut 0;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/static-no-inner-mut.rs:14:1
+   |
+LL | static REFMUT: &mut i32 = &mut 0;
+   | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               ╾ALLOC1╼                         │ ╾──────╼
+           }
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:29:1
+  --> $DIR/static-no-inner-mut.rs:20:1
+   |
+LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/static-no-inner-mut.rs:20:1
+   |
+LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
+   | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.v: encountered `UnsafeCell` in read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               ╾ALLOC2╼                         │ ╾──────╼
+           }
+
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:25:1
+   |
+LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/static-no-inner-mut.rs:25:1
+   |
+LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               ╾ALLOC3╼                         │ ╾──────╼
+           }
+
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:43:1
    |
 LL | static RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:31:1
+  --> $DIR/static-no-inner-mut.rs:47:1
    |
 LL | static RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/static-no-inner-mut.rs:33:1
+  --> $DIR/static-no-inner-mut.rs:51:1
    |
 LL | static RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
 
 warning: skipping const checks
    |
@@ -48,35 +118,141 @@ help: skipping check that does not even have a feature gate
 LL | static REF: &AtomicI32 = &AtomicI32::new(42);
    |                          ^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:10:27
+  --> $DIR/static-no-inner-mut.rs:14:27
    |
 LL | static REFMUT: &mut i32 = &mut 0;
    |                           ^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:13:56
+  --> $DIR/static-no-inner-mut.rs:20:56
    |
 LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
    |                                                        ^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:14:44
+  --> $DIR/static-no-inner-mut.rs:25:44
    |
 LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
    |                                            ^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:29:52
+  --> $DIR/static-no-inner-mut.rs:43:52
    |
 LL | static RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    |                                                    ^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:31:51
+  --> $DIR/static-no-inner-mut.rs:47:51
    |
 LL | static RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    |                                                   ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/static-no-inner-mut.rs:33:52
+  --> $DIR/static-no-inner-mut.rs:51:52
    |
 LL | static RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                    ^^^^^^
 
-error: aborting due to 7 previous errors; 1 warning emitted
+error: aborting due to 11 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0080`.
+Future incompatibility report: Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:9:1
+   |
+LL | static REF: &AtomicI32 = &AtomicI32::new(42);
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:14:1
+   |
+LL | static REFMUT: &mut i32 = &mut 0;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:20:1
+   |
+LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:25:1
+   |
+LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:43:1
+   |
+LL | static RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:47:1
+   |
+LL | static RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+error: encountered mutable pointer in final value of static
+  --> $DIR/static-no-inner-mut.rs:51:1
+   |
+LL | static RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+note: the lint level is defined here
+  --> $DIR/static-no-inner-mut.rs:6:9
+   |
+LL | #![deny(const_eval_mutable_ptr_in_final_value)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.rs
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.rs
@@ -3,15 +3,29 @@
 #![feature(const_refs_to_cell, const_mut_refs)]
 // All "inner" allocations that come with a `static` are interned immutably. This means it is
 // crucial that we do not accept any form of (interior) mutability there.
-
+#![deny(const_eval_mutable_ptr_in_final_value)]
 use std::sync::atomic::*;
 
-static REF: &AtomicI32 = &AtomicI32::new(42); //~ERROR mutable pointer in final value
-static REFMUT: &mut i32 = &mut 0; //~ERROR mutable pointer in final value
+static REF: &AtomicI32 = &AtomicI32::new(42);
+//~^ ERROR mutable pointer in final value
+//~| WARNING this was previously accepted by the compiler
+//~| ERROR it is undefined behavior to use this value
+
+static REFMUT: &mut i32 = &mut 0;
+//~^ ERROR mutable pointer in final value
+//~| WARNING this was previously accepted by the compiler
+//~| ERROR it is undefined behavior to use this value
 
 // Different way of writing this that avoids promotion.
-static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}}; //~ERROR mutable pointer in final value
-static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}}; //~ERROR mutable pointer in final value
+static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
+//~^ ERROR mutable pointer in final value
+//~| WARNING this was previously accepted by the compiler
+//~| ERROR it is undefined behavior to use this value
+
+static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
+//~^ ERROR mutable pointer in final value
+//~| WARNING this was previously accepted by the compiler
+//~| ERROR it is undefined behavior to use this value
 
 // This one is obvious, since it is non-Sync. (It also suppresses the other errors, so it is
 // commented out.)
@@ -28,9 +42,14 @@ unsafe impl<T> Sync for SyncPtr<T> {}
 // non-dangling raw pointers.
 static RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
 //~^ ERROR mutable pointer in final value
+//~| WARNING this was previously accepted by the compiler
+
 static RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
 //~^ ERROR mutable pointer in final value
+//~| WARNING this was previously accepted by the compiler
+
 static RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
 //~^ ERROR mutable pointer in final value
+//~| WARNING this was previously accepted by the compiler
 
 fn main() {}

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.rs
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.rs
@@ -9,7 +9,6 @@ use std::sync::atomic::*;
 static REF: &AtomicI32 = &AtomicI32::new(42);
 //~^ ERROR mutable pointer in final value
 //~| WARNING this was previously accepted by the compiler
-//~| ERROR it is undefined behavior to use this value
 
 static REFMUT: &mut i32 = &mut 0;
 //~^ ERROR mutable pointer in final value
@@ -20,7 +19,6 @@ static REFMUT: &mut i32 = &mut 0;
 static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
 //~^ ERROR mutable pointer in final value
 //~| WARNING this was previously accepted by the compiler
-//~| ERROR it is undefined behavior to use this value
 
 static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
 //~^ ERROR mutable pointer in final value

--- a/tests/ui/consts/refs-to-cell-in-final.rs
+++ b/tests/ui/consts/refs-to-cell-in-final.rs
@@ -28,7 +28,8 @@ impl Drop for JsValue {
     fn drop(&mut self) {}
 }
 const UNDEFINED: &JsValue = &JsValue::Undefined;
-//~^ERROR: mutable pointer in final value of constant
+//~^ WARNING: mutable pointer in final value of constant
+//~| WARNING: this was previously accepted by the compiler but is being phased out
 
 // In contrast, this one works since it is being promoted.
 const NONE: &'static Option<Cell<i32>> = &None;

--- a/tests/ui/consts/refs-to-cell-in-final.stderr
+++ b/tests/ui/consts/refs-to-cell-in-final.stderr
@@ -12,12 +12,27 @@ error[E0492]: constants cannot refer to interior mutable data
 LL | const RAW_SYNC_C: SyncPtr<Cell<i32>> = SyncPtr { x: &Cell::new(42) };
    |                                                     ^^^^^^^^^^^^^^ this borrow of an interior mutable value may end up in the final value
 
-error: encountered mutable pointer in final value of constant
+warning: encountered mutable pointer in final value of constant
   --> $DIR/refs-to-cell-in-final.rs:30:1
    |
 LL | const UNDEFINED: &JsValue = &JsValue::Undefined;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+   = note: `#[warn(const_eval_mutable_ptr_in_final_value)]` on by default
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0492`.
+Future incompatibility report: Future breakage diagnostic:
+warning: encountered mutable pointer in final value of constant
+  --> $DIR/refs-to-cell-in-final.rs:30:1
+   |
+LL | const UNDEFINED: &JsValue = &JsValue::Undefined;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #122153 <https://github.com/rust-lang/rust/issues/122153>
+   = note: `#[warn(const_eval_mutable_ptr_in_final_value)]` on by default
+


### PR DESCRIPTION
Short term band-aid for issue #121610, downgrading the prior hard error to a future-incompat lint (tracked in issue #122153).

Note we should not mark #121610 as resolved until after this (or something analogous) is beta backported.