### PR TITLE
fix incorrect path resolution in tidy

### DIFF
--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
         check!(tests_placement, &root_path);
         check!(tests_revision_unpaired_stdout_stderr, &tests_path);
         check!(debug_artifacts, &tests_path);
-        check!(ui_tests, &tests_path, bless);
+        check!(ui_tests, &root_path, bless);
         check!(mir_opt_tests, &tests_path, bless);
         check!(rustdoc_gui_tests, &tests_path);
         check!(rustdoc_css_themes, &librustdoc_path);

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -99,7 +99,8 @@ fn check_entries(tests_path: &Path, bad: &mut bool) {
     }
 }
 
-pub fn check(path: &Path, bless: bool, bad: &mut bool) {
+pub fn check(root_path: &Path, bless: bool, bad: &mut bool) {
+    let path = &root_path.join("tests");
     check_entries(&path, bad);
 
     // the list of files in ui tests that are allowed to start with `issue-XXXX`
@@ -193,7 +194,7 @@ pub fn check(path: &Path, bless: bool, bad: &mut bool) {
 */
 [
 "#;
-        let tidy_src = std::env::current_dir().unwrap().join("src/tools/tidy/src");
+        let tidy_src = root_path.join("src/tools/tidy/src");
         // instead of overwriting the file, recreate it and use an "atomic rename"
         // so we don't bork things on panic or a contributor using Ctrl+C
         let blessed_issues_path = tidy_src.join("issues_blessed.txt");


### PR DESCRIPTION
Previously, reading the current path from the environment led to failure when invoking x from outside the source root. This change fixes this issue by passing the already resolved root path into `ui_tests::check`.

Fixes #122202