### PR TITLE
Windows msvc: No libc (take 2)

### DIFF
--- a/library/panic_abort/Cargo.toml
+++ b/library/panic_abort/Cargo.toml
@@ -15,5 +15,7 @@ doc = false
 alloc = { path = "../alloc" }
 cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 core = { path = "../core" }
-libc = { version = "0.2", default-features = false }
 compiler_builtins = "0.1.0"
+
+[target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
+libc = { version = "0.2", default-features = false }

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -48,9 +48,9 @@
 
 use alloc::boxed::Box;
 use core::any::Any;
+use core::ffi::{c_int, c_uint, c_void};
 use core::mem::{self, ManuallyDrop};
 use core::ptr::{addr_of, addr_of_mut};
-use libc::{c_int, c_uint, c_void};
 
 // NOTE(nbdd0121): The `canary` field is part of stable ABI.
 #[repr(C)]

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -11,7 +11,7 @@ use crate::{fmt, io, mem, ptr};
 #[cfg(not(unix))]
 #[allow(non_camel_case_types)]
 mod libc {
-    pub use libc::c_int;
+    pub use core::ffi::c_int;
     pub type socklen_t = u32;
     pub struct sockaddr;
     #[derive(Clone)]

--- a/library/std/src/os/unix/net/ancillary.rs
+++ b/library/std/src/os/unix/net/ancillary.rs
@@ -20,7 +20,7 @@ use crate::sys::net::Socket;
 ))]
 #[allow(non_camel_case_types)]
 mod libc {
-    pub use libc::c_int;
+    pub use core::ffi::c_int;
     pub struct ucred;
     pub struct cmsghdr;
     pub struct sockcred2;

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -33,7 +33,7 @@ use libc::MSG_NOSIGNAL;
     target_os = "haiku",
     target_os = "nto",
 )))]
-const MSG_NOSIGNAL: libc::c_int = 0x0;
+const MSG_NOSIGNAL: core::ffi::c_int = 0x0;
 
 /// A Unix datagram socket.
 ///
@@ -312,7 +312,7 @@ impl UnixDatagram {
     fn recv_from_flags(
         &self,
         buf: &mut [u8],
-        flags: libc::c_int,
+        flags: core::ffi::c_int,
     ) -> io::Result<(usize, SocketAddr)> {
         let mut count = 0;
         let addr = SocketAddr::new(|addr, len| unsafe {

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -79,14 +79,14 @@ impl UnixListener {
                 target_os = "espidf",
                 target_os = "horizon"
             ))]
-            const backlog: libc::c_int = 128;
+            const backlog: core::ffi::c_int = 128;
             #[cfg(any(
                 target_os = "linux",
                 target_os = "freebsd",
                 target_os = "openbsd",
                 target_os = "macos"
             ))]
-            const backlog: libc::c_int = -1;
+            const backlog: core::ffi::c_int = -1;
             #[cfg(not(any(
                 target_os = "windows",
                 target_os = "redox",
@@ -138,9 +138,9 @@ impl UnixListener {
         unsafe {
             let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;
             #[cfg(target_os = "linux")]
-            const backlog: libc::c_int = -1;
+            const backlog: core::ffi::c_int = -1;
             #[cfg(not(target_os = "linux"))]
-            const backlog: libc::c_int = 128;
+            const backlog: core::ffi::c_int = 128;
             cvt(libc::bind(
                 inner.as_raw_fd(),
                 core::ptr::addr_of!(socket_addr.addr) as *const _,

--- a/library/test/Cargo.toml
+++ b/library/test/Cargo.toml
@@ -9,4 +9,6 @@ std = { path = "../std" }
 core = { path = "../core" }
 panic_unwind = { path = "../panic_unwind" }
 panic_abort = { path = "../panic_abort" }
+
+[target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
 libc = { version = "0.2.150", default-features = false }

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -8,6 +8,10 @@
 #![cfg_attr(not(target_env = "msvc"), feature(libc))]
 #![allow(internal_features)]
 
+// Force libc to be included even if unused. This is required by many platforms.
+#[allow(unused_extern_crates)]
+extern crate libc;
+
 cfg_if::cfg_if! {
     if #[cfg(target_env = "msvc")] {
         // Windows MSVC no extra unwinder support needed

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -1,6 +1,6 @@
 #![allow(nonstandard_style)]
 
-use libc::{c_int, c_void};
+use core::ffi::{c_int, c_void};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/library/unwind/src/unwinding.rs
+++ b/library/unwind/src/unwinding.rs
@@ -1,6 +1,6 @@
 #![allow(nonstandard_style)]
 
-use libc::{c_int, c_void};
+use core::ffi::{c_int, c_void};
 
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq)]


### PR DESCRIPTION
We don't use the libc crate on Windows so it makes sense to remove it as a dependency. Note that there's still [one test](https://github.com/rust-lang/rust/blob/01d73d4041969cde4a79bf9793521ef323248a24/library/std/src/os/raw/tests.rs) that relies on libc so I haven't fully removed it from `library/std`'s Cargo.toml yet but I have removed the `extern crate libc` from `library/std/src/lib.rs`.

Also note that this moves the logic for including the C startup/shutdown lib from libc to std (I personally feel this should be a compiler concern but I'm not looking to change that here). See: https://github.com/rust-lang/libc/blob/a0f5b4b21391252fe38b2df9310dc65e37b07d9f/src/windows/mod.rs#L258