### PR TITLE
deref patterns: bare-bones feature gate and typechecking

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -413,7 +413,10 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
             }
             PatKind::Box(..) => {
-                gate!(&self, box_patterns, pattern.span, "box pattern syntax is experimental");
+                if !self.features.deref_patterns {
+                    // Allow box patterns under `deref_patterns`.
+                    gate!(&self, box_patterns, pattern.span, "box pattern syntax is experimental");
+                }
             }
             PatKind::Range(_, Some(_), Spanned { node: RangeEnd::Excluded, .. }) => {
                 gate!(
@@ -607,13 +610,16 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
         };
     }
 
+    if !visitor.features.deref_patterns {
+        // Allow box patterns under `deref_patterns`.
+        gate_all_legacy_dont_use!(box_patterns, "box pattern syntax is experimental");
+    }
     gate_all_legacy_dont_use!(trait_alias, "trait aliases are experimental");
     // Despite being a new feature, `where T: Trait<Assoc(): Sized>`, which is RTN syntax now,
     // used to be gated under associated_type_bounds, which are right above, so RTN needs to
     // be too.
     gate_all_legacy_dont_use!(return_type_notation, "return type notation is experimental");
     gate_all_legacy_dont_use!(decl_macro, "`macro` is experimental");
-    gate_all_legacy_dont_use!(box_patterns, "box pattern syntax is experimental");
     gate_all_legacy_dont_use!(
         exclusive_range_pattern,
         "exclusive range pattern syntax is experimental"

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -436,6 +436,8 @@ declare_features! (
     (unstable, deprecated_safe, "1.61.0", Some(94978)),
     /// Allows having using `suggestion` in the `#[deprecated]` attribute.
     (unstable, deprecated_suggestion, "1.61.0", Some(94785)),
+    /// Allows deref patterns.
+    (incomplete, deref_patterns, "CURRENT_RUSTC_VERSION", Some(87121)),
     /// Controls errors in trait implementations.
     (unstable, do_not_recommend, "1.67.0", Some(51992)),
     /// Tells rustdoc to automatically generate `#[doc(cfg(...))]`.

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -647,6 +647,7 @@ impl<'tcx> Pat<'tcx> {
             AscribeUserType { subpattern, .. }
             | Binding { subpattern: Some(subpattern), .. }
             | Deref { subpattern }
+            | DerefPattern { subpattern }
             | InlineConstant { subpattern, .. } => subpattern.walk_(it),
             Leaf { subpatterns } | Variant { subpatterns, .. } => {
                 subpatterns.iter().for_each(|field| field.pattern.walk_(it))
@@ -759,6 +760,11 @@ pub enum PatKind<'tcx> {
 
     /// `box P`, `&P`, `&mut P`, etc.
     Deref {
+        subpattern: Box<Pat<'tcx>>,
+    },
+
+    /// Deref pattern, written `box P` for now.
+    DerefPattern {
         subpattern: Box<Pat<'tcx>>,
     },
 
@@ -1171,6 +1177,9 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
                     _ => bug!("{} is a bad Deref pattern type", self.ty),
                 }
                 write!(f, "{subpattern}")
+            }
+            PatKind::DerefPattern { ref subpattern } => {
+                write!(f, "k#deref {subpattern}")
             }
             PatKind::Constant { value } => write!(f, "{value}"),
             PatKind::InlineConstant { def: _, ref subpattern } => {

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -229,6 +229,7 @@ pub fn walk_pat<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
     match &pat.kind {
         AscribeUserType { subpattern, ascription: _ }
         | Deref { subpattern }
+        | DerefPattern { subpattern }
         | Binding {
             subpattern: Some(subpattern),
             mutability: _,

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -879,6 +879,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.visit_primary_bindings(subpattern, pattern_user_ty.deref(), f);
             }
 
+            PatKind::DerefPattern { ref subpattern } => {
+                self.visit_primary_bindings(subpattern, UserTypeProjections::none(), f);
+            }
+
             PatKind::AscribeUserType {
                 ref subpattern,
                 ascription: thir::Ascription { ref annotation, variance: _ },

--- a/compiler/rustc_mir_build/src/build/matches/util.rs
+++ b/compiler/rustc_mir_build/src/build/matches/util.rs
@@ -256,6 +256,12 @@ impl<'pat, 'tcx> MatchPair<'pat, 'tcx> {
                 subpairs.push(MatchPair::new(place_builder, subpattern, cx));
                 default_irrefutable()
             }
+
+            PatKind::DerefPattern { .. } => {
+                // FIXME(deref_patterns)
+                // Treat it like a wildcard for now.
+                default_irrefutable()
+            }
         };
 
         MatchPair { place, test_case, subpairs, pattern }

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -250,6 +250,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 | PatKind::Variant { .. }
                 | PatKind::Leaf { .. }
                 | PatKind::Deref { .. }
+                | PatKind::DerefPattern { .. }
                 | PatKind::Range { .. }
                 | PatKind::Slice { .. }
                 | PatKind::Array { .. } => {
@@ -310,7 +311,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 }
                 visit::walk_pat(self, pat);
             }
-            PatKind::Deref { .. } => {
+            PatKind::Deref { .. } | PatKind::DerefPattern { .. } => {
                 let old_inside_adt = std::mem::replace(&mut self.inside_adt, false);
                 visit::walk_pat(self, pat);
                 self.inside_adt = old_inside_adt;

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -257,6 +257,9 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                 return self.lower_path(qpath, pat.hir_id, pat.span);
             }
 
+            hir::PatKind::Box(subpattern) if self.tcx.features().deref_patterns => {
+                PatKind::DerefPattern { subpattern: self.lower_pattern(subpattern) }
+            }
             hir::PatKind::Ref(subpattern, _) | hir::PatKind::Box(subpattern) => {
                 PatKind::Deref { subpattern: self.lower_pattern(subpattern) }
             }

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -688,6 +688,12 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
                 self.print_pat(subpattern, depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl + 1);
             }
+            PatKind::DerefPattern { subpattern } => {
+                print_indented!(self, "DerefPattern { ", depth_lvl + 1);
+                print_indented!(self, "subpattern:", depth_lvl + 2);
+                self.print_pat(subpattern, depth_lvl + 2);
+                print_indented!(self, "}", depth_lvl + 1);
+            }
             PatKind::Constant { value } => {
                 print_indented!(self, "Constant {", depth_lvl + 1);
                 print_indented!(self, format!("value: {:?}", value), depth_lvl + 2);

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -462,6 +462,12 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                     _ => bug!("pattern has unexpected type: pat: {:?}, ty: {:?}", pat, ty),
                 };
             }
+            PatKind::DerefPattern { .. } => {
+                // FIXME(deref_patterns): At least detect that `box _` is irrefutable.
+                fields = vec![];
+                arity = 0;
+                ctor = Opaque(OpaqueId::new());
+            }
             PatKind::Leaf { subpatterns } | PatKind::Variant { subpatterns, .. } => {
                 match ty.kind() {
                     ty::Tuple(fs) => {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -674,6 +674,7 @@ symbols! {
         deref_method,
         deref_mut,
         deref_mut_method,
+        deref_patterns,
         deref_target,
         derive,
         derive_const,

--- a/tests/ui/cfg/cfg-false-feature.stderr
+++ b/tests/ui/cfg/cfg-false-feature.stderr
@@ -1,15 +1,3 @@
-warning: trait aliases are experimental
-  --> $DIR/cfg-false-feature.rs:12:1
-   |
-LL | trait A = Clone;
-   | ^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #41517 <https://github.com/rust-lang/rust/issues/41517> for more information
-   = help: add `#![feature(trait_alias)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
-
 warning: box pattern syntax is experimental
   --> $DIR/cfg-false-feature.rs:16:9
    |
@@ -18,6 +6,18 @@ LL |     let box _ = Box::new(0);
    |
    = note: see issue #29641 <https://github.com/rust-lang/rust/issues/29641> for more information
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = warning: unstable syntax can change at any point in the future, causing a hard error!
+   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+
+warning: trait aliases are experimental
+  --> $DIR/cfg-false-feature.rs:12:1
+   |
+LL | trait A = Clone;
+   | ^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #41517 <https://github.com/rust-lang/rust/issues/41517> for more information
+   = help: add `#![feature(trait_alias)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>

--- a/tests/ui/feature-gates/feature-gate-deref_patterns.rs
+++ b/tests/ui/feature-gates/feature-gate-deref_patterns.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // We reuse the `box` syntax so this doesn't actually test the feature gate but eh.
+    let box x = Box::new('c'); //~ ERROR box pattern syntax is experimental
+    println!("x: {}", x);
+
+    // `box` syntax is allowed to be cfg-ed out for historical reasons (#65742).
+    #[cfg(FALSE)]
+    let box _x = Box::new('c');
+}

--- a/tests/ui/feature-gates/feature-gate-deref_patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-deref_patterns.stderr
@@ -1,0 +1,13 @@
+error[E0658]: box pattern syntax is experimental
+  --> $DIR/feature-gate-deref_patterns.rs:3:9
+   |
+LL |     let box x = Box::new('c');
+   |         ^^^^^
+   |
+   = note: see issue #29641 <https://github.com/rust-lang/rust/issues/29641> for more information
+   = help: add `#![feature(box_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/pattern/deref-patterns/typeck.rs
+++ b/tests/ui/pattern/deref-patterns/typeck.rs
@@ -1,0 +1,31 @@
+//@ check-pass
+#![feature(deref_patterns)]
+#![allow(incomplete_features)]
+
+use std::rc::Rc;
+
+fn main() {
+    let vec: Vec<u32> = Vec::new();
+    match vec {
+        box [..] => {}
+        _ => {}
+    }
+    match Box::new(true) {
+        box true => {}
+        _ => {}
+    }
+    match &Box::new(true) {
+        box true => {}
+        _ => {}
+    }
+    match &Rc::new(0) {
+        box (1..) => {}
+        _ => {}
+    }
+    // FIXME(deref_patterns): fails to typecheck because `"foo"` has type &str but deref creates a
+    // place of type `str`.
+    // match "foo".to_string() {
+    //     box "foo" => {}
+    //     _ => {}
+    // }
+}


### PR DESCRIPTION
I am restarting the deref patterns experimentation. This introduces a feature gate under the lang-team [experimental feature](https://github.com/rust-lang/lang-team/blob/master/src/how_to/experiment.md) process, with [@cramertj as lang-team liaison](https://github.com/rust-lang/lang-team/issues/88) (it's been a while though, you still ok with this @cramertj?). Tracking issue: https://github.com/rust-lang/rust/issues/87121.

This is the barest-bones implementation I could think of:
- explicit syntax, reusing `box <pat>` because that saves me a ton of work;
- use `Deref` as a marker trait (instead of a yet-to-design `DerefPure`);
- no support for mutable patterns with `DerefMut` for now;
- MIR lowering will come in the next PR. It's the trickiest part.

My goal is to let us figure out the MIR lowering part, which might take some work. And hopefully get something working for std types soon.

This is in large part salvaged from @fee1-dead's https://github.com/rust-lang/rust/pull/119467.

r? @compiler-errors 