### PR TITLE
Add test to check unused_lifetimes don't duplicate "parameter is never used" error

### DIFF
--- a/tests/ui/single-use-lifetime/dedup.rs
+++ b/tests/ui/single-use-lifetime/dedup.rs
@@ -1,0 +1,9 @@
+// Check that `unused_lifetimes` lint doesn't duplicate a "parameter is never used" error.
+// Fixed in <https://github.com/rust-lang/rust/pull/96833>.
+// Issue: <https://github.com/rust-lang/rust/issues/72587>.
+
+#![warn(unused_lifetimes)]
+struct Foo<'a>;
+//~^ ERROR parameter `'a` is never used
+
+fn main() {}

--- a/tests/ui/single-use-lifetime/dedup.stderr
+++ b/tests/ui/single-use-lifetime/dedup.stderr
@@ -1,0 +1,11 @@
+error[E0392]: lifetime parameter `'a` is never used
+  --> $DIR/dedup.rs:6:12
+   |
+LL | struct Foo<'a>;
+   |            ^^ unused lifetime parameter
+   |
+   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0392`.


### PR DESCRIPTION
Closes #72587.