### PR TITLE
Use `min_exhaustive_patterns` in core & std

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -203,8 +203,10 @@
 // Language features:
 // tidy-alphabetical-start
 #![cfg_attr(bootstrap, feature(diagnostic_namespace))]
+#![cfg_attr(bootstrap, feature(exhaustive_patterns))]
 #![cfg_attr(bootstrap, feature(platform_intrinsics))]
 #![cfg_attr(not(bootstrap), feature(freeze_impls))]
+#![cfg_attr(not(bootstrap), feature(min_exhaustive_patterns))]
 #![feature(abi_unadjusted)]
 #![feature(adt_const_params)]
 #![feature(allow_internal_unsafe)]
@@ -229,7 +231,6 @@
 #![feature(doc_cfg_hide)]
 #![feature(doc_notable_trait)]
 #![feature(effects)]
-#![feature(exhaustive_patterns)]
 #![feature(extern_types)]
 #![feature(fundamental)]
 #![feature(generic_arg_infer)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -270,7 +270,9 @@
 //
 // Language features:
 // tidy-alphabetical-start
+#![cfg_attr(bootstrap, feature(exhaustive_patterns))]
 #![cfg_attr(bootstrap, feature(platform_intrinsics))]
+#![cfg_attr(not(bootstrap), feature(min_exhaustive_patterns))]
 #![feature(alloc_error_handler)]
 #![feature(allocator_internals)]
 #![feature(allow_internal_unsafe)]
@@ -289,7 +291,6 @@
 #![feature(doc_masked)]
 #![feature(doc_notable_trait)]
 #![feature(dropck_eyepatch)]
-#![feature(exhaustive_patterns)]
 #![feature(if_let_guard)]
 #![feature(intra_doc_pointers)]
 #![feature(lang_items)]

--- a/library/std/src/sync/poison.rs
+++ b/library/std/src/sync/poison.rs
@@ -270,6 +270,8 @@ impl<T> fmt::Debug for TryLockError<T> {
         match *self {
             #[cfg(panic = "unwind")]
             TryLockError::Poisoned(..) => "Poisoned(..)".fmt(f),
+            #[cfg(not(panic = "unwind"))]
+            TryLockError::Poisoned(ref p) => match p._never {},
             TryLockError::WouldBlock => "WouldBlock".fmt(f),
         }
     }
@@ -281,6 +283,8 @@ impl<T> fmt::Display for TryLockError<T> {
         match *self {
             #[cfg(panic = "unwind")]
             TryLockError::Poisoned(..) => "poisoned lock: another task failed inside",
+            #[cfg(not(panic = "unwind"))]
+            TryLockError::Poisoned(ref p) => match p._never {},
             TryLockError::WouldBlock => "try_lock failed because the operation would block",
         }
         .fmt(f)
@@ -294,6 +298,8 @@ impl<T> Error for TryLockError<T> {
         match *self {
             #[cfg(panic = "unwind")]
             TryLockError::Poisoned(ref p) => p.description(),
+            #[cfg(not(panic = "unwind"))]
+            TryLockError::Poisoned(ref p) => match p._never {},
             TryLockError::WouldBlock => "try_lock failed because the operation would block",
         }
     }
@@ -303,6 +309,8 @@ impl<T> Error for TryLockError<T> {
         match *self {
             #[cfg(panic = "unwind")]
             TryLockError::Poisoned(ref p) => Some(p),
+            #[cfg(not(panic = "unwind"))]
+            TryLockError::Poisoned(ref p) => match p._never {},
             _ => None,
         }
     }


### PR DESCRIPTION
[`min_exhaustive_patterns`](https://github.com/rust-lang/rust/issues/119612) provides a subset of the functionality of [`exhaustive_patterns`](https://github.com/rust-lang/rust/issues/51085) which is likely to be stabilized much earlier than the full feature.

The subset covers all the compiler and std use cases. `compiler/` [already uses it](https://github.com/rust-lang/rust/pull/120742/commits/9dd6eda778b5320be1a9fbfb21eae3c1b733e744); this PR switches `std` over.