### PR TITLE
mir-opt tests: run current target on --bless; enable --keep-stage-std

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1549,6 +1549,8 @@ impl Step for MirOpt {
             })
         };
 
+        run(self.target);
+
         if builder.config.cmd.bless() {
             // All that we really need to do is cover all combinations of 32/64-bit and unwind/abort,
             // but while we're at it we might as well flex our cross-compilation support. This
@@ -1567,8 +1569,6 @@ impl Step for MirOpt {
                 });
                 run(panic_abort_target);
             }
-        } else {
-            run(self.target);
         }
     }
 }


### PR DESCRIPTION
Currently, `./x.py test tests/mir-opt` runs only the tests for the current target, and `./x.py test tests/mir-opt --bless` runs tests for a representative set of targets.

I find this confusing and not what I want: for one I never run tests without `--bless` because I prefer to look at a git diff. What I however like to do is pass `--keep-stage-std` when I'm working on the compiler; this doesn't work today with `--bless` because it tries a bunch of targets for which I don't have a built std.

In this PR, I make it so `./x.py test tests/mir-opt` runs the same set of tests regardless of `--bless`. By default it runs a representative sample of targets, and if `--keep-stage-std` is set it only runs tests for the current target.

Fixes https://github.com/rust-lang/rust/issues/122292