### PR TITLE
fix `long-linker-command-lines` failure caused by `rust.rpath=false`

### DIFF
--- a/tests/run-make/long-linker-command-lines/Makefile
+++ b/tests/run-make/long-linker-command-lines/Makefile
@@ -1,6 +1,8 @@
 # ignore-cross-compile
 include ../tools.mk
 
+export LD_LIBRARY_PATH := $(HOST_RPATH_DIR)
+
 all:
 	$(RUSTC) foo.rs -g -O
 	RUSTC="$(RUSTC_ORIGINAL)" $(call RUN,foo)


### PR DESCRIPTION
Fixes `long-linker-command-lines` test failure (which happens when `rust.rpath` is set to `false`) by adjusting `LD_LIBRARY_PATH`.

Fixes https://github.com/rust-lang/rust/issues/90921