### PR TITLE
disable OOM test in Miri

### DIFF
--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -694,6 +694,8 @@ fn read_buf_full_read() {
 }
 
 #[test]
+// Miri does not support signalling OOM
+#[cfg_attr(miri, ignore)]
 // 64-bit only to be sure the allocator will fail fast on an impossible to satsify size
 #[cfg(target_pointer_width = "64")]
 fn try_oom_error() {


### PR DESCRIPTION
Needed for https://github.com/rust-lang/miri-test-libstd