### PR TITLE
BorrowedCursor docs clarification

### DIFF
--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -139,9 +139,11 @@ impl<'data> BorrowedBuf<'data> {
     }
 }
 
-/// A writeable view of the unfilled portion of a [`BorrowedBuf`](BorrowedBuf).
+/// A writeable view of the unfilled portion of a [`BorrowedBuf`].
 ///
-/// Provides access to the initialized and uninitialized parts of the underlying `BorrowedBuf`.
+/// The unfilled portion consists of an initialized and an uninitialized part; see [`BorrowedBuf`]
+/// for details.
+///
 /// Data can be written directly to the cursor by using [`append`](BorrowedCursor::append) or
 /// indirectly by getting a slice of part or all of the cursor and writing into the slice. In the
 /// indirect case, the caller must call [`advance`](BorrowedCursor::advance) after writing to inform


### PR DESCRIPTION
If one reads the `BorrowedCursor` docs without having seen `BorrowedBuf` before, it is quite easy to assume that "unfilled" and "uninit" are synonyms.