### PR TITLE
[Proof of concept] Recover from struct literals with placeholder path 

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -507,6 +507,7 @@ struct DiagCtxtInner {
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum StashKey {
     ItemNoType,
+    StructLitNoType,
     UnderscoreForArrayLengths,
     EarlySyntaxWarning,
     CallIntoMethod,

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -708,6 +708,11 @@ parse_struct_literal_needing_parens =
 parse_struct_literal_not_allowed_here = struct literals are not allowed here
     .suggestion = surround the struct literal with parentheses
 
+parse_struct_literal_placeholder_path =
+    the placeholder `_` is not allowed for the path in struct literals
+    .label = not allowed in struct literals
+    .suggestion = replace it with an appropriate type
+
 parse_suffixed_literal_in_attribute = suffixed literals are not allowed in attributes
     .help = instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2974,3 +2974,12 @@ pub(crate) struct AsyncImpl {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(parse_struct_literal_placeholder_path)]
+pub(crate) struct StructLiteralPlaceholderPath {
+    #[primary_span]
+    #[label]
+    #[suggestion(applicability = "has-placeholders", code = "/*Type*/")]
+    pub span: Span,
+}

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -951,6 +951,10 @@ impl<'a> Parser<'a> {
                             return None;
                         }
                     } else {
+                        // FIXME(fmease): Under certain conditions return a struct literal
+                        // here and stash this diagnostic under StructLitNoType.
+                        // FIXME(fmease): Furthermore don't suggest redundant curly braces
+                        // around the potential struct literal if possible.
                         self.dcx().emit_err(StructLiteralBodyWithoutPath {
                             span: expr.span,
                             sugg: StructLiteralBodyWithoutPathSugg {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4304,6 +4304,13 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
             }
 
             ExprKind::Struct(ref se) => {
+                // FIXME(fmease): Add a comment maybe.
+                if se.path == kw::Empty
+                    && self.r.dcx().has_stashed_diagnostic(expr.span, StashKey::StructLitNoType)
+                {
+                    return;
+                }
+
                 self.smart_resolve_path(expr.id, &se.qself, &se.path, PathSource::Struct);
                 // This is the same as `visit::walk_expr(self, expr);`, but we want to pass the
                 // parent in for accurate suggestions when encountering `Foo { bar }` that should

--- a/tests/ui/suggestions/struct-lit-placeholder-path.rs
+++ b/tests/ui/suggestions/struct-lit-placeholder-path.rs
@@ -1,0 +1,21 @@
+// Regression test for issue #98282.
+
+mod blah {
+    pub struct Stuff { x: i32 }
+    pub fn do_stuff(_: Stuff) {}
+}
+
+fn main() {
+    blah::do_stuff(_ { x: 10 });
+    //~^ ERROR the placeholder `_` is not allowed for the path in struct literals
+    //~| NOTE not allowed in struct literals
+    //~| HELP replace it with the correct type
+}
+
+#[cfg(FALSE)]
+fn disabled() {
+    blah::do_stuff(_ { x: 10 });
+    //~^ ERROR the placeholder `_` is not allowed for the path in struct literals
+    //~| NOTE not allowed in struct literals
+    //~| HELP replace it with an appropriate type
+}

--- a/tests/ui/suggestions/struct-lit-placeholder-path.stderr
+++ b/tests/ui/suggestions/struct-lit-placeholder-path.stderr
@@ -1,0 +1,20 @@
+error: the placeholder `_` is not allowed for the path in struct literals
+  --> $DIR/struct-lit-placeholder-path.rs:9:20
+   |
+LL |     blah::do_stuff(_ { x: 10 });
+   |                    -^^^^^^^^^^
+   |                    |
+   |                    not allowed in struct literals
+   |                    help: replace it with the correct type: `Stuff`
+
+error: the placeholder `_` is not allowed for the path in struct literals
+  --> $DIR/struct-lit-placeholder-path.rs:17:20
+   |
+LL |     blah::do_stuff(_ { x: 10 });
+   |                    ^^^^^^^^^^^
+   |                    |
+   |                    not allowed in struct literals
+   |                    help: replace it with an appropriate type: `/*Type*/`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
I'm surprised my naive approach seems to work but it feels more than hacky (skipping name resolution entirely). I hope to gather some feedback for how to make this more robust and a bit cleaner and for how to resolve the various `FIXME(fmease)`s I added.

Not sure if I will continue this work by the way, it was a fun experiment on a Saturday evening. Of course, it would be awesome if this landed in some way or another :)

Fixes #98282.
Doesn't address #105398 yet.

r? diagnostics