### PR TITLE
MIR printing: print the path of uneval'd const

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -67,7 +67,7 @@ fn eval_body_using_ecx<'mir, 'tcx>(
     trace!(
         "eval_body_using_ecx: pushing stack frame for global: {}{}",
         with_no_trimmed_paths!(ecx.tcx.def_path_str(cid.instance.def_id())),
-        cid.promoted.map_or_else(String::new, |p| format!("::promoted[{p:?}]"))
+        cid.promoted.map_or_else(String::new, |p| format!("::{p:?}"))
     );
 
     ecx.push_stack_frame(

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -496,7 +496,7 @@ fn write_mir_sig(tcx: TyCtxt<'_>, body: &Body<'_>, w: &mut dyn io::Write) -> io:
         _ => tcx.is_closure_like(def_id),
     };
     match (kind, body.source.promoted) {
-        (_, Some(i)) => write!(w, "{i:?} in ")?,
+        (_, Some(_)) => write!(w, "const ")?, // promoteds are the closest to consts
         (DefKind::Const | DefKind::AssocConst, _) => write!(w, "const ")?,
         (DefKind::Static(hir::Mutability::Not), _) => write!(w, "static ")?,
         (DefKind::Static(hir::Mutability::Mut), _) => write!(w, "static mut ")?,
@@ -508,6 +508,9 @@ fn write_mir_sig(tcx: TyCtxt<'_>, body: &Body<'_>, w: &mut dyn io::Write) -> io:
     ty::print::with_forced_impl_filename_line! {
         // see notes on #41697 elsewhere
         write!(w, "{}", tcx.def_path_str(def_id))?
+    }
+    if let Some(p) = body.source.promoted {
+        write!(w, "::{p:?}")?;
     }
 
     if body.source.promoted.is_none() && is_function {

--- a/tests/mir-opt/building/custom/consts.consts.built.after.mir
+++ b/tests/mir-opt/building/custom/consts.consts.built.after.mir
@@ -10,9 +10,9 @@ fn consts() -> () {
 
     bb0: {
         _1 = const 5_u8;
-        _2 = const _;
+        _2 = const consts::<C>::{constant#0};
         _3 = const C;
-        _4 = const _;
+        _4 = const D;
         _5 = consts::<10>;
         return;
     }

--- a/tests/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-elaborate-drops.after.mir
@@ -1,6 +1,6 @@
 // MIR for `BAR::promoted[0]` after SimplifyCfg-elaborate-drops
 
-promoted[0] in BAR: &[&i32; 1] = {
+const BAR::promoted[0]: &[&i32; 1] = {
     let mut _0: &[&i32; 1];
     let mut _1: [&i32; 1];
     let mut _2: &i32;

--- a/tests/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/tests/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -20,7 +20,7 @@
 -         _4 = &(*_5);
 -         _3 = [move _4];
 -         _2 = &_3;
-+         _6 = const _;
++         _6 = const BAR::promoted[0];
 +         _2 = &(*_6);
           _1 = move _2 as &[&i32] (PointerCoercion(Unsize));
 -         StorageDead(_4);

--- a/tests/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-elaborate-drops.after.mir
@@ -1,6 +1,6 @@
 // MIR for `FOO::promoted[0]` after SimplifyCfg-elaborate-drops
 
-promoted[0] in FOO: &[&i32; 1] = {
+const FOO::promoted[0]: &[&i32; 1] = {
     let mut _0: &[&i32; 1];
     let mut _1: [&i32; 1];
     let mut _2: &i32;

--- a/tests/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
+++ b/tests/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
@@ -22,7 +22,7 @@
 -         _4 = &(*_5);
 -         _3 = [move _4];
 -         _2 = &_3;
-+         _6 = const _;
++         _6 = const FOO::promoted[0];
 +         _2 = &(*_6);
           _1 = move _2 as &[&i32] (PointerCoercion(Unsize));
 -         StorageDead(_4);

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.32bit.panic-abort.diff
@@ -25,7 +25,7 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          _9 = const _;
+          _9 = const main::promoted[0];
           _3 = &(*_9);
           _2 = &raw const (*_3);
           _1 = move _2 as *const [i32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.32bit.panic-unwind.diff
@@ -25,7 +25,7 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          _9 = const _;
+          _9 = const main::promoted[0];
           _3 = &(*_9);
           _2 = &raw const (*_3);
           _1 = move _2 as *const [i32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.64bit.panic-abort.diff
@@ -25,7 +25,7 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          _9 = const _;
+          _9 = const main::promoted[0];
           _3 = &(*_9);
           _2 = &raw const (*_3);
           _1 = move _2 as *const [i32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.64bit.panic-unwind.diff
@@ -25,7 +25,7 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          _9 = const _;
+          _9 = const main::promoted[0];
           _3 = &(*_9);
           _2 = &raw const (*_3);
           _1 = move _2 as *const [i32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-abort.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-abort.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = const _;
+          _1 = const <bool as NeedsDrop>::NEEDS;
 -         switchInt(move _1) -> [0: bb2, otherwise: bb1];
 +         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-unwind.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = const _;
+          _1 = const <bool as NeedsDrop>::NEEDS;
 -         switchInt(move _1) -> [0: bb2, otherwise: bb1];
 +         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }

--- a/tests/mir-opt/const_prop/overwrite_with_const_with_params.rs
+++ b/tests/mir-opt/const_prop/overwrite_with_const_with_params.rs
@@ -14,7 +14,7 @@ impl<T> SizeOfConst<T> {
 fn size_of<T>() -> usize {
     // CHECK-LABEL: fn size_of(
     // CHECK: _1 = const 0_usize;
-    // CHECK-NEXT: _1 = const _;
+    // CHECK-NEXT: _1 = const SizeOfConst::<T>::SIZE;
     // CHECK-NEXT: _0 = _1;
     let mut a = 0;
     a = SizeOfConst::<T>::SIZE;

--- a/tests/mir-opt/const_prop/overwrite_with_const_with_params.size_of.GVN.diff
+++ b/tests/mir-opt/const_prop/overwrite_with_const_with_params.size_of.GVN.diff
@@ -11,7 +11,7 @@
       bb0: {
           StorageLive(_1);
           _1 = const 0_usize;
-          _1 = const _;
+          _1 = const SizeOfConst::<T>::SIZE;
           _0 = _1;
           StorageDead(_1);
           return;

--- a/tests/mir-opt/const_prop/pointer_expose_address.main.GVN.panic-abort.diff
+++ b/tests/mir-opt/const_prop/pointer_expose_address.main.GVN.panic-abort.diff
@@ -17,7 +17,7 @@
 +         nop;
           StorageLive(_2);
           StorageLive(_3);
-          _3 = const _;
+          _3 = const main::FOO;
           _2 = &raw const (*_3);
           _1 = move _2 as usize (PointerExposeAddress);
           StorageDead(_2);

--- a/tests/mir-opt/const_prop/pointer_expose_address.main.GVN.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/pointer_expose_address.main.GVN.panic-unwind.diff
@@ -17,7 +17,7 @@
 +         nop;
           StorageLive(_2);
           StorageLive(_3);
-          _3 = const _;
+          _3 = const main::FOO;
           _2 = &raw const (*_3);
           _1 = move _2 as usize (PointerExposeAddress);
           StorageDead(_2);

--- a/tests/mir-opt/const_prop/pointer_expose_address.rs
+++ b/tests/mir-opt/const_prop/pointer_expose_address.rs
@@ -7,7 +7,7 @@ fn read(_: usize) { }
 // EMIT_MIR pointer_expose_address.main.GVN.diff
 fn main() {
     // CHECK-LABEL: fn main(
-    // CHECK: [[ptr:_.*]] = const _;
+    // CHECK: [[ptr:_.*]] = const main::FOO;
     // CHECK: [[ref:_.*]] = &raw const (*[[ptr]]);
     // CHECK: [[x:_.*]] = move [[ref]] as usize (PointerExposeAddress);
     // CHECK: = read([[x]])

--- a/tests/mir-opt/const_prop/ref_deref.main.GVN.diff
+++ b/tests/mir-opt/const_prop/ref_deref.main.GVN.diff
@@ -14,7 +14,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _4 = const _;
+          _4 = const main::promoted[0];
           _2 = &(*_4);
 -         _1 = (*_2);
 +         _1 = const 4_i32;

--- a/tests/mir-opt/const_prop/ref_deref_project.main.GVN.diff
+++ b/tests/mir-opt/const_prop/ref_deref_project.main.GVN.diff
@@ -14,7 +14,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _4 = const _;
+          _4 = const main::promoted[0];
           _2 = &((*_4).1: i32);
 -         _1 = (*_2);
 +         _1 = const 5_i32;

--- a/tests/mir-opt/const_prop/slice_len.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.GVN.32bit.panic-abort.diff
@@ -21,7 +21,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _4 = _9;
 -         _3 = _4;
 -         _2 = move _3 as &[u32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/slice_len.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.GVN.32bit.panic-unwind.diff
@@ -21,7 +21,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _4 = _9;
 -         _3 = _4;
 -         _2 = move _3 as &[u32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/slice_len.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.GVN.64bit.panic-abort.diff
@@ -21,7 +21,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _4 = _9;
 -         _3 = _4;
 -         _2 = move _3 as &[u32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/slice_len.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.GVN.64bit.panic-unwind.diff
@@ -21,7 +21,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _4 = _9;
 -         _3 = _4;
 -         _2 = move _3 as &[u32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/transmute.invalid_char.GVN.32bit.diff
+++ b/tests/mir-opt/const_prop/transmute.invalid_char.GVN.32bit.diff
@@ -7,7 +7,7 @@
       }
   
       bb0: {
--         _0 = const _ as char (Transmute);
+-         _0 = const core::num::<impl i32>::MAX as char (Transmute);
 +         _0 = const {transmute(0x7fffffff): char};
           return;
       }

--- a/tests/mir-opt/const_prop/transmute.invalid_char.GVN.64bit.diff
+++ b/tests/mir-opt/const_prop/transmute.invalid_char.GVN.64bit.diff
@@ -7,7 +7,7 @@
       }
   
       bb0: {
--         _0 = const _ as char (Transmute);
+-         _0 = const core::num::<impl i32>::MAX as char (Transmute);
 +         _0 = const {transmute(0x7fffffff): char};
           return;
       }

--- a/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-abort.diff
@@ -53,7 +53,7 @@
           StorageDead(_5);
           StorageDead(_4);
           StorageLive(_7);
-          _7 = const _;
+          _7 = const core::num::<impl i32>::MAX;
           StorageLive(_8);
           StorageLive(_9);
 -         _9 = _7;

--- a/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-unwind.diff
@@ -53,7 +53,7 @@
           StorageDead(_5);
           StorageDead(_4);
           StorageLive(_7);
-          _7 = const _;
+          _7 = const core::num::<impl i32>::MAX;
           StorageLive(_8);
           StorageLive(_9);
 -         _9 = _7;

--- a/tests/mir-opt/dataflow-const-prop/checked.rs
+++ b/tests/mir-opt/dataflow-const-prop/checked.rs
@@ -23,7 +23,7 @@ fn main() {
     // CHECK: [[c]] = const 3_i32;
     let c = a + b;
 
-    // CHECK: [[d]] = const _;
+    // CHECK: [[d]] = const core::num::<impl i32>::MAX;
     let d = i32::MAX;
 
     // CHECK: assert(!const true,

--- a/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.32bit.diff
@@ -23,7 +23,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = const _;
+          _1 = const constant::C;
           StorageLive(_2);
 -         _3 = discriminant(_1);
 -         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];

--- a/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.64bit.diff
@@ -23,7 +23,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = const _;
+          _1 = const constant::C;
           StorageLive(_2);
 -         _3 = discriminant(_1);
 -         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -34,7 +34,7 @@ fn constant() {
     // CHECK: debug x => [[x:_.*]];
     const C: E = E::V1(0);
 
-    // CHECK: [[e]] = const _;
+    // CHECK: [[e]] = const constant::C;
     let e = C;
     // CHECK: switchInt(const 0_isize) -> [0: [[target_bb:bb.*]], 1: bb2, otherwise: bb1];
     // CHECK: [[target_bb]]: {

--- a/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.32bit.panic-abort.diff
@@ -29,7 +29,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _4 = _14;
           _3 = _4;
           _2 = move _3 as &[u32] (PointerCoercion(Unsize));
@@ -52,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_9);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SLICE;
           StorageLive(_11);
           _11 = const 1_usize;
 -         _12 = Len((*_10));

--- a/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -29,7 +29,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _4 = _14;
           _3 = _4;
           _2 = move _3 as &[u32] (PointerCoercion(Unsize));
@@ -52,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_9);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SLICE;
           StorageLive(_11);
           _11 = const 1_usize;
 -         _12 = Len((*_10));

--- a/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.64bit.panic-abort.diff
@@ -29,7 +29,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _4 = _14;
           _3 = _4;
           _2 = move _3 as &[u32] (PointerCoercion(Unsize));
@@ -52,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_9);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SLICE;
           StorageLive(_11);
           _11 = const 1_usize;
 -         _12 = Len((*_10));

--- a/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -29,7 +29,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _4 = _14;
           _3 = _4;
           _2 = move _3 as &[u32] (PointerCoercion(Unsize));
@@ -52,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_9);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SLICE;
           StorageLive(_11);
           _11 = const 1_usize;
 -         _12 = Len((*_10));

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
@@ -101,7 +101,7 @@
           StorageDead(_6);
           StorageDead(_5);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SMALL_VAL;
           StorageLive(_7);
 -         _7 = (_10.0: f32);
 +         _7 = const 4f32;
@@ -139,7 +139,7 @@
           StorageDead(_17);
           StorageDead(_16);
           StorageLive(_22);
-          _22 = const _;
+          _22 = const main::BIG_VAL;
           StorageLive(_19);
 -         _19 = (_22.0: f32);
 +         _19 = const 25f32;

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
@@ -101,7 +101,7 @@
           StorageDead(_6);
           StorageDead(_5);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SMALL_VAL;
           StorageLive(_7);
 -         _7 = (_10.0: f32);
 +         _7 = const 4f32;
@@ -139,7 +139,7 @@
           StorageDead(_17);
           StorageDead(_16);
           StorageLive(_22);
-          _22 = const _;
+          _22 = const main::BIG_VAL;
           StorageLive(_19);
 -         _19 = (_22.0: f32);
 +         _19 = const 25f32;

--- a/tests/mir-opt/dataflow-const-prop/transmute.invalid_char.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.invalid_char.DataflowConstProp.32bit.diff
@@ -7,7 +7,7 @@
       }
   
       bb0: {
--         _0 = const _ as char (Transmute);
+-         _0 = const core::num::<impl i32>::MAX as char (Transmute);
 +         _0 = const {transmute(0x7fffffff): char};
           return;
       }

--- a/tests/mir-opt/dataflow-const-prop/transmute.invalid_char.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.invalid_char.DataflowConstProp.64bit.diff
@@ -7,7 +7,7 @@
       }
   
       bb0: {
--         _0 = const _ as char (Transmute);
+-         _0 = const core::num::<impl i32>::MAX as char (Transmute);
 +         _0 = const {transmute(0x7fffffff): char};
           return;
       }

--- a/tests/mir-opt/derefer_complex_case.main.Derefer.panic-abort.diff
+++ b/tests/mir-opt/derefer_complex_case.main.Derefer.panic-abort.diff
@@ -28,7 +28,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _2 = &(*_14);
           _1 = <&[i32; 2] as IntoIterator>::into_iter(move _2) -> [return: bb1, unwind: bb8];
       }

--- a/tests/mir-opt/derefer_complex_case.main.Derefer.panic-unwind.diff
+++ b/tests/mir-opt/derefer_complex_case.main.Derefer.panic-unwind.diff
@@ -28,7 +28,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _2 = &(*_14);
           _1 = <&[i32; 2] as IntoIterator>::into_iter(move _2) -> [return: bb1, unwind continue];
       }

--- a/tests/mir-opt/gvn.arithmetic.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.arithmetic.GVN.panic-abort.diff
@@ -336,7 +336,7 @@
           StorageLive(_54);
           StorageLive(_55);
           _55 = _1;
--         _54 = BitAnd(move _55, const _);
+-         _54 = BitAnd(move _55, const core::num::<impl u64>::MAX);
 +         _54 = _1;
           StorageDead(_55);
 -         _53 = opaque::<u64>(move _54) -> [return: bb23, unwind unreachable];
@@ -364,7 +364,7 @@
           StorageLive(_60);
           StorageLive(_61);
           _61 = _1;
--         _60 = BitOr(move _61, const _);
+-         _60 = BitOr(move _61, const core::num::<impl u64>::MAX);
 +         _60 = const u64::MAX;
           StorageDead(_61);
 -         _59 = opaque::<u64>(move _60) -> [return: bb25, unwind unreachable];

--- a/tests/mir-opt/gvn.arithmetic.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.arithmetic.GVN.panic-unwind.diff
@@ -336,7 +336,7 @@
           StorageLive(_54);
           StorageLive(_55);
           _55 = _1;
--         _54 = BitAnd(move _55, const _);
+-         _54 = BitAnd(move _55, const core::num::<impl u64>::MAX);
 +         _54 = _1;
           StorageDead(_55);
 -         _53 = opaque::<u64>(move _54) -> [return: bb23, unwind continue];
@@ -364,7 +364,7 @@
           StorageLive(_60);
           StorageLive(_61);
           _61 = _1;
--         _60 = BitOr(move _61, const _);
+-         _60 = BitOr(move _61, const core::num::<impl u64>::MAX);
 +         _60 = const u64::MAX;
           StorageDead(_61);
 -         _59 = opaque::<u64>(move _60) -> [return: bb25, unwind continue];

--- a/tests/mir-opt/gvn.constant_index_overflow.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.constant_index_overflow.GVN.panic-abort.diff
@@ -26,7 +26,7 @@
   
       bb0: {
 -         StorageLive(_2);
--         _2 = const _ as usize (IntToInt);
+-         _2 = const core::num::<impl u64>::MAX as usize (IntToInt);
 +         nop;
 +         _2 = const usize::MAX;
           StorageLive(_3);

--- a/tests/mir-opt/gvn.constant_index_overflow.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.constant_index_overflow.GVN.panic-unwind.diff
@@ -26,7 +26,7 @@
   
       bb0: {
 -         StorageLive(_2);
--         _2 = const _ as usize (IntToInt);
+-         _2 = const core::num::<impl u64>::MAX as usize (IntToInt);
 +         nop;
 +         _2 = const usize::MAX;
           StorageLive(_3);

--- a/tests/mir-opt/gvn.wide_ptr_provenance.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.wide_ptr_provenance.GVN.panic-abort.diff
@@ -61,7 +61,7 @@
           StorageLive(_3);
           StorageLive(_4);
           StorageLive(_5);
-          _44 = const _;
+          _44 = const wide_ptr_provenance::promoted[1];
           _5 = &(*_44);
           _4 = &(*_5);
           _3 = move _4 as &dyn std::marker::Send (PointerCoercion(Unsize));
@@ -79,7 +79,7 @@
           StorageLive(_9);
           StorageLive(_10);
           StorageLive(_11);
-          _43 = const _;
+          _43 = const wide_ptr_provenance::promoted[0];
           _11 = &(*_43);
           _10 = &(*_11);
           _9 = move _10 as &dyn std::marker::Send (PointerCoercion(Unsize));

--- a/tests/mir-opt/gvn.wide_ptr_provenance.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.wide_ptr_provenance.GVN.panic-unwind.diff
@@ -61,7 +61,7 @@
           StorageLive(_3);
           StorageLive(_4);
           StorageLive(_5);
-          _44 = const _;
+          _44 = const wide_ptr_provenance::promoted[1];
           _5 = &(*_44);
           _4 = &(*_5);
           _3 = move _4 as &dyn std::marker::Send (PointerCoercion(Unsize));
@@ -79,7 +79,7 @@
           StorageLive(_9);
           StorageLive(_10);
           StorageLive(_11);
-          _43 = const _;
+          _43 = const wide_ptr_provenance::promoted[0];
           _11 = &(*_43);
           _10 = &(*_11);
           _9 = move _10 as &dyn std::marker::Send (PointerCoercion(Unsize));

--- a/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-abort.diff
@@ -64,7 +64,7 @@
   
       bb0: {
           StorageLive(_1);
-          _49 = const _;
+          _49 = const wide_ptr_same_provenance::promoted[0];
           _1 = &(*_49);
           StorageLive(_3);
 -         StorageLive(_4);

--- a/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-unwind.diff
@@ -64,7 +64,7 @@
   
       bb0: {
           StorageLive(_1);
-          _49 = const _;
+          _49 = const wide_ptr_same_provenance::promoted[0];
           _1 = &(*_49);
           StorageLive(_3);
 -         StorageLive(_4);

--- a/tests/mir-opt/gvn_uninhabited.f.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn_uninhabited.f.GVN.panic-abort.diff
@@ -17,7 +17,7 @@
       bb0: {
           StorageLive(_2);
           StorageLive(_3);
-          _5 = const _;
+          _5 = const f::promoted[0];
           _3 = &(*_5);
           _2 = ((*_3).1: E);
           StorageLive(_1);

--- a/tests/mir-opt/gvn_uninhabited.f.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn_uninhabited.f.GVN.panic-unwind.diff
@@ -17,7 +17,7 @@
       bb0: {
           StorageLive(_2);
           StorageLive(_3);
-          _5 = const _;
+          _5 = const f::promoted[0];
           _3 = &(*_5);
           _2 = ((*_3).1: E);
           StorageLive(_1);

--- a/tests/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/tests/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -29,13 +29,13 @@ fn bar() -> bool {
         _2 = _1;
         StorageLive(_3);
         StorageLive(_4);
-        _10 = const _;
+        _10 = const bar::promoted[1];
         Retag(_10);
         _4 = &(*_10);
         _3 = &(*_4);
         StorageLive(_6);
         StorageLive(_7);
-        _9 = const _;
+        _9 = const bar::promoted[0];
         Retag(_9);
         _7 = &(*_9);
         _6 = &(*_7);

--- a/tests/mir-opt/inline/issue_106141.outer.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/issue_106141.outer.Inline.panic-abort.diff
@@ -8,7 +8,7 @@
 +         let mut _2: bool;
 +         let mut _3: bool;
 +         scope 2 {
-+             debug buffer => const _;
++             debug buffer => const inner::promoted[0];
 +             scope 3 {
 +                 debug index => _0;
 +             }
@@ -19,7 +19,7 @@
 -         _0 = inner() -> [return: bb1, unwind unreachable];
 +         StorageLive(_1);
 +         StorageLive(_2);
-+         _1 = const _;
++         _1 = const inner::promoted[0];
 +         _0 = index() -> [return: bb1, unwind unreachable];
       }
   

--- a/tests/mir-opt/inline/issue_106141.outer.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/issue_106141.outer.Inline.panic-unwind.diff
@@ -8,7 +8,7 @@
 +         let mut _2: bool;
 +         let mut _3: bool;
 +         scope 2 {
-+             debug buffer => const _;
++             debug buffer => const inner::promoted[0];
 +             scope 3 {
 +                 debug index => _0;
 +             }
@@ -19,7 +19,7 @@
 -         _0 = inner() -> [return: bb1, unwind continue];
 +         StorageLive(_1);
 +         StorageLive(_2);
-+         _1 = const _;
++         _1 = const inner::promoted[0];
 +         _0 = index() -> [return: bb1, unwind continue];
       }
   

--- a/tests/mir-opt/instsimplify/combine_transmutes.adt_transmutes.InstSimplify.diff
+++ b/tests/mir-opt/instsimplify/combine_transmutes.adt_transmutes.InstSimplify.diff
@@ -37,7 +37,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = Option::<NonZero<u8>>::Some(const _);
+          _2 = Option::<NonZero<u8>>::Some(const std::num::NonZero::<u8>::MAX);
           _1 = move _2 as u8 (Transmute);
           StorageDead(_2);
           StorageLive(_3);

--- a/tests/mir-opt/jump_threading.aggregate.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.aggregate.JumpThreading.panic-abort.diff
@@ -16,7 +16,7 @@
   
       bb0: {
           StorageLive(_4);
-          _4 = const _;
+          _4 = const aggregate::FOO;
           StorageLive(_2);
           _2 = (_4.0: u8);
           StorageLive(_3);

--- a/tests/mir-opt/jump_threading.aggregate.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.aggregate.JumpThreading.panic-unwind.diff
@@ -16,7 +16,7 @@
   
       bb0: {
           StorageLive(_4);
-          _4 = const _;
+          _4 = const aggregate::FOO;
           StorageLive(_2);
           _2 = (_4.0: u8);
           StorageLive(_3);

--- a/tests/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.panic-abort.diff
+++ b/tests/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.panic-abort.diff
@@ -41,7 +41,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _19 = const _;
+          _19 = const discriminant::<T>::promoted[2];
           _7 = &(*_19);
           _6 = &(*_7);
 -         _5 = discriminant_value::<i32>(move _6) -> [return: bb2, unwind unreachable];
@@ -56,7 +56,7 @@
           StorageLive(_9);
           StorageLive(_10);
           StorageLive(_11);
-          _18 = const _;
+          _18 = const discriminant::<T>::promoted[1];
           _11 = &(*_18);
           _10 = &(*_11);
 -         _9 = discriminant_value::<()>(move _10) -> [return: bb3, unwind unreachable];
@@ -71,7 +71,7 @@
           StorageLive(_13);
           StorageLive(_14);
           StorageLive(_15);
-          _17 = const _;
+          _17 = const discriminant::<T>::promoted[0];
           _15 = &(*_17);
           _14 = &(*_15);
 -         _13 = discriminant_value::<E>(move _14) -> [return: bb4, unwind unreachable];

--- a/tests/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.panic-unwind.diff
+++ b/tests/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.panic-unwind.diff
@@ -41,7 +41,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _19 = const _;
+          _19 = const discriminant::<T>::promoted[2];
           _7 = &(*_19);
           _6 = &(*_7);
 -         _5 = discriminant_value::<i32>(move _6) -> [return: bb2, unwind unreachable];
@@ -56,7 +56,7 @@
           StorageLive(_9);
           StorageLive(_10);
           StorageLive(_11);
-          _18 = const _;
+          _18 = const discriminant::<T>::promoted[1];
           _11 = &(*_18);
           _10 = &(*_11);
 -         _9 = discriminant_value::<()>(move _10) -> [return: bb3, unwind unreachable];
@@ -71,7 +71,7 @@
           StorageLive(_13);
           StorageLive(_14);
           StorageLive(_15);
-          _17 = const _;
+          _17 = const discriminant::<T>::promoted[0];
           _15 = &(*_17);
           _14 = &(*_15);
 -         _13 = discriminant_value::<E>(move _14) -> [return: bb4, unwind unreachable];

--- a/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
@@ -40,7 +40,7 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
         _3 = BitAnd(_2, const 31_u32);
         _4 = ShlUnchecked(_1, _3);
         StorageDead(_3);
-        _5 = Ge(_2, const _);
+        _5 = Ge(_2, const core::num::<impl u32>::BITS);
         StorageLive(_6);
         _6 = unlikely(move _5) -> [return: bb1, unwind unreachable];
     }

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -81,7 +81,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _7 = _9;
 +         _7 = const {ALLOC1<imm>: &std::alloc::Global};
           StorageLive(_8);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
@@ -85,7 +85,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _7 = _9;
 +         _7 = const {ALLOC1<imm>: &std::alloc::Global};
           StorageLive(_8);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -81,7 +81,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _7 = _9;
 +         _7 = const {ALLOC1<imm>: &std::alloc::Global};
           StorageLive(_8);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -85,7 +85,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _7 = _9;
 +         _7 = const {ALLOC1<imm>: &std::alloc::Global};
           StorageLive(_8);

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
@@ -101,7 +101,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -101,7 +101,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -91,7 +91,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -91,7 +91,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
@@ -103,7 +103,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -103,7 +103,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
@@ -59,7 +59,7 @@
           _2 = const 5_u8;
           _1 = &mut _2;
           StorageLive(_3);
-          _28 = const _;
+          _28 = const debuginfo::promoted[2];
           _3 = &((*_28).0: u8);
 -         StorageLive(_5);
 -         _5 = &(*_1);
@@ -76,7 +76,7 @@
   
       bb2: {
           StorageLive(_9);
-          _27 = const _;
+          _27 = const debuginfo::promoted[1];
           _9 = &(((*_27) as Some).0: i32);
 -         _6 = const ();
           StorageDead(_9);
@@ -95,7 +95,7 @@
 -         StorageLive(_11);
 -         StorageLive(_12);
           StorageLive(_13);
-          _26 = const _;
+          _26 = const debuginfo::promoted[0];
           _13 = &(*_26);
           StorageLive(_15);
           _15 = RangeFull;

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.panic-abort.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.panic-abort.mir
@@ -109,7 +109,7 @@ fn array_casts() -> () {
         _15 = (*_16);
         _14 = &_15;
         StorageLive(_18);
-        _34 = const _;
+        _34 = const array_casts::promoted[0];
         Retag(_34);
         _18 = &(*_34);
         _13 = (move _14, move _18);

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -109,7 +109,7 @@ fn array_casts() -> () {
         _15 = (*_16);
         _14 = &_15;
         StorageLive(_18);
-        _34 = const _;
+        _34 = const array_casts::promoted[0];
         Retag(_34);
         _18 = &(*_34);
         _13 = (move _14, move _18);

--- a/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-abort.mir
+++ b/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-abort.mir
@@ -129,7 +129,7 @@ fn main() -> () {
         _20 = &_21;
         StorageLive(_22);
         StorageLive(_23);
-        _28 = const _;
+        _28 = const main::promoted[0];
         Retag(_28);
         _23 = &(*_28);
         _22 = &(*_23);

--- a/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -129,7 +129,7 @@ fn main() -> () {
         _20 = &_21;
         StorageLive(_22);
         StorageLive(_23);
-        _28 = const _;
+        _28 = const main::promoted[0];
         Retag(_28);
         _23 = &(*_28);
         _22 = &(*_23);

--- a/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
@@ -93,7 +93,7 @@
           StorageLive(_12);
           StorageLive(_13);
           StorageLive(_14);
-          _26 = const _;
+          _26 = const foo::<T>::promoted[0];
           _14 = &(*_26);
           _13 = &(*_14);
           _12 = move _13 as &[&str] (PointerCoercion(Unsize));

--- a/tests/mir-opt/sroa/structs.constant.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/structs.constant.ScalarReplacementOfAggregates.diff
@@ -25,7 +25,7 @@
 +         StorageLive(_4);
 +         StorageLive(_5);
 +         nop;
-          _1 = const _;
+          _1 = const constant::U;
 +         _4 = move (_1.0: usize);
 +         _5 = move (_1.1: u8);
           StorageLive(_2);


### PR DESCRIPTION
Currently it just prints `const _` which makes it impossible to say which constant is being referred to.

Also refer to promoteds in a consistent way; previously MIR printing would do
```
promoted[0] in C1: &Option<Cell<i32>> = {
    // ...
}
```
Now that should be
```
const C1::promoted[0]: &Option<Cell<i32>> = {
    // ...
}
```

We don't seem to have a test for that so I tried it by hand, it seems to work:
```
const main::promoted[12]: &[&str; 3] = {
    let mut _0: &[&str; 3];
    let mut _1: [&str; 3];
    let mut _2: &str;
    let mut _3: &str;
    let mut _4: &str;
    let mut _5: &str;

    bb0: {
        _3 = const "b";
        _2 = &(*_3);
        _5 = const "c";
        _4 = &(*_5);
        _1 = [const "a", move _2, move _4];
        _0 = &_1;
        return;
    }
}
```