### PR TITLE
diagnostics: Do not suggest using `#[unix_sigpipe]` without a value

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -389,7 +389,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
 
     // Entry point:
-    gated!(unix_sigpipe, Normal, template!(Word, NameValueStr: "inherit|sig_ign|sig_dfl"), ErrorFollowing, experimental!(unix_sigpipe)),
+    gated!(unix_sigpipe, Normal, template!(NameValueStr: "inherit|sig_ign|sig_dfl"), ErrorFollowing, experimental!(unix_sigpipe)),
     ungated!(start, Normal, template!(Word), WarnFollowing, @only_local: true),
     ungated!(no_start, CrateLevel, template!(Word), WarnFollowing, @only_local: true),
     ungated!(no_main, CrateLevel, template!(Word), WarnFollowing, @only_local: true),

--- a/compiler/rustc_passes/src/entry.rs
+++ b/compiler/rustc_passes/src/entry.rs
@@ -156,13 +156,13 @@ fn sigpipe(tcx: TyCtxt<'_>, def_id: DefId) -> u8 {
             (Some(sym::inherit), None) => sigpipe::INHERIT,
             (Some(sym::sig_ign), None) => sigpipe::SIG_IGN,
             (Some(sym::sig_dfl), None) => sigpipe::SIG_DFL,
-            (_, Some(_)) => {
-                // Keep going so that `fn emit_malformed_attribute()` can print
-                // an excellent error message
+            (Some(_), None) => {
+                tcx.dcx().emit_err(UnixSigpipeValues { span: attr.span });
                 sigpipe::DEFAULT
             }
             _ => {
-                tcx.dcx().emit_err(UnixSigpipeValues { span: attr.span });
+                // Keep going so that `fn emit_malformed_attribute()` can print
+                // an excellent error message
                 sigpipe::DEFAULT
             }
         }

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-bare.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-bare.rs
@@ -1,4 +1,4 @@
 #![feature(unix_sigpipe)]
 
-#[unix_sigpipe] //~ error: valid values for `#[unix_sigpipe = "..."]` are `inherit`, `sig_ign`, or `sig_dfl`
+#[unix_sigpipe] //~ error: malformed `unix_sigpipe` attribute input
 fn main() {}

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-bare.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-bare.stderr
@@ -1,8 +1,8 @@
-error: valid values for `#[unix_sigpipe = "..."]` are `inherit`, `sig_ign`, or `sig_dfl`
+error: malformed `unix_sigpipe` attribute input
   --> $DIR/unix_sigpipe-bare.rs:3:1
    |
 LL | #[unix_sigpipe]
-   | ^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^ help: must be of the form: `#[unix_sigpipe = "inherit|sig_ign|sig_dfl"]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.stderr
@@ -2,14 +2,7 @@ error: malformed `unix_sigpipe` attribute input
   --> $DIR/unix_sigpipe-list.rs:3:1
    |
 LL | #[unix_sigpipe(inherit)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL | #[unix_sigpipe = "inherit|sig_ign|sig_dfl"]
-   | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-LL | #[unix_sigpipe]
-   | ~~~~~~~~~~~~~~~
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[unix_sigpipe = "inherit|sig_ign|sig_dfl"]`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Remove `Word` from the `unix_sigpipe` attribute template so that plain `#[unix_sigpipe]` is not included in suggestions of valid forms of the attribute. Also re-arrange diagnostics code slightly to avoid duplicate diagnostics.

Tracking issue is https://github.com/rust-lang/rust/issues/97889.