### PR TITLE
mir-opt: always run tests for the current target

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1549,6 +1549,10 @@ impl Step for MirOpt {
             })
         };
 
+        run(self.target);
+
+        // Run more targets with `--bless`. But we always run the host target first, since some
+        // tests use very specific `only` clauses that are not covered by the target set below.
         if builder.config.cmd.bless() {
             // All that we really need to do is cover all combinations of 32/64-bit and unwind/abort,
             // but while we're at it we might as well flex our cross-compilation support. This
@@ -1567,8 +1571,6 @@ impl Step for MirOpt {
                 });
                 run(panic_abort_target);
             }
-        } else {
-            run(self.target);
         }
     }
 }


### PR DESCRIPTION
Currently, `./x.py test tests/mir-opt` runs only the tests for the current target, and `./x.py test tests/mir-opt --bless` runs tests for a representative set of targets. That representative set does not include the current target however, which means `--bless` can succeed when tests fail without it. This PR ensures we run the current target always.

Fixes https://github.com/rust-lang/rust/issues/122292
cc @RalfJung