### PR TITLE
Add FileCheck annotations to mir-opt/dest-prop tests

### DIFF
--- a/tests/mir-opt/dest-prop/branch.rs
+++ b/tests/mir-opt/dest-prop/branch.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //! Tests that assignment in both branches of an `if` are eliminated.
 //@ unit-test: DestinationPropagation
@@ -12,6 +11,10 @@ fn cond() -> bool {
 
 // EMIT_MIR branch.foo.DestinationPropagation.diff
 fn foo() -> i32 {
+    // CHECK-LABEL: fn foo(
+    // CHECK: debug y => [[y:_.*]];
+    // CHECK: [[y]] = val()
+    // CHECK-NOT: [[y]] = {{_.*}};
     let x = val();
 
     let y = if cond() {

--- a/tests/mir-opt/dest-prop/copy_propagation_arg.rs
+++ b/tests/mir-opt/dest-prop/copy_propagation_arg.rs
@@ -30,7 +30,7 @@ fn bar(mut x: u8) {
 fn baz(mut x: i32) -> i32 {
     // CHECK-LABEL: fn baz(
     // CHECK: debug x => [[x:_.*]];
-    // CHECK-NOT: [[x]] = {{_.*}}
+    // CHECK-NOT: [[x]] =
     // self-assignment to a function argument should be eliminated
     x = x;
     x

--- a/tests/mir-opt/dest-prop/copy_propagation_arg.rs
+++ b/tests/mir-opt/dest-prop/copy_propagation_arg.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // Check that DestinationPropagation does not propagate an assignment to a function argument
 // (doing so can break usages of the original argument value)
@@ -9,18 +8,29 @@ fn dummy(x: u8) -> u8 {
 
 // EMIT_MIR copy_propagation_arg.foo.DestinationPropagation.diff
 fn foo(mut x: u8) {
+    // CHECK-LABEL: fn foo(
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK: dummy(move [[x]])
+    // CHECK: [[x]] = move {{_.*}};
     // calling `dummy` to make a use of `x` that copyprop cannot eliminate
     x = dummy(x); // this will assign a local to `x`
 }
 
 // EMIT_MIR copy_propagation_arg.bar.DestinationPropagation.diff
 fn bar(mut x: u8) {
+    // CHECK-LABEL: fn bar(
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK: dummy(move [[x]])
+    // CHECK: [[x]] = const 5_u8;
     dummy(x);
     x = 5;
 }
 
 // EMIT_MIR copy_propagation_arg.baz.DestinationPropagation.diff
 fn baz(mut x: i32) -> i32 {
+    // CHECK-LABEL: fn baz(
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK-NOT: [[x]] = {{_.*}}
     // self-assignment to a function argument should be eliminated
     x = x;
     x
@@ -28,6 +38,12 @@ fn baz(mut x: i32) -> i32 {
 
 // EMIT_MIR copy_propagation_arg.arg_src.DestinationPropagation.diff
 fn arg_src(mut x: i32) -> i32 {
+    // CHECK-LABEL: fn arg_src(
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK: debug y => [[y:_.*]];
+    // CHECK: [[y]] = [[x]]
+    // CHECK: [[x]] = const 123_i32;
+    // CHECK-NOT: {{_.*}} = [[y]];
     let y = x;
     x = 123; // Don't propagate this assignment to `y`
     y

--- a/tests/mir-opt/dest-prop/cycle.rs
+++ b/tests/mir-opt/dest-prop/cycle.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //! Tests that cyclic assignments don't hang DestinationPropagation, and result in reasonable code.
 //@ unit-test: DestinationPropagation
@@ -8,6 +7,10 @@ fn val() -> i32 {
 
 // EMIT_MIR cycle.main.DestinationPropagation.diff
 fn main() {
+    // CHECK-LABEL: main(
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK: [[x]] = val()
+    // CHECK-NOT: [[x]] = {{_.*}};
     let mut x = val();
     let y = x;
     let z = y;

--- a/tests/mir-opt/dest-prop/dead_stores_79191.rs
+++ b/tests/mir-opt/dest-prop/dead_stores_79191.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //@ unit-test: DestinationPropagation
 
@@ -8,6 +7,13 @@ fn id<T>(x: T) -> T {
 
 // EMIT_MIR dead_stores_79191.f.DestinationPropagation.after.mir
 fn f(mut a: usize) -> usize {
+    // CHECK-LABEL: fn f(
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+    // CHECK: [[b]] = [[a]];
+    // CHECK: [[a]] = const 5_usize;
+    // CHECK: [[a]] = move [[b]];
+    // CHECK: id::<usize>(move [[a]])
     let b = a;
     a = 5;
     a = b;

--- a/tests/mir-opt/dest-prop/dead_stores_better.rs
+++ b/tests/mir-opt/dest-prop/dead_stores_better.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // This is a copy of the `dead_stores_79191` test, except that we turn on DSE. This demonstrates
 // that that pass enables this one to do more optimizations.
@@ -12,6 +11,13 @@ fn id<T>(x: T) -> T {
 
 // EMIT_MIR dead_stores_better.f.DestinationPropagation.after.mir
 pub fn f(mut a: usize) -> usize {
+    // CHECK-LABEL: fn f(
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+    // CHECK: [[b]] = [[a]];
+    // CHECK: [[a]] = const 5_usize;
+    // CHECK: [[a]] = move [[b]];
+    // CHECK: id::<usize>(move [[a]])
     let b = a;
     a = 5;
     a = b;

--- a/tests/mir-opt/dest-prop/simple.rs
+++ b/tests/mir-opt/dest-prop/simple.rs
@@ -5,8 +5,11 @@
 fn nrvo(init: fn(&mut [u8; 1024])) -> [u8; 1024] {
     // CHECK-LABEL: fn nrvo(
     // CHECK: debug init => [[init:_.*]];
+    // CHECK: debug buf => [[buf:_.*]];
+    // CHECK: [[buf]] = [const 0_u8; 1024];
     // CHECK-NOT: {{_.*}} = [[init]];
     // CHECK: move [[init]](move {{_.*}})
+    // CHECK: {{_.*}} = [[buf]]
     let mut buf = [0; 1024];
     init(&mut buf);
     buf

--- a/tests/mir-opt/dest-prop/simple.rs
+++ b/tests/mir-opt/dest-prop/simple.rs
@@ -1,9 +1,12 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //! Copy of `nrvo-simple.rs`, to ensure that full dest-prop handles it too.
 //@ unit-test: DestinationPropagation
 // EMIT_MIR simple.nrvo.DestinationPropagation.diff
 fn nrvo(init: fn(&mut [u8; 1024])) -> [u8; 1024] {
+    // CHECK-LABEL: fn nrvo(
+    // CHECK: debug init => [[init:_.*]];
+    // CHECK-NOT: {{_.*}} = [[init]];
+    // CHECK: move [[init]](move {{_.*}})
     let mut buf = [0; 1024];
     init(&mut buf);
     buf

--- a/tests/mir-opt/dest-prop/union.rs
+++ b/tests/mir-opt/dest-prop/union.rs
@@ -8,6 +8,8 @@ fn val() -> u32 {
 
 // EMIT_MIR union.main.DestinationPropagation.diff
 fn main() {
+    // CHECK-LABEL: fn args(
+    // CHECK: {{_.*}} = Un { us: const 1_u32 };
     union Un {
         us: u32,
     }


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/116971, adds FileCheck annotations to MIR-opt tests in tests/mir-opt/dest-prop.

I would like some feedback. Also, I don't know how to approach `union.rs`.  I couldn't figure out what it is testing.

r? cjgillot