### PR TITLE
fix metadata for dyn-star in new solver

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalizes_to/mod.rs
@@ -542,13 +542,14 @@ impl<'tcx> assembly::GoalKind<'tcx> for NormalizesTo<'tcx> {
                 | ty::Coroutine(..)
                 | ty::CoroutineWitness(..)
                 | ty::Never
-                | ty::Foreign(..) => tcx.types.unit,
+                | ty::Foreign(..)
+                | ty::Dynamic(_, _, ty::DynStar) => tcx.types.unit,
 
                 ty::Error(e) => Ty::new_error(tcx, *e),
 
                 ty::Str | ty::Slice(_) => tcx.types.usize,
 
-                ty::Dynamic(_, _, _) => {
+                ty::Dynamic(_, _, ty::Dyn) => {
                     let dyn_metadata = tcx.require_lang_item(LangItem::DynMetadata, None);
                     tcx.type_of(dyn_metadata)
                         .instantiate(tcx, &[ty::GenericArg::from(goal.predicate.self_ty())])

--- a/tests/ui/dyn-star/thin.next.stderr
+++ b/tests/ui/dyn-star/thin.next.stderr
@@ -1,0 +1,11 @@
+warning: the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/thin.rs:6:12
+   |
+LL | #![feature(dyn_star)]
+   |            ^^^^^^^^
+   |
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/dyn-star/thin.old.stderr
+++ b/tests/ui/dyn-star/thin.old.stderr
@@ -1,0 +1,11 @@
+warning: the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/thin.rs:6:12
+   |
+LL | #![feature(dyn_star)]
+   |            ^^^^^^^^
+   |
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/dyn-star/thin.rs
+++ b/tests/ui/dyn-star/thin.rs
@@ -1,0 +1,16 @@
+//@check-pass
+//@revisions: old next
+//@[next] compile-flags: -Znext-solver
+
+#![feature(ptr_metadata)]
+#![feature(dyn_star)]
+//~^ WARN the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+
+use std::fmt::Debug;
+use std::ptr::Thin;
+
+fn check_thin<T: ?Sized + Thin>() {}
+
+fn main() {
+    check_thin::<dyn* Debug>();
+}


### PR DESCRIPTION
The pointee metadata of `dyn* Trait` types is `()` and not a vtable.