### PR TITLE
[WIP] [crater-only] Make a watered-down version of lazy type aliases the default

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -1,4 +1,3 @@
-use core::ops::ControlFlow;
 use rustc_errors::{Applicability, StashKey};
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -671,21 +670,8 @@ fn check_feature_inherent_assoc_ty(tcx: TyCtxt<'_>, span: Span) {
     }
 }
 
-pub fn type_alias_is_lazy<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> bool {
-    use hir::intravisit::Visitor;
-    if tcx.features().lazy_type_alias {
-        return true;
-    }
-    struct HasTait;
-    impl<'tcx> Visitor<'tcx> for HasTait {
-        type Result = ControlFlow<()>;
-        fn visit_ty(&mut self, t: &'tcx hir::Ty<'tcx>) -> Self::Result {
-            if let hir::TyKind::OpaqueDef(..) = t.kind {
-                ControlFlow::Break(())
-            } else {
-                hir::intravisit::walk_ty(self, t)
-            }
-        }
-    }
-    HasTait.visit_ty(tcx.hir().expect_item(def_id).expect_ty_alias().0).is_break()
+pub fn type_alias_is_lazy<'tcx>(_: TyCtxt<'tcx>, _: LocalDefId) -> bool {
+    // [[[[ /!\ CRATER-ONLY /!\ ]]]]
+    //      All type aliases are lazy.
+    true
 }

--- a/compiler/rustc_hir_analysis/src/outlives/utils.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/utils.rs
@@ -21,7 +21,7 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
 ) {
     // If the `'a` region is bound within the field type itself, we
     // don't want to propagate this constraint to the header.
-    if !is_free_region(outlived_region) {
+    if !is_early_bound_region(outlived_region) {
         return;
     }
 
@@ -132,7 +132,7 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
         }
 
         GenericArgKind::Lifetime(r) => {
-            if !is_free_region(r) {
+            if !is_early_bound_region(r) {
                 return;
             }
             required_predicates.entry(ty::OutlivesPredicate(kind, outlived_region)).or_insert(span);
@@ -144,7 +144,7 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
     }
 }
 
-fn is_free_region(region: Region<'_>) -> bool {
+fn is_early_bound_region(region: Region<'_>) -> bool {
     // First, screen for regions that might appear in a type header.
     match *region {
         // These correspond to `T: 'a` relationships:

--- a/compiler/rustc_infer/src/infer/outlives/components.rs
+++ b/compiler/rustc_infer/src/infer/outlives/components.rs
@@ -138,7 +138,7 @@ fn compute_components<'tcx>(
             // trait-ref. Therefore, if we see any higher-ranked regions,
             // we simply fallback to the most restrictive rule, which
             // requires that `Pi: 'a` for all `i`.
-            ty::Alias(_, alias_ty) => {
+            ty::Alias(ty::Projection | ty::Inherent | ty::Opaque, alias_ty) => {
                 if !alias_ty.has_escaping_bound_vars() {
                     // best case: no escaping regions, so push the
                     // projection and skip the subtree (thus generating no
@@ -178,6 +178,7 @@ fn compute_components<'tcx>(
             ty::Float(..) |       // OutlivesScalar
             ty::Never |           // ...
             ty::Adt(..) |         // OutlivesNominalType
+            ty::Alias(ty::Weak, _) |
             ty::Foreign(..) |     // OutlivesNominalType
             ty::Str |             // OutlivesScalar (ish)
             ty::Slice(..) |       // ...

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -567,6 +567,8 @@ impl<'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'tcx> {
             i.kind,
             hir::ItemKind::Impl(hir::Impl { of_trait: None, .. })
                 | hir::ItemKind::ForeignMod { .. }
+                // [[[[ /!\ CRATER-ONLY /!\ ]]]]
+                | hir::ItemKind::TyAlias(..)
         ) {
             self.check_missing_stability(i.owner_id.def_id, i.span);
         }
@@ -585,8 +587,13 @@ impl<'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'tcx> {
     fn visit_impl_item(&mut self, ii: &'tcx hir::ImplItem<'tcx>) {
         let impl_def_id = self.tcx.hir().get_parent_item(ii.hir_id());
         if self.tcx.impl_trait_ref(impl_def_id).is_none() {
-            self.check_missing_stability(ii.owner_id.def_id, ii.span);
-            self.check_missing_const_stability(ii.owner_id.def_id, ii.span);
+            // [[[[ /!\ CRATER-ONLY /!\ ]]]]
+            // FIXME(fmease): The proper fix would be to peel_off_weak_alias_tys(impl_self_ty)
+            // and to get the owner this way. Not entirely sure.
+            if false {
+                self.check_missing_stability(ii.owner_id.def_id, ii.span);
+                self.check_missing_const_stability(ii.owner_id.def_id, ii.span);
+            }
         }
         intravisit::walk_impl_item(self, ii);
     }

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -203,7 +203,8 @@ where
                     }
                 }
             }
-            ty::Alias(kind @ (ty::Inherent | ty::Weak | ty::Projection), data) => {
+            // [[[[ /!\ CRATER-ONLY /!\ ]]]]
+            ty::Alias(kind @ (ty::Inherent | ty::Projection), data) => {
                 if V::SKIP_ASSOC_TYS {
                     // Visitors searching for minimal visibility/reachability want to
                     // conservatively approximate associated types like `Type::Alias`
@@ -233,6 +234,10 @@ where
                         data.args.iter().try_for_each(|arg| arg.visit_with(self).branch()),
                     )
                 };
+            }
+            // [[[[ /!\ CRATER-ONLY /!\ ]]]]
+            ty::Alias(ty::Weak, _) => {
+                return V::Result::output();
             }
             ty::Dynamic(predicates, ..) => {
                 // All traits in the list are considered the "primary" part of the type

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -801,6 +801,7 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
                 }
             }
 
+            // NOTE(fmease): It should be fine to keep this.
             ty::Alias(ty::Weak, ty::AliasTy { def_id, args, .. }) => {
                 let obligations = self.nominal_obligations(def_id, args);
                 self.out.extend(obligations);

--- a/compiler/rustc_traits/src/normalize_projection_ty.rs
+++ b/compiler/rustc_traits/src/normalize_projection_ty.rs
@@ -79,6 +79,7 @@ fn normalize_canonicalized_weak_ty<'tcx>(
     tcx.infer_ctxt().enter_canonical_trait_query(
         &goal,
         |ocx, ParamEnvAnd { param_env, value: goal }| {
+            // NOTE(fmease): It should be fine to keep this for the crater run.
             let obligations = tcx.predicates_of(goal.def_id).instantiate_own(tcx, goal.args).map(
                 |(predicate, span)| {
                     traits::Obligation::new(


### PR DESCRIPTION
Not ready for crater yet since this patch can't build stage1 std at the moment :smiling_face_with_tear:, still need to figure that out.
I've at least managed to make it build stage1 core & alloc.