### PR TITLE
Enforce predicates which link bivariant opaque lifetimes

### DIFF
--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -610,6 +610,15 @@ impl<'tcx> InferCtxt<'tcx> {
             ty::ClauseKind::WellFormed(hidden_ty.into()),
         ));
 
+        // This enforces the region obligations that link the bivariant
+        // lifetimes of an opaque to their invariant copies.
+        obligations.push(traits::Obligation::new(
+            tcx,
+            cause.clone(),
+            param_env,
+            ty::ClauseKind::WellFormed(Ty::new_opaque(self.tcx, def_id, args).into()),
+        ));
+
         let item_bounds = tcx.explicit_item_bounds(def_id);
         for (predicate, _) in item_bounds.iter_instantiated_copied(tcx, args) {
             let predicate = predicate.fold_with(&mut BottomUpFolder {

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -792,13 +792,8 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
             }
 
             ty::Alias(ty::Opaque, ty::AliasTy { def_id, args, .. }) => {
-                // All of the requirements on type parameters
-                // have already been checked for `impl Trait` in
-                // return position. We do need to check type-alias-impl-trait though.
-                if self.tcx().is_type_alias_impl_trait(def_id) {
-                    let obligations = self.nominal_obligations(def_id, args);
-                    self.out.extend(obligations);
-                }
+                let obligations = self.nominal_obligations(def_id, args);
+                self.out.extend(obligations);
             }
 
             ty::Alias(ty::Weak, ty::AliasTy { def_id, args, .. }) => {

--- a/tests/ui/impl-trait/bivariant-duplicated-lifetime.rs
+++ b/tests/ui/impl-trait/bivariant-duplicated-lifetime.rs
@@ -1,0 +1,9 @@
+//@ check-pass
+
+#![allow(unconditional_recursion)]
+
+fn test<'a>() -> impl Sized + 'a {
+    let _: () = test::<'a>();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.rs
+++ b/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.rs
@@ -9,6 +9,7 @@ impl Foo<char> for Bar {
         //~^ ERROR: the trait bound `impl Foo<u8>: Foo<char>` is not satisfied [E0277]
         //~| ERROR: the trait bound `Bar: Foo<u8>` is not satisfied [E0277]
         //~| ERROR: impl has stricter requirements than trait
+        //~| ERROR: the trait bound `F2: Foo<u8>` is not satisfied
         self
     }
 }

--- a/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
@@ -11,6 +11,22 @@ note: required by a bound in `Foo::{synthetic#0}`
 LL |     fn foo<F2>(self) -> impl Foo<T>;
    |                              ^^^^^^ required by this bound in `Foo::{synthetic#0}`
 
+error[E0277]: the trait bound `F2: Foo<u8>` is not satisfied
+  --> $DIR/return-dont-satisfy-bounds.rs:8:34
+   |
+LL |     fn foo<F2: Foo<u8>>(self) -> impl Foo<u8> {
+   |                                  ^^^^^^^^^^^^ the trait `Foo<u8>` is not implemented for `F2`
+   |
+note: required by a bound in `<Bar as Foo<char>>::foo`
+  --> $DIR/return-dont-satisfy-bounds.rs:8:16
+   |
+LL |     fn foo<F2: Foo<u8>>(self) -> impl Foo<u8> {
+   |                ^^^^^^^ required by this bound in `<Bar as Foo<char>>::foo`
+help: consider further restricting this bound
+   |
+LL |     fn foo<F2: Foo<u8> + Foo<u8>>(self) -> impl Foo<u8> {
+   |                        +++++++++
+
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/return-dont-satisfy-bounds.rs:8:16
    |
@@ -32,7 +48,7 @@ LL |         self
    = help: the trait `Foo<char>` is implemented for `Bar`
    = help: for that trait implementation, expected `char`, found `u8`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0276, E0277.
 For more information about an error, try `rustc --explain E0276`.

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
@@ -7,6 +7,7 @@ async fn wrapper<F>(f: F)
 //~^ ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 //~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 //~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+//~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 where
 F:,
 for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
@@ -5,7 +5,7 @@ LL | / async fn wrapper<F>(f: F)
 LL | |
 LL | |
 LL | |
-LL | | where
+...  |
 LL | | F:,
 LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
    | |__________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
@@ -27,7 +27,7 @@ LL | / async fn wrapper<F>(f: F)
 LL | |
 LL | |
 LL | |
-LL | | where
+...  |
 LL | | F:,
 LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
    | |__________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
@@ -35,7 +35,22 @@ LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a
    = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
 
 error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-  --> $DIR/issue-76168-hr-outlives-3.rs:13:1
+  --> $DIR/issue-76168-hr-outlives-3.rs:6:1
+   |
+LL | / async fn wrapper<F>(f: F)
+LL | |
+LL | |
+LL | |
+...  |
+LL | | F:,
+LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
+   | |__________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
+   |
+   = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+  --> $DIR/issue-76168-hr-outlives-3.rs:14:1
    |
 LL | / {
 LL | |
@@ -46,6 +61,6 @@ LL | | }
    |
    = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.stderr
+++ b/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.stderr
@@ -8,6 +8,27 @@ LL | #![feature(non_lifetime_binders)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0309]: the placeholder type `!1_"F"` may not live long enough
+  --> $DIR/type-match-with-late-bound.rs:8:1
+   |
+LL |   async fn walk2<'a, T: 'a>(_: T)
+   |   ^              -- the placeholder type `!1_"F"` must be valid for the lifetime `'a` as defined here...
+   |  _|
+   | |
+LL | | where
+LL | |     for<F> F: 'a,
+   | |_________________^ ...so that the type `F` will meet its required lifetime bounds...
+   |
+note: ...that is required by this bound
+  --> $DIR/type-match-with-late-bound.rs:10:15
+   |
+LL |     for<F> F: 'a,
+   |               ^^
+help: consider adding an explicit lifetime bound
+   |
+LL |     for<F> F: 'a, !1_"F": 'a
+   |                 ~~~~~~~~~~~~
+
+error[E0309]: the placeholder type `!1_"F"` may not live long enough
   --> $DIR/type-match-with-late-bound.rs:11:1
    |
 LL | async fn walk2<'a, T: 'a>(_: T)
@@ -35,6 +56,20 @@ help: consider adding an explicit lifetime bound
 LL |     for<F> F: 'a, !2_"F": 'a
    |                 ~~~~~~~~~~~~
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error[E0309]: the placeholder type `!3_"F"` may not live long enough
+  --> $DIR/type-match-with-late-bound.rs:11:1
+   |
+LL | async fn walk2<'a, T: 'a>(_: T)
+   |                -- the placeholder type `!3_"F"` must be valid for the lifetime `'a` as defined here...
+...
+LL | {}
+   | ^^ ...so that the type `F` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound
+   |
+LL |     for<F> F: 'a, !3_"F": 'a
+   |                 ~~~~~~~~~~~~
+
+error: aborting due to 4 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0309`.

--- a/tests/ui/type-alias-impl-trait/bivariant-duplicated-lifetime.rs
+++ b/tests/ui/type-alias-impl-trait/bivariant-duplicated-lifetime.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+
+#![feature(type_alias_impl_trait)]
+#![allow(unconditional_recursion)]
+
+type Opaque<'a> = impl Sized + 'a;
+
+fn test<'a>() -> Opaque<'a> {
+    let _: () = test::<'a>();
+}
+
+fn main() {}


### PR DESCRIPTION
During `predicates_of`, we install outlives obligations which link the bivariant lifetimes of an opaque to their invariant (captured) copies. During NLL, we don't enforce well-formedness of an opaque that we are trying to define, and therefore we never actually enforce that these lifetimes are equal. This means that we have strange errors (#122307), or ICEs (#121512) from unconstrained lifetimes that *should* be constrained.

Fix this by requiring the opaque in `add_item_bounds_for_hidden_type` to be well-formed, which will enforce its own predicates.

r? @aliemjay cc @lcnr @oli-obk

You have any thoughts about this approach? I guess f72f5d8f3f04798751e6d2334c8efface8a6b799 is unnecessary, because it's still possible to ICE with RPITs and uncaptured lifetimes, e.g.

```rust
fn test<'a: 'a>() -> impl Sized {
    let _: () = test::<'a>();
}
```

---

side-note: I'm feeling a déjà-vu writing this PR, like this has been attempted before... if it has, could you remind me where this was, and why this approach ultimately wasn't taken?