### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/main_shim.rs
+++ b/compiler/rustc_codegen_cranelift/src/main_shim.rs
@@ -115,14 +115,12 @@ pub(crate) fn maybe_create_entry_wrapper(
                         termination_trait,
                     )
                     .unwrap();
-                let report = Instance::resolve(
+                let report = Instance::expect_resolve(
                     tcx,
                     ParamEnv::reveal_all(),
                     report.def_id,
                     tcx.mk_args(&[GenericArg::from(main_ret_ty)]),
                 )
-                .unwrap()
-                .unwrap()
                 .polymorphize(tcx);
 
                 let report_name = tcx.symbol_name(report).name;
@@ -142,14 +140,12 @@ pub(crate) fn maybe_create_entry_wrapper(
                 }
             } else if is_main_fn {
                 let start_def_id = tcx.require_lang_item(LangItem::Start, None);
-                let start_instance = Instance::resolve(
+                let start_instance = Instance::expect_resolve(
                     tcx,
                     ParamEnv::reveal_all(),
                     start_def_id,
                     tcx.mk_args(&[main_ret_ty.into()]),
                 )
-                .unwrap()
-                .unwrap()
                 .polymorphize(tcx);
                 let start_func_id = import_function(tcx, m, start_instance);
 

--- a/compiler/rustc_codegen_gcc/src/context.rs
+++ b/compiler/rustc_codegen_gcc/src/context.rs
@@ -473,14 +473,12 @@ impl<'gcc, 'tcx> MiscMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
         let tcx = self.tcx;
         let func = match tcx.lang_items().eh_personality() {
             Some(def_id) if !wants_msvc_seh(self.sess()) => {
-                let instance = ty::Instance::resolve(
+                let instance = ty::Instance::expect_resolve(
                     tcx,
                     ty::ParamEnv::reveal_all(),
                     def_id,
                     ty::List::empty(),
-                )
-                .unwrap()
-                .unwrap();
+                );
 
                 let symbol_name = tcx.symbol_name(instance).name;
                 let fn_abi = self.fn_abi_of_instance(instance, ty::List::empty());

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -558,11 +558,12 @@ impl<'ll, 'tcx> MiscMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
         let tcx = self.tcx;
         let llfn = match tcx.lang_items().eh_personality() {
-            Some(def_id) if name.is_none() => self.get_fn_addr(
-                ty::Instance::resolve(tcx, ty::ParamEnv::reveal_all(), def_id, ty::List::empty())
-                    .unwrap()
-                    .unwrap(),
-            ),
+            Some(def_id) if name.is_none() => self.get_fn_addr(ty::Instance::expect_resolve(
+                tcx,
+                ty::ParamEnv::reveal_all(),
+                def_id,
+                ty::List::empty(),
+            )),
             _ => {
                 let name = name.unwrap_or("rust_eh_personality");
                 if let Some(llfn) = self.get_declared_value(name) {

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -467,16 +467,12 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 
         let (start_fn, start_ty, args) = if let EntryFnType::Main { sigpipe } = entry_type {
             let start_def_id = cx.tcx().require_lang_item(LangItem::Start, None);
-            let start_fn = cx.get_fn_addr(
-                ty::Instance::resolve(
-                    cx.tcx(),
-                    ty::ParamEnv::reveal_all(),
-                    start_def_id,
-                    cx.tcx().mk_args(&[main_ret_ty.into()]),
-                )
-                .unwrap()
-                .unwrap(),
-            );
+            let start_fn = cx.get_fn_addr(ty::Instance::expect_resolve(
+                cx.tcx(),
+                ty::ParamEnv::reveal_all(),
+                start_def_id,
+                cx.tcx().mk_args(&[main_ret_ty.into()]),
+            ));
 
             let i8_ty = cx.type_i8();
             let arg_sigpipe = bx.const_u8(sigpipe);

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -67,7 +67,7 @@ fn eval_body_using_ecx<'mir, 'tcx>(
     trace!(
         "eval_body_using_ecx: pushing stack frame for global: {}{}",
         with_no_trimmed_paths!(ecx.tcx.def_path_str(cid.instance.def_id())),
-        cid.promoted.map_or_else(String::new, |p| format!("::promoted[{p:?}]"))
+        cid.promoted.map_or_else(String::new, |p| format!("::{p:?}"))
     );
 
     ecx.push_stack_frame(

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -243,14 +243,12 @@ impl<'mir, 'tcx: 'mir> CompileTimeEvalContext<'mir, 'tcx> {
         } else if Some(def_id) == self.tcx.lang_items().panic_fmt() {
             // For panic_fmt, call const_panic_fmt instead.
             let const_def_id = self.tcx.require_lang_item(LangItem::ConstPanicFmt, None);
-            let new_instance = ty::Instance::resolve(
+            let new_instance = ty::Instance::expect_resolve(
                 *self.tcx,
                 ty::ParamEnv::reveal_all(),
                 const_def_id,
                 instance.args,
-            )
-            .unwrap()
-            .unwrap();
+            );
 
             return Ok(Some(new_instance));
         } else if Some(def_id) == self.tcx.lang_items().align_offset_fn() {

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -389,7 +389,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
 
     // Entry point:
-    gated!(unix_sigpipe, Normal, template!(Word, NameValueStr: "inherit|sig_ign|sig_dfl"), ErrorFollowing, experimental!(unix_sigpipe)),
+    gated!(unix_sigpipe, Normal, template!(NameValueStr: "inherit|sig_ign|sig_dfl"), ErrorFollowing, experimental!(unix_sigpipe)),
     ungated!(start, Normal, template!(Word), WarnFollowing, @only_local: true),
     ungated!(no_start, CrateLevel, template!(Word), WarnFollowing, @only_local: true),
     ungated!(no_main, CrateLevel, template!(Word), WarnFollowing, @only_local: true),

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -496,7 +496,7 @@ fn write_mir_sig(tcx: TyCtxt<'_>, body: &Body<'_>, w: &mut dyn io::Write) -> io:
         _ => tcx.is_closure_like(def_id),
     };
     match (kind, body.source.promoted) {
-        (_, Some(i)) => write!(w, "{i:?} in ")?,
+        (_, Some(_)) => write!(w, "const ")?, // promoteds are the closest to consts
         (DefKind::Const | DefKind::AssocConst, _) => write!(w, "const ")?,
         (DefKind::Static(hir::Mutability::Not), _) => write!(w, "static ")?,
         (DefKind::Static(hir::Mutability::Mut), _) => write!(w, "static mut ")?,
@@ -508,6 +508,9 @@ fn write_mir_sig(tcx: TyCtxt<'_>, body: &Body<'_>, w: &mut dyn io::Write) -> io:
     ty::print::with_forced_impl_filename_line! {
         // see notes on #41697 elsewhere
         write!(w, "{}", tcx.def_path_str(def_id))?
+    }
+    if let Some(p) = body.source.promoted {
+        write!(w, "::{p:?}")?;
     }
 
     if body.source.promoted.is_none() && is_function {

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1339,14 +1339,12 @@ impl<'v> RootCollector<'_, 'v> {
             main_ret_ty.no_bound_vars().unwrap(),
         );
 
-        let start_instance = Instance::resolve(
+        let start_instance = Instance::expect_resolve(
             self.tcx,
             ty::ParamEnv::reveal_all(),
             start_def_id,
             self.tcx.mk_args(&[main_ret_ty.into()]),
-        )
-        .unwrap()
-        .unwrap();
+        );
 
         self.output.push(create_fn_mono_item(self.tcx, start_instance, DUMMY_SP));
     }

--- a/compiler/rustc_passes/src/entry.rs
+++ b/compiler/rustc_passes/src/entry.rs
@@ -156,13 +156,13 @@ fn sigpipe(tcx: TyCtxt<'_>, def_id: DefId) -> u8 {
             (Some(sym::inherit), None) => sigpipe::INHERIT,
             (Some(sym::sig_ign), None) => sigpipe::SIG_IGN,
             (Some(sym::sig_dfl), None) => sigpipe::SIG_DFL,
-            (_, Some(_)) => {
-                // Keep going so that `fn emit_malformed_attribute()` can print
-                // an excellent error message
+            (Some(_), None) => {
+                tcx.dcx().emit_err(UnixSigpipeValues { span: attr.span });
                 sigpipe::DEFAULT
             }
             _ => {
-                tcx.dcx().emit_err(UnixSigpipeValues { span: attr.span });
+                // Keep going so that `fn emit_malformed_attribute()` can print
+                // an excellent error message
                 sigpipe::DEFAULT
             }
         }

--- a/compiler/rustc_trait_selection/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalizes_to/mod.rs
@@ -542,13 +542,14 @@ impl<'tcx> assembly::GoalKind<'tcx> for NormalizesTo<'tcx> {
                 | ty::Coroutine(..)
                 | ty::CoroutineWitness(..)
                 | ty::Never
-                | ty::Foreign(..) => tcx.types.unit,
+                | ty::Foreign(..)
+                | ty::Dynamic(_, _, ty::DynStar) => tcx.types.unit,
 
                 ty::Error(e) => Ty::new_error(tcx, *e),
 
                 ty::Str | ty::Slice(_) => tcx.types.usize,
 
-                ty::Dynamic(_, _, _) => {
+                ty::Dynamic(_, _, ty::Dyn) => {
                     let dyn_metadata = tcx.require_lang_item(LangItem::DynMetadata, None);
                     tcx.type_of(dyn_metadata)
                         .instantiate(tcx, &[ty::GenericArg::from(goal.predicate.self_ty())])

--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -139,9 +139,11 @@ impl<'data> BorrowedBuf<'data> {
     }
 }
 
-/// A writeable view of the unfilled portion of a [`BorrowedBuf`](BorrowedBuf).
+/// A writeable view of the unfilled portion of a [`BorrowedBuf`].
 ///
-/// Provides access to the initialized and uninitialized parts of the underlying `BorrowedBuf`.
+/// The unfilled portion consists of an initialized and an uninitialized part; see [`BorrowedBuf`]
+/// for details.
+///
 /// Data can be written directly to the cursor by using [`append`](BorrowedCursor::append) or
 /// indirectly by getting a slice of part or all of the cursor and writing into the slice. In the
 /// indirect case, the caller must call [`advance`](BorrowedCursor::advance) after writing to inform

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -180,19 +180,19 @@ pub unsafe trait SliceIndex<T: ?Sized>: private_slice_index::Sealed {
     #[unstable(feature = "slice_index_methods", issue = "none")]
     fn get_mut(self, slice: &mut T) -> Option<&mut Self::Output>;
 
-    /// Returns a shared reference to the output at this location, without
+    /// Returns a pointer to the output at this location, without
     /// performing any bounds checking.
     /// Calling this method with an out-of-bounds index or a dangling `slice` pointer
-    /// is *[undefined behavior]* even if the resulting reference is not used.
+    /// is *[undefined behavior]* even if the resulting pointer is not used.
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     #[unstable(feature = "slice_index_methods", issue = "none")]
     unsafe fn get_unchecked(self, slice: *const T) -> *const Self::Output;
 
-    /// Returns a mutable reference to the output at this location, without
+    /// Returns a mutable pointer to the output at this location, without
     /// performing any bounds checking.
     /// Calling this method with an out-of-bounds index or a dangling `slice` pointer
-    /// is *[undefined behavior]* even if the resulting reference is not used.
+    /// is *[undefined behavior]* even if the resulting pointer is not used.
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     #[unstable(feature = "slice_index_methods", issue = "none")]

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -692,10 +692,9 @@ pub trait Read {
     /// Callers have to ensure that no unchecked out-of-bounds accesses are possible even if
     /// `n > buf.len()`.
     ///
-    /// No guarantees are provided about the contents of `buf` when this
-    /// function is called, so implementations cannot rely on any property of the
-    /// contents of `buf` being true. It is recommended that *implementations*
-    /// only write data to `buf` instead of reading its contents.
+    /// *Implementations* of this method can make no assumptions about the contents of `buf` when
+    /// this function is called. It is recommended that implementations only write data to `buf`
+    /// instead of reading its contents.
     ///
     /// Correspondingly, however, *callers* of this method in unsafe code must not assume
     /// any guarantees about how the implementation uses `buf`. The trait is safe to implement,
@@ -901,12 +900,10 @@ pub trait Read {
     /// This function reads as many bytes as necessary to completely fill the
     /// specified buffer `buf`.
     ///
-    /// No guarantees are provided about the contents of `buf` when this
-    /// function is called, so implementations cannot rely on any property of the
-    /// contents of `buf` being true. It is recommended that implementations
-    /// only write data to `buf` instead of reading its contents. The
-    /// documentation on [`read`] has a more detailed explanation on this
-    /// subject.
+    /// *Implementations* of this method can make no assumptions about the contents of `buf` when
+    /// this function is called. It is recommended that implementations only write data to `buf`
+    /// instead of reading its contents. The documentation on [`read`] has a more detailed
+    /// explanation of this subject.
     ///
     /// # Errors
     ///

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -694,6 +694,8 @@ fn read_buf_full_read() {
 }
 
 #[test]
+// Miri does not support signalling OOM
+#[cfg_attr(miri, ignore)]
 // 64-bit only to be sure the allocator will fail fast on an impossible to satsify size
 #[cfg(target_pointer_width = "64")]
 fn try_oom_error() {

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -171,9 +171,11 @@ pub struct Build {
     doc_tests: DocTests,
     verbosity: usize,
 
-    // Targets for which to build
+    /// Build triple for the pre-compiled snapshot compiler.
     build: TargetSelection,
+    /// Which triples to produce a compiler toolchain for.
     hosts: Vec<TargetSelection>,
+    /// Which triples to build libraries (core/alloc/std/test/proc_macro) for.
     targets: Vec<TargetSelection>,
 
     initial_rustc: PathBuf,

--- a/tests/mir-opt/building/custom/consts.consts.built.after.mir
+++ b/tests/mir-opt/building/custom/consts.consts.built.after.mir
@@ -10,9 +10,9 @@ fn consts() -> () {
 
     bb0: {
         _1 = const 5_u8;
-        _2 = const _;
+        _2 = const consts::<C>::{constant#0};
         _3 = const C;
-        _4 = const _;
+        _4 = const D;
         _5 = consts::<10>;
         return;
     }

--- a/tests/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-elaborate-drops.after.mir
@@ -1,6 +1,6 @@
 // MIR for `BAR::promoted[0]` after SimplifyCfg-elaborate-drops
 
-promoted[0] in BAR: &[&i32; 1] = {
+const BAR::promoted[0]: &[&i32; 1] = {
     let mut _0: &[&i32; 1];
     let mut _1: [&i32; 1];
     let mut _2: &i32;

--- a/tests/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/tests/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -20,7 +20,7 @@
 -         _4 = &(*_5);
 -         _3 = [move _4];
 -         _2 = &_3;
-+         _6 = const _;
++         _6 = const BAR::promoted[0];
 +         _2 = &(*_6);
           _1 = move _2 as &[&i32] (PointerCoercion(Unsize));
 -         StorageDead(_4);

--- a/tests/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-elaborate-drops.after.mir
@@ -1,6 +1,6 @@
 // MIR for `FOO::promoted[0]` after SimplifyCfg-elaborate-drops
 
-promoted[0] in FOO: &[&i32; 1] = {
+const FOO::promoted[0]: &[&i32; 1] = {
     let mut _0: &[&i32; 1];
     let mut _1: [&i32; 1];
     let mut _2: &i32;

--- a/tests/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
+++ b/tests/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
@@ -22,7 +22,7 @@
 -         _4 = &(*_5);
 -         _3 = [move _4];
 -         _2 = &_3;
-+         _6 = const _;
++         _6 = const FOO::promoted[0];
 +         _2 = &(*_6);
           _1 = move _2 as &[&i32] (PointerCoercion(Unsize));
 -         StorageDead(_4);

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.32bit.panic-abort.diff
@@ -25,7 +25,7 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          _9 = const _;
+          _9 = const main::promoted[0];
           _3 = &(*_9);
           _2 = &raw const (*_3);
           _1 = move _2 as *const [i32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.32bit.panic-unwind.diff
@@ -25,7 +25,7 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          _9 = const _;
+          _9 = const main::promoted[0];
           _3 = &(*_9);
           _2 = &raw const (*_3);
           _1 = move _2 as *const [i32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.64bit.panic-abort.diff
@@ -25,7 +25,7 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          _9 = const _;
+          _9 = const main::promoted[0];
           _3 = &(*_9);
           _2 = &raw const (*_3);
           _1 = move _2 as *const [i32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.GVN.64bit.panic-unwind.diff
@@ -25,7 +25,7 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          _9 = const _;
+          _9 = const main::promoted[0];
           _3 = &(*_9);
           _2 = &raw const (*_3);
           _1 = move _2 as *const [i32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-abort.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-abort.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = const _;
+          _1 = const <bool as NeedsDrop>::NEEDS;
 -         switchInt(move _1) -> [0: bb2, otherwise: bb1];
 +         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-unwind.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = const _;
+          _1 = const <bool as NeedsDrop>::NEEDS;
 -         switchInt(move _1) -> [0: bb2, otherwise: bb1];
 +         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }

--- a/tests/mir-opt/const_prop/overwrite_with_const_with_params.rs
+++ b/tests/mir-opt/const_prop/overwrite_with_const_with_params.rs
@@ -14,7 +14,7 @@ impl<T> SizeOfConst<T> {
 fn size_of<T>() -> usize {
     // CHECK-LABEL: fn size_of(
     // CHECK: _1 = const 0_usize;
-    // CHECK-NEXT: _1 = const _;
+    // CHECK-NEXT: _1 = const SizeOfConst::<T>::SIZE;
     // CHECK-NEXT: _0 = _1;
     let mut a = 0;
     a = SizeOfConst::<T>::SIZE;

--- a/tests/mir-opt/const_prop/overwrite_with_const_with_params.size_of.GVN.diff
+++ b/tests/mir-opt/const_prop/overwrite_with_const_with_params.size_of.GVN.diff
@@ -11,7 +11,7 @@
       bb0: {
           StorageLive(_1);
           _1 = const 0_usize;
-          _1 = const _;
+          _1 = const SizeOfConst::<T>::SIZE;
           _0 = _1;
           StorageDead(_1);
           return;

--- a/tests/mir-opt/const_prop/pointer_expose_address.main.GVN.panic-abort.diff
+++ b/tests/mir-opt/const_prop/pointer_expose_address.main.GVN.panic-abort.diff
@@ -17,7 +17,7 @@
 +         nop;
           StorageLive(_2);
           StorageLive(_3);
-          _3 = const _;
+          _3 = const main::FOO;
           _2 = &raw const (*_3);
           _1 = move _2 as usize (PointerExposeAddress);
           StorageDead(_2);

--- a/tests/mir-opt/const_prop/pointer_expose_address.main.GVN.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/pointer_expose_address.main.GVN.panic-unwind.diff
@@ -17,7 +17,7 @@
 +         nop;
           StorageLive(_2);
           StorageLive(_3);
-          _3 = const _;
+          _3 = const main::FOO;
           _2 = &raw const (*_3);
           _1 = move _2 as usize (PointerExposeAddress);
           StorageDead(_2);

--- a/tests/mir-opt/const_prop/pointer_expose_address.rs
+++ b/tests/mir-opt/const_prop/pointer_expose_address.rs
@@ -7,7 +7,7 @@ fn read(_: usize) { }
 // EMIT_MIR pointer_expose_address.main.GVN.diff
 fn main() {
     // CHECK-LABEL: fn main(
-    // CHECK: [[ptr:_.*]] = const _;
+    // CHECK: [[ptr:_.*]] = const main::FOO;
     // CHECK: [[ref:_.*]] = &raw const (*[[ptr]]);
     // CHECK: [[x:_.*]] = move [[ref]] as usize (PointerExposeAddress);
     // CHECK: = read([[x]])

--- a/tests/mir-opt/const_prop/ref_deref.main.GVN.diff
+++ b/tests/mir-opt/const_prop/ref_deref.main.GVN.diff
@@ -14,7 +14,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _4 = const _;
+          _4 = const main::promoted[0];
           _2 = &(*_4);
 -         _1 = (*_2);
 +         _1 = const 4_i32;

--- a/tests/mir-opt/const_prop/ref_deref_project.main.GVN.diff
+++ b/tests/mir-opt/const_prop/ref_deref_project.main.GVN.diff
@@ -14,7 +14,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _4 = const _;
+          _4 = const main::promoted[0];
           _2 = &((*_4).1: i32);
 -         _1 = (*_2);
 +         _1 = const 5_i32;

--- a/tests/mir-opt/const_prop/slice_len.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.GVN.32bit.panic-abort.diff
@@ -21,7 +21,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _4 = _9;
 -         _3 = _4;
 -         _2 = move _3 as &[u32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/slice_len.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.GVN.32bit.panic-unwind.diff
@@ -21,7 +21,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _4 = _9;
 -         _3 = _4;
 -         _2 = move _3 as &[u32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/slice_len.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.GVN.64bit.panic-abort.diff
@@ -21,7 +21,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _4 = _9;
 -         _3 = _4;
 -         _2 = move _3 as &[u32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/slice_len.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/slice_len.main.GVN.64bit.panic-unwind.diff
@@ -21,7 +21,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _4 = _9;
 -         _3 = _4;
 -         _2 = move _3 as &[u32] (PointerCoercion(Unsize));

--- a/tests/mir-opt/const_prop/transmute.invalid_char.GVN.32bit.diff
+++ b/tests/mir-opt/const_prop/transmute.invalid_char.GVN.32bit.diff
@@ -7,7 +7,7 @@
       }
   
       bb0: {
--         _0 = const _ as char (Transmute);
+-         _0 = const core::num::<impl i32>::MAX as char (Transmute);
 +         _0 = const {transmute(0x7fffffff): char};
           return;
       }

--- a/tests/mir-opt/const_prop/transmute.invalid_char.GVN.64bit.diff
+++ b/tests/mir-opt/const_prop/transmute.invalid_char.GVN.64bit.diff
@@ -7,7 +7,7 @@
       }
   
       bb0: {
--         _0 = const _ as char (Transmute);
+-         _0 = const core::num::<impl i32>::MAX as char (Transmute);
 +         _0 = const {transmute(0x7fffffff): char};
           return;
       }

--- a/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-abort.diff
@@ -53,7 +53,7 @@
           StorageDead(_5);
           StorageDead(_4);
           StorageLive(_7);
-          _7 = const _;
+          _7 = const core::num::<impl i32>::MAX;
           StorageLive(_8);
           StorageLive(_9);
 -         _9 = _7;

--- a/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/checked.main.DataflowConstProp.panic-unwind.diff
@@ -53,7 +53,7 @@
           StorageDead(_5);
           StorageDead(_4);
           StorageLive(_7);
-          _7 = const _;
+          _7 = const core::num::<impl i32>::MAX;
           StorageLive(_8);
           StorageLive(_9);
 -         _9 = _7;

--- a/tests/mir-opt/dataflow-const-prop/checked.rs
+++ b/tests/mir-opt/dataflow-const-prop/checked.rs
@@ -23,7 +23,7 @@ fn main() {
     // CHECK: [[c]] = const 3_i32;
     let c = a + b;
 
-    // CHECK: [[d]] = const _;
+    // CHECK: [[d]] = const core::num::<impl i32>::MAX;
     let d = i32::MAX;
 
     // CHECK: assert(!const true,

--- a/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.32bit.diff
@@ -23,7 +23,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = const _;
+          _1 = const constant::C;
           StorageLive(_2);
 -         _3 = discriminant(_1);
 -         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];

--- a/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.64bit.diff
@@ -23,7 +23,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = const _;
+          _1 = const constant::C;
           StorageLive(_2);
 -         _3 = discriminant(_1);
 -         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -34,7 +34,7 @@ fn constant() {
     // CHECK: debug x => [[x:_.*]];
     const C: E = E::V1(0);
 
-    // CHECK: [[e]] = const _;
+    // CHECK: [[e]] = const constant::C;
     let e = C;
     // CHECK: switchInt(const 0_isize) -> [0: [[target_bb:bb.*]], 1: bb2, otherwise: bb1];
     // CHECK: [[target_bb]]: {

--- a/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.32bit.panic-abort.diff
@@ -29,7 +29,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _4 = _14;
           _3 = _4;
           _2 = move _3 as &[u32] (PointerCoercion(Unsize));
@@ -52,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_9);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SLICE;
           StorageLive(_11);
           _11 = const 1_usize;
 -         _12 = Len((*_10));

--- a/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -29,7 +29,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _4 = _14;
           _3 = _4;
           _2 = move _3 as &[u32] (PointerCoercion(Unsize));
@@ -52,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_9);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SLICE;
           StorageLive(_11);
           _11 = const 1_usize;
 -         _12 = Len((*_10));

--- a/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.64bit.panic-abort.diff
@@ -29,7 +29,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _4 = _14;
           _3 = _4;
           _2 = move _3 as &[u32] (PointerCoercion(Unsize));
@@ -52,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_9);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SLICE;
           StorageLive(_11);
           _11 = const 1_usize;
 -         _12 = Len((*_10));

--- a/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -29,7 +29,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _4 = _14;
           _3 = _4;
           _2 = move _3 as &[u32] (PointerCoercion(Unsize));
@@ -52,7 +52,7 @@
           StorageDead(_2);
           StorageLive(_9);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SLICE;
           StorageLive(_11);
           _11 = const 1_usize;
 -         _12 = Len((*_10));

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
@@ -101,7 +101,7 @@
           StorageDead(_6);
           StorageDead(_5);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SMALL_VAL;
           StorageLive(_7);
 -         _7 = (_10.0: f32);
 +         _7 = const 4f32;
@@ -139,7 +139,7 @@
           StorageDead(_17);
           StorageDead(_16);
           StorageLive(_22);
-          _22 = const _;
+          _22 = const main::BIG_VAL;
           StorageLive(_19);
 -         _19 = (_22.0: f32);
 +         _19 = const 25f32;

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
@@ -101,7 +101,7 @@
           StorageDead(_6);
           StorageDead(_5);
           StorageLive(_10);
-          _10 = const _;
+          _10 = const main::SMALL_VAL;
           StorageLive(_7);
 -         _7 = (_10.0: f32);
 +         _7 = const 4f32;
@@ -139,7 +139,7 @@
           StorageDead(_17);
           StorageDead(_16);
           StorageLive(_22);
-          _22 = const _;
+          _22 = const main::BIG_VAL;
           StorageLive(_19);
 -         _19 = (_22.0: f32);
 +         _19 = const 25f32;

--- a/tests/mir-opt/dataflow-const-prop/transmute.invalid_char.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.invalid_char.DataflowConstProp.32bit.diff
@@ -7,7 +7,7 @@
       }
   
       bb0: {
--         _0 = const _ as char (Transmute);
+-         _0 = const core::num::<impl i32>::MAX as char (Transmute);
 +         _0 = const {transmute(0x7fffffff): char};
           return;
       }

--- a/tests/mir-opt/dataflow-const-prop/transmute.invalid_char.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.invalid_char.DataflowConstProp.64bit.diff
@@ -7,7 +7,7 @@
       }
   
       bb0: {
--         _0 = const _ as char (Transmute);
+-         _0 = const core::num::<impl i32>::MAX as char (Transmute);
 +         _0 = const {transmute(0x7fffffff): char};
           return;
       }

--- a/tests/mir-opt/derefer_complex_case.main.Derefer.panic-abort.diff
+++ b/tests/mir-opt/derefer_complex_case.main.Derefer.panic-abort.diff
@@ -28,7 +28,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _2 = &(*_14);
           _1 = <&[i32; 2] as IntoIterator>::into_iter(move _2) -> [return: bb1, unwind: bb8];
       }

--- a/tests/mir-opt/derefer_complex_case.main.Derefer.panic-unwind.diff
+++ b/tests/mir-opt/derefer_complex_case.main.Derefer.panic-unwind.diff
@@ -28,7 +28,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _14 = const _;
+          _14 = const main::promoted[0];
           _2 = &(*_14);
           _1 = <&[i32; 2] as IntoIterator>::into_iter(move _2) -> [return: bb1, unwind continue];
       }

--- a/tests/mir-opt/gvn.arithmetic.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.arithmetic.GVN.panic-abort.diff
@@ -336,7 +336,7 @@
           StorageLive(_54);
           StorageLive(_55);
           _55 = _1;
--         _54 = BitAnd(move _55, const _);
+-         _54 = BitAnd(move _55, const core::num::<impl u64>::MAX);
 +         _54 = _1;
           StorageDead(_55);
 -         _53 = opaque::<u64>(move _54) -> [return: bb23, unwind unreachable];
@@ -364,7 +364,7 @@
           StorageLive(_60);
           StorageLive(_61);
           _61 = _1;
--         _60 = BitOr(move _61, const _);
+-         _60 = BitOr(move _61, const core::num::<impl u64>::MAX);
 +         _60 = const u64::MAX;
           StorageDead(_61);
 -         _59 = opaque::<u64>(move _60) -> [return: bb25, unwind unreachable];

--- a/tests/mir-opt/gvn.arithmetic.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.arithmetic.GVN.panic-unwind.diff
@@ -336,7 +336,7 @@
           StorageLive(_54);
           StorageLive(_55);
           _55 = _1;
--         _54 = BitAnd(move _55, const _);
+-         _54 = BitAnd(move _55, const core::num::<impl u64>::MAX);
 +         _54 = _1;
           StorageDead(_55);
 -         _53 = opaque::<u64>(move _54) -> [return: bb23, unwind continue];
@@ -364,7 +364,7 @@
           StorageLive(_60);
           StorageLive(_61);
           _61 = _1;
--         _60 = BitOr(move _61, const _);
+-         _60 = BitOr(move _61, const core::num::<impl u64>::MAX);
 +         _60 = const u64::MAX;
           StorageDead(_61);
 -         _59 = opaque::<u64>(move _60) -> [return: bb25, unwind continue];

--- a/tests/mir-opt/gvn.constant_index_overflow.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.constant_index_overflow.GVN.panic-abort.diff
@@ -26,7 +26,7 @@
   
       bb0: {
 -         StorageLive(_2);
--         _2 = const _ as usize (IntToInt);
+-         _2 = const core::num::<impl u64>::MAX as usize (IntToInt);
 +         nop;
 +         _2 = const usize::MAX;
           StorageLive(_3);

--- a/tests/mir-opt/gvn.constant_index_overflow.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.constant_index_overflow.GVN.panic-unwind.diff
@@ -26,7 +26,7 @@
   
       bb0: {
 -         StorageLive(_2);
--         _2 = const _ as usize (IntToInt);
+-         _2 = const core::num::<impl u64>::MAX as usize (IntToInt);
 +         nop;
 +         _2 = const usize::MAX;
           StorageLive(_3);

--- a/tests/mir-opt/gvn.wide_ptr_provenance.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.wide_ptr_provenance.GVN.panic-abort.diff
@@ -61,7 +61,7 @@
           StorageLive(_3);
           StorageLive(_4);
           StorageLive(_5);
-          _44 = const _;
+          _44 = const wide_ptr_provenance::promoted[1];
           _5 = &(*_44);
           _4 = &(*_5);
           _3 = move _4 as &dyn std::marker::Send (PointerCoercion(Unsize));
@@ -79,7 +79,7 @@
           StorageLive(_9);
           StorageLive(_10);
           StorageLive(_11);
-          _43 = const _;
+          _43 = const wide_ptr_provenance::promoted[0];
           _11 = &(*_43);
           _10 = &(*_11);
           _9 = move _10 as &dyn std::marker::Send (PointerCoercion(Unsize));

--- a/tests/mir-opt/gvn.wide_ptr_provenance.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.wide_ptr_provenance.GVN.panic-unwind.diff
@@ -61,7 +61,7 @@
           StorageLive(_3);
           StorageLive(_4);
           StorageLive(_5);
-          _44 = const _;
+          _44 = const wide_ptr_provenance::promoted[1];
           _5 = &(*_44);
           _4 = &(*_5);
           _3 = move _4 as &dyn std::marker::Send (PointerCoercion(Unsize));
@@ -79,7 +79,7 @@
           StorageLive(_9);
           StorageLive(_10);
           StorageLive(_11);
-          _43 = const _;
+          _43 = const wide_ptr_provenance::promoted[0];
           _11 = &(*_43);
           _10 = &(*_11);
           _9 = move _10 as &dyn std::marker::Send (PointerCoercion(Unsize));

--- a/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-abort.diff
@@ -64,7 +64,7 @@
   
       bb0: {
           StorageLive(_1);
-          _49 = const _;
+          _49 = const wide_ptr_same_provenance::promoted[0];
           _1 = &(*_49);
           StorageLive(_3);
 -         StorageLive(_4);

--- a/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.wide_ptr_same_provenance.GVN.panic-unwind.diff
@@ -64,7 +64,7 @@
   
       bb0: {
           StorageLive(_1);
-          _49 = const _;
+          _49 = const wide_ptr_same_provenance::promoted[0];
           _1 = &(*_49);
           StorageLive(_3);
 -         StorageLive(_4);

--- a/tests/mir-opt/gvn_uninhabited.f.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn_uninhabited.f.GVN.panic-abort.diff
@@ -17,7 +17,7 @@
       bb0: {
           StorageLive(_2);
           StorageLive(_3);
-          _5 = const _;
+          _5 = const f::promoted[0];
           _3 = &(*_5);
           _2 = ((*_3).1: E);
           StorageLive(_1);

--- a/tests/mir-opt/gvn_uninhabited.f.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn_uninhabited.f.GVN.panic-unwind.diff
@@ -17,7 +17,7 @@
       bb0: {
           StorageLive(_2);
           StorageLive(_3);
-          _5 = const _;
+          _5 = const f::promoted[0];
           _3 = &(*_5);
           _2 = ((*_3).1: E);
           StorageLive(_1);

--- a/tests/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/tests/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -29,13 +29,13 @@ fn bar() -> bool {
         _2 = _1;
         StorageLive(_3);
         StorageLive(_4);
-        _10 = const _;
+        _10 = const bar::promoted[1];
         Retag(_10);
         _4 = &(*_10);
         _3 = &(*_4);
         StorageLive(_6);
         StorageLive(_7);
-        _9 = const _;
+        _9 = const bar::promoted[0];
         Retag(_9);
         _7 = &(*_9);
         _6 = &(*_7);

--- a/tests/mir-opt/inline/issue_106141.outer.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/issue_106141.outer.Inline.panic-abort.diff
@@ -8,7 +8,7 @@
 +         let mut _2: bool;
 +         let mut _3: bool;
 +         scope 2 {
-+             debug buffer => const _;
++             debug buffer => const inner::promoted[0];
 +             scope 3 {
 +                 debug index => _0;
 +             }
@@ -19,7 +19,7 @@
 -         _0 = inner() -> [return: bb1, unwind unreachable];
 +         StorageLive(_1);
 +         StorageLive(_2);
-+         _1 = const _;
++         _1 = const inner::promoted[0];
 +         _0 = index() -> [return: bb1, unwind unreachable];
       }
   

--- a/tests/mir-opt/inline/issue_106141.outer.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/issue_106141.outer.Inline.panic-unwind.diff
@@ -8,7 +8,7 @@
 +         let mut _2: bool;
 +         let mut _3: bool;
 +         scope 2 {
-+             debug buffer => const _;
++             debug buffer => const inner::promoted[0];
 +             scope 3 {
 +                 debug index => _0;
 +             }
@@ -19,7 +19,7 @@
 -         _0 = inner() -> [return: bb1, unwind continue];
 +         StorageLive(_1);
 +         StorageLive(_2);
-+         _1 = const _;
++         _1 = const inner::promoted[0];
 +         _0 = index() -> [return: bb1, unwind continue];
       }
   

--- a/tests/mir-opt/instsimplify/combine_transmutes.adt_transmutes.InstSimplify.diff
+++ b/tests/mir-opt/instsimplify/combine_transmutes.adt_transmutes.InstSimplify.diff
@@ -37,7 +37,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = Option::<NonZero<u8>>::Some(const _);
+          _2 = Option::<NonZero<u8>>::Some(const std::num::NonZero::<u8>::MAX);
           _1 = move _2 as u8 (Transmute);
           StorageDead(_2);
           StorageLive(_3);

--- a/tests/mir-opt/jump_threading.aggregate.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.aggregate.JumpThreading.panic-abort.diff
@@ -16,7 +16,7 @@
   
       bb0: {
           StorageLive(_4);
-          _4 = const _;
+          _4 = const aggregate::FOO;
           StorageLive(_2);
           _2 = (_4.0: u8);
           StorageLive(_3);

--- a/tests/mir-opt/jump_threading.aggregate.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.aggregate.JumpThreading.panic-unwind.diff
@@ -16,7 +16,7 @@
   
       bb0: {
           StorageLive(_4);
-          _4 = const _;
+          _4 = const aggregate::FOO;
           StorageLive(_2);
           _2 = (_4.0: u8);
           StorageLive(_3);

--- a/tests/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.panic-abort.diff
+++ b/tests/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.panic-abort.diff
@@ -41,7 +41,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _19 = const _;
+          _19 = const discriminant::<T>::promoted[2];
           _7 = &(*_19);
           _6 = &(*_7);
 -         _5 = discriminant_value::<i32>(move _6) -> [return: bb2, unwind unreachable];
@@ -56,7 +56,7 @@
           StorageLive(_9);
           StorageLive(_10);
           StorageLive(_11);
-          _18 = const _;
+          _18 = const discriminant::<T>::promoted[1];
           _11 = &(*_18);
           _10 = &(*_11);
 -         _9 = discriminant_value::<()>(move _10) -> [return: bb3, unwind unreachable];
@@ -71,7 +71,7 @@
           StorageLive(_13);
           StorageLive(_14);
           StorageLive(_15);
-          _17 = const _;
+          _17 = const discriminant::<T>::promoted[0];
           _15 = &(*_17);
           _14 = &(*_15);
 -         _13 = discriminant_value::<E>(move _14) -> [return: bb4, unwind unreachable];

--- a/tests/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.panic-unwind.diff
+++ b/tests/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.panic-unwind.diff
@@ -41,7 +41,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _19 = const _;
+          _19 = const discriminant::<T>::promoted[2];
           _7 = &(*_19);
           _6 = &(*_7);
 -         _5 = discriminant_value::<i32>(move _6) -> [return: bb2, unwind unreachable];
@@ -56,7 +56,7 @@
           StorageLive(_9);
           StorageLive(_10);
           StorageLive(_11);
-          _18 = const _;
+          _18 = const discriminant::<T>::promoted[1];
           _11 = &(*_18);
           _10 = &(*_11);
 -         _9 = discriminant_value::<()>(move _10) -> [return: bb3, unwind unreachable];
@@ -71,7 +71,7 @@
           StorageLive(_13);
           StorageLive(_14);
           StorageLive(_15);
-          _17 = const _;
+          _17 = const discriminant::<T>::promoted[0];
           _15 = &(*_17);
           _14 = &(*_15);
 -         _13 = discriminant_value::<E>(move _14) -> [return: bb4, unwind unreachable];

--- a/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
@@ -40,7 +40,7 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
         _3 = BitAnd(_2, const 31_u32);
         _4 = ShlUnchecked(_1, _3);
         StorageDead(_3);
-        _5 = Ge(_2, const _);
+        _5 = Ge(_2, const core::num::<impl u32>::BITS);
         StorageLive(_6);
         _6 = unlikely(move _5) -> [return: bb1, unwind unreachable];
     }

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -81,7 +81,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _7 = _9;
 +         _7 = const {ALLOC1<imm>: &std::alloc::Global};
           StorageLive(_8);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
@@ -85,7 +85,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _7 = _9;
 +         _7 = const {ALLOC1<imm>: &std::alloc::Global};
           StorageLive(_8);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -81,7 +81,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _7 = _9;
 +         _7 = const {ALLOC1<imm>: &std::alloc::Global};
           StorageLive(_8);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -85,7 +85,7 @@
           StorageLive(_5);
           StorageLive(_6);
           StorageLive(_7);
-          _9 = const _;
+          _9 = const main::promoted[0];
 -         _7 = _9;
 +         _7 = const {ALLOC1<imm>: &std::alloc::Global};
           StorageLive(_8);

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
@@ -101,7 +101,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -101,7 +101,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -91,7 +91,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -91,7 +91,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
@@ -103,7 +103,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -103,7 +103,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_5);
         StorageLive(_11);
         StorageLive(_8);
-        _8 = const _;
+        _8 = const <T as std::mem::SizedTypeProperties>::IS_ZST;
         switchInt(move _8) -> [0: bb1, otherwise: bb2];
     }
 

--- a/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
@@ -59,7 +59,7 @@
           _2 = const 5_u8;
           _1 = &mut _2;
           StorageLive(_3);
-          _28 = const _;
+          _28 = const debuginfo::promoted[2];
           _3 = &((*_28).0: u8);
 -         StorageLive(_5);
 -         _5 = &(*_1);
@@ -76,7 +76,7 @@
   
       bb2: {
           StorageLive(_9);
-          _27 = const _;
+          _27 = const debuginfo::promoted[1];
           _9 = &(((*_27) as Some).0: i32);
 -         _6 = const ();
           StorageDead(_9);
@@ -95,7 +95,7 @@
 -         StorageLive(_11);
 -         StorageLive(_12);
           StorageLive(_13);
-          _26 = const _;
+          _26 = const debuginfo::promoted[0];
           _13 = &(*_26);
           StorageLive(_15);
           _15 = RangeFull;

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.panic-abort.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.panic-abort.mir
@@ -109,7 +109,7 @@ fn array_casts() -> () {
         _15 = (*_16);
         _14 = &_15;
         StorageLive(_18);
-        _34 = const _;
+        _34 = const array_casts::promoted[0];
         Retag(_34);
         _18 = &(*_34);
         _13 = (move _14, move _18);

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -109,7 +109,7 @@ fn array_casts() -> () {
         _15 = (*_16);
         _14 = &_15;
         StorageLive(_18);
-        _34 = const _;
+        _34 = const array_casts::promoted[0];
         Retag(_34);
         _18 = &(*_34);
         _13 = (move _14, move _18);

--- a/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-abort.mir
+++ b/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-abort.mir
@@ -129,7 +129,7 @@ fn main() -> () {
         _20 = &_21;
         StorageLive(_22);
         StorageLive(_23);
-        _28 = const _;
+        _28 = const main::promoted[0];
         Retag(_28);
         _23 = &(*_28);
         _22 = &(*_23);

--- a/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -129,7 +129,7 @@ fn main() -> () {
         _20 = &_21;
         StorageLive(_22);
         StorageLive(_23);
-        _28 = const _;
+        _28 = const main::promoted[0];
         Retag(_28);
         _23 = &(*_28);
         _22 = &(*_23);

--- a/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
@@ -93,7 +93,7 @@
           StorageLive(_12);
           StorageLive(_13);
           StorageLive(_14);
-          _26 = const _;
+          _26 = const foo::<T>::promoted[0];
           _14 = &(*_26);
           _13 = &(*_14);
           _12 = move _13 as &[&str] (PointerCoercion(Unsize));

--- a/tests/mir-opt/sroa/structs.constant.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/structs.constant.ScalarReplacementOfAggregates.diff
@@ -25,7 +25,7 @@
 +         StorageLive(_4);
 +         StorageLive(_5);
 +         nop;
-          _1 = const _;
+          _1 = const constant::U;
 +         _4 = move (_1.0: usize);
 +         _5 = move (_1.1: u8);
           StorageLive(_2);

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-bare.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-bare.rs
@@ -1,4 +1,4 @@
 #![feature(unix_sigpipe)]
 
-#[unix_sigpipe] //~ error: valid values for `#[unix_sigpipe = "..."]` are `inherit`, `sig_ign`, or `sig_dfl`
+#[unix_sigpipe] //~ error: malformed `unix_sigpipe` attribute input
 fn main() {}

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-bare.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-bare.stderr
@@ -1,8 +1,8 @@
-error: valid values for `#[unix_sigpipe = "..."]` are `inherit`, `sig_ign`, or `sig_dfl`
+error: malformed `unix_sigpipe` attribute input
   --> $DIR/unix_sigpipe-bare.rs:3:1
    |
 LL | #[unix_sigpipe]
-   | ^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^ help: must be of the form: `#[unix_sigpipe = "inherit|sig_ign|sig_dfl"]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.stderr
@@ -2,14 +2,7 @@ error: malformed `unix_sigpipe` attribute input
   --> $DIR/unix_sigpipe-list.rs:3:1
    |
 LL | #[unix_sigpipe(inherit)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL | #[unix_sigpipe = "inherit|sig_ign|sig_dfl"]
-   | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-LL | #[unix_sigpipe]
-   | ~~~~~~~~~~~~~~~
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[unix_sigpipe = "inherit|sig_ign|sig_dfl"]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/dyn-star/thin.next.stderr
+++ b/tests/ui/dyn-star/thin.next.stderr
@@ -1,0 +1,11 @@
+warning: the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/thin.rs:6:12
+   |
+LL | #![feature(dyn_star)]
+   |            ^^^^^^^^
+   |
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/dyn-star/thin.old.stderr
+++ b/tests/ui/dyn-star/thin.old.stderr
@@ -1,0 +1,11 @@
+warning: the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/thin.rs:6:12
+   |
+LL | #![feature(dyn_star)]
+   |            ^^^^^^^^
+   |
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/dyn-star/thin.rs
+++ b/tests/ui/dyn-star/thin.rs
@@ -1,0 +1,16 @@
+//@check-pass
+//@revisions: old next
+//@[next] compile-flags: -Znext-solver
+
+#![feature(ptr_metadata)]
+#![feature(dyn_star)]
+//~^ WARN the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+
+use std::fmt::Debug;
+use std::ptr::Thin;
+
+fn check_thin<T: ?Sized + Thin>() {}
+
+fn main() {
+    check_thin::<dyn* Debug>();
+}


### PR DESCRIPTION
Successful merges:

 - #122275 (disable OOM test in Miri)
 - #122276 (io::Read trait: make it more clear when we are adressing implementations vs callers)
 - #122277 (BorrowedCursor docs clarification)
 - #122286 (use Instance::expect_resolve() instead of unwraping Instance::resolve())
 - #122290 (MIR printing: print the path of uneval'd const)
 - #122293 (diagnostics: Do not suggest using `#[unix_sigpipe]` without a value)
 - #122297 (bootstrap: document what the triples in 'Build' mean)
 - #122302 (docs: Correct ptr/ref verbiage in SliceIndex docs.)
 - #122304 (fix metadata for dyn-star in new solver)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=122275,122276,122277,122286,122290,122293,122297,122302,122304)
<!-- homu-ignore:end -->