### PR TITLE
[WIP] Perf experiment for rustc-hash with ones-idiom init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,8 +3341,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+source = "git+https://github.com/workingjubilee/rustc-hash?branch=stay-positive#e8dab147f2fed7405a348b510fec7fe350094f74"
 
 [[package]]
 name = "rustc-main"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,5 +120,7 @@ rustc-std-workspace-core = { path = 'library/rustc-std-workspace-core' }
 rustc-std-workspace-alloc = { path = 'library/rustc-std-workspace-alloc' }
 rustc-std-workspace-std = { path = 'library/rustc-std-workspace-std' }
 
+rustc-hash = { git = "https://github.com/workingjubilee/rustc-hash", branch = "stay-positive" }
+
 [patch."https://github.com/rust-lang/rust-clippy"]
 clippy_lints = { path = "src/tools/clippy/clippy_lints" }


### PR DESCRIPTION
CPUs for a while now know (at least) PCMPEQ as a dependency-breaking "ones idiom", and it's not a huge encoding next to constant loads. Let's try it out and see how the hashing goes.

Spurred by https://github.com/rust-lang/rustc-hash/issues/17