### PR TITLE
`mv` tools off the path instead of `rm -r`-ing them in `install-msys2.sh`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -154,11 +154,11 @@ toolchain.
    however this is not recommended as it's excrutiatingly slow, and not frequently
    tested for compatability.
 
-2. Start a MINGW64 or MINGW32 shell (depending on whether you want 32-bit
+3. Start a MINGW64 or MINGW32 shell (depending on whether you want 32-bit
    or 64-bit Rust) either from your start menu, or by running `mingw64.exe`
    or `mingw32.exe` from your MSYS2 installation directory (e.g. `C:\msys64`).
 
-3. From this terminal, install the required tools:
+4. From this terminal, install the required tools:
 
    ```sh
    # Update package mirrors (may be needed if you have a fresh install of MSYS2)
@@ -178,7 +178,7 @@ toolchain.
                mingw-w64-x86_64-ninja
    ```
 
-4. Navigate to Rust's source code (or clone it), then build it:
+5. Navigate to Rust's source code (or clone it), then build it:
 
    ```sh
    python x.py setup dist && python x.py build && python x.py install

--- a/src/ci/scripts/install-msys2.sh
+++ b/src/ci/scripts/install-msys2.sh
@@ -28,16 +28,19 @@ if isWindows; then
     # Install pacboy for easily installing packages
     pacman -S --noconfirm pactoys
 
-    # Delete these pre-installed tools so we can't accidentally use them, because we are using the
-    # MSYS2 setup action versions instead.
-    # Delete pre-installed version of MSYS2
-    echo "Cleaning up tools in PATH"
-    rm -r "/c/msys64/"
-    # Delete Strawberry Perl, which contains a version of mingw
-    rm -r "/c/Strawberry/"
-    # Delete these other copies of mingw, I don't even know where they come from.
-    rm -r "/c/mingw64/"
-    rm -r "/c/mingw32/"
+    # Remove these pre-installed tools so we can't accidentally use them, because we are using the
+    # MSYS2 setup action versions instead. Because `rm -r`-ing them is slow, we mv them off path
+    # instead.
+    # Remove pre-installed version of MSYS2
+    echo "Cleaning up existing tools in PATH"
+    notpath="/c/NOT/ON/PATH/"
+    mkdir --parents "$notpath"
+    mv -t "$notpath" "/c/msys64/"
+    # Remove Strawberry Perl, which contains a version of mingw
+    mv -t "$notpath" "/c/Strawberry/"
+    # Remove these other copies of mingw, I don't even know where they come from.
+    mv -t "$notpath" "/c/mingw64/"
+    mv -t "$notpath" "/c/mingw32/"
     echo "Finished cleaning up tools in PATH"
 
     if isKnownToBeMingwBuild; then


### PR DESCRIPTION
This is a follow up patch to https://github.com/rust-lang/rust/pull/121182

r? @Mark-Simulacrum