### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -8,6 +8,7 @@
     rustc_attrs,
     transparent_unions,
     auto_traits,
+    freeze_impls,
     thread_local
 )]
 #![no_core]

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -1,6 +1,6 @@
 #![feature(
     no_core, lang_items, intrinsics, unboxed_closures, type_ascription, extern_types,
-    decl_macro, rustc_attrs, transparent_unions, auto_traits,
+    decl_macro, rustc_attrs, transparent_unions, auto_traits, freeze_impls,
     thread_local
 )]
 #![no_core]

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -469,6 +469,8 @@ declare_features! (
     (unstable, fn_align, "1.53.0", Some(82232)),
     /// Support delegating implementation of functions to other already implemented functions.
     (incomplete, fn_delegation, "1.76.0", Some(118212)),
+    /// Allows impls for the Freeze trait.
+    (internal, freeze_impls, "CURRENT_RUSTC_VERSION", Some(121675)),
     /// Allows defining gen blocks and `gen fn`.
     (unstable, gen_blocks, "1.75.0", Some(117078)),
     /// Infer generic args for both consts and types.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -841,6 +841,7 @@ symbols! {
         format_placeholder,
         format_unsafe_arg,
         freeze,
+        freeze_impls,
         freg,
         frem_algebraic,
         frem_fast,

--- a/config.example.toml
+++ b/config.example.toml
@@ -842,6 +842,17 @@
 # See that option for more info.
 #codegen-backends = rust.codegen-backends (array)
 
+# This is a "runner" to pass to `compiletest` when executing tests. Tests will
+# execute this tool where the binary-to-test is passed as an argument. Can
+# be useful for situations such as when WebAssembly is being tested and a
+# runtime needs to be configured. This value is similar to
+# Cargo's `CARGO_$target_RUNNER` configuration.
+#
+# This configuration is a space-separated list of arguments so `foo bar` would
+# execute the program `foo` with the first argument as `bar` and the second
+# argument as the test binary.
+#runner = <none> (string)
+
 # =============================================================================
 # Distribution options
 #

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -5,7 +5,6 @@ use core::cmp;
 use core::hint;
 use core::mem::{self, ManuallyDrop, MaybeUninit, SizedTypeProperties};
 use core::ptr::{self, NonNull, Unique};
-use core::slice;
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
@@ -192,7 +191,7 @@ impl<T, A: Allocator> RawVec<T, A> {
 
         let me = ManuallyDrop::new(self);
         unsafe {
-            let slice = slice::from_raw_parts_mut(me.ptr() as *mut MaybeUninit<T>, len);
+            let slice = ptr::slice_from_raw_parts_mut(me.ptr() as *mut MaybeUninit<T>, len);
             Box::from_raw_in(slice, ptr::read(&me.alloc))
         }
     }

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -33,8 +33,6 @@ use crate::vec::Vec;
 #[cfg(test)]
 mod tests;
 
-#[unstable(feature = "slice_range", issue = "76393")]
-pub use core::slice::range;
 #[unstable(feature = "array_chunks", issue = "74985")]
 pub use core::slice::ArrayChunks;
 #[unstable(feature = "array_chunks", issue = "74985")]
@@ -51,6 +49,8 @@ pub use core::slice::{from_mut, from_ref};
 pub use core::slice::{from_mut_ptr_range, from_ptr_range};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{from_raw_parts, from_raw_parts_mut};
+#[unstable(feature = "slice_range", issue = "76393")]
+pub use core::slice::{range, try_range};
 #[stable(feature = "slice_group_by", since = "1.77.0")]
 pub use core::slice::{ChunkBy, ChunkByMut};
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -203,6 +203,7 @@
 // Language features:
 // tidy-alphabetical-start
 #![cfg_attr(bootstrap, feature(platform_intrinsics))]
+#![cfg_attr(not(bootstrap), feature(freeze_impls))]
 #![feature(abi_unadjusted)]
 #![feature(adt_const_params)]
 #![feature(allow_internal_unsafe)]

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -810,15 +810,21 @@ pub trait DiscriminantKind {
     type Discriminant: Clone + Copy + Debug + Eq + PartialEq + Hash + Send + Sync + Unpin;
 }
 
-/// Compiler-internal trait used to determine whether a type contains
+/// Used to determine whether a type contains
 /// any `UnsafeCell` internally, but not through an indirection.
 /// This affects, for example, whether a `static` of that type is
 /// placed in read-only static memory or writable static memory.
+/// This can be used to declare that a constant with a generic type
+/// will not contain interior mutability, and subsequently allow
+/// placing the constant behind references.
 #[lang = "freeze"]
-pub(crate) unsafe auto trait Freeze {}
+#[unstable(feature = "freeze", issue = "60715")]
+pub unsafe auto trait Freeze {}
 
+#[unstable(feature = "freeze", issue = "60715")]
 impl<T: ?Sized> !Freeze for UnsafeCell<T> {}
 marker_impls! {
+    #[unstable(feature = "freeze", issue = "60715")]
     unsafe Freeze for
         {T: ?Sized} PhantomData<T>,
         {T: ?Sized} *const T,

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -818,13 +818,13 @@ pub trait DiscriminantKind {
 /// will not contain interior mutability, and subsequently allow
 /// placing the constant behind references.
 #[lang = "freeze"]
-#[unstable(feature = "freeze", issue = "60715")]
+#[unstable(feature = "freeze", issue = "121675")]
 pub unsafe auto trait Freeze {}
 
-#[unstable(feature = "freeze", issue = "60715")]
+#[unstable(feature = "freeze", issue = "121675")]
 impl<T: ?Sized> !Freeze for UnsafeCell<T> {}
 marker_impls! {
-    #[unstable(feature = "freeze", issue = "60715")]
+    #[unstable(feature = "freeze", issue = "121675")]
     unsafe Freeze for
         {T: ?Sized} PhantomData<T>,
         {T: ?Sized} *const T,

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -681,8 +681,7 @@ where
 {
     let len = bounds.end;
 
-    let start: ops::Bound<&usize> = range.start_bound();
-    let start = match start {
+    let start = match range.start_bound() {
         ops::Bound::Included(&start) => start,
         ops::Bound::Excluded(start) => {
             start.checked_add(1).unwrap_or_else(|| slice_start_index_overflow_fail())
@@ -690,8 +689,7 @@ where
         ops::Bound::Unbounded => 0,
     };
 
-    let end: ops::Bound<&usize> = range.end_bound();
-    let end = match end {
+    let end = match range.end_bound() {
         ops::Bound::Included(end) => {
             end.checked_add(1).unwrap_or_else(|| slice_end_index_overflow_fail())
         }
@@ -707,6 +705,59 @@ where
     }
 
     ops::Range { start, end }
+}
+
+/// Performs bounds-checking of a range without panicking.
+///
+/// This is a version of [`range`] that returns [`None`] instead of panicking.
+///
+/// # Examples
+///
+/// ```
+/// #![feature(slice_range)]
+///
+/// use std::slice;
+///
+/// let v = [10, 40, 30];
+/// assert_eq!(Some(1..2), slice::try_range(1..2, ..v.len()));
+/// assert_eq!(Some(0..2), slice::try_range(..2, ..v.len()));
+/// assert_eq!(Some(1..3), slice::try_range(1.., ..v.len()));
+/// ```
+///
+/// Returns [`None`] when [`Index::index`] would panic:
+///
+/// ```
+/// #![feature(slice_range)]
+///
+/// use std::slice;
+///
+/// assert_eq!(None, slice::try_range(2..1, ..3));
+/// assert_eq!(None, slice::try_range(1..4, ..3));
+/// assert_eq!(None, slice::try_range(1..=usize::MAX, ..3));
+/// ```
+///
+/// [`Index::index`]: ops::Index::index
+#[unstable(feature = "slice_range", issue = "76393")]
+#[must_use]
+pub fn try_range<R>(range: R, bounds: ops::RangeTo<usize>) -> Option<ops::Range<usize>>
+where
+    R: ops::RangeBounds<usize>,
+{
+    let len = bounds.end;
+
+    let start = match range.start_bound() {
+        ops::Bound::Included(&start) => start,
+        ops::Bound::Excluded(start) => start.checked_add(1)?,
+        ops::Bound::Unbounded => 0,
+    };
+
+    let end = match range.end_bound() {
+        ops::Bound::Included(end) => end.checked_add(1)?,
+        ops::Bound::Excluded(&end) => end,
+        ops::Bound::Unbounded => len,
+    };
+
+    if start > end || end > len { None } else { Some(ops::Range { start, end }) }
 }
 
 /// Convert pair of `ops::Bound`s into `ops::Range` without performing any bounds checking and (in debug) overflow checking

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -91,7 +91,7 @@ pub use sort::heapsort;
 pub use index::SliceIndex;
 
 #[unstable(feature = "slice_range", issue = "76393")]
-pub use index::range;
+pub use index::{range, try_range};
 
 #[stable(feature = "inherent_ascii_escape", since = "1.60.0")]
 pub use ascii::EscapeAscii;

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -803,28 +803,10 @@ pub mod guard {
         Some(stack_ptr.with_addr(stackaddr))
     }
 
-    #[cfg(target_os = "netbsd")]
-    unsafe fn get_stack_start() -> Option<*mut libc::c_void> {
-        let mut ret = None;
-        let mut attr: libc::pthread_attr_t = crate::mem::zeroed();
-        let e = libc::pthread_getattr_np(libc::pthread_self(), &mut attr);
-        if e == 0 {
-            let mut stackaddr = crate::ptr::null_mut();
-            let mut stacksize = 0;
-            let mut guardsize = 0;
-            assert_eq!(libc::pthread_attr_getstack(&attr, &mut stackaddr, &mut stacksize), 0);
-            // on netbsd, we need to take in account the guard size to push up
-            // the stack's address from the bottom.
-            assert_eq!(libc::pthread_attr_getguardsize(&attr, &mut guardsize), 0);
-            stackaddr = stackaddr.add(guardsize);
-            ret = Some(stackaddr);
-        }
-        ret
-    }
-
     #[cfg(any(
         target_os = "android",
         target_os = "freebsd",
+        target_os = "netbsd",
         target_os = "hurd",
         target_os = "linux",
         target_os = "l4re"

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -346,6 +346,7 @@ compat_fn_with_fallback! {
 
     // >= Win8 / Server 2012
     // https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime
+    #[cfg(target_vendor = "win7")]
     pub fn GetSystemTimePreciseAsFileTime(lpsystemtimeasfiletime: *mut FILETIME) -> () {
         GetSystemTimeAsFileTime(lpsystemtimeasfiletime)
     }

--- a/library/std/src/sys/pal/windows/c/bindings.txt
+++ b/library/std/src/sys/pal/windows/c/bindings.txt
@@ -2475,6 +2475,7 @@ Windows.Win32.System.Pipes.PIPE_WAIT
 Windows.Win32.System.SystemInformation.GetSystemDirectoryW
 Windows.Win32.System.SystemInformation.GetSystemInfo
 Windows.Win32.System.SystemInformation.GetSystemTimeAsFileTime
+Windows.Win32.System.SystemInformation.GetSystemTimePreciseAsFileTime
 Windows.Win32.System.SystemInformation.GetWindowsDirectoryW
 Windows.Win32.System.SystemInformation.PROCESSOR_ARCHITECTURE
 Windows.Win32.System.SystemInformation.SYSTEM_INFO

--- a/library/std/src/sys/pal/windows/c/windows_sys.rs
+++ b/library/std/src/sys/pal/windows/c/windows_sys.rs
@@ -346,6 +346,10 @@ extern "system" {
 }
 #[link(name = "kernel32")]
 extern "system" {
+    pub fn GetSystemTimePreciseAsFileTime(lpsystemtimeasfiletime: *mut FILETIME) -> ();
+}
+#[link(name = "kernel32")]
+extern "system" {
     pub fn GetTempPathW(nbufferlength: u32, lpbuffer: PWSTR) -> u32;
 }
 #[link(name = "kernel32")]

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1970,6 +1970,8 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
 
         if builder.remote_tested(target) {
             cmd.arg("--remote-test-client").arg(builder.tool_exe(Tool::RemoteTestClient));
+        } else if let Some(tool) = builder.runner(target) {
+            cmd.arg("--runner").arg(tool);
         }
 
         if suite != "mir-opt" {
@@ -2519,6 +2521,8 @@ fn prepare_cargo_test(
             format!("CARGO_TARGET_{}_RUNNER", envify(&target.triple)),
             format!("{} run 0", builder.tool_exe(Tool::RemoteTestClient).display()),
         );
+    } else if let Some(tool) = builder.runner(target) {
+        cargo.env(format!("CARGO_TARGET_{}_RUNNER", envify(&target.triple)), tool);
     }
 
     cargo

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -579,6 +579,7 @@ pub struct Target {
     pub musl_libdir: Option<PathBuf>,
     pub wasi_root: Option<PathBuf>,
     pub qemu_rootfs: Option<PathBuf>,
+    pub runner: Option<String>,
     pub no_std: bool,
     pub codegen_backends: Option<Vec<Interned<String>>>,
 }
@@ -1142,6 +1143,7 @@ define_config! {
         qemu_rootfs: Option<String> = "qemu-rootfs",
         no_std: Option<bool> = "no-std",
         codegen_backends: Option<Vec<String>> = "codegen-backends",
+        runner: Option<String> = "runner",
     }
 }
 
@@ -1862,6 +1864,7 @@ impl Config {
                 target.musl_libdir = cfg.musl_libdir.map(PathBuf::from);
                 target.wasi_root = cfg.wasi_root.map(PathBuf::from);
                 target.qemu_rootfs = cfg.qemu_rootfs.map(PathBuf::from);
+                target.runner = cfg.runner;
                 target.sanitizers = cfg.sanitizers;
                 target.profiler = cfg.profiler;
                 target.rpath = cfg.rpath;

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1353,6 +1353,17 @@ impl Build {
             || env::var_os("TEST_DEVICE_ADDR").is_some()
     }
 
+    /// Returns an optional "runner" to pass to `compiletest` when executing
+    /// test binaries.
+    ///
+    /// An example of this would be a WebAssembly runtime when testing the wasm
+    /// targets.
+    fn runner(&self, target: TargetSelection) -> Option<String> {
+        let target = self.config.target_config.get(&target)?;
+        let runner = target.runner.as_ref()?;
+        Some(runner.to_owned())
+    }
+
     /// Returns the root of the "rootfs" image that this target will be using,
     /// if one was configured.
     ///

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -141,4 +141,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "A new `boostrap-cache-path` option has been introduced which can be utilized to modify the cache path for bootstrap.",
     },
+    ChangeInfo {
+        change_id: 122108,
+        severity: ChangeSeverity::Info,
+        summary: "a new `target.*.runner` option is available to specify a wrapper executable required to run tests for a target",
+    },
 ];

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -266,8 +266,10 @@ pub struct Config {
     pub logfile: Option<PathBuf>,
 
     /// A command line to prefix program execution with,
-    /// for running under valgrind
-    pub runtool: Option<String>,
+    /// for running under valgrind for example.
+    ///
+    /// Similar to `CARGO_*_RUNNER` configuration.
+    pub runner: Option<String>,
 
     /// Flags to pass to the compiler when building for the host
     pub host_rustcflags: Vec<String>,

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -86,7 +86,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         .optflag("", "exact", "filters match exactly")
         .optopt(
             "",
-            "runtool",
+            "runner",
             "supervisor program to run tests under \
              (eg. emulator, valgrind)",
             "PROGRAM",
@@ -256,7 +256,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
             _ => panic!("unknown `--run` option `{}` given", mode),
         }),
         logfile: matches.opt_str("logfile").map(|s| PathBuf::from(&s)),
-        runtool: matches.opt_str("runtool"),
+        runner: matches.opt_str("runner"),
         host_rustcflags: matches.opt_strs("host-rustcflags"),
         target_rustcflags: matches.opt_strs("target-rustcflags"),
         optimize_tests: matches.opt_present("optimize-tests"),
@@ -341,7 +341,7 @@ pub fn log_config(config: &Config) {
         c,
         format!("force_pass_mode: {}", opt_str(&config.force_pass_mode.map(|m| format!("{}", m))),),
     );
-    logv(c, format!("runtool: {}", opt_str(&config.runtool)));
+    logv(c, format!("runner: {}", opt_str(&config.runner)));
     logv(c, format!("host-rustcflags: {:?}", config.host_rustcflags));
     logv(c, format!("target-rustcflags: {:?}", config.target_rustcflags));
     logv(c, format!("target: {}", config.target));

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -461,7 +461,7 @@ impl<'test> TestCx<'test> {
         }
 
         let mut new_config = self.config.clone();
-        new_config.runtool = new_config.valgrind_path.clone();
+        new_config.runner = new_config.valgrind_path.clone();
         let new_cx = TestCx { config: &new_config, ..*self };
         proc_res = new_cx.exec_compiled_test();
 
@@ -2647,7 +2647,7 @@ impl<'test> TestCx<'test> {
     fn make_run_args(&self) -> ProcArgs {
         // If we've got another tool to run under (valgrind),
         // then split apart its command
-        let mut args = self.split_maybe_args(&self.config.runtool);
+        let mut args = self.split_maybe_args(&self.config.runner);
 
         // If this is emscripten, then run tests under nodejs
         if self.config.target.contains("emscripten") {

--- a/src/tools/miri/src/shims/time.rs
+++ b/src/tools/miri/src/shims/time.rs
@@ -110,12 +110,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     #[allow(non_snake_case, clippy::arithmetic_side_effects)]
     fn GetSystemTimeAsFileTime(
         &mut self,
+        shim_name: &str,
         LPFILETIME_op: &OpTy<'tcx, Provenance>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
-        this.assert_target_os("windows", "GetSystemTimeAsFileTime");
-        this.check_no_isolation("`GetSystemTimeAsFileTime`")?;
+        this.assert_target_os("windows", shim_name);
+        this.check_no_isolation(shim_name)?;
 
         let filetime = this.deref_pointer_as(LPFILETIME_op, this.windows_ty_layout("FILETIME"))?;
 

--- a/src/tools/miri/src/shims/windows/foreign_items.rs
+++ b/src/tools/miri/src/shims/windows/foreign_items.rs
@@ -246,11 +246,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             }
 
             // Time related shims
-            "GetSystemTimeAsFileTime" => {
+            "GetSystemTimeAsFileTime" | "GetSystemTimePreciseAsFileTime" => {
                 #[allow(non_snake_case)]
                 let [LPFILETIME] =
                     this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
-                this.GetSystemTimeAsFileTime(LPFILETIME)?;
+                this.GetSystemTimeAsFileTime(link_name.as_str(), LPFILETIME)?;
             }
             "QueryPerformanceCounter" => {
                 #[allow(non_snake_case)]

--- a/tests/run-make/min-global-align/min_global_align.rs
+++ b/tests/run-make/min-global-align/min_global_align.rs
@@ -1,4 +1,4 @@
-#![feature(no_core, lang_items)]
+#![feature(no_core, lang_items, freeze_impls)]
 #![crate_type = "rlib"]
 #![no_core]
 

--- a/tests/run-make/sigpipe-in-child-processes/Makefile
+++ b/tests/run-make/sigpipe-in-child-processes/Makefile
@@ -1,0 +1,15 @@
+# ignore-cross-compile because we run the compiled code
+# only-unix
+
+# See main.rs for a description of this test.
+
+include ../tools.mk
+
+all:
+	$(RUSTC) assert-sigpipe-disposition.rs -o $(TMPDIR)/assert-sigpipe-disposition;
+	for revision in default sig_dfl sig_ign inherit; do \
+		echo -n "Testing revision $$revision ... "; \
+		$(RUSTC) main.rs --cfg $$revision -o $(TMPDIR)/main.$$revision || exit 1; \
+		$(TMPDIR)/main.$$revision $(TMPDIR)/assert-sigpipe-disposition || exit 1; \
+		echo "ok"; \
+	done

--- a/tests/run-make/sigpipe-in-child-processes/assert-sigpipe-disposition.rs
+++ b/tests/run-make/sigpipe-in-child-processes/assert-sigpipe-disposition.rs
@@ -1,0 +1,25 @@
+#![feature(start, rustc_private)]
+
+extern crate libc;
+
+// Use #[start] so we don't have a runtime that messes with SIGPIPE.
+#[start]
+fn start(argc: isize, argv: *const *const u8) -> isize {
+    assert_eq!(argc, 2, "Must pass SIG_IGN or SIG_DFL as first arg");
+    let expected =
+        match unsafe { std::ffi::CStr::from_ptr(*argv.offset(1) as *const i8) }.to_str().unwrap() {
+            "SIG_IGN" => libc::SIG_IGN,
+            "SIG_DFL" => libc::SIG_DFL,
+            arg => panic!("Must pass SIG_IGN or SIG_DFL as first arg. Got: {}", arg),
+        };
+
+    let actual = unsafe {
+        let mut actual: libc::sigaction = std::mem::zeroed();
+        libc::sigaction(libc::SIGPIPE, std::ptr::null(), &mut actual);
+        actual.sa_sigaction
+    };
+
+    assert_eq!(actual, expected, "actual and expected SIGPIPE disposition in child differs");
+
+    return 0;
+}

--- a/tests/run-make/sigpipe-in-child-processes/main.rs
+++ b/tests/run-make/sigpipe-in-child-processes/main.rs
@@ -1,0 +1,51 @@
+// Checks the signal disposition of `SIGPIPE` in child processes, and in our own
+// process for robustness. Without any `unix_sigpipe` attribute, `SIG_IGN` is
+// the default. But there is a difference in how `SIGPIPE` is treated in child
+// processes with and without the attribute. Search for
+// `unix_sigpipe_attr_specified()` in the code base to learn more.
+//
+// Note that there are many other tests for `unix_sigpipe` in
+// tests/ui/attributes/unix_sigpipe.
+
+#![feature(rustc_private)]
+#![cfg_attr(any(sig_dfl, sig_ign, inherit), feature(unix_sigpipe))]
+
+extern crate libc;
+
+#[cfg_attr(sig_dfl, unix_sigpipe = "sig_dfl")]
+#[cfg_attr(sig_ign, unix_sigpipe = "sig_ign")]
+#[cfg_attr(inherit, unix_sigpipe = "inherit")]
+fn main() {
+    // By default, we get SIG_IGN but the child gets SIG_DFL.
+    #[cfg(default)]
+    let (we_expect, child_expects) = (libc::SIG_IGN, libc::SIG_DFL);
+
+    // With #[unix_sigpipe = "sig_dfl"] we get SIG_DFL and the child does too.
+    #[cfg(sig_dfl)]
+    let (we_expect, child_expects) = (libc::SIG_DFL, libc::SIG_DFL);
+
+    // With #[unix_sigpipe = "sig_ign"] we get SIG_IGN and the child does too.
+    #[cfg(sig_ign)]
+    let (we_expect, child_expects) = (libc::SIG_IGN, libc::SIG_IGN);
+
+    // With #[unix_sigpipe = "inherit"] we get SIG_DFL and the child does too.
+    #[cfg(inherit)]
+    let (we_expect, child_expects) = (libc::SIG_DFL, libc::SIG_DFL);
+
+    let actual = unsafe {
+        let mut actual: libc::sigaction = std::mem::zeroed();
+        libc::sigaction(libc::SIGPIPE, std::ptr::null(), &mut actual);
+        actual.sa_sigaction
+    };
+    assert_eq!(actual, we_expect, "we did not get the SIGPIPE disposition we expect");
+
+    let child_program = std::env::args().nth(1).unwrap();
+    let child_expects = match child_expects {
+        libc::SIG_DFL => "SIG_DFL",
+        libc::SIG_IGN => "SIG_IGN",
+        _ => unreachable!(),
+    };
+    assert!(
+        std::process::Command::new(child_program).arg(child_expects).status().unwrap().success()
+    );
+}

--- a/tests/rustdoc/auto-trait-bounds-by-associated-type-50159.rs
+++ b/tests/rustdoc/auto-trait-bounds-by-associated-type-50159.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/issues/50159
-#![crate_name="foo"]
+#![crate_name = "foo"]
 
 pub trait Signal {
     type Item;
@@ -9,7 +9,10 @@ pub trait Signal2 {
     type Item2;
 }
 
-impl<B, C> Signal2 for B where B: Signal<Item = C> {
+impl<B, C> Signal2 for B
+where
+    B: Signal<Item = C>,
+{
     type Item2 = C;
 }
 
@@ -17,7 +20,7 @@ impl<B, C> Signal2 for B where B: Signal<Item = C> {
 // @has - '//h3[@class="code-header"]' 'impl<B> Send for Switch<B>where <B as Signal>::Item: Send'
 // @has - '//h3[@class="code-header"]' 'impl<B> Sync for Switch<B>where <B as Signal>::Item: Sync'
 // @count - '//*[@id="implementations-list"]//*[@class="impl"]' 0
-// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 5
+// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 6
 pub struct Switch<B: Signal> {
     pub inner: <B as Signal2>::Item2,
 }

--- a/tests/rustdoc/empty-section.rs
+++ b/tests/rustdoc/empty-section.rs
@@ -1,6 +1,5 @@
 #![crate_name = "foo"]
-
-#![feature(negative_impls)]
+#![feature(negative_impls, freeze_impls, freeze)]
 
 pub struct Foo;
 
@@ -8,6 +7,7 @@ pub struct Foo;
 // @!hasraw - 'Auto Trait Implementations'
 impl !Send for Foo {}
 impl !Sync for Foo {}
+impl !std::marker::Freeze for Foo {}
 impl !std::marker::Unpin for Foo {}
 impl !std::panic::RefUnwindSafe for Foo {}
 impl !std::panic::UnwindSafe for Foo {}

--- a/tests/rustdoc/synthetic_auto/basic.rs
+++ b/tests/rustdoc/synthetic_auto/basic.rs
@@ -2,7 +2,7 @@
 // @has - '//h3[@class="code-header"]' 'impl<T> Send for Foo<T>where T: Send'
 // @has - '//h3[@class="code-header"]' 'impl<T> Sync for Foo<T>where T: Sync'
 // @count - '//*[@id="implementations-list"]//*[@class="impl"]' 0
-// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 5
+// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 6
 pub struct Foo<T> {
     field: T,
 }

--- a/tests/rustdoc/synthetic_auto/manual.rs
+++ b/tests/rustdoc/synthetic_auto/manual.rs
@@ -6,7 +6,7 @@
 // 'impl<T> Send for Foo<T>'
 //
 // @count - '//*[@id="trait-implementations-list"]//*[@class="impl"]' 1
-// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 4
+// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 5
 pub struct Foo<T> {
     field: T,
 }

--- a/tests/ui/associated-consts/freeze.rs
+++ b/tests/ui/associated-consts/freeze.rs
@@ -1,0 +1,12 @@
+#![feature(freeze)]
+
+//@ check-pass
+
+use std::marker::Freeze;
+
+trait Trait<T: Freeze + 'static> {
+    const VALUE: T;
+    const VALUE_REF: &'static T = &Self::VALUE;
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-freeze-impls.rs
+++ b/tests/ui/feature-gates/feature-gate-freeze-impls.rs
@@ -1,0 +1,15 @@
+#![feature(freeze, negative_impls)]
+
+use std::marker::Freeze;
+
+struct Foo;
+
+unsafe impl Freeze for Foo {}
+//~^ explicit impls for the `Freeze` trait are not permitted
+
+struct Bar;
+
+impl !Freeze for Bar {}
+//~^ explicit impls for the `Freeze` trait are not permitted
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-freeze-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-freeze-impls.stderr
@@ -1,0 +1,23 @@
+error[E0658]: explicit impls for the `Freeze` trait are not permitted
+  --> $DIR/feature-gate-freeze-impls.rs:7:1
+   |
+LL | unsafe impl Freeze for Foo {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ impl of `Freeze` not allowed
+   |
+   = note: see issue #121675 <https://github.com/rust-lang/rust/issues/121675> for more information
+   = help: add `#![feature(freeze_impls)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: explicit impls for the `Freeze` trait are not permitted
+  --> $DIR/feature-gate-freeze-impls.rs:12:1
+   |
+LL | impl !Freeze for Bar {}
+   | ^^^^^^^^^^^^^^^^^^^^ impl of `Freeze` not allowed
+   |
+   = note: see issue #121675 <https://github.com/rust-lang/rust/issues/121675> for more information
+   = help: add `#![feature(freeze_impls)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/hygiene/panic-location.rs
+++ b/tests/ui/hygiene/panic-location.rs
@@ -1,6 +1,7 @@
 //@ run-fail
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
+//@ normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
 //
 // Regression test for issue #70963
 // The captured stderr from this test reports a location

--- a/tests/ui/hygiene/panic-location.run.stderr
+++ b/tests/ui/hygiene/panic-location.run.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at library/alloc/src/raw_vec.rs:26:5:
+thread 'main' panicked at library/alloc/src/raw_vec.rs:LL:CC:
 capacity overflow
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
Successful merges:

 - #121148 (Add slice::try_range)
 - #121573 (unix_sigpipe: Add test for SIGPIPE disposition in child processes)
 - #121633 (Win10: Use `GetSystemTimePreciseAsFileTime` directly)
 - #121840 (Expose the Freeze trait again (unstably) and forbid implementing it manually)
 - #121907 (skip sanity check for non-host targets in `check` builds)
 - #122002 (std::threads: revisit stack address calculation on netbsd.)
 - #122108 (Add `target.*.runner` configuration for targets)
 - #122298 (RawVec::into_box: avoid unnecessary intermediate reference)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=121148,121573,121633,121840,121907,122002,122108,122298)
<!-- homu-ignore:end -->