### PR TITLE
unix_sigpipe: Replace `inherit` with `sig_dfl` in syntax tests

### DIFF
--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-crate.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-crate.rs
@@ -1,4 +1,4 @@
 #![feature(unix_sigpipe)]
-#![unix_sigpipe = "inherit"] //~ error: `unix_sigpipe` attribute cannot be used at crate level
+#![unix_sigpipe = "sig_dfl"] //~ error: `unix_sigpipe` attribute cannot be used at crate level
 
 fn main() {}

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-crate.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-crate.stderr
@@ -1,7 +1,7 @@
 error: `unix_sigpipe` attribute cannot be used at crate level
   --> $DIR/unix_sigpipe-crate.rs:2:1
    |
-LL | #![unix_sigpipe = "inherit"]
+LL | #![unix_sigpipe = "sig_dfl"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | fn main() {}
@@ -9,8 +9,8 @@ LL | fn main() {}
    |
 help: perhaps you meant to use an outer attribute
    |
-LL - #![unix_sigpipe = "inherit"]
-LL + #[unix_sigpipe = "inherit"]
+LL - #![unix_sigpipe = "sig_dfl"]
+LL + #[unix_sigpipe = "sig_dfl"]
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.rs
@@ -1,4 +1,4 @@
 #![feature(unix_sigpipe)]
 
-#[unix_sigpipe(inherit)] //~ error: malformed `unix_sigpipe` attribute input
+#[unix_sigpipe(sig_dfl)] //~ error: malformed `unix_sigpipe` attribute input
 fn main() {}

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.stderr
@@ -1,7 +1,7 @@
 error: malformed `unix_sigpipe` attribute input
   --> $DIR/unix_sigpipe-list.rs:3:1
    |
-LL | #[unix_sigpipe(inherit)]
+LL | #[unix_sigpipe(sig_dfl)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[unix_sigpipe = "inherit|sig_ign|sig_dfl"]`
 
 error: aborting due to 1 previous error

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-main-fn.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-main-fn.rs
@@ -1,6 +1,6 @@
 #![feature(unix_sigpipe)]
 
-#[unix_sigpipe = "inherit"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
+#[unix_sigpipe = "sig_dfl"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
 fn f() {}
 
 fn main() {}

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-main-fn.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-main-fn.stderr
@@ -1,7 +1,7 @@
 error: `unix_sigpipe` attribute can only be used on `fn main()`
   --> $DIR/unix_sigpipe-non-main-fn.rs:3:1
    |
-LL | #[unix_sigpipe = "inherit"]
+LL | #[unix_sigpipe = "sig_dfl"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-root-main.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-root-main.rs
@@ -1,7 +1,7 @@
 #![feature(unix_sigpipe)]
 
 mod m {
-    #[unix_sigpipe = "inherit"] //~ error: `unix_sigpipe` attribute can only be used on root `fn main()`
+    #[unix_sigpipe = "sig_dfl"] //~ error: `unix_sigpipe` attribute can only be used on root `fn main()`
     fn main() {}
 }
 

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-root-main.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-root-main.stderr
@@ -1,7 +1,7 @@
 error: `unix_sigpipe` attribute can only be used on root `fn main()`
   --> $DIR/unix_sigpipe-non-root-main.rs:4:5
    |
-LL |     #[unix_sigpipe = "inherit"]
+LL |     #[unix_sigpipe = "sig_dfl"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-start.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-start.rs
@@ -2,5 +2,5 @@
 #![feature(unix_sigpipe)]
 
 #[start]
-#[unix_sigpipe = "inherit"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
+#[unix_sigpipe = "sig_dfl"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
 fn custom_start(argc: isize, argv: *const *const u8) -> isize { 0 }

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-start.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-start.stderr
@@ -1,7 +1,7 @@
 error: `unix_sigpipe` attribute can only be used on `fn main()`
   --> $DIR/unix_sigpipe-start.rs:5:1
    |
-LL | #[unix_sigpipe = "inherit"]
+LL | #[unix_sigpipe = "sig_dfl"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-struct.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-struct.rs
@@ -1,6 +1,6 @@
 #![feature(unix_sigpipe)]
 
-#[unix_sigpipe = "inherit"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
+#[unix_sigpipe = "sig_dfl"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
 struct S;
 
 fn main() {}

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-struct.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-struct.stderr
@@ -1,7 +1,7 @@
 error: `unix_sigpipe` attribute can only be used on `fn main()`
   --> $DIR/unix_sigpipe-struct.rs:3:1
    |
-LL | #[unix_sigpipe = "inherit"]
+LL | #[unix_sigpipe = "sig_dfl"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
The `sig_dfl` variant of the attribute is the most likely variant to be stabilized first, and thus to become the "most allowed" variant of the attribute. Because of this, it is the most appropriate variant to use in syntax tests, because even if the most allowed variant is used, the compiler shall still emit errors if it e.g. is used in the wrong places.

r? @davidtwco who already [approved ](https://github.com/rust-lang/rust/pull/120832#pullrequestreview-1875075341) this commit in https://github.com/rust-lang/rust/pull/120832.

It would be nice to land the last preparatory commit of that PR before we begin to [rename ](https://github.com/rust-lang/rust/pull/120832#issuecomment-1987023484) things which will of course create a lot of code conflicts.