### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -77,8 +77,8 @@ pub struct CodegenCx<'ll, 'tcx> {
     /// See <https://llvm.org/docs/LangRef.html#the-llvm-compiler-used-global-variable> for details
     pub compiler_used_statics: RefCell<Vec<&'ll Value>>,
 
-    /// Mapping of non-scalar types to llvm types and field remapping if needed.
-    pub type_lowering: RefCell<FxHashMap<(Ty<'tcx>, Option<VariantIdx>), TypeLowering<'ll>>>,
+    /// Mapping of non-scalar types to llvm types.
+    pub type_lowering: RefCell<FxHashMap<(Ty<'tcx>, Option<VariantIdx>), &'ll Type>>,
 
     /// Mapping of scalar types to llvm types.
     pub scalar_lltypes: RefCell<FxHashMap<Ty<'tcx>, &'ll Type>>,
@@ -103,15 +103,6 @@ pub struct CodegenCx<'ll, 'tcx> {
     /// `global_asm!` needs to be able to find this new global so that it can
     /// compute the correct mangled symbol name to insert into the asm.
     pub renamed_statics: RefCell<FxHashMap<DefId, &'ll Value>>,
-}
-
-pub struct TypeLowering<'ll> {
-    /// Associated LLVM type
-    pub lltype: &'ll Type,
-
-    /// If padding is used the slice maps fields from source order
-    /// to llvm order.
-    pub field_remapping: Option<SmallVec<[u32; 4]>>,
 }
 
 fn to_llvm_tls_model(tls_model: TlsModel) -> llvm::ThreadLocalMode {

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1399,7 +1399,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
                             .binary_search_by_key(&cost, |&(_, cost)| cost)
                             .unwrap_or_else(|e| e);
                         work_items.insert(insertion_index, (work, cost));
-                        if !cgcx.opts.unstable_opts.no_parallel_llvm {
+                        if !cgcx.opts.unstable_opts.no_parallel_backend {
                             helper.request_token();
                         }
                     }
@@ -1522,7 +1522,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
                     };
                     work_items.insert(insertion_index, (llvm_work_item, cost));
 
-                    if !cgcx.opts.unstable_opts.no_parallel_llvm {
+                    if !cgcx.opts.unstable_opts.no_parallel_backend {
                         helper.request_token();
                     }
                     assert_eq!(main_thread_state, MainThreadState::Codegenning);

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -111,6 +111,13 @@ pub trait CodegenBackend {
         codegen_results: CodegenResults,
         outputs: &OutputFilenames,
     ) -> Result<(), ErrorGuaranteed>;
+
+    /// Returns `true` if this backend can be safely called from multiple threads.
+    ///
+    /// Defaults to `true`.
+    fn supports_parallel(&self) -> bool {
+        true
+    }
 }
 
 pub trait ExtraBackendMethods:

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -412,10 +412,10 @@ pub fn const_validate_mplace<'mir, 'tcx>(
             _ if cid.promoted.is_some() => CtfeValidationMode::Promoted,
             Some(mutbl) => CtfeValidationMode::Static { mutbl }, // a `static`
             None => {
-                // In normal `const` (not promoted), the outermost allocation is always only copied,
-                // so having `UnsafeCell` in there is okay despite them being in immutable memory.
-                let allow_immutable_unsafe_cell = cid.promoted.is_none() && !inner;
-                CtfeValidationMode::Const { allow_immutable_unsafe_cell }
+                // This is a normal `const` (not promoted).
+                // The outermost allocation is always only copied, so having `UnsafeCell` in there
+                // is okay despite them being in immutable memory.
+                CtfeValidationMode::Const { allow_immutable_unsafe_cell: !inner }
             }
         };
         ecx.const_validate_operand(&mplace.into(), path, &mut ref_tracking, mode)?;

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -380,16 +380,12 @@ pub fn eval_in_interpreter<'mir, 'tcx>(
         }
         Ok(mplace) => {
             // Since evaluation had no errors, validate the resulting constant.
-
-            // Temporarily allow access to the static_root_alloc_id for the purpose of validation.
-            let static_root_alloc_id = ecx.machine.static_root_alloc_id.take();
-            let validation = const_validate_mplace(&ecx, &mplace, cid);
-            ecx.machine.static_root_alloc_id = static_root_alloc_id;
+            let res = const_validate_mplace(&ecx, &mplace, cid);
 
             let alloc_id = mplace.ptr().provenance.unwrap().alloc_id();
 
             // Validation failed, report an error.
-            if let Err(error) = validation {
+            if let Err(error) = res {
                 Err(const_report_error(&ecx, error, alloc_id))
             } else {
                 // Convert to raw constant

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -391,6 +391,8 @@ pub trait Machine<'mir, 'tcx: 'mir>: Sized {
 
     /// Hook for performing extra checks on a memory read access.
     ///
+    /// This will *not* be called during validation!
+    ///
     /// Takes read-only access to the allocation so we can keep all the memory read
     /// operations take `&self`. Use a `RefCell` in `AllocExtra` if you
     /// need to mutate.
@@ -409,6 +411,8 @@ pub trait Machine<'mir, 'tcx: 'mir>: Sized {
 
     /// Hook for performing extra checks on any memory read access,
     /// that involves an allocation, even ZST reads.
+    ///
+    /// This will *not* be called during validation!
     ///
     /// Used to prevent statics from self-initializing by reading from their own memory
     /// as it is being initialized.

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -8,6 +8,7 @@
 
 use std::assert_matches::assert_matches;
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::collections::VecDeque;
 use std::fmt;
 use std::ptr;
@@ -111,6 +112,11 @@ pub struct Memory<'mir, 'tcx, M: Machine<'mir, 'tcx>> {
     /// that do not exist any more.
     // FIXME: this should not be public, but interning currently needs access to it
     pub(super) dead_alloc_map: FxIndexMap<AllocId, (Size, Align)>,
+
+    /// This stores whether we are currently doing reads purely for the purpose of validation.
+    /// Those reads do not trigger the machine's hooks for memory reads.
+    /// Needless to say, this must only be set with great care!
+    validation_in_progress: Cell<bool>,
 }
 
 /// A reference to some allocation that was already bounds-checked for the given region
@@ -137,6 +143,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
             alloc_map: M::MemoryMap::default(),
             extra_fn_ptr_map: FxIndexMap::default(),
             dead_alloc_map: FxIndexMap::default(),
+            validation_in_progress: Cell::new(false),
         }
     }
 
@@ -624,10 +631,12 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             size,
             CheckInAllocMsg::MemoryAccessTest,
             |alloc_id, offset, prov| {
-                // We want to call the hook on *all* accesses that involve an AllocId,
-                // including zero-sized accesses. That means we have to do it here
-                // rather than below in the `Some` branch.
-                M::before_alloc_read(self, alloc_id)?;
+                if !self.memory.validation_in_progress.get() {
+                    // We want to call the hook on *all* accesses that involve an AllocId,
+                    // including zero-sized accesses. That means we have to do it here
+                    // rather than below in the `Some` branch.
+                    M::before_alloc_read(self, alloc_id)?;
+                }
                 let alloc = self.get_alloc_raw(alloc_id)?;
                 Ok((alloc.size(), alloc.align, (alloc_id, offset, prov, alloc)))
             },
@@ -635,7 +644,15 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
         if let Some((alloc_id, offset, prov, alloc)) = ptr_and_alloc {
             let range = alloc_range(offset, size);
-            M::before_memory_read(self.tcx, &self.machine, &alloc.extra, (alloc_id, prov), range)?;
+            if !self.memory.validation_in_progress.get() {
+                M::before_memory_read(
+                    self.tcx,
+                    &self.machine,
+                    &alloc.extra,
+                    (alloc_id, prov),
+                    range,
+                )?;
+            }
             Ok(Some(AllocRef { alloc, range, tcx: *self.tcx, alloc_id }))
         } else {
             Ok(None)
@@ -909,6 +926,21 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
         })
     }
+
+    /// Runs the close in "validation" mode, which means the machine's memory read hooks will be
+    /// suppressed. Needless to say, this must only be set with great care! Cannot be nested.
+    pub(super) fn run_for_validation<R>(&self, f: impl FnOnce() -> R) -> R {
+        assert!(
+            self.memory.validation_in_progress.replace(true) == false,
+            "`validation_in_progress` was already set"
+        );
+        let res = f();
+        assert!(
+            self.memory.validation_in_progress.replace(false) == true,
+            "`validation_in_progress` was unset by someone else"
+        );
+        res
+    }
 }
 
 #[doc(hidden)]
@@ -1154,6 +1186,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         };
         let src_alloc = self.get_alloc_raw(src_alloc_id)?;
         let src_range = alloc_range(src_offset, size);
+        assert!(!self.memory.validation_in_progress.get(), "we can't be copying during validation");
         M::before_memory_read(
             tcx,
             &self.machine,

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -967,7 +967,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let mut visitor = ValidityVisitor { path, ref_tracking, ctfe_mode, ecx: self };
 
         // Run it.
-        match visitor.visit_value(op) {
+        match self.run_for_validation(|| visitor.visit_value(op)) {
             Ok(()) => Ok(()),
             // Pass through validation failures and "invalid program" issues.
             Err(err)

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -30,7 +30,7 @@ type QualifResults<'mir, 'tcx, Q> =
     rustc_mir_dataflow::ResultsCursor<'mir, 'tcx, FlowSensitiveAnalysis<'mir, 'mir, 'tcx, Q>>;
 
 #[derive(Default)]
-pub struct Qualifs<'mir, 'tcx> {
+pub(crate) struct Qualifs<'mir, 'tcx> {
     has_mut_interior: Option<QualifResults<'mir, 'tcx, HasMutInterior>>,
     needs_drop: Option<QualifResults<'mir, 'tcx, NeedsDrop>>,
     needs_non_const_drop: Option<QualifResults<'mir, 'tcx, NeedsNonConstDrop>>,

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -284,6 +284,7 @@ where
                 if Q::in_adt_inherently(cx, def, args) {
                     return true;
                 }
+                // Don't do any value-based reasoning for unions.
                 if def.is_union() && Q::in_any_value_of_ty(cx, rvalue.ty(cx.body, cx.tcx)) {
                     return true;
                 }

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -442,8 +442,8 @@ struct DiagCtxtInner {
     emitter: Box<DynEmitter>,
 
     /// Must we produce a diagnostic to justify the use of the expensive
-    /// `trimmed_def_paths` function?
-    must_produce_diag: bool,
+    /// `trimmed_def_paths` function? Backtrace is the location of the call.
+    must_produce_diag: Option<Backtrace>,
 
     /// Has this diagnostic context printed any diagnostics? (I.e. has
     /// `self.emitter.emit_diagnostic()` been called?
@@ -572,10 +572,11 @@ impl Drop for DiagCtxtInner {
         }
 
         if !self.has_printed && !self.suppressed_expected_diag && !std::thread::panicking() {
-            if self.must_produce_diag {
+            if let Some(backtrace) = &self.must_produce_diag {
                 panic!(
-                    "must_produce_diag: trimmed_def_paths called but no diagnostics emitted; \
-                       use `DelayDm` for lints or `with_no_trimmed_paths` for debugging"
+                    "must_produce_diag: `trimmed_def_paths` called but no diagnostics emitted; \
+                       use `DelayDm` for lints or `with_no_trimmed_paths` for debugging. \
+                       called at: {backtrace}"
                 );
             }
         }
@@ -721,7 +722,7 @@ impl DiagCtxt {
         *delayed_bugs = Default::default();
         *deduplicated_err_count = 0;
         *deduplicated_warn_count = 0;
-        *must_produce_diag = false;
+        *must_produce_diag = None;
         *has_printed = false;
         *suppressed_expected_diag = false;
         *taught_diagnostics = Default::default();
@@ -1091,8 +1092,13 @@ impl DiagCtxt {
 
     /// Used when trimmed_def_paths is called and we must produce a diagnostic
     /// to justify its cost.
+    #[track_caller]
     pub fn set_must_produce_diag(&self) {
-        self.inner.borrow_mut().must_produce_diag = true;
+        assert!(
+            self.inner.borrow().must_produce_diag.is_none(),
+            "should only need to collect a backtrace once"
+        );
+        self.inner.borrow_mut().must_produce_diag = Some(Backtrace::capture());
     }
 }
 
@@ -1387,7 +1393,7 @@ impl DiagCtxtInner {
             deduplicated_err_count: 0,
             deduplicated_warn_count: 0,
             emitter,
-            must_produce_diag: false,
+            must_produce_diag: None,
             has_printed: false,
             suppressed_expected_diag: false,
             taught_diagnostics: Default::default(),

--- a/compiler/rustc_hir_analysis/src/astconv/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/bounds.rs
@@ -433,12 +433,10 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
             });
 
             // Provide the resolved type of the associated constant to `type_of(AnonConst)`.
-            if !speculative && let ty::AssocKind::Const = assoc_kind {
-                let hir::TypeBindingKind::Equality { term: hir::Term::Const(anon_const) } =
+            if !speculative
+                && let hir::TypeBindingKind::Equality { term: hir::Term::Const(anon_const) } =
                     binding.kind
-                else {
-                    bug!()
-                };
+            {
                 let ty = alias_ty.map_bound(|ty| tcx.type_of(ty.def_id).instantiate(tcx, ty.args));
                 // Since the arguments passed to the alias type above may contain early-bound
                 // generic parameters, the instantiated type may contain some as well.

--- a/compiler/rustc_hir_analysis/src/astconv/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/bounds.rs
@@ -434,11 +434,20 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
 
             // Provide the resolved type of the associated constant to `type_of(AnonConst)`.
             if !speculative && let ty::AssocKind::Const = assoc_kind {
+                let hir::TypeBindingKind::Equality { term: hir::Term::Const(anon_const) } =
+                    binding.kind
+                else {
+                    bug!()
+                };
                 let ty = alias_ty.map_bound(|ty| tcx.type_of(ty.def_id).instantiate(tcx, ty.args));
                 // Since the arguments passed to the alias type above may contain early-bound
                 // generic parameters, the instantiated type may contain some as well.
                 // Therefore wrap it in `EarlyBinder`.
-                tcx.feed_type_of_assoc_const_binding(binding.hir_id, ty::EarlyBinder::bind(ty));
+                // FIXME(fmease): Reject escaping late-bound vars.
+                tcx.feed_anon_const_type(
+                    anon_const.def_id,
+                    ty::EarlyBinder::bind(ty.skip_binder()),
+                );
             }
 
             alias_ty

--- a/compiler/rustc_hir_analysis/src/astconv/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/bounds.rs
@@ -408,7 +408,7 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
             // Create the generic arguments for the associated type or constant by joining the
             // parent arguments (the arguments of the trait) and the own arguments (the ones of
             // the associated item itself) and construct an alias type using them.
-            candidate.map_bound(|trait_ref| {
+            let alias_ty = candidate.map_bound(|trait_ref| {
                 let ident = Ident::new(assoc_item.name, binding.ident.span);
                 let item_segment = hir::PathSegment {
                     ident,
@@ -430,7 +430,18 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
                 // *constants* to represent *const projections*. Alias *term* would be a more
                 // appropriate name but alas.
                 ty::AliasTy::new(tcx, assoc_item.def_id, alias_args)
-            })
+            });
+
+            // Provide the resolved type of the associated constant to `type_of(AnonConst)`.
+            if !speculative && let ty::AssocKind::Const = assoc_kind {
+                let ty = alias_ty.map_bound(|ty| tcx.type_of(ty.def_id).instantiate(tcx, ty.args));
+                // Since the arguments passed to the alias type above may contain early-bound
+                // generic parameters, the instantiated type may contain some as well.
+                // Therefore wrap it in `EarlyBinder`.
+                tcx.feed_type_of_assoc_const_binding(binding.hir_id, ty::EarlyBinder::bind(ty));
+            }
+
+            alias_ty
         };
 
         match binding.kind {

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -63,6 +63,7 @@ pub fn provide(providers: &mut Providers) {
     *providers = Providers {
         type_of: type_of::type_of,
         type_of_opaque: type_of::type_of_opaque,
+        type_of_assoc_const_binding: type_of::type_of_assoc_const_binding,
         type_alias_is_lazy: type_of::type_alias_is_lazy,
         item_bounds: item_bounds::item_bounds,
         explicit_item_bounds: item_bounds::explicit_item_bounds,

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -63,7 +63,6 @@ pub fn provide(providers: &mut Providers) {
     *providers = Providers {
         type_of: type_of::type_of,
         type_of_opaque: type_of::type_of_opaque,
-        type_of_assoc_const_binding: type_of::type_of_assoc_const_binding,
         type_alias_is_lazy: type_of::type_alias_is_lazy,
         item_bounds: item_bounds::item_bounds,
         explicit_item_bounds: item_bounds::explicit_item_bounds,

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -78,12 +78,6 @@ fn anon_const_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
                 .expect("const parameter types cannot be generic");
         }
 
-        Node::TypeBinding(&TypeBinding { hir_id, .. }) => {
-            // FIXME(fmease): Reject “escaping” early-bound generic parameters.
-            // FIXME(fmease): Reject escaping late-bound vars.
-            return tcx.type_of_assoc_const_binding(hir_id).skip_binder().skip_binder();
-        }
-
         // This match arm is for when the def_id appears in a GAT whose
         // path can't be resolved without typechecking e.g.
         //
@@ -288,18 +282,6 @@ fn anon_const_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
             format!("const generic parameter not found in {generics:?} at position {arg_idx:?}"),
         );
     }
-}
-
-pub(super) fn type_of_assoc_const_binding<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    hir_id: HirId,
-) -> ty::EarlyBinder<ty::Binder<'tcx, Ty<'tcx>>> {
-    let reported = tcx.dcx().delayed_bug(format!(
-        "attempt to obtain type of assoc const binding `{hir_id}` before \
-         it was resolved by `add_predicates_for_ast_type_binding`"
-    ));
-
-    ty::EarlyBinder::bind(ty::Binder::dummy(Ty::new_error(tcx, reported)))
 }
 
 fn get_path_containing_arg_in_pat<'hir>(

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -685,7 +685,7 @@ fn test_unstable_options_tracking_hash() {
     untracked!(nll_facts, true);
     untracked!(no_analysis, true);
     untracked!(no_leak_check, true);
-    untracked!(no_parallel_llvm, true);
+    untracked!(no_parallel_backend, true);
     untracked!(parse_only, true);
     // `pre_link_arg` is omitted because it just forwards to `pre_link_args`.
     untracked!(pre_link_args, vec![String::from("abc"), String::from("def")]);

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -193,10 +193,6 @@ impl<T: EraseType> EraseType for ty::EarlyBinder<T> {
     type Result = T::Result;
 }
 
-impl EraseType for ty::Binder<'_, Ty<'_>> {
-    type Result = [u8; size_of::<ty::Binder<'static, Ty<'static>>>()];
-}
-
 impl EraseType for ty::Binder<'_, ty::FnSig<'_>> {
     type Result = [u8; size_of::<ty::Binder<'static, ty::FnSig<'static>>>()];
 }

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -193,6 +193,10 @@ impl<T: EraseType> EraseType for ty::EarlyBinder<T> {
     type Result = T::Result;
 }
 
+impl EraseType for ty::Binder<'_, Ty<'_>> {
+    type Result = [u8; size_of::<ty::Binder<'static, Ty<'static>>>()];
+}
+
 impl EraseType for ty::Binder<'_, ty::FnSig<'_>> {
     type Result = [u8; size_of::<ty::Binder<'static, ty::FnSig<'static>>>()];
 }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -248,11 +248,6 @@ rustc_queries! {
         cycle_stash
     }
 
-    query type_of_assoc_const_binding(key: hir::HirId) -> ty::EarlyBinder<ty::Binder<'tcx, Ty<'tcx>>> {
-        desc { |tcx| "getting type of associated constant binding `{key:?}`" }
-        feedable
-    }
-
     query type_alias_is_lazy(key: DefId) -> bool {
         desc { |tcx|
             "computing whether `{path}` is a lazy type alias",

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -248,6 +248,11 @@ rustc_queries! {
         cycle_stash
     }
 
+    query type_of_assoc_const_binding(key: hir::HirId) -> ty::EarlyBinder<ty::Binder<'tcx, Ty<'tcx>>> {
+        desc { |tcx| "getting type of associated constant binding `{key:?}`" }
+        feedable
+    }
+
     query type_alias_is_lazy(key: DefId) -> bool {
         desc { |tcx|
             "computing whether `{path}` is a lazy type alias",

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -71,6 +71,7 @@ use rustc_type_ir::TyKind::*;
 use rustc_type_ir::WithCachedTypeInfo;
 use rustc_type_ir::{CollectAndApply, Interner, TypeFlags};
 
+use std::assert_matches::debug_assert_matches;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt;
@@ -539,6 +540,22 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn feed_anon_const_type(self, key: LocalDefId, value: ty::EarlyBinder<Ty<'tcx>>) {
         debug_assert_eq!(self.def_kind(key), DefKind::AnonConst);
         TyCtxtFeed { tcx: self, key }.type_of(value)
+    }
+
+    pub fn feed_type_of_assoc_const_binding(
+        self,
+        key: hir::HirId,
+        value: ty::EarlyBinder<ty::Binder<'tcx, Ty<'tcx>>>,
+    ) {
+        debug_assert_matches!(
+            self.hir_node(key),
+            hir::Node::TypeBinding(hir::TypeBinding {
+                kind: hir::TypeBindingKind::Equality { term: hir::Term::Const(_) },
+                ..
+            })
+        );
+
+        TyCtxtFeed { tcx: self, key }.type_of_assoc_const_binding(value)
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -71,7 +71,6 @@ use rustc_type_ir::TyKind::*;
 use rustc_type_ir::WithCachedTypeInfo;
 use rustc_type_ir::{CollectAndApply, Interner, TypeFlags};
 
-use std::assert_matches::debug_assert_matches;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt;
@@ -540,22 +539,6 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn feed_anon_const_type(self, key: LocalDefId, value: ty::EarlyBinder<Ty<'tcx>>) {
         debug_assert_eq!(self.def_kind(key), DefKind::AnonConst);
         TyCtxtFeed { tcx: self, key }.type_of(value)
-    }
-
-    pub fn feed_type_of_assoc_const_binding(
-        self,
-        key: hir::HirId,
-        value: ty::EarlyBinder<ty::Binder<'tcx, Ty<'tcx>>>,
-    ) {
-        debug_assert_matches!(
-            self.hir_node(key),
-            hir::Node::TypeBinding(hir::TypeBinding {
-                kind: hir::TypeBindingKind::Equality { term: hir::Term::Const(_) },
-                ..
-            })
-        );
-
-        TyCtxtFeed { tcx: self, key }.type_of_assoc_const_binding(value)
     }
 }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1753,7 +1753,7 @@ options! {
         "disable the 'leak check' for subtyping; unsound, but useful for tests"),
     no_link: bool = (false, parse_no_flag, [TRACKED],
         "compile without linking"),
-    no_parallel_llvm: bool = (false, parse_no_flag, [UNTRACKED],
+    no_parallel_backend: bool = (false, parse_no_flag, [UNTRACKED],
         "run LLVM in non-parallel mode (while keeping codegen-units and ThinLTO)"),
     no_profiler_runtime: bool = (false, parse_no_flag, [TRACKED],
         "prevent automatic injection of the profiler_builtins crate"),

--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -1,7 +1,7 @@
 # rustbuild - Bootstrapping Rust
 
-This README is aimed at helping to explain how Rust is bootstrapped and in general,
-some of the technical details of the build system.
+This README is aimed at helping to explain how Rust is bootstrapped,
+and some of the technical details of the build system.
 
 Note that this README only covers internal information, not how to use the tool.
 Please check [bootstrapping dev guide][bootstrapping-dev-guide] for further information.
@@ -10,12 +10,12 @@ Please check [bootstrapping dev guide][bootstrapping-dev-guide] for further info
 
 ## Introduction
 
-The build system defers most of the complicated logic managing invocations
+The build system defers most of the complicated logic of managing invocations
 of rustc and rustdoc to Cargo itself. However, moving through various stages
 and copying artifacts is still necessary for it to do. Each time rustbuild
 is invoked, it will iterate through the list of predefined steps and execute
 each serially in turn if it matches the paths passed or is a default rule.
-For each step rustbuild relies on the step internally being incremental and
+For each step, rustbuild relies on the step internally being incremental and
 parallel. Note, though, that the `-j` parameter to rustbuild gets forwarded
 to appropriate test harnesses and such.
 
@@ -24,7 +24,7 @@ to appropriate test harnesses and such.
 The rustbuild build system goes through a few phases to actually build the
 compiler. What actually happens when you invoke rustbuild is:
 
-1. The entry point script(`x` for unix like systems, `x.ps1` for windows systems,
+1. The entry point script (`x` for unix like systems, `x.ps1` for windows systems,
    `x.py` cross-platform) is run. This script is responsible for downloading the stage0
    compiler/Cargo binaries, and it then compiles the build system itself (this folder).
    Finally, it then invokes the actual `bootstrap` binary build system.
@@ -107,12 +107,13 @@ build/
 
     # Location where the stage0 Cargo and Rust compiler are unpacked. This
     # directory is purely an extracted and overlaid tarball of these two (done
-    # by the bootstrap python script). In theory, the build system does not
+    # by the bootstrap Python script). In theory, the build system does not
     # modify anything under this directory afterwards.
     stage0/
 
     # These to-build directories are the cargo output directories for builds of
-    # the standard library and compiler, respectively. Internally, these may also
+    # the standard library, the test system, the compiler, and various tools,
+    # respectively. Internally, these may also
     # have other target directories, which represent artifacts being compiled
     # from the host to the specified target.
     #
@@ -169,17 +170,17 @@ read by the other.
 
 Some general areas that you may be interested in modifying are:
 
-* Adding a new build tool? Take a look at `bootstrap/tool.rs` for examples of
-  other tools.
+* Adding a new build tool? Take a look at `bootstrap/src/core/build_steps/tool.rs`
+  for examples of other tools.
 * Adding a new compiler crate? Look no further! Adding crates can be done by
-  adding a new directory with `Cargo.toml` followed by configuring all
+  adding a new directory with `Cargo.toml`, followed by configuring all
   `Cargo.toml` files accordingly.
 * Adding a new dependency from crates.io? This should just work inside the
   compiler artifacts stage (everything other than libtest and libstd).
-* Adding a new configuration option? You'll want to modify `bootstrap/flags.rs`
-  for command line flags and then `bootstrap/config.rs` to copy the flags to the
+* Adding a new configuration option? You'll want to modify `bootstrap/src/core/config/flags.rs`
+  for command line flags and then `bootstrap/src/core/config/config.rs` to copy the flags to the
   `Config` struct.
-* Adding a sanity check? Take a look at `bootstrap/sanity.rs`.
+* Adding a sanity check? Take a look at `bootstrap/src/core/sanity.rs`.
 
 If you make a major change on bootstrap configuration, please remember to:
 

--- a/src/tools/miri/tests/pass/alloc-access-tracking.rs
+++ b/src/tools/miri/tests/pass/alloc-access-tracking.rs
@@ -1,0 +1,25 @@
+#![feature(start)]
+#![no_std]
+//@compile-flags: -Zmiri-track-alloc-id=17 -Zmiri-track-alloc-accesses -Cpanic=abort
+//@only-target-linux: alloc IDs differ between OSes for some reason
+
+extern "Rust" {
+    fn miri_alloc(size: usize, align: usize) -> *mut u8;
+    fn miri_dealloc(ptr: *mut u8, size: usize, align: usize);
+}
+
+#[start]
+fn start(_: isize, _: *const *const u8) -> isize {
+    unsafe {
+        let ptr = miri_alloc(123, 1);
+        *ptr = 42; // Crucially, only a write is printed here, no read!
+        assert_eq!(*ptr, 42);
+        miri_dealloc(ptr, 123, 1);
+    }
+    0
+}
+
+#[panic_handler]
+fn panic_handler(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/src/tools/miri/tests/pass/alloc-access-tracking.stderr
+++ b/src/tools/miri/tests/pass/alloc-access-tracking.stderr
@@ -1,0 +1,37 @@
+note: tracking was triggered
+  --> $DIR/alloc-access-tracking.rs:LL:CC
+   |
+LL |         let ptr = miri_alloc(123, 1);
+   |                   ^^^^^^^^^^^^^^^^^^ created Miri bare-metal heap allocation of 123 bytes (alignment ALIGN bytes) with id 17
+   |
+   = note: BACKTRACE:
+   = note: inside `start` at $DIR/alloc-access-tracking.rs:LL:CC
+
+note: tracking was triggered
+  --> $DIR/alloc-access-tracking.rs:LL:CC
+   |
+LL |         *ptr = 42; // Crucially, only a write is printed here, no read!
+   |         ^^^^^^^^^ write access to allocation with id 17
+   |
+   = note: BACKTRACE:
+   = note: inside `start` at $DIR/alloc-access-tracking.rs:LL:CC
+
+note: tracking was triggered
+  --> $DIR/alloc-access-tracking.rs:LL:CC
+   |
+LL |         assert_eq!(*ptr, 42);
+   |         ^^^^^^^^^^^^^^^^^^^^ read access to allocation with id 17
+   |
+   = note: BACKTRACE:
+   = note: inside `start` at RUSTLIB/core/src/macros/mod.rs:LL:CC
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: tracking was triggered
+  --> $DIR/alloc-access-tracking.rs:LL:CC
+   |
+LL |         miri_dealloc(ptr, 123, 1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ freed allocation with id 17
+   |
+   = note: BACKTRACE:
+   = note: inside `start` at $DIR/alloc-access-tracking.rs:LL:CC
+

--- a/tests/ui/associated-consts/assoc-const-eq-supertraits.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-supertraits.rs
@@ -1,0 +1,16 @@
+// Regression test for issue #118040.
+// Ensure that we support assoc const eq bounds where the assoc const comes from a supertrait.
+
+//@ check-pass
+
+#![feature(associated_const_equality)]
+
+trait Trait: SuperTrait {}
+trait SuperTrait: SuperSuperTrait<i32> {}
+trait SuperSuperTrait<T> {
+    const K: T;
+}
+
+fn take(_: impl Trait<K = 0>) {}
+
+fn main() {}

--- a/tests/ui/associated-consts/assoc-const-eq-ty-alias-noninteracting.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-ty-alias-noninteracting.rs
@@ -1,21 +1,25 @@
 // Regression test for issue #112560.
 // Respect the fact that (associated) types and constants live in different namespaces and
 // therefore equality bounds involving identically named associated items don't conflict if
-// their kind (type vs. const) differs.
-
-// FIXME(fmease): Extend this test to cover supertraits again
-// once #118040 is fixed. See initial version of PR #118360.
+// their kind (type vs. const) differs. This obviously extends to supertraits.
 
 //@ check-pass
 
 #![feature(associated_const_equality)]
 
-trait Trait {
+trait Trait: SuperTrait {
     type N;
+    type Q;
 
     const N: usize;
 }
 
-fn take(_: impl Trait<N = 0, N = ()>) {}
+trait SuperTrait {
+    const Q: &'static str;
+}
+
+fn take0(_: impl Trait<N = 0, N = ()>) {}
+
+fn take1(_: impl Trait<Q = "...", Q = [()]>) {}
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/bugs/wf-check-skipped.next.stderr
+++ b/tests/ui/associated-inherent-types/bugs/wf-check-skipped.next.stderr
@@ -1,0 +1,8 @@
+error: the type `Foo::Bar<Vec<[u32]>>` is not well-formed
+  --> $DIR/wf-check-skipped.rs:17:14
+   |
+LL | fn main() -> Foo::Bar::<Vec<[u32]>> {}
+   |              ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/associated-inherent-types/bugs/wf-check-skipped.rs
+++ b/tests/ui/associated-inherent-types/bugs/wf-check-skipped.rs
@@ -1,10 +1,12 @@
-//@ known-bug: #100041
-//@ check-pass
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[current] known-bug: #100041
+//@[current] check-pass
+// FIXME(inherent_associated_types): This should fail.
 
 #![feature(inherent_associated_types)]
 #![allow(incomplete_features)]
-
-// FIXME(inherent_associated_types): This should fail.
 
 struct Foo;
 
@@ -13,3 +15,4 @@ impl Foo {
 }
 
 fn main() -> Foo::Bar::<Vec<[u32]>> {}
+//[next]~^ ERROR the type `Foo::Bar<Vec<[u32]>>` is not well-formed

--- a/tests/ui/associated-inherent-types/inference.rs
+++ b/tests/ui/associated-inherent-types/inference.rs
@@ -1,6 +1,7 @@
 // Testing inference capabilities.
 //@ check-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(inherent_associated_types)]

--- a/tests/ui/associated-types/defaults-unsound-62211-1.current.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.current.stderr
@@ -1,12 +1,12 @@
 error[E0277]: `Self` doesn't implement `std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-2.rs:20:96
+  --> $DIR/defaults-unsound-62211-1.rs:26:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
    |
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:20:86
+  --> $DIR/defaults-unsound-62211-1.rs:26:86
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -16,13 +16,13 @@ LL | trait UncheckedCopy: Sized + std::fmt::Display {
    |                            +++++++++++++++++++
 
 error[E0277]: cannot add-assign `&'static str` to `Self`
-  --> $DIR/defaults-unsound-62211-2.rs:20:96
+  --> $DIR/defaults-unsound-62211-1.rs:26:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ no implementation for `Self += &'static str`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:20:47
+  --> $DIR/defaults-unsound-62211-1.rs:26:47
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -32,13 +32,13 @@ LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
    |                            +++++++++++++++++++++++++
 
 error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-2.rs:20:96
+  --> $DIR/defaults-unsound-62211-1.rs:26:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:20:25
+  --> $DIR/defaults-unsound-62211-1.rs:26:25
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -48,13 +48,13 @@ LL | trait UncheckedCopy: Sized + Deref {
    |                            +++++++
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
-  --> $DIR/defaults-unsound-62211-2.rs:20:96
+  --> $DIR/defaults-unsound-62211-1.rs:26:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:20:18
+  --> $DIR/defaults-unsound-62211-1.rs:26:18
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                  ^^^^ required by this bound in `UncheckedCopy::Output`

--- a/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
@@ -1,0 +1,13 @@
+warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/defaults-unsound-62211-1.rs:52:5
+   |
+LL |     drop(origin);
+   |     ^^^^^------^
+   |          |
+   |          argument has type `<T as UncheckedCopy>::Output`
+   |
+   = note: use `let _ = ...` to ignore the expression or result
+   = note: `#[warn(dropping_copy_types)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-types/defaults-unsound-62211-1.rs
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.rs
@@ -1,3 +1,9 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] known-bug: rust-lang/trait-system-refactor-initiative#46
+//@[next] check-pass
+
 //! Regression test for https://github.com/rust-lang/rust/issues/62211
 //!
 //! The old implementation of defaults did not check whether the provided
@@ -18,10 +24,10 @@ trait UncheckedCopy: Sized {
     // This Output is said to be Copy. Yet we default to Self
     // and it's accepted, not knowing if Self ineed is Copy
     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-    //~^ ERROR the trait bound `Self: Copy` is not satisfied
-    //~| ERROR the trait bound `Self: Deref` is not satisfied
-    //~| ERROR cannot add-assign `&'static str` to `Self`
-    //~| ERROR `Self` doesn't implement `std::fmt::Display`
+    //[current]~^ ERROR the trait bound `Self: Copy` is not satisfied
+    //[current]~| ERROR the trait bound `Self: Deref` is not satisfied
+    //[current]~| ERROR cannot add-assign `&'static str` to `Self`
+    //[current]~| ERROR `Self` doesn't implement `std::fmt::Display`
 
     // We said the Output type was Copy, so we can Copy it freely!
     fn unchecked_copy(other: &Self::Output) -> Self::Output {

--- a/tests/ui/associated-types/defaults-unsound-62211-2.current.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.current.stderr
@@ -1,12 +1,12 @@
 error[E0277]: `Self` doesn't implement `std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-1.rs:20:96
+  --> $DIR/defaults-unsound-62211-2.rs:26:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
    |
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:20:86
+  --> $DIR/defaults-unsound-62211-2.rs:26:86
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -16,13 +16,13 @@ LL | trait UncheckedCopy: Sized + std::fmt::Display {
    |                            +++++++++++++++++++
 
 error[E0277]: cannot add-assign `&'static str` to `Self`
-  --> $DIR/defaults-unsound-62211-1.rs:20:96
+  --> $DIR/defaults-unsound-62211-2.rs:26:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ no implementation for `Self += &'static str`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:20:47
+  --> $DIR/defaults-unsound-62211-2.rs:26:47
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -32,13 +32,13 @@ LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
    |                            +++++++++++++++++++++++++
 
 error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-1.rs:20:96
+  --> $DIR/defaults-unsound-62211-2.rs:26:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:20:25
+  --> $DIR/defaults-unsound-62211-2.rs:26:25
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -48,13 +48,13 @@ LL | trait UncheckedCopy: Sized + Deref {
    |                            +++++++
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
-  --> $DIR/defaults-unsound-62211-1.rs:20:96
+  --> $DIR/defaults-unsound-62211-2.rs:26:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:20:18
+  --> $DIR/defaults-unsound-62211-2.rs:26:18
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                  ^^^^ required by this bound in `UncheckedCopy::Output`

--- a/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
@@ -1,0 +1,13 @@
+warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/defaults-unsound-62211-2.rs:52:5
+   |
+LL |     drop(origin);
+   |     ^^^^^------^
+   |          |
+   |          argument has type `<T as UncheckedCopy>::Output`
+   |
+   = note: use `let _ = ...` to ignore the expression or result
+   = note: `#[warn(dropping_copy_types)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-types/defaults-unsound-62211-2.rs
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.rs
@@ -1,3 +1,9 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] known-bug: rust-lang/trait-system-refactor-initiative#46
+//@[next] check-pass
+
 //! Regression test for https://github.com/rust-lang/rust/issues/62211
 //!
 //! The old implementation of defaults did not check whether the provided
@@ -18,10 +24,10 @@ trait UncheckedCopy: Sized {
     // This Output is said to be Copy. Yet we default to Self
     // and it's accepted, not knowing if Self ineed is Copy
     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-    //~^ ERROR the trait bound `Self: Copy` is not satisfied
-    //~| ERROR the trait bound `Self: Deref` is not satisfied
-    //~| ERROR cannot add-assign `&'static str` to `Self`
-    //~| ERROR `Self` doesn't implement `std::fmt::Display`
+    //[current]~^ ERROR the trait bound `Self: Copy` is not satisfied
+    //[current]~| ERROR the trait bound `Self: Deref` is not satisfied
+    //[current]~| ERROR cannot add-assign `&'static str` to `Self`
+    //[current]~| ERROR `Self` doesn't implement `std::fmt::Display`
 
     // We said the Output type was Copy, so we can Copy it freely!
     fn unchecked_copy(other: &Self::Output) -> Self::Output {

--- a/tests/ui/async-await/async-closures/is-fn.rs
+++ b/tests/ui/async-await/async-closures/is-fn.rs
@@ -2,6 +2,7 @@
 //@ edition:2021
 //@ build-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(async_closure)]

--- a/tests/ui/async-await/async-closures/once.rs
+++ b/tests/ui/async-await/async-closures/once.rs
@@ -2,6 +2,7 @@
 //@ edition:2021
 //@ build-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(async_closure)]

--- a/tests/ui/async-await/async-fn/higher-ranked-async-fn.rs
+++ b/tests/ui/async-await/async-fn/higher-ranked-async-fn.rs
@@ -1,6 +1,7 @@
 //@ aux-build:block-on.rs
 //@ edition:2018
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ build-pass (since it ICEs during mono)
 

--- a/tests/ui/async-await/async-fn/project.rs
+++ b/tests/ui/async-await/async-fn/project.rs
@@ -1,5 +1,6 @@
 //@ edition:2018
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 

--- a/tests/ui/async-await/normalize-output-in-signature-deduction.rs
+++ b/tests/ui/async-await/normalize-output-in-signature-deduction.rs
@@ -1,5 +1,6 @@
 //@ edition:2021
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 

--- a/tests/ui/async-await/return-type-notation/normalizing-self-auto-trait-issue-109924.current.stderr
+++ b/tests/ui/async-await/return-type-notation/normalizing-self-auto-trait-issue-109924.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/normalizing-self-auto-trait-issue-109924.rs:6:12
+  --> $DIR/normalizing-self-auto-trait-issue-109924.rs:7:12
    |
 LL | #![feature(return_type_notation)]
    |            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/return-type-notation/normalizing-self-auto-trait-issue-109924.next.stderr
+++ b/tests/ui/async-await/return-type-notation/normalizing-self-auto-trait-issue-109924.next.stderr
@@ -1,5 +1,5 @@
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/normalizing-self-auto-trait-issue-109924.rs:6:12
+  --> $DIR/normalizing-self-auto-trait-issue-109924.rs:7:12
    |
 LL | #![feature(return_type_notation)]
    |            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/return-type-notation/normalizing-self-auto-trait-issue-109924.rs
+++ b/tests/ui/async-await/return-type-notation/normalizing-self-auto-trait-issue-109924.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ edition:2021
 

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-crate.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-crate.rs
@@ -1,4 +1,4 @@
 #![feature(unix_sigpipe)]
-#![unix_sigpipe = "inherit"] //~ error: `unix_sigpipe` attribute cannot be used at crate level
+#![unix_sigpipe = "sig_dfl"] //~ error: `unix_sigpipe` attribute cannot be used at crate level
 
 fn main() {}

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-crate.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-crate.stderr
@@ -1,7 +1,7 @@
 error: `unix_sigpipe` attribute cannot be used at crate level
   --> $DIR/unix_sigpipe-crate.rs:2:1
    |
-LL | #![unix_sigpipe = "inherit"]
+LL | #![unix_sigpipe = "sig_dfl"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | fn main() {}
@@ -9,8 +9,8 @@ LL | fn main() {}
    |
 help: perhaps you meant to use an outer attribute
    |
-LL - #![unix_sigpipe = "inherit"]
-LL + #[unix_sigpipe = "inherit"]
+LL - #![unix_sigpipe = "sig_dfl"]
+LL + #[unix_sigpipe = "sig_dfl"]
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.rs
@@ -1,4 +1,4 @@
 #![feature(unix_sigpipe)]
 
-#[unix_sigpipe(inherit)] //~ error: malformed `unix_sigpipe` attribute input
+#[unix_sigpipe(sig_dfl)] //~ error: malformed `unix_sigpipe` attribute input
 fn main() {}

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-list.stderr
@@ -1,7 +1,7 @@
 error: malformed `unix_sigpipe` attribute input
   --> $DIR/unix_sigpipe-list.rs:3:1
    |
-LL | #[unix_sigpipe(inherit)]
+LL | #[unix_sigpipe(sig_dfl)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[unix_sigpipe = "inherit|sig_ign|sig_dfl"]`
 
 error: aborting due to 1 previous error

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-main-fn.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-main-fn.rs
@@ -1,6 +1,6 @@
 #![feature(unix_sigpipe)]
 
-#[unix_sigpipe = "inherit"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
+#[unix_sigpipe = "sig_dfl"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
 fn f() {}
 
 fn main() {}

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-main-fn.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-main-fn.stderr
@@ -1,7 +1,7 @@
 error: `unix_sigpipe` attribute can only be used on `fn main()`
   --> $DIR/unix_sigpipe-non-main-fn.rs:3:1
    |
-LL | #[unix_sigpipe = "inherit"]
+LL | #[unix_sigpipe = "sig_dfl"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-root-main.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-root-main.rs
@@ -1,7 +1,7 @@
 #![feature(unix_sigpipe)]
 
 mod m {
-    #[unix_sigpipe = "inherit"] //~ error: `unix_sigpipe` attribute can only be used on root `fn main()`
+    #[unix_sigpipe = "sig_dfl"] //~ error: `unix_sigpipe` attribute can only be used on root `fn main()`
     fn main() {}
 }
 

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-root-main.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-non-root-main.stderr
@@ -1,7 +1,7 @@
 error: `unix_sigpipe` attribute can only be used on root `fn main()`
   --> $DIR/unix_sigpipe-non-root-main.rs:4:5
    |
-LL |     #[unix_sigpipe = "inherit"]
+LL |     #[unix_sigpipe = "sig_dfl"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-start.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-start.rs
@@ -2,5 +2,5 @@
 #![feature(unix_sigpipe)]
 
 #[start]
-#[unix_sigpipe = "inherit"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
+#[unix_sigpipe = "sig_dfl"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
 fn custom_start(argc: isize, argv: *const *const u8) -> isize { 0 }

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-start.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-start.stderr
@@ -1,7 +1,7 @@
 error: `unix_sigpipe` attribute can only be used on `fn main()`
   --> $DIR/unix_sigpipe-start.rs:5:1
    |
-LL | #[unix_sigpipe = "inherit"]
+LL | #[unix_sigpipe = "sig_dfl"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-struct.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-struct.rs
@@ -1,6 +1,6 @@
 #![feature(unix_sigpipe)]
 
-#[unix_sigpipe = "inherit"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
+#[unix_sigpipe = "sig_dfl"] //~ error: `unix_sigpipe` attribute can only be used on `fn main()`
 struct S;
 
 fn main() {}

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-struct.stderr
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-struct.stderr
@@ -1,7 +1,7 @@
 error: `unix_sigpipe` attribute can only be used on `fn main()`
   --> $DIR/unix_sigpipe-struct.rs:3:1
    |
-LL | #[unix_sigpipe = "inherit"]
+LL | #[unix_sigpipe = "sig_dfl"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/tests/ui/auto-traits/issue-23080-2.current.stderr
+++ b/tests/ui/auto-traits/issue-23080-2.current.stderr
@@ -1,5 +1,5 @@
 error[E0380]: auto traits cannot have associated items
-  --> $DIR/issue-23080-2.rs:8:10
+  --> $DIR/issue-23080-2.rs:9:10
    |
 LL | unsafe auto trait Trait {
    |                   ----- auto traits cannot have associated items

--- a/tests/ui/auto-traits/issue-23080-2.next.stderr
+++ b/tests/ui/auto-traits/issue-23080-2.next.stderr
@@ -1,5 +1,5 @@
 error[E0380]: auto traits cannot have associated items
-  --> $DIR/issue-23080-2.rs:8:10
+  --> $DIR/issue-23080-2.rs:9:10
    |
 LL | unsafe auto trait Trait {
    |                   ----- auto traits cannot have associated items

--- a/tests/ui/auto-traits/issue-23080-2.rs
+++ b/tests/ui/auto-traits/issue-23080-2.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(auto_traits)]

--- a/tests/ui/closures/infer-signature-from-impl.next.stderr
+++ b/tests/ui/closures/infer-signature-from-impl.next.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
-  --> $DIR/infer-signature-from-impl.rs:17:16
+  --> $DIR/infer-signature-from-impl.rs:18:16
    |
 LL |     needs_foo(|x| {
    |                ^

--- a/tests/ui/closures/infer-signature-from-impl.rs
+++ b/tests/ui/closures/infer-signature-from-impl.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[next] known-bug: trait-system-refactor-initiative#71
 //@[current] check-pass

--- a/tests/ui/coherence/indirect-impl-for-trait-obj-coherence.next.stderr
+++ b/tests/ui/coherence/indirect-impl-for-trait-obj-coherence.next.stderr
@@ -1,0 +1,9 @@
+error[E0284]: type annotations needed: cannot satisfy `<dyn Object<U, Output = T> as Object<U>>::Output == T`
+  --> $DIR/indirect-impl-for-trait-obj-coherence.rs:25:41
+   |
+LL |     foo::<dyn Object<U, Output = T>, U>(x)
+   |                                         ^ cannot satisfy `<dyn Object<U, Output = T> as Object<U>>::Output == T`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/coherence/indirect-impl-for-trait-obj-coherence.rs
+++ b/tests/ui/coherence/indirect-impl-for-trait-obj-coherence.rs
@@ -1,5 +1,8 @@
-//@ check-pass
-//@ known-bug: #57893
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[current] check-pass
+//@[current] known-bug: #57893
 
 // Should fail. Because we see an impl that uses a certain associated type, we
 // type-check assuming that impl is used. However, this conflicts with the
@@ -20,6 +23,7 @@ fn foo<T: ?Sized, U>(x: <T as Object<U>>::Output) -> U {
 #[allow(dead_code)]
 fn transmute<T, U>(x: T) -> U {
     foo::<dyn Object<U, Output = T>, U>(x)
+    //[next]~^ ERROR type annotations needed: cannot satisfy `<dyn Object<U, Output = T> as Object<U>>::Output == T`
 }
 
 fn main() {}

--- a/tests/ui/coherence/normalize-for-errors.current.stderr
+++ b/tests/ui/coherence/normalize-for-errors.current.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `MyTrait<_>` for type `(Box<(MyType,)>, _)`
-  --> $DIR/normalize-for-errors.rs:16:1
+  --> $DIR/normalize-for-errors.rs:17:1
    |
 LL | impl<T: Copy, S: Iterator> MyTrait<S> for (T, S::Item) {}
    | ------------------------------------------------------ first implementation here

--- a/tests/ui/coherence/normalize-for-errors.next.stderr
+++ b/tests/ui/coherence/normalize-for-errors.next.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `MyTrait<_>` for type `(Box<(MyType,)>, <_ as Iterator>::Item)`
-  --> $DIR/normalize-for-errors.rs:16:1
+  --> $DIR/normalize-for-errors.rs:17:1
    |
 LL | impl<T: Copy, S: Iterator> MyTrait<S> for (T, S::Item) {}
    | ------------------------------------------------------ first implementation here

--- a/tests/ui/coherence/normalize-for-errors.rs
+++ b/tests/ui/coherence/normalize-for-errors.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 struct MyType;

--- a/tests/ui/consts/enclosing-scope-rule.rs
+++ b/tests/ui/consts/enclosing-scope-rule.rs
@@ -1,0 +1,16 @@
+//@build-pass
+// Some code that looks like it might be relying on promotion, but actually this is using the
+// enclosing-scope rule, meaning the reference is "extended" to outlive its block and live as long
+// as the surrounding block (which in this case is the entire program). There are multiple
+// allocations being interned at once.
+
+struct Gen<T>(T);
+impl<'a, T> Gen<&'a T> {
+    // Can't be promoted because `T` might not be `'static`.
+    const C: &'a [T] = &[];
+}
+
+// Can't be promoted because of `Drop`.
+const V: &Vec<i32> = &Vec::new();
+
+fn main() {}

--- a/tests/ui/consts/promote-not.rs
+++ b/tests/ui/consts/promote-not.rs
@@ -40,7 +40,16 @@ const TEST_INTERIOR_MUT: () = {
     let _val: &'static _ = &(Cell::new(1), 2).1; //~ ERROR temporary value dropped while borrowed
 };
 
-const TEST_DROP: String = String::new();
+// This gets accepted by the "outer scope" rule, not promotion.
+const TEST_DROP_OUTER_SCOPE: &String = &String::new();
+// To demonstrate that, we can rewrite it as follows. If this was promotion it would still work.
+const TEST_DROP_NOT_PROMOTE: &String = {
+    let x = &String::new(); //~ ERROR destructor of `String` cannot be evaluated at compile-time
+    // The "dropped while borrowed" error seems to be suppressed, but the key point is that this
+    // fails to compile.
+    x
+};
+
 
 fn main() {
     // We must not promote things with interior mutability. Not even if we "project it away".
@@ -59,6 +68,7 @@ fn main() {
     let _val: &'static _ = &([1,2,3][4]+1); //~ ERROR temporary value dropped while borrowed
 
     // No promotion of temporaries that need to be dropped.
+    const TEST_DROP: String = String::new();
     let _val: &'static _ = &TEST_DROP;
     //~^ ERROR temporary value dropped while borrowed
     let _val: &'static _ = &&TEST_DROP;

--- a/tests/ui/consts/promote-not.rs
+++ b/tests/ui/consts/promote-not.rs
@@ -3,6 +3,7 @@
 #![allow(unconditional_panic)]
 
 use std::cell::Cell;
+use std::mem::ManuallyDrop;
 
 // We do not promote mutable references.
 static mut TEST1: Option<&mut [i32]> = Some(&mut [1, 2, 3]); //~ ERROR temporary value dropped while borrowed
@@ -69,4 +70,12 @@ fn main() {
     let _val: &'static _ = &[&TEST_DROP; 1];
     //~^ ERROR temporary value dropped while borrowed
     //~| ERROR temporary value dropped while borrowed
+
+    // Make sure there is no value-based reasoning for unions.
+    union UnionWithCell {
+        f1: i32,
+        f2: ManuallyDrop<Cell<i32>>,
+    }
+    let x: &'static _ = &UnionWithCell { f1: 0 };
+    //~^ ERROR temporary value dropped while borrowed
 }

--- a/tests/ui/consts/promote-not.stderr
+++ b/tests/ui/consts/promote-not.stderr
@@ -38,6 +38,15 @@ LL |     let _val: &'static _ = &(Cell::new(1), 2).1;
 LL | };
    | - temporary value is freed at the end of this statement
 
+error[E0493]: destructor of `String` cannot be evaluated at compile-time
+  --> $DIR/promote-not.rs:47:14
+   |
+LL |     let x = &String::new();
+   |              ^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constants
+...
+LL | };
+   | - value is dropped here
+
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:21:32
    |
@@ -59,7 +68,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:47:29
+  --> $DIR/promote-not.rs:56:29
    |
 LL |     let _val: &'static _ = &(Cell::new(1), 2).0;
    |               ----------    ^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -70,7 +79,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:48:29
+  --> $DIR/promote-not.rs:57:29
    |
 LL |     let _val: &'static _ = &(Cell::new(1), 2).1;
    |               ----------    ^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -81,7 +90,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:51:29
+  --> $DIR/promote-not.rs:60:29
    |
 LL |     let _val: &'static _ = &(1/0);
    |               ----------    ^^^^^ creates a temporary value which is freed while still in use
@@ -92,7 +101,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:52:29
+  --> $DIR/promote-not.rs:61:29
    |
 LL |     let _val: &'static _ = &(1/(1-1));
    |               ----------    ^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -103,7 +112,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:53:29
+  --> $DIR/promote-not.rs:62:29
    |
 LL |     let _val: &'static _ = &((1+1)/(1-1));
    |               ----------    ^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -114,7 +123,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:54:29
+  --> $DIR/promote-not.rs:63:29
    |
 LL |     let _val: &'static _ = &(i32::MIN/-1);
    |               ----------    ^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -125,7 +134,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:55:29
+  --> $DIR/promote-not.rs:64:29
    |
 LL |     let _val: &'static _ = &(i32::MIN/(0-1));
    |               ----------    ^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -136,7 +145,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:56:29
+  --> $DIR/promote-not.rs:65:29
    |
 LL |     let _val: &'static _ = &(-128i8/-1);
    |               ----------    ^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -147,7 +156,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:57:29
+  --> $DIR/promote-not.rs:66:29
    |
 LL |     let _val: &'static _ = &(1%0);
    |               ----------    ^^^^^ creates a temporary value which is freed while still in use
@@ -158,7 +167,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:58:29
+  --> $DIR/promote-not.rs:67:29
    |
 LL |     let _val: &'static _ = &(1%(1-1));
    |               ----------    ^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -169,7 +178,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:59:29
+  --> $DIR/promote-not.rs:68:29
    |
 LL |     let _val: &'static _ = &([1,2,3][4]+1);
    |               ----------    ^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -180,7 +189,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:62:29
+  --> $DIR/promote-not.rs:72:29
    |
 LL |     let _val: &'static _ = &TEST_DROP;
    |               ----------    ^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -191,7 +200,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:64:29
+  --> $DIR/promote-not.rs:74:29
    |
 LL |     let _val: &'static _ = &&TEST_DROP;
    |               ----------    ^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -202,7 +211,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:64:30
+  --> $DIR/promote-not.rs:74:30
    |
 LL |     let _val: &'static _ = &&TEST_DROP;
    |               ----------     ^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -213,7 +222,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:67:29
+  --> $DIR/promote-not.rs:77:29
    |
 LL |     let _val: &'static _ = &(&TEST_DROP,);
    |               ----------    ^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -224,7 +233,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:67:31
+  --> $DIR/promote-not.rs:77:31
    |
 LL |     let _val: &'static _ = &(&TEST_DROP,);
    |               ----------      ^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -235,7 +244,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:70:29
+  --> $DIR/promote-not.rs:80:29
    |
 LL |     let _val: &'static _ = &[&TEST_DROP; 1];
    |               ----------    ^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -246,7 +255,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:70:31
+  --> $DIR/promote-not.rs:80:31
    |
 LL |     let _val: &'static _ = &[&TEST_DROP; 1];
    |               ----------      ^^^^^^^^^    - temporary value is freed at the end of this statement
@@ -255,7 +264,7 @@ LL |     let _val: &'static _ = &[&TEST_DROP; 1];
    |               type annotation requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:79:26
+  --> $DIR/promote-not.rs:89:26
    |
 LL |     let x: &'static _ = &UnionWithCell { f1: 0 };
    |            ----------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -265,6 +274,7 @@ LL |
 LL | }
    | - temporary value is freed at the end of this statement
 
-error: aborting due to 25 previous errors
+error: aborting due to 26 previous errors
 
-For more information about this error, try `rustc --explain E0716`.
+Some errors have detailed explanations: E0493, E0716.
+For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/consts/promote-not.stderr
+++ b/tests/ui/consts/promote-not.stderr
@@ -1,5 +1,5 @@
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:8:50
+  --> $DIR/promote-not.rs:9:50
    |
 LL | static mut TEST1: Option<&mut [i32]> = Some(&mut [1, 2, 3]);
    |                                        ----------^^^^^^^^^-
@@ -9,7 +9,7 @@ LL | static mut TEST1: Option<&mut [i32]> = Some(&mut [1, 2, 3]);
    |                                        using this value as a static requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:11:18
+  --> $DIR/promote-not.rs:12:18
    |
 LL |     let x = &mut [1,2,3];
    |                  ^^^^^^^ creates a temporary value which is freed while still in use
@@ -19,7 +19,7 @@ LL | };
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:33:29
+  --> $DIR/promote-not.rs:34:29
    |
 LL |     let _x: &'static i32 = &unsafe { U { x: 0 }.x };
    |             ------------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -29,7 +29,7 @@ LL | };
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:39:29
+  --> $DIR/promote-not.rs:40:29
    |
 LL |     let _val: &'static _ = &(Cell::new(1), 2).1;
    |               ----------    ^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -39,7 +39,7 @@ LL | };
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:20:32
+  --> $DIR/promote-not.rs:21:32
    |
 LL |         let _x: &'static () = &foo();
    |                 -----------    ^^^^^ creates a temporary value which is freed while still in use
@@ -49,7 +49,7 @@ LL |     }
    |     - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:28:29
+  --> $DIR/promote-not.rs:29:29
    |
 LL |     let _x: &'static i32 = &unsafe { U { x: 0 }.x };
    |             ------------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -59,7 +59,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:46:29
+  --> $DIR/promote-not.rs:47:29
    |
 LL |     let _val: &'static _ = &(Cell::new(1), 2).0;
    |               ----------    ^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -70,7 +70,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:47:29
+  --> $DIR/promote-not.rs:48:29
    |
 LL |     let _val: &'static _ = &(Cell::new(1), 2).1;
    |               ----------    ^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -81,7 +81,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:50:29
+  --> $DIR/promote-not.rs:51:29
    |
 LL |     let _val: &'static _ = &(1/0);
    |               ----------    ^^^^^ creates a temporary value which is freed while still in use
@@ -92,7 +92,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:51:29
+  --> $DIR/promote-not.rs:52:29
    |
 LL |     let _val: &'static _ = &(1/(1-1));
    |               ----------    ^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -103,7 +103,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:52:29
+  --> $DIR/promote-not.rs:53:29
    |
 LL |     let _val: &'static _ = &((1+1)/(1-1));
    |               ----------    ^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -114,7 +114,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:53:29
+  --> $DIR/promote-not.rs:54:29
    |
 LL |     let _val: &'static _ = &(i32::MIN/-1);
    |               ----------    ^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -125,7 +125,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:54:29
+  --> $DIR/promote-not.rs:55:29
    |
 LL |     let _val: &'static _ = &(i32::MIN/(0-1));
    |               ----------    ^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -136,7 +136,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:55:29
+  --> $DIR/promote-not.rs:56:29
    |
 LL |     let _val: &'static _ = &(-128i8/-1);
    |               ----------    ^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -147,7 +147,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:56:29
+  --> $DIR/promote-not.rs:57:29
    |
 LL |     let _val: &'static _ = &(1%0);
    |               ----------    ^^^^^ creates a temporary value which is freed while still in use
@@ -158,7 +158,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:57:29
+  --> $DIR/promote-not.rs:58:29
    |
 LL |     let _val: &'static _ = &(1%(1-1));
    |               ----------    ^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -169,7 +169,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:58:29
+  --> $DIR/promote-not.rs:59:29
    |
 LL |     let _val: &'static _ = &([1,2,3][4]+1);
    |               ----------    ^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -180,7 +180,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:61:29
+  --> $DIR/promote-not.rs:62:29
    |
 LL |     let _val: &'static _ = &TEST_DROP;
    |               ----------    ^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -191,7 +191,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:63:29
+  --> $DIR/promote-not.rs:64:29
    |
 LL |     let _val: &'static _ = &&TEST_DROP;
    |               ----------    ^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -202,7 +202,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:63:30
+  --> $DIR/promote-not.rs:64:30
    |
 LL |     let _val: &'static _ = &&TEST_DROP;
    |               ----------     ^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -213,7 +213,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:66:29
+  --> $DIR/promote-not.rs:67:29
    |
 LL |     let _val: &'static _ = &(&TEST_DROP,);
    |               ----------    ^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -224,7 +224,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:66:31
+  --> $DIR/promote-not.rs:67:31
    |
 LL |     let _val: &'static _ = &(&TEST_DROP,);
    |               ----------      ^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -235,7 +235,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:69:29
+  --> $DIR/promote-not.rs:70:29
    |
 LL |     let _val: &'static _ = &[&TEST_DROP; 1];
    |               ----------    ^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -246,7 +246,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:69:31
+  --> $DIR/promote-not.rs:70:31
    |
 LL |     let _val: &'static _ = &[&TEST_DROP; 1];
    |               ----------      ^^^^^^^^^    - temporary value is freed at the end of this statement
@@ -254,6 +254,17 @@ LL |     let _val: &'static _ = &[&TEST_DROP; 1];
    |               |               creates a temporary value which is freed while still in use
    |               type annotation requires that borrow lasts for `'static`
 
-error: aborting due to 24 previous errors
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/promote-not.rs:79:26
+   |
+LL |     let x: &'static _ = &UnionWithCell { f1: 0 };
+   |            ----------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
+LL |
+LL | }
+   | - temporary value is freed at the end of this statement
+
+error: aborting due to 25 previous errors
 
 For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/consts/refs-to-cell-in-final.rs
+++ b/tests/ui/consts/refs-to-cell-in-final.rs
@@ -15,4 +15,27 @@ static RAW_SYNC_S: SyncPtr<Cell<i32>> = SyncPtr { x: &Cell::new(42) };
 const RAW_SYNC_C: SyncPtr<Cell<i32>> = SyncPtr { x: &Cell::new(42) };
 //~^ ERROR: cannot refer to interior mutable data
 
+// This one does not get promoted because of `Drop`, and then enters interesting codepaths because
+// as a value it has no interior mutability, but as a type it does. See
+// <https://github.com/rust-lang/rust/issues/121610>. Value-based reasoning for interior mutability
+// is questionable (https://github.com/rust-lang/unsafe-code-guidelines/issues/493) so for now we
+// reject this, though not with a great error message.
+pub enum JsValue {
+    Undefined,
+    Object(Cell<bool>),
+}
+impl Drop for JsValue {
+    fn drop(&mut self) {}
+}
+const UNDEFINED: &JsValue = &JsValue::Undefined;
+//~^ERROR: mutable pointer in final value of constant
+
+// In contrast, this one works since it is being promoted.
+const NONE: &'static Option<Cell<i32>> = &None;
+// Making it clear that this is promotion, not "outer scope".
+const NONE_EXPLICIT_PROMOTED: &'static Option<Cell<i32>> = {
+    let x = &None;
+    x
+};
+
 fn main() {}

--- a/tests/ui/consts/refs-to-cell-in-final.stderr
+++ b/tests/ui/consts/refs-to-cell-in-final.stderr
@@ -12,6 +12,12 @@ error[E0492]: constants cannot refer to interior mutable data
 LL | const RAW_SYNC_C: SyncPtr<Cell<i32>> = SyncPtr { x: &Cell::new(42) };
    |                                                     ^^^^^^^^^^^^^^ this borrow of an interior mutable value may end up in the final value
 
-error: aborting due to 2 previous errors
+error: encountered mutable pointer in final value of constant
+  --> $DIR/refs-to-cell-in-final.rs:30:1
+   |
+LL | const UNDEFINED: &JsValue = &JsValue::Undefined;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0492`.

--- a/tests/ui/coroutine/clone-rpit.next.stderr
+++ b/tests/ui/coroutine/clone-rpit.next.stderr
@@ -1,47 +1,47 @@
 error[E0391]: cycle detected when type-checking `foo`
-  --> $DIR/clone-rpit.rs:12:1
+  --> $DIR/clone-rpit.rs:13:1
    |
 LL | pub fn foo<'a, 'b>() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: ...which requires coroutine witness types for `foo::{closure#0}`...
-  --> $DIR/clone-rpit.rs:13:5
+  --> $DIR/clone-rpit.rs:14:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
 note: ...which requires promoting constants in MIR for `foo::{closure#0}`...
-  --> $DIR/clone-rpit.rs:13:5
+  --> $DIR/clone-rpit.rs:14:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
 note: ...which requires preparing `foo::{closure#0}` for borrow checking...
-  --> $DIR/clone-rpit.rs:13:5
+  --> $DIR/clone-rpit.rs:14:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
 note: ...which requires checking if `foo::{closure#0}` contains FFI-unwind calls...
-  --> $DIR/clone-rpit.rs:13:5
+  --> $DIR/clone-rpit.rs:14:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
 note: ...which requires building MIR for `foo::{closure#0}`...
-  --> $DIR/clone-rpit.rs:13:5
+  --> $DIR/clone-rpit.rs:14:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
 note: ...which requires match-checking `foo::{closure#0}`...
-  --> $DIR/clone-rpit.rs:13:5
+  --> $DIR/clone-rpit.rs:14:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
 note: ...which requires type-checking `foo::{closure#0}`...
-  --> $DIR/clone-rpit.rs:13:5
+  --> $DIR/clone-rpit.rs:14:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
    = note: ...which again requires type-checking `foo`, completing the cycle
 note: cycle used when computing type of opaque `foo::{opaque#0}`
-  --> $DIR/clone-rpit.rs:12:25
+  --> $DIR/clone-rpit.rs:13:25
    |
 LL | pub fn foo<'a, 'b>() -> impl Clone {
    |                         ^^^^^^^^^^

--- a/tests/ui/coroutine/clone-rpit.rs
+++ b/tests/ui/coroutine/clone-rpit.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[current] check-pass
 //@[next] known-bug: trait-system-refactor-initiative#82

--- a/tests/ui/coroutine/non-static-is-unpin.rs
+++ b/tests/ui/coroutine/non-static-is-unpin.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ run-pass
 

--- a/tests/ui/coroutine/static-not-unpin.current.stderr
+++ b/tests/ui/coroutine/static-not-unpin.current.stderr
@@ -1,15 +1,15 @@
-error[E0277]: `{static coroutine@$DIR/static-not-unpin.rs:14:25: 14:34}` cannot be unpinned
-  --> $DIR/static-not-unpin.rs:17:18
+error[E0277]: `{static coroutine@$DIR/static-not-unpin.rs:15:25: 15:34}` cannot be unpinned
+  --> $DIR/static-not-unpin.rs:18:18
    |
 LL |     assert_unpin(coroutine);
-   |     ------------ ^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/static-not-unpin.rs:14:25: 14:34}`
+   |     ------------ ^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/static-not-unpin.rs:15:25: 15:34}`
    |     |
    |     required by a bound introduced by this call
    |
    = note: consider using the `pin!` macro
            consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `assert_unpin`
-  --> $DIR/static-not-unpin.rs:10:20
+  --> $DIR/static-not-unpin.rs:11:20
    |
 LL | fn assert_unpin<T: Unpin>(_: T) {
    |                    ^^^^^ required by this bound in `assert_unpin`

--- a/tests/ui/coroutine/static-not-unpin.next.stderr
+++ b/tests/ui/coroutine/static-not-unpin.next.stderr
@@ -1,15 +1,15 @@
-error[E0277]: `{static coroutine@$DIR/static-not-unpin.rs:14:25: 14:34}` cannot be unpinned
-  --> $DIR/static-not-unpin.rs:17:18
+error[E0277]: `{static coroutine@$DIR/static-not-unpin.rs:15:25: 15:34}` cannot be unpinned
+  --> $DIR/static-not-unpin.rs:18:18
    |
 LL |     assert_unpin(coroutine);
-   |     ------------ ^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/static-not-unpin.rs:14:25: 14:34}`
+   |     ------------ ^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/static-not-unpin.rs:15:25: 15:34}`
    |     |
    |     required by a bound introduced by this call
    |
    = note: consider using the `pin!` macro
            consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `assert_unpin`
-  --> $DIR/static-not-unpin.rs:10:20
+  --> $DIR/static-not-unpin.rs:11:20
    |
 LL | fn assert_unpin<T: Unpin>(_: T) {
    |                    ^^^^^ required by this bound in `assert_unpin`

--- a/tests/ui/coroutine/static-not-unpin.rs
+++ b/tests/ui/coroutine/static-not-unpin.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(coroutines)]

--- a/tests/ui/dyn-star/box.rs
+++ b/tests/ui/dyn-star/box.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[current] compile-flags: -C opt-level=0
 //@[next] compile-flags: -Znext-solver -C opt-level=0
 

--- a/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.current.stderr
+++ b/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.current.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `&T` needs to have the same ABI as a pointer
-  --> $DIR/check-size-at-cast-polymorphic-bad.rs:14:15
+  --> $DIR/check-size-at-cast-polymorphic-bad.rs:15:15
    |
 LL |     dyn_debug(t);
    |               ^ `&T` needs to be a pointer-like type

--- a/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.next.stderr
+++ b/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.next.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `&T` needs to have the same ABI as a pointer
-  --> $DIR/check-size-at-cast-polymorphic-bad.rs:14:15
+  --> $DIR/check-size-at-cast-polymorphic-bad.rs:15:15
    |
 LL |     dyn_debug(t);
    |               ^ `&T` needs to be a pointer-like type

--- a/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.rs
+++ b/tests/ui/dyn-star/check-size-at-cast-polymorphic-bad.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(dyn_star)]

--- a/tests/ui/for/issue-20605.current.stderr
+++ b/tests/ui/for/issue-20605.current.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `dyn Iterator<Item = &'a mut u8>` is not an iterator
-  --> $DIR/issue-20605.rs:5:17
+  --> $DIR/issue-20605.rs:6:17
    |
 LL |     for item in *things { *item = 0 }
    |                 ^^^^^^^ the trait `IntoIterator` is not implemented for `dyn Iterator<Item = &'a mut u8>`

--- a/tests/ui/for/issue-20605.next.stderr
+++ b/tests/ui/for/issue-20605.next.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `dyn Iterator<Item = &'a mut u8>` is not an iterator
-  --> $DIR/issue-20605.rs:5:17
+  --> $DIR/issue-20605.rs:6:17
    |
 LL |     for item in *things { *item = 0 }
    |                 ^^^^^^^ `dyn Iterator<Item = &'a mut u8>` is not an iterator
@@ -7,25 +7,25 @@ LL |     for item in *things { *item = 0 }
    = help: the trait `IntoIterator` is not implemented for `dyn Iterator<Item = &'a mut u8>`
 
 error: the type `<dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter` is not well-formed
-  --> $DIR/issue-20605.rs:5:17
+  --> $DIR/issue-20605.rs:6:17
    |
 LL |     for item in *things { *item = 0 }
    |                 ^^^^^^^
 
 error: the type `&mut <dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter` is not well-formed
-  --> $DIR/issue-20605.rs:5:17
+  --> $DIR/issue-20605.rs:6:17
    |
 LL |     for item in *things { *item = 0 }
    |                 ^^^^^^^
 
 error: the type `Option<<<dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter as Iterator>::Item>` is not well-formed
-  --> $DIR/issue-20605.rs:5:17
+  --> $DIR/issue-20605.rs:6:17
    |
 LL |     for item in *things { *item = 0 }
    |                 ^^^^^^^
 
 error[E0614]: type `<dyn Iterator<Item = &'a mut u8> as IntoIterator>::Item` cannot be dereferenced
-  --> $DIR/issue-20605.rs:5:27
+  --> $DIR/issue-20605.rs:6:27
    |
 LL |     for item in *things { *item = 0 }
    |                           ^^^^^

--- a/tests/ui/for/issue-20605.rs
+++ b/tests/ui/for/issue-20605.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 fn changer<'a>(mut things: Box<dyn Iterator<Item=&'a mut u8>>) {

--- a/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.current.stderr
+++ b/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.current.stderr
@@ -1,16 +1,16 @@
 error[E0277]: the trait bound `<Self as Foo>::Bar<()>: Eq<i32>` is not satisfied
-  --> $DIR/assume-gat-normalization-for-nested-goals.rs:6:30
+  --> $DIR/assume-gat-normalization-for-nested-goals.rs:10:30
    |
 LL |     type Bar<T>: Baz<Self> = i32;
    |                              ^^^ the trait `Eq<i32>` is not implemented for `<Self as Foo>::Bar<()>`, which is required by `i32: Baz<Self>`
    |
 note: required for `i32` to implement `Baz<Self>`
-  --> $DIR/assume-gat-normalization-for-nested-goals.rs:13:23
+  --> $DIR/assume-gat-normalization-for-nested-goals.rs:17:23
    |
 LL | impl<T: Foo + ?Sized> Baz<T> for i32 where T::Bar<()>: Eq<i32> {}
    |                       ^^^^^^     ^^^                   ------- unsatisfied trait bound introduced here
 note: required by a bound in `Foo::Bar`
-  --> $DIR/assume-gat-normalization-for-nested-goals.rs:6:18
+  --> $DIR/assume-gat-normalization-for-nested-goals.rs:10:18
    |
 LL |     type Bar<T>: Baz<Self> = i32;
    |                  ^^^^^^^^^ required by this bound in `Foo::Bar`

--- a/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.rs
+++ b/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.rs
@@ -1,4 +1,8 @@
-//@ known-bug: #117606
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[current] known-bug: #117606
+//@[next] check-pass
 
 #![feature(associated_type_defaults)]
 

--- a/tests/ui/generic-associated-types/issue-102114.current.stderr
+++ b/tests/ui/generic-associated-types/issue-102114.current.stderr
@@ -1,5 +1,5 @@
 error[E0049]: type `B` has 1 type parameter but its trait declaration has 0 type parameters
-  --> $DIR/issue-102114.rs:14:12
+  --> $DIR/issue-102114.rs:15:12
    |
 LL |     type B<'b>;
    |            -- expected 0 type parameters

--- a/tests/ui/generic-associated-types/issue-102114.next.stderr
+++ b/tests/ui/generic-associated-types/issue-102114.next.stderr
@@ -1,5 +1,5 @@
 error[E0049]: type `B` has 1 type parameter but its trait declaration has 0 type parameters
-  --> $DIR/issue-102114.rs:14:12
+  --> $DIR/issue-102114.rs:15:12
    |
 LL |     type B<'b>;
    |            -- expected 0 type parameters

--- a/tests/ui/generic-associated-types/issue-102114.rs
+++ b/tests/ui/generic-associated-types/issue-102114.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 trait A {

--- a/tests/ui/generic-associated-types/issue-90014-tait2.next-solver.stderr
+++ b/tests/ui/generic-associated-types/issue-90014-tait2.next-solver.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-90014-tait2.rs:27:9
+   |
+LL |     fn make_fut(&self) -> Box<dyn for<'a> Trait<'a, Thing = Fut<'a>>> {
+   |                           ------------------------------------------- expected `Box<(dyn for<'a> Trait<'a, Thing = Fut<'a>> + 'static)>` because of return type
+LL |         Box::new((async { () },))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Box<dyn Trait<'a, Thing = Fut<'_>>>`, found `Box<(...,)>`
+   |
+   = note: expected struct `Box<(dyn for<'a> Trait<'a, Thing = Fut<'a>> + 'static)>`
+              found struct `Box<({async block@$DIR/issue-90014-tait2.rs:27:19: 27:31},)>`
+   = help: `({async block@$DIR/issue-90014-tait2.rs:27:19: 27:31},)` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/generic-const-items/associated-const-equality.rs
+++ b/tests/ui/generic-const-items/associated-const-equality.rs
@@ -1,22 +1,31 @@
 //@ check-pass
 
-#![feature(generic_const_items, associated_const_equality)]
+#![feature(generic_const_items, associated_const_equality, adt_const_params)]
 #![allow(incomplete_features)]
 
 trait Owner {
     const C<const N: u32>: u32;
     const K<const N: u32>: u32;
+    const Q<T>: Maybe<T>;
 }
 
 impl Owner for () {
     const C<const N: u32>: u32 = N;
     const K<const N: u32>: u32 = N + 1;
+    const Q<T>: Maybe<T> = Maybe::Nothing;
 }
 
 fn take0<const N: u32>(_: impl Owner<C<N> = { N }>) {}
 fn take1(_: impl Owner<K<99> = 100>) {}
+fn take2(_: impl Owner<Q<()> = { Maybe::Just(()) }>) {}
 
 fn main() {
     take0::<128>(());
     take1(());
+}
+
+#[derive(PartialEq, Eq, std::marker::ConstParamTy)]
+enum Maybe<T> {
+    Nothing,
+    Just(T),
 }

--- a/tests/ui/higher-ranked/trait-bounds/fn-ptr.current.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/fn-ptr.current.stderr
@@ -1,0 +1,19 @@
+error[E0277]: expected a `Fn(&'w ())` closure, found `fn(&'w ())`
+  --> $DIR/fn-ptr.rs:13:5
+   |
+LL |     ice();
+   |     ^^^^^ expected an `Fn(&'w ())` closure, found `fn(&'w ())`
+   |
+   = help: the trait `for<'w> Fn<(&'w (),)>` is not implemented for `fn(&'w ())`
+note: required by a bound in `ice`
+  --> $DIR/fn-ptr.rs:8:25
+   |
+LL | fn ice()
+   |    --- required by a bound in this function
+LL | where
+LL |     for<'w> fn(&'w ()): Fn(&'w ()),
+   |                         ^^^^^^^^^^ required by this bound in `ice`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/higher-ranked/trait-bounds/fn-ptr.rs
+++ b/tests/ui/higher-ranked/trait-bounds/fn-ptr.rs
@@ -1,4 +1,5 @@
-//@ revisions: classic next
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[next] check-pass
 
@@ -10,5 +11,5 @@ where
 
 fn main() {
     ice();
-    //[classic]~^ ERROR expected a `Fn(&'w ())` closure, found `fn(&'w ())`
+    //[current]~^ ERROR expected a `Fn(&'w ())` closure, found `fn(&'w ())`
 }

--- a/tests/ui/higher-ranked/trait-bounds/future.current.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/future.current.stderr
@@ -1,0 +1,6 @@
+error: the compiler unexpectedly panicked. this is a bug.
+
+query stack during panic:
+#0 [evaluate_obligation] evaluating trait selection obligation `for<'a> {async fn body@$DIR/future.rs:33:35: 35:2}: core::future::future::Future`
+#1 [codegen_select_candidate] computing candidate for `<strlen as Trait>`
+end of query stack

--- a/tests/ui/higher-ranked/trait-bounds/future.rs
+++ b/tests/ui/higher-ranked/trait-bounds/future.rs
@@ -1,15 +1,16 @@
 // ignore-tidy-linelength
 //@ edition:2021
-//@ revisions: classic next
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[next] check-pass
-//@[classic] known-bug: #112347
-//@[classic] build-fail
-//@[classic] failure-status: 101
-//@[classic] normalize-stderr-test "note: .*\n\n" -> ""
-//@[classic] normalize-stderr-test "thread 'rustc' panicked.*\n.*\n" -> ""
-//@[classic] normalize-stderr-test "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
-//@[classic] rustc-env:RUST_BACKTRACE=0
+//@[current] known-bug: #112347
+//@[current] build-fail
+//@[current] failure-status: 101
+//@[current] normalize-stderr-test "note: .*\n\n" -> ""
+//@[current] normalize-stderr-test "thread 'rustc' panicked.*\n.*\n" -> ""
+//@[current] normalize-stderr-test "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
+//@[current] rustc-env:RUST_BACKTRACE=0
 
 #![feature(unboxed_closures)]
 

--- a/tests/ui/impl-trait/autoderef.rs
+++ b/tests/ui/impl-trait/autoderef.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.current.stderr
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.current.stderr
@@ -1,11 +1,11 @@
 error: {foo<ReEarlyParam(DefId(..), 0, 'a)>::{closure#0} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
-  --> $DIR/erased-regions-in-hidden-ty.rs:11:36
+  --> $DIR/erased-regions-in-hidden-ty.rs:12:36
    |
 LL | fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {
    |                                    ^^^^^^^^^^^^^^^^^^^
 
 error: Opaque(DefId(..), [ReErased])
-  --> $DIR/erased-regions-in-hidden-ty.rs:17:13
+  --> $DIR/erased-regions-in-hidden-ty.rs:18:13
    |
 LL | fn bar() -> impl Fn() + 'static {
    |             ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.next.stderr
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.next.stderr
@@ -1,11 +1,11 @@
 error: {foo<ReEarlyParam(DefId(..), 0, 'a)>::{closure#0} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
-  --> $DIR/erased-regions-in-hidden-ty.rs:11:36
+  --> $DIR/erased-regions-in-hidden-ty.rs:12:36
    |
 LL | fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {
    |                                    ^^^^^^^^^^^^^^^^^^^
 
 error: Opaque(DefId(..), [ReErased])
-  --> $DIR/erased-regions-in-hidden-ty.rs:17:13
+  --> $DIR/erased-regions-in-hidden-ty.rs:18:13
    |
 LL | fn bar() -> impl Fn() + 'static {
    |             ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@ compile-flags: -Zverbose-internals
 //@[next] compile-flags: -Znext-solver
 //@ normalize-stderr-test "DefId\([^\)]+\)" -> "DefId(..)"

--- a/tests/ui/impl-trait/in-trait/object-safety-sized.rs
+++ b/tests/ui/impl-trait/in-trait/object-safety-sized.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 

--- a/tests/ui/impl-trait/in-trait/refine-normalize.rs
+++ b/tests/ui/impl-trait/in-trait/refine-normalize.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 //@ edition: 2021
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![deny(refining_impl_trait)]

--- a/tests/ui/impl-trait/issue-103181-1.current.stderr
+++ b/tests/ui/impl-trait/issue-103181-1.current.stderr
@@ -1,5 +1,5 @@
 error[E0046]: not all trait items implemented, missing: `Error`
-  --> $DIR/issue-103181-1.rs:11:5
+  --> $DIR/issue-103181-1.rs:12:5
    |
 LL |         type Error;
    |         ---------- `Error` from trait

--- a/tests/ui/impl-trait/issue-103181-1.next.stderr
+++ b/tests/ui/impl-trait/issue-103181-1.next.stderr
@@ -1,5 +1,5 @@
 error[E0046]: not all trait items implemented, missing: `Error`
-  --> $DIR/issue-103181-1.rs:11:5
+  --> $DIR/issue-103181-1.rs:12:5
    |
 LL |         type Error;
    |         ---------- `Error` from trait

--- a/tests/ui/impl-trait/issue-103181-1.rs
+++ b/tests/ui/impl-trait/issue-103181-1.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ edition:2021
 

--- a/tests/ui/impl-trait/recursive-coroutine-boxed.next.stderr
+++ b/tests/ui/impl-trait/recursive-coroutine-boxed.next.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
-  --> $DIR/recursive-coroutine-boxed.rs:11:23
+  --> $DIR/recursive-coroutine-boxed.rs:12:23
    |
 LL |         let mut gen = Box::pin(foo());
    |                       ^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `Box`
@@ -13,7 +13,7 @@ LL |         let mut gen = Box::<T>::pin(foo());
    |                          +++++
 
 error[E0282]: type annotations needed
-  --> $DIR/recursive-coroutine-boxed.rs:8:13
+  --> $DIR/recursive-coroutine-boxed.rs:9:13
    |
 LL | fn foo() -> impl Coroutine<Yield = (), Return = ()> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for opaque type `impl Coroutine<Yield = (), Return = ()>`

--- a/tests/ui/impl-trait/recursive-coroutine-boxed.rs
+++ b/tests/ui/impl-trait/recursive-coroutine-boxed.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[current] check-pass
 //@[next] compile-flags: -Znext-solver
 #![feature(coroutines, coroutine_trait)]

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.current.stderr
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.current.stderr
@@ -1,5 +1,5 @@
 error[E0733]: recursion in a coroutine requires boxing
-  --> $DIR/recursive-coroutine-indirect.rs:10:5
+  --> $DIR/recursive-coroutine-indirect.rs:11:5
    |
 LL |     move || {
    |     ^^^^^^^

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.next.stderr
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.next.stderr
@@ -1,5 +1,5 @@
 error[E0733]: recursion in a coroutine requires boxing
-  --> $DIR/recursive-coroutine-indirect.rs:10:5
+  --> $DIR/recursive-coroutine-indirect.rs:11:5
    |
 LL |     move || {
    |     ^^^^^^^

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.rs
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 //@[next] build-fail

--- a/tests/ui/impl-trait/reveal-during-codegen.rs
+++ b/tests/ui/impl-trait/reveal-during-codegen.rs
@@ -1,5 +1,6 @@
 //@ build-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 fn test() -> Option<impl Sized> {

--- a/tests/ui/impl-trait/two_tait_defining_each_other.current.stderr
+++ b/tests/ui/impl-trait/two_tait_defining_each_other.current.stderr
@@ -1,16 +1,16 @@
 error: opaque type's hidden type cannot be another opaque type from the same scope
-  --> $DIR/two_tait_defining_each_other.rs:16:5
+  --> $DIR/two_tait_defining_each_other.rs:17:5
    |
 LL |     x // A's hidden type is `Bar`, because all the hidden types of `B` are compared with each other
    |     ^ one of the two opaque types used here has to be outside its defining scope
    |
 note: opaque type whose hidden type is being assigned
-  --> $DIR/two_tait_defining_each_other.rs:8:10
+  --> $DIR/two_tait_defining_each_other.rs:9:10
    |
 LL | type B = impl Foo;
    |          ^^^^^^^^
 note: opaque type being used as hidden type
-  --> $DIR/two_tait_defining_each_other.rs:7:10
+  --> $DIR/two_tait_defining_each_other.rs:8:10
    |
 LL | type A = impl Foo;
    |          ^^^^^^^^

--- a/tests/ui/impl-trait/two_tait_defining_each_other.rs
+++ b/tests/ui/impl-trait/two_tait_defining_each_other.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[next] check-pass
 

--- a/tests/ui/impl-trait/two_tait_defining_each_other2.current.stderr
+++ b/tests/ui/impl-trait/two_tait_defining_each_other2.current.stderr
@@ -1,5 +1,5 @@
 error: unconstrained opaque type
-  --> $DIR/two_tait_defining_each_other2.rs:5:10
+  --> $DIR/two_tait_defining_each_other2.rs:6:10
    |
 LL | type A = impl Foo;
    |          ^^^^^^^^
@@ -7,18 +7,18 @@ LL | type A = impl Foo;
    = note: `A` must be used in combination with a concrete type within the same module
 
 error: opaque type's hidden type cannot be another opaque type from the same scope
-  --> $DIR/two_tait_defining_each_other2.rs:12:5
+  --> $DIR/two_tait_defining_each_other2.rs:13:5
    |
 LL |     x // B's hidden type is A (opaquely)
    |     ^ one of the two opaque types used here has to be outside its defining scope
    |
 note: opaque type whose hidden type is being assigned
-  --> $DIR/two_tait_defining_each_other2.rs:6:10
+  --> $DIR/two_tait_defining_each_other2.rs:7:10
    |
 LL | type B = impl Foo;
    |          ^^^^^^^^
 note: opaque type being used as hidden type
-  --> $DIR/two_tait_defining_each_other2.rs:5:10
+  --> $DIR/two_tait_defining_each_other2.rs:6:10
    |
 LL | type A = impl Foo;
    |          ^^^^^^^^

--- a/tests/ui/impl-trait/two_tait_defining_each_other2.next.stderr
+++ b/tests/ui/impl-trait/two_tait_defining_each_other2.next.stderr
@@ -1,5 +1,5 @@
 error[E0284]: type annotations needed: cannot satisfy `_ == A`
-  --> $DIR/two_tait_defining_each_other2.rs:10:8
+  --> $DIR/two_tait_defining_each_other2.rs:11:8
    |
 LL | fn muh(x: A) -> B {
    |        ^ cannot satisfy `_ == A`

--- a/tests/ui/impl-trait/two_tait_defining_each_other2.rs
+++ b/tests/ui/impl-trait/two_tait_defining_each_other2.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 #![feature(type_alias_impl_trait)]
 

--- a/tests/ui/impl-trait/two_tait_defining_each_other3.current.stderr
+++ b/tests/ui/impl-trait/two_tait_defining_each_other3.current.stderr
@@ -1,16 +1,16 @@
 error: opaque type's hidden type cannot be another opaque type from the same scope
-  --> $DIR/two_tait_defining_each_other3.rs:13:16
+  --> $DIR/two_tait_defining_each_other3.rs:14:16
    |
 LL |         return x;  // B's hidden type is A (opaquely)
    |                ^ one of the two opaque types used here has to be outside its defining scope
    |
 note: opaque type whose hidden type is being assigned
-  --> $DIR/two_tait_defining_each_other3.rs:7:10
+  --> $DIR/two_tait_defining_each_other3.rs:8:10
    |
 LL | type B = impl Foo;
    |          ^^^^^^^^
 note: opaque type being used as hidden type
-  --> $DIR/two_tait_defining_each_other3.rs:6:10
+  --> $DIR/two_tait_defining_each_other3.rs:7:10
    |
 LL | type A = impl Foo;
    |          ^^^^^^^^

--- a/tests/ui/impl-trait/two_tait_defining_each_other3.rs
+++ b/tests/ui/impl-trait/two_tait_defining_each_other3.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[next] check-pass
 #![feature(type_alias_impl_trait)]

--- a/tests/ui/inference/type-infer-generalize-ty-var.rs
+++ b/tests/ui/inference/type-infer-generalize-ty-var.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![allow(non_upper_case_globals)]

--- a/tests/ui/issues/issue-13167.rs
+++ b/tests/ui/issues/issue-13167.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 //@ pretty-expanded FIXME #23616
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 use std::slice;

--- a/tests/ui/issues/issue-15734.rs
+++ b/tests/ui/issues/issue-15734.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 use std::ops::Index;

--- a/tests/ui/lazy-type-alias/coerce-behind-lazy.current.stderr
+++ b/tests/ui/lazy-type-alias/coerce-behind-lazy.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `lazy_type_alias` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/coerce-behind-lazy.rs:5:12
+  --> $DIR/coerce-behind-lazy.rs:6:12
    |
 LL | #![feature(lazy_type_alias)]
    |            ^^^^^^^^^^^^^^^

--- a/tests/ui/lazy-type-alias/coerce-behind-lazy.next.stderr
+++ b/tests/ui/lazy-type-alias/coerce-behind-lazy.next.stderr
@@ -1,5 +1,5 @@
 warning: the feature `lazy_type_alias` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/coerce-behind-lazy.rs:5:12
+  --> $DIR/coerce-behind-lazy.rs:6:12
    |
 LL | #![feature(lazy_type_alias)]
    |            ^^^^^^^^^^^^^^^

--- a/tests/ui/lazy-type-alias/coerce-behind-lazy.rs
+++ b/tests/ui/lazy-type-alias/coerce-behind-lazy.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(lazy_type_alias)]

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
@@ -1,0 +1,43 @@
+error[E0275]: overflow normalizing the type alias `Loop`
+  --> $DIR/inherent-impls-overflow.rs:8:13
+   |
+LL | type Loop = Loop;
+   |             ^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error[E0275]: overflow normalizing the type alias `Loop`
+  --> $DIR/inherent-impls-overflow.rs:10:1
+   |
+LL | impl Loop {}
+   | ^^^^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error[E0275]: overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
+  --> $DIR/inherent-impls-overflow.rs:14:17
+   |
+LL | type Poly0<T> = Poly1<(T,)>;
+   |                 ^^^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error[E0275]: overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+  --> $DIR/inherent-impls-overflow.rs:17:17
+   |
+LL | type Poly1<T> = Poly0<(T,)>;
+   |                 ^^^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error[E0275]: overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+  --> $DIR/inherent-impls-overflow.rs:21:1
+   |
+LL | impl Poly0<()> {}
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.next.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.next.stderr
@@ -1,11 +1,11 @@
 error[E0275]: overflow evaluating the requirement `Loop == _`
-  --> $DIR/inherent-impls-overflow.rs:9:6
+  --> $DIR/inherent-impls-overflow.rs:10:6
    |
 LL | impl Loop {}
    |      ^^^^
 
 error[E0392]: type parameter `T` is never used
-  --> $DIR/inherent-impls-overflow.rs:13:12
+  --> $DIR/inherent-impls-overflow.rs:14:12
    |
 LL | type Poly0<T> = Poly1<(T,)>;
    |            ^ unused type parameter
@@ -14,7 +14,7 @@ LL | type Poly0<T> = Poly1<(T,)>;
    = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
 error[E0392]: type parameter `T` is never used
-  --> $DIR/inherent-impls-overflow.rs:16:12
+  --> $DIR/inherent-impls-overflow.rs:17:12
    |
 LL | type Poly1<T> = Poly0<(T,)>;
    |            ^ unused type parameter
@@ -23,7 +23,7 @@ LL | type Poly1<T> = Poly0<(T,)>;
    = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
 error[E0275]: overflow evaluating the requirement `Poly0<()> == _`
-  --> $DIR/inherent-impls-overflow.rs:20:6
+  --> $DIR/inherent-impls-overflow.rs:21:6
    |
 LL | impl Poly0<()> {}
    |      ^^^^^^^^^

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
@@ -1,24 +1,25 @@
-//@ revisions: classic next
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(lazy_type_alias)]
 #![allow(incomplete_features)]
 
-type Loop = Loop; //[classic]~ ERROR overflow normalizing the type alias `Loop`
+type Loop = Loop; //[current]~ ERROR overflow normalizing the type alias `Loop`
 
 impl Loop {}
-//[classic]~^ ERROR overflow normalizing the type alias `Loop`
+//[current]~^ ERROR overflow normalizing the type alias `Loop`
 //[next]~^^ ERROR overflow evaluating the requirement `Loop == _`
 
 type Poly0<T> = Poly1<(T,)>;
-//[classic]~^ ERROR overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
+//[current]~^ ERROR overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
 //[next]~^^ ERROR type parameter `T` is never used
 type Poly1<T> = Poly0<(T,)>;
-//[classic]~^ ERROR  overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+//[current]~^ ERROR  overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
 //[next]~^^ ERROR type parameter `T` is never used
 
 impl Poly0<()> {}
-//[classic]~^ ERROR overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+//[current]~^ ERROR overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
 //[next]~^^ ERROR overflow evaluating the requirement `Poly0<()> == _`
 
 fn main() {}

--- a/tests/ui/never_type/never-from-impl-is-reserved.current.stderr
+++ b/tests/ui/never_type/never-from-impl-is-reserved.current.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `MyTrait` for type `MyFoo`
-  --> $DIR/never-from-impl-is-reserved.rs:13:1
+  --> $DIR/never-from-impl-is-reserved.rs:14:1
    |
 LL | impl MyTrait for MyFoo {}
    | ---------------------- first implementation here

--- a/tests/ui/never_type/never-from-impl-is-reserved.next.stderr
+++ b/tests/ui/never_type/never-from-impl-is-reserved.next.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `MyTrait` for type `MyFoo`
-  --> $DIR/never-from-impl-is-reserved.rs:13:1
+  --> $DIR/never-from-impl-is-reserved.rs:14:1
    |
 LL | impl MyTrait for MyFoo {}
    | ---------------------- first implementation here

--- a/tests/ui/never_type/never-from-impl-is-reserved.rs
+++ b/tests/ui/never_type/never-from-impl-is-reserved.rs
@@ -1,6 +1,7 @@
 // check that the `for<T> T: From<!>` impl is reserved
 
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver=coherence
 
 #![feature(never_type)]

--- a/tests/ui/nll/issue-53119.rs
+++ b/tests/ui/nll/issue-53119.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 use std::ops::Deref;

--- a/tests/ui/object-safety/call-when-assoc-ty-is-sized.rs
+++ b/tests/ui/object-safety/call-when-assoc-ty-is-sized.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 trait Foo {

--- a/tests/ui/panics/abort-on-panic.rs
+++ b/tests/ui/panics/abort-on-panic.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![allow(unused_must_use)]

--- a/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-1.rs
+++ b/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-1.rs
@@ -1,0 +1,14 @@
+fn main() {
+  foo::( //~ HELP: consider removing the `::` here to call the expression
+    //~^ NOTE: while parsing this parenthesized list of type arguments starting
+    bar(x, y, z),
+    bar(x, y, z),
+    bar(x, y, z),
+    bar(x, y, z),
+    bar(x, y, z),
+    bar(x, y, z),
+    bar(x, y, z),
+    baz("test"), //~ ERROR: expected type, found `"test"`
+    //~^ NOTE: expected type
+  )
+}

--- a/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-1.stderr
+++ b/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-1.stderr
@@ -1,0 +1,17 @@
+error: expected type, found `"test"`
+  --> $DIR/diagnostics-parenthesized-type-arguments-issue-120892-1.rs:11:9
+   |
+LL |   foo::(
+   |      --- while parsing this parenthesized list of type arguments starting here
+...
+LL |     baz("test"),
+   |         ^^^^^^ expected type
+   |
+help: consider removing the `::` here to call the expression
+   |
+LL -   foo::(
+LL +   foo(
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-2.rs
+++ b/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-2.rs
@@ -1,0 +1,5 @@
+fn main() {
+  foo::/* definitely not harmful comment */(123, "foo") -> (u32); //~ ERROR: expected type, found `123`
+  //~^ NOTE: while parsing this parenthesized list of type arguments starting
+  //~^^ NOTE: expected type
+}

--- a/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-2.stderr
+++ b/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-2.stderr
@@ -1,0 +1,10 @@
+error: expected type, found `123`
+  --> $DIR/diagnostics-parenthesized-type-arguments-issue-120892-2.rs:2:45
+   |
+LL |   foo::/* definitely not harmful comment */(123, "foo") -> (u32);
+   |      ---------------------------------------^^^ expected type
+   |      |
+   |      while parsing this parenthesized list of type arguments starting here
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-3.rs
+++ b/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-3.rs
@@ -1,0 +1,14 @@
+struct Foo(u32, u32);
+impl Foo {
+    fn foo(&self) {
+        match *self {
+            Foo::(1, 2) => {}, //~ HELP: consider removing the `::` here to turn this into a tuple struct pattern
+            //~^ NOTE: while parsing this parenthesized list of type arguments starting
+            //~^^ ERROR: expected type, found `1`
+            //~^^^ NOTE: expected type
+             _ => {},
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-3.stderr
+++ b/tests/ui/parser/issues/diagnostics-parenthesized-type-arguments-issue-120892-3.stderr
@@ -1,0 +1,16 @@
+error: expected type, found `1`
+  --> $DIR/diagnostics-parenthesized-type-arguments-issue-120892-3.rs:5:19
+   |
+LL |             Foo::(1, 2) => {},
+   |                ---^ expected type
+   |                |
+   |                while parsing this parenthesized list of type arguments starting here
+   |
+help: consider removing the `::` here to turn this into a tuple struct pattern
+   |
+LL -             Foo::(1, 2) => {},
+LL +             Foo(1, 2) => {},
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.current.stderr
+++ b/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.current.stderr
@@ -1,5 +1,5 @@
 warning: methods `good_virt` and `good_indirect` are never used
-  --> $DIR/manual-self-impl-for-unsafe-obj.rs:22:8
+  --> $DIR/manual-self-impl-for-unsafe-obj.rs:23:8
    |
 LL | trait Good {
    |       ---- methods in this trait

--- a/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.next.stderr
+++ b/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.next.stderr
@@ -1,5 +1,5 @@
 warning: methods `good_virt` and `good_indirect` are never used
-  --> $DIR/manual-self-impl-for-unsafe-obj.rs:22:8
+  --> $DIR/manual-self-impl-for-unsafe-obj.rs:23:8
    |
 LL | trait Good {
    |       ---- methods in this trait

--- a/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.rs
+++ b/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.rs
@@ -1,6 +1,7 @@
 // Check that we can manually implement an object-unsafe trait for its trait object.
 
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ run-pass
 

--- a/tests/ui/traits/deny-builtin-object-impl.current.stderr
+++ b/tests/ui/traits/deny-builtin-object-impl.current.stderr
@@ -1,16 +1,16 @@
 error[E0277]: the trait bound `dyn NotObject: NotObject` is not satisfied
-  --> $DIR/deny-builtin-object-impl.rs:18:23
+  --> $DIR/deny-builtin-object-impl.rs:19:23
    |
 LL |     test_not_object::<dyn NotObject>();
    |                       ^^^^^^^^^^^^^ the trait `NotObject` is not implemented for `dyn NotObject`
    |
 help: this trait has no implementations, consider adding one
-  --> $DIR/deny-builtin-object-impl.rs:10:1
+  --> $DIR/deny-builtin-object-impl.rs:11:1
    |
 LL | trait NotObject {}
    | ^^^^^^^^^^^^^^^
 note: required by a bound in `test_not_object`
-  --> $DIR/deny-builtin-object-impl.rs:14:23
+  --> $DIR/deny-builtin-object-impl.rs:15:23
    |
 LL | fn test_not_object<T: NotObject + ?Sized>() {}
    |                       ^^^^^^^^^ required by this bound in `test_not_object`

--- a/tests/ui/traits/deny-builtin-object-impl.next.stderr
+++ b/tests/ui/traits/deny-builtin-object-impl.next.stderr
@@ -1,16 +1,16 @@
 error[E0277]: the trait bound `dyn NotObject: NotObject` is not satisfied
-  --> $DIR/deny-builtin-object-impl.rs:18:23
+  --> $DIR/deny-builtin-object-impl.rs:19:23
    |
 LL |     test_not_object::<dyn NotObject>();
    |                       ^^^^^^^^^^^^^ the trait `NotObject` is not implemented for `dyn NotObject`
    |
 help: this trait has no implementations, consider adding one
-  --> $DIR/deny-builtin-object-impl.rs:10:1
+  --> $DIR/deny-builtin-object-impl.rs:11:1
    |
 LL | trait NotObject {}
    | ^^^^^^^^^^^^^^^
 note: required by a bound in `test_not_object`
-  --> $DIR/deny-builtin-object-impl.rs:14:23
+  --> $DIR/deny-builtin-object-impl.rs:15:23
    |
 LL | fn test_not_object<T: NotObject + ?Sized>() {}
    |                       ^^^^^^^^^ required by this bound in `test_not_object`

--- a/tests/ui/traits/deny-builtin-object-impl.rs
+++ b/tests/ui/traits/deny-builtin-object-impl.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(rustc_attrs)]

--- a/tests/ui/traits/issue-24010.rs
+++ b/tests/ui/traits/issue-24010.rs
@@ -1,5 +1,6 @@
 //@ run-pass
-//@ revisions: classic next
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 trait Foo: Fn(i32) -> i32 + Send {}

--- a/tests/ui/traits/negative-impls/negative-impl-normalizes-to.rs
+++ b/tests/ui/traits/negative-impls/negative-impl-normalizes-to.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 

--- a/tests/ui/traits/next-solver/env-shadows-impls/discard-impls-shadowed-by-env-2.rs
+++ b/tests/ui/traits/next-solver/env-shadows-impls/discard-impls-shadowed-by-env-2.rs
@@ -1,4 +1,5 @@
-//@ revisions: next current
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 

--- a/tests/ui/traits/next-solver/normalize-param-env-4.next.stderr
+++ b/tests/ui/traits/next-solver/normalize-param-env-4.next.stderr
@@ -1,23 +1,23 @@
 error[E0275]: overflow evaluating the requirement `<T as Trait>::Assoc: Trait`
-  --> $DIR/normalize-param-env-4.rs:18:26
+  --> $DIR/normalize-param-env-4.rs:19:26
    |
 LL |     <T as Trait>::Assoc: Trait,
    |                          ^^^^^
 
 error[E0275]: overflow evaluating the requirement `<T as Trait>::Assoc well-formed`
-  --> $DIR/normalize-param-env-4.rs:18:26
+  --> $DIR/normalize-param-env-4.rs:19:26
    |
 LL |     <T as Trait>::Assoc: Trait,
    |                          ^^^^^
 
 error[E0275]: overflow evaluating the requirement `T: Trait`
-  --> $DIR/normalize-param-env-4.rs:31:19
+  --> $DIR/normalize-param-env-4.rs:32:19
    |
 LL |     impls_trait::<T>();
    |                   ^
    |
 note: required by a bound in `impls_trait`
-  --> $DIR/normalize-param-env-4.rs:14:19
+  --> $DIR/normalize-param-env-4.rs:15:19
    |
 LL | fn impls_trait<T: Trait>() {}
    |                   ^^^^^ required by this bound in `impls_trait`

--- a/tests/ui/traits/next-solver/normalize-param-env-4.rs
+++ b/tests/ui/traits/next-solver/normalize-param-env-4.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[next] known-bug: #92505
 //@[current] check-pass

--- a/tests/ui/traits/non-lifetime-via-dyn-builtin.current.stderr
+++ b/tests/ui/traits/non-lifetime-via-dyn-builtin.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/non-lifetime-via-dyn-builtin.rs:5:12
+  --> $DIR/non-lifetime-via-dyn-builtin.rs:6:12
    |
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/traits/non-lifetime-via-dyn-builtin.next.stderr
+++ b/tests/ui/traits/non-lifetime-via-dyn-builtin.next.stderr
@@ -1,5 +1,5 @@
 warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/non-lifetime-via-dyn-builtin.rs:5:12
+  --> $DIR/non-lifetime-via-dyn-builtin.rs:6:12
    |
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/traits/non-lifetime-via-dyn-builtin.rs
+++ b/tests/ui/traits/non-lifetime-via-dyn-builtin.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 

--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.current.stderr
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/unifying-placeholders-in-query-response-2.rs:5:12
+  --> $DIR/unifying-placeholders-in-query-response-2.rs:6:12
    |
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.next.stderr
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.next.stderr
@@ -1,5 +1,5 @@
 warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/unifying-placeholders-in-query-response-2.rs:5:12
+  --> $DIR/unifying-placeholders-in-query-response-2.rs:6:12
    |
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.rs
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 

--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.current.stderr
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.current.stderr
@@ -1,5 +1,5 @@
 warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/unifying-placeholders-in-query-response.rs:5:12
+  --> $DIR/unifying-placeholders-in-query-response.rs:6:12
    |
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.next.stderr
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.next.stderr
@@ -1,5 +1,5 @@
 warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/unifying-placeholders-in-query-response.rs:5:12
+  --> $DIR/unifying-placeholders-in-query-response.rs:6:12
    |
 LL | #![feature(non_lifetime_binders)]
    |            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.rs
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 

--- a/tests/ui/traits/pointee-tail-is-generic.rs
+++ b/tests/ui/traits/pointee-tail-is-generic.rs
@@ -4,10 +4,12 @@
 #![feature(ptr_metadata)]
 #![feature(type_alias_impl_trait)]
 
-type Opaque = impl std::future::Future;
+mod opaque {
+    pub type Opaque = impl std::future::Future;
 
-fn opaque() -> Opaque {
-    async {}
+    fn opaque() -> Opaque {
+        async {}
+    }
 }
 
 fn a<T>() {
@@ -16,7 +18,7 @@ fn a<T>() {
     // tail of ADT (which is a type param) is known to be sized
     is_thin::<std::cell::Cell<T>>();
     // opaque type is known to be sized
-    is_thin::<Opaque>();
+    is_thin::<opaque::Opaque>();
 }
 
 fn a2<T: Iterator>() {

--- a/tests/ui/traits/trait-upcasting/add-supertrait-auto-traits.rs
+++ b/tests/ui/traits/trait-upcasting/add-supertrait-auto-traits.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(trait_upcasting)]

--- a/tests/ui/traits/trait-upcasting/fewer-associated.rs
+++ b/tests/ui/traits/trait-upcasting/fewer-associated.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 // issue: 114035
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(trait_upcasting)]

--- a/tests/ui/traits/trait-upcasting/illegal-upcast-from-impl.current.stderr
+++ b/tests/ui/traits/trait-upcasting/illegal-upcast-from-impl.current.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/illegal-upcast-from-impl.rs:16:66
+  --> $DIR/illegal-upcast-from-impl.rs:17:66
    |
 LL | fn illegal(x: &dyn Sub<Assoc = ()>) -> &dyn Super<Assoc = i32> { x }
    |                                        -----------------------   ^ expected trait `Super`, found trait `Sub`

--- a/tests/ui/traits/trait-upcasting/illegal-upcast-from-impl.next.stderr
+++ b/tests/ui/traits/trait-upcasting/illegal-upcast-from-impl.next.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/illegal-upcast-from-impl.rs:16:66
+  --> $DIR/illegal-upcast-from-impl.rs:17:66
    |
 LL | fn illegal(x: &dyn Sub<Assoc = ()>) -> &dyn Super<Assoc = i32> { x }
    |                                        -----------------------   ^ expected trait `Super`, found trait `Sub`

--- a/tests/ui/traits/trait-upcasting/illegal-upcast-from-impl.rs
+++ b/tests/ui/traits/trait-upcasting/illegal-upcast-from-impl.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(trait_upcasting)]

--- a/tests/ui/traits/trait-upcasting/issue-11515.current.stderr
+++ b/tests/ui/traits/trait-upcasting/issue-11515.current.stderr
@@ -1,5 +1,5 @@
 error[E0658]: cannot cast `dyn Fn()` to `dyn FnMut()`, trait upcasting coercion is experimental
-  --> $DIR/issue-11515.rs:10:38
+  --> $DIR/issue-11515.rs:11:38
    |
 LL |     let test = Box::new(Test { func: closure });
    |                                      ^^^^^^^

--- a/tests/ui/traits/trait-upcasting/issue-11515.next.stderr
+++ b/tests/ui/traits/trait-upcasting/issue-11515.next.stderr
@@ -1,5 +1,5 @@
 error[E0658]: cannot cast `dyn Fn()` to `dyn FnMut()`, trait upcasting coercion is experimental
-  --> $DIR/issue-11515.rs:10:38
+  --> $DIR/issue-11515.rs:11:38
    |
 LL |     let test = Box::new(Test { func: closure });
    |                                      ^^^^^^^

--- a/tests/ui/traits/trait-upcasting/issue-11515.rs
+++ b/tests/ui/traits/trait-upcasting/issue-11515.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 struct Test {

--- a/tests/ui/traits/trait-upcasting/normalization.rs
+++ b/tests/ui/traits/trait-upcasting/normalization.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 // issue: 114113
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(trait_upcasting)]

--- a/tests/ui/traits/trait-upcasting/type-checking-test-1.current.stderr
+++ b/tests/ui/traits/trait-upcasting/type-checking-test-1.current.stderr
@@ -1,5 +1,5 @@
 error[E0605]: non-primitive cast: `&dyn Foo` as `&dyn Bar<_>`
-  --> $DIR/type-checking-test-1.rs:19:13
+  --> $DIR/type-checking-test-1.rs:20:13
    |
 LL |     let _ = x as &dyn Bar<_>; // Ambiguous
    |             ^^^^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object

--- a/tests/ui/traits/trait-upcasting/type-checking-test-1.next.stderr
+++ b/tests/ui/traits/trait-upcasting/type-checking-test-1.next.stderr
@@ -1,5 +1,5 @@
 error[E0605]: non-primitive cast: `&dyn Foo` as `&dyn Bar<_>`
-  --> $DIR/type-checking-test-1.rs:19:13
+  --> $DIR/type-checking-test-1.rs:20:13
    |
 LL |     let _ = x as &dyn Bar<_>; // Ambiguous
    |             ^^^^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object

--- a/tests/ui/traits/trait-upcasting/type-checking-test-1.rs
+++ b/tests/ui/traits/trait-upcasting/type-checking-test-1.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(trait_upcasting)]

--- a/tests/ui/traits/trait-upcasting/upcast-through-struct-tail.current.stderr
+++ b/tests/ui/traits/trait-upcasting/upcast-through-struct-tail.current.stderr
@@ -1,5 +1,5 @@
 error[E0658]: cannot cast `dyn A` to `dyn B`, trait upcasting coercion is experimental
-  --> $DIR/upcast-through-struct-tail.rs:10:5
+  --> $DIR/upcast-through-struct-tail.rs:11:5
    |
 LL |     x
    |     ^

--- a/tests/ui/traits/trait-upcasting/upcast-through-struct-tail.next.stderr
+++ b/tests/ui/traits/trait-upcasting/upcast-through-struct-tail.next.stderr
@@ -1,5 +1,5 @@
 error[E0658]: cannot cast `dyn A` to `dyn B`, trait upcasting coercion is experimental
-  --> $DIR/upcast-through-struct-tail.rs:10:5
+  --> $DIR/upcast-through-struct-tail.rs:11:5
    |
 LL |     x
    |     ^

--- a/tests/ui/traits/trait-upcasting/upcast-through-struct-tail.rs
+++ b/tests/ui/traits/trait-upcasting/upcast-through-struct-tail.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 struct Wrapper<T: ?Sized>(T);

--- a/tests/ui/transmutability/primitives/bool.current.stderr
+++ b/tests/ui/transmutability/primitives/bool.current.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `u8` cannot be safely transmuted into `bool`
-  --> $DIR/bool.rs:20:35
+  --> $DIR/bool.rs:21:35
    |
 LL |     assert::is_transmutable::<u8, bool>();
    |                                   ^^^^ At least one value of `u8` isn't a bit-valid value of `bool`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/bool.rs:10:14
+  --> $DIR/bool.rs:11:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function

--- a/tests/ui/transmutability/primitives/bool.next.stderr
+++ b/tests/ui/transmutability/primitives/bool.next.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `u8` cannot be safely transmuted into `bool`
-  --> $DIR/bool.rs:20:35
+  --> $DIR/bool.rs:21:35
    |
 LL |     assert::is_transmutable::<u8, bool>();
    |                                   ^^^^ At least one value of `u8` isn't a bit-valid value of `bool`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/bool.rs:10:14
+  --> $DIR/bool.rs:11:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function

--- a/tests/ui/transmutability/primitives/bool.rs
+++ b/tests/ui/transmutability/primitives/bool.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(transmutability)]

--- a/tests/ui/transmutability/primitives/numbers.current.stderr
+++ b/tests/ui/transmutability/primitives/numbers.current.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `i8` cannot be safely transmuted into `i16`
-  --> $DIR/numbers.rs:64:40
+  --> $DIR/numbers.rs:65:40
    |
 LL |     assert::is_transmutable::<   i8,   i16>();
    |                                        ^^^ The size of `i8` is smaller than the size of `i16`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -14,13 +14,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u16`
-  --> $DIR/numbers.rs:65:40
+  --> $DIR/numbers.rs:66:40
    |
 LL |     assert::is_transmutable::<   i8,   u16>();
    |                                        ^^^ The size of `i8` is smaller than the size of `u16`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -29,13 +29,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i32`
-  --> $DIR/numbers.rs:66:40
+  --> $DIR/numbers.rs:67:40
    |
 LL |     assert::is_transmutable::<   i8,   i32>();
    |                                        ^^^ The size of `i8` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -44,13 +44,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `f32`
-  --> $DIR/numbers.rs:67:40
+  --> $DIR/numbers.rs:68:40
    |
 LL |     assert::is_transmutable::<   i8,   f32>();
    |                                        ^^^ The size of `i8` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -59,13 +59,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u32`
-  --> $DIR/numbers.rs:68:40
+  --> $DIR/numbers.rs:69:40
    |
 LL |     assert::is_transmutable::<   i8,   u32>();
    |                                        ^^^ The size of `i8` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -74,13 +74,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:69:40
+  --> $DIR/numbers.rs:70:40
    |
 LL |     assert::is_transmutable::<   i8,   u64>();
    |                                        ^^^ The size of `i8` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -89,13 +89,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:70:40
+  --> $DIR/numbers.rs:71:40
    |
 LL |     assert::is_transmutable::<   i8,   i64>();
    |                                        ^^^ The size of `i8` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -104,13 +104,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:71:40
+  --> $DIR/numbers.rs:72:40
    |
 LL |     assert::is_transmutable::<   i8,   f64>();
    |                                        ^^^ The size of `i8` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -119,13 +119,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:72:39
+  --> $DIR/numbers.rs:73:39
    |
 LL |     assert::is_transmutable::<   i8,  u128>();
    |                                       ^^^^ The size of `i8` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -134,13 +134,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:73:39
+  --> $DIR/numbers.rs:74:39
    |
 LL |     assert::is_transmutable::<   i8,  i128>();
    |                                       ^^^^ The size of `i8` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -149,13 +149,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i16`
-  --> $DIR/numbers.rs:75:40
+  --> $DIR/numbers.rs:76:40
    |
 LL |     assert::is_transmutable::<   u8,   i16>();
    |                                        ^^^ The size of `u8` is smaller than the size of `i16`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -164,13 +164,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u16`
-  --> $DIR/numbers.rs:76:40
+  --> $DIR/numbers.rs:77:40
    |
 LL |     assert::is_transmutable::<   u8,   u16>();
    |                                        ^^^ The size of `u8` is smaller than the size of `u16`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -179,13 +179,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i32`
-  --> $DIR/numbers.rs:77:40
+  --> $DIR/numbers.rs:78:40
    |
 LL |     assert::is_transmutable::<   u8,   i32>();
    |                                        ^^^ The size of `u8` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -194,13 +194,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `f32`
-  --> $DIR/numbers.rs:78:40
+  --> $DIR/numbers.rs:79:40
    |
 LL |     assert::is_transmutable::<   u8,   f32>();
    |                                        ^^^ The size of `u8` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -209,13 +209,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u32`
-  --> $DIR/numbers.rs:79:40
+  --> $DIR/numbers.rs:80:40
    |
 LL |     assert::is_transmutable::<   u8,   u32>();
    |                                        ^^^ The size of `u8` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -224,13 +224,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:80:40
+  --> $DIR/numbers.rs:81:40
    |
 LL |     assert::is_transmutable::<   u8,   u64>();
    |                                        ^^^ The size of `u8` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -239,13 +239,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:81:40
+  --> $DIR/numbers.rs:82:40
    |
 LL |     assert::is_transmutable::<   u8,   i64>();
    |                                        ^^^ The size of `u8` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -254,13 +254,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:82:40
+  --> $DIR/numbers.rs:83:40
    |
 LL |     assert::is_transmutable::<   u8,   f64>();
    |                                        ^^^ The size of `u8` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -269,13 +269,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:83:39
+  --> $DIR/numbers.rs:84:39
    |
 LL |     assert::is_transmutable::<   u8,  u128>();
    |                                       ^^^^ The size of `u8` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -284,13 +284,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:84:39
+  --> $DIR/numbers.rs:85:39
    |
 LL |     assert::is_transmutable::<   u8,  i128>();
    |                                       ^^^^ The size of `u8` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -299,13 +299,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i32`
-  --> $DIR/numbers.rs:86:40
+  --> $DIR/numbers.rs:87:40
    |
 LL |     assert::is_transmutable::<  i16,   i32>();
    |                                        ^^^ The size of `i16` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -314,13 +314,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `f32`
-  --> $DIR/numbers.rs:87:40
+  --> $DIR/numbers.rs:88:40
    |
 LL |     assert::is_transmutable::<  i16,   f32>();
    |                                        ^^^ The size of `i16` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -329,13 +329,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u32`
-  --> $DIR/numbers.rs:88:40
+  --> $DIR/numbers.rs:89:40
    |
 LL |     assert::is_transmutable::<  i16,   u32>();
    |                                        ^^^ The size of `i16` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -344,13 +344,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:89:40
+  --> $DIR/numbers.rs:90:40
    |
 LL |     assert::is_transmutable::<  i16,   u64>();
    |                                        ^^^ The size of `i16` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -359,13 +359,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:90:40
+  --> $DIR/numbers.rs:91:40
    |
 LL |     assert::is_transmutable::<  i16,   i64>();
    |                                        ^^^ The size of `i16` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -374,13 +374,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:91:40
+  --> $DIR/numbers.rs:92:40
    |
 LL |     assert::is_transmutable::<  i16,   f64>();
    |                                        ^^^ The size of `i16` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -389,13 +389,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:92:39
+  --> $DIR/numbers.rs:93:39
    |
 LL |     assert::is_transmutable::<  i16,  u128>();
    |                                       ^^^^ The size of `i16` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -404,13 +404,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:93:39
+  --> $DIR/numbers.rs:94:39
    |
 LL |     assert::is_transmutable::<  i16,  i128>();
    |                                       ^^^^ The size of `i16` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -419,13 +419,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i32`
-  --> $DIR/numbers.rs:95:40
+  --> $DIR/numbers.rs:96:40
    |
 LL |     assert::is_transmutable::<  u16,   i32>();
    |                                        ^^^ The size of `u16` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -434,13 +434,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `f32`
-  --> $DIR/numbers.rs:96:40
+  --> $DIR/numbers.rs:97:40
    |
 LL |     assert::is_transmutable::<  u16,   f32>();
    |                                        ^^^ The size of `u16` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -449,13 +449,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u32`
-  --> $DIR/numbers.rs:97:40
+  --> $DIR/numbers.rs:98:40
    |
 LL |     assert::is_transmutable::<  u16,   u32>();
    |                                        ^^^ The size of `u16` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -464,13 +464,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:98:40
+  --> $DIR/numbers.rs:99:40
    |
 LL |     assert::is_transmutable::<  u16,   u64>();
    |                                        ^^^ The size of `u16` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -479,13 +479,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:99:40
+  --> $DIR/numbers.rs:100:40
    |
 LL |     assert::is_transmutable::<  u16,   i64>();
    |                                        ^^^ The size of `u16` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -494,13 +494,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:100:40
+  --> $DIR/numbers.rs:101:40
    |
 LL |     assert::is_transmutable::<  u16,   f64>();
    |                                        ^^^ The size of `u16` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -509,13 +509,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:101:39
+  --> $DIR/numbers.rs:102:39
    |
 LL |     assert::is_transmutable::<  u16,  u128>();
    |                                       ^^^^ The size of `u16` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -524,13 +524,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:102:39
+  --> $DIR/numbers.rs:103:39
    |
 LL |     assert::is_transmutable::<  u16,  i128>();
    |                                       ^^^^ The size of `u16` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -539,13 +539,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:104:40
+  --> $DIR/numbers.rs:105:40
    |
 LL |     assert::is_transmutable::<  i32,   u64>();
    |                                        ^^^ The size of `i32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -554,13 +554,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:105:40
+  --> $DIR/numbers.rs:106:40
    |
 LL |     assert::is_transmutable::<  i32,   i64>();
    |                                        ^^^ The size of `i32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -569,13 +569,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:106:40
+  --> $DIR/numbers.rs:107:40
    |
 LL |     assert::is_transmutable::<  i32,   f64>();
    |                                        ^^^ The size of `i32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -584,13 +584,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:107:39
+  --> $DIR/numbers.rs:108:39
    |
 LL |     assert::is_transmutable::<  i32,  u128>();
    |                                       ^^^^ The size of `i32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -599,13 +599,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:108:39
+  --> $DIR/numbers.rs:109:39
    |
 LL |     assert::is_transmutable::<  i32,  i128>();
    |                                       ^^^^ The size of `i32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -614,13 +614,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:110:40
+  --> $DIR/numbers.rs:111:40
    |
 LL |     assert::is_transmutable::<  f32,   u64>();
    |                                        ^^^ The size of `f32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -629,13 +629,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:111:40
+  --> $DIR/numbers.rs:112:40
    |
 LL |     assert::is_transmutable::<  f32,   i64>();
    |                                        ^^^ The size of `f32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -644,13 +644,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:112:40
+  --> $DIR/numbers.rs:113:40
    |
 LL |     assert::is_transmutable::<  f32,   f64>();
    |                                        ^^^ The size of `f32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -659,13 +659,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:113:39
+  --> $DIR/numbers.rs:114:39
    |
 LL |     assert::is_transmutable::<  f32,  u128>();
    |                                       ^^^^ The size of `f32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -674,13 +674,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:114:39
+  --> $DIR/numbers.rs:115:39
    |
 LL |     assert::is_transmutable::<  f32,  i128>();
    |                                       ^^^^ The size of `f32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -689,13 +689,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:116:40
+  --> $DIR/numbers.rs:117:40
    |
 LL |     assert::is_transmutable::<  u32,   u64>();
    |                                        ^^^ The size of `u32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -704,13 +704,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:117:40
+  --> $DIR/numbers.rs:118:40
    |
 LL |     assert::is_transmutable::<  u32,   i64>();
    |                                        ^^^ The size of `u32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -719,13 +719,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:118:40
+  --> $DIR/numbers.rs:119:40
    |
 LL |     assert::is_transmutable::<  u32,   f64>();
    |                                        ^^^ The size of `u32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -734,13 +734,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:119:39
+  --> $DIR/numbers.rs:120:39
    |
 LL |     assert::is_transmutable::<  u32,  u128>();
    |                                       ^^^^ The size of `u32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -749,13 +749,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:120:39
+  --> $DIR/numbers.rs:121:39
    |
 LL |     assert::is_transmutable::<  u32,  i128>();
    |                                       ^^^^ The size of `u32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -764,13 +764,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u64` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:122:39
+  --> $DIR/numbers.rs:123:39
    |
 LL |     assert::is_transmutable::<  u64,  u128>();
    |                                       ^^^^ The size of `u64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -779,13 +779,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u64` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:123:39
+  --> $DIR/numbers.rs:124:39
    |
 LL |     assert::is_transmutable::<  u64,  i128>();
    |                                       ^^^^ The size of `u64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -794,13 +794,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i64` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:125:39
+  --> $DIR/numbers.rs:126:39
    |
 LL |     assert::is_transmutable::<  i64,  u128>();
    |                                       ^^^^ The size of `i64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -809,13 +809,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i64` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:126:39
+  --> $DIR/numbers.rs:127:39
    |
 LL |     assert::is_transmutable::<  i64,  i128>();
    |                                       ^^^^ The size of `i64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -824,13 +824,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f64` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:128:39
+  --> $DIR/numbers.rs:129:39
    |
 LL |     assert::is_transmutable::<  f64,  u128>();
    |                                       ^^^^ The size of `f64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -839,13 +839,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f64` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:129:39
+  --> $DIR/numbers.rs:130:39
    |
 LL |     assert::is_transmutable::<  f64,  i128>();
    |                                       ^^^^ The size of `f64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function

--- a/tests/ui/transmutability/primitives/numbers.next.stderr
+++ b/tests/ui/transmutability/primitives/numbers.next.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `i8` cannot be safely transmuted into `i16`
-  --> $DIR/numbers.rs:64:40
+  --> $DIR/numbers.rs:65:40
    |
 LL |     assert::is_transmutable::<   i8,   i16>();
    |                                        ^^^ The size of `i8` is smaller than the size of `i16`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -14,13 +14,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u16`
-  --> $DIR/numbers.rs:65:40
+  --> $DIR/numbers.rs:66:40
    |
 LL |     assert::is_transmutable::<   i8,   u16>();
    |                                        ^^^ The size of `i8` is smaller than the size of `u16`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -29,13 +29,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i32`
-  --> $DIR/numbers.rs:66:40
+  --> $DIR/numbers.rs:67:40
    |
 LL |     assert::is_transmutable::<   i8,   i32>();
    |                                        ^^^ The size of `i8` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -44,13 +44,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `f32`
-  --> $DIR/numbers.rs:67:40
+  --> $DIR/numbers.rs:68:40
    |
 LL |     assert::is_transmutable::<   i8,   f32>();
    |                                        ^^^ The size of `i8` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -59,13 +59,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u32`
-  --> $DIR/numbers.rs:68:40
+  --> $DIR/numbers.rs:69:40
    |
 LL |     assert::is_transmutable::<   i8,   u32>();
    |                                        ^^^ The size of `i8` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -74,13 +74,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:69:40
+  --> $DIR/numbers.rs:70:40
    |
 LL |     assert::is_transmutable::<   i8,   u64>();
    |                                        ^^^ The size of `i8` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -89,13 +89,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:70:40
+  --> $DIR/numbers.rs:71:40
    |
 LL |     assert::is_transmutable::<   i8,   i64>();
    |                                        ^^^ The size of `i8` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -104,13 +104,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:71:40
+  --> $DIR/numbers.rs:72:40
    |
 LL |     assert::is_transmutable::<   i8,   f64>();
    |                                        ^^^ The size of `i8` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -119,13 +119,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:72:39
+  --> $DIR/numbers.rs:73:39
    |
 LL |     assert::is_transmutable::<   i8,  u128>();
    |                                       ^^^^ The size of `i8` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -134,13 +134,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:73:39
+  --> $DIR/numbers.rs:74:39
    |
 LL |     assert::is_transmutable::<   i8,  i128>();
    |                                       ^^^^ The size of `i8` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -149,13 +149,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i16`
-  --> $DIR/numbers.rs:75:40
+  --> $DIR/numbers.rs:76:40
    |
 LL |     assert::is_transmutable::<   u8,   i16>();
    |                                        ^^^ The size of `u8` is smaller than the size of `i16`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -164,13 +164,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u16`
-  --> $DIR/numbers.rs:76:40
+  --> $DIR/numbers.rs:77:40
    |
 LL |     assert::is_transmutable::<   u8,   u16>();
    |                                        ^^^ The size of `u8` is smaller than the size of `u16`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -179,13 +179,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i32`
-  --> $DIR/numbers.rs:77:40
+  --> $DIR/numbers.rs:78:40
    |
 LL |     assert::is_transmutable::<   u8,   i32>();
    |                                        ^^^ The size of `u8` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -194,13 +194,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `f32`
-  --> $DIR/numbers.rs:78:40
+  --> $DIR/numbers.rs:79:40
    |
 LL |     assert::is_transmutable::<   u8,   f32>();
    |                                        ^^^ The size of `u8` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -209,13 +209,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u32`
-  --> $DIR/numbers.rs:79:40
+  --> $DIR/numbers.rs:80:40
    |
 LL |     assert::is_transmutable::<   u8,   u32>();
    |                                        ^^^ The size of `u8` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -224,13 +224,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:80:40
+  --> $DIR/numbers.rs:81:40
    |
 LL |     assert::is_transmutable::<   u8,   u64>();
    |                                        ^^^ The size of `u8` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -239,13 +239,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:81:40
+  --> $DIR/numbers.rs:82:40
    |
 LL |     assert::is_transmutable::<   u8,   i64>();
    |                                        ^^^ The size of `u8` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -254,13 +254,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:82:40
+  --> $DIR/numbers.rs:83:40
    |
 LL |     assert::is_transmutable::<   u8,   f64>();
    |                                        ^^^ The size of `u8` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -269,13 +269,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:83:39
+  --> $DIR/numbers.rs:84:39
    |
 LL |     assert::is_transmutable::<   u8,  u128>();
    |                                       ^^^^ The size of `u8` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -284,13 +284,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:84:39
+  --> $DIR/numbers.rs:85:39
    |
 LL |     assert::is_transmutable::<   u8,  i128>();
    |                                       ^^^^ The size of `u8` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -299,13 +299,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i32`
-  --> $DIR/numbers.rs:86:40
+  --> $DIR/numbers.rs:87:40
    |
 LL |     assert::is_transmutable::<  i16,   i32>();
    |                                        ^^^ The size of `i16` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -314,13 +314,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `f32`
-  --> $DIR/numbers.rs:87:40
+  --> $DIR/numbers.rs:88:40
    |
 LL |     assert::is_transmutable::<  i16,   f32>();
    |                                        ^^^ The size of `i16` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -329,13 +329,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u32`
-  --> $DIR/numbers.rs:88:40
+  --> $DIR/numbers.rs:89:40
    |
 LL |     assert::is_transmutable::<  i16,   u32>();
    |                                        ^^^ The size of `i16` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -344,13 +344,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:89:40
+  --> $DIR/numbers.rs:90:40
    |
 LL |     assert::is_transmutable::<  i16,   u64>();
    |                                        ^^^ The size of `i16` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -359,13 +359,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:90:40
+  --> $DIR/numbers.rs:91:40
    |
 LL |     assert::is_transmutable::<  i16,   i64>();
    |                                        ^^^ The size of `i16` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -374,13 +374,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:91:40
+  --> $DIR/numbers.rs:92:40
    |
 LL |     assert::is_transmutable::<  i16,   f64>();
    |                                        ^^^ The size of `i16` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -389,13 +389,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:92:39
+  --> $DIR/numbers.rs:93:39
    |
 LL |     assert::is_transmutable::<  i16,  u128>();
    |                                       ^^^^ The size of `i16` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -404,13 +404,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:93:39
+  --> $DIR/numbers.rs:94:39
    |
 LL |     assert::is_transmutable::<  i16,  i128>();
    |                                       ^^^^ The size of `i16` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -419,13 +419,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i32`
-  --> $DIR/numbers.rs:95:40
+  --> $DIR/numbers.rs:96:40
    |
 LL |     assert::is_transmutable::<  u16,   i32>();
    |                                        ^^^ The size of `u16` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -434,13 +434,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `f32`
-  --> $DIR/numbers.rs:96:40
+  --> $DIR/numbers.rs:97:40
    |
 LL |     assert::is_transmutable::<  u16,   f32>();
    |                                        ^^^ The size of `u16` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -449,13 +449,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u32`
-  --> $DIR/numbers.rs:97:40
+  --> $DIR/numbers.rs:98:40
    |
 LL |     assert::is_transmutable::<  u16,   u32>();
    |                                        ^^^ The size of `u16` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -464,13 +464,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:98:40
+  --> $DIR/numbers.rs:99:40
    |
 LL |     assert::is_transmutable::<  u16,   u64>();
    |                                        ^^^ The size of `u16` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -479,13 +479,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:99:40
+  --> $DIR/numbers.rs:100:40
    |
 LL |     assert::is_transmutable::<  u16,   i64>();
    |                                        ^^^ The size of `u16` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -494,13 +494,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:100:40
+  --> $DIR/numbers.rs:101:40
    |
 LL |     assert::is_transmutable::<  u16,   f64>();
    |                                        ^^^ The size of `u16` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -509,13 +509,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:101:39
+  --> $DIR/numbers.rs:102:39
    |
 LL |     assert::is_transmutable::<  u16,  u128>();
    |                                       ^^^^ The size of `u16` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -524,13 +524,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:102:39
+  --> $DIR/numbers.rs:103:39
    |
 LL |     assert::is_transmutable::<  u16,  i128>();
    |                                       ^^^^ The size of `u16` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -539,13 +539,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:104:40
+  --> $DIR/numbers.rs:105:40
    |
 LL |     assert::is_transmutable::<  i32,   u64>();
    |                                        ^^^ The size of `i32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -554,13 +554,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:105:40
+  --> $DIR/numbers.rs:106:40
    |
 LL |     assert::is_transmutable::<  i32,   i64>();
    |                                        ^^^ The size of `i32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -569,13 +569,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:106:40
+  --> $DIR/numbers.rs:107:40
    |
 LL |     assert::is_transmutable::<  i32,   f64>();
    |                                        ^^^ The size of `i32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -584,13 +584,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:107:39
+  --> $DIR/numbers.rs:108:39
    |
 LL |     assert::is_transmutable::<  i32,  u128>();
    |                                       ^^^^ The size of `i32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -599,13 +599,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:108:39
+  --> $DIR/numbers.rs:109:39
    |
 LL |     assert::is_transmutable::<  i32,  i128>();
    |                                       ^^^^ The size of `i32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -614,13 +614,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:110:40
+  --> $DIR/numbers.rs:111:40
    |
 LL |     assert::is_transmutable::<  f32,   u64>();
    |                                        ^^^ The size of `f32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -629,13 +629,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:111:40
+  --> $DIR/numbers.rs:112:40
    |
 LL |     assert::is_transmutable::<  f32,   i64>();
    |                                        ^^^ The size of `f32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -644,13 +644,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:112:40
+  --> $DIR/numbers.rs:113:40
    |
 LL |     assert::is_transmutable::<  f32,   f64>();
    |                                        ^^^ The size of `f32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -659,13 +659,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:113:39
+  --> $DIR/numbers.rs:114:39
    |
 LL |     assert::is_transmutable::<  f32,  u128>();
    |                                       ^^^^ The size of `f32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -674,13 +674,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:114:39
+  --> $DIR/numbers.rs:115:39
    |
 LL |     assert::is_transmutable::<  f32,  i128>();
    |                                       ^^^^ The size of `f32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -689,13 +689,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `u64`
-  --> $DIR/numbers.rs:116:40
+  --> $DIR/numbers.rs:117:40
    |
 LL |     assert::is_transmutable::<  u32,   u64>();
    |                                        ^^^ The size of `u32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -704,13 +704,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `i64`
-  --> $DIR/numbers.rs:117:40
+  --> $DIR/numbers.rs:118:40
    |
 LL |     assert::is_transmutable::<  u32,   i64>();
    |                                        ^^^ The size of `u32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -719,13 +719,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `f64`
-  --> $DIR/numbers.rs:118:40
+  --> $DIR/numbers.rs:119:40
    |
 LL |     assert::is_transmutable::<  u32,   f64>();
    |                                        ^^^ The size of `u32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -734,13 +734,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:119:39
+  --> $DIR/numbers.rs:120:39
    |
 LL |     assert::is_transmutable::<  u32,  u128>();
    |                                       ^^^^ The size of `u32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -749,13 +749,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:120:39
+  --> $DIR/numbers.rs:121:39
    |
 LL |     assert::is_transmutable::<  u32,  i128>();
    |                                       ^^^^ The size of `u32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -764,13 +764,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u64` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:122:39
+  --> $DIR/numbers.rs:123:39
    |
 LL |     assert::is_transmutable::<  u64,  u128>();
    |                                       ^^^^ The size of `u64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -779,13 +779,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u64` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:123:39
+  --> $DIR/numbers.rs:124:39
    |
 LL |     assert::is_transmutable::<  u64,  i128>();
    |                                       ^^^^ The size of `u64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -794,13 +794,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i64` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:125:39
+  --> $DIR/numbers.rs:126:39
    |
 LL |     assert::is_transmutable::<  i64,  u128>();
    |                                       ^^^^ The size of `i64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -809,13 +809,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i64` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:126:39
+  --> $DIR/numbers.rs:127:39
    |
 LL |     assert::is_transmutable::<  i64,  i128>();
    |                                       ^^^^ The size of `i64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -824,13 +824,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f64` cannot be safely transmuted into `u128`
-  --> $DIR/numbers.rs:128:39
+  --> $DIR/numbers.rs:129:39
    |
 LL |     assert::is_transmutable::<  f64,  u128>();
    |                                       ^^^^ The size of `f64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
@@ -839,13 +839,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f64` cannot be safely transmuted into `i128`
-  --> $DIR/numbers.rs:129:39
+  --> $DIR/numbers.rs:130:39
    |
 LL |     assert::is_transmutable::<  f64,  i128>();
    |                                       ^^^^ The size of `f64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/numbers.rs:14:14
+  --> $DIR/numbers.rs:15:14
    |
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function

--- a/tests/ui/transmutability/primitives/numbers.rs
+++ b/tests/ui/transmutability/primitives/numbers.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![crate_type = "lib"]

--- a/tests/ui/transmutability/primitives/unit.current.stderr
+++ b/tests/ui/transmutability/primitives/unit.current.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `()` cannot be safely transmuted into `u8`
-  --> $DIR/unit.rs:30:35
+  --> $DIR/unit.rs:31:35
    |
 LL |     assert::is_transmutable::<(), u8>();
    |                                   ^^ The size of `()` is smaller than the size of `u8`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/unit.rs:15:14
+  --> $DIR/unit.rs:16:14
    |
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function

--- a/tests/ui/transmutability/primitives/unit.next.stderr
+++ b/tests/ui/transmutability/primitives/unit.next.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `()` cannot be safely transmuted into `u8`
-  --> $DIR/unit.rs:30:35
+  --> $DIR/unit.rs:31:35
    |
 LL |     assert::is_transmutable::<(), u8>();
    |                                   ^^ The size of `()` is smaller than the size of `u8`
    |
 note: required by a bound in `is_transmutable`
-  --> $DIR/unit.rs:15:14
+  --> $DIR/unit.rs:16:14
    |
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function

--- a/tests/ui/transmutability/primitives/unit.rs
+++ b/tests/ui/transmutability/primitives/unit.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 //! The unit type, `()`, should be one byte.

--- a/tests/ui/type-alias-impl-trait/assoc-type-const.rs
+++ b/tests/ui/type-alias-impl-trait/assoc-type-const.rs
@@ -3,6 +3,7 @@
 
 //@ check-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 #![feature(impl_trait_in_assoc_type)]
 

--- a/tests/ui/type-alias-impl-trait/cross_inference.rs
+++ b/tests/ui/type-alias-impl-trait/cross_inference.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 

--- a/tests/ui/type-alias-impl-trait/issue-76202-trait-impl-for-tait.rs
+++ b/tests/ui/type-alias-impl-trait/issue-76202-trait-impl-for-tait.rs
@@ -2,6 +2,7 @@
 // Tests that we don't ICE when we have a trait impl on a TAIT.
 
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 #![feature(type_alias_impl_trait)]

--- a/tests/ui/type-alias-impl-trait/issue-78450.rs
+++ b/tests/ui/type-alias-impl-trait/issue-78450.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(impl_trait_in_assoc_type)]

--- a/tests/ui/type-alias-impl-trait/nested_inference_failure.rs
+++ b/tests/ui/type-alias-impl-trait/nested_inference_failure.rs
@@ -1,6 +1,7 @@
 //@ check-pass
-//@ revisions: new old
-//@[new] compile-flags: -Znext-solver
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
 
 //! This test checks that we can successfully infer
 //! the hidden type of `FooImpl` to be `Foo<i32, {closure}>`

--- a/tests/ui/type-alias-impl-trait/normalize-hidden-types.current.stderr
+++ b/tests/ui/type-alias-impl-trait/normalize-hidden-types.current.stderr
@@ -1,29 +1,29 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/normalize-hidden-types.rs:25:20
+  --> $DIR/normalize-hidden-types.rs:26:20
    |
 LL |     fn define() -> Opaque {
    |                    ^^^^^^ expected `*const (dyn FnOnce(()) + 'static)`, got `*const dyn for<'a> FnOnce(<u8 as Trait>::Gat<'a>)`
    |
 note: previous use here
-  --> $DIR/normalize-hidden-types.rs:26:9
+  --> $DIR/normalize-hidden-types.rs:27:9
    |
 LL |         dyn_hoops::<_>(0)
    |         ^^^^^^^^^^^^^^^^^
 
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/normalize-hidden-types.rs:33:22
+  --> $DIR/normalize-hidden-types.rs:34:22
    |
 LL |     fn define_1() -> Opaque { dyn_hoops::<_>(0) }
    |                      ^^^^^^ expected `*const (dyn FnOnce(()) + 'static)`, got `*const dyn for<'a> FnOnce(<u8 as Trait>::Gat<'a>)`
    |
 note: previous use here
-  --> $DIR/normalize-hidden-types.rs:33:31
+  --> $DIR/normalize-hidden-types.rs:34:31
    |
 LL |     fn define_1() -> Opaque { dyn_hoops::<_>(0) }
    |                               ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/normalize-hidden-types.rs:42:25
+  --> $DIR/normalize-hidden-types.rs:43:25
    |
 LL |     type Opaque = impl Sized;
    |                   ---------- the expected opaque type
@@ -39,13 +39,13 @@ LL |         let _: Opaque = dyn_hoops::<u8>(0);
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
 
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/normalize-hidden-types.rs:51:25
+  --> $DIR/normalize-hidden-types.rs:52:25
    |
 LL |         let _: Opaque = dyn_hoops::<_>(0);
    |                         ^^^^^^^^^^^^^^^^^ expected `*const (dyn FnOnce(()) + 'static)`, got `*const dyn for<'a> FnOnce(<u8 as Trait>::Gat<'a>)`
    |
 note: previous use here
-  --> $DIR/normalize-hidden-types.rs:52:9
+  --> $DIR/normalize-hidden-types.rs:53:9
    |
 LL |         None
    |         ^^^^

--- a/tests/ui/type-alias-impl-trait/normalize-hidden-types.rs
+++ b/tests/ui/type-alias-impl-trait/normalize-hidden-types.rs
@@ -1,6 +1,7 @@
 // Regression test for #112691
 //
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@ [next] compile-flags: -Znext-solver
 //@ [next] check-pass
 //@ [current] known-bug: #112691

--- a/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.current.stderr
+++ b/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.current.stderr
@@ -8,13 +8,13 @@ error: internal compiler error: {OpaqueTypeKey { def_id: DefId(get_rpit::{opaque
            
 
 error: internal compiler error: error performing ParamEnvAnd { param_env: ParamEnv { caller_bounds: [], reveal: UserFacing }, value: ProvePredicate { predicate: Binder { value: ProjectionPredicate(AliasTy { args: [FnDef(DefId(get_rpit), []), ()], def_id: DefId(ops::function::FnOnce::Output) }, Term::Ty(Alias(Opaque, AliasTy { args: [], def_id: DefId(Opaque::{opaque#0}) }))), bound_vars: [] } } }
-  --> $DIR/rpit_tait_equality_in_canonical_query.rs:31:5
+  --> $DIR/rpit_tait_equality_in_canonical_query.rs:32:5
    |
 LL |     query(get_rpit);
    |     ^^^^^^^^^^^^^^^
    |
 
-  --> $DIR/rpit_tait_equality_in_canonical_query.rs:31:5
+  --> $DIR/rpit_tait_equality_in_canonical_query.rs:32:5
    |
 LL |     query(get_rpit);
    |     ^^^^^^^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.rs
+++ b/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.rs
@@ -6,6 +6,7 @@
 //! have a situation where the RPIT gets constrained outside its anchor.
 
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[next] check-pass
 

--- a/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
@@ -1,5 +1,5 @@
 error[E0277]: can't compare `i32` with `Foo`
-  --> $DIR/self-referential-2.rs:9:13
+  --> $DIR/self-referential-2.rs:10:13
    |
 LL | fn bar() -> Bar {
    |             ^^^ no implementation for `i32 == Foo`

--- a/tests/ui/type-alias-impl-trait/self-referential-2.rs
+++ b/tests/ui/type-alias-impl-trait/self-referential-2.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[next] check-pass
 #![feature(type_alias_impl_trait)]

--- a/tests/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.next.stderr
+++ b/tests/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.next.stderr
@@ -1,11 +1,11 @@
 error[E0284]: type annotations needed: cannot satisfy `Foo == _`
-  --> $DIR/type-alias-impl-trait-tuple.rs:21:24
+  --> $DIR/type-alias-impl-trait-tuple.rs:22:24
    |
 LL |         Blah { my_foo: make_foo(), my_u8: 12 }
    |                        ^^^^^^^^^^ cannot satisfy `Foo == _`
 
 error[E0284]: type annotations needed: cannot satisfy `Foo == _`
-  --> $DIR/type-alias-impl-trait-tuple.rs:25:10
+  --> $DIR/type-alias-impl-trait-tuple.rs:26:10
    |
 LL |         (self.my_foo, self.my_u8, make_foo())
    |          ^^^^^^^^^^^ cannot satisfy `Foo == _`

--- a/tests/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.rs
+++ b/tests/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[current] check-pass
 

--- a/tests/ui/type-alias-impl-trait/type_of_a_let.current.stderr
+++ b/tests/ui/type-alias-impl-trait/type_of_a_let.current.stderr
@@ -1,5 +1,5 @@
 error[E0382]: use of moved value: `x`
-  --> $DIR/type_of_a_let.rs:20:16
+  --> $DIR/type_of_a_let.rs:21:16
    |
 LL |     let x: Foo = 22_u32;
    |         - move occurs because `x` has type `Foo`, which does not implement the `Copy` trait
@@ -9,7 +9,7 @@ LL |     same_type((x, y));
    |                ^ value used here after move
 
 error[E0382]: use of moved value: `y`
-  --> $DIR/type_of_a_let.rs:21:6
+  --> $DIR/type_of_a_let.rs:22:6
    |
 LL |     let y: Foo = x;
    |         - move occurs because `y` has type `Foo`, which does not implement the `Copy` trait

--- a/tests/ui/type-alias-impl-trait/type_of_a_let.rs
+++ b/tests/ui/type-alias-impl-trait/type_of_a_let.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@[next] check-pass
 

--- a/tests/ui/typeck/issue-103899.rs
+++ b/tests/ui/typeck/issue-103899.rs
@@ -1,7 +1,11 @@
-//@ check-fail
-//@ failure-status: 101
-//@ dont-check-compiler-stderr
-//@ known-bug: #103899
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@[next] check-pass
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[current] check-fail
+//@[current] failure-status: 101
+//@[current] dont-check-compiler-stderr
+//@[current] known-bug: #103899
 
 trait BaseWithAssoc {
     type Assoc;

--- a/tests/ui/unsized/issue-71659.current.stderr
+++ b/tests/ui/unsized/issue-71659.current.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `dyn Foo: CastTo<[i32]>` is not satisfied
-  --> $DIR/issue-71659.rs:33:15
+  --> $DIR/issue-71659.rs:34:15
    |
 LL |     let x = x.cast::<[i32]>();
    |               ^^^^ the trait `CastTo<[i32]>` is not implemented for `dyn Foo`
    |
 note: required by a bound in `Cast::cast`
-  --> $DIR/issue-71659.rs:22:15
+  --> $DIR/issue-71659.rs:23:15
    |
 LL |     fn cast<T: ?Sized>(&self) -> &T
    |        ---- required by a bound in this associated function

--- a/tests/ui/unsized/issue-71659.next.stderr
+++ b/tests/ui/unsized/issue-71659.next.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `dyn Foo: CastTo<[i32]>` is not satisfied
-  --> $DIR/issue-71659.rs:33:15
+  --> $DIR/issue-71659.rs:34:15
    |
 LL |     let x = x.cast::<[i32]>();
    |               ^^^^ the trait `CastTo<[i32]>` is not implemented for `dyn Foo`
    |
 note: required by a bound in `Cast::cast`
-  --> $DIR/issue-71659.rs:22:15
+  --> $DIR/issue-71659.rs:23:15
    |
 LL |     fn cast<T: ?Sized>(&self) -> &T
    |        ---- required by a bound in this associated function

--- a/tests/ui/unsized/issue-71659.rs
+++ b/tests/ui/unsized/issue-71659.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
 #![feature(unsize)]

--- a/tests/ui/unsized/issue-75899.rs
+++ b/tests/ui/unsized/issue-75899.rs
@@ -1,4 +1,5 @@
 //@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 

--- a/tests/ui/wf/wf-normalization-sized.next.stderr
+++ b/tests/ui/wf/wf-normalization-sized.next.stderr
@@ -1,0 +1,30 @@
+error: the type `<[[[[[[u8]]]]]] as WellUnformed>::RequestNormalize` is not well-formed
+  --> $DIR/wf-normalization-sized.rs:19:10
+   |
+LL | const _: <[[[[[[u8]]]]]] as WellUnformed>::RequestNormalize = ();
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the type `<[[[[[[u8]]]]]] as WellUnformed>::RequestNormalize` is not well-formed
+  --> $DIR/wf-normalization-sized.rs:19:10
+   |
+LL | const _: <[[[[[[u8]]]]]] as WellUnformed>::RequestNormalize = ();
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: the type `<Vec<str> as WellUnformed>::RequestNormalize` is not well-formed
+  --> $DIR/wf-normalization-sized.rs:22:10
+   |
+LL | const _: <Vec<str> as WellUnformed>::RequestNormalize = ();
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the type `<Vec<str> as WellUnformed>::RequestNormalize` is not well-formed
+  --> $DIR/wf-normalization-sized.rs:22:10
+   |
+LL | const _: <Vec<str> as WellUnformed>::RequestNormalize = ();
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/wf/wf-normalization-sized.rs
+++ b/tests/ui/wf/wf-normalization-sized.rs
@@ -1,5 +1,8 @@
-//@ check-pass
-//@ known-bug: #100041
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[current] check-pass
+//@[current] known-bug: #100041
 
 // Should fail. Normalization can bypass well-formedness checking.
 // `[[[[[[u8]]]]]]` is not a well-formed type since size of type `[u8]` cannot
@@ -14,6 +17,10 @@ impl<T: ?Sized> WellUnformed for T {
 }
 
 const _: <[[[[[[u8]]]]]] as WellUnformed>::RequestNormalize = ();
+//[next]~^ the type
+//[next]~| the type
 const _: <Vec<str> as WellUnformed>::RequestNormalize = ();
+//[next]~^ the type
+//[next]~| the type
 
 fn main() {}


### PR DESCRIPTION
Successful merges:

 - #116791 (Allow codegen backends to opt-out of parallel codegen)
 - #119385 (Fix type resolution of associated const equality bounds (take 2))
 - #121893 (Add tests (and a bit of cleanup) for interior mut handling in promotion and const-checking)
 - #122080 (Clarity improvements to `DropTree`)
 - #122152 (Improve diagnostics for parenthesized type arguments)
 - #122166 (Remove the unused `field_remapping` field from `TypeLowering`)
 - #122249 (interpret: do not call machine read hooks during validation)
 - #122299 (Store backtrace for `must_produce_diag`)
 - #122318 (Revision-related tweaks for next-solver tests)
 - #122328 (unix_sigpipe: Replace `inherit` with `sig_dfl` in syntax tests)
 - #122330 (bootstrap readme: fix, improve, update)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=116791,119385,121893,122080,122152,122166,122249,122299,122318,122328,122330)
<!-- homu-ignore:end -->