### PR TITLE
Treat weak alias types more like ADTs when computing implied bounds

### DIFF
--- a/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
@@ -299,7 +299,7 @@ fn check_explicit_predicates<'tcx>(
     }
 }
 
-/// Check the inferred predicates declared on the type.
+/// Check the inferred predicates of the type.
 ///
 /// ### Example
 ///

--- a/compiler/rustc_hir_analysis/src/outlives/utils.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/utils.rs
@@ -21,7 +21,7 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
 ) {
     // If the `'a` region is bound within the field type itself, we
     // don't want to propagate this constraint to the header.
-    if !is_free_region(outlived_region) {
+    if !is_early_bound_region(outlived_region) {
         return;
     }
 
@@ -132,7 +132,7 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
         }
 
         GenericArgKind::Lifetime(r) => {
-            if !is_free_region(r) {
+            if !is_early_bound_region(r) {
                 return;
             }
             required_predicates.entry(ty::OutlivesPredicate(kind, outlived_region)).or_insert(span);
@@ -144,7 +144,7 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
     }
 }
 
-fn is_free_region(region: Region<'_>) -> bool {
+fn is_early_bound_region(region: Region<'_>) -> bool {
     // First, screen for regions that might appear in a type header.
     match *region {
         // These correspond to `T: 'a` relationships:

--- a/compiler/rustc_type_ir/src/outlives.rs
+++ b/compiler/rustc_type_ir/src/outlives.rs
@@ -148,7 +148,7 @@ impl<I: Interner> TypeVisitor<I> for OutlivesCollector<'_, I> {
             // trait-ref. Therefore, if we see any higher-ranked regions,
             // we simply fallback to the most restrictive rule, which
             // requires that `Pi: 'a` for all `i`.
-            ty::Alias(_, alias_ty) => {
+            ty::Alias(ty::Projection | ty::Opaque | ty::Inherent, alias_ty) => {
                 if !alias_ty.has_escaping_bound_vars() {
                     // best case: no escaping regions, so push the
                     // projection and skip the subtree (thus generating no
@@ -195,6 +195,7 @@ impl<I: Interner> TypeVisitor<I> for OutlivesCollector<'_, I> {
             }
 
             ty::Adt(_, _)
+            | ty::Alias(ty::Weak, _)
             | ty::Foreign(_)
             | ty::Array(_, _)
             | ty::Pat(_, _)

--- a/tests/ui/lazy-type-alias/implied-outlives-bounds-1.print.stderr
+++ b/tests/ui/lazy-type-alias/implied-outlives-bounds-1.print.stderr
@@ -1,0 +1,11 @@
+error: rustc_outlives
+  --> $DIR/implied-outlives-bounds-1.rs:16:1
+   |
+LL | struct Type<'a, K, V>(&'a mut Alias<K, V>);
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: K: 'a
+   = note: V: 'a
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lazy-type-alias/implied-outlives-bounds-1.rs
+++ b/tests/ui/lazy-type-alias/implied-outlives-bounds-1.rs
@@ -1,0 +1,20 @@
+// Check that we infer the outlives-predicates `K: 'a`, `V: 'a` for `Type`
+// from the weak alias `Alias`.
+// This mirrors the behavior of ADTs instead of other kinds of alias types
+// like projections and opaque types.
+// If we were to mirror the semantics of the latter, we would infer the
+// outlives-predicate `Alias<K, V>: 'a` instead which is not what we want.
+
+//@ revisions: default print
+//@[default] check-pass
+
+#![feature(lazy_type_alias)]
+#![cfg_attr(print, feature(rustc_attrs))]
+#![allow(incomplete_features)]
+
+#[cfg_attr(print, rustc_outlives)]
+struct Type<'a, K, V>(&'a mut Alias<K, V>); //[print]~ ERROR rustc_outlives
+
+type Alias<K, V> = (K, V);
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check3.rs
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check3.rs
@@ -12,7 +12,6 @@ where
     test_lifetime_param::Ty<'a>: 'static,
 {
     test_lifetime_param::assert_static::<'a>()
-    //~^ ERROR: lifetime may not live long enough
 }
 
 mod test_higher_kinded_lifetime_param {
@@ -50,7 +49,6 @@ where
     test_type_param::Ty<A>: 'static,
 {
     test_type_param::assert_static::<A>()
-    //~^ ERROR: parameter type `A` may not live long enough
 }
 
 mod test_implied_from_fn_sig {

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check3.stderr
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check3.stderr
@@ -1,14 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/implied_lifetime_wf_check3.rs:14:5
-   |
-LL | fn test_lifetime_param_test<'a>()
-   |                             -- lifetime `'a` defined here
-...
-LL |     test_lifetime_param::assert_static::<'a>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-
-error: lifetime may not live long enough
-  --> $DIR/implied_lifetime_wf_check3.rs:29:5
+  --> $DIR/implied_lifetime_wf_check3.rs:28:5
    |
 LL | fn test_higher_kinded_lifetime_param_test<'a>()
    |                                           -- lifetime `'a` defined here
@@ -17,27 +8,12 @@ LL |     test_higher_kinded_lifetime_param::assert_static::<'a>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
 
 error: lifetime may not live long enough
-  --> $DIR/implied_lifetime_wf_check3.rs:36:9
+  --> $DIR/implied_lifetime_wf_check3.rs:35:9
    |
 LL |     fn test<'a>() {
    |             -- lifetime `'a` defined here
 LL |         assert_static::<'a>()
    |         ^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
 
-error[E0310]: the parameter type `A` may not live long enough
-  --> $DIR/implied_lifetime_wf_check3.rs:52:5
-   |
-LL |     test_type_param::assert_static::<A>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     the parameter type `A` must be valid for the static lifetime...
-   |     ...so that the type `A` will meet its required lifetime bounds
-   |
-help: consider adding an explicit lifetime bound
-   |
-LL | fn test_type_param_test<A: 'static>()
-   |                          +++++++++
+error: aborting due to 2 previous errors
 
-error: aborting due to 4 previous errors
-
-For more information about this error, try `rustc --explain E0310`.

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.rs
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.rs
@@ -15,7 +15,6 @@ where
     Ty<A>: 'static,
 {
     assert_static::<A>()
-    //~^ ERROR: the parameter type `A` may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.stderr
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.stderr
@@ -17,20 +17,6 @@ help: consider adding an explicit lifetime bound
 LL |     pub type Ty<A: 'static> = impl Sized + 'static;
    |                  +++++++++
 
-error[E0310]: the parameter type `A` may not live long enough
-  --> $DIR/implied_lifetime_wf_check4_static.rs:17:5
-   |
-LL |     assert_static::<A>()
-   |     ^^^^^^^^^^^^^^^^^^
-   |     |
-   |     the parameter type `A` must be valid for the static lifetime...
-   |     ...so that the type `A` will meet its required lifetime bounds
-   |
-help: consider adding an explicit lifetime bound
-   |
-LL | fn test<A: 'static>()
-   |          +++++++++
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0310`.


### PR DESCRIPTION
For context, we want to treat lazy type aliases / weak alias types just like ADTs when computing implied bounds (#118479, T-lang design meeting 2023-11-09) but the way I've implemented it in #119350, there are some deviations in behavior which this PR eliminates.

I found this oversight while trying to build `alloc` with LTAs enabled by default: `struct ExtractIfInner<'a, K, V>` would no longer build requiring the explicit bounds `K: 'a` and `V: 'a`.

With this patch, we imply `K: 'a`, `V: 'a` instead of `Root<K, V>: 'a` in the following code which is consistent with ADTs:

```rs
#![feature(lazy_type_alias)]
struct ExtractIfInner<'a, K, V>(&'a mut Root<K, V>);
type Root<K, V> = (K, V);
```

Instead of treating weak alias types as *abstract* when computing the *outlives-components* like we do for the other kinds of alias types, we shallowly walk their generic args like we do with ADTs.

This is yet another case in a series (#121344, #120780) where weak alias types deviate in behavior from the other kinds of alias types, well... ^^'.

r? @oli-obk