### PR TITLE
Update /NODEFAUTLIB comment for msvc

### DIFF
--- a/compiler/rustc_target/src/spec/base/windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/base/windows_msvc.rs
@@ -17,15 +17,19 @@ pub fn opts() -> TargetOptions {
         crt_static_allows_dylibs: true,
         crt_static_respected: true,
         requires_uwtable: true,
-        // Currently we don't pass the /NODEFAULTLIB flag to the linker on MSVC
-        // as there's been trouble in the past of linking the C++ standard
-        // library required by LLVM. This likely needs to happen one day, but
-        // in general Windows is also a more controlled environment than
-        // Unix, so it's not necessarily as critical that this be implemented.
+        // We don't pass the /NODEFAULTLIB flag to the linker on MSVC
+        // as that prevents linker directives embedded in object files from
+        // including other necessary libraries.
         //
-        // Note that there are also some licensing worries about statically
-        // linking some libraries which require a specific agreement, so it may
-        // not ever be possible for us to pass this flag.
+        // For example, msvcrt.lib embeds a linker directive like:
+        //    /DEFAULTLIB:vcruntime.lib /DEFAULTLIB:ucrt.lib
+        // So that vcruntime.lib and ucrt.lib are included when the entry point
+        // in msvcrt.lib is used. Using /NODEFAULTLIB would mean having to
+        // manually add those two libraries and potentially further dependencies
+        // they bring in.
+        //
+        // See also https://learn.microsoft.com/en-us/cpp/preprocessor/comment-c-cpp?view=msvc-170#lib
+        // for documention on including library dependencies in C/C++ code.
         no_default_libraries: false,
         has_thread_local: true,
 


### PR DESCRIPTION
I've tried to explain a bit more about the effects of `/NODEFAULTLIB` when using msvc link.exe (or compatible) as they're different from `-nodefaultlib` on gnu.

I also removed the part about licensing as I'm not sure licensing is an issue? Or rather, it's no more or less of an issue no matter how you link msvc libraries. The license is the one you get if using VS at all and even dynamic linking includes static code (e.g. startup/shutdown code, etc).

r? petrochenkov 