### PR TITLE
Revert "Auto merge of #122140 - oli-obk:track_errors13, r=davidtwco"

### DIFF
--- a/compiler/rustc_driver_impl/src/pretty.rs
+++ b/compiler/rustc_driver_impl/src/pretty.rs
@@ -336,8 +336,7 @@ pub fn print<'tcx>(sess: &Session, ppm: PpMode, ex: PrintExtra<'tcx>) {
         ThirTree => {
             let tcx = ex.tcx();
             let mut out = String::new();
-            rustc_hir_analysis::check_crate(tcx);
-            if tcx.dcx().has_errors().is_some() {
+            if rustc_hir_analysis::check_crate(tcx).is_err() {
                 FatalError.raise();
             }
             debug!("pretty printing THIR tree");
@@ -349,8 +348,7 @@ pub fn print<'tcx>(sess: &Session, ppm: PpMode, ex: PrintExtra<'tcx>) {
         ThirFlat => {
             let tcx = ex.tcx();
             let mut out = String::new();
-            rustc_hir_analysis::check_crate(tcx);
-            if tcx.dcx().has_errors().is_some() {
+            if rustc_hir_analysis::check_crate(tcx).is_err() {
                 FatalError.raise();
             }
             debug!("pretty printing THIR flat");

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -98,6 +98,7 @@ mod outlives;
 pub mod structured_errors;
 mod variance;
 
+use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
 use rustc_middle::middle;
 use rustc_middle::query::Providers;
@@ -155,13 +156,11 @@ pub fn provide(providers: &mut Providers) {
     hir_wf_check::provide(providers);
 }
 
-pub fn check_crate(tcx: TyCtxt<'_>) {
+pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
     let _prof_timer = tcx.sess.timer("type_check_crate");
 
     if tcx.features().rustc_attrs {
-        tcx.sess.time("outlives_testing", || outlives::test::test_inferred_outlives(tcx));
-        tcx.sess.time("variance_testing", || variance::test::test_variance(tcx));
-        collect::test_opaque_hidden_types(tcx);
+        tcx.sess.time("outlives_testing", || outlives::test::test_inferred_outlives(tcx))?;
     }
 
     tcx.sess.time("coherence_checking", || {
@@ -177,6 +176,14 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
         let _ = tcx.ensure().crate_inherent_impls_overlap_check(());
     });
 
+    if tcx.features().rustc_attrs {
+        tcx.sess.time("variance_testing", || variance::test::test_variance(tcx))?;
+    }
+
+    if tcx.features().rustc_attrs {
+        collect::test_opaque_hidden_types(tcx)?;
+    }
+
     // Make sure we evaluate all static and (non-associated) const items, even if unused.
     // If any of these fail to evaluate, we do not want this crate to pass compilation.
     tcx.hir().par_body_owners(|item_def_id| {
@@ -191,6 +198,21 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
     // Freeze definitions as we don't add new ones at this point. This improves performance by
     // allowing lock-free access to them.
     tcx.untracked().definitions.freeze();
+
+    // FIXME: Remove this when we implement creating `DefId`s
+    // for anon constants during their parents' typeck.
+    // Typeck all body owners in parallel will produce queries
+    // cycle errors because it may typeck on anon constants directly.
+    tcx.hir().par_body_owners(|item_def_id| {
+        let def_kind = tcx.def_kind(item_def_id);
+        if !matches!(def_kind, DefKind::AnonConst) {
+            tcx.ensure().typeck(item_def_id);
+        }
+    });
+
+    tcx.ensure().check_unused_traits(());
+
+    Ok(())
 }
 
 /// A quasi-deprecated helper used in rustdoc and clippy to get

--- a/compiler/rustc_hir_analysis/src/outlives/test.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/test.rs
@@ -1,7 +1,8 @@
 use rustc_middle::ty::{self, TyCtxt};
-use rustc_span::symbol::sym;
+use rustc_span::{symbol::sym, ErrorGuaranteed};
 
-pub fn test_inferred_outlives(tcx: TyCtxt<'_>) {
+pub fn test_inferred_outlives(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
+    let mut res = Ok(());
     for id in tcx.hir().items() {
         // For unit testing: check for a special "rustc_outlives"
         // attribute and report an error with various results if found.
@@ -22,7 +23,8 @@ pub fn test_inferred_outlives(tcx: TyCtxt<'_>) {
             for p in pred {
                 err.note(p);
             }
-            err.emit();
+            res = Err(err.emit());
         }
     }
+    res
 }

--- a/compiler/rustc_hir_analysis/src/variance/test.rs
+++ b/compiler/rustc_hir_analysis/src/variance/test.rs
@@ -2,19 +2,21 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::CRATE_DEF_ID;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::symbol::sym;
+use rustc_span::ErrorGuaranteed;
 
 use crate::errors;
 
-pub fn test_variance(tcx: TyCtxt<'_>) {
+pub fn test_variance(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
+    let mut res = Ok(());
     if tcx.has_attr(CRATE_DEF_ID, sym::rustc_variance_of_opaques) {
         for id in tcx.hir().items() {
             if matches!(tcx.def_kind(id.owner_id), DefKind::OpaqueTy) {
                 let variances_of = tcx.variances_of(id.owner_id);
 
-                tcx.dcx().emit_err(errors::VariancesOf {
+                res = Err(tcx.dcx().emit_err(errors::VariancesOf {
                     span: tcx.def_span(id.owner_id),
                     variances_of: format!("{variances_of:?}"),
-                });
+                }));
             }
         }
     }
@@ -25,10 +27,11 @@ pub fn test_variance(tcx: TyCtxt<'_>) {
         if tcx.has_attr(id.owner_id, sym::rustc_variance) {
             let variances_of = tcx.variances_of(id.owner_id);
 
-            tcx.dcx().emit_err(errors::VariancesOf {
+            res = Err(tcx.dcx().emit_err(errors::VariancesOf {
                 span: tcx.def_span(id.owner_id),
                 variances_of: format!("{variances_of:?}"),
-            });
+            }));
         }
     }
+    res
 }

--- a/tests/ui/binop/issue-77910-1.stderr
+++ b/tests/ui/binop/issue-77910-1.stderr
@@ -1,16 +1,3 @@
-error[E0381]: used binding `xs` isn't initialized
-  --> $DIR/issue-77910-1.rs:3:5
-   |
-LL |     let xs;
-   |         -- binding declared here but left uninitialized
-LL |     xs
-   |     ^^ `xs` used here but it isn't initialized
-   |
-help: consider assigning a value
-   |
-LL |     let xs = todo!();
-   |            +++++++++
-
 error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a i32) -> &'a i32 {foo}`
   --> $DIR/issue-77910-1.rs:8:5
    |
@@ -34,6 +21,19 @@ LL |     assert_eq!(foo, y);
    = help: the trait `Debug` is not implemented for fn item `for<'a> fn(&'a i32) -> &'a i32 {foo}`
    = help: use parentheses to call this function: `foo(/* &i32 */)`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0381]: used binding `xs` isn't initialized
+  --> $DIR/issue-77910-1.rs:3:5
+   |
+LL |     let xs;
+   |         -- binding declared here but left uninitialized
+LL |     xs
+   |     ^^ `xs` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |     let xs = todo!();
+   |            +++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/binop/issue-77910-2.stderr
+++ b/tests/ui/binop/issue-77910-2.stderr
@@ -1,16 +1,3 @@
-error[E0381]: used binding `xs` isn't initialized
-  --> $DIR/issue-77910-2.rs:3:5
-   |
-LL |     let xs;
-   |         -- binding declared here but left uninitialized
-LL |     xs
-   |     ^^ `xs` used here but it isn't initialized
-   |
-help: consider assigning a value
-   |
-LL |     let xs = todo!();
-   |            +++++++++
-
 error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a i32) -> &'a i32 {foo}`
   --> $DIR/issue-77910-2.rs:7:12
    |
@@ -23,6 +10,19 @@ help: use parentheses to call this function
    |
 LL |     if foo(/* &i32 */) == y {}
    |           ++++++++++++
+
+error[E0381]: used binding `xs` isn't initialized
+  --> $DIR/issue-77910-2.rs:3:5
+   |
+LL |     let xs;
+   |         -- binding declared here but left uninitialized
+LL |     xs
+   |     ^^ `xs` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |     let xs = todo!();
+   |            +++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.stderr
+++ b/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.stderr
@@ -13,15 +13,6 @@ help: use `addr_of_mut!` instead to create a raw pointer
 LL |             c1(addr_of_mut!(Y));
    |                ~~~~~~~~~~~~~~~
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:9:46
-   |
-LL |     pub fn e(x: &'static mut isize) {
-   |              - help: consider changing this to be mutable: `mut x`
-LL |         static mut Y: isize = 3;
-LL |         let mut c1 = |y: &'static mut isize| x = y;
-   |                                              ^^^^^ cannot assign
-
 warning: creating a mutable reference to mutable static is discouraged
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:27:16
    |
@@ -35,6 +26,29 @@ help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |             c1(addr_of_mut!(Z));
    |                ~~~~~~~~~~~~~~~
+
+warning: creating a mutable reference to mutable static is discouraged
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:64:37
+   |
+LL |         borrowck_closures_unique::e(&mut X);
+   |                                     ^^^^^^ mutable reference to mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: this will be a hard error in the 2024 edition
+   = note: this mutable reference has lifetime `'static`, but if the static gets accessed (read or written) by any other means, or any other reference is created, then any further use of this mutable reference is Undefined Behavior
+help: use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |         borrowck_closures_unique::e(addr_of_mut!(X));
+   |                                     ~~~~~~~~~~~~~~~
+
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:9:46
+   |
+LL |     pub fn e(x: &'static mut isize) {
+   |              - help: consider changing this to be mutable: `mut x`
+LL |         static mut Y: isize = 3;
+LL |         let mut c1 = |y: &'static mut isize| x = y;
+   |                                              ^^^^^ cannot assign
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:22:50
@@ -80,20 +94,6 @@ LL |     pub fn capture_reborrow_part(x: (i32,)) {
 LL |         || {
 LL |             &mut x.0;
    |             ^^^^^^^^ cannot borrow as mutable
-
-warning: creating a mutable reference to mutable static is discouraged
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:64:37
-   |
-LL |         borrowck_closures_unique::e(&mut X);
-   |                                     ^^^^^^ mutable reference to mutable static
-   |
-   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
-   = note: this will be a hard error in the 2024 edition
-   = note: this mutable reference has lifetime `'static`, but if the static gets accessed (read or written) by any other means, or any other reference is created, then any further use of this mutable reference is Undefined Behavior
-help: use `addr_of_mut!` instead to create a raw pointer
-   |
-LL |         borrowck_closures_unique::e(addr_of_mut!(X));
-   |                                     ~~~~~~~~~~~~~~~
 
 error: aborting due to 6 previous errors; 3 warnings emitted
 

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
@@ -22,18 +22,18 @@ LL | impl<const N: u64> Q for [u8; N] {}
    |      unsatisfied trait bound introduced here
 
 error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:8:31
-   |
-LL | impl<const N: u64> Q for [u8; N] {}
-   |                               ^ expected `usize`, found `u64`
-
-error[E0308]: mismatched types
   --> $DIR/type_mismatch.rs:12:20
    |
 LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
    |        ------      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `[u8; <[u8; 13] as Q>::ASSOC]`, found `()`
    |        |
    |        implicitly returns `()` as its body has no tail or `return` expression
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:8:31
+   |
+LL | impl<const N: u64> Q for [u8; N] {}
+   |                               ^ expected `usize`, found `u64`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/unify-op-with-fn-call.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unify-op-with-fn-call.stderr
@@ -34,6 +34,14 @@ LL + #[derive(ConstParamTy)]
 LL | struct Foo(u8);
    |
 
+error: unconstrained generic constant
+  --> $DIR/unify-op-with-fn-call.rs:30:12
+   |
+LL |     bar2::<{ std::ops::Add::add(N, N) }>();
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { std::ops::Add::add(N, N) }]:`
+
 error[E0015]: cannot call non-const operator in constants
   --> $DIR/unify-op-with-fn-call.rs:20:39
    |
@@ -56,14 +64,6 @@ LL |     bar::<{ std::ops::Add::add(N, N) }>();
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
    = help: add `#![feature(effects)]` to the crate attributes to enable
-
-error: unconstrained generic constant
-  --> $DIR/unify-op-with-fn-call.rs:30:12
-   |
-LL |     bar2::<{ std::ops::Add::add(N, N) }>();
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: try adding a `where` bound using this expression: `where [(); { std::ops::Add::add(N, N) }]:`
 
 error[E0015]: cannot call non-const fn `<usize as Add>::add` in constants
   --> $DIR/unify-op-with-fn-call.rs:30:14

--- a/tests/ui/const-generics/transmute-fail.stderr
+++ b/tests/ui/const-generics/transmute-fail.stderr
@@ -16,18 +16,6 @@ LL |     std::mem::transmute(v)
    = note: source type: `[[u32; H]; W]` (this type does not have a fixed size)
    = note: target type: `[[u32; W]; H]` (size can vary because of [u32; W])
 
-error[E0308]: mismatched types
-  --> $DIR/transmute-fail.rs:12:53
-   |
-LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
-   |                                                     ^ expected `usize`, found `bool`
-
-error[E0308]: mismatched types
-  --> $DIR/transmute-fail.rs:12:67
-   |
-LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
-   |                                                                   ^ expected `usize`, found `bool`
-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-fail.rs:23:5
    |
@@ -45,6 +33,18 @@ LL |     std::mem::transmute(v)
    |
    = note: source type: `[[[u32; 8888888]; 9999999]; 777777777]` (values of the type `[[u32; 8888888]; 9999999]` are too big for the current architecture)
    = note: target type: `[[[u32; 9999999]; 777777777]; 8888888]` (values of the type `[[u32; 9999999]; 777777777]` are too big for the current architecture)
+
+error[E0308]: mismatched types
+  --> $DIR/transmute-fail.rs:12:53
+   |
+LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
+   |                                                     ^ expected `usize`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/transmute-fail.rs:12:67
+   |
+LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
+   |                                                                   ^ expected `usize`, found `bool`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/const-generics/type_mismatch.stderr
+++ b/tests/ui/const-generics/type_mismatch.stderr
@@ -11,18 +11,18 @@ LL | fn bar<const N: u8>() -> [u8; N] {}
    |        ^^^^^^^^^^^ required by this bound in `bar`
 
 error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:2:11
-   |
-LL |     bar::<N>()
-   |           ^ expected `u8`, found `usize`
-
-error[E0308]: mismatched types
   --> $DIR/type_mismatch.rs:6:26
    |
 LL | fn bar<const N: u8>() -> [u8; N] {}
    |    ---                   ^^^^^^^ expected `[u8; N]`, found `()`
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:2:11
+   |
+LL |     bar::<N>()
+   |           ^ expected `u8`, found `usize`
 
 error[E0308]: mismatched types
   --> $DIR/type_mismatch.rs:6:31

--- a/tests/ui/explicit-tail-calls/return-mismatches.stderr
+++ b/tests/ui/explicit-tail-calls/return-mismatches.stderr
@@ -16,6 +16,12 @@ LL |     become _g1();
    = note: expected unit type `()`
                    found type `!`
 
+error[E0308]: mismatched types
+  --> $DIR/return-mismatches.rs:21:5
+   |
+LL |     become _g2();
+   |     ^^^^^^^^^^^^ expected `u32`, found `u16`
+
 warning: function cannot return without recursing
   --> $DIR/return-mismatches.rs:16:1
    |
@@ -26,12 +32,6 @@ LL |     become _g1();
    |
    = help: a `loop` may express intention better if this is on purpose
    = note: `#[warn(unconditional_recursion)]` on by default
-
-error[E0308]: mismatched types
-  --> $DIR/return-mismatches.rs:21:5
-   |
-LL |     become _g2();
-   |     ^^^^^^^^^^^^ expected `u32`, found `u16`
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/tests/ui/expr/if/if-no-match-bindings.stderr
+++ b/tests/ui/expr/if/if-no-match-bindings.stderr
@@ -1,12 +1,3 @@
-error[E0515]: cannot return reference to temporary value
-  --> $DIR/if-no-match-bindings.rs:8:38
-   |
-LL | fn b_mut_ref<'a>() -> &'a mut bool { &mut true }
-   |                                      ^^^^^----
-   |                                      |    |
-   |                                      |    temporary value created here
-   |                                      returns a reference to data owned by the current function
-
 error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:19:8
    |
@@ -98,6 +89,15 @@ help: consider removing the borrow
 LL -     while &mut true {}
 LL +     while true {}
    |
+
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/if-no-match-bindings.rs:8:38
+   |
+LL | fn b_mut_ref<'a>() -> &'a mut bool { &mut true }
+   |                                      ^^^^^----
+   |                                      |    |
+   |                                      |    temporary value created here
+   |                                      returns a reference to data owned by the current function
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/generic-associated-types/issue-74684-2.stderr
+++ b/tests/ui/generic-associated-types/issue-74684-2.stderr
@@ -1,19 +1,3 @@
-error[E0597]: `a` does not live long enough
-  --> $DIR/issue-74684-2.rs:13:25
-   |
-LL | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
-   |        -- lifetime `'a` defined here
-LL |     let a = [0; 1];
-   |         - binding `a` declared here
-LL |     let x = T::identity(&a);
-   |             ------------^^-
-   |             |           |
-   |             |           borrowed value does not live long enough
-   |             argument requires that `a` is borrowed for `'a`
-LL |     todo!()
-LL | }
-   | - `a` dropped here while still borrowed
-
 error[E0271]: type mismatch resolving `<{integer} as Fun>::F<'_> == [u8]`
   --> $DIR/issue-74684-2.rs:21:9
    |
@@ -32,6 +16,22 @@ note: required by a bound in `bug`
    |
 LL | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
    |                            ^^^^^^^^^^^^ required by this bound in `bug`
+
+error[E0597]: `a` does not live long enough
+  --> $DIR/issue-74684-2.rs:13:25
+   |
+LL | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
+   |        -- lifetime `'a` defined here
+LL |     let a = [0; 1];
+   |         - binding `a` declared here
+LL |     let x = T::identity(&a);
+   |             ------------^^-
+   |             |           |
+   |             |           borrowed value does not live long enough
+   |             argument requires that `a` is borrowed for `'a`
+LL |     todo!()
+LL | }
+   | - `a` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.stderr
@@ -18,19 +18,6 @@ help: consider further restricting this bound
 LL |     where F : Foo<'x> + for<'tcx> Foo<'tcx>
    |                       +++++++++++++++++++++
 
-warning: function cannot return without recursing
-  --> $DIR/hrtb-higher-ranker-supertraits.rs:21:1
-   |
-LL | / fn want_foo_for_any_tcx<F>(f: &F)
-LL | |     where F : for<'tcx> Foo<'tcx>
-   | |_________________________________^ cannot return without recursing
-...
-LL |       want_foo_for_any_tcx(f);
-   |       ----------------------- recursive call site
-   |
-   = help: a `loop` may express intention better if this is on purpose
-   = note: `#[warn(unconditional_recursion)]` on by default
-
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:35:26
    |
@@ -50,6 +37,19 @@ help: consider further restricting this bound
    |
 LL |     where B : Bar<'x> + for<'ccx> Bar<'ccx>
    |                       +++++++++++++++++++++
+
+warning: function cannot return without recursing
+  --> $DIR/hrtb-higher-ranker-supertraits.rs:21:1
+   |
+LL | / fn want_foo_for_any_tcx<F>(f: &F)
+LL | |     where F : for<'tcx> Foo<'tcx>
+   | |_________________________________^ cannot return without recursing
+...
+LL |       want_foo_for_any_tcx(f);
+   |       ----------------------- recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
 
 warning: function cannot return without recursing
   --> $DIR/hrtb-higher-ranker-supertraits.rs:38:1

--- a/tests/ui/issues/issue-11374.stderr
+++ b/tests/ui/issues/issue-11374.stderr
@@ -1,12 +1,3 @@
-error[E0515]: cannot return value referencing local variable `r`
-  --> $DIR/issue-11374.rs:20:5
-   |
-LL |     Container::wrap(&mut r as &mut dyn io::Read)
-   |     ^^^^^^^^^^^^^^^^------^^^^^^^^^^^^^^^^^^^^^^
-   |     |               |
-   |     |               `r` is borrowed here
-   |     returns a value referencing data owned by the current function
-
 error[E0308]: mismatched types
   --> $DIR/issue-11374.rs:27:15
    |
@@ -26,6 +17,15 @@ help: consider mutably borrowing here
    |
 LL |     c.read_to(&mut v);
    |               ++++
+
+error[E0515]: cannot return value referencing local variable `r`
+  --> $DIR/issue-11374.rs:20:5
+   |
+LL |     Container::wrap(&mut r as &mut dyn io::Read)
+   |     ^^^^^^^^^^^^^^^^------^^^^^^^^^^^^^^^^^^^^^^
+   |     |               |
+   |     |               `r` is borrowed here
+   |     returns a value referencing data owned by the current function
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/kindck/kindck-impl-type-params.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params.stderr
@@ -74,15 +74,6 @@ help: consider restricting type parameter `T`
 LL | fn g<T: std::marker::Copy>(val: T) {
    |       +++++++++++++++++++
 
-error: lifetime may not live long enough
-  --> $DIR/kindck-impl-type-params.rs:30:13
-   |
-LL | fn foo<'a>() {
-   |        -- lifetime `'a` defined here
-LL |     let t: S<&'a isize> = S(marker::PhantomData);
-LL |     let a = &t as &dyn Gettable<&'a isize>;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-
 error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:36:13
    |
@@ -119,6 +110,15 @@ help: consider annotating `Foo` with `#[derive(Copy)]`
 LL +     #[derive(Copy)]
 LL |     struct Foo; // does not impl Copy
    |
+
+error: lifetime may not live long enough
+  --> $DIR/kindck-impl-type-params.rs:30:13
+   |
+LL | fn foo<'a>() {
+   |        -- lifetime `'a` defined here
+LL |     let t: S<&'a isize> = S(marker::PhantomData);
+LL |     let a = &t as &dyn Gettable<&'a isize>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/kindck/kindck-send-object1.stderr
+++ b/tests/ui/kindck/kindck-send-object1.stderr
@@ -12,14 +12,6 @@ note: required by a bound in `assert_send`
 LL | fn assert_send<T:Send+'static>() { }
    |                  ^^^^ required by this bound in `assert_send`
 
-error: lifetime may not live long enough
-  --> $DIR/kindck-send-object1.rs:14:5
-   |
-LL | fn test52<'a>() {
-   |           -- lifetime `'a` defined here
-LL |     assert_send::<&'a (dyn Dummy + Sync)>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-
 error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
   --> $DIR/kindck-send-object1.rs:29:19
    |
@@ -35,6 +27,14 @@ note: required by a bound in `assert_send`
    |
 LL | fn assert_send<T:Send+'static>() { }
    |                  ^^^^ required by this bound in `assert_send`
+
+error: lifetime may not live long enough
+  --> $DIR/kindck-send-object1.rs:14:5
+   |
+LL | fn test52<'a>() {
+   |           -- lifetime `'a` defined here
+LL |     assert_send::<&'a (dyn Dummy + Sync)>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/lifetimes/issue-17728.stderr
+++ b/tests/ui/lifetimes/issue-17728.stderr
@@ -1,19 +1,3 @@
-error: lifetime may not live long enough
-  --> $DIR/issue-17728.rs:15:28
-   |
-LL |     fn attemptTraverse(&self, room: &Room, directionStr: &str) -> Result<&Room, &str> {
-   |                        -            - let's call the lifetime of this reference `'1`
-   |                        |
-   |                        let's call the lifetime of this reference `'2`
-...
-LL |             Some(entry) => Ok(entry),
-   |                            ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |     fn attemptTraverse<'a>(&'a self, room: &'a Room, directionStr: &str) -> Result<&Room, &str> {
-   |                       ++++  ++              ++
-
 error[E0308]: `match` arms have incompatible types
   --> $DIR/issue-17728.rs:108:14
    |
@@ -31,6 +15,22 @@ LL | |     }
    |
    = note: expected enum `RoomDirection`
               found enum `Option<_>`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-17728.rs:15:28
+   |
+LL |     fn attemptTraverse(&self, room: &Room, directionStr: &str) -> Result<&Room, &str> {
+   |                        -            - let's call the lifetime of this reference `'1`
+   |                        |
+   |                        let's call the lifetime of this reference `'2`
+...
+LL |             Some(entry) => Ok(entry),
+   |                            ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn attemptTraverse<'a>(&'a self, room: &'a Room, directionStr: &str) -> Result<&Room, &str> {
+   |                       ++++  ++              ++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/liveness/liveness-consts.stderr
+++ b/tests/ui/liveness/liveness-consts.stderr
@@ -40,6 +40,12 @@ LL |     b += 1;
    = help: maybe it is overwritten before being read?
    = note: `#[warn(unused_assignments)]` implied by `#[warn(unused)]`
 
+warning: unused variable: `z`
+  --> $DIR/liveness-consts.rs:60:13
+   |
+LL |         let z = 42;
+   |             ^ help: if this is intentional, prefix it with an underscore: `_z`
+
 warning: value assigned to `t` is never read
   --> $DIR/liveness-consts.rs:42:9
    |
@@ -53,12 +59,6 @@ warning: unused variable: `w`
    |
 LL |         let w = 10;
    |             ^ help: if this is intentional, prefix it with an underscore: `_w`
-
-warning: unused variable: `z`
-  --> $DIR/liveness-consts.rs:60:13
-   |
-LL |         let z = 42;
-   |             ^ help: if this is intentional, prefix it with an underscore: `_z`
 
 warning: 8 warnings emitted
 

--- a/tests/ui/liveness/liveness-forgot-ret.stderr
+++ b/tests/ui/liveness/liveness-forgot-ret.stderr
@@ -1,14 +1,3 @@
-warning: function cannot return without recursing
-  --> $DIR/liveness-forgot-ret.rs:1:1
-   |
-LL | fn god_exists(a: isize) -> bool { return god_exists(a); }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          ------------- recursive call site
-   | |
-   | cannot return without recursing
-   |
-   = help: a `loop` may express intention better if this is on purpose
-   = note: `#[warn(unconditional_recursion)]` on by default
-
 error[E0308]: mismatched types
   --> $DIR/liveness-forgot-ret.rs:4:19
    |
@@ -21,6 +10,17 @@ help: consider returning the local binding `a`
    |
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; a }
    |                                                           +
+
+warning: function cannot return without recursing
+  --> $DIR/liveness-forgot-ret.rs:1:1
+   |
+LL | fn god_exists(a: isize) -> bool { return god_exists(a); }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          ------------- recursive call site
+   | |
+   | cannot return without recursing
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/liveness/liveness-unused.stderr
+++ b/tests/ui/liveness/liveness-unused.stderr
@@ -1,3 +1,18 @@
+warning: unreachable statement
+  --> $DIR/liveness-unused.rs:92:9
+   |
+LL |         continue;
+   |         -------- any code following this expression is unreachable
+LL |         drop(*x as i32);
+   |         ^^^^^^^^^^^^^^^^ unreachable statement
+   |
+note: the lint level is defined here
+  --> $DIR/liveness-unused.rs:1:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unreachable_code)]` implied by `#[warn(unused)]`
+
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:8:7
    |
@@ -74,21 +89,6 @@ error: unused variable: `x`
    |
 LL |     for (x, _) in [1, 2, 3].iter().enumerate() { }
    |          ^ help: if this is intentional, prefix it with an underscore: `_x`
-
-warning: unreachable statement
-  --> $DIR/liveness-unused.rs:92:9
-   |
-LL |         continue;
-   |         -------- any code following this expression is unreachable
-LL |         drop(*x as i32);
-   |         ^^^^^^^^^^^^^^^^ unreachable statement
-   |
-note: the lint level is defined here
-  --> $DIR/liveness-unused.rs:1:9
-   |
-LL | #![warn(unused)]
-   |         ^^^^^^
-   = note: `#[warn(unreachable_code)]` implied by `#[warn(unused)]`
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:89:13

--- a/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
@@ -1,3 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:20:43
+   |
+LL |     let _: fn(&mut &isize, &mut &isize) = a;
+   |            ----------------------------   ^ one type is more general than the other
+   |            |
+   |            expected due to this
+   |
+   = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b _, &'c mut &'d _)`
+                 found fn item `for<'a, 'b> fn(&'a mut &_, &'b mut &_) {a::<'_, '_>}`
+
 error: lifetime may not live long enough
   --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:8:5
    |
@@ -26,17 +37,6 @@ LL |     a(x, y);
    = note: requirement occurs because of a mutable reference to `&isize`
    = note: mutable references are invariant over their type parameter
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-error[E0308]: mismatched types
-  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:20:43
-   |
-LL |     let _: fn(&mut &isize, &mut &isize) = a;
-   |            ----------------------------   ^ one type is more general than the other
-   |            |
-   |            expected due to this
-   |
-   = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b _, &'c mut &'d _)`
-                 found fn item `for<'a, 'b> fn(&'a mut &_, &'b mut &_) {a::<'_, '_>}`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
@@ -1,3 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:22:56
+   |
+LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
+   |            -----------------------------------------   ^ one type is more general than the other
+   |            |
+   |            expected due to this
+   |
+   = note: expected fn pointer `for<'a, 'b, 'c, 'd, 'e, 'f> fn(&'a mut &'b _, &'c mut &'d _, &'e mut &'f _)`
+                 found fn item `for<'a, 'b, 'c> fn(&'a mut &_, &'b mut &_, &'c mut &_) {a::<'_, '_, '_>}`
+
 error: lifetime may not live long enough
   --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:9:5
    |
@@ -26,17 +37,6 @@ LL |     a(x, y, z);
    = note: requirement occurs because of a mutable reference to `&isize`
    = note: mutable references are invariant over their type parameter
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-error[E0308]: mismatched types
-  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:22:56
-   |
-LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
-   |            -----------------------------------------   ^ one type is more general than the other
-   |            |
-   |            expected due to this
-   |
-   = note: expected fn pointer `for<'a, 'b, 'c, 'd, 'e, 'f> fn(&'a mut &'b _, &'c mut &'d _, &'e mut &'f _)`
-                 found fn item `for<'a, 'b, 'c> fn(&'a mut &_, &'b mut &_, &'c mut &_) {a::<'_, '_, '_>}`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
+++ b/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
@@ -1,3 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/regions-lifetime-bounds-on-fns.rs:20:43
+   |
+LL |     let _: fn(&mut &isize, &mut &isize) = a;
+   |            ----------------------------   ^ one type is more general than the other
+   |            |
+   |            expected due to this
+   |
+   = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b _, &'c mut &'d _)`
+                 found fn item `for<'a, 'b> fn(&'a mut &_, &'b mut &_) {a::<'_, '_>}`
+
 error: lifetime may not live long enough
   --> $DIR/regions-lifetime-bounds-on-fns.rs:8:5
    |
@@ -26,17 +37,6 @@ LL |     a(x, y);
    = note: requirement occurs because of a mutable reference to `&isize`
    = note: mutable references are invariant over their type parameter
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-error[E0308]: mismatched types
-  --> $DIR/regions-lifetime-bounds-on-fns.rs:20:43
-   |
-LL |     let _: fn(&mut &isize, &mut &isize) = a;
-   |            ----------------------------   ^ one type is more general than the other
-   |            |
-   |            expected due to this
-   |
-   = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b _, &'c mut &'d _)`
-                 found fn item `for<'a, 'b> fn(&'a mut &_, &'b mut &_) {a::<'_, '_>}`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/suggestions/issue-102892.stderr
+++ b/tests/ui/suggestions/issue-102892.stderr
@@ -1,19 +1,3 @@
-error[E0507]: cannot move out of an `Arc`
-  --> $DIR/issue-102892.rs:11:18
-   |
-LL |     let (a, b) = **arc; // suggests putting `&**arc` here; with that, fixed!
-   |          -  -    ^^^^^
-   |          |  |
-   |          |  ...and here
-   |          data moved here
-   |
-   = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider removing the dereference here
-   |
-LL -     let (a, b) = **arc; // suggests putting `&**arc` here; with that, fixed!
-LL +     let (a, b) = *arc; // suggests putting `&**arc` here; with that, fixed!
-   |
-
 error[E0308]: mismatched types
   --> $DIR/issue-102892.rs:16:26
    |
@@ -67,6 +51,22 @@ help: alternatively, consider changing the type annotation
    |
 LL |     let (a, b): ((A, B), &A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
    |                          +
+
+error[E0507]: cannot move out of an `Arc`
+  --> $DIR/issue-102892.rs:11:18
+   |
+LL |     let (a, b) = **arc; // suggests putting `&**arc` here; with that, fixed!
+   |          -  -    ^^^^^
+   |          |  |
+   |          |  ...and here
+   |          data moved here
+   |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the dereference here
+   |
+LL -     let (a, b) = **arc; // suggests putting `&**arc` here; with that, fixed!
+LL +     let (a, b) = *arc; // suggests putting `&**arc` here; with that, fixed!
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/type-alias-impl-trait/variance.stderr
+++ b/tests/ui/type-alias-impl-trait/variance.stderr
@@ -1,69 +1,3 @@
-error: [*, o]
-  --> $DIR/variance.rs:8:29
-   |
-LL | type NotCapturedEarly<'a> = impl Sized;
-   |                             ^^^^^^^^^^
-
-error: [*, o]
-  --> $DIR/variance.rs:11:26
-   |
-LL | type CapturedEarly<'a> = impl Sized + Captures<'a>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [*, o, o]
-  --> $DIR/variance.rs:14:56
-   |
-LL | type NotCapturedLate<'a> = dyn for<'b> Iterator<Item = impl Sized>;
-   |                                                        ^^^^^^^^^^
-
-error: [*, o, o]
-  --> $DIR/variance.rs:18:49
-   |
-LL | type Captured<'a> = dyn for<'b> Iterator<Item = impl Sized + Captures<'a>>;
-   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [*, *, o, o, o]
-  --> $DIR/variance.rs:22:27
-   |
-LL | type Bar<'a, 'b: 'b, T> = impl Sized;
-   |                           ^^^^^^^^^^
-
-error: [*, *, o, o]
-  --> $DIR/variance.rs:34:32
-   |
-LL |     type ImplicitCapture<'a> = impl Sized;
-   |                                ^^^^^^^^^^
-
-error: [*, *, o, o]
-  --> $DIR/variance.rs:37:42
-   |
-LL |     type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>;
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [*, *, o, o]
-  --> $DIR/variance.rs:40:39
-   |
-LL |     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>;
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [*, *, o, o]
-  --> $DIR/variance.rs:45:32
-   |
-LL |     type ImplicitCapture<'a> = impl Sized;
-   |                                ^^^^^^^^^^
-
-error: [*, *, o, o]
-  --> $DIR/variance.rs:48:42
-   |
-LL |     type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>;
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [*, *, o, o]
-  --> $DIR/variance.rs:51:39
-   |
-LL |     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>;
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from `dyn` type
   --> $DIR/variance.rs:14:56
    |
@@ -175,6 +109,72 @@ LL |     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>;
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `ExplicitCaptureFromGat` must be used in combination with a concrete type within the same impl
+
+error: [*, o]
+  --> $DIR/variance.rs:8:29
+   |
+LL | type NotCapturedEarly<'a> = impl Sized;
+   |                             ^^^^^^^^^^
+
+error: [*, o]
+  --> $DIR/variance.rs:11:26
+   |
+LL | type CapturedEarly<'a> = impl Sized + Captures<'a>;
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [*, o, o]
+  --> $DIR/variance.rs:14:56
+   |
+LL | type NotCapturedLate<'a> = dyn for<'b> Iterator<Item = impl Sized>;
+   |                                                        ^^^^^^^^^^
+
+error: [*, o, o]
+  --> $DIR/variance.rs:18:49
+   |
+LL | type Captured<'a> = dyn for<'b> Iterator<Item = impl Sized + Captures<'a>>;
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [*, *, o, o, o]
+  --> $DIR/variance.rs:22:27
+   |
+LL | type Bar<'a, 'b: 'b, T> = impl Sized;
+   |                           ^^^^^^^^^^
+
+error: [*, *, o, o]
+  --> $DIR/variance.rs:34:32
+   |
+LL |     type ImplicitCapture<'a> = impl Sized;
+   |                                ^^^^^^^^^^
+
+error: [*, *, o, o]
+  --> $DIR/variance.rs:37:42
+   |
+LL |     type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>;
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [*, *, o, o]
+  --> $DIR/variance.rs:40:39
+   |
+LL |     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>;
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [*, *, o, o]
+  --> $DIR/variance.rs:45:32
+   |
+LL |     type ImplicitCapture<'a> = impl Sized;
+   |                                ^^^^^^^^^^
+
+error: [*, *, o, o]
+  --> $DIR/variance.rs:48:42
+   |
+LL |     type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>;
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [*, *, o, o]
+  --> $DIR/variance.rs:51:39
+   |
+LL |     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>;
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 24 previous errors
 

--- a/tests/ui/variance/variance-associated-consts.stderr
+++ b/tests/ui/variance/variance-associated-consts.stderr
@@ -1,9 +1,3 @@
-error: [o]
-  --> $DIR/variance-associated-consts.rs:13:1
-   |
-LL | struct Foo<T: Trait> {
-   | ^^^^^^^^^^^^^^^^^^^^
-
 error: unconstrained generic constant
   --> $DIR/variance-associated-consts.rs:14:12
    |
@@ -11,6 +5,12 @@ LL |     field: [u8; <T as Trait>::Const]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try adding a `where` bound using this expression: `where [(); <T as Trait>::Const]:`
+
+error: [o]
+  --> $DIR/variance-associated-consts.rs:13:1
+   |
+LL | struct Foo<T: Trait> {
+   | ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/variance/variance-regions-direct.stderr
+++ b/tests/ui/variance/variance-regions-direct.stderr
@@ -1,3 +1,11 @@
+error[E0392]: lifetime parameter `'a` is never used
+  --> $DIR/variance-regions-direct.rs:52:14
+   |
+LL | struct Test7<'a> {
+   |              ^^ unused lifetime parameter
+   |
+   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
+
 error: [+, +, +]
   --> $DIR/variance-regions-direct.rs:9:1
    |
@@ -39,14 +47,6 @@ error: [-, +, o]
    |
 LL | enum Test8<'a, 'b, 'c:'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0392]: lifetime parameter `'a` is never used
-  --> $DIR/variance-regions-direct.rs:52:14
-   |
-LL | struct Test7<'a> {
-   |              ^^ unused lifetime parameter
-   |
-   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/variance/variance-regions-indirect.stderr
+++ b/tests/ui/variance/variance-regions-indirect.stderr
@@ -1,33 +1,3 @@
-error: [-, +, o, *]
-  --> $DIR/variance-regions-indirect.rs:8:1
-   |
-LL | enum Base<'a, 'b, 'c:'b, 'd> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [*, o, +, -]
-  --> $DIR/variance-regions-indirect.rs:16:1
-   |
-LL | struct Derived1<'w, 'x:'y, 'y, 'z> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [o, o, *]
-  --> $DIR/variance-regions-indirect.rs:22:1
-   |
-LL | struct Derived2<'a, 'b:'a, 'c> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [o, +, *]
-  --> $DIR/variance-regions-indirect.rs:28:1
-   |
-LL | struct Derived3<'a:'b, 'b, 'c> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [-, +, o]
-  --> $DIR/variance-regions-indirect.rs:34:1
-   |
-LL | struct Derived4<'a, 'b, 'c:'b> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0392]: lifetime parameter `'d` is never used
   --> $DIR/variance-regions-indirect.rs:8:26
    |
@@ -59,6 +29,36 @@ LL | struct Derived3<'a:'b, 'b, 'c> {
    |                            ^^ unused lifetime parameter
    |
    = help: consider removing `'c`, referring to it in a field, or using a marker such as `PhantomData`
+
+error: [-, +, o, *]
+  --> $DIR/variance-regions-indirect.rs:8:1
+   |
+LL | enum Base<'a, 'b, 'c:'b, 'd> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [*, o, +, -]
+  --> $DIR/variance-regions-indirect.rs:16:1
+   |
+LL | struct Derived1<'w, 'x:'y, 'y, 'z> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [o, o, *]
+  --> $DIR/variance-regions-indirect.rs:22:1
+   |
+LL | struct Derived2<'a, 'b:'a, 'c> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [o, +, *]
+  --> $DIR/variance-regions-indirect.rs:28:1
+   |
+LL | struct Derived3<'a:'b, 'b, 'c> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [-, +, o]
+  --> $DIR/variance-regions-indirect.rs:34:1
+   |
+LL | struct Derived4<'a, 'b, 'c:'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/variance/variance-trait-bounds.stderr
+++ b/tests/ui/variance/variance-trait-bounds.stderr
@@ -1,27 +1,3 @@
-error: [+, +]
-  --> $DIR/variance-trait-bounds.rs:16:1
-   |
-LL | struct TestStruct<U,T:Setter<U>> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [*, +]
-  --> $DIR/variance-trait-bounds.rs:21:1
-   |
-LL | enum TestEnum<U,T:Setter<U>> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [*, +]
-  --> $DIR/variance-trait-bounds.rs:27:1
-   |
-LL | struct TestContraStruct<U,T:Setter<U>> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [*, +]
-  --> $DIR/variance-trait-bounds.rs:33:1
-   |
-LL | struct TestBox<U,T:Getter<U>+Setter<U>> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0392]: type parameter `U` is never used
   --> $DIR/variance-trait-bounds.rs:21:15
    |
@@ -48,6 +24,30 @@ LL | struct TestBox<U,T:Getter<U>+Setter<U>> {
    |
    = help: consider removing `U`, referring to it in a field, or using a marker such as `PhantomData`
    = help: if you intended `U` to be a const parameter, use `const U: /* Type */` instead
+
+error: [+, +]
+  --> $DIR/variance-trait-bounds.rs:16:1
+   |
+LL | struct TestStruct<U,T:Setter<U>> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [*, +]
+  --> $DIR/variance-trait-bounds.rs:21:1
+   |
+LL | enum TestEnum<U,T:Setter<U>> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [*, +]
+  --> $DIR/variance-trait-bounds.rs:27:1
+   |
+LL | struct TestContraStruct<U,T:Setter<U>> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: [*, +]
+  --> $DIR/variance-trait-bounds.rs:33:1
+   |
+LL | struct TestBox<U,T:Getter<U>+Setter<U>> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This reverts commit 65cd843ae06ad00123c131a431ed5304e4cd577a, reversing changes made to d255c6a57c393db6221b1ff700daea478436f1cd.

reverts https://github.com/rust-lang/rust/pull/122140

It was a large regression in wall time due to trashing CPU caches