### PR TITLE
rustdoc: fix up old test

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -694,7 +694,6 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "check-stdout",
     "check-test-line-numbers-match",
     "compile-flags",
-    "count",
     "dont-check-compiler-stderr",
     "dont-check-compiler-stdout",
     "dont-check-failure-status",

--- a/tests/rustdoc/line-breaks.rs
+++ b/tests/rustdoc/line-breaks.rs
@@ -1,26 +1,37 @@
 #![crate_name = "foo"]
 
-use std::ops::Add;
 use std::fmt::Display;
+use std::ops::Add;
 
-//@count foo/fn.function_with_a_really_long_name.html //pre/br 2
-pub fn function_with_a_really_long_name(parameter_one: i32,
-                                        parameter_two: i32)
-                                        -> Option<i32> {
+// @matches foo/fn.function_with_a_really_long_name.html '//*[@class="rust item-decl"]//code' "\
+//     function_with_a_really_long_name\(\n\
+//    \    parameter_one: i32,\n\
+//    \    parameter_two: i32\n\
+//    \) -> Option<i32>$"
+pub fn function_with_a_really_long_name(parameter_one: i32, parameter_two: i32) -> Option<i32> {
     Some(parameter_one + parameter_two)
 }
 
-//@count foo/fn.short_name.html //pre/br 0
-pub fn short_name(param: i32) -> i32 { param + 1 }
+// @matches foo/fn.short_name.html '//*[@class="rust item-decl"]//code' \
+//     "short_name\(param: i32\) -> i32$"
+pub fn short_name(param: i32) -> i32 {
+    param + 1
+}
 
-//@count foo/fn.where_clause.html //pre/br 4
-pub fn where_clause<T, U>(param_one: T,
-                          param_two: U)
-    where T: Add<U> + Display + Copy,
-          U: Add<T> + Display + Copy,
-          T::Output: Display + Add<U::Output> + Copy,
-          <T::Output as Add<U::Output>>::Output: Display,
-          U::Output: Display + Copy
+// @matches foo/fn.where_clause.html '//*[@class="rust item-decl"]//code' "\
+//     where_clause<T, U>\(param_one: T, param_two: U\)where\n\
+//    \    T: Add<U> \+ Display \+ Copy,\n\
+//    \    U: Add<T> \+ Display \+ Copy,\n\
+//    \    T::Output: Display \+ Add<U::Output> \+ Copy,\n\
+//    \    <T::Output as Add<U::Output>>::Output: Display,\n\
+//    \    U::Output: Display \+ Copy,$"
+pub fn where_clause<T, U>(param_one: T, param_two: U)
+where
+    T: Add<U> + Display + Copy,
+    U: Add<T> + Display + Copy,
+    T::Output: Display + Add<U::Output> + Copy,
+    <T::Output as Add<U::Output>>::Output: Display,
+    U::Output: Display + Copy,
 {
     let x = param_one + param_two;
     println!("{} + {} = {}", param_one, param_two, x);


### PR DESCRIPTION
`tests/rustdoc/line-breaks.rs` had several issues:

1. It used `//@count` instead of `// @count` (notice the space!) which gets treated as a `ui_test` directive instead of a `htmldocck` one. `compiletest` didn't flag it as an error because it's allowlisted ([#121561](https://github.com/rust-lang/rust/pull/121561)) presumably precisely because of this test. And before the compiletest→ui_test migration, these directives must've been ignored, too, because …
2. … the checks themselves no longer work either: The count of `<br>`s is actually 0 in all 3 cases because – well – we no longer generate any `<br>`s inside `<pre>`s.

Since I don't know how to `@count` `\n`s instead of `<br>`s, I've turned them into `@matches`. Btw, I don't know if this test is still desirable or if we have other tests that cover this (I haven't checked).

r? rustdoc