### PR TITLE
Enable PR tracking review assignment for rust-lang/rust

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -854,3 +854,7 @@ project-stable-mir = [
 "/src/tools/tidy" =                                      ["bootstrap"]
 "/src/tools/x" =                                         ["bootstrap"]
 "/src/tools/rustdoc-gui-test" =                          ["bootstrap", "@onur-ozkan"]
+
+# Enable tracking of PR review assignment
+# Documentation at: https://forge.rust-lang.org/triagebot/pr-assignment-tracking.html
+[pr-tracking]


### PR DESCRIPTION
This flag enables tracking pull requests review assignment to Rust contributors.

The URL pointing to the documentation will become real once https://github.com/rust-lang/rust-forge/pull/729 is merged

r? @jackh726 

cc: @Mark-Simulacrum 