### PR TITLE
Fix ICE in diagnostics for parenthesized type arguments

### DIFF
--- a/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs
+++ b/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs
@@ -1,0 +1,7 @@
+fn main() {
+    unsafe {
+        dealloc(ptr2, Layout::(x: !)(1, 1)); //~ ERROR: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `:`
+        //~^ ERROR: expected one of `.`, `;`, `?`, `}`, or an operator, found `)`
+        //~| while parsing this parenthesized list of type arguments starting here
+    }
+}

--- a/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.stderr
+++ b/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.stderr
@@ -1,0 +1,16 @@
+error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `:`
+  --> $DIR/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs:3:33
+   |
+LL |         dealloc(ptr2, Layout::(x: !)(1, 1));
+   |                             --- ^ expected one of 7 possible tokens
+   |                             |
+   |                             while parsing this parenthesized list of type arguments starting here
+
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found `)`
+  --> $DIR/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs:3:43
+   |
+LL |         dealloc(ptr2, Layout::(x: !)(1, 1));
+   |                                           ^ expected one of `.`, `;`, `?`, `}`, or an operator
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
The second time is the charm :crossed_fingers: :grin: 

Fixes #122345

r? fmease