### PR TITLE
Fix WF for `AsyncFnKindHelper` in new trait solver

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2436,8 +2436,9 @@ impl<'tcx> Ty<'tcx> {
             },
 
             // "Bound" types appear in canonical queries when the
-            // closure type is not yet known
-            Bound(..) | Param(_) | Infer(_) => None,
+            // closure type is not yet known, and `Placeholder` and `Param`
+            // may be encountered in generic `AsyncFnKindHelper` goals.
+            Bound(..) | Placeholder(_) | Param(_) | Infer(_) => None,
 
             Error(_) => Some(ty::ClosureKind::Fn),
 


### PR DESCRIPTION
`to_opt_closure_kind` ICEs when it sees placeholders... so don't do that

no test b/c I'm too lazy to write a no-core test for this, but I could be convinced otherwise

r? lcnr