### PR TITLE
rustdoc: do not preload fonts when browsing locally

### DIFF
--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -6,11 +6,13 @@
     <meta name="generator" content="rustdoc"> {# #}
     <meta name="description" content="{{page.description}}"> {# #}
     <title>{{page.title}}</title> {# #}
+    <script> if (window.location.protocol !== "file:") document.write(` {# Hack to skip preloading fonts locally - see #98769 #}
     <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_serif_4_regular}}"> {# #}
     <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.fira_sans_regular}}"> {# #}
     <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.fira_sans_medium}}"> {# #}
     <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_code_pro_regular}}"> {# #}
     <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path|safe}}{{files.source_code_pro_semibold}}"> {# #}
+    `)</script> {# #}
     <link rel="stylesheet" {#+ #}
           href="{{static_root_path|safe}}{{files.normalize_css}}"> {# #}
     <link rel="stylesheet" {#+ #}


### PR DESCRIPTION
First PR, please let me know if I'm doing anything wrong.

As noted in #98769, currently `cargo doc --open` on macOS/Safari (17.2.1) doesn't load fonts due to a CORS issue. (webkit issue [here](https://bugs.webkit.org/show_bug.cgi?id=249887)). This patch moves the font preloads inside a js if statement as suggested in the GitHub issue.

I tried something more elegant with iterating over a tera array of fonts, but ran into issues, so here's the dumb fix. Only thing to note is that the font path is interpolated into a template string, so HTML escaping works fine, but it will break if there's a backtick or `${` in the font path. Not sure if this is a big deal.