### PR TITLE
Stop skewing inference in ?'s desugaring

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -130,6 +130,7 @@ struct LoweringContext<'a, 'hir> {
     node_id_to_local_id: NodeMap<hir::ItemLocalId>,
 
     allow_try_trait: Lrc<[Symbol]>,
+    allow_convert_absurd: Lrc<[Symbol]>,
     allow_gen_future: Lrc<[Symbol]>,
     allow_async_iterator: Lrc<[Symbol]>,
     allow_for_await: Lrc<[Symbol]>,
@@ -173,6 +174,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             impl_trait_defs: Vec::new(),
             impl_trait_bounds: Vec::new(),
             allow_try_trait: [sym::try_trait_v2, sym::yeet_desugar_details].into(),
+            allow_convert_absurd: [sym::convert_absurd].into(),
             allow_gen_future: if tcx.features().async_fn_track_caller {
                 [sym::gen_future, sym::closure_track_caller].into()
             } else {

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -317,6 +317,8 @@ language_item_table! {
     TryTraitBranch,          sym::branch,              branch_fn,                  Target::Method(MethodKind::Trait { body: false }), GenericRequirement::None;
     TryTraitFromYeet,        sym::from_yeet,           from_yeet_fn,               Target::Fn,             GenericRequirement::None;
 
+    Absurd,                  sym::absurd,              absurd,                     Target::Fn,             GenericRequirement::Exact(1);
+
     PointerLike,             sym::pointer_like,        pointer_like,               Target::Trait,          GenericRequirement::Exact(0);
 
     ConstParamTy,            sym::const_param_ty,      const_param_ty_trait,       Target::Trait,          GenericRequirement::Exact(0);

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -602,6 +602,7 @@ symbols! {
         const_try,
         constant,
         constructor,
+        convert_absurd,
         convert_identity,
         copy,
         copy_closures,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -354,6 +354,7 @@ symbols! {
         abi_vectorcall,
         abi_x86_interrupt,
         abort,
+        absurd,
         add,
         add_assign,
         add_with_overflow,

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -105,6 +105,66 @@ pub const fn identity<T>(x: T) -> T {
     x
 }
 
+/// Converts [`!`] (the never type) to any type.
+///
+/// This is possible because `!` is uninhabited (has no values), so this function can't actually
+/// be ever called at runtime.
+///
+/// Even though `!` can be coerced to any type implicitly anyway (and indeed this function
+/// implemented by just "returning" the argument), this is still useful, as this prevents the
+/// fallback from happening during typechecking.
+///
+/// For example, this snippet type checks:
+///
+/// ```rust
+/// let x: Result<_, ()> = Err(());
+/// let y = match x {
+///     Ok(v) => v,
+///     Err(()) => return,
+/// };
+/// ```
+///
+/// This is a bit unexpected, because the type of `y` is seemingly unbound (indeed, it can be any
+/// type). However, the `match` unifies type of `v` with type of `return` (which is `!`), so `y`
+/// becomes `!` (or `()`, because of backwards compatibility shenanigans).
+///
+/// This can be avoided by adding `absurd`;
+///
+/// ```compile_fail,E0282
+/// use core::convert::absurd;
+///
+/// let x: Result<_, ()> = Err(());
+/// let y = match x { //~ error[E0282]: type annotations needed
+///     Ok(v) => v,
+///
+///     // the call to `absurd` *is* unreachable, but it's still important for type check reasons
+///     #[allow(unreachable_code)]
+///     Err(()) => absurd(return),
+/// };
+/// ```
+///
+/// This might be handy when writing macros.
+///
+/// `absurd` can also be passed to higher order functions, just like any other function:
+///
+/// ```
+/// #![feature(never_type)]
+/// use core::convert::absurd;
+///
+/// let x: Result<_, !> = Ok(1);
+/// let x: u32 = x.unwrap_or_else(absurd);
+/// ```
+///
+/// [`!`]: ../../primitive.never.html
+#[inline(always)]
+#[lang = "absurd"]
+#[unstable(feature = "convert_absurd", issue = "none")]
+#[rustc_const_unstable(feature = "convert_absurd", issue = "none")]
+#[cfg(not(bootstrap))]
+pub const fn absurd<T>(x: !) -> T {
+    x
+}
+
 /// Used to do a cheap reference-to-reference conversion.
 ///
 /// This trait is similar to [`AsMut`] which is used for converting between mutable references.

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -534,25 +534,10 @@ impl Step for Cargo {
         )
     }
 
-    fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(Cargo {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
-            target: run.target,
-        });
-    }
+    fn make_run(_run: RunConfig<'_>) {}
 
     fn run(self, builder: &Builder<'_>) -> PathBuf {
-        let cargo_bin_path = builder.ensure(ToolBuild {
-            compiler: self.compiler,
-            target: self.target,
-            tool: "cargo",
-            mode: Mode::ToolRustc,
-            path: "src/tools/cargo",
-            source_type: SourceType::Submodule,
-            extra_features: Vec::new(),
-            allow_features: "",
-        });
-        cargo_bin_path
+        builder.initial_cargo.clone()
     }
 }
 

--- a/src/tools/opt-dist/src/training.rs
+++ b/src/tools/opt-dist/src/training.rs
@@ -8,7 +8,7 @@ use humansize::BINARY;
 
 const LLVM_PGO_CRATES: &[&str] = &[
     "syn-1.0.89",
-    "cargo-0.60.0",
+    //"cargo-0.60.0",
     "serde-1.0.136",
     "ripgrep-13.0.0",
     "regex-1.5.5",
@@ -19,7 +19,7 @@ const LLVM_PGO_CRATES: &[&str] = &[
 const RUSTC_PGO_CRATES: &[&str] = &[
     "externs",
     "ctfe-stress-5",
-    "cargo-0.60.0",
+    //"cargo-0.60.0",
     "token-stream-stress",
     "match-stress",
     "tuple-stress",

--- a/tests/ui/async-await/issue-67765-async-diagnostic.rs
+++ b/tests/ui/async-await/issue-67765-async-diagnostic.rs
@@ -10,7 +10,7 @@ async fn func<'a>() -> Result<(), &'a str> {
 
     let b = &s[..];
 
-    Err(b)?; //~ ERROR cannot return value referencing local variable `s`
+    Err::<(), _>(b)?; //~ ERROR cannot return value referencing local variable `s`
 
     Ok(())
 }

--- a/tests/ui/async-await/issue-67765-async-diagnostic.stderr
+++ b/tests/ui/async-await/issue-67765-async-diagnostic.stderr
@@ -4,8 +4,8 @@ error[E0515]: cannot return value referencing local variable `s`
 LL |     let b = &s[..];
    |              - `s` is borrowed here
 LL |
-LL |     Err(b)?;
-   |     ^^^^^^^ returns a value referencing data owned by the current function
+LL |     Err::<(), _>(b)?;
+   |     ^^^^^^^^^^^^^^^^ returns a value referencing data owned by the current function
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/try-operator.rs
+++ b/tests/ui/consts/try-operator.rs
@@ -7,7 +7,7 @@
 
 fn main() {
     const fn result() -> Result<bool, ()> {
-        Err(())?;
+        Err::<(), _>(())?;
         Ok(true)
     }
 
@@ -15,7 +15,7 @@ fn main() {
     assert_eq!(Err(()), FOO);
 
     const fn option() -> Option<()> {
-        None?;
+        None::<()>?;
         Some(())
     }
     const BAR: Option<()> = option();

--- a/tests/ui/consts/try-operator.stderr
+++ b/tests/ui/consts/try-operator.stderr
@@ -7,8 +7,8 @@ LL | #![feature(const_convert)]
 error[E0015]: `?` cannot determine the branch of `Result<(), ()>` in constant functions
   --> $DIR/try-operator.rs:10:9
    |
-LL |         Err(())?;
-   |         ^^^^^^^^
+LL |         Err::<(), _>(())?;
+   |         ^^^^^^^^^^^^^^^^^
    |
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -21,8 +21,8 @@ LL + #![feature(effects)]
 error[E0015]: `?` cannot convert from residual of `Result<bool, ()>` in constant functions
   --> $DIR/try-operator.rs:10:9
    |
-LL |         Err(())?;
-   |         ^^^^^^^^
+LL |         Err::<(), _>(())?;
+   |         ^^^^^^^^^^^^^^^^^
    |
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -35,8 +35,8 @@ LL + #![feature(effects)]
 error[E0015]: `?` cannot determine the branch of `Option<()>` in constant functions
   --> $DIR/try-operator.rs:18:9
    |
-LL |         None?;
-   |         ^^^^^
+LL |         None::<()>?;
+   |         ^^^^^^^^^^^
    |
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -49,8 +49,8 @@ LL + #![feature(effects)]
 error[E0015]: `?` cannot convert from residual of `Option<()>` in constant functions
   --> $DIR/try-operator.rs:18:9
    |
-LL |         None?;
-   |         ^^^^^
+LL |         None::<()>?;
+   |         ^^^^^^^^^^^
    |
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/ui/did_you_mean/compatible-variants.stderr
+++ b/tests/ui/did_you_mean/compatible-variants.stderr
@@ -61,8 +61,6 @@ LL +     Some(())
 error[E0308]: `?` operator has incompatible types
   --> $DIR/compatible-variants.rs:35:5
    |
-LL | fn d() -> Option<()> {
-   |           ---------- expected `Option<()>` because of return type
 LL |     c()?
    |     ^^^^ expected `Option<()>`, found `()`
    |

--- a/tests/ui/impl-trait/cross-return-site-inference.rs
+++ b/tests/ui/impl-trait/cross-return-site-inference.rs
@@ -2,34 +2,34 @@
 
 fn foo(b: bool) -> impl std::fmt::Debug {
     if b {
-        return vec![42]
+        return vec![42];
     }
     [].into_iter().collect()
 }
 
 fn bar(b: bool) -> impl std::fmt::Debug {
     if b {
-        return [].into_iter().collect()
+        return [].into_iter().collect();
     }
     vec![42]
 }
 
 fn bak(b: bool) -> impl std::fmt::Debug {
     if b {
-        return std::iter::empty().collect()
+        return std::iter::empty().collect();
     }
     vec![42]
 }
 
 fn baa(b: bool) -> impl std::fmt::Debug {
     if b {
-        return [42].into_iter().collect()
+        return [42].into_iter().collect();
     }
     vec![]
 }
 
 fn muh() -> Result<(), impl std::fmt::Debug> {
-    Err("whoops")?;
+    Err::<(), _>("whoops")?;
     Ok(())
     //~^ ERROR type annotations needed
 }

--- a/tests/ui/inference/cannot-infer-closure.rs
+++ b/tests/ui/inference/cannot-infer-closure.rs
@@ -1,6 +1,6 @@
 fn main() {
     let x = |a: (), b: ()| {
-        Err(a)?;
+        Err::<(), _>(a)?;
         Ok(b)
         //~^ ERROR type annotations needed
     };

--- a/tests/ui/issues/issue-51632-try-desugar-incompatible-types.stderr
+++ b/tests/ui/issues/issue-51632-try-desugar-incompatible-types.stderr
@@ -1,8 +1,6 @@
 error[E0308]: `?` operator has incompatible types
   --> $DIR/issue-51632-try-desugar-incompatible-types.rs:8:5
    |
-LL | fn forbidden_narratives() -> Result<isize, ()> {
-   |                              ----------------- expected `Result<isize, ()>` because of return type
 LL |     missing_discourses()?
    |     ^^^^^^^^^^^^^^^^^^^^^ expected `Result<isize, ()>`, found `isize`
    |

--- a/tests/ui/label/label_break_value_desugared_break.rs
+++ b/tests/ui/label/label_break_value_desugared_break.rs
@@ -5,14 +5,14 @@
 fn main() {
     let _: Result<(), ()> = try {
         'foo: {
-            Err(())?;
+            Err::<(), _>(())?;
             break 'foo;
         }
     };
 
     'foo: {
         let _: Result<(), ()> = try {
-            Err(())?;
+            Err::<(), _>(())?;
             break 'foo;
         };
     }

--- a/tests/ui/parser/try-with-nonterminal-block.rs
+++ b/tests/ui/parser/try-with-nonterminal-block.rs
@@ -11,7 +11,7 @@ macro_rules! create_try {
 
 fn main() {
     let x: Option<&str> = create_try! {{
-        None?;
+        None::<()>?;
         "Hello world"
     }};
 

--- a/tests/ui/suggestions/remove-question-symbol-with-paren.stderr
+++ b/tests/ui/suggestions/remove-question-symbol-with-paren.stderr
@@ -1,9 +1,6 @@
 error[E0308]: `?` operator has incompatible types
   --> $DIR/remove-question-symbol-with-paren.rs:5:6
    |
-LL | fn foo() -> Option<()> {
-   |             ---------- expected `Option<()>` because of return type
-LL |     let x = Some(());
 LL |     (x?)
    |      ^^ expected `Option<()>`, found `()`
    |

--- a/tests/ui/suggestions/suggest-box.fixed
+++ b/tests/ui/suggestions/suggest-box.fixed
@@ -2,7 +2,7 @@
 
 fn main() {
     let _x: Box<dyn Fn() -> Result<(), ()>> = Box::new(|| { //~ ERROR mismatched types
-        Err(())?;
+        Err::<(), _>(())?;
         Ok(())
     });
 }

--- a/tests/ui/suggestions/suggest-box.rs
+++ b/tests/ui/suggestions/suggest-box.rs
@@ -2,7 +2,7 @@
 
 fn main() {
     let _x: Box<dyn Fn() -> Result<(), ()>> = || { //~ ERROR mismatched types
-        Err(())?;
+        Err::<(), _>(())?;
         Ok(())
     };
 }

--- a/tests/ui/suggestions/suggest-box.stderr
+++ b/tests/ui/suggestions/suggest-box.stderr
@@ -5,7 +5,7 @@ LL |       let _x: Box<dyn Fn() -> Result<(), ()>> = || {
    |  _____________-------------------------------___^
    | |             |
    | |             expected due to this
-LL | |         Err(())?;
+LL | |         Err::<(), _>(())?;
 LL | |         Ok(())
 LL | |     };
    | |_____^ expected `Box<dyn Fn() -> Result<(), ()>>`, found closure
@@ -16,7 +16,7 @@ LL | |     };
 help: store this in the heap by calling `Box::new`
    |
 LL ~     let _x: Box<dyn Fn() -> Result<(), ()>> = Box::new(|| {
-LL |         Err(())?;
+LL |         Err::<(), _>(())?;
 LL |         Ok(())
 LL ~     });
    |

--- a/tests/ui/try-block/try-block-bad-lifetime.rs
+++ b/tests/ui/try-block/try-block-bad-lifetime.rs
@@ -12,10 +12,10 @@ pub fn main() {
         // result variable
         let result: Result<(), &str> = try {
             let my_string = String::from("");
-            let my_str: & str = & my_string;
+            let my_str: &str = &my_string;
             //~^ ERROR `my_string` does not live long enough
-            Err(my_str) ?;
-            Err("") ?;
+            Err::<(), _>(my_str)?;
+            Err::<(), _>("")?;
         };
         do_something_with(result);
     }
@@ -25,13 +25,13 @@ pub fn main() {
         let mut i = 5;
         let k = &mut i;
         let mut j: Result<(), &mut i32> = try {
-            Err(k) ?;
+            Err::<(), _>(k)?;
             i = 10; //~ ERROR cannot assign to `i` because it is borrowed
         };
         ::std::mem::drop(k); //~ ERROR use of moved value: `k`
         i = 40; //~ ERROR cannot assign to `i` because it is borrowed
 
-        let i_ptr = if let Err(i_ptr) = j { i_ptr } else { panic ! ("") };
+        let i_ptr = if let Err(i_ptr) = j { i_ptr } else { panic!("") };
         *i_ptr = 50;
     }
 }

--- a/tests/ui/try-block/try-block-bad-lifetime.stderr
+++ b/tests/ui/try-block/try-block-bad-lifetime.stderr
@@ -1,12 +1,12 @@
 error[E0597]: `my_string` does not live long enough
-  --> $DIR/try-block-bad-lifetime.rs:15:33
+  --> $DIR/try-block-bad-lifetime.rs:15:32
    |
 LL |         let result: Result<(), &str> = try {
    |             ------ borrow later stored here
 LL |             let my_string = String::from("");
    |                 --------- binding `my_string` declared here
-LL |             let my_str: & str = & my_string;
-   |                                 ^^^^^^^^^^^ borrowed value does not live long enough
+LL |             let my_str: &str = &my_string;
+   |                                ^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         };
    |         - `my_string` dropped here while still borrowed
@@ -29,8 +29,8 @@ error[E0382]: use of moved value: `k`
 LL |         let k = &mut i;
    |             - move occurs because `k` has type `&mut i32`, which does not implement the `Copy` trait
 LL |         let mut j: Result<(), &mut i32> = try {
-LL |             Err(k) ?;
-   |                 - value moved here
+LL |             Err::<(), _>(k)?;
+   |                          - value moved here
 ...
 LL |         ::std::mem::drop(k);
    |                          ^ value used here after move
@@ -44,7 +44,7 @@ LL |         let k = &mut i;
 LL |         i = 40;
    |         ^^^^^^ `i` is assigned to here but it was already borrowed
 LL |
-LL |         let i_ptr = if let Err(i_ptr) = j { i_ptr } else { panic ! ("") };
+LL |         let i_ptr = if let Err(i_ptr) = j { i_ptr } else { panic!("") };
    |                                         - borrow later used here
 
 error: aborting due to 4 previous errors

--- a/tests/ui/try-block/try-block-maybe-bad-lifetime.rs
+++ b/tests/ui/try-block/try-block-maybe-bad-lifetime.rs
@@ -11,7 +11,7 @@ pub fn main() {
         // Test that a borrow which *might* be returned still freezes its referent
         let mut i = 222;
         let x: Result<&i32, ()> = try {
-            Err(())?;
+            Err::<(), _>(())?;
             &i
         };
         i = 0; //~ ERROR cannot assign to `i` because it is borrowed
@@ -22,7 +22,7 @@ pub fn main() {
     {
         let x = String::new();
         let _y: Result<(), ()> = try {
-            Err(())?;
+            Err::<(), _>(())?;
             ::std::mem::drop(x);
         };
         println!("{}", x); //~ ERROR borrow of moved value: `x`
@@ -34,7 +34,7 @@ pub fn main() {
         let mut i = 222;
         let mut j = &-1;
         let _x: Result<(), ()> = try {
-            Err(())?;
+            Err::<(), _>(())?;
             j = &i;
         };
         i = 0; //~ ERROR cannot assign to `i` because it is borrowed

--- a/tests/ui/try-block/try-block-opt-init.rs
+++ b/tests/ui/try-block/try-block-opt-init.rs
@@ -7,7 +7,7 @@ fn use_val<T: Sized>(_x: T) {}
 pub fn main() {
     let cfg_res;
     let _: Result<(), ()> = try {
-        Err(())?;
+        Err::<(), _>(())?;
         cfg_res = 5;
         Ok::<(), ()>(())?;
         use_val(cfg_res);

--- a/tests/ui/try-block/try-block.rs
+++ b/tests/ui/try-block/try-block.rs
@@ -3,7 +3,6 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 //@ compile-flags: --edition 2018
-
 #![feature(try_blocks)]
 
 struct catch {}
@@ -16,7 +15,9 @@ pub fn main() {
     assert_eq!(catch_result, Some(5));
 
     let mut catch = true;
-    while catch { catch = false; }
+    while catch {
+        catch = false;
+    }
     assert_eq!(catch, false);
 
     catch = if catch { false } else { true };
@@ -27,13 +28,15 @@ pub fn main() {
     };
 
     let catch_err: Result<_, i32> = try {
-        Err(22)?;
+        Err::<(), _>(22)?;
         1
     };
     assert_eq!(catch_err, Err(22));
 
     let catch_okay: Result<i32, i32> = try {
-        if false { Err(25)?; }
+        if false {
+            Err::<(), _>(25)?;
+        }
         Ok::<(), i32>(())?;
         28
     };
@@ -41,7 +44,11 @@ pub fn main() {
 
     let catch_from_loop: Result<i32, i32> = try {
         for i in 0..10 {
-            if i < 5 { Ok::<i32, i32>(i)?; } else { Err(i)?; }
+            if i < 5 {
+                Ok::<i32, i32>(i)?;
+            } else {
+                Err::<(), _>(i)?;
+            }
         }
         22
     };
@@ -56,7 +63,7 @@ pub fn main() {
     let cfg_init_2;
     let _res: Result<(), ()> = try {
         cfg_init_2 = 6;
-        Err(())?;
+        Err::<(), _>(())?;
     };
     assert_eq!(cfg_init_2, 6);
 
@@ -70,6 +77,6 @@ pub fn main() {
     let my_opt: Option<_> = try { () };
     assert_eq!(my_opt, Some(()));
 
-    let my_opt: Option<_> = try { };
+    let my_opt: Option<_> = try {};
     assert_eq!(my_opt, Some(()));
 }


### PR DESCRIPTION
**NB**: this is a breaking change (although arguably a bug fix) and as such shouldn't be taken lightly.

This changes `expr?`'s desugaring like so (simplified, see code for more info):
```rust
// old
match expr {
    Ok(val) => val,
    Err(err) => return Err(err),
}

// new
match expr {
    Ok(val) => val,
    Err(err) => core::convert::absurd(return Err(err)),
}

// core::convert
pub const fn absurd<T>(x: !) -> T { x }
```

This prevents `!` from the `return` from skewing inference:
```rust
// previously: ok (never type spontaneous decay skews inference, `T = ()`)
// with this pr: can't infer the type for `T`
Err(())?;
```

Fixes #51125
Closes #39216