### PR TITLE
Assert Spans are well-formed

### DIFF
--- a/compiler/rustc_span/src/span_encoding.rs
+++ b/compiler/rustc_span/src/span_encoding.rs
@@ -103,6 +103,10 @@ impl Span {
         ctxt: SyntaxContext,
         parent: Option<LocalDefId>,
     ) -> Self {
+        if cfg!(debug_assertions) {
+            assert!(hi > lo, "low end of span is after high");
+        }
+
         if lo > hi {
             std::mem::swap(&mut lo, &mut hi);
         }


### PR DESCRIPTION
Makes invalid spans easier to debug by asserting that the low end must be less than high.
First time writing a PR for rust, so let me know if I'm doing this right :)

Resolves #47504.
