### PR TITLE
Fix StableMIR `WrappingRange::is_full` computation

### DIFF
--- a/compiler/stable_mir/src/abi.rs
+++ b/compiler/stable_mir/src/abi.rs
@@ -383,7 +383,7 @@ impl WrappingRange {
             return Err(error!("Expected size <= 128 bits, but found {} instead", size.bits()));
         };
         if self.start <= max_value && self.end <= max_value {
-            Ok(self.start == 0 && max_value == self.end)
+            Ok(self.start == (self.end.wrapping_add(1) & max_value))
         } else {
             Err(error!("Range `{self:?}` out of bounds for size `{}` bits.", size.bits()))
         }


### PR DESCRIPTION
`WrappingRange::is_full` computation assumed that to be full the range couldn't wrap, which is not necessarily true.

For example, a range of 1..=0 is a valid representation of a full wrapping range.