### PR TITLE
Assert that we only use compare-exchange on pointers and no other rmw op

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1138,7 +1138,6 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         // The only RMW operation that LLVM supports on pointers is compare-exchange.
         if self.val_ty(src) == self.type_ptr() {
             assert_eq!(op, rustc_codegen_ssa::common::AtomicRmwBinOp::AtomicXchg);
-            src = self.ptrtoint(src, self.type_isize());
         }
         unsafe {
             llvm::LLVMBuildAtomicRMW(

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1132,7 +1132,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         &mut self,
         op: rustc_codegen_ssa::common::AtomicRmwBinOp,
         dst: &'ll Value,
-        mut src: &'ll Value,
+        src: &'ll Value,
         order: rustc_codegen_ssa::common::AtomicOrdering,
     ) -> &'ll Value {
         // The only RMW operation that LLVM supports on pointers is compare-exchange.

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1136,9 +1136,8 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         order: rustc_codegen_ssa::common::AtomicOrdering,
     ) -> &'ll Value {
         // The only RMW operation that LLVM supports on pointers is compare-exchange.
-        if self.val_ty(src) == self.type_ptr()
-            && op != rustc_codegen_ssa::common::AtomicRmwBinOp::AtomicXchg
-        {
+        if self.val_ty(src) == self.type_ptr() {
+            assert_eq!(op, rustc_codegen_ssa::common::AtomicRmwBinOp::AtomicXchg);
             src = self.ptrtoint(src, self.type_isize());
         }
         unsafe {

--- a/compiler/rustc_codegen_ssa/src/common.rs
+++ b/compiler/rustc_codegen_ssa/src/common.rs
@@ -42,7 +42,7 @@ pub enum RealPredicate {
     RealPredicateTrue,
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum AtomicRmwBinOp {
     AtomicXchg,
     AtomicAdd,


### PR DESCRIPTION
r? @saethlin @nikic

discussion that led up to this: https://github.com/rust-lang/rust/pull/122220#discussion_r1519428170

the other rmw ops make no sense for pointers (addition, ...)