### PR TITLE
extend docs of -Zprint-mono-items

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1831,7 +1831,9 @@ options! {
     print_llvm_passes: bool = (false, parse_bool, [UNTRACKED],
         "print the LLVM optimization passes being run (default: no)"),
     print_mono_items: Option<String> = (None, parse_opt_string, [UNTRACKED],
-        "print the result of the monomorphization collection pass"),
+        "print the result of the monomorphization collection pass. \
+         Value `lazy` means to use normal collection; `eager` means to collect all items.
+         Note that this overwrites the effect `-Clink-dead-code` has on collection!"),
     print_type_sizes: bool = (false, parse_bool, [UNTRACKED],
         "print layout information for each type encountered (default: no)"),
     print_vtable_sizes: bool = (false, parse_bool, [UNTRACKED],


### PR DESCRIPTION
Currently the values one can set this to are not documented anywhere.

I think ideally this flag wouldn't overwrite the collector's behavior, a "print" flag should just print what happens but not change what happens. But our codegen-units tests rely on being able to collect all items without the other side-effects of `-C link-dead-code` and I can't tell whether that reliance is incidental or crucial, so I'm not touching this and just documenting the (messy) status quo.