### PR TITLE
Simplify trim-paths feature by merging all debuginfo options together

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/debuginfo/line_info.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/line_info.rs
@@ -89,11 +89,7 @@ impl DebugContext {
             match &source_file.name {
                 FileName::Real(path) => {
                     let (dir_path, file_name) =
-                        split_path_dir_and_file(if self.should_remap_filepaths {
-                            path.remapped_path_if_available()
-                        } else {
-                            path.local_path_if_available()
-                        });
+                        split_path_dir_and_file(path.to_path(self.filename_display_preference));
                     let dir_name = osstr_as_utf8_bytes(dir_path.as_os_str());
                     let file_name = osstr_as_utf8_bytes(file_name);
 
@@ -115,14 +111,7 @@ impl DebugContext {
                 filename => {
                     let dir_id = line_program.default_directory();
                     let dummy_file_name = LineString::new(
-                        filename
-                            .display(if self.should_remap_filepaths {
-                                FileNameDisplayPreference::Remapped
-                            } else {
-                                FileNameDisplayPreference::Local
-                            })
-                            .to_string()
-                            .into_bytes(),
+                        filename.display(self.filename_display_preference).to_string().into_bytes(),
                         line_program.encoding(),
                         line_strings,
                     );

--- a/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
@@ -84,7 +84,9 @@ impl DebugContext {
 
         let mut dwarf = DwarfUnit::new(encoding);
 
-        let should_remap_filepaths = tcx.sess.should_prefer_remapped_for_codegen();
+        use rustc_session::config::RemapPathScopeComponents;
+        let should_remap_filepaths =
+            tcx.sess.should_prefer_remapped(RemapPathScopeComponents::DEBUGINFO);
 
         let producer = producer(tcx.sess);
         let comp_dir = tcx

--- a/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
@@ -99,9 +99,16 @@ impl DebugContext {
                 FileNameDisplayPreference::Local
             })
             .into_owned();
+
         let (name, file_info) = match tcx.sess.local_crate_source_file() {
             Some(path) => {
-                let name = path.to_string_lossy().into_owned();
+                let name = path
+                    .to_string_lossy(if should_remap_filepaths {
+                        FileNameDisplayPreference::Remapped
+                    } else {
+                        FileNameDisplayPreference::Local
+                    })
+                    .into_owned();
                 (name, None)
             }
             None => (tcx.crate_name(LOCAL_CRATE).to_string(), None),

--- a/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
@@ -85,6 +85,8 @@ impl DebugContext {
         let mut dwarf = DwarfUnit::new(encoding);
 
         use rustc_session::config::RemapPathScopeComponents;
+        use rustc_session::RemapFileNameExt;
+
         let should_remap_filepaths =
             tcx.sess.should_prefer_remapped(RemapPathScopeComponents::DEBUGINFO);
 
@@ -93,22 +95,16 @@ impl DebugContext {
             .sess
             .opts
             .working_dir
-            .to_string_lossy(if should_remap_filepaths {
-                FileNameDisplayPreference::Remapped
-            } else {
-                FileNameDisplayPreference::Local
-            })
-            .into_owned();
+            .for_scope(tcx.sess, RemapPathScopeComponents::DEBUGINFO)
+            .to_string_lossy()
+            .to_string();
 
         let (name, file_info) = match tcx.sess.local_crate_source_file() {
             Some(path) => {
                 let name = path
-                    .to_string_lossy(if should_remap_filepaths {
-                        FileNameDisplayPreference::Remapped
-                    } else {
-                        FileNameDisplayPreference::Local
-                    })
-                    .into_owned();
+                    .for_scope(tcx.sess, RemapPathScopeComponents::DEBUGINFO)
+                    .to_string_lossy()
+                    .to_string();
                 (name, None)
             }
             None => (tcx.crate_name(LOCAL_CRATE).to_string(), None),

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -257,13 +257,12 @@ pub fn target_machine_factory(
     };
     let debuginfo_compression = SmallCStr::new(&debuginfo_compression);
 
-    let should_prefer_remapped_for_split_debuginfo_paths =
-        sess.should_prefer_remapped_for_split_debuginfo_paths();
+    let should_prefer_remapped_paths = sess.should_prefer_remapped_for_codegen();
 
     Arc::new(move |config: TargetMachineFactoryConfig| {
         let path_to_cstring_helper = |path: Option<PathBuf>| -> CString {
             let path = path.unwrap_or_default();
-            let path = if should_prefer_remapped_for_split_debuginfo_paths {
+            let path = if should_prefer_remapped_paths {
                 path_mapping.map_prefix(path).0
             } else {
                 path.into()

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -264,10 +264,11 @@ pub fn target_machine_factory(
     Arc::new(move |config: TargetMachineFactoryConfig| {
         let path_to_cstring_helper = |path: Option<PathBuf>| -> CString {
             let path = path.unwrap_or_default();
+            let path = path_mapping.to_real_filename(path);
             let path = if should_prefer_remapped_paths {
-                path_mapping.map_prefix(path).0
+                path.remapped_path_if_available()
             } else {
-                path.into()
+                path.local_path_if_available()
             };
             CString::new(path.to_str().unwrap()).unwrap()
         };

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -29,7 +29,8 @@ use rustc_data_structures::small_c_str::SmallCStr;
 use rustc_errors::{DiagCtxt, FatalError, Level};
 use rustc_fs_util::{link_or_copy, path_to_c_string};
 use rustc_middle::ty::TyCtxt;
-use rustc_session::config::{self, Lto, OutputType, Passes, SplitDwarfKind, SwitchWithOptPath};
+use rustc_session::config::{self, Lto, OutputType, Passes};
+use rustc_session::config::{RemapPathScopeComponents, SplitDwarfKind, SwitchWithOptPath};
 use rustc_session::Session;
 use rustc_span::symbol::sym;
 use rustc_span::InnerSpan;
@@ -257,7 +258,8 @@ pub fn target_machine_factory(
     };
     let debuginfo_compression = SmallCStr::new(&debuginfo_compression);
 
-    let should_prefer_remapped_paths = sess.should_prefer_remapped_for_codegen();
+    let should_prefer_remapped_paths =
+        sess.should_prefer_remapped(RemapPathScopeComponents::DEBUGINFO);
 
     Arc::new(move |config: TargetMachineFactoryConfig| {
         let path_to_cstring_helper = |path: Option<PathBuf>| -> CString {

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -258,19 +258,17 @@ pub fn target_machine_factory(
     };
     let debuginfo_compression = SmallCStr::new(&debuginfo_compression);
 
-    let should_prefer_remapped_paths =
-        sess.should_prefer_remapped(RemapPathScopeComponents::DEBUGINFO);
+    let file_name_display_preference =
+        sess.filename_display_preference(RemapPathScopeComponents::DEBUGINFO);
 
     Arc::new(move |config: TargetMachineFactoryConfig| {
         let path_to_cstring_helper = |path: Option<PathBuf>| -> CString {
             let path = path.unwrap_or_default();
-            let path = path_mapping.to_real_filename(path);
-            let path = if should_prefer_remapped_paths {
-                path.remapped_path_if_available()
-            } else {
-                path.local_path_if_available()
-            };
-            CString::new(path.to_str().unwrap()).unwrap()
+            let path = path_mapping
+                .to_real_filename(path)
+                .to_string_lossy(file_name_display_preference)
+                .into_owned();
+            CString::new(path).unwrap()
         };
 
         let split_dwarf_file = path_to_cstring_helper(config.split_dwarf_file);

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
@@ -173,8 +173,14 @@ impl GlobalFileTable {
         // Since rustc generates coverage maps with relative paths, the
         // compilation directory can be combined with the relative paths
         // to get absolute paths, if needed.
+        use rustc_session::config::RemapPathScopeComponents;
         use rustc_session::RemapFileNameExt;
-        let working_dir: &str = &tcx.sess.opts.working_dir.for_codegen(tcx.sess).to_string_lossy();
+        let working_dir: &str = &tcx
+            .sess
+            .opts
+            .working_dir
+            .for_scope(tcx.sess, RemapPathScopeComponents::MACRO)
+            .to_string_lossy();
 
         llvm::build_byte_buffer(|buffer| {
             coverageinfo::write_filenames_section_to_buffer(

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -875,7 +875,7 @@ pub fn build_compile_unit_di_node<'ll, 'tcx>(
             )
             // We get a path relative to the working directory from split_dwarf_path
             .map(|f| {
-                if tcx.sess.should_prefer_remapped_for_split_debuginfo_paths() {
+                if tcx.sess.should_prefer_remapped_for_codegen() {
                     tcx.sess.source_map().path_mapping().map_prefix(f).0
                 } else {
                     f.into()

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -838,9 +838,11 @@ pub fn build_compile_unit_di_node<'ll, 'tcx>(
     codegen_unit_name: &str,
     debug_context: &CodegenUnitDebugContext<'ll, 'tcx>,
 ) -> &'ll DIDescriptor {
+    use rustc_session::{config::RemapPathScopeComponents, RemapFileNameExt};
     let mut name_in_debuginfo = tcx
         .sess
         .local_crate_source_file()
+        .map(|src| src.for_scope(&tcx.sess, RemapPathScopeComponents::DEBUGINFO).to_path_buf())
         .unwrap_or_else(|| PathBuf::from(tcx.crate_name(LOCAL_CRATE).as_str()));
 
     // To avoid breaking split DWARF, we need to ensure that each codegen unit
@@ -868,7 +870,6 @@ pub fn build_compile_unit_di_node<'ll, 'tcx>(
     // FIXME(#41252) Remove "clang LLVM" if we can get GDB and LLVM to play nice.
     let producer = format!("clang LLVM ({rustc_producer})");
 
-    use rustc_session::{config::RemapPathScopeComponents, RemapFileNameExt};
     let name_in_debuginfo = name_in_debuginfo.to_string_lossy();
     let work_dir = tcx
         .sess

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -554,13 +554,16 @@ pub fn file_metadata<'ll>(cx: &CodegenCx<'ll, '_>, source_file: &SourceFile) -> 
     ) -> &'ll DIFile {
         debug!(?source_file.name);
 
-        use rustc_session::{config::RemapPathScopeComponents, RemapFileNameExt};
+        let filename_display_preference =
+            cx.sess().filename_display_preference(RemapPathScopeComponents::DEBUGINFO);
+
+        use rustc_session::config::RemapPathScopeComponents;
         let (directory, file_name) = match &source_file.name {
             FileName::Real(filename) => {
                 let working_directory = &cx.sess().opts.working_dir;
                 debug!(?working_directory);
 
-                if cx.sess().should_prefer_remapped(RemapPathScopeComponents::DEBUGINFO) {
+                if filename_display_preference == FileNameDisplayPreference::Remapped {
                     let filename = cx
                         .sess()
                         .source_map()
@@ -623,13 +626,7 @@ pub fn file_metadata<'ll>(cx: &CodegenCx<'ll, '_>, source_file: &SourceFile) -> 
             }
             other => {
                 debug!(?other);
-                (
-                    "".into(),
-                    other
-                        .for_scope(cx.sess(), RemapPathScopeComponents::DEBUGINFO)
-                        .to_string_lossy()
-                        .into_owned(),
-                )
+                ("".into(), other.display(filename_display_preference).to_string())
             }
         };
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -549,17 +549,11 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
             match source_file.name {
                 FileName::Real(ref original_file_name) => {
-                    let adapted_file_name = if self.tcx.sess.should_prefer_remapped_for_codegen() {
-                        source_map.path_mapping().to_embeddable_absolute_path(
-                            original_file_name.clone(),
-                            working_directory,
-                        )
-                    } else {
-                        source_map.path_mapping().to_local_embeddable_absolute_path(
-                            original_file_name.clone(),
-                            working_directory,
-                        )
-                    };
+                    // FIXME: This should probably to conditionally remapped under
+                    // a RemapPathScopeComponents but which one?
+                    let adapted_file_name = source_map
+                        .path_mapping()
+                        .to_embeddable_absolute_path(original_file_name.clone(), working_directory);
 
                     adapted_source_file.name = FileName::Real(adapted_file_name);
                 }

--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Debug, Display, Formatter};
 
 use rustc_hir::def_id::DefId;
-use rustc_session::RemapFileNameExt;
+use rustc_session::{config::RemapPathScopeComponents, RemapFileNameExt};
 use rustc_span::{Span, DUMMY_SP};
 use rustc_target::abi::{HasDataLayout, Size};
 
@@ -516,7 +516,11 @@ impl<'tcx> TyCtxt<'tcx> {
         let caller = self.sess.source_map().lookup_char_pos(topmost.lo());
         self.const_caller_location(
             rustc_span::symbol::Symbol::intern(
-                &caller.file.name.for_codegen(self.sess).to_string_lossy(),
+                &caller
+                    .file
+                    .name
+                    .for_scope(self.sess, RemapPathScopeComponents::MACRO)
+                    .to_string_lossy(),
             ),
             caller.line as u32,
             caller.col_display as u32 + 1,

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -123,8 +123,11 @@ fn create_mappings<'tcx>(
     let body_span = hir_info.body_span;
 
     let source_file = source_map.lookup_source_file(body_span.lo());
-    use rustc_session::RemapFileNameExt;
-    let file_name = Symbol::intern(&source_file.name.for_codegen(tcx.sess).to_string_lossy());
+
+    use rustc_session::{config::RemapPathScopeComponents, RemapFileNameExt};
+    let file_name = Symbol::intern(
+        &source_file.name.for_scope(tcx.sess, RemapPathScopeComponents::MACRO).to_string_lossy(),
+    );
 
     let term_for_bcb = |bcb| {
         coverage_counters

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2842,13 +2842,8 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
         early_dcx.early_fatal(format!("Current directory is invalid: {e}"));
     });
 
-    let remap = file_path_mapping(remap_path_prefix.clone(), &unstable_opts);
-    let (path, remapped) = remap.map_prefix(&working_dir);
-    let working_dir = if remapped {
-        RealFileName::Remapped { virtual_name: path.into_owned(), local_path: Some(working_dir) }
-    } else {
-        RealFileName::LocalPath(path.into_owned())
-    };
+    let file_mapping = file_path_mapping(remap_path_prefix.clone(), &unstable_opts);
+    let working_dir = file_mapping.to_real_filename(&working_dir);
 
     let verbose = matches.opt_present("verbose") || unstable_opts.verbose_internals;
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -990,22 +990,12 @@ bitflags::bitflags! {
         const MACRO = 1 << 0;
         /// Apply remappings to printed compiler diagnostics
         const DIAGNOSTICS = 1 << 1;
-        /// Apply remappings to debug information only when they are written to
-        /// compiled executables or libraries, but not when they are in split
-        /// debuginfo files
-        const UNSPLIT_DEBUGINFO = 1 << 2;
-        /// Apply remappings to debug information only when they are written to
-        /// split debug information files, but not in compiled executables or
-        /// libraries
-        const SPLIT_DEBUGINFO = 1 << 3;
-        /// Apply remappings to the paths pointing to split debug information
-        /// files. Does nothing when these files are not generated.
-        const SPLIT_DEBUGINFO_PATH = 1 << 4;
+        /// Apply remappings to debug informations
+        const DEBUGINFO = 1 << 3;
 
-        /// An alias for macro,unsplit-debuginfo,split-debuginfo-path. This
-        /// ensures all paths in compiled executables or libraries are remapped
-        /// but not elsewhere.
-        const OBJECT = Self::MACRO.bits() | Self::UNSPLIT_DEBUGINFO.bits() | Self::SPLIT_DEBUGINFO_PATH.bits();
+        /// An alias for `macro` and `debuginfo`. This ensures all paths in compiled
+        /// executables or libraries are remapped but not elsewhere.
+        const OBJECT = Self::MACRO.bits() | Self::DEBUGINFO.bits();
     }
 }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -433,7 +433,8 @@ mod desc {
         "a `,` separated combination of `bti`, `b-key`, `pac-ret`, or `leaf`";
     pub const parse_proc_macro_execution_strategy: &str =
         "one of supported execution strategies (`same-thread`, or `cross-thread`)";
-    pub const parse_remap_path_scope: &str = "comma separated list of scopes: `macro`, `diagnostics`, `unsplit-debuginfo`, `split-debuginfo`, `split-debuginfo-path`, `object`, `all`";
+    pub const parse_remap_path_scope: &str =
+        "comma separated list of scopes: `macro`, `diagnostics`, `debuginfo`, `object`, `all`";
     pub const parse_inlining_threshold: &str =
         "either a boolean (`yes`, `no`, `on`, `off`, etc), or a non-negative number";
     pub const parse_llvm_module_flag: &str = "<key>:<type>:<value>:<behavior>. Type must currently be `u32`. Behavior should be one of (`error`, `warning`, `require`, `override`, `append`, `appendunique`, `max`, `min`)";
@@ -1156,9 +1157,7 @@ mod parse {
                 *slot |= match s {
                     "macro" => RemapPathScopeComponents::MACRO,
                     "diagnostics" => RemapPathScopeComponents::DIAGNOSTICS,
-                    "unsplit-debuginfo" => RemapPathScopeComponents::UNSPLIT_DEBUGINFO,
-                    "split-debuginfo" => RemapPathScopeComponents::SPLIT_DEBUGINFO,
-                    "split-debuginfo-path" => RemapPathScopeComponents::SPLIT_DEBUGINFO_PATH,
+                    "debuginfo" => RemapPathScopeComponents::DEBUGINFO,
                     "object" => RemapPathScopeComponents::OBJECT,
                     "all" => RemapPathScopeComponents::all(),
                     _ => return false,

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -887,37 +887,7 @@ impl Session {
     }
 
     pub fn should_prefer_remapped_for_codegen(&self) -> bool {
-        let has_split_debuginfo = match self.split_debuginfo() {
-            SplitDebuginfo::Off => false,
-            SplitDebuginfo::Packed => true,
-            SplitDebuginfo::Unpacked => true,
-        };
-
-        let remap_path_scopes = &self.opts.unstable_opts.remap_path_scope;
-        let mut prefer_remapped = false;
-
-        if remap_path_scopes.contains(RemapPathScopeComponents::UNSPLIT_DEBUGINFO) {
-            prefer_remapped |= !has_split_debuginfo;
-        }
-
-        if remap_path_scopes.contains(RemapPathScopeComponents::SPLIT_DEBUGINFO) {
-            prefer_remapped |= has_split_debuginfo;
-        }
-
-        prefer_remapped
-    }
-
-    pub fn should_prefer_remapped_for_split_debuginfo_paths(&self) -> bool {
-        let has_split_debuginfo = match self.split_debuginfo() {
-            SplitDebuginfo::Off => false,
-            SplitDebuginfo::Packed | SplitDebuginfo::Unpacked => true,
-        };
-
-        self.opts
-            .unstable_opts
-            .remap_path_scope
-            .contains(RemapPathScopeComponents::SPLIT_DEBUGINFO_PATH)
-            && has_split_debuginfo
+        self.opts.unstable_opts.remap_path_scope.contains(RemapPathScopeComponents::DEBUGINFO)
     }
 }
 

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -29,6 +29,7 @@ use rustc_macros::HashStable_Generic;
 pub use rustc_span::def_id::StableCrateId;
 use rustc_span::edition::Edition;
 use rustc_span::source_map::{FileLoader, FilePathMapping, RealFileLoader, SourceMap};
+use rustc_span::RealFileName;
 use rustc_span::{SourceFileHashAlgorithm, Span, Symbol};
 use rustc_target::asm::InlineAsmArch;
 use rustc_target::spec::{CodeModel, PanicStrategy, RelocModel, RelroLevel};
@@ -250,14 +251,9 @@ impl Session {
         self.miri_unleashed_features.lock().push((span, feature_gate));
     }
 
-    pub fn local_crate_source_file(&self) -> Option<PathBuf> {
+    pub fn local_crate_source_file(&self) -> Option<RealFileName> {
         let path = self.io.input.opt_path()?;
-        // FIXME: The remap path scope should probably not be hardcoded.
-        if self.should_prefer_remapped(RemapPathScopeComponents::DEBUGINFO) {
-            Some(self.opts.file_path_mapping().map_prefix(path).0.into_owned())
-        } else {
-            Some(path.to_path_buf())
-        }
+        Some(RealFileName::LocalPath(path.to_path_buf()))
     }
 
     fn check_miri_unleashed_features(&self) -> Option<ErrorGuaranteed> {

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -252,8 +252,7 @@ impl Session {
     }
 
     pub fn local_crate_source_file(&self) -> Option<RealFileName> {
-        let path = self.io.input.opt_path()?;
-        Some(RealFileName::LocalPath(path.to_path_buf()))
+        Some(self.source_map().path_mapping().to_real_filename(self.io.input.opt_path()?))
     }
 
     fn check_miri_unleashed_features(&self) -> Option<ErrorGuaranteed> {

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -29,7 +29,7 @@ use rustc_macros::HashStable_Generic;
 pub use rustc_span::def_id::StableCrateId;
 use rustc_span::edition::Edition;
 use rustc_span::source_map::{FileLoader, FilePathMapping, RealFileLoader, SourceMap};
-use rustc_span::RealFileName;
+use rustc_span::{FileNameDisplayPreference, RealFileName};
 use rustc_span::{SourceFileHashAlgorithm, Span, Symbol};
 use rustc_target::asm::InlineAsmArch;
 use rustc_target::spec::{CodeModel, PanicStrategy, RelocModel, RelroLevel};
@@ -882,8 +882,19 @@ impl Session {
         self.opts.cg.link_dead_code.unwrap_or(false)
     }
 
-    pub fn should_prefer_remapped(&self, scope: RemapPathScopeComponents) -> bool {
-        self.opts.unstable_opts.remap_path_scope.contains(scope)
+    pub fn filename_display_preference(
+        &self,
+        scope: RemapPathScopeComponents,
+    ) -> FileNameDisplayPreference {
+        assert!(
+            scope.bits().count_ones() == 1,
+            "one and only one scope should be passed to `Session::filename_display_preference`"
+        );
+        if self.opts.unstable_opts.remap_path_scope.contains(scope) {
+            FileNameDisplayPreference::Remapped
+        } else {
+            FileNameDisplayPreference::Local
+        }
     }
 }
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -271,6 +271,18 @@ impl RealFileName {
         }
     }
 
+    /// Return the path remmapped or not depending on the [`FileNameDisplayPreference`].
+    ///
+    /// For the purpose of this function, local and short preference are equal.
+    pub fn to_path(&self, display_pref: FileNameDisplayPreference) -> &Path {
+        match display_pref {
+            FileNameDisplayPreference::Local | FileNameDisplayPreference::Short => {
+                self.local_path_if_available()
+            }
+            FileNameDisplayPreference::Remapped => self.remapped_path_if_available(),
+        }
+    }
+
     pub fn to_string_lossy(&self, display_pref: FileNameDisplayPreference) -> Cow<'_, str> {
         match display_pref {
             FileNameDisplayPreference::Local => self.local_path_if_available().to_string_lossy(),

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -1129,6 +1129,21 @@ impl FilePathMapping {
         }
     }
 
+    /// Applies any path prefix substitution as defined by the mapping.
+    /// The return value is the local path with a "virtual path" representing the remapped
+    /// part if any remapping was performed.
+    pub fn to_real_filename<'a>(&self, local_path: impl Into<Cow<'a, Path>>) -> RealFileName {
+        let local_path = local_path.into();
+        if let (remapped_path, true) = self.map_prefix(&*local_path) {
+            RealFileName::Remapped {
+                virtual_name: remapped_path.into_owned(),
+                local_path: Some(local_path.into_owned()),
+            }
+        } else {
+            RealFileName::LocalPath(local_path.into_owned())
+        }
+    }
+
     /// Expand a relative path to an absolute path with remapping taken into account.
     /// Use this when absolute paths are required (e.g. debuginfo or crate metadata).
     ///

--- a/src/doc/unstable-book/src/compiler-flags/remap-path-scope.md
+++ b/src/doc/unstable-book/src/compiler-flags/remap-path-scope.md
@@ -10,11 +10,9 @@ This flag accepts a comma-separated list of values and may be specified multiple
 
 - `macro` - apply remappings to the expansion of `std::file!()` macro. This is where paths in embedded panic messages come from
 - `diagnostics` - apply remappings to printed compiler diagnostics
-- `unsplit-debuginfo` - apply remappings to debug information only when they are written to compiled executables or libraries, but not when they are in split debuginfo files
-- `split-debuginfo` - apply remappings to debug information only when they are written to split debug information files, but not in compiled executables or libraries
-- `split-debuginfo-path` - apply remappings to the paths pointing to split debug information files. Does nothing when these files are not generated.
-- `object` - an alias for `macro,unsplit-debuginfo,split-debuginfo-path`. This ensures all paths in compiled executables or libraries are remapped, but not elsewhere.
-- `all` and `true` - an alias for all of the above, also equivalent to supplying only `--remap-path-prefix` without `--remap-path-scope`.
+- `debuginfo` - apply remappings to debug informations
+- `object` - apply remappings to all paths in compiled executables or libraries, but not elsewhere. Currently an alias for `macro,debuginfo`.
+- `all` - an alias for all of the above, also equivalent to supplying only `--remap-path-prefix` without `--remap-path-scope`.
 
 ## Example
 ```sh

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2506,7 +2506,7 @@ fn render_call_locations<W: fmt::Write>(mut w: W, cx: &mut Context<'_>, item: &c
         // Look for the example file in the source map if it exists, otherwise return a dummy span
         let file_span = (|| {
             let source_map = tcx.sess.source_map();
-            let crate_src = tcx.sess.local_crate_source_file()?;
+            let crate_src = tcx.sess.local_crate_source_file()?.into_local_path()?;
             let abs_crate_src = crate_src.canonicalize().ok()?;
             let crate_root = abs_crate_src.parent()?.parent()?;
             let rel_path = path.strip_prefix(crate_root).ok()?;

--- a/tests/run-make/remap-path-prefix/Makefile
+++ b/tests/run-make/remap-path-prefix/Makefile
@@ -21,9 +21,9 @@ remap-with-scope:
 	grep "/the/aux/lib.rs" $(TMPDIR)/liblib.rmeta || exit 1
 	! grep "$$PWD/auxiliary" $(TMPDIR)/liblib.rmeta || exit 1
 
-	$(RUSTC) --remap-path-prefix $$PWD/auxiliary=/the/aux -Zremap-path-scope=diagnostics $(DEBUGINFOOPTS) --crate-type=lib --emit=metadata auxiliary/lib.rs
-	! grep "/the/aux/lib.rs" $(TMPDIR)/liblib.rmeta || exit 1
-	grep "$$PWD/auxiliary" $(TMPDIR)/liblib.rmeta || exit 1
+	$(RUSTC) --remap-path-prefix $$PWD/auxiliary=/the/aux -Zremap-path-scope=macro $(DEBUGINFOOPTS) --crate-type=lib --emit=metadata auxiliary/lib.rs
+	grep "/the/aux/lib.rs" $(TMPDIR)/liblib.rmeta || exit 1
+	! grep "$$PWD/auxiliary" $(TMPDIR)/liblib.rmeta || exit 1
 
 	$(RUSTC) --remap-path-prefix $$PWD/auxiliary=/the/aux -Zremap-path-scope=diagnostics,object $(DEBUGINFOOPTS) --crate-type=lib --emit=metadata auxiliary/lib.rs
 	grep "/the/aux/lib.rs" $(TMPDIR)/liblib.rmeta || exit 1

--- a/tests/run-make/remap-path-prefix/Makefile
+++ b/tests/run-make/remap-path-prefix/Makefile
@@ -28,12 +28,3 @@ remap-with-scope:
 	$(RUSTC) --remap-path-prefix $$PWD/auxiliary=/the/aux -Zremap-path-scope=diagnostics,object $(DEBUGINFOOPTS) --crate-type=lib --emit=metadata auxiliary/lib.rs
 	grep "/the/aux/lib.rs" $(TMPDIR)/liblib.rmeta || exit 1
 	! grep "$$PWD/auxiliary" $(TMPDIR)/liblib.rmeta || exit 1
-
-	$(RUSTC) --remap-path-prefix $$PWD/auxiliary=/the/aux -Zremap-path-scope=split-debuginfo $(DEBUGINFOOPTS) --crate-type=lib --emit=metadata auxiliary/lib.rs
-	! grep "/the/aux/lib.rs" $(TMPDIR)/liblib.rmeta || exit 1
-	grep "$$PWD/auxiliary" $(TMPDIR)/liblib.rmeta || exit 1
-
-    # FIXME: We should test the split debuginfo files, but we don't currently a good infra for that
-	$(RUSTC) --remap-path-prefix $$PWD/auxiliary=/the/aux -Zremap-path-scope=split-debuginfo -Zunstable-options -Csplit-debuginfo=packed --crate-type=lib --emit=metadata auxiliary/lib.rs
-	grep "/the/aux/lib.rs" $(TMPDIR)/liblib.rmeta || exit 1
-	! grep "$$PWD/auxiliary" $(TMPDIR)/liblib.rmeta || exit 1

--- a/tests/run-make/split-debuginfo/Makefile
+++ b/tests/run-make/split-debuginfo/Makefile
@@ -142,7 +142,7 @@ packed-remapped-single:
 packed-remapped-scope:
 	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=packed -C debuginfo=2 \
 		-Z split-dwarf-kind=single --remap-path-prefix $(TMPDIR)=/a \
-		-Z remap-path-scope=split-debuginfo-path foo.rs -g
+		-Z remap-path-scope=debuginfo foo.rs -g
 	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (! grep $(TMPDIR)) || exit 1
 	ls $(TMPDIR)/*.o && exit 1 || exit 0
 	ls $(TMPDIR)/*.dwo && exit 1 || exit 0
@@ -298,7 +298,7 @@ unpacked-remapped-single:
 unpacked-remapped-scope:
 	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
 		-Z split-dwarf-kind=single --remap-path-prefix $(TMPDIR)=/a \
-		-Z remap-path-scope=split-debuginfo-path foo.rs -g
+		-Z remap-path-scope=debuginfo foo.rs -g
 	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (! grep $(TMPDIR)) || exit 1
 	rm $(TMPDIR)/*.o
 	ls $(TMPDIR)/*.dwo && exit 1 || exit 0


### PR DESCRIPTION
This PR simplifies the trim-paths feature by merging all debuginfo options together, as described in https://github.com/rust-lang/rust/issues/111540#issuecomment-1994010274.

And also do some correctness fixes found during the review.

cc @weihanglo 
r? @michaelwoerister 