### PR TITLE
Update build instructions for OpenHarmony

### DIFF
--- a/src/doc/rustc/src/platform-support/openharmony.md
+++ b/src/doc/rustc/src/platform-support/openharmony.md
@@ -96,9 +96,34 @@ exec /path/to/ohos-sdk/linux/native/llvm/bin/clang++ \
 
 Future versions of the OpenHarmony SDK will avoid the need for this process.
 
-## Building the target
+## Building Rust programs
 
-To build a rust toolchain, create a `config.toml` with the following contents:
+Rustup ships pre-compiled artifacts for this target, which you can install with:
+```sh
+rustup target add aarch64-unknown-linux-ohos
+rustup target add armv7-unknown-linux-ohos
+rustup target add x86_64-unknown-linux-ohos
+```
+
+You will need to configure the linker to use in `~/.cargo/config.toml`:
+```toml
+[target.aarch64-unknown-linux-ohos]
+ar = "/path/to/ohos-sdk/linux/native/llvm/bin/llvm-ar"
+linker = "/path/to/aarch64-unknown-linux-ohos-clang.sh"
+
+[target.armv7-unknown-linux-ohos]
+ar = "/path/to/ohos-sdk/linux/native/llvm/bin/llvm-ar"
+linker = "/path/to/armv7-unknown-linux-ohos-clang.sh"
+
+[target.x86_64-unknown-linux-ohos]
+ar = "/path/to/ohos-sdk/linux/native/llvm/bin/llvm-ar"
+linker = "/path/to/x86_64-unknown-linux-ohos-clang.sh"
+```
+
+## Building the target from source
+
+Instead of using `rustup`, you can instead build a rust toolchain from source.
+Create a `config.toml` with the following contents:
 
 ```toml
 profile = "compiler"
@@ -128,28 +153,6 @@ cxx = "/path/to/x86_64-unknown-linux-ohos-clang++.sh"
 ar = "/path/to/ohos-sdk/linux/native/llvm/bin/llvm-ar"
 ranlib = "/path/to/ohos-sdk/linux/native/llvm/bin/llvm-ranlib"
 linker  = "/path/to/x86_64-unknown-linux-ohos-clang.sh"
-```
-
-## Building Rust programs
-
-Rust does not yet ship pre-compiled artifacts for this target. To compile for
-this target, you will either need to build Rust with the target enabled (see
-"Building the target" above), or build your own copy of `core` by using
-`build-std` or similar.
-
-You will need to configure the linker to use in `~/.cargo/config`:
-```toml
-[target.aarch64-unknown-linux-ohos]
-ar = "/path/to/ohos-sdk/linux/native/llvm/bin/llvm-ar"
-linker = "/path/to/aarch64-unknown-linux-ohos-clang.sh"
-
-[target.armv7-unknown-linux-ohos]
-ar = "/path/to/ohos-sdk/linux/native/llvm/bin/llvm-ar"
-linker = "/path/to/armv7-unknown-linux-ohos-clang.sh"
-
-[target.x86_64-unknown-linux-ohos]
-ar = "/path/to/ohos-sdk/linux/native/llvm/bin/llvm-ar"
-linker = "/path/to/x86_64-unknown-linux-ohos-clang.sh"
 ```
 
 ## Testing


### PR DESCRIPTION
The platform page now recommends using rustup since the target is now tier 2.