### PR TITLE
Greatly reduce GCC build logs

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
@@ -1,8 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -ex
 
 cd $1
+
+source shared.sh
 
 # Setting up folders for GCC
 git clone https://github.com/antoyo/gcc gcc-src
@@ -20,9 +22,11 @@ cd ../gcc-build
     --enable-checking=release \
     --disable-bootstrap \
     --disable-multilib \
-    --prefix=$(pwd)/../gcc-install
-make
-make install
+    --prefix=$(pwd)/../gcc-install \
+    --quiet
+
+hide_output make
+hide_output make install
 
 rm -rf ../gcc-src
 ln -s /scripts/gcc-install/lib/libgccjit.so /usr/lib/x86_64-linux-gnu/libgccjit.so

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
@@ -16,16 +16,16 @@ mkdir ../gcc-build ../gcc-install
 cd ../gcc-build
 
 # Building GCC.
-../gcc-src/configure \
+hide_output \
+  ../gcc-src/configure \
     --enable-host-shared \
     --enable-languages=jit \
     --enable-checking=release \
     --disable-bootstrap \
     --disable-multilib \
     --prefix=$(pwd)/../gcc-install \
-    --quiet
 
-hide_output make
+hide_output make -j$(nproc)
 hide_output make install
 
 rm -rf ../gcc-src

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-16/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-16/Dockerfile
@@ -59,8 +59,9 @@ ENV RUST_CONFIGURE_ARGS \
 
 COPY host-x86_64/x86_64-gnu-llvm-16/script.sh /tmp/
 
+COPY host-x86_64/dist-x86_64-linux/shared.sh /scripts/
 COPY host-x86_64/dist-x86_64-linux/build-gccjit.sh /scripts/
 
-RUN sh /scripts/build-gccjit.sh /scripts
+RUN /scripts/build-gccjit.sh /scripts
 
 ENV SCRIPT /tmp/script.sh

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-17/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-17/Dockerfile
@@ -58,8 +58,9 @@ ENV RUST_CONFIGURE_ARGS \
 
 COPY host-x86_64/x86_64-gnu-llvm-16/script.sh /tmp/
 
+COPY host-x86_64/dist-x86_64-linux/shared.sh /scripts/
 COPY host-x86_64/dist-x86_64-linux/build-gccjit.sh /scripts/
 
-RUN sh /scripts/build-gccjit.sh /scripts
+RUN /scripts/build-gccjit.sh /scripts
 
 ENV SCRIPT /tmp/script.sh

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -95,9 +95,10 @@ ENV RUST_CONFIGURE_ARGS \
 
 ENV HOST_TARGET x86_64-unknown-linux-gnu
 
+COPY host-x86_64/dist-x86_64-linux/shared.sh /scripts/
 COPY host-x86_64/dist-x86_64-linux/build-gccjit.sh /scripts/
 
-RUN sh /scripts/build-gccjit.sh /scripts
+RUN /scripts/build-gccjit.sh /scripts
 
 ENV SCRIPT /tmp/checktools.sh ../x.py && \
   NODE_PATH=`npm root -g` python3 ../x.py test tests/rustdoc-gui --stage 2 \


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-log-analyzer/issues/80.

Based on [makefile documentation](https://www.gnu.org/software/make/manual/html_node/Options-Summary.html#index-_002d_002dquiet-1) and [configure documentation](https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/configure-Invocation.html).

cc @RalfJung @antoyo 