### PR TITLE
Make `SubdiagMessageOp` well-formed

### DIFF
--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -189,7 +189,8 @@ where
     );
 }
 
-pub trait SubdiagMessageOp<G> = Fn(&mut Diag<'_, G>, SubdiagMessage) -> SubdiagMessage;
+pub trait SubdiagMessageOp<G: EmissionGuarantee> =
+    Fn(&mut Diag<'_, G>, SubdiagMessage) -> SubdiagMessage;
 
 /// Trait implemented by lint types. This should not be implemented manually. Instead, use
 /// `#[derive(LintDiagnostic)]` -- see [rustc_macros::LintDiagnostic].


### PR DESCRIPTION
`WF(Diag<'_, G>)` requires `G: EmissionGuarantee`, but we don't currently check this is true due to limitations in the solver. Probably still worth enforcing.

r? @nnethercote (or anyone can r+ this, really)