### PR TITLE
Don't walk the bodies of free constants for reachability.

### DIFF
--- a/tests/codegen/dont_codegen_private_const_fn_only_used_in_const_eval.rs
+++ b/tests/codegen/dont_codegen_private_const_fn_only_used_in_const_eval.rs
@@ -8,3 +8,9 @@ const fn foo() {}
 pub static FOO: () = foo();
 
 // CHECK-NOT: define{{.*}}foo{{.*}}
+
+const fn bar() {}
+
+pub const BAR: () = bar();
+
+// CHECK: define{{.*}}bar{{.*}}

--- a/tests/codegen/dont_codegen_private_const_fn_only_used_in_const_eval.rs
+++ b/tests/codegen/dont_codegen_private_const_fn_only_used_in_const_eval.rs
@@ -3,6 +3,8 @@
 
 //@compile-flags: --crate-type=lib -Copt-level=0
 
+#![feature(generic_const_items)]
+
 const fn foo() {}
 
 pub static FOO: () = foo();
@@ -14,3 +16,12 @@ const fn bar() {}
 pub const BAR: () = bar();
 
 // CHECK-NOT: define{{.*}}bar{{.*}}
+
+const fn baz() {}
+
+#[rustfmt::skip]
+pub const BAZ<const C: bool>: () = if C {
+    baz()
+};
+
+// CHECK: define{{.*}}baz{{.*}}

--- a/tests/codegen/dont_codegen_private_const_fn_only_used_in_const_eval.rs
+++ b/tests/codegen/dont_codegen_private_const_fn_only_used_in_const_eval.rs
@@ -13,4 +13,4 @@ const fn bar() {}
 
 pub const BAR: () = bar();
 
-// CHECK: define{{.*}}bar{{.*}}
+// CHECK-NOT: define{{.*}}bar{{.*}}


### PR DESCRIPTION
follow-up to #122371

cc #119214

This avoids codegening items (e.g. functions) that are only used during const eval, but do not reach their final constant value (e.g. via function pointers).

r? @tmiasko 