### PR TITLE
Fill in HIR hash for associated opaque types

### DIFF
--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -240,8 +240,14 @@ fn associated_types_for_impl_traits_in_associated_fn(
 
 fn feed_hir(feed: &TyCtxtFeed<'_, LocalDefId>) {
     feed.local_def_id_to_hir_id(HirId::make_owner(feed.def_id()));
+
+    let node = hir::OwnerNode::AssocOpaqueTy(&hir::AssocOpaqueTy {});
+    let bodies = Default::default();
+    let attrs = hir::AttributeMap::EMPTY;
+
+    let (opt_hash_including_bodies, _) = feed.tcx.hash_owner_nodes(node, &bodies, &attrs.map);
     feed.opt_hir_owner_nodes(Some(feed.tcx.arena.alloc(hir::OwnerNodes {
-        opt_hash_including_bodies: None,
+        opt_hash_including_bodies,
         nodes: IndexVec::from_elem_n(
             hir::ParentedNode {
                 parent: hir::ItemLocalId::INVALID,
@@ -249,9 +255,9 @@ fn feed_hir(feed: &TyCtxtFeed<'_, LocalDefId>) {
             },
             1,
         ),
-        bodies: Default::default(),
+        bodies,
     })));
-    feed.feed_owner_id().hir_attrs(hir::AttributeMap::EMPTY);
+    feed.feed_owner_id().hir_attrs(attrs);
 }
 
 /// Given an `opaque_ty_def_id` corresponding to an `impl Trait` in an associated

--- a/tests/ui/async-await/in-trait/hir-hash.rs
+++ b/tests/ui/async-await/in-trait/hir-hash.rs
@@ -1,0 +1,11 @@
+// Issue #122508
+
+//@ check-pass
+//@ incremental
+//@ edition:2021
+
+trait MyTrait {
+    async fn bar(&self) -> i32;
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/122508