### PR TITLE
Build core, alloc, std with 1 CGU

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,14 @@ exclude = [
   "library/stdarch",
 ]
 
+# Building these core crates with 1 CGU makes them a lot smaller.
+[profile.release.package.core]
+codegen-units = 1
+[profile.release.package.alloc]
+codegen-units = 1
+[profile.release.package.std]
+codegen-units = 1
+
 [profile.release.package.compiler_builtins]
 # The compiler-builtins crate cannot reference libcore, and its own CI will
 # verify that this is the case. This requires, however, that the crate is built


### PR DESCRIPTION
Locally, this makes helloworld ~24% smaller:

```
Stats for benchmark `helloworld`
--------------------
Target `helloworld` (artifact `helloworld`)
┌─────────────────────┬───────────────┬──────────────┬─────────┬──────────┐
│ Section             │ Size (before) │ Size (after) │    Diff │ Diff (%) │
├─────────────────────┼───────────────┼──────────────┼─────────┼──────────┤
│ .strtab             │     98.78 KiB │    52.35 KiB │  -47543 │   -47.0% │
│ .text               │    276.83 KiB │   250.88 KiB │  -26576 │    -9.4% │
│ .eh_frame           │     42.02 KiB │    22.45 KiB │  -20048 │   -46.6% │
│ .symtab             │     37.69 KiB │    18.75 KiB │  -19392 │   -50.2% │
│ .gcc_except_table   │     11.00 KiB │     4.33 KiB │   -6824 │   -60.6% │
│ .rodata             │     28.42 KiB │    24.43 KiB │   -4083 │   -14.0% │
│ .eh_frame_hdr       │      8.16 KiB │     4.19 KiB │   -4064 │   -48.6% │
│ .rela.dyn           │     20.37 KiB │    17.06 KiB │   -3384 │   -16.2% │
│ .data.rel.ro        │     10.56 KiB │     9.05 KiB │   -1544 │   -14.3% │
│ .got                │      1.98 KiB │     1.66 KiB │    -328 │   -16.2% │
│ .dynstr             │      1.04 KiB │     1.02 KiB │     -25 │    -2.3% │
│ .dynsym             │      1.59 KiB │     1.57 KiB │     -24 │    -1.5% │
│ .gnu.version_r      │         288 B │        272 B │     -16 │    -5.6% │
│ .bss                │         200 B │        216 B │     +16 │    +8.0% │
│ .gnu.version        │         136 B │        134 B │      -2 │    -1.5% │
│ .tbss               │          81 B │         80 B │      -1 │    -1.2% │
│ <16 unchanged rows> │      1.28 KiB │     1.28 KiB │       0 │     0.0% │
│─────────────────────│───────────────│──────────────│─────────│──────────│
│ Total               │    540.41 KiB │   409.71 KiB │ -133838 │   -24.2% │
└─────────────────────┴───────────────┴──────────────┴─────────┴──────────┘
```

It also makes `./x build --stage 1` ~10% slower after a change to the stdlib (2:45 -> 3:00).

I'm not sure if that tradeoff is worthwhile.

Let's do a perf run first.

r? @ghost