### PR TITLE
Ensure RPITITs are created before def-id freezing

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -595,12 +595,14 @@ fn convert_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
             tcx.ensure().type_of(def_id);
             tcx.ensure().impl_trait_header(def_id);
             tcx.ensure().predicates_of(def_id);
+            tcx.ensure().associated_items(def_id);
         }
         hir::ItemKind::Trait(..) => {
             tcx.ensure().generics_of(def_id);
             tcx.ensure().trait_def(def_id);
             tcx.at(it.span).super_predicates_of(def_id);
             tcx.ensure().predicates_of(def_id);
+            tcx.ensure().associated_items(def_id);
         }
         hir::ItemKind::TraitAlias(..) => {
             tcx.ensure().generics_of(def_id);

--- a/tests/ui/impl-trait/in-trait/ensure-rpitits-are-created-before-freezing.rs
+++ b/tests/ui/impl-trait/in-trait/ensure-rpitits-are-created-before-freezing.rs
@@ -1,0 +1,13 @@
+trait Iterable {
+    type Item;
+    fn iter(&self) -> impl Sized;
+}
+
+// `ty::Error` in a trait ref will silence any missing item errors, but will also
+// prevent the `associated_items` query from being called before def ids are frozen.
+impl Iterable for Missing {
+//~^ ERROR cannot find type `Missing` in this scope
+    fn iter(&self) -> Self::Item {}
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/ensure-rpitits-are-created-before-freezing.stderr
+++ b/tests/ui/impl-trait/in-trait/ensure-rpitits-are-created-before-freezing.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/ensure-rpitits-are-created-before-freezing.rs:8:19
+   |
+LL | impl Iterable for Missing {
+   |                   ^^^^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
From the test:

```rust
// `ty::Error` in a trait ref will silence any missing item errors, but will also
// prevent the `associated_items` query from being called before def ids are frozen.
```

Essentially, the code that checks that `impl`s have all their items (`check_impl_items_against_trait`) is also (implicitly) responsible for fetching the `associated_items` query before, but since we early return here:
https://github.com/rust-lang/rust/blob/c2901f543577af99b9cb708f5c0d28525eb7f08f/compiler/rustc_hir_analysis/src/check/check.rs#L732-L737
...that means that this never happens for trait refs that reference errors.

Fixes #122518
r? oli-obk