### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1213,16 +1213,16 @@ fn add_sanitizer_libraries(
         return;
     }
 
-    // On macOS the runtimes are distributed as dylibs which should be linked to
-    // both executables and dynamic shared objects. On most other platforms the
-    // runtimes are currently distributed as static libraries which should be
-    // linked to executables only.
     if matches!(crate_type, CrateType::Rlib | CrateType::Staticlib) {
         return;
     }
 
+    // On macOS and Windows using MSVC the runtimes are distributed as dylibs
+    // which should be linked to both executables and dynamic libraries.
+    // Everywhere else the runtimes are currently distributed as static
+    // libraries which should be linked to executables only.
     if matches!(crate_type, CrateType::Dylib | CrateType::Cdylib | CrateType::ProcMacro)
-        && (sess.target.is_like_osx || sess.target.is_like_msvc)
+        && !(sess.target.is_like_osx || sess.target.is_like_msvc)
     {
         return;
     }

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1201,21 +1201,29 @@ fn add_sanitizer_libraries(
     crate_type: CrateType,
     linker: &mut dyn Linker,
 ) {
-    // On macOS and Windows using MSVC the runtimes are distributed as dylibs
-    // which should be linked to both executables and dynamic libraries.
-    // Everywhere else the runtimes are currently distributed as static
-    // libraries which should be linked to executables only.
-    let needs_runtime = !sess.target.is_like_android
-        && !sess.opts.unstable_opts.external_clangrt
-        && match crate_type {
-            CrateType::Executable => true,
-            CrateType::Dylib | CrateType::Cdylib | CrateType::ProcMacro => {
-                sess.target.is_like_osx || sess.target.is_like_msvc
-            }
-            CrateType::Rlib | CrateType::Staticlib => false,
-        };
+    if sess.target.is_like_android {
+        // Sanitizer runtime libraries are provided dynamically on Android
+        // targets.
+        return;
+    }
 
-    if !needs_runtime {
+    if sess.opts.unstable_opts.external_clangrt {
+        // Linking against in-tree sanitizer runtimes is disabled via
+        // `-Z external-clangrt`
+        return;
+    }
+
+    // On macOS the runtimes are distributed as dylibs which should be linked to
+    // both executables and dynamic shared objects. On most other platforms the
+    // runtimes are currently distributed as static libraries which should be
+    // linked to executables only.
+    if matches!(crate_type, CrateType::Rlib | CrateType::Staticlib) {
+        return;
+    }
+
+    if matches!(crate_type, CrateType::Dylib | CrateType::Cdylib | CrateType::ProcMacro)
+        && (sess.target.is_like_osx || sess.target.is_like_msvc)
+    {
         return;
     }
 

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1206,6 +1206,7 @@ fn add_sanitizer_libraries(
     // Everywhere else the runtimes are currently distributed as static
     // libraries which should be linked to executables only.
     let needs_runtime = !sess.target.is_like_android
+        && !sess.opts.unstable_opts.external_clangrt
         && match crate_type {
             CrateType::Executable => true,
             CrateType::Dylib | CrateType::Cdylib | CrateType::ProcMacro => {

--- a/compiler/rustc_hir_analysis/src/astconv/lint.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/lint.rs
@@ -8,7 +8,7 @@ use rustc_trait_selection::traits::error_reporting::suggestions::NextTypeParamNa
 
 use super::AstConv;
 
-impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
+impl<'tcx> dyn AstConv<'tcx> + '_ {
     /// Make sure that we are in the condition to suggest the blanket implementation.
     pub(super) fn maybe_lint_blanket_trait_impl<G: EmissionGuarantee>(
         &self,

--- a/compiler/rustc_hir_analysis/src/astconv/object_safety.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/object_safety.rs
@@ -17,7 +17,7 @@ use smallvec::{smallvec, SmallVec};
 
 use super::AstConv;
 
-impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
+impl<'tcx> dyn AstConv<'tcx> + '_ {
     pub(super) fn conv_object_ty_poly_trait_ref(
         &self,
         span: Span,

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -595,12 +595,14 @@ fn convert_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
             tcx.ensure().type_of(def_id);
             tcx.ensure().impl_trait_header(def_id);
             tcx.ensure().predicates_of(def_id);
+            tcx.ensure().associated_items(def_id);
         }
         hir::ItemKind::Trait(..) => {
             tcx.ensure().generics_of(def_id);
             tcx.ensure().trait_def(def_id);
             tcx.at(it.span).super_predicates_of(def_id);
             tcx.ensure().predicates_of(def_id);
+            tcx.ensure().associated_items(def_id);
         }
         hir::ItemKind::TraitAlias(..) => {
             tcx.ensure().generics_of(def_id);

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -108,8 +108,7 @@ fn anon_const_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
                 .unwrap()
                 .0
                 .def_id;
-            let item_ctxt = &ItemCtxt::new(tcx, item_def_id) as &dyn crate::astconv::AstConv<'_>;
-            let ty = item_ctxt.ast_ty_to_ty(hir_ty);
+            let ty = ItemCtxt::new(tcx, item_def_id).to_ty(hir_ty);
 
             // Iterate through the generics of the projection to find the one that corresponds to
             // the def_id that this query was called with. We filter to only type and const args here

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -99,18 +99,15 @@ pub mod structured_errors;
 mod variance;
 
 use rustc_hir as hir;
+use rustc_hir::def::DefKind;
 use rustc_middle::middle;
 use rustc_middle::query::Providers;
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_middle::util;
 use rustc_session::parse::feature_err;
-use rustc_span::{symbol::sym, Span, DUMMY_SP};
+use rustc_span::{symbol::sym, Span};
 use rustc_target::spec::abi::Abi;
 use rustc_trait_selection::traits;
-
-use astconv::{AstConv, OnlySelfBounds};
-use bounds::Bounds;
-use rustc_hir::def::DefKind;
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
 
@@ -200,31 +197,5 @@ pub fn hir_ty_to_ty<'tcx>(tcx: TyCtxt<'tcx>, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx>
     // def-ID that will be used to determine the traits/predicates in
     // scope. This is derived from the enclosing item-like thing.
     let env_def_id = tcx.hir().get_parent_item(hir_ty.hir_id);
-    let item_cx = self::collect::ItemCtxt::new(tcx, env_def_id.def_id);
-    item_cx.astconv().ast_ty_to_ty(hir_ty)
-}
-
-pub fn hir_trait_to_predicates<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    hir_trait: &hir::TraitRef<'tcx>,
-    self_ty: Ty<'tcx>,
-) -> Bounds<'tcx> {
-    // In case there are any projections, etc., find the "environment"
-    // def-ID that will be used to determine the traits/predicates in
-    // scope. This is derived from the enclosing item-like thing.
-    let env_def_id = tcx.hir().get_parent_item(hir_trait.hir_ref_id);
-    let item_cx = self::collect::ItemCtxt::new(tcx, env_def_id.def_id);
-    let mut bounds = Bounds::default();
-    let _ = &item_cx.astconv().instantiate_poly_trait_ref(
-        hir_trait,
-        DUMMY_SP,
-        ty::BoundConstness::NotConst,
-        ty::ImplPolarity::Positive,
-        self_ty,
-        &mut bounds,
-        true,
-        OnlySelfBounds(false),
-    );
-
-    bounds
+    collect::ItemCtxt::new(tcx, env_def_id.def_id).to_ty(hir_ty)
 }

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -780,7 +780,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         decl: &hir::FnDecl<'tcx>,
         closure_kind: hir::ClosureKind,
     ) -> ty::PolyFnSig<'tcx> {
-        let astconv: &dyn AstConv<'_> = self;
+        let astconv = self.astconv();
 
         trace!("decl = {:#?}", decl);
         debug!(?closure_kind);
@@ -985,7 +985,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         decl: &hir::FnDecl<'tcx>,
         guar: ErrorGuaranteed,
     ) -> ty::PolyFnSig<'tcx> {
-        let astconv: &dyn AstConv<'_> = self;
+        let astconv = self.astconv();
         let err_ty = Ty::new_error(self.tcx, guar);
 
         let supplied_arguments = decl.inputs.iter().map(|a| {

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -1071,7 +1071,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     err.span_suggestion_verbose(
                         *span,
                         "use the type name directly",
-                        self.tcx.value_path_str_with_args(*alias_to, e_args),
+                        self.tcx.value_path_str_with_args(e_def.did(), e_args),
                         Applicability::MaybeIncorrect,
                     );
                 }

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -321,9 +321,13 @@ pub enum ExprKind<'tcx> {
     Cast {
         source: ExprId,
     },
+    /// Forces its contents to be treated as a value expression, not a place
+    /// expression. This is inserted in some places where an operation would
+    /// otherwise be erased completely (e.g. some no-op casts), but we still
+    /// need to ensure that its operand is treated as a value and not a place.
     Use {
         source: ExprId,
-    }, // Use a lexpr to get a vexpr.
+    },
     /// A coercion from `!` to any type.
     NeverToAny {
         source: ExprId,
@@ -338,6 +342,13 @@ pub enum ExprKind<'tcx> {
     Loop {
         body: ExprId,
     },
+    /// Special expression representing the `let` part of an `if let` or similar construct
+    /// (including `if let` guards in match arms, and let-chains formed by `&&`).
+    ///
+    /// This isn't considered a real expression in surface Rust syntax, so it can
+    /// only appear in specific situations, such as within the condition of an `if`.
+    ///
+    /// (Not to be confused with [`StmtKind::Let`], which is a normal `let` statement.)
     Let {
         expr: ExprId,
         pat: Box<Pat<'tcx>>,

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -393,7 +393,9 @@ impl<'a, 'tcx> ConstAnalysis<'a, 'tcx> {
                 }
             }
             Operand::Constant(box constant) => {
-                if let Ok(constant) = self.ecx.eval_mir_constant(&constant.const_, None, None) {
+                if let Ok(constant) =
+                    self.ecx.eval_mir_constant(&constant.const_, Some(constant.span), None)
+                {
                     self.assign_constant(state, place, constant, &[]);
                 }
             }

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -416,7 +416,8 @@ impl<'tcx, 'a> TOFinder<'tcx, 'a> {
         match rhs {
             // If we expect `lhs ?= A`, we have an opportunity if we assume `constant == A`.
             Operand::Constant(constant) => {
-                let constant = self.ecx.eval_mir_constant(&constant.const_, None, None).ok()?;
+                let constant =
+                    self.ecx.eval_mir_constant(&constant.const_, Some(constant.span), None).ok()?;
                 self.process_constant(bb, lhs, constant, state);
             }
             // Transfer the conditions on the copied rhs.

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -828,14 +828,17 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
         // a codegen-time error). rustc stops after collection if there was an error, so this
         // ensures codegen never has to worry about failing consts.
         // (codegen relies on this and ICEs will happen if this is violated.)
-        let val = match const_.eval(self.tcx, param_env, None) {
+        let val = match const_.eval(self.tcx, param_env, Some(constant.span)) {
             Ok(v) => v,
-            Err(ErrorHandled::Reported(..)) => return,
             Err(ErrorHandled::TooGeneric(..)) => span_bug!(
                 self.body.source_info(location).span,
                 "collection encountered polymorphic constant: {:?}",
                 const_
             ),
+            Err(err @ ErrorHandled::Reported(..)) => {
+                err.emit_note(self.tcx);
+                return;
+            }
         };
         collect_const_value(self.tcx, val, self.output);
         MirVisitor::visit_ty(self, const_.ty(), TyContext::Location(location));

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1645,6 +1645,8 @@ options! {
         "emit the bc module with thin LTO info (default: yes)"),
     export_executable_symbols: bool = (false, parse_bool, [TRACKED],
         "export symbols from executables, as if they were dynamic libraries"),
+    external_clangrt: bool = (false, parse_bool, [UNTRACKED],
+        "rely on user specified linker commands to find clangrt"),
     extra_const_ub_checks: bool = (false, parse_bool, [TRACKED],
         "turns on more checks to detect const UB, which can be slow (default: no)"),
     #[rustc_lint_opt_deny_field_access("use `Session::fewer_names` instead of this field")]

--- a/compiler/rustc_smir/src/rustc_smir/builder.rs
+++ b/compiler/rustc_smir/src/rustc_smir/builder.rs
@@ -56,7 +56,7 @@ impl<'tcx> MutVisitor<'tcx> for BodyBuilder<'tcx> {
 
     fn visit_constant(&mut self, constant: &mut mir::ConstOperand<'tcx>, location: mir::Location) {
         let const_ = self.monomorphize(constant.const_);
-        let val = match const_.eval(self.tcx, ty::ParamEnv::reveal_all(), None) {
+        let val = match const_.eval(self.tcx, ty::ParamEnv::reveal_all(), Some(constant.span)) {
             Ok(v) => v,
             Err(mir::interpret::ErrorHandled::Reported(..)) => return,
             Err(mir::interpret::ErrorHandled::TooGeneric(..)) => {

--- a/tests/ui/consts/assoc_const_generic_impl.stderr
+++ b/tests/ui/consts/assoc_const_generic_impl.stderr
@@ -4,6 +4,12 @@ error[E0080]: evaluation of `<u32 as ZeroSized>::I_AM_ZERO_SIZED` failed
 LL |     const I_AM_ZERO_SIZED: ()  = [()][std::mem::size_of::<Self>()];
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 4
 
+note: erroneous constant encountered
+  --> $DIR/assoc_const_generic_impl.rs:11:9
+   |
+LL |         Self::I_AM_ZERO_SIZED;
+   |         ^^^^^^^^^^^^^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn <u32 as ZeroSized>::requires_zero_size`
   --> $DIR/assoc_const_generic_impl.rs:18:5
    |

--- a/tests/ui/consts/const-eval/index-out-of-bounds-never-type.stderr
+++ b/tests/ui/consts/const-eval/index-out-of-bounds-never-type.stderr
@@ -4,6 +4,12 @@ error[E0080]: evaluation of `PrintName::<()>::VOID` failed
 LL |     const VOID: ! = { let x = 0 * std::mem::size_of::<T>(); [][x] };
    |                                                             ^^^^^ index out of bounds: the length is 0 but the index is 0
 
+note: erroneous constant encountered
+  --> $DIR/index-out-of-bounds-never-type.rs:16:13
+   |
+LL |     let _ = PrintName::<T>::VOID;
+   |             ^^^^^^^^^^^^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn f::<()>`
   --> $DIR/index-out-of-bounds-never-type.rs:20:5
    |

--- a/tests/ui/consts/const-eval/issue-50814-2.mir-opt.stderr
+++ b/tests/ui/consts/const-eval/issue-50814-2.mir-opt.stderr
@@ -10,6 +10,52 @@ note: erroneous constant encountered
 LL |     &<A<T> as Foo<T>>::BAR
    |      ^^^^^^^^^^^^^^^^^^^^^
 
+note: erroneous constant encountered
+  --> $DIR/issue-50814-2.rs:20:5
+   |
+LL |     &<A<T> as Foo<T>>::BAR
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/issue-50814-2.rs:20:5
+   |
+LL |     &<A<T> as Foo<T>>::BAR
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-50814-2.rs:20:5
+   |
+LL |     &<A<T> as Foo<T>>::BAR
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-50814-2.rs:20:5
+   |
+LL |     &<A<T> as Foo<T>>::BAR
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-50814-2.rs:20:6
+   |
+LL |     &<A<T> as Foo<T>>::BAR
+   |      ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-50814-2.rs:20:6
+   |
+LL |     &<A<T> as Foo<T>>::BAR
+   |      ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-eval/issue-50814-2.normal.stderr
+++ b/tests/ui/consts/const-eval/issue-50814-2.normal.stderr
@@ -10,6 +10,20 @@ note: erroneous constant encountered
 LL |     &<A<T> as Foo<T>>::BAR
    |      ^^^^^^^^^^^^^^^^^^^^^
 
+note: erroneous constant encountered
+  --> $DIR/issue-50814-2.rs:20:5
+   |
+LL |     &<A<T> as Foo<T>>::BAR
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/issue-50814-2.rs:20:6
+   |
+LL |     &<A<T> as Foo<T>>::BAR
+   |      ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 note: the above error was encountered while instantiating `fn foo::<()>`
   --> $DIR/issue-50814-2.rs:32:22
    |

--- a/tests/ui/consts/const-eval/issue-50814.stderr
+++ b/tests/ui/consts/const-eval/issue-50814.stderr
@@ -26,6 +26,20 @@ LL |     &Sum::<U8, U8>::MAX
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
+note: erroneous constant encountered
+  --> $DIR/issue-50814.rs:21:5
+   |
+LL |     &Sum::<U8, U8>::MAX
+   |     ^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/issue-50814.rs:21:6
+   |
+LL |     &Sum::<U8, U8>::MAX
+   |      ^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 note: the above error was encountered while instantiating `fn foo::<i32>`
   --> $DIR/issue-50814.rs:26:5
    |

--- a/tests/ui/consts/const-eval/issue-85155.stderr
+++ b/tests/ui/consts/const-eval/issue-85155.stderr
@@ -4,6 +4,14 @@ error[E0080]: evaluation of `post_monomorphization_error::ValidateConstImm::<2, 
 LL |         let _ = 1 / ((IMM >= MIN && IMM <= MAX) as usize);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to divide `1_usize` by zero
 
+note: erroneous constant encountered
+  --> $DIR/auxiliary/post_monomorphization_error.rs:19:5
+   |
+LL |     static_assert_imm1!(IMM1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `static_assert_imm1` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 note: the above error was encountered while instantiating `fn post_monomorphization_error::stdarch_intrinsic::<2>`
   --> $DIR/issue-85155.rs:19:5
    |

--- a/tests/ui/consts/required-consts/collect-in-called-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-called-fn.noopt.stderr
@@ -6,6 +6,12 @@ LL |     const C: () = panic!();
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/collect-in-called-fn.rs:18:17
+   |
+LL |         let _ = Fail::<T>::C;
+   |                 ^^^^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn called::<i32>`
   --> $DIR/collect-in-called-fn.rs:23:5
    |

--- a/tests/ui/consts/required-consts/collect-in-called-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-called-fn.opt.stderr
@@ -6,6 +6,12 @@ LL |     const C: () = panic!();
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/collect-in-called-fn.rs:18:17
+   |
+LL |         let _ = Fail::<T>::C;
+   |                 ^^^^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn called::<i32>`
   --> $DIR/collect-in-called-fn.rs:23:5
    |

--- a/tests/ui/consts/required-consts/collect-in-dead-drop.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-drop.noopt.stderr
@@ -6,6 +6,12 @@ LL |     const C: () = panic!();
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/collect-in-dead-drop.rs:19:17
+   |
+LL |         let _ = Fail::<T>::C;
+   |                 ^^^^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn <Fail<i32> as std::ops::Drop>::drop`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn.noopt.stderr
@@ -6,6 +6,12 @@ LL |     const C: () = panic!();
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/collect-in-dead-fn.rs:22:17
+   |
+LL |         let _ = Fail::<T>::C;
+   |                 ^^^^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn not_called::<i32>`
   --> $DIR/collect-in-dead-fn.rs:29:9
    |

--- a/tests/ui/consts/required-consts/collect-in-dead-move.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-move.noopt.stderr
@@ -6,6 +6,12 @@ LL |     const C: () = panic!();
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/collect-in-dead-move.rs:19:17
+   |
+LL |         let _ = Fail::<T>::C;
+   |                 ^^^^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn <Fail<i32> as std::ops::Drop>::drop`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 

--- a/tests/ui/consts/required-consts/collect-in-dead-vtable.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-vtable.noopt.stderr
@@ -6,6 +6,12 @@ LL |     const C: () = panic!();
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/collect-in-dead-vtable.rs:26:21
+   |
+LL |             let _ = Fail::<T>::C;
+   |                     ^^^^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn <std::vec::Vec<i32> as MyTrait>::not_called`
   --> $DIR/collect-in-dead-vtable.rs:35:40
    |

--- a/tests/ui/generics/post_monomorphization_error_backtrace.rs
+++ b/tests/ui/generics/post_monomorphization_error_backtrace.rs
@@ -12,6 +12,9 @@ fn assert_zst<T>() {
         //~| NOTE: the evaluated program panicked
     }
     F::<T>::V;
+    //~^NOTE: erroneous constant
+    //~|NOTE: erroneous constant
+    //~|NOTE: duplicate
 }
 
 fn foo<U>() {

--- a/tests/ui/generics/post_monomorphization_error_backtrace.stderr
+++ b/tests/ui/generics/post_monomorphization_error_backtrace.stderr
@@ -6,8 +6,14 @@ LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/post_monomorphization_error_backtrace.rs:14:5
+   |
+LL |     F::<T>::V;
+   |     ^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn assert_zst::<u32>`
-  --> $DIR/post_monomorphization_error_backtrace.rs:18:5
+  --> $DIR/post_monomorphization_error_backtrace.rs:21:5
    |
 LL |     assert_zst::<U>()
    |     ^^^^^^^^^^^^^^^^^
@@ -20,8 +26,16 @@ LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/post_monomorphization_error_backtrace.rs:14:5
+   |
+LL |     F::<T>::V;
+   |     ^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 note: the above error was encountered while instantiating `fn assert_zst::<i32>`
-  --> $DIR/post_monomorphization_error_backtrace.rs:18:5
+  --> $DIR/post_monomorphization_error_backtrace.rs:21:5
    |
 LL |     assert_zst::<U>()
    |     ^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-trait/in-trait/ensure-rpitits-are-created-before-freezing.rs
+++ b/tests/ui/impl-trait/in-trait/ensure-rpitits-are-created-before-freezing.rs
@@ -1,0 +1,13 @@
+trait Iterable {
+    type Item;
+    fn iter(&self) -> impl Sized;
+}
+
+// `ty::Error` in a trait ref will silence any missing item errors, but will also
+// prevent the `associated_items` query from being called before def ids are frozen.
+impl Iterable for Missing {
+//~^ ERROR cannot find type `Missing` in this scope
+    fn iter(&self) -> Self::Item {}
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/ensure-rpitits-are-created-before-freezing.stderr
+++ b/tests/ui/impl-trait/in-trait/ensure-rpitits-are-created-before-freezing.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/ensure-rpitits-are-created-before-freezing.rs:8:19
+   |
+LL | impl Iterable for Missing {
+   |                   ^^^^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/inline-const/const-expr-generic-err.stderr
+++ b/tests/ui/inline-const/const-expr-generic-err.stderr
@@ -6,6 +6,12 @@ LL |     const { assert!(std::mem::size_of::<T>() == 0); }
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/const-expr-generic-err.rs:5:5
+   |
+LL |     const { assert!(std::mem::size_of::<T>() == 0); }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn foo::<i32>`
   --> $DIR/const-expr-generic-err.rs:13:5
    |
@@ -17,6 +23,20 @@ error[E0080]: evaluation of `bar::<0>::{constant#0}` failed
    |
 LL |     const { N - 1 }
    |             ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-expr-generic-err.rs:9:5
+   |
+LL |     const { N - 1 }
+   |     ^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/const-expr-generic-err.rs:9:5
+   |
+LL |     const { N - 1 }
+   |     ^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: the above error was encountered while instantiating `fn bar::<0>`
   --> $DIR/const-expr-generic-err.rs:14:5

--- a/tests/ui/inline-const/required-const.stderr
+++ b/tests/ui/inline-const/required-const.stderr
@@ -6,6 +6,12 @@ LL |         const { panic!() }
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/required-const.rs:7:9
+   |
+LL |         const { panic!() }
+   |         ^^^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/simd/const-err-trumps-simd-err.stderr
+++ b/tests/ui/simd/const-err-trumps-simd-err.stderr
@@ -6,6 +6,12 @@ LL |     const { assert!(LANE < 4); } // the error should be here...
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/const-err-trumps-simd-err.rs:16:5
+   |
+LL |     const { assert!(LANE < 4); } // the error should be here...
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn get_elem::<4>`
   --> $DIR/const-err-trumps-simd-err.rs:23:5
    |

--- a/tests/ui/suggestions/clone-bounds-121524.rs
+++ b/tests/ui/suggestions/clone-bounds-121524.rs
@@ -1,0 +1,19 @@
+#[derive(Clone)]
+struct ThingThatDoesAThing;
+
+trait DoesAThing {}
+
+impl DoesAThing for ThingThatDoesAThing {}
+
+fn clones_impl_ref_inline(thing: &impl DoesAThing) {
+    //~^ HELP consider further restricting this bound
+    drops_impl_owned(thing.clone()); //~ ERROR E0277
+    //~^ NOTE copies the reference
+    //~| NOTE the trait `DoesAThing` is not implemented for `&impl DoesAThing`
+}
+
+fn drops_impl_owned(_thing: impl DoesAThing) { }
+
+fn main() {
+    clones_impl_ref_inline(&ThingThatDoesAThing);
+}

--- a/tests/ui/suggestions/clone-bounds-121524.stderr
+++ b/tests/ui/suggestions/clone-bounds-121524.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `&impl DoesAThing: DoesAThing` is not satisfied
+  --> $DIR/clone-bounds-121524.rs:10:22
+   |
+LL |     drops_impl_owned(thing.clone());
+   |                      ^^^^^^^^^^^^^ the trait `DoesAThing` is not implemented for `&impl DoesAThing`
+   |
+note: this `clone()` copies the reference, which does not do anything, because `impl DoesAThing` does not implement `Clone`
+  --> $DIR/clone-bounds-121524.rs:10:28
+   |
+LL |     drops_impl_owned(thing.clone());
+   |                            ^^^^^
+help: consider further restricting this bound
+   |
+LL | fn clones_impl_ref_inline(thing: &impl DoesAThing + Clone) {
+   |                                                   +++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/typeck/ice-self-mismatch-const-generics.rs
+++ b/tests/ui/typeck/ice-self-mismatch-const-generics.rs
@@ -1,0 +1,25 @@
+// Checks that the following does not ICE when constructing type mismatch diagnostic involving
+// `Self` and const generics.
+// Issue: <https://github.com/rust-lang/rust/issues/122467>
+
+pub struct GenericStruct<const N: usize, T> {
+    thing: T,
+}
+
+impl<T> GenericStruct<0, T> {
+    pub fn new(thing: T) -> GenericStruct<1, T> {
+        Self { thing }
+        //~^ ERROR mismatched types
+    }
+}
+
+pub struct GenericStruct2<const M: usize, T>(T);
+
+impl<T> GenericStruct2<0, T> {
+    pub fn new(thing: T) -> GenericStruct2<1, T> {
+        Self { 0: thing }
+        //~^ ERROR mismatched types
+    }
+}
+
+fn main() {}

--- a/tests/ui/typeck/ice-self-mismatch-const-generics.stderr
+++ b/tests/ui/typeck/ice-self-mismatch-const-generics.stderr
@@ -1,0 +1,37 @@
+error[E0308]: mismatched types
+  --> $DIR/ice-self-mismatch-const-generics.rs:11:9
+   |
+LL | impl<T> GenericStruct<0, T> {
+   |         ------------------- this is the type of the `Self` literal
+LL |     pub fn new(thing: T) -> GenericStruct<1, T> {
+   |                             ------------------- expected `GenericStruct<1, T>` because of return type
+LL |         Self { thing }
+   |         ^^^^^^^^^^^^^^ expected `1`, found `0`
+   |
+   = note: expected struct `GenericStruct<_, 1>`
+              found struct `GenericStruct<_, 0>`
+help: use the type name directly
+   |
+LL |         GenericStruct::<1, T> { thing }
+   |         ~~~~~~~~~~~~~~~~~~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/ice-self-mismatch-const-generics.rs:20:9
+   |
+LL | impl<T> GenericStruct2<0, T> {
+   |         -------------------- this is the type of the `Self` literal
+LL |     pub fn new(thing: T) -> GenericStruct2<1, T> {
+   |                             -------------------- expected `GenericStruct2<1, T>` because of return type
+LL |         Self { 0: thing }
+   |         ^^^^^^^^^^^^^^^^^ expected `1`, found `0`
+   |
+   = note: expected struct `GenericStruct2<_, 1>`
+              found struct `GenericStruct2<_, 0>`
+help: use the type name directly
+   |
+LL |         GenericStruct2::<1, T> { 0: thing }
+   |         ~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #121207 (Add `-Z external-clangrt`)
 - #122174 (diagnostics: suggest `Clone` bounds when noop `clone()`)
 - #122471 (preserve span when evaluating mir::ConstOperand)
 - #122515 (Pass the correct DefId when suggesting writing the aliased Self type out)
 - #122523 (Ensure RPITITs are created before def-id freezing)
 - #122526 (Docs for `thir::ExprKind::Use` and `thir::ExprKind::Let`)
 - #122527 (Clean up AstConv)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=121207,122174,122471,122515,122523,122526,122527)
<!-- homu-ignore:end -->