### PR TITLE
Improve documentation of hir::EnumKind::Let to make it obvious that it is not a `let` statement

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1848,10 +1848,10 @@ pub enum ExprKind<'hir> {
     /// This construct only exists to tweak the drop order in HIR lowering.
     /// An example of that is the desugaring of `for` loops.
     DropTemps(&'hir Expr<'hir>),
-    /// A `let $pat = $expr` expression.
-    ///
-    /// These are not `Local` and only occur as expressions.
+    /// These are not [`Local`] and only occur as expressions.
     /// The `let Some(x) = foo()` in `if let Some(x) = foo()` is an example of `Let(..)`.
+    ///
+    /// A `let $pat = $expr` expression.
     Let(&'hir Let<'hir>),
     /// An `if` block, with an optional else block.
     ///


### PR DESCRIPTION
The short description (which is displayed in search results) will now mention that it is not the `let` statement.

r? @oli-obk 