### PR TITLE
Do not use `?`-induced skewing of type inference in the compiler

### DIFF
--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -189,7 +189,7 @@ pub fn parse_asm_args<'a>(
             args.templates.push(template);
             continue;
         } else {
-            return p.unexpected();
+            p.unexpected_any()?
         };
 
         allow_templates = false;

--- a/compiler/rustc_builtin_macros/src/assert.rs
+++ b/compiler/rustc_builtin_macros/src/assert.rs
@@ -151,7 +151,7 @@ fn parse_assert<'a>(cx: &mut ExtCtxt<'a>, sp: Span, stream: TokenStream) -> PRes
         };
 
     if parser.token != token::Eof {
-        return parser.unexpected();
+        parser.unexpected()?;
     }
 
     Ok(Assert { cond_expr, custom_message })

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -12,6 +12,7 @@
 #![feature(proc_macro_internals)]
 #![feature(proc_macro_span)]
 #![feature(try_blocks)]
+#![feature(yeet_expr)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(internal_features)]
 

--- a/compiler/rustc_expand/src/module.rs
+++ b/compiler/rustc_expand/src/module.rs
@@ -62,7 +62,7 @@ pub(crate) fn parse_external_mod(
 
         // Ensure file paths are acyclic.
         if let Some(pos) = module.file_path_stack.iter().position(|p| p == &mp.file_path) {
-            Err(ModError::CircularInclusion(module.file_path_stack[pos..].to_vec()))?;
+            do yeet ModError::CircularInclusion(module.file_path_stack[pos..].to_vec());
         }
 
         // Actually parse the external file as a module.

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -990,7 +990,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
             let generics_def_id = tcx.res_generics_def_id(path.res)?;
             let generics = tcx.generics_of(generics_def_id);
             if generics.has_impl_trait() {
-                None?;
+                do yeet ();
             }
             let insert_span =
                 path.segments.last().unwrap().ident.span.shrink_to_hi().with_hi(path.span.hi());
@@ -1044,7 +1044,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
                 let generics = tcx.generics_of(def_id);
                 let segment: Option<_> = try {
                     if !segment.infer_args || generics.has_impl_trait() {
-                        None?;
+                        do yeet ();
                     }
                     let span = tcx.hir().span(segment.hir_id);
                     let insert_span = segment.ident.span.shrink_to_hi().with_hi(span.hi());

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -27,6 +27,7 @@
 #![feature(iterator_try_collect)]
 #![cfg_attr(bootstrap, feature(min_specialization))]
 #![feature(try_blocks)]
+#![feature(yeet_expr)]
 #![recursion_limit = "512"] // For rustdoc
 
 #[macro_use]

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -380,12 +380,12 @@ impl<'a> Parser<'a> {
         };
 
         if let Some(item) = nt_meta {
-            return match item.meta(item.path.span) {
+            match item.meta(item.path.span) {
                 Some(meta) => {
                     self.bump();
-                    Ok(meta)
+                    return Ok(meta);
                 }
-                None => self.unexpected(),
+                None => self.unexpected()?,
             };
         }
 

--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -481,7 +481,7 @@ impl<'a> Parser<'a> {
             }))
         } else {
             self.maybe_recover_bounds_doubled_colon(&ty)?;
-            self.unexpected()
+            self.unexpected_any()
         }
     }
 

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1514,7 +1514,7 @@ impl<'a> Parser<'a> {
                 let ident = this.parse_field_ident("enum", vlo)?;
 
                 if this.token == token::Not {
-                    if let Err(err) = this.unexpected::<()>() {
+                    if let Err(err) = this.unexpected() {
                         err.with_note(fluent::parse_macro_expands_to_enum_variant).emit();
                     }
 
@@ -1937,7 +1937,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, FieldDef> {
         let name = self.parse_field_ident(adt_ty, lo)?;
         if self.token.kind == token::Not {
-            if let Err(mut err) = self.unexpected::<FieldDef>() {
+            if let Err(mut err) = self.unexpected() {
                 // Encounter the macro invocation
                 err.subdiagnostic(self.dcx(), MacroExpandsToAdtField { adt_ty });
                 return Err(err);
@@ -2067,7 +2067,7 @@ impl<'a> Parser<'a> {
             let params = self.parse_token_tree(); // `MacParams`
             let pspan = params.span();
             if !self.check(&token::OpenDelim(Delimiter::Brace)) {
-                return self.unexpected();
+                self.unexpected()?;
             }
             let body = self.parse_token_tree(); // `MacBody`
             // Convert `MacParams MacBody` into `{ MacParams => MacBody }`.
@@ -2077,7 +2077,7 @@ impl<'a> Parser<'a> {
             let dspan = DelimSpan::from_pair(pspan.shrink_to_lo(), bspan.shrink_to_hi());
             P(DelimArgs { dspan, delim: Delimiter::Brace, tokens })
         } else {
-            return self.unexpected();
+            self.unexpected_any()?
         };
 
         self.psess.gated_spans.gate(sym::decl_macro, lo.to(self.prev_token.span));
@@ -2692,7 +2692,7 @@ impl<'a> Parser<'a> {
                 debug!("parse_param_general parse_pat (is_name_required:{})", is_name_required);
                 let (pat, colon) = this.parse_fn_param_pat_colon()?;
                 if !colon {
-                    let mut err = this.unexpected::<()>().unwrap_err();
+                    let mut err = this.unexpected().unwrap_err();
                     return if let Some(ident) =
                         this.parameter_without_type(&mut err, pat, is_name_required, first_param)
                     {
@@ -2716,7 +2716,7 @@ impl<'a> Parser<'a> {
                 {
                     // This wasn't actually a type, but a pattern looking like a type,
                     // so we are going to rollback and re-parse for recovery.
-                    ty = this.unexpected();
+                    ty = this.unexpected_any();
                 }
                 match ty {
                     Ok(ty) => {

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -465,13 +465,19 @@ impl<'a> Parser<'a> {
         matches!(self.recovery, Recovery::Allowed)
     }
 
-    pub fn unexpected<T>(&mut self) -> PResult<'a, T> {
+    /// Version of [`unexpected`](Parser::unexpected) that "returns" any type in the `Ok`
+    /// (both those functions never return "Ok", and so can lie like that in the type).
+    pub fn unexpected_any<T>(&mut self) -> PResult<'a, T> {
         match self.expect_one_of(&[], &[]) {
             Err(e) => Err(e),
             // We can get `Ok(true)` from `recover_closing_delimiter`
             // which is called in `expected_one_of_not_found`.
             Ok(_) => FatalError.raise(),
         }
+    }
+
+    pub fn unexpected(&mut self) -> PResult<'a, ()> {
+        self.unexpected_any()
     }
 
     /// Expects and consumes the token `t`. Signals an error if the next token is not `t`.
@@ -1278,7 +1284,11 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_delim_args(&mut self) -> PResult<'a, P<DelimArgs>> {
-        if let Some(args) = self.parse_delim_args_inner() { Ok(P(args)) } else { self.unexpected() }
+        if let Some(args) = self.parse_delim_args_inner() {
+            Ok(P(args))
+        } else {
+            self.unexpected_any()
+        }
     }
 
     fn parse_attr_args(&mut self) -> PResult<'a, AttrArgs> {

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -660,7 +660,7 @@ impl<'a> Parser<'a> {
                     // Add `>` to the list of expected tokens.
                     self.check(&token::Gt);
                     // Handle `,` to `;` substitution
-                    let mut err = self.unexpected::<()>().unwrap_err();
+                    let mut err = self.unexpected().unwrap_err();
                     self.bump();
                     err.span_suggestion_verbose(
                         self.prev_token.span.until(self.token.span),


### PR DESCRIPTION
This prevents breakage from #122412 and is generally a good idea.

r? @estebank 