### PR TITLE
Ignore paths from expansion in `unused_qualifications`

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4672,7 +4672,9 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
             return;
         }
 
-        if path.iter().any(|seg| seg.ident.span.from_expansion()) {
+        if finalize.path_span.from_expansion()
+            || path.iter().any(|seg| seg.ident.span.from_expansion())
+        {
             return;
         }
 

--- a/tests/ui/lint/lint-qualification.fixed
+++ b/tests/ui/lint/lint-qualification.fixed
@@ -35,6 +35,7 @@ fn main() {
         foo::bar();
         foo::$b(); // issue #96698
         $a::bar();
+        $a::$b();
     } }
     m!(foo, bar);
 }

--- a/tests/ui/lint/lint-qualification.rs
+++ b/tests/ui/lint/lint-qualification.rs
@@ -35,6 +35,7 @@ fn main() {
         foo::bar();
         foo::$b(); // issue #96698
         $a::bar();
+        $a::$b();
     } }
     m!(foo, bar);
 }


### PR DESCRIPTION
If any of the path segments are from an expansion the lint is skipped currently, but a path from an expansion where all of the segments are passed in would not be. Doesn't seem that likely to occur but it could happen