### PR TITLE
Extend format arg help for simple tuple index access expression

### DIFF
--- a/tests/ui/fmt/format-args-non-identifier-diagnostics.fixed
+++ b/tests/ui/fmt/format-args-non-identifier-diagnostics.fixed
@@ -1,0 +1,10 @@
+// Checks that there is a suggestion for simple tuple index access expression (used where an
+// identifier is expected in a format arg) to use positional arg instead.
+// Issue: <https://github.com/rust-lang/rust/issues/122535>.
+//@ run-rustfix
+
+fn main() {
+    let x = (1,);
+    println!("{0}", x.0);
+    //~^ ERROR invalid format string
+}

--- a/tests/ui/fmt/format-args-non-identifier-diagnostics.rs
+++ b/tests/ui/fmt/format-args-non-identifier-diagnostics.rs
@@ -1,0 +1,10 @@
+// Checks that there is a suggestion for simple tuple index access expression (used where an
+// identifier is expected in a format arg) to use positional arg instead.
+// Issue: <https://github.com/rust-lang/rust/issues/122535>.
+//@ run-rustfix
+
+fn main() {
+    let x = (1,);
+    println!("{x.0}");
+    //~^ ERROR invalid format string
+}

--- a/tests/ui/fmt/format-args-non-identifier-diagnostics.stderr
+++ b/tests/ui/fmt/format-args-non-identifier-diagnostics.stderr
@@ -1,0 +1,13 @@
+error: invalid format string: tuple index access isn't supported
+  --> $DIR/format-args-non-identifier-diagnostics.rs:8:16
+   |
+LL |     println!("{x.0}");
+   |                ^^^ not supported in format string
+   |
+help: consider using a positional formatting argument instead
+   |
+LL |     println!("{0}", x.0);
+   |                ~  +++++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
The help is only applicable for simple field access `a.b` and (with this PR) simple tuple index access expressions `a.0`.

Closes #122535.