### PR TITLE
Safe Transmute: Use 'not yet supported', not 'unspecified' in errors

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -3082,20 +3082,20 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     }
 
                     rustc_transmute::Reason::DstIsBitIncompatible => {
-                        format!("At least one value of `{src}` isn't a bit-valid value of `{dst}`")
+                        format!("at least one value of `{src}` isn't a bit-valid value of `{dst}`")
                     }
 
                     rustc_transmute::Reason::DstMayHaveSafetyInvariants => {
                         format!("`{dst}` may carry safety invariants")
                     }
                     rustc_transmute::Reason::DstIsTooBig => {
-                        format!("The size of `{src}` is smaller than the size of `{dst}`")
+                        format!("the size of `{src}` is smaller than the size of `{dst}`")
                     }
                     rustc_transmute::Reason::DstRefIsTooBig { src, dst } => {
                         let src_size = src.size;
                         let dst_size = dst.size;
                         format!(
-                            "The referent size of `{src}` ({src_size} bytes) is smaller than that of `{dst}` ({dst_size} bytes)"
+                            "the referent size of `{src}` ({src_size} bytes) is smaller than that of `{dst}` ({dst_size} bytes)"
                         )
                     }
                     rustc_transmute::Reason::SrcSizeOverflow => {
@@ -3113,7 +3113,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         dst_min_align,
                     } => {
                         format!(
-                            "The minimum alignment of `{src}` ({src_min_align}) should be greater than that of `{dst}` ({dst_min_align})"
+                            "the minimum alignment of `{src}` ({src_min_align}) should be greater than that of `{dst}` ({dst_min_align})"
                         )
                     }
                     rustc_transmute::Reason::DstIsMoreUnique => {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -3073,12 +3073,12 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 let src = trait_ref.args.type_at(1);
                 let err_msg = format!("`{src}` cannot be safely transmuted into `{dst}`");
                 let safe_transmute_explanation = match reason {
-                    rustc_transmute::Reason::SrcIsUnspecified => {
-                        format!("`{src}` does not have a well-specified layout")
+                    rustc_transmute::Reason::SrcIsNotYetSupported => {
+                        format!("analyzing the transmutability of `{src}` is not yet supported.")
                     }
 
-                    rustc_transmute::Reason::DstIsUnspecified => {
-                        format!("`{dst}` does not have a well-specified layout")
+                    rustc_transmute::Reason::DstIsNotYetSupported => {
+                        format!("analyzing the transmutability of `{dst}` is not yet supported.")
                     }
 
                     rustc_transmute::Reason::DstIsBitIncompatible => {

--- a/compiler/rustc_transmute/src/layout/tree.rs
+++ b/compiler/rustc_transmute/src/layout/tree.rs
@@ -186,8 +186,8 @@ pub(crate) mod rustc {
 
     #[derive(Debug, Copy, Clone)]
     pub(crate) enum Err {
-        /// The layout of the type is unspecified.
-        Unspecified,
+        /// The layout of the type is not yet supported.
+        NotYetSupported,
         /// This error will be surfaced elsewhere by rustc, so don't surface it.
         UnknownLayout,
         /// Overflow size
@@ -288,14 +288,14 @@ pub(crate) mod rustc {
                     if members.len() == 0 {
                         Ok(Tree::unit())
                     } else {
-                        Err(Err::Unspecified)
+                        Err(Err::NotYetSupported)
                     }
                 }
 
                 ty::Array(ty, len) => {
                     let len = len
                         .try_eval_target_usize(tcx, ParamEnv::reveal_all())
-                        .ok_or(Err::Unspecified)?;
+                        .ok_or(Err::NotYetSupported)?;
                     let elt = Tree::from_ty(*ty, tcx)?;
                     Ok(std::iter::repeat(elt)
                         .take(len as usize)
@@ -307,7 +307,7 @@ pub(crate) mod rustc {
 
                     // If the layout is ill-specified, halt.
                     if !(adt_def.repr().c() || adt_def.repr().int.is_some()) {
-                        return Err(Err::Unspecified);
+                        return Err(Err::NotYetSupported);
                     }
 
                     // Compute a summary of the type's layout.
@@ -348,7 +348,7 @@ pub(crate) mod rustc {
                         AdtKind::Union => {
                             // is the layout well-defined?
                             if !adt_def.repr().c() {
-                                return Err(Err::Unspecified);
+                                return Err(Err::NotYetSupported);
                             }
 
                             let ty_layout = layout_of(tcx, ty)?;
@@ -384,7 +384,7 @@ pub(crate) mod rustc {
                     }))
                 }
 
-                _ => Err(Err::Unspecified),
+                _ => Err(Err::NotYetSupported),
             }
         }
 

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -43,10 +43,10 @@ pub enum Condition<R> {
 /// Answers "why wasn't the source type transmutable into the destination type?"
 #[derive(Debug, Hash, Eq, PartialEq, PartialOrd, Ord, Clone)]
 pub enum Reason<T> {
-    /// The layout of the source type is unspecified.
-    SrcIsUnspecified,
-    /// The layout of the destination type is unspecified.
-    DstIsUnspecified,
+    /// The layout of the source type is not yet supported.
+    SrcIsNotYetSupported,
+    /// The layout of the destination type is not yet supported.
+    DstIsNotYetSupported,
     /// The layout of the destination type is bit-incompatible with the source type.
     DstIsBitIncompatible,
     /// The destination type may carry safety invariants.

--- a/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
+++ b/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
@@ -56,8 +56,8 @@ mod rustc {
                 }
                 (Err(Err::UnknownLayout), _) => Answer::No(Reason::SrcLayoutUnknown),
                 (_, Err(Err::UnknownLayout)) => Answer::No(Reason::DstLayoutUnknown),
-                (Err(Err::Unspecified), _) => Answer::No(Reason::SrcIsUnspecified),
-                (_, Err(Err::Unspecified)) => Answer::No(Reason::DstIsUnspecified),
+                (Err(Err::NotYetSupported), _) => Answer::No(Reason::SrcIsNotYetSupported),
+                (_, Err(Err::NotYetSupported)) => Answer::No(Reason::DstIsNotYetSupported),
                 (Err(Err::SizeOverflow), _) => Answer::No(Reason::SrcSizeOverflow),
                 (_, Err(Err::SizeOverflow)) => Answer::No(Reason::DstSizeOverflow),
                 (Ok(src), Ok(dst)) => MaybeTransmutableQuery { src, dst, assume, context }.answer(),

--- a/tests/ui/transmutability/alignment/align-fail.stderr
+++ b/tests/ui/transmutability/alignment/align-fail.stderr
@@ -2,7 +2,7 @@ error[E0277]: `&[u8; 0]` cannot be safely transmuted into `&[u16; 0]`
   --> $DIR/align-fail.rs:21:55
    |
 LL | ...tatic [u8; 0], &'static [u16; 0]>();
-   |                   ^^^^^^^^^^^^^^^^^ The minimum alignment of `&[u8; 0]` (1) should be greater than that of `&[u16; 0]` (2)
+   |                   ^^^^^^^^^^^^^^^^^ the minimum alignment of `&[u8; 0]` (1) should be greater than that of `&[u16; 0]` (2)
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/align-fail.rs:9:14

--- a/tests/ui/transmutability/arrays/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/arrays/should_require_well_defined_layout.stderr
@@ -2,7 +2,7 @@ error[E0277]: `[String; 0]` cannot be safely transmuted into `()`
   --> $DIR/should_require_well_defined_layout.rs:25:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `[String; 0]` does not have a well-specified layout
+   |                                                    ^^ analyzing the transmutability of `[String; 0]` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -23,7 +23,7 @@ error[E0277]: `u128` cannot be safely transmuted into `[String; 0]`
   --> $DIR/should_require_well_defined_layout.rs:26:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `[String; 0]` does not have a well-specified layout
+   |                                               ^^^^^^^^^ analyzing the transmutability of `[String; 0]` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -44,7 +44,7 @@ error[E0277]: `[String; 1]` cannot be safely transmuted into `()`
   --> $DIR/should_require_well_defined_layout.rs:31:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `[String; 1]` does not have a well-specified layout
+   |                                                    ^^ analyzing the transmutability of `[String; 1]` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -65,7 +65,7 @@ error[E0277]: `u128` cannot be safely transmuted into `[String; 1]`
   --> $DIR/should_require_well_defined_layout.rs:32:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `[String; 1]` does not have a well-specified layout
+   |                                               ^^^^^^^^^ analyzing the transmutability of `[String; 1]` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -86,7 +86,7 @@ error[E0277]: `[String; 2]` cannot be safely transmuted into `()`
   --> $DIR/should_require_well_defined_layout.rs:37:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `[String; 2]` does not have a well-specified layout
+   |                                                    ^^ analyzing the transmutability of `[String; 2]` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -107,7 +107,7 @@ error[E0277]: `u128` cannot be safely transmuted into `[String; 2]`
   --> $DIR/should_require_well_defined_layout.rs:38:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `[String; 2]` does not have a well-specified layout
+   |                                               ^^^^^^^^^ analyzing the transmutability of `[String; 2]` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14

--- a/tests/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.stderr
+++ b/tests/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.stderr
@@ -2,7 +2,7 @@ error[E0277]: `Zst` cannot be safely transmuted into `V0i8`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:46:44
    |
 LL |         assert::is_transmutable::<Smaller, Current>();
-   |                                            ^^^^^^^ The size of `Zst` is smaller than the size of `V0i8`
+   |                                            ^^^^^^^ the size of `Zst` is smaller than the size of `V0i8`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -24,7 +24,7 @@ error[E0277]: `V0i8` cannot be safely transmuted into `u16`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:48:44
    |
 LL |         assert::is_transmutable::<Current, Larger>();
-   |                                            ^^^^^^ The size of `V0i8` is smaller than the size of `u16`
+   |                                            ^^^^^^ the size of `V0i8` is smaller than the size of `u16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -46,7 +46,7 @@ error[E0277]: `Zst` cannot be safely transmuted into `V0u8`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:54:44
    |
 LL |         assert::is_transmutable::<Smaller, Current>();
-   |                                            ^^^^^^^ The size of `Zst` is smaller than the size of `V0u8`
+   |                                            ^^^^^^^ the size of `Zst` is smaller than the size of `V0u8`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -68,7 +68,7 @@ error[E0277]: `V0u8` cannot be safely transmuted into `u16`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:56:44
    |
 LL |         assert::is_transmutable::<Current, Larger>();
-   |                                            ^^^^^^ The size of `V0u8` is smaller than the size of `u16`
+   |                                            ^^^^^^ the size of `V0u8` is smaller than the size of `u16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -90,7 +90,7 @@ error[E0277]: `u8` cannot be safely transmuted into `V0i16`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:68:44
    |
 LL |         assert::is_transmutable::<Smaller, Current>();
-   |                                            ^^^^^^^ The size of `u8` is smaller than the size of `V0i16`
+   |                                            ^^^^^^^ the size of `u8` is smaller than the size of `V0i16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -112,7 +112,7 @@ error[E0277]: `V0i16` cannot be safely transmuted into `u32`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:70:44
    |
 LL |         assert::is_transmutable::<Current, Larger>();
-   |                                            ^^^^^^ The size of `V0i16` is smaller than the size of `u32`
+   |                                            ^^^^^^ the size of `V0i16` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -134,7 +134,7 @@ error[E0277]: `u8` cannot be safely transmuted into `V0u16`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:76:44
    |
 LL |         assert::is_transmutable::<Smaller, Current>();
-   |                                            ^^^^^^^ The size of `u8` is smaller than the size of `V0u16`
+   |                                            ^^^^^^^ the size of `u8` is smaller than the size of `V0u16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -156,7 +156,7 @@ error[E0277]: `V0u16` cannot be safely transmuted into `u32`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:78:44
    |
 LL |         assert::is_transmutable::<Current, Larger>();
-   |                                            ^^^^^^ The size of `V0u16` is smaller than the size of `u32`
+   |                                            ^^^^^^ the size of `V0u16` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -178,7 +178,7 @@ error[E0277]: `u16` cannot be safely transmuted into `V0i32`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:90:44
    |
 LL |         assert::is_transmutable::<Smaller, Current>();
-   |                                            ^^^^^^^ The size of `u16` is smaller than the size of `V0i32`
+   |                                            ^^^^^^^ the size of `u16` is smaller than the size of `V0i32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -200,7 +200,7 @@ error[E0277]: `V0i32` cannot be safely transmuted into `u64`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:92:44
    |
 LL |         assert::is_transmutable::<Current, Larger>();
-   |                                            ^^^^^^ The size of `V0i32` is smaller than the size of `u64`
+   |                                            ^^^^^^ the size of `V0i32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -222,7 +222,7 @@ error[E0277]: `u16` cannot be safely transmuted into `V0u32`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:98:44
    |
 LL |         assert::is_transmutable::<Smaller, Current>();
-   |                                            ^^^^^^^ The size of `u16` is smaller than the size of `V0u32`
+   |                                            ^^^^^^^ the size of `u16` is smaller than the size of `V0u32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -244,7 +244,7 @@ error[E0277]: `V0u32` cannot be safely transmuted into `u64`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:100:44
    |
 LL |         assert::is_transmutable::<Current, Larger>();
-   |                                            ^^^^^^ The size of `V0u32` is smaller than the size of `u64`
+   |                                            ^^^^^^ the size of `V0u32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -266,7 +266,7 @@ error[E0277]: `u32` cannot be safely transmuted into `V0i64`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:112:44
    |
 LL |         assert::is_transmutable::<Smaller, Current>();
-   |                                            ^^^^^^^ The size of `u32` is smaller than the size of `V0i64`
+   |                                            ^^^^^^^ the size of `u32` is smaller than the size of `V0i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -288,7 +288,7 @@ error[E0277]: `V0i64` cannot be safely transmuted into `u128`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:114:44
    |
 LL |         assert::is_transmutable::<Current, Larger>();
-   |                                            ^^^^^^ The size of `V0i64` is smaller than the size of `u128`
+   |                                            ^^^^^^ the size of `V0i64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -310,7 +310,7 @@ error[E0277]: `u32` cannot be safely transmuted into `V0u64`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:120:44
    |
 LL |         assert::is_transmutable::<Smaller, Current>();
-   |                                            ^^^^^^^ The size of `u32` is smaller than the size of `V0u64`
+   |                                            ^^^^^^^ the size of `u32` is smaller than the size of `V0u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -332,7 +332,7 @@ error[E0277]: `V0u64` cannot be safely transmuted into `u128`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:122:44
    |
 LL |         assert::is_transmutable::<Current, Larger>();
-   |                                            ^^^^^^ The size of `V0u64` is smaller than the size of `u128`
+   |                                            ^^^^^^ the size of `V0u64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -354,7 +354,7 @@ error[E0277]: `u8` cannot be safely transmuted into `V0isize`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:134:44
    |
 LL |         assert::is_transmutable::<Smaller, Current>();
-   |                                            ^^^^^^^ The size of `u8` is smaller than the size of `V0isize`
+   |                                            ^^^^^^^ the size of `u8` is smaller than the size of `V0isize`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -376,7 +376,7 @@ error[E0277]: `V0isize` cannot be safely transmuted into `[usize; 2]`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:136:44
    |
 LL |         assert::is_transmutable::<Current, Larger>();
-   |                                            ^^^^^^ The size of `V0isize` is smaller than the size of `[usize; 2]`
+   |                                            ^^^^^^ the size of `V0isize` is smaller than the size of `[usize; 2]`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -398,7 +398,7 @@ error[E0277]: `u8` cannot be safely transmuted into `V0usize`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:142:44
    |
 LL |         assert::is_transmutable::<Smaller, Current>();
-   |                                            ^^^^^^^ The size of `u8` is smaller than the size of `V0usize`
+   |                                            ^^^^^^^ the size of `u8` is smaller than the size of `V0usize`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14
@@ -420,7 +420,7 @@ error[E0277]: `V0usize` cannot be safely transmuted into `[usize; 2]`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:144:44
    |
 LL |         assert::is_transmutable::<Current, Larger>();
-   |                                            ^^^^^^ The size of `V0usize` is smaller than the size of `[usize; 2]`
+   |                                            ^^^^^^ the size of `V0usize` is smaller than the size of `[usize; 2]`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:12:14

--- a/tests/ui/transmutability/enums/repr/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/enums/repr/should_require_well_defined_layout.stderr
@@ -2,7 +2,7 @@ error[E0277]: `void::repr_rust` cannot be safely transmuted into `()`
   --> $DIR/should_require_well_defined_layout.rs:27:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `void::repr_rust` does not have a well-specified layout
+   |                                                    ^^ analyzing the transmutability of `void::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
@@ -24,7 +24,7 @@ error[E0277]: `u128` cannot be safely transmuted into `void::repr_rust`
   --> $DIR/should_require_well_defined_layout.rs:28:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `void::repr_rust` does not have a well-specified layout
+   |                                               ^^^^^^^^^ analyzing the transmutability of `void::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
@@ -46,7 +46,7 @@ error[E0277]: `singleton::repr_rust` cannot be safely transmuted into `()`
   --> $DIR/should_require_well_defined_layout.rs:33:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `singleton::repr_rust` does not have a well-specified layout
+   |                                                    ^^ analyzing the transmutability of `singleton::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
@@ -68,7 +68,7 @@ error[E0277]: `u128` cannot be safely transmuted into `singleton::repr_rust`
   --> $DIR/should_require_well_defined_layout.rs:34:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `singleton::repr_rust` does not have a well-specified layout
+   |                                               ^^^^^^^^^ analyzing the transmutability of `singleton::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
@@ -90,7 +90,7 @@ error[E0277]: `duplex::repr_rust` cannot be safely transmuted into `()`
   --> $DIR/should_require_well_defined_layout.rs:39:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `duplex::repr_rust` does not have a well-specified layout
+   |                                                    ^^ analyzing the transmutability of `duplex::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14
@@ -112,7 +112,7 @@ error[E0277]: `u128` cannot be safely transmuted into `duplex::repr_rust`
   --> $DIR/should_require_well_defined_layout.rs:40:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `duplex::repr_rust` does not have a well-specified layout
+   |                                               ^^^^^^^^^ analyzing the transmutability of `duplex::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:13:14

--- a/tests/ui/transmutability/enums/should_pad_variants.stderr
+++ b/tests/ui/transmutability/enums/should_pad_variants.stderr
@@ -2,7 +2,7 @@ error[E0277]: `Src` cannot be safely transmuted into `Dst`
   --> $DIR/should_pad_variants.rs:43:36
    |
 LL |     assert::is_transmutable::<Src, Dst>();
-   |                                    ^^^ The size of `Src` is smaller than the size of `Dst`
+   |                                    ^^^ the size of `Src` is smaller than the size of `Dst`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/should_pad_variants.rs:13:14

--- a/tests/ui/transmutability/enums/should_respect_endianness.stderr
+++ b/tests/ui/transmutability/enums/should_respect_endianness.stderr
@@ -2,7 +2,7 @@ error[E0277]: `Src` cannot be safely transmuted into `Unexpected`
   --> $DIR/should_respect_endianness.rs:35:36
    |
 LL |     assert::is_transmutable::<Src, Unexpected>();
-   |                                    ^^^^^^^^^^ At least one value of `Src` isn't a bit-valid value of `Unexpected`
+   |                                    ^^^^^^^^^^ at least one value of `Src` isn't a bit-valid value of `Unexpected`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/should_respect_endianness.rs:13:14

--- a/tests/ui/transmutability/primitives/bool-mut.stderr
+++ b/tests/ui/transmutability/primitives/bool-mut.stderr
@@ -2,7 +2,7 @@ error[E0277]: `u8` cannot be safely transmuted into `bool`
   --> $DIR/bool-mut.rs:15:50
    |
 LL |     assert::is_transmutable::<&'static mut bool, &'static mut u8>()
-   |                                                  ^^^^^^^^^^^^^^^ At least one value of `u8` isn't a bit-valid value of `bool`
+   |                                                  ^^^^^^^^^^^^^^^ at least one value of `u8` isn't a bit-valid value of `bool`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/bool-mut.rs:10:14

--- a/tests/ui/transmutability/primitives/bool.current.stderr
+++ b/tests/ui/transmutability/primitives/bool.current.stderr
@@ -2,7 +2,7 @@ error[E0277]: `u8` cannot be safely transmuted into `bool`
   --> $DIR/bool.rs:21:35
    |
 LL |     assert::is_transmutable::<u8, bool>();
-   |                                   ^^^^ At least one value of `u8` isn't a bit-valid value of `bool`
+   |                                   ^^^^ at least one value of `u8` isn't a bit-valid value of `bool`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/bool.rs:11:14

--- a/tests/ui/transmutability/primitives/bool.next.stderr
+++ b/tests/ui/transmutability/primitives/bool.next.stderr
@@ -2,7 +2,7 @@ error[E0277]: `u8` cannot be safely transmuted into `bool`
   --> $DIR/bool.rs:21:35
    |
 LL |     assert::is_transmutable::<u8, bool>();
-   |                                   ^^^^ At least one value of `u8` isn't a bit-valid value of `bool`
+   |                                   ^^^^ at least one value of `u8` isn't a bit-valid value of `bool`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/bool.rs:11:14

--- a/tests/ui/transmutability/primitives/numbers.current.stderr
+++ b/tests/ui/transmutability/primitives/numbers.current.stderr
@@ -2,7 +2,7 @@ error[E0277]: `i8` cannot be safely transmuted into `i16`
   --> $DIR/numbers.rs:64:40
    |
 LL |     assert::is_transmutable::<   i8,   i16>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `i16`
+   |                                        ^^^ the size of `i8` is smaller than the size of `i16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -17,7 +17,7 @@ error[E0277]: `i8` cannot be safely transmuted into `u16`
   --> $DIR/numbers.rs:65:40
    |
 LL |     assert::is_transmutable::<   i8,   u16>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `u16`
+   |                                        ^^^ the size of `i8` is smaller than the size of `u16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -32,7 +32,7 @@ error[E0277]: `i8` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:66:40
    |
 LL |     assert::is_transmutable::<   i8,   i32>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `i32`
+   |                                        ^^^ the size of `i8` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -47,7 +47,7 @@ error[E0277]: `i8` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:67:40
    |
 LL |     assert::is_transmutable::<   i8,   f32>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `f32`
+   |                                        ^^^ the size of `i8` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -62,7 +62,7 @@ error[E0277]: `i8` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:68:40
    |
 LL |     assert::is_transmutable::<   i8,   u32>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `u32`
+   |                                        ^^^ the size of `i8` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -77,7 +77,7 @@ error[E0277]: `i8` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:69:40
    |
 LL |     assert::is_transmutable::<   i8,   u64>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `u64`
+   |                                        ^^^ the size of `i8` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -92,7 +92,7 @@ error[E0277]: `i8` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:70:40
    |
 LL |     assert::is_transmutable::<   i8,   i64>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `i64`
+   |                                        ^^^ the size of `i8` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -107,7 +107,7 @@ error[E0277]: `i8` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:71:40
    |
 LL |     assert::is_transmutable::<   i8,   f64>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `f64`
+   |                                        ^^^ the size of `i8` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -122,7 +122,7 @@ error[E0277]: `i8` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:72:39
    |
 LL |     assert::is_transmutable::<   i8,  u128>();
-   |                                       ^^^^ The size of `i8` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `i8` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -137,7 +137,7 @@ error[E0277]: `i8` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:73:39
    |
 LL |     assert::is_transmutable::<   i8,  i128>();
-   |                                       ^^^^ The size of `i8` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `i8` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -152,7 +152,7 @@ error[E0277]: `u8` cannot be safely transmuted into `i16`
   --> $DIR/numbers.rs:75:40
    |
 LL |     assert::is_transmutable::<   u8,   i16>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `i16`
+   |                                        ^^^ the size of `u8` is smaller than the size of `i16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -167,7 +167,7 @@ error[E0277]: `u8` cannot be safely transmuted into `u16`
   --> $DIR/numbers.rs:76:40
    |
 LL |     assert::is_transmutable::<   u8,   u16>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `u16`
+   |                                        ^^^ the size of `u8` is smaller than the size of `u16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -182,7 +182,7 @@ error[E0277]: `u8` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:77:40
    |
 LL |     assert::is_transmutable::<   u8,   i32>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `i32`
+   |                                        ^^^ the size of `u8` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -197,7 +197,7 @@ error[E0277]: `u8` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:78:40
    |
 LL |     assert::is_transmutable::<   u8,   f32>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `f32`
+   |                                        ^^^ the size of `u8` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -212,7 +212,7 @@ error[E0277]: `u8` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:79:40
    |
 LL |     assert::is_transmutable::<   u8,   u32>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `u32`
+   |                                        ^^^ the size of `u8` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -227,7 +227,7 @@ error[E0277]: `u8` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:80:40
    |
 LL |     assert::is_transmutable::<   u8,   u64>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `u64`
+   |                                        ^^^ the size of `u8` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -242,7 +242,7 @@ error[E0277]: `u8` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:81:40
    |
 LL |     assert::is_transmutable::<   u8,   i64>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `i64`
+   |                                        ^^^ the size of `u8` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -257,7 +257,7 @@ error[E0277]: `u8` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:82:40
    |
 LL |     assert::is_transmutable::<   u8,   f64>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `f64`
+   |                                        ^^^ the size of `u8` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -272,7 +272,7 @@ error[E0277]: `u8` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:83:39
    |
 LL |     assert::is_transmutable::<   u8,  u128>();
-   |                                       ^^^^ The size of `u8` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `u8` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -287,7 +287,7 @@ error[E0277]: `u8` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:84:39
    |
 LL |     assert::is_transmutable::<   u8,  i128>();
-   |                                       ^^^^ The size of `u8` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `u8` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -302,7 +302,7 @@ error[E0277]: `i16` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:86:40
    |
 LL |     assert::is_transmutable::<  i16,   i32>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `i32`
+   |                                        ^^^ the size of `i16` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -317,7 +317,7 @@ error[E0277]: `i16` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:87:40
    |
 LL |     assert::is_transmutable::<  i16,   f32>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `f32`
+   |                                        ^^^ the size of `i16` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -332,7 +332,7 @@ error[E0277]: `i16` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:88:40
    |
 LL |     assert::is_transmutable::<  i16,   u32>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `u32`
+   |                                        ^^^ the size of `i16` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -347,7 +347,7 @@ error[E0277]: `i16` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:89:40
    |
 LL |     assert::is_transmutable::<  i16,   u64>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `u64`
+   |                                        ^^^ the size of `i16` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -362,7 +362,7 @@ error[E0277]: `i16` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:90:40
    |
 LL |     assert::is_transmutable::<  i16,   i64>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `i64`
+   |                                        ^^^ the size of `i16` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -377,7 +377,7 @@ error[E0277]: `i16` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:91:40
    |
 LL |     assert::is_transmutable::<  i16,   f64>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `f64`
+   |                                        ^^^ the size of `i16` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -392,7 +392,7 @@ error[E0277]: `i16` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:92:39
    |
 LL |     assert::is_transmutable::<  i16,  u128>();
-   |                                       ^^^^ The size of `i16` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `i16` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -407,7 +407,7 @@ error[E0277]: `i16` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:93:39
    |
 LL |     assert::is_transmutable::<  i16,  i128>();
-   |                                       ^^^^ The size of `i16` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `i16` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -422,7 +422,7 @@ error[E0277]: `u16` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:95:40
    |
 LL |     assert::is_transmutable::<  u16,   i32>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `i32`
+   |                                        ^^^ the size of `u16` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -437,7 +437,7 @@ error[E0277]: `u16` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:96:40
    |
 LL |     assert::is_transmutable::<  u16,   f32>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `f32`
+   |                                        ^^^ the size of `u16` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -452,7 +452,7 @@ error[E0277]: `u16` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:97:40
    |
 LL |     assert::is_transmutable::<  u16,   u32>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `u32`
+   |                                        ^^^ the size of `u16` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -467,7 +467,7 @@ error[E0277]: `u16` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:98:40
    |
 LL |     assert::is_transmutable::<  u16,   u64>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `u64`
+   |                                        ^^^ the size of `u16` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -482,7 +482,7 @@ error[E0277]: `u16` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:99:40
    |
 LL |     assert::is_transmutable::<  u16,   i64>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `i64`
+   |                                        ^^^ the size of `u16` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -497,7 +497,7 @@ error[E0277]: `u16` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:100:40
    |
 LL |     assert::is_transmutable::<  u16,   f64>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `f64`
+   |                                        ^^^ the size of `u16` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -512,7 +512,7 @@ error[E0277]: `u16` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:101:39
    |
 LL |     assert::is_transmutable::<  u16,  u128>();
-   |                                       ^^^^ The size of `u16` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `u16` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -527,7 +527,7 @@ error[E0277]: `u16` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:102:39
    |
 LL |     assert::is_transmutable::<  u16,  i128>();
-   |                                       ^^^^ The size of `u16` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `u16` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -542,7 +542,7 @@ error[E0277]: `i32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:104:40
    |
 LL |     assert::is_transmutable::<  i32,   u64>();
-   |                                        ^^^ The size of `i32` is smaller than the size of `u64`
+   |                                        ^^^ the size of `i32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -557,7 +557,7 @@ error[E0277]: `i32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:105:40
    |
 LL |     assert::is_transmutable::<  i32,   i64>();
-   |                                        ^^^ The size of `i32` is smaller than the size of `i64`
+   |                                        ^^^ the size of `i32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -572,7 +572,7 @@ error[E0277]: `i32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:106:40
    |
 LL |     assert::is_transmutable::<  i32,   f64>();
-   |                                        ^^^ The size of `i32` is smaller than the size of `f64`
+   |                                        ^^^ the size of `i32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -587,7 +587,7 @@ error[E0277]: `i32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:107:39
    |
 LL |     assert::is_transmutable::<  i32,  u128>();
-   |                                       ^^^^ The size of `i32` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `i32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -602,7 +602,7 @@ error[E0277]: `i32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:108:39
    |
 LL |     assert::is_transmutable::<  i32,  i128>();
-   |                                       ^^^^ The size of `i32` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `i32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -617,7 +617,7 @@ error[E0277]: `f32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:110:40
    |
 LL |     assert::is_transmutable::<  f32,   u64>();
-   |                                        ^^^ The size of `f32` is smaller than the size of `u64`
+   |                                        ^^^ the size of `f32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -632,7 +632,7 @@ error[E0277]: `f32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:111:40
    |
 LL |     assert::is_transmutable::<  f32,   i64>();
-   |                                        ^^^ The size of `f32` is smaller than the size of `i64`
+   |                                        ^^^ the size of `f32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -647,7 +647,7 @@ error[E0277]: `f32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:112:40
    |
 LL |     assert::is_transmutable::<  f32,   f64>();
-   |                                        ^^^ The size of `f32` is smaller than the size of `f64`
+   |                                        ^^^ the size of `f32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -662,7 +662,7 @@ error[E0277]: `f32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:113:39
    |
 LL |     assert::is_transmutable::<  f32,  u128>();
-   |                                       ^^^^ The size of `f32` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `f32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -677,7 +677,7 @@ error[E0277]: `f32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:114:39
    |
 LL |     assert::is_transmutable::<  f32,  i128>();
-   |                                       ^^^^ The size of `f32` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `f32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -692,7 +692,7 @@ error[E0277]: `u32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:116:40
    |
 LL |     assert::is_transmutable::<  u32,   u64>();
-   |                                        ^^^ The size of `u32` is smaller than the size of `u64`
+   |                                        ^^^ the size of `u32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -707,7 +707,7 @@ error[E0277]: `u32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:117:40
    |
 LL |     assert::is_transmutable::<  u32,   i64>();
-   |                                        ^^^ The size of `u32` is smaller than the size of `i64`
+   |                                        ^^^ the size of `u32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -722,7 +722,7 @@ error[E0277]: `u32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:118:40
    |
 LL |     assert::is_transmutable::<  u32,   f64>();
-   |                                        ^^^ The size of `u32` is smaller than the size of `f64`
+   |                                        ^^^ the size of `u32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -737,7 +737,7 @@ error[E0277]: `u32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:119:39
    |
 LL |     assert::is_transmutable::<  u32,  u128>();
-   |                                       ^^^^ The size of `u32` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `u32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -752,7 +752,7 @@ error[E0277]: `u32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:120:39
    |
 LL |     assert::is_transmutable::<  u32,  i128>();
-   |                                       ^^^^ The size of `u32` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `u32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -767,7 +767,7 @@ error[E0277]: `u64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:122:39
    |
 LL |     assert::is_transmutable::<  u64,  u128>();
-   |                                       ^^^^ The size of `u64` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `u64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -782,7 +782,7 @@ error[E0277]: `u64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:123:39
    |
 LL |     assert::is_transmutable::<  u64,  i128>();
-   |                                       ^^^^ The size of `u64` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `u64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -797,7 +797,7 @@ error[E0277]: `i64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:125:39
    |
 LL |     assert::is_transmutable::<  i64,  u128>();
-   |                                       ^^^^ The size of `i64` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `i64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -812,7 +812,7 @@ error[E0277]: `i64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:126:39
    |
 LL |     assert::is_transmutable::<  i64,  i128>();
-   |                                       ^^^^ The size of `i64` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `i64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -827,7 +827,7 @@ error[E0277]: `f64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:128:39
    |
 LL |     assert::is_transmutable::<  f64,  u128>();
-   |                                       ^^^^ The size of `f64` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `f64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -842,7 +842,7 @@ error[E0277]: `f64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:129:39
    |
 LL |     assert::is_transmutable::<  f64,  i128>();
-   |                                       ^^^^ The size of `f64` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `f64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14

--- a/tests/ui/transmutability/primitives/numbers.next.stderr
+++ b/tests/ui/transmutability/primitives/numbers.next.stderr
@@ -2,7 +2,7 @@ error[E0277]: `i8` cannot be safely transmuted into `i16`
   --> $DIR/numbers.rs:64:40
    |
 LL |     assert::is_transmutable::<   i8,   i16>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `i16`
+   |                                        ^^^ the size of `i8` is smaller than the size of `i16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -17,7 +17,7 @@ error[E0277]: `i8` cannot be safely transmuted into `u16`
   --> $DIR/numbers.rs:65:40
    |
 LL |     assert::is_transmutable::<   i8,   u16>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `u16`
+   |                                        ^^^ the size of `i8` is smaller than the size of `u16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -32,7 +32,7 @@ error[E0277]: `i8` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:66:40
    |
 LL |     assert::is_transmutable::<   i8,   i32>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `i32`
+   |                                        ^^^ the size of `i8` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -47,7 +47,7 @@ error[E0277]: `i8` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:67:40
    |
 LL |     assert::is_transmutable::<   i8,   f32>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `f32`
+   |                                        ^^^ the size of `i8` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -62,7 +62,7 @@ error[E0277]: `i8` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:68:40
    |
 LL |     assert::is_transmutable::<   i8,   u32>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `u32`
+   |                                        ^^^ the size of `i8` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -77,7 +77,7 @@ error[E0277]: `i8` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:69:40
    |
 LL |     assert::is_transmutable::<   i8,   u64>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `u64`
+   |                                        ^^^ the size of `i8` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -92,7 +92,7 @@ error[E0277]: `i8` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:70:40
    |
 LL |     assert::is_transmutable::<   i8,   i64>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `i64`
+   |                                        ^^^ the size of `i8` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -107,7 +107,7 @@ error[E0277]: `i8` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:71:40
    |
 LL |     assert::is_transmutable::<   i8,   f64>();
-   |                                        ^^^ The size of `i8` is smaller than the size of `f64`
+   |                                        ^^^ the size of `i8` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -122,7 +122,7 @@ error[E0277]: `i8` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:72:39
    |
 LL |     assert::is_transmutable::<   i8,  u128>();
-   |                                       ^^^^ The size of `i8` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `i8` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -137,7 +137,7 @@ error[E0277]: `i8` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:73:39
    |
 LL |     assert::is_transmutable::<   i8,  i128>();
-   |                                       ^^^^ The size of `i8` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `i8` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -152,7 +152,7 @@ error[E0277]: `u8` cannot be safely transmuted into `i16`
   --> $DIR/numbers.rs:75:40
    |
 LL |     assert::is_transmutable::<   u8,   i16>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `i16`
+   |                                        ^^^ the size of `u8` is smaller than the size of `i16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -167,7 +167,7 @@ error[E0277]: `u8` cannot be safely transmuted into `u16`
   --> $DIR/numbers.rs:76:40
    |
 LL |     assert::is_transmutable::<   u8,   u16>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `u16`
+   |                                        ^^^ the size of `u8` is smaller than the size of `u16`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -182,7 +182,7 @@ error[E0277]: `u8` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:77:40
    |
 LL |     assert::is_transmutable::<   u8,   i32>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `i32`
+   |                                        ^^^ the size of `u8` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -197,7 +197,7 @@ error[E0277]: `u8` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:78:40
    |
 LL |     assert::is_transmutable::<   u8,   f32>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `f32`
+   |                                        ^^^ the size of `u8` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -212,7 +212,7 @@ error[E0277]: `u8` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:79:40
    |
 LL |     assert::is_transmutable::<   u8,   u32>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `u32`
+   |                                        ^^^ the size of `u8` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -227,7 +227,7 @@ error[E0277]: `u8` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:80:40
    |
 LL |     assert::is_transmutable::<   u8,   u64>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `u64`
+   |                                        ^^^ the size of `u8` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -242,7 +242,7 @@ error[E0277]: `u8` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:81:40
    |
 LL |     assert::is_transmutable::<   u8,   i64>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `i64`
+   |                                        ^^^ the size of `u8` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -257,7 +257,7 @@ error[E0277]: `u8` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:82:40
    |
 LL |     assert::is_transmutable::<   u8,   f64>();
-   |                                        ^^^ The size of `u8` is smaller than the size of `f64`
+   |                                        ^^^ the size of `u8` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -272,7 +272,7 @@ error[E0277]: `u8` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:83:39
    |
 LL |     assert::is_transmutable::<   u8,  u128>();
-   |                                       ^^^^ The size of `u8` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `u8` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -287,7 +287,7 @@ error[E0277]: `u8` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:84:39
    |
 LL |     assert::is_transmutable::<   u8,  i128>();
-   |                                       ^^^^ The size of `u8` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `u8` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -302,7 +302,7 @@ error[E0277]: `i16` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:86:40
    |
 LL |     assert::is_transmutable::<  i16,   i32>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `i32`
+   |                                        ^^^ the size of `i16` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -317,7 +317,7 @@ error[E0277]: `i16` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:87:40
    |
 LL |     assert::is_transmutable::<  i16,   f32>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `f32`
+   |                                        ^^^ the size of `i16` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -332,7 +332,7 @@ error[E0277]: `i16` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:88:40
    |
 LL |     assert::is_transmutable::<  i16,   u32>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `u32`
+   |                                        ^^^ the size of `i16` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -347,7 +347,7 @@ error[E0277]: `i16` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:89:40
    |
 LL |     assert::is_transmutable::<  i16,   u64>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `u64`
+   |                                        ^^^ the size of `i16` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -362,7 +362,7 @@ error[E0277]: `i16` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:90:40
    |
 LL |     assert::is_transmutable::<  i16,   i64>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `i64`
+   |                                        ^^^ the size of `i16` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -377,7 +377,7 @@ error[E0277]: `i16` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:91:40
    |
 LL |     assert::is_transmutable::<  i16,   f64>();
-   |                                        ^^^ The size of `i16` is smaller than the size of `f64`
+   |                                        ^^^ the size of `i16` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -392,7 +392,7 @@ error[E0277]: `i16` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:92:39
    |
 LL |     assert::is_transmutable::<  i16,  u128>();
-   |                                       ^^^^ The size of `i16` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `i16` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -407,7 +407,7 @@ error[E0277]: `i16` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:93:39
    |
 LL |     assert::is_transmutable::<  i16,  i128>();
-   |                                       ^^^^ The size of `i16` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `i16` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -422,7 +422,7 @@ error[E0277]: `u16` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:95:40
    |
 LL |     assert::is_transmutable::<  u16,   i32>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `i32`
+   |                                        ^^^ the size of `u16` is smaller than the size of `i32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -437,7 +437,7 @@ error[E0277]: `u16` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:96:40
    |
 LL |     assert::is_transmutable::<  u16,   f32>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `f32`
+   |                                        ^^^ the size of `u16` is smaller than the size of `f32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -452,7 +452,7 @@ error[E0277]: `u16` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:97:40
    |
 LL |     assert::is_transmutable::<  u16,   u32>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `u32`
+   |                                        ^^^ the size of `u16` is smaller than the size of `u32`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -467,7 +467,7 @@ error[E0277]: `u16` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:98:40
    |
 LL |     assert::is_transmutable::<  u16,   u64>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `u64`
+   |                                        ^^^ the size of `u16` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -482,7 +482,7 @@ error[E0277]: `u16` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:99:40
    |
 LL |     assert::is_transmutable::<  u16,   i64>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `i64`
+   |                                        ^^^ the size of `u16` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -497,7 +497,7 @@ error[E0277]: `u16` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:100:40
    |
 LL |     assert::is_transmutable::<  u16,   f64>();
-   |                                        ^^^ The size of `u16` is smaller than the size of `f64`
+   |                                        ^^^ the size of `u16` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -512,7 +512,7 @@ error[E0277]: `u16` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:101:39
    |
 LL |     assert::is_transmutable::<  u16,  u128>();
-   |                                       ^^^^ The size of `u16` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `u16` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -527,7 +527,7 @@ error[E0277]: `u16` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:102:39
    |
 LL |     assert::is_transmutable::<  u16,  i128>();
-   |                                       ^^^^ The size of `u16` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `u16` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -542,7 +542,7 @@ error[E0277]: `i32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:104:40
    |
 LL |     assert::is_transmutable::<  i32,   u64>();
-   |                                        ^^^ The size of `i32` is smaller than the size of `u64`
+   |                                        ^^^ the size of `i32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -557,7 +557,7 @@ error[E0277]: `i32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:105:40
    |
 LL |     assert::is_transmutable::<  i32,   i64>();
-   |                                        ^^^ The size of `i32` is smaller than the size of `i64`
+   |                                        ^^^ the size of `i32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -572,7 +572,7 @@ error[E0277]: `i32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:106:40
    |
 LL |     assert::is_transmutable::<  i32,   f64>();
-   |                                        ^^^ The size of `i32` is smaller than the size of `f64`
+   |                                        ^^^ the size of `i32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -587,7 +587,7 @@ error[E0277]: `i32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:107:39
    |
 LL |     assert::is_transmutable::<  i32,  u128>();
-   |                                       ^^^^ The size of `i32` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `i32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -602,7 +602,7 @@ error[E0277]: `i32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:108:39
    |
 LL |     assert::is_transmutable::<  i32,  i128>();
-   |                                       ^^^^ The size of `i32` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `i32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -617,7 +617,7 @@ error[E0277]: `f32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:110:40
    |
 LL |     assert::is_transmutable::<  f32,   u64>();
-   |                                        ^^^ The size of `f32` is smaller than the size of `u64`
+   |                                        ^^^ the size of `f32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -632,7 +632,7 @@ error[E0277]: `f32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:111:40
    |
 LL |     assert::is_transmutable::<  f32,   i64>();
-   |                                        ^^^ The size of `f32` is smaller than the size of `i64`
+   |                                        ^^^ the size of `f32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -647,7 +647,7 @@ error[E0277]: `f32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:112:40
    |
 LL |     assert::is_transmutable::<  f32,   f64>();
-   |                                        ^^^ The size of `f32` is smaller than the size of `f64`
+   |                                        ^^^ the size of `f32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -662,7 +662,7 @@ error[E0277]: `f32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:113:39
    |
 LL |     assert::is_transmutable::<  f32,  u128>();
-   |                                       ^^^^ The size of `f32` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `f32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -677,7 +677,7 @@ error[E0277]: `f32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:114:39
    |
 LL |     assert::is_transmutable::<  f32,  i128>();
-   |                                       ^^^^ The size of `f32` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `f32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -692,7 +692,7 @@ error[E0277]: `u32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:116:40
    |
 LL |     assert::is_transmutable::<  u32,   u64>();
-   |                                        ^^^ The size of `u32` is smaller than the size of `u64`
+   |                                        ^^^ the size of `u32` is smaller than the size of `u64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -707,7 +707,7 @@ error[E0277]: `u32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:117:40
    |
 LL |     assert::is_transmutable::<  u32,   i64>();
-   |                                        ^^^ The size of `u32` is smaller than the size of `i64`
+   |                                        ^^^ the size of `u32` is smaller than the size of `i64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -722,7 +722,7 @@ error[E0277]: `u32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:118:40
    |
 LL |     assert::is_transmutable::<  u32,   f64>();
-   |                                        ^^^ The size of `u32` is smaller than the size of `f64`
+   |                                        ^^^ the size of `u32` is smaller than the size of `f64`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -737,7 +737,7 @@ error[E0277]: `u32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:119:39
    |
 LL |     assert::is_transmutable::<  u32,  u128>();
-   |                                       ^^^^ The size of `u32` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `u32` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -752,7 +752,7 @@ error[E0277]: `u32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:120:39
    |
 LL |     assert::is_transmutable::<  u32,  i128>();
-   |                                       ^^^^ The size of `u32` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `u32` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -767,7 +767,7 @@ error[E0277]: `u64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:122:39
    |
 LL |     assert::is_transmutable::<  u64,  u128>();
-   |                                       ^^^^ The size of `u64` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `u64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -782,7 +782,7 @@ error[E0277]: `u64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:123:39
    |
 LL |     assert::is_transmutable::<  u64,  i128>();
-   |                                       ^^^^ The size of `u64` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `u64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -797,7 +797,7 @@ error[E0277]: `i64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:125:39
    |
 LL |     assert::is_transmutable::<  i64,  u128>();
-   |                                       ^^^^ The size of `i64` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `i64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -812,7 +812,7 @@ error[E0277]: `i64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:126:39
    |
 LL |     assert::is_transmutable::<  i64,  i128>();
-   |                                       ^^^^ The size of `i64` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `i64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -827,7 +827,7 @@ error[E0277]: `f64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:128:39
    |
 LL |     assert::is_transmutable::<  f64,  u128>();
-   |                                       ^^^^ The size of `f64` is smaller than the size of `u128`
+   |                                       ^^^^ the size of `f64` is smaller than the size of `u128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14
@@ -842,7 +842,7 @@ error[E0277]: `f64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:129:39
    |
 LL |     assert::is_transmutable::<  f64,  i128>();
-   |                                       ^^^^ The size of `f64` is smaller than the size of `i128`
+   |                                       ^^^^ the size of `f64` is smaller than the size of `i128`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/numbers.rs:14:14

--- a/tests/ui/transmutability/primitives/unit.current.stderr
+++ b/tests/ui/transmutability/primitives/unit.current.stderr
@@ -2,7 +2,7 @@ error[E0277]: `()` cannot be safely transmuted into `u8`
   --> $DIR/unit.rs:31:35
    |
 LL |     assert::is_transmutable::<(), u8>();
-   |                                   ^^ The size of `()` is smaller than the size of `u8`
+   |                                   ^^ the size of `()` is smaller than the size of `u8`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/unit.rs:16:14

--- a/tests/ui/transmutability/primitives/unit.next.stderr
+++ b/tests/ui/transmutability/primitives/unit.next.stderr
@@ -2,7 +2,7 @@ error[E0277]: `()` cannot be safely transmuted into `u8`
   --> $DIR/unit.rs:31:35
    |
 LL |     assert::is_transmutable::<(), u8>();
-   |                                   ^^ The size of `()` is smaller than the size of `u8`
+   |                                   ^^ the size of `()` is smaller than the size of `u8`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/unit.rs:16:14

--- a/tests/ui/transmutability/references/recursive-wrapper-types-bit-incompatible.stderr
+++ b/tests/ui/transmutability/references/recursive-wrapper-types-bit-incompatible.stderr
@@ -2,7 +2,7 @@ error[E0277]: `B` cannot be safely transmuted into `A`
   --> $DIR/recursive-wrapper-types-bit-incompatible.rs:23:49
    |
 LL |     assert::is_maybe_transmutable::<&'static B, &'static A>();
-   |                                                 ^^^^^^^^^^ At least one value of `B` isn't a bit-valid value of `A`
+   |                                                 ^^^^^^^^^^ at least one value of `B` isn't a bit-valid value of `A`
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/recursive-wrapper-types-bit-incompatible.rs:9:14

--- a/tests/ui/transmutability/references/reject_extension.stderr
+++ b/tests/ui/transmutability/references/reject_extension.stderr
@@ -2,7 +2,7 @@ error[E0277]: `&Packed<Two>` cannot be safely transmuted into `&Packed<Four>`
   --> $DIR/reject_extension.rs:48:37
    |
 LL |     assert::is_transmutable::<&Src, &Dst>();
-   |                                     ^^^^ The referent size of `&Packed<Two>` (2 bytes) is smaller than that of `&Packed<Four>` (4 bytes)
+   |                                     ^^^^ the referent size of `&Packed<Two>` (2 bytes) is smaller than that of `&Packed<Four>` (4 bytes)
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/reject_extension.rs:13:14

--- a/tests/ui/transmutability/references/unit-to-u8.stderr
+++ b/tests/ui/transmutability/references/unit-to-u8.stderr
@@ -2,7 +2,7 @@ error[E0277]: `&Unit` cannot be safely transmuted into `&u8`
   --> $DIR/unit-to-u8.rs:22:52
    |
 LL |     assert::is_maybe_transmutable::<&'static Unit, &'static u8>();
-   |                                                    ^^^^^^^^^^^ The referent size of `&Unit` (0 bytes) is smaller than that of `&u8` (1 bytes)
+   |                                                    ^^^^^^^^^^^ the referent size of `&Unit` (0 bytes) is smaller than that of `&u8` (1 bytes)
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/unit-to-u8.rs:9:14

--- a/tests/ui/transmutability/region-infer.stderr
+++ b/tests/ui/transmutability/region-infer.stderr
@@ -2,7 +2,7 @@ error[E0277]: `()` cannot be safely transmuted into `W<'_>`
   --> $DIR/region-infer.rs:18:5
    |
 LL |     test();
-   |     ^^^^^^ The size of `()` is smaller than the size of `W<'_>`
+   |     ^^^^^^ the size of `()` is smaller than the size of `W<'_>`
    |
 note: required by a bound in `test`
   --> $DIR/region-infer.rs:10:12

--- a/tests/ui/transmutability/structs/repr/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/structs/repr/should_require_well_defined_layout.stderr
@@ -2,7 +2,7 @@ error[E0277]: `should_reject_repr_rust::unit::repr_rust` cannot be safely transm
   --> $DIR/should_require_well_defined_layout.rs:27:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `should_reject_repr_rust::unit::repr_rust` does not have a well-specified layout
+   |                                                    ^^ analyzing the transmutability of `should_reject_repr_rust::unit::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -24,7 +24,7 @@ error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::
   --> $DIR/should_require_well_defined_layout.rs:28:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `should_reject_repr_rust::unit::repr_rust` does not have a well-specified layout
+   |                                               ^^^^^^^^^ analyzing the transmutability of `should_reject_repr_rust::unit::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -46,7 +46,7 @@ error[E0277]: `should_reject_repr_rust::tuple::repr_rust` cannot be safely trans
   --> $DIR/should_require_well_defined_layout.rs:33:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `should_reject_repr_rust::tuple::repr_rust` does not have a well-specified layout
+   |                                                    ^^ analyzing the transmutability of `should_reject_repr_rust::tuple::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -68,7 +68,7 @@ error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::
   --> $DIR/should_require_well_defined_layout.rs:34:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `should_reject_repr_rust::tuple::repr_rust` does not have a well-specified layout
+   |                                               ^^^^^^^^^ analyzing the transmutability of `should_reject_repr_rust::tuple::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -90,7 +90,7 @@ error[E0277]: `should_reject_repr_rust::braces::repr_rust` cannot be safely tran
   --> $DIR/should_require_well_defined_layout.rs:39:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `should_reject_repr_rust::braces::repr_rust` does not have a well-specified layout
+   |                                                    ^^ analyzing the transmutability of `should_reject_repr_rust::braces::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -112,7 +112,7 @@ error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::
   --> $DIR/should_require_well_defined_layout.rs:40:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `should_reject_repr_rust::braces::repr_rust` does not have a well-specified layout
+   |                                               ^^^^^^^^^ analyzing the transmutability of `should_reject_repr_rust::braces::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -134,7 +134,7 @@ error[E0277]: `aligned::repr_rust` cannot be safely transmuted into `()`
   --> $DIR/should_require_well_defined_layout.rs:45:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `aligned::repr_rust` does not have a well-specified layout
+   |                                                    ^^ analyzing the transmutability of `aligned::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -156,7 +156,7 @@ error[E0277]: `u128` cannot be safely transmuted into `aligned::repr_rust`
   --> $DIR/should_require_well_defined_layout.rs:46:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `aligned::repr_rust` does not have a well-specified layout
+   |                                               ^^^^^^^^^ analyzing the transmutability of `aligned::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -178,7 +178,7 @@ error[E0277]: `packed::repr_rust` cannot be safely transmuted into `()`
   --> $DIR/should_require_well_defined_layout.rs:51:52
    |
 LL |         assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                    ^^ `packed::repr_rust` does not have a well-specified layout
+   |                                                    ^^ analyzing the transmutability of `packed::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -200,7 +200,7 @@ error[E0277]: `u128` cannot be safely transmuted into `packed::repr_rust`
   --> $DIR/should_require_well_defined_layout.rs:52:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                               ^^^^^^^^^ `packed::repr_rust` does not have a well-specified layout
+   |                                               ^^^^^^^^^ analyzing the transmutability of `packed::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -222,7 +222,7 @@ error[E0277]: `nested::repr_c` cannot be safely transmuted into `()`
   --> $DIR/should_require_well_defined_layout.rs:58:49
    |
 LL |         assert::is_maybe_transmutable::<repr_c, ()>();
-   |                                                 ^^ `nested::repr_c` does not have a well-specified layout
+   |                                                 ^^ analyzing the transmutability of `nested::repr_c` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -244,7 +244,7 @@ error[E0277]: `u128` cannot be safely transmuted into `nested::repr_c`
   --> $DIR/should_require_well_defined_layout.rs:59:47
    |
 LL |         assert::is_maybe_transmutable::<u128, repr_c>();
-   |                                               ^^^^^^ `nested::repr_c` does not have a well-specified layout
+   |                                               ^^^^^^ analyzing the transmutability of `nested::repr_c` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14

--- a/tests/ui/transmutability/transmute-padding-ice.stderr
+++ b/tests/ui/transmutability/transmute-padding-ice.stderr
@@ -2,7 +2,7 @@ error[E0277]: `B` cannot be safely transmuted into `A`
   --> $DIR/transmute-padding-ice.rs:25:40
    |
 LL |     assert::is_maybe_transmutable::<B, A>();
-   |                                        ^ The size of `B` is smaller than the size of `A`
+   |                                        ^ the size of `B` is smaller than the size of `A`
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/transmute-padding-ice.rs:10:14

--- a/tests/ui/transmutability/unions/repr/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/unions/repr/should_require_well_defined_layout.stderr
@@ -2,7 +2,7 @@ error[E0277]: `should_reject_repr_rust::repr_rust` cannot be safely transmuted i
   --> $DIR/should_require_well_defined_layout.rs:29:48
    |
 LL |     assert::is_maybe_transmutable::<repr_rust, ()>();
-   |                                                ^^ `should_reject_repr_rust::repr_rust` does not have a well-specified layout
+   |                                                ^^ analyzing the transmutability of `should_reject_repr_rust::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14
@@ -24,7 +24,7 @@ error[E0277]: `u128` cannot be safely transmuted into `should_reject_repr_rust::
   --> $DIR/should_require_well_defined_layout.rs:30:43
    |
 LL |     assert::is_maybe_transmutable::<u128, repr_rust>();
-   |                                           ^^^^^^^^^ `should_reject_repr_rust::repr_rust` does not have a well-specified layout
+   |                                           ^^^^^^^^^ analyzing the transmutability of `should_reject_repr_rust::repr_rust` is not yet supported.
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_require_well_defined_layout.rs:12:14

--- a/tests/ui/transmutability/unions/should_pad_variants.stderr
+++ b/tests/ui/transmutability/unions/should_pad_variants.stderr
@@ -2,7 +2,7 @@ error[E0277]: `Src` cannot be safely transmuted into `Dst`
   --> $DIR/should_pad_variants.rs:43:36
    |
 LL |     assert::is_transmutable::<Src, Dst>();
-   |                                    ^^^ The size of `Src` is smaller than the size of `Dst`
+   |                                    ^^^ the size of `Src` is smaller than the size of `Dst`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/should_pad_variants.rs:13:14

--- a/tests/ui/transmutability/unions/should_reject_contraction.stderr
+++ b/tests/ui/transmutability/unions/should_reject_contraction.stderr
@@ -2,7 +2,7 @@ error[E0277]: `Superset` cannot be safely transmuted into `Subset`
   --> $DIR/should_reject_contraction.rs:34:41
    |
 LL |     assert::is_transmutable::<Superset, Subset>();
-   |                                         ^^^^^^ At least one value of `Superset` isn't a bit-valid value of `Subset`
+   |                                         ^^^^^^ at least one value of `Superset` isn't a bit-valid value of `Subset`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_contraction.rs:12:14

--- a/tests/ui/transmutability/unions/should_reject_disjoint.stderr
+++ b/tests/ui/transmutability/unions/should_reject_disjoint.stderr
@@ -2,7 +2,7 @@ error[E0277]: `A` cannot be safely transmuted into `B`
   --> $DIR/should_reject_disjoint.rs:32:40
    |
 LL |     assert::is_maybe_transmutable::<A, B>();
-   |                                        ^ At least one value of `A` isn't a bit-valid value of `B`
+   |                                        ^ at least one value of `A` isn't a bit-valid value of `B`
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_reject_disjoint.rs:12:14
@@ -17,7 +17,7 @@ error[E0277]: `B` cannot be safely transmuted into `A`
   --> $DIR/should_reject_disjoint.rs:33:40
    |
 LL |     assert::is_maybe_transmutable::<B, A>();
-   |                                        ^ At least one value of `B` isn't a bit-valid value of `A`
+   |                                        ^ at least one value of `B` isn't a bit-valid value of `A`
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/should_reject_disjoint.rs:12:14

--- a/tests/ui/transmutability/unions/should_reject_intersecting.stderr
+++ b/tests/ui/transmutability/unions/should_reject_intersecting.stderr
@@ -2,7 +2,7 @@ error[E0277]: `A` cannot be safely transmuted into `B`
   --> $DIR/should_reject_intersecting.rs:35:34
    |
 LL |     assert::is_transmutable::<A, B>();
-   |                                  ^ At least one value of `A` isn't a bit-valid value of `B`
+   |                                  ^ at least one value of `A` isn't a bit-valid value of `B`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_intersecting.rs:13:14
@@ -17,7 +17,7 @@ error[E0277]: `B` cannot be safely transmuted into `A`
   --> $DIR/should_reject_intersecting.rs:36:34
    |
 LL |     assert::is_transmutable::<B, A>();
-   |                                  ^ At least one value of `B` isn't a bit-valid value of `A`
+   |                                  ^ at least one value of `B` isn't a bit-valid value of `A`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/should_reject_intersecting.rs:13:14


### PR DESCRIPTION
We can (and will) support analyzing the transmutability of types whose layouts aren't completely specified by its repr. This change ensures that the error messages remain sensible after this support lands.

r? @compiler-errors