### PR TITLE
Delegation: fix ICE on duplicated associative items

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -373,6 +373,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         (trait_ref, lowered_ty)
                     });
 
+                self.is_in_trait_impl = trait_ref.is_some();
                 let new_impl_items = self
                     .arena
                     .alloc_from_iter(impl_items.iter().map(|item| self.lower_impl_item_ref(item)));
@@ -978,13 +979,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     fn lower_impl_item_ref(&mut self, i: &AssocItem) -> hir::ImplItemRef {
-        let trait_item_def_id = self
-            .resolver
-            .get_partial_res(i.id)
-            .map(|r| r.expect_full_res().opt_def_id())
-            .unwrap_or(None);
-        self.is_in_trait_impl = trait_item_def_id.is_some();
-
         hir::ImplItemRef {
             id: hir::ImplItemId { owner_id: hir::OwnerId { def_id: self.local_def_id(i.id) } },
             ident: self.lower_ident(i.ident),
@@ -1000,7 +994,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 },
                 AssocItemKind::MacCall(..) => unimplemented!(),
             },
-            trait_item_def_id,
+            trait_item_def_id: self
+                .resolver
+                .get_partial_res(i.id)
+                .map(|r| r.expect_full_res().opt_def_id())
+                .unwrap_or(None),
         }
     }
 

--- a/tests/ui/delegation/duplicate-definition-inside-trait-impl.rs
+++ b/tests/ui/delegation/duplicate-definition-inside-trait-impl.rs
@@ -1,0 +1,23 @@
+#![feature(fn_delegation)]
+//~^ WARN the feature `fn_delegation` is incomplete
+
+trait Trait {
+    fn foo(&self) -> u32 { 0 }
+}
+
+struct F;
+struct S;
+
+mod to_reuse {
+    use crate::S;
+
+    pub fn foo(_: &S) -> u32 { 0 }
+}
+
+impl Trait for S {
+    reuse to_reuse::foo { self }
+    reuse Trait::foo;
+    //~^ ERROR  duplicate definitions with name `foo`
+}
+
+fn main() {}

--- a/tests/ui/delegation/duplicate-definition-inside-trait-impl.stderr
+++ b/tests/ui/delegation/duplicate-definition-inside-trait-impl.stderr
@@ -1,0 +1,23 @@
+error[E0201]: duplicate definitions with name `foo`:
+  --> $DIR/duplicate-definition-inside-trait-impl.rs:19:5
+   |
+LL |     fn foo(&self) -> u32 { 0 }
+   |     -------------------------- item in trait
+...
+LL |     reuse to_reuse::foo { self }
+   |     ---------------------------- previous definition here
+LL |     reuse Trait::foo;
+   |     ^^^^^^^^^^^^^^^^^ duplicate definition
+
+warning: the feature `fn_delegation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/duplicate-definition-inside-trait-impl.rs:1:12
+   |
+LL | #![feature(fn_delegation)]
+   |            ^^^^^^^^^^^^^
+   |
+   = note: see issue #118212 <https://github.com/rust-lang/rust/issues/118212> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0201`.


### PR DESCRIPTION
Currently, functions delegation is only supported for delegation items with early resolved paths e.g. free functions and trait methods. During name resolution, information about function signatures is collected, including the number of parameters and whether there are self arguments. This information is then used when lowering from a delegation item into a regular function(`rustc_ast_lowering/src/delegation.rs`). The signature is usually inherited from path resolution id(`path_id`). However, in the case of trait impls `path_id` and `item_id` may be different:

```rust
trait Trait {
    fn foo(&self) -> u32 { 0 }
}

struct S;

mod to_reuse {
    use crate::S;

    pub fn foo(_: &S) -> u32 { 0 }
}

impl Trait for S {
    reuse to_reuse::foo { self }
    //~^ The signature should be inherited from item id instead of resolution id
}

```

Let's now consider an example from [issue](https://github.com/rust-lang/rust/issues/119920). Due to duplicated associative elements partial resolution for one of them will not be recorded:

https://github.com/rust-lang/rust/blob/9023f908cfbe7a475f369717a61cb8eb865cfd25/compiler/rustc_resolve/src/late.rs#L3153-L3162

Which leads to an incorrect `is_in_trait_impl` 

https://github.com/rust-lang/rust/blob/9023f908cfbe7a475f369717a61cb8eb865cfd25/compiler/rustc_ast_lowering/src/item.rs#L981-L986

Which leads to an incorrect id for signature inheritance

https://github.com/rust-lang/rust/blob/9023f908cfbe7a475f369717a61cb8eb865cfd25/compiler/rustc_ast_lowering/src/delegation.rs#L99-L105

Which lead to an ICE from original issue.

This patch fixes wrong `is_in_trait_impl`  calculation.

fixes https://github.com/rust-lang/rust/issues/119920
