### PR TITLE
Use MSVC-style escaping when passing a response/@ file to lld on windows

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/command.rs
+++ b/compiler/rustc_codegen_ssa/src/back/command.rs
@@ -100,12 +100,6 @@ impl Command {
             Program::Lld(ref p, flavor) => {
                 let mut c = process::Command::new(p);
                 c.arg("-flavor").arg(flavor.as_str());
-                if let LldFlavor::Wasm = flavor {
-                    // LLVM expects host-specific formatting for @file
-                    // arguments, but we always generate posix formatted files
-                    // at this time. Indicate as such.
-                    c.arg("--rsp-quoting=posix");
-                }
                 c
             }
         };

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1609,7 +1609,7 @@ fn exec_linker(
         args.push_str(
             &Escape {
                 arg: arg.to_str().unwrap(),
-                // LLD also uses MSVC-like parsing for @-files on windows
+                // LLD also uses MSVC-like parsing for @-files by default when running on windows hosts
                 is_like_msvc: sess.target.is_like_msvc || (cfg!(windows) && flavor.uses_lld()),
             }
             .to_string(),


### PR DESCRIPTION
LLD parses @ files like the command arguments on the platform it's on, so on windows it needs to follow the MSVC style to work correctly. Otherwise builds can fail if the linker command gets too long and the build path contains spaces.