### PR TITLE
Lower assume(false) to an unreachable terminator

### DIFF
--- a/tests/codegen/discriminant-swap.rs
+++ b/tests/codegen/discriminant-swap.rs
@@ -1,0 +1,28 @@
+// The lowering of the function below initially reads and writes to the entire pointee, even
+// though it only needs to do a store to the discriminant.
+// This test ensures that std::hint::unreachable_unchecked does not prevent the desired
+// optimization.
+
+//@ compile-flags: -O
+
+#![crate_type = "lib"]
+
+use std::hint::unreachable_unchecked;
+use std::ptr::{read, write};
+
+type T = [u8; 753];
+
+pub enum State {
+    A(T),
+    B(T),
+}
+
+// CHECK-LABEL: @init(ptr {{.*}}s)
+// CHECK-NEXT: start
+// CHECK-NEXT: store i8 1, ptr %s, align 1
+// CHECK-NEXT: ret void
+#[no_mangle]
+unsafe fn init(s: *mut State) {
+    let State::A(v) = read(s) else { unreachable_unchecked() };
+    write(s, State::B(v));
+}


### PR DESCRIPTION
This turns IR like:
```
  call void @llvm.assume(i1 false)
  call void @core::hint::unreachable_unchecked::precondition_check() #7
  br label %bb3
```
Into just:
```
  unreachable
```
I'm not sure why LLVM needs its hand held like this, but also this is a chance to emit less IR so even if the optimization is fixed in LLVM we still come out ahead.

The only part of this PR I'm not happy with is the complexity in the loop that iterates over the MIR blocks. The structure of it was a bit subtle before, and now it's just out of control. Please help?