### PR TITLE
fetch submodule before checking llvm stamp

### DIFF
--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -94,6 +94,7 @@ pub fn prebuilt_llvm_config(
         }
     }
 
+    builder.update_submodule(&Path::new("src").join("llvm-project"));
     let root = "src/llvm-project/llvm";
     let out_dir = builder.llvm_out(target);
 
@@ -279,7 +280,6 @@ impl Step for Llvm {
             Err(m) => m,
         };
 
-        builder.update_submodule(&Path::new("src").join("llvm-project"));
         if builder.llvm_link_shared() && target.is_windows() {
             panic!("shared linking to LLVM is not currently supported on {}", target.triple);
         }

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -76,6 +76,9 @@ pub fn prebuilt_llvm_config(
     builder: &Builder<'_>,
     target: TargetSelection,
 ) -> Result<LlvmResult, Meta> {
+    // If we have llvm submodule initialized already, sync it.
+    builder.update_existing_submodule(&Path::new("src").join("llvm-project"));
+
     builder.config.maybe_download_ci_llvm();
 
     // If we're using a custom LLVM bail out here, but we can only use a
@@ -94,7 +97,9 @@ pub fn prebuilt_llvm_config(
         }
     }
 
+    // Initialize the llvm submodule if not initialized already.
     builder.update_submodule(&Path::new("src").join("llvm-project"));
+
     let root = "src/llvm-project/llvm";
     let out_dir = builder.llvm_out(target);
 

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -625,6 +625,18 @@ impl Build {
         }
     }
 
+    /// Updates the given submodule only if it's initialized already; nothing happens otherwise.
+    pub fn update_existing_submodule(&self, submodule: &Path) {
+        // Avoid running git when there isn't a git checkout.
+        if !self.config.submodules(self.rust_info()) {
+            return;
+        }
+
+        if GitInfo::new(false, submodule).is_managed_git_subrepository() {
+            self.update_submodule(submodule);
+        }
+    }
+
     /// Executes the entire build, as configured by the flags and configuration.
     pub fn build(&mut self) {
         unsafe {


### PR DESCRIPTION
Previously, we were checking the LLVM stamp before fetching the submodule which leads to not being able to compile llvm on submodule updates.

Fixes #122612
Fixes #122787