### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -408,10 +408,7 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
                              traits with associated type `{name}`, you could use the \
                              fully-qualified path",
                         ),
-                        traits
-                            .iter()
-                            .map(|trait_str| format!("<Example as {trait_str}>::{name}"))
-                            .collect::<Vec<_>>(),
+                        traits.iter().map(|trait_str| format!("<Example as {trait_str}>::{name}")),
                         Applicability::HasPlaceholders,
                     );
                 }

--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -14,7 +14,8 @@ use std::{
 };
 
 use bootstrap::{
-    find_recent_config_change_ids, t, Build, Config, Subcommand, CONFIG_CHANGE_HISTORY,
+    find_recent_config_change_ids, human_readable_changes, t, Build, Config, Subcommand,
+    CONFIG_CHANGE_HISTORY,
 };
 
 fn main() {
@@ -154,14 +155,7 @@ fn check_version(config: &Config) -> Option<String> {
         }
 
         msg.push_str("There have been changes to x.py since you last updated:\n");
-
-        for change in changes {
-            msg.push_str(&format!("  [{}] {}\n", change.severity, change.summary));
-            msg.push_str(&format!(
-                "    - PR Link https://github.com/rust-lang/rust/pull/{}\n",
-                change.change_id
-            ));
-        }
+        msg.push_str(&human_readable_changes(&changes));
 
         msg.push_str("NOTE: to silence this warning, ");
         msg.push_str(&format!(

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -618,7 +618,7 @@ pub(crate) struct TomlConfig {
 #[derive(Deserialize, Default)]
 pub(crate) struct ChangeIdWrapper {
     #[serde(alias = "change-id")]
-    inner: Option<usize>,
+    pub(crate) inner: Option<usize>,
 }
 
 /// Describes how to handle conflicts in merging two [`TomlConfig`]

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -600,7 +600,8 @@ impl Target {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct TomlConfig {
     changelog_seen: Option<usize>, // FIXME: Deprecated field. Remove it at 2024.
-    change_id: Option<usize>,
+    #[serde(flatten)]
+    change_id: ChangeIdWrapper,
     build: Option<Build>,
     install: Option<Install>,
     llvm: Option<Llvm>,
@@ -608,6 +609,16 @@ pub(crate) struct TomlConfig {
     target: Option<HashMap<String, TomlTarget>>,
     dist: Option<Dist>,
     profile: Option<String>,
+}
+
+/// Since we use `#[serde(deny_unknown_fields)]` on `TomlConfig`, we need a wrapper type
+/// for the "change-id" field to parse it even if other fields are invalid. This ensures
+/// that if deserialization fails due to other fields, we can still provide the changelogs
+/// to allow developers to potentially find the reason for the failure in the logs..
+#[derive(Deserialize, Default)]
+pub(crate) struct ChangeIdWrapper {
+    #[serde(alias = "change-id")]
+    inner: Option<usize>,
 }
 
 /// Describes how to handle conflicts in merging two [`TomlConfig`]
@@ -651,7 +662,7 @@ impl Merge for TomlConfig {
             }
         }
         self.changelog_seen.merge(changelog_seen, replace);
-        self.change_id.merge(change_id, replace);
+        self.change_id.inner.merge(change_id.inner, replace);
         do_merge(&mut self.build, build, replace);
         do_merge(&mut self.install, install, replace);
         do_merge(&mut self.llvm, llvm, replace);
@@ -1200,6 +1211,20 @@ impl Config {
             toml::from_str(&contents)
                 .and_then(|table: toml::Value| TomlConfig::deserialize(table))
                 .unwrap_or_else(|err| {
+                    if let Ok(Some(changes)) = toml::from_str(&contents)
+                        .and_then(|table: toml::Value| ChangeIdWrapper::deserialize(table))
+                        .and_then(|change_id| {
+                            Ok(change_id.inner.map(|id| crate::find_recent_config_change_ids(id)))
+                        })
+                    {
+                        if !changes.is_empty() {
+                            println!(
+                                "WARNING: There have been changes to x.py since you last updated:\n{}",
+                                crate::human_readable_changes(&changes)
+                            );
+                        }
+                    }
+
                     eprintln!("failed to parse TOML configuration '{}': {err}", file.display());
                     exit!(2);
                 })
@@ -1366,7 +1391,7 @@ impl Config {
         toml.merge(override_toml, ReplaceOpt::Override);
 
         config.changelog_seen = toml.changelog_seen;
-        config.change_id = toml.change_id;
+        config.change_id = toml.change_id.inner;
 
         let Build {
             build,

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -1,4 +1,4 @@
-use super::{flags::Flags, Config};
+use super::{flags::Flags, ChangeIdWrapper, Config};
 use crate::core::config::{LldMode, TomlConfig};
 
 use clap::CommandFactory;
@@ -236,4 +236,21 @@ fn rust_lld() {
     assert!(matches!(parse("rust.use-lld = \"external\"").lld_mode, LldMode::External));
     assert!(matches!(parse("rust.use-lld = true").lld_mode, LldMode::External));
     assert!(matches!(parse("rust.use-lld = false").lld_mode, LldMode::Unused));
+}
+
+#[test]
+#[should_panic]
+fn parse_config_with_unknown_field() {
+    parse("unknown-key = 1");
+}
+
+#[test]
+fn parse_change_id_with_unknown_field() {
+    let config = r#"
+        change-id = 3461
+        unknown-key = 1
+    "#;
+
+    let change_id_wrapper: ChangeIdWrapper = toml::from_str(config).unwrap();
+    assert_eq!(change_id_wrapper.inner, Some(3461));
 }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -51,7 +51,9 @@ mod utils;
 pub use core::builder::PathSet;
 pub use core::config::flags::Subcommand;
 pub use core::config::Config;
-pub use utils::change_tracker::{find_recent_config_change_ids, CONFIG_CHANGE_HISTORY};
+pub use utils::change_tracker::{
+    find_recent_config_change_ids, human_readable_changes, CONFIG_CHANGE_HISTORY,
+};
 
 const LLVM_TOOLS: &[&str] = &[
     "llvm-cov",      // used to generate coverage report

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -60,6 +60,20 @@ pub fn find_recent_config_change_ids(current_id: usize) -> Vec<ChangeInfo> {
         .collect()
 }
 
+pub fn human_readable_changes(changes: &[ChangeInfo]) -> String {
+    let mut message = String::new();
+
+    for change in changes {
+        message.push_str(&format!("  [{}] {}\n", change.severity, change.summary));
+        message.push_str(&format!(
+            "    - PR Link https://github.com/rust-lang/rust/pull/{}\n",
+            change.change_id
+        ));
+    }
+
+    message
+}
+
 /// Keeps track of major changes made to the bootstrap configuration.
 ///
 /// If you make any major changes (such as adding new values or changing default values),

--- a/tests/ui/suggestions/suppress-consider-slicing-issue-120605.rs
+++ b/tests/ui/suggestions/suppress-consider-slicing-issue-120605.rs
@@ -1,0 +1,20 @@
+pub struct Struct {
+    a: Vec<Struct>,
+}
+
+impl Struct {
+    pub fn test(&self) {
+        if let [Struct { a: [] }] = &self.a {
+            //~^ ERROR expected an array or slice
+            //~| ERROR expected an array or slice
+            println!("matches!")
+        }
+
+        if let [Struct { a: [] }] = &self.a[..] {
+            //~^ ERROR expected an array or slice
+            println!("matches!")
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/suggestions/suppress-consider-slicing-issue-120605.stderr
+++ b/tests/ui/suggestions/suppress-consider-slicing-issue-120605.stderr
@@ -1,0 +1,23 @@
+error[E0529]: expected an array or slice, found `Vec<Struct>`
+  --> $DIR/suppress-consider-slicing-issue-120605.rs:7:16
+   |
+LL |         if let [Struct { a: [] }] = &self.a {
+   |                ^^^^^^^^^^^^^^^^^^   ------- help: consider slicing here: `&self.a[..]`
+   |                |
+   |                pattern cannot match with input type `Vec<Struct>`
+
+error[E0529]: expected an array or slice, found `Vec<Struct>`
+  --> $DIR/suppress-consider-slicing-issue-120605.rs:7:29
+   |
+LL |         if let [Struct { a: [] }] = &self.a {
+   |                             ^^ pattern cannot match with input type `Vec<Struct>`
+
+error[E0529]: expected an array or slice, found `Vec<Struct>`
+  --> $DIR/suppress-consider-slicing-issue-120605.rs:13:29
+   |
+LL |         if let [Struct { a: [] }] = &self.a[..] {
+   |                             ^^ pattern cannot match with input type `Vec<Struct>`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0529`.


### PR DESCRIPTION
Successful merges:

 - #121236 (Don't show suggestion if slice pattern is not top-level)
 - #121787 (run change tracker even when config parse fails)
 - #122633 (avoid unnecessary collect())

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=121236,121787,122633)
<!-- homu-ignore:end -->