### PR TITLE
Remove some only- clauses from mir-opt tests

### DIFF
--- a/tests/mir-opt/asm_unwind_panic_abort.rs
+++ b/tests/mir-opt/asm_unwind_panic_abort.rs
@@ -1,9 +1,8 @@
 //! Tests that unwinding from an asm block is caught and forced to abort
 //! when `-C panic=abort`.
 
-//@ only-x86_64
 //@ compile-flags: -C panic=abort
-//@ no-prefer-dynamic
+//@ needs-asm-support
 
 #![feature(asm_unwind)]
 

--- a/tests/mir-opt/pre-codegen/checked_ops.rs
+++ b/tests/mir-opt/pre-codegen/checked_ops.rs
@@ -1,7 +1,6 @@
 // skip-filecheck
 //@ compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=2
 //@ needs-unwind
-//@ only-x86_64
 
 #![crate_type = "lib"]
 #![feature(step_trait)]

--- a/tests/mir-opt/pre-codegen/intrinsics.rs
+++ b/tests/mir-opt/pre-codegen/intrinsics.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 
 // Checks that we do not have any branches in the MIR for the two tested functions.
 

--- a/tests/mir-opt/pre-codegen/loops.rs
+++ b/tests/mir-opt/pre-codegen/loops.rs
@@ -1,7 +1,6 @@
 // skip-filecheck
 //@ compile-flags: -O -Zmir-opt-level=2 -g
 //@ needs-unwind
-//@ only-64bit
 
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/pre-codegen/mem_replace.rs
+++ b/tests/mir-opt/pre-codegen/mem_replace.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2 -Zinline-mir
-//@ only-64bit
 //@ ignore-debug the standard library debug assertions leak into this test
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/pre-codegen/range_iter.rs
+++ b/tests/mir-opt/pre-codegen/range_iter.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![crate_type = "lib"]

--- a/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
@@ -3,9 +3,9 @@
 fn ezmap(_1: Option<i32>) -> Option<i32> {
     debug x => _1;
     let mut _0: std::option::Option<i32>;
-    scope 1 (inlined map::<i32, i32, {closure@$DIR/simple_option_map.rs:18:12: 18:15}>) {
+    scope 1 (inlined map::<i32, i32, {closure@$DIR/simple_option_map.rs:17:12: 17:15}>) {
         debug slf => _1;
-        debug f => const ZeroSized: {closure@$DIR/simple_option_map.rs:18:12: 18:15};
+        debug f => const ZeroSized: {closure@$DIR/simple_option_map.rs:17:12: 17:15};
         let mut _2: isize;
         let _3: i32;
         let mut _4: i32;

--- a/tests/mir-opt/pre-codegen/simple_option_map.rs
+++ b/tests/mir-opt/pre-codegen/simple_option_map.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 
 #[inline(always)]
 fn map<T, U, F>(slf: Option<T>, f: F) -> Option<U>

--- a/tests/mir-opt/pre-codegen/slice_index.rs
+++ b/tests/mir-opt/pre-codegen/slice_index.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 //@ ignore-debug the standard library debug assertions leak into this test
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/pre-codegen/slice_iter.rs
+++ b/tests/mir-opt/pre-codegen/slice_iter.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 //@ ignore-debug the standard library debug assertions leak into this test
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/pre-codegen/try_identity.rs
+++ b/tests/mir-opt/pre-codegen/try_identity.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 
 // Track the status of MIR optimizations simplifying `Ok(res?)` for both the old and new desugarings
 // of that syntax.


### PR DESCRIPTION
Derived from https://github.com/rust-lang/rust/pull/122295

Many of these tests were originally codegen tests, and MIR is more trivially portable than LLVM IR. We simply don't need to restrict the platform in most cases.

r? Nadrieril

