### PR TITLE
Enable frame pointers for the standard library

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -550,6 +550,10 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, stage: u32, car
         cargo.rustflag("-Cforce-unwind-tables=yes");
     }
 
+    // Enable frame pointers by default for the library. Note that they are still controlled by a
+    // separate setting for the compiler.
+    cargo.rustflag("-Cforce-frame-pointers=yes");
+
     let html_root =
         format!("-Zcrate-attr=doc(html_root_url=\"{}/\")", builder.doc_rust_lang_org_channel(),);
     cargo.rustflag(&html_root);


### PR DESCRIPTION
There's been a few past experiments for enabling frame pointers for all our artifacts. I don't think that frame pointers in the distributed compiler are nearly as useful as frame pointers in the standard library. Our users are much more likely to be profiling apps written in Rust than they are profiling the Rust compiler.

So yeah it would be cool to have frame pointers in the compiler, but much more of the value is having them on the precompiled standard library. That's what this PR does.