### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/tests/mir-opt/asm_unwind_panic_abort.rs
+++ b/tests/mir-opt/asm_unwind_panic_abort.rs
@@ -1,7 +1,6 @@
 //! Tests that unwinding from an asm block is caught and forced to abort
 //! when `-C panic=abort`.
 
-//@ only-x86_64
 //@ compile-flags: -C panic=abort
 //@ no-prefer-dynamic
 

--- a/tests/mir-opt/pre-codegen/checked_ops.rs
+++ b/tests/mir-opt/pre-codegen/checked_ops.rs
@@ -1,7 +1,6 @@
 // skip-filecheck
 //@ compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=2
 //@ needs-unwind
-//@ only-x86_64
 
 #![crate_type = "lib"]
 #![feature(step_trait)]

--- a/tests/mir-opt/pre-codegen/intrinsics.rs
+++ b/tests/mir-opt/pre-codegen/intrinsics.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 
 // Checks that we do not have any branches in the MIR for the two tested functions.
 

--- a/tests/mir-opt/pre-codegen/loops.rs
+++ b/tests/mir-opt/pre-codegen/loops.rs
@@ -1,7 +1,6 @@
 // skip-filecheck
 //@ compile-flags: -O -Zmir-opt-level=2 -g
 //@ needs-unwind
-//@ only-64bit
 
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/pre-codegen/mem_replace.rs
+++ b/tests/mir-opt/pre-codegen/mem_replace.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2 -Zinline-mir
-//@ only-64bit
 //@ ignore-debug the standard library debug assertions leak into this test
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/pre-codegen/range_iter.rs
+++ b/tests/mir-opt/pre-codegen/range_iter.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![crate_type = "lib"]

--- a/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
@@ -3,9 +3,9 @@
 fn ezmap(_1: Option<i32>) -> Option<i32> {
     debug x => _1;
     let mut _0: std::option::Option<i32>;
-    scope 1 (inlined map::<i32, i32, {closure@$DIR/simple_option_map.rs:18:12: 18:15}>) {
+    scope 1 (inlined map::<i32, i32, {closure@$DIR/simple_option_map.rs:17:12: 17:15}>) {
         debug slf => _1;
-        debug f => const ZeroSized: {closure@$DIR/simple_option_map.rs:18:12: 18:15};
+        debug f => const ZeroSized: {closure@$DIR/simple_option_map.rs:17:12: 17:15};
         let mut _2: isize;
         let _3: i32;
         let mut _4: i32;

--- a/tests/mir-opt/pre-codegen/simple_option_map.rs
+++ b/tests/mir-opt/pre-codegen/simple_option_map.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 
 #[inline(always)]
 fn map<T, U, F>(slf: Option<T>, f: F) -> Option<U>

--- a/tests/mir-opt/pre-codegen/slice_index.rs
+++ b/tests/mir-opt/pre-codegen/slice_index.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 //@ ignore-debug the standard library debug assertions leak into this test
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/pre-codegen/slice_iter.rs
+++ b/tests/mir-opt/pre-codegen/slice_iter.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 //@ ignore-debug the standard library debug assertions leak into this test
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/pre-codegen/try_identity.rs
+++ b/tests/mir-opt/pre-codegen/try_identity.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ only-64bit
 
 // Track the status of MIR optimizations simplifying `Ok(res?)` for both the old and new desugarings
 // of that syntax.

--- a/tests/ui/consts/control-flow/dead_branches_dont_eval.rs
+++ b/tests/ui/consts/control-flow/dead_branches_dont_eval.rs
@@ -1,0 +1,46 @@
+//@ build-pass
+
+// issue 122301 - currently the only way to supress
+// const eval and codegen of code conditional on some other const
+
+struct Foo<T, const N: usize>(T);
+
+impl<T, const N: usize> Foo<T, N> {
+    const BAR: () = if N == 0 {
+        panic!()
+    };
+}
+
+struct Invoke<T, const N: usize>(T);
+
+impl<T, const N: usize> Invoke<T, N> {
+    const FUN: fn() = if N != 0 {
+        || Foo::<T, N>::BAR
+    } else {
+        || {}
+    };
+}
+
+// without closures
+
+struct S<T>(T);
+impl<T> S<T> {
+    const C: () = panic!();
+}
+
+const fn bar<T>() { S::<T>::C }
+
+struct ConstIf<T, const N: usize>(T);
+
+impl<T, const N: usize> ConstIf<T, N> {
+    const VAL: () = if N != 0 {
+        bar::<T>() // not called for N == 0, and hence not monomorphized
+    } else {
+        ()
+    };
+}
+
+fn main() {
+    let _val = Invoke::<(), 0>::FUN();
+    let _val = ConstIf::<(), 0>::VAL;
+}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -726,6 +726,30 @@ cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 [mentions."tests/ui/check-cfg"]
 cc = ["@Urgau"]
 
+[mentions."compiler/rustc_middle/src/mir/coverage.rs"]
+message = "Some changes occurred in coverage instrumentation."
+cc = ["@Zalathar"]
+
+[mentions."compiler/rustc_mir_build/src/build/coverageinfo.rs"]
+message = "Some changes occurred in coverage instrumentation."
+cc = ["@Zalathar"]
+
+[mentions."compiler/rustc_mir_transform/src/coverage"]
+message = "Some changes occurred in coverage instrumentation."
+cc = ["@Zalathar"]
+
+[mentions."compiler/rustc_codegen_llvm/src/coverageinfo"]
+message = "Some changes occurred in coverage instrumentation."
+cc = ["@Zalathar"]
+
+[mentions."compiler/rustc_codegen_ssa/src/mir/coverageinfo.rs"]
+message = "Some changes occurred in coverage instrumentation."
+cc = ["@Zalathar"]
+
+[mentions."tests/coverage"]
+message = "Some changes occurred in coverage tests."
+cc = ["@Zalathar"]
+
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"


### PR DESCRIPTION
Successful merges:

 - #122572 (add test for #122301 to cover behavior that's on stable)
 - #122615 (Mention Zalathar for coverage changes)
 - #122645 (Remove some only- clauses from mir-opt tests)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=122572,122615,122645)
<!-- homu-ignore:end -->