### PR TITLE
simplify_cfg: rename some passes so that they make more sense

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -507,7 +507,7 @@ fn run_analysis_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     let passes: &[&dyn MirPass<'tcx>] = &[
         &cleanup_post_borrowck::CleanupPostBorrowck,
         &remove_noop_landing_pads::RemoveNoopLandingPads,
-        &simplify::SimplifyCfg::EarlyOpt,
+        &simplify::SimplifyCfg::PostAnalysis,
         &deref_separator::Derefer,
     ];
 
@@ -544,7 +544,7 @@ fn run_runtime_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     let passes: &[&dyn MirPass<'tcx>] = &[
         &lower_intrinsics::LowerIntrinsics,
         &remove_place_mention::RemovePlaceMention,
-        &simplify::SimplifyCfg::ElaborateDrops,
+        &simplify::SimplifyCfg::PreOptimizations,
     ];
 
     pm::run_passes(tcx, body, passes, Some(MirPhase::Runtime(RuntimePhase::PostCleanup)));

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -37,8 +37,11 @@ pub enum SimplifyCfg {
     Initial,
     PromoteConsts,
     RemoveFalseEdges,
-    EarlyOpt,
-    ElaborateDrops,
+    /// Runs at the beginning of "analysis to runtime" lowering, *before* drop elaboration.
+    PostAnalysis,
+    /// Runs at the end of "analysis to runtime" lowering, *after* drop elaboration.
+    /// This is before the main optimization passes on runtime MIR kick in.
+    PreOptimizations,
     Final,
     MakeShim,
     AfterUninhabitedEnumBranching,
@@ -50,8 +53,8 @@ impl SimplifyCfg {
             SimplifyCfg::Initial => "SimplifyCfg-initial",
             SimplifyCfg::PromoteConsts => "SimplifyCfg-promote-consts",
             SimplifyCfg::RemoveFalseEdges => "SimplifyCfg-remove-false-edges",
-            SimplifyCfg::EarlyOpt => "SimplifyCfg-early-opt",
-            SimplifyCfg::ElaborateDrops => "SimplifyCfg-elaborate-drops",
+            SimplifyCfg::PostAnalysis => "SimplifyCfg-post-analysis",
+            SimplifyCfg::PreOptimizations => "SimplifyCfg-pre-optimizations",
             SimplifyCfg::Final => "SimplifyCfg-final",
             SimplifyCfg::MakeShim => "SimplifyCfg-make_shim",
             SimplifyCfg::AfterUninhabitedEnumBranching => {

--- a/tests/mir-opt/array_index_is_temporary.main.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/array_index_is_temporary.main.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -1,4 +1,4 @@
-// MIR for `main` after SimplifyCfg-elaborate-drops
+// MIR for `main` after SimplifyCfg-pre-optimizations
 
 fn main() -> () {
     let mut _0: ();
@@ -36,7 +36,7 @@ fn main() -> () {
         StorageLive(_5);
         StorageLive(_6);
         _6 = _3;
-        _5 = foo(move _6) -> [return: bb1, unwind continue];
+        _5 = foo(move _6) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
@@ -45,7 +45,7 @@ fn main() -> () {
         _7 = _2;
         _8 = Len(_1);
         _9 = Lt(_7, _8);
-        assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> [success: bb2, unwind continue];
+        assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> [success: bb2, unwind unreachable];
     }
 
     bb2: {

--- a/tests/mir-opt/array_index_is_temporary.main.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/array_index_is_temporary.main.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -1,4 +1,4 @@
-// MIR for `main` after SimplifyCfg-elaborate-drops
+// MIR for `main` after SimplifyCfg-pre-optimizations
 
 fn main() -> () {
     let mut _0: ();
@@ -36,7 +36,7 @@ fn main() -> () {
         StorageLive(_5);
         StorageLive(_6);
         _6 = _3;
-        _5 = foo(move _6) -> [return: bb1, unwind unreachable];
+        _5 = foo(move _6) -> [return: bb1, unwind continue];
     }
 
     bb1: {
@@ -45,7 +45,7 @@ fn main() -> () {
         _7 = _2;
         _8 = Len(_1);
         _9 = Lt(_7, _8);
-        assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> [success: bb2, unwind unreachable];
+        assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> [success: bb2, unwind continue];
     }
 
     bb2: {

--- a/tests/mir-opt/array_index_is_temporary.rs
+++ b/tests/mir-opt/array_index_is_temporary.rs
@@ -1,4 +1,4 @@
-//@ unit-test: SimplifyCfg-elaborate-drops
+//@ unit-test: SimplifyCfg-pre-optimizations
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // Retagging (from Stacked Borrows) relies on the array index being a fresh
 // temporary, so that side-effects cannot change it.
@@ -10,7 +10,7 @@ unsafe fn foo(z: *mut usize) -> u32 {
 }
 
 
-// EMIT_MIR array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.mir
+// EMIT_MIR array_index_is_temporary.main.SimplifyCfg-pre-optimizations.after.mir
 fn main() {
     // CHECK-LABEL: fn main(
     // CHECK: debug x => [[x:_.*]];

--- a/tests/mir-opt/byte_slice.main.SimplifyCfg-pre-optimizations.after.mir
+++ b/tests/mir-opt/byte_slice.main.SimplifyCfg-pre-optimizations.after.mir
@@ -1,4 +1,4 @@
-// MIR for `main` after SimplifyCfg-elaborate-drops
+// MIR for `main` after SimplifyCfg-pre-optimizations
 
 fn main() -> () {
     let mut _0: ();

--- a/tests/mir-opt/byte_slice.rs
+++ b/tests/mir-opt/byte_slice.rs
@@ -1,7 +1,7 @@
 // skip-filecheck
 //@ compile-flags: -Z mir-opt-level=0
 
-// EMIT_MIR byte_slice.main.SimplifyCfg-elaborate-drops.after.mir
+// EMIT_MIR byte_slice.main.SimplifyCfg-pre-optimizations.after.mir
 fn main() {
     let x = b"foo";
     let y = [5u8, b'x'];

--- a/tests/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-pre-optimizations.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-pre-optimizations.after.mir
@@ -1,4 +1,4 @@
-// MIR for `BAR::promoted[0]` after SimplifyCfg-elaborate-drops
+// MIR for `BAR::promoted[0]` after SimplifyCfg-pre-optimizations
 
 const BAR::promoted[0]: &[&i32; 1] = {
     let mut _0: &[&i32; 1];

--- a/tests/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-pre-optimizations.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-pre-optimizations.after.mir
@@ -1,4 +1,4 @@
-// MIR for `FOO::promoted[0]` after SimplifyCfg-elaborate-drops
+// MIR for `FOO::promoted[0]` after SimplifyCfg-pre-optimizations
 
 const FOO::promoted[0]: &[&i32; 1] = {
     let mut _0: &[&i32; 1];

--- a/tests/mir-opt/const_promotion_extern_static.rs
+++ b/tests/mir-opt/const_promotion_extern_static.rs
@@ -6,11 +6,11 @@ extern "C" {
 static Y: i32 = 42;
 
 // EMIT_MIR const_promotion_extern_static.BAR.PromoteTemps.diff
-// EMIT_MIR const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+// EMIT_MIR const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-pre-optimizations.after.mir
 static mut BAR: *const &i32 = [&Y].as_ptr();
 
 // EMIT_MIR const_promotion_extern_static.FOO.PromoteTemps.diff
-// EMIT_MIR const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+// EMIT_MIR const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-pre-optimizations.after.mir
 static mut FOO: *const &i32 = [unsafe { &X }].as_ptr();
 
 // EMIT_MIR const_promotion_extern_static.BOP.built.after.mir

--- a/tests/mir-opt/no_drop_for_inactive_variant.rs
+++ b/tests/mir-opt/no_drop_for_inactive_variant.rs
@@ -4,7 +4,7 @@
 // Ensure that there are no drop terminators in `unwrap<T>` (except the one along the cleanup
 // path).
 
-// EMIT_MIR no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
+// EMIT_MIR no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.mir
 fn unwrap<T>(opt: Option<T>) -> T {
     match opt {
         Some(x) => x,

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -1,4 +1,4 @@
-// MIR for `unwrap` after SimplifyCfg-elaborate-drops
+// MIR for `unwrap` after SimplifyCfg-pre-optimizations
 
 fn unwrap(_1: Option<T>) -> T {
     debug opt => _1;
@@ -24,7 +24,7 @@ fn unwrap(_1: Option<T>) -> T {
 
     bb2: {
         StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> bb4;
+        _4 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
     }
 
     bb3: {
@@ -34,10 +34,5 @@ fn unwrap(_1: Option<T>) -> T {
         StorageDead(_3);
         _5 = discriminant(_1);
         return;
-    }
-
-    bb4 (cleanup): {
-        _7 = discriminant(_1);
-        resume;
     }
 }

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -1,4 +1,4 @@
-// MIR for `unwrap` after SimplifyCfg-elaborate-drops
+// MIR for `unwrap` after SimplifyCfg-pre-optimizations
 
 fn unwrap(_1: Option<T>) -> T {
     debug opt => _1;
@@ -24,7 +24,7 @@ fn unwrap(_1: Option<T>) -> T {
 
     bb2: {
         StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+        _4 = begin_panic::<&str>(const "explicit panic") -> bb4;
     }
 
     bb3: {
@@ -34,5 +34,10 @@ fn unwrap(_1: Option<T>) -> T {
         StorageDead(_3);
         _5 = discriminant(_1);
         return;
+    }
+
+    bb4 (cleanup): {
+        _7 = discriminant(_1);
+        resume;
     }
 }

--- a/tests/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -1,4 +1,4 @@
-// MIR for `main` after SimplifyCfg-elaborate-drops
+// MIR for `main` after SimplifyCfg-pre-optimizations
 
 fn main() -> () {
     let mut _0: ();

--- a/tests/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -1,4 +1,4 @@
-// MIR for `main` after SimplifyCfg-elaborate-drops
+// MIR for `main` after SimplifyCfg-pre-optimizations
 
 fn main() -> () {
     let mut _0: ();

--- a/tests/mir-opt/packed_struct_drop_aligned.rs
+++ b/tests/mir-opt/packed_struct_drop_aligned.rs
@@ -2,7 +2,7 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 
-// EMIT_MIR packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.mir
+// EMIT_MIR packed_struct_drop_aligned.main.SimplifyCfg-pre-optimizations.after.mir
 fn main() {
     let mut x = Packed(Aligned(Droppy(0)));
     x.0 = Aligned(Droppy(0));

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -1,4 +1,4 @@
-// MIR for `array_casts` after SimplifyCfg-elaborate-drops
+// MIR for `array_casts` after SimplifyCfg-pre-optimizations
 
 fn array_casts() -> () {
     let mut _0: ();

--- a/tests/mir-opt/retag.array_casts.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.array_casts.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -1,4 +1,4 @@
-// MIR for `array_casts` after SimplifyCfg-elaborate-drops
+// MIR for `array_casts` after SimplifyCfg-pre-optimizations
 
 fn array_casts() -> () {
     let mut _0: ();

--- a/tests/mir-opt/retag.main-{closure#0}.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/retag.main-{closure#0}.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -1,4 +1,4 @@
-// MIR for `main::{closure#0}` after SimplifyCfg-elaborate-drops
+// MIR for `main::{closure#0}` after SimplifyCfg-pre-optimizations
 
 fn main::{closure#0}(_1: &{closure@main::{closure#0}}, _2: &i32) -> &i32 {
     debug x => _2;

--- a/tests/mir-opt/retag.main-{closure#0}.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.main-{closure#0}.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -1,4 +1,4 @@
-// MIR for `main::{closure#0}` after SimplifyCfg-elaborate-drops
+// MIR for `main::{closure#0}` after SimplifyCfg-pre-optimizations
 
 fn main::{closure#0}(_1: &{closure@main::{closure#0}}, _2: &i32) -> &i32 {
     debug x => _2;

--- a/tests/mir-opt/retag.main.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/retag.main.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -1,4 +1,4 @@
-// MIR for `main` after SimplifyCfg-elaborate-drops
+// MIR for `main` after SimplifyCfg-pre-optimizations
 
 fn main() -> () {
     let mut _0: ();

--- a/tests/mir-opt/retag.main.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.main.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -1,4 +1,4 @@
-// MIR for `main` after SimplifyCfg-elaborate-drops
+// MIR for `main` after SimplifyCfg-pre-optimizations
 
 fn main() -> () {
     let mut _0: ();

--- a/tests/mir-opt/retag.rs
+++ b/tests/mir-opt/retag.rs
@@ -8,8 +8,8 @@
 
 struct Test(i32);
 
-// EMIT_MIR retag.{impl#0}-foo.SimplifyCfg-elaborate-drops.after.mir
-// EMIT_MIR retag.{impl#0}-foo_shr.SimplifyCfg-elaborate-drops.after.mir
+// EMIT_MIR retag.{impl#0}-foo.SimplifyCfg-pre-optimizations.after.mir
+// EMIT_MIR retag.{impl#0}-foo_shr.SimplifyCfg-pre-optimizations.after.mir
 impl Test {
     // Make sure we run the pass on a method, not just on bare functions.
     fn foo<'x>(&self, x: &'x mut i32) -> &'x mut i32 {
@@ -26,8 +26,8 @@ impl Drop for Test {
     fn drop(&mut self) {}
 }
 
-// EMIT_MIR retag.main.SimplifyCfg-elaborate-drops.after.mir
-// EMIT_MIR retag.main-{closure#0}.SimplifyCfg-elaborate-drops.after.mir
+// EMIT_MIR retag.main.SimplifyCfg-pre-optimizations.after.mir
+// EMIT_MIR retag.main-{closure#0}.SimplifyCfg-pre-optimizations.after.mir
 pub fn main() {
     let mut x = 0;
     {
@@ -55,7 +55,7 @@ pub fn main() {
 }
 
 /// Casting directly to an array should also go through `&raw` and thus add appropriate retags.
-// EMIT_MIR retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+// EMIT_MIR retag.array_casts.SimplifyCfg-pre-optimizations.after.mir
 fn array_casts() {
     let mut x: [usize; 2] = [0, 0];
     let p = &mut x as *mut usize;

--- a/tests/mir-opt/retag.{impl#0}-foo.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/retag.{impl#0}-foo.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -1,4 +1,4 @@
-// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo` after SimplifyCfg-elaborate-drops
+// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo` after SimplifyCfg-pre-optimizations
 
 fn <impl at $DIR/retag.rs:13:1: 13:10>::foo(_1: &Test, _2: &mut i32) -> &mut i32 {
     debug self => _1;

--- a/tests/mir-opt/retag.{impl#0}-foo.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.{impl#0}-foo.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -1,4 +1,4 @@
-// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo` after SimplifyCfg-elaborate-drops
+// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo` after SimplifyCfg-pre-optimizations
 
 fn <impl at $DIR/retag.rs:13:1: 13:10>::foo(_1: &Test, _2: &mut i32) -> &mut i32 {
     debug self => _1;

--- a/tests/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -1,4 +1,4 @@
-// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo_shr` after SimplifyCfg-elaborate-drops
+// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo_shr` after SimplifyCfg-pre-optimizations
 
 fn <impl at $DIR/retag.rs:13:1: 13:10>::foo_shr(_1: &Test, _2: &i32) -> &i32 {
     debug self => _1;

--- a/tests/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -1,4 +1,4 @@
-// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo_shr` after SimplifyCfg-elaborate-drops
+// MIR for `<impl at $DIR/retag.rs:13:1: 13:10>::foo_shr` after SimplifyCfg-pre-optimizations
 
 fn <impl at $DIR/retag.rs:13:1: 13:10>::foo_shr(_1: &Test, _2: &i32) -> &i32 {
     debug self => _1;

--- a/tests/mir-opt/simplify_cfg.main.SimplifyCfg-post-analysis.diff
+++ b/tests/mir-opt/simplify_cfg.main.SimplifyCfg-post-analysis.diff
@@ -1,5 +1,5 @@
-- // MIR for `main` before SimplifyCfg-early-opt
-+ // MIR for `main` after SimplifyCfg-early-opt
+- // MIR for `main` before SimplifyCfg-post-analysis
++ // MIR for `main` after SimplifyCfg-post-analysis
   
   fn main() -> () {
       let mut _0: ();

--- a/tests/mir-opt/simplify_cfg.rs
+++ b/tests/mir-opt/simplify_cfg.rs
@@ -4,7 +4,7 @@
 //@ no-prefer-dynamic
 
 // EMIT_MIR simplify_cfg.main.SimplifyCfg-initial.diff
-// EMIT_MIR simplify_cfg.main.SimplifyCfg-early-opt.diff
+// EMIT_MIR simplify_cfg.main.SimplifyCfg-post-analysis.diff
 fn main() {
     loop {
         if bar() {


### PR DESCRIPTION
I was extremely confused by `SimplifyCfg::ElaborateDrops`, since it runs way later than drop elaboration. It is used e.g. in `mir-opt/retag.rs` even though that pass doesn't care about drop elaboration at all.

"Early opt" is also very confusing since that makes it sounds like it runs early during optimizations, i.e. on runtime MIR, but actually it runs way before that.

So I decided to rename
- early-opt -> post-analysis
- elaborate-drops -> pre-optimizations

I am open to other suggestions.