### PR TITLE
ci: Build gccjit from a git archive

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+GIT_REPO="https://github.com/antoyo/gcc"
+
+# This commit hash needs to be updated to use a more recent gcc fork version.
+GIT_COMMIT="78dc50f0e50e6cd1433149520bd512a4e0eaa1bc"
+
 set -ex
 
 cd $1
@@ -7,13 +12,11 @@ cd $1
 source shared.sh
 
 # Setting up folders for GCC
-git clone https://github.com/antoyo/gcc gcc-src
-cd gcc-src
-# This commit hash needs to be updated to use a more recent gcc fork version.
-git checkout 78dc50f0e50e6cd1433149520bd512a4e0eaa1bc
+curl -L "$GIT_REPO/archive/$GIT_COMMIT.tar.gz" |
+    tar -xz --transform "s/gcc-$GIT_COMMIT/gcc-src/"
 
-mkdir ../gcc-build ../gcc-install
-cd ../gcc-build
+mkdir gcc-build gcc-install
+cd gcc-build
 
 # Building GCC.
 hide_output \
@@ -28,6 +31,7 @@ hide_output \
 hide_output make -j$(nproc)
 hide_output make install
 
-rm -rf ../gcc-src
+cd ..
+rm -rf gcc-src gcc-build
 ln -s /scripts/gcc-install/lib/libgccjit.so /usr/lib/x86_64-linux-gnu/libgccjit.so
 ln -s /scripts/gcc-install/lib/libgccjit.so /usr/lib/x86_64-linux-gnu/libgccjit.so.0

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
@@ -16,7 +16,7 @@ curl -L "$GIT_REPO/archive/$GIT_COMMIT.tar.gz" |
     tar -xz --transform "s/gcc-$GIT_COMMIT/gcc-src/"
 
 mkdir gcc-build gcc-install
-cd gcc-build
+pushd gcc-build
 
 # Building GCC.
 hide_output \
@@ -31,7 +31,7 @@ hide_output \
 hide_output make -j$(nproc)
 hide_output make install
 
-cd ..
+popd
 rm -rf gcc-src gcc-build
 ln -s /scripts/gcc-install/lib/libgccjit.so /usr/lib/x86_64-linux-gnu/libgccjit.so
 ln -s /scripts/gcc-install/lib/libgccjit.so /usr/lib/x86_64-linux-gnu/libgccjit.so.0

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GIT_REPO="https://github.com/antoyo/gcc"
+GIT_REPO="https://github.com/rust-lang/gcc"
 
 # This commit hash needs to be updated to use a more recent gcc fork version.
 GIT_COMMIT="78dc50f0e50e6cd1433149520bd512a4e0eaa1bc"


### PR DESCRIPTION
A full `git clone` of GCC includes quite a lot of history, and it's
completely unnecessary for building it in CI. We can use a GitHub
archive URL to get a simple tarball that is much faster to download.

Also, the `gcc-build` directory can be removed after install to reduce
the image size even further.
