### PR TITLE
Use `i1` to represent discriminant of non-niche-optimized bivariant `#[repr(Rust)]` enum immediates

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -42,6 +42,7 @@ pub trait LayoutCalculator {
         &self,
         a: Scalar,
         b: Scalar,
+        repr_ctxt: ReprOptions,
     ) -> LayoutS<FieldIdx, VariantIdx> {
         let dl = self.current_data_layout();
         let dl = dl.borrow();
@@ -69,6 +70,7 @@ pub trait LayoutCalculator {
             size,
             max_repr_align: None,
             unadjusted_abi_align: align.abi,
+            repr_ctxt,
         }
     }
 
@@ -160,6 +162,7 @@ pub trait LayoutCalculator {
             size: Size::ZERO,
             max_repr_align: None,
             unadjusted_abi_align: dl.i8_align.abi,
+            repr_ctxt: ReprOptions::default(),
         }
     }
 
@@ -334,6 +337,7 @@ pub trait LayoutCalculator {
             size: size.align_to(align.abi),
             max_repr_align,
             unadjusted_abi_align,
+            repr_ctxt: ReprOptions::default(),
         })
     }
 }
@@ -610,6 +614,7 @@ where
             align,
             max_repr_align,
             unadjusted_abi_align,
+            repr_ctxt: repr.clone(),
         };
 
         Some(TmpLayout { layout, variants: variant_layouts })
@@ -860,7 +865,8 @@ where
                 // Common prim might be uninit.
                 Scalar::Union { value: prim }
             };
-            let pair = layout_calc.scalar_pair::<FieldIdx, VariantIdx>(tag, prim_scalar);
+            let pair =
+                layout_calc.scalar_pair::<FieldIdx, VariantIdx>(tag, prim_scalar, repr.clone());
             let pair_offsets = match pair.fields {
                 FieldsShape::Arbitrary { ref offsets, ref memory_index } => {
                     assert_eq!(memory_index.raw, [0, 1]);
@@ -913,6 +919,7 @@ where
         size,
         max_repr_align,
         unadjusted_abi_align,
+        repr_ctxt: repr.clone(),
     };
 
     let tagged_layout = TmpLayout { layout: tagged_layout, variants: layout_variants };
@@ -1227,7 +1234,7 @@ fn univariant<
                         } else {
                             ((j, b), (i, a))
                         };
-                        let pair = this.scalar_pair::<FieldIdx, VariantIdx>(a, b);
+                        let pair = this.scalar_pair::<FieldIdx, VariantIdx>(a, b, repr.clone());
                         let pair_offsets = match pair.fields {
                             FieldsShape::Arbitrary { ref offsets, ref memory_index } => {
                                 assert_eq!(memory_index.raw, [0, 1]);
@@ -1281,6 +1288,7 @@ fn univariant<
         size,
         max_repr_align,
         unadjusted_abi_align,
+        repr_ctxt: repr.clone(),
     })
 }
 

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -1702,21 +1702,6 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
 
     fn set_span(&mut self, _span: Span) {}
 
-    fn from_immediate(&mut self, val: Self::Value) -> Self::Value {
-        if self.cx().val_ty(val) == self.cx().type_i1() {
-            self.zext(val, self.cx().type_i8())
-        } else {
-            val
-        }
-    }
-
-    fn to_immediate_scalar(&mut self, val: Self::Value, scalar: abi::Scalar) -> Self::Value {
-        if scalar.is_bool() {
-            return self.trunc(val, self.cx().type_i1());
-        }
-        val
-    }
-
     fn fptoui_sat(&mut self, val: RValue<'gcc>, dest_ty: Type<'gcc>) -> RValue<'gcc> {
         self.fptoint_sat(false, val, dest_ty)
     }

--- a/compiler/rustc_codegen_gcc/src/consts.rs
+++ b/compiler/rustc_codegen_gcc/src/consts.rs
@@ -11,7 +11,7 @@ use rustc_middle::span_bug;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{self, Instance, Ty};
 use rustc_span::def_id::DefId;
-use rustc_target::abi::{self, Align, HasDataLayout, Primitive, Size, WrappingRange};
+use rustc_target::abi::{self, Align, HasDataLayout, Primitive, Size, WrappingRange, LayoutS, ReprOptions};
 
 use crate::base;
 use crate::context::CodegenCx;
@@ -326,10 +326,10 @@ pub fn const_alloc_to_gcc<'gcc, 'tcx>(
                 interpret::Pointer::new(prov, Size::from_bytes(ptr_offset)),
                 &cx.tcx,
             ),
-            abi::Scalar::Initialized {
+            cx.tcx.mk_layout(LayoutS::scalar(cx, abi::Scalar::Initialized {
                 value: Primitive::Pointer(address_space),
                 valid_range: WrappingRange::full(dl.pointer_size),
-            },
+            }, ReprOptions::default())),
             cx.type_i8p_ext(address_space),
         ));
         next_offset = offset + pointer_size;

--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -22,7 +22,8 @@ use rustc_middle::ty::{self, Instance};
 use rustc_middle::{bug, span_bug};
 use rustc_session::config::Lto;
 use rustc_target::abi::{
-    Align, AlignFromBytesError, HasDataLayout, Primitive, Scalar, Size, WrappingRange,
+    Align, AlignFromBytesError, HasDataLayout, LayoutS, Primitive, ReprOptions, Scalar, Size,
+    WrappingRange,
 };
 use std::ops::Range;
 
@@ -96,10 +97,14 @@ pub fn const_alloc_to_llvm<'ll>(cx: &CodegenCx<'ll, '_>, alloc: ConstAllocation<
 
         llvals.push(cx.scalar_to_backend(
             InterpScalar::from_pointer(Pointer::new(prov, Size::from_bytes(ptr_offset)), &cx.tcx),
-            Scalar::Initialized {
-                value: Primitive::Pointer(address_space),
-                valid_range: WrappingRange::full(dl.pointer_size),
-            },
+            cx.tcx.mk_layout(LayoutS::scalar(
+                cx,
+                Scalar::Initialized {
+                    value: Primitive::Pointer(address_space),
+                    valid_range: WrappingRange::full(dl.pointer_size),
+                },
+                ReprOptions::default(),
+            )),
             cx.type_ptr_ext(address_space),
         ));
         next_offset = offset + pointer_size;

--- a/compiler/rustc_codegen_ssa/src/mir/constant.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/constant.rs
@@ -5,7 +5,7 @@ use rustc_middle::mir;
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::ty::layout::HasTyCtxt;
 use rustc_middle::ty::{self, Ty};
-use rustc_target::abi::Abi;
+use rustc_target::abi::{Abi, LayoutS};
 
 use super::FunctionCx;
 
@@ -81,7 +81,15 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             let Abi::Scalar(scalar) = layout.abi else {
                                 bug!("from_const: invalid ByVal layout: {:#?}", layout);
                             };
-                            bx.scalar_to_backend(prim, scalar, bx.immediate_backend_type(layout))
+                            bx.scalar_to_backend(
+                                prim,
+                                bx.tcx().mk_layout(LayoutS::scalar(
+                                    bx.cx(),
+                                    scalar,
+                                    layout.repr_ctxt,
+                                )),
+                                bx.immediate_backend_type(layout),
+                            )
                         } else {
                             bug!("simd shuffle field {:?}", field)
                         }

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -209,9 +209,10 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
                     // e.g., `#[repr(i8)] enum E { A, B }`, but we can't
                     // let LLVM interpret the `i1` as signed, because
                     // then `i1 1` (i.e., `E::B`) is effectively `i8 -1`.
-                    Int(_, signed) => !tag_scalar.is_bool() && signed,
+                    Int(_, signed) => !tag_scalar.fits_in_i1() && signed,
                     _ => false,
                 };
+                debug!(target: "PEEKABOOL", ?tag_imm, ?cast_to, ?signed);
                 bx.intcast(tag_imm, cast_to, signed)
             }
             TagEncoding::Niche { untagged_variant, ref niche_variants, niche_start } => {

--- a/compiler/rustc_codegen_ssa/src/traits/consts.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/consts.rs
@@ -34,7 +34,12 @@ pub trait ConstMethods<'tcx>: BackendTypes {
 
     fn const_data_from_alloc(&self, alloc: ConstAllocation<'tcx>) -> Self::Value;
 
-    fn scalar_to_backend(&self, cv: Scalar, layout: abi::Scalar, llty: Self::Type) -> Self::Value;
+    fn scalar_to_backend(
+        &self,
+        cv: Scalar,
+        layout: abi::Layout<'_>,
+        llty: Self::Type,
+    ) -> Self::Value;
 
     fn const_bitcast(&self, val: Self::Value, ty: Self::Type) -> Self::Value;
     fn const_ptr_byte_offset(&self, val: Self::Value, offset: abi::Size) -> Self::Value;

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -757,6 +757,7 @@ where
                     size: Size::ZERO,
                     max_repr_align: None,
                     unadjusted_abi_align: tcx.data_layout.i8_align.abi,
+                    repr_ctxt: this.layout.repr_ctxt
                 })
             }
 
@@ -782,7 +783,7 @@ where
             let tcx = cx.tcx();
             let tag_layout = |tag: Scalar| -> TyAndLayout<'tcx> {
                 TyAndLayout {
-                    layout: tcx.mk_layout(LayoutS::scalar(cx, tag)),
+                    layout: tcx.mk_layout(LayoutS::scalar(cx, tag, this.layout.repr_ctxt)),
                     ty: tag.primitive().to_ty(tcx),
                 }
             };

--- a/src/tools/rust-analyzer/crates/hir-ty/src/layout.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/layout.rs
@@ -193,6 +193,7 @@ fn layout_of_simd_ty(
         align,
         max_repr_align: None,
         unadjusted_abi_align: align.abi,
+        repr_ctxt: ReprOptions::default()
     }))
 }
 
@@ -226,6 +227,7 @@ pub fn layout_of_ty_query(
                     value: Primitive::Int(Integer::I8, false),
                     valid_range: WrappingRange { start: 0, end: 1 },
                 },
+                ReprOptions::default()
             ),
             chalk_ir::Scalar::Char => Layout::scalar(
                 dl,
@@ -233,6 +235,7 @@ pub fn layout_of_ty_query(
                     value: Primitive::Int(Integer::I32, false),
                     valid_range: WrappingRange { start: 0, end: 0x10FFFF },
                 },
+                ReprOptions::default()
             ),
             chalk_ir::Scalar::Int(i) => scalar(
                 dl,
@@ -303,6 +306,7 @@ pub fn layout_of_ty_query(
                 size,
                 max_repr_align: None,
                 unadjusted_abi_align: element.align.abi,
+                repr_ctxt: ReprOptions::default()
             }
         }
         TyKind::Slice(element) => {
@@ -316,6 +320,7 @@ pub fn layout_of_ty_query(
                 size: Size::ZERO,
                 max_repr_align: None,
                 unadjusted_abi_align: element.align.abi,
+                repr_ctxt: ReprOptions::default()
             }
         }
         TyKind::Str => Layout {
@@ -327,6 +332,7 @@ pub fn layout_of_ty_query(
             size: Size::ZERO,
             max_repr_align: None,
             unadjusted_abi_align: dl.i8_align.abi,
+            repr_ctxt: ReprOptions::default()
         },
         // Potentially-wide pointers.
         TyKind::Ref(_, _, pointee) | TyKind::Raw(_, pointee) => {
@@ -360,12 +366,12 @@ pub fn layout_of_ty_query(
                 }
                 _ => {
                     // pointee is sized
-                    return Ok(Arc::new(Layout::scalar(dl, data_ptr)));
+                    return Ok(Arc::new(Layout::scalar(dl, data_ptr, ReprOptions::default())));
                 }
             };
 
             // Effectively a (ptr, meta) tuple.
-            cx.scalar_pair(data_ptr, metadata)
+            cx.scalar_pair(data_ptr, metadata, ReprOptions::default())
         }
         TyKind::FnDef(_, _) => layout_of_unit(&cx, dl)?,
         TyKind::Never => cx.layout_of_never_type(),
@@ -380,7 +386,7 @@ pub fn layout_of_ty_query(
         TyKind::Function(_) => {
             let mut ptr = scalar_unit(dl, Primitive::Pointer(dl.instruction_address_space));
             ptr.valid_range_mut().start = 1;
-            Layout::scalar(dl, ptr)
+            Layout::scalar(dl, ptr, ReprOptions::default())
         }
         TyKind::OpaqueType(opaque_ty_id, _) => {
             let impl_trait_id = db.lookup_intern_impl_trait_id((*opaque_ty_id).into());
@@ -483,7 +489,7 @@ fn scalar_unit(dl: &TargetDataLayout, value: Primitive) -> Scalar {
 }
 
 fn scalar(dl: &TargetDataLayout, value: Primitive) -> Layout {
-    Layout::scalar(dl, scalar_unit(dl, value))
+    Layout::scalar(dl, scalar_unit(dl, value), ReprOptions::default())
 }
 
 #[cfg(test)]

--- a/tests/codegen/enum/discriminant-i1.rs
+++ b/tests/codegen/enum/discriminant-i1.rs
@@ -1,0 +1,14 @@
+// Check that `Option<u32>` in argument position and return position are represented as immediates
+// with `ScalarPair(i1, i32)` "in-register" format.
+//@ compile-flags: -C no-prepopulate-passes
+#![crate_type = "lib"]
+
+// CHECK: define void @arg(i1 noundef %_x.0, i32 %_x.1)
+#[no_mangle]
+pub fn arg(_x: Option<u32>) {}
+
+// CHECK: define { i1, i32 } @ret()
+#[no_mangle]
+pub fn ret() -> Option<u32> {
+    None
+}

--- a/tests/codegen/enum/discriminant-not-immediate.rs
+++ b/tests/codegen/enum/discriminant-not-immediate.rs
@@ -1,0 +1,28 @@
+// Checks that upon read/write of non-immediate enums that the discriminant has correct layout.
+//@ compile-flags: -C no-prepopulate-passes
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @write_option_to_memory(
+#[no_mangle]
+pub fn write_option_to_memory(store: &mut Option<u32>, reg: Option<u32>) {
+    // CHECK: %[[Z:.+]] = zext i1 %reg.0 to i32
+    // CHECK: store i32 %[[Z]], ptr %store, align 4
+    // CHECK: %[[P:.+]] = getelementptr inbounds i8, ptr %store, i64 4
+    // CHECK: store i32 %reg.1, ptr %[[P]], align 4
+    *store = reg;
+}
+
+// CHECK-LABEL: @read_option_from_memory(
+#[no_mangle]
+pub fn read_option_from_memory(store: &Option<u32>) -> Option<u32> {
+    // CHECK: %[[RAW_STORE_DISCRIM:.+]] = load i32, ptr %store, align 4
+    // CHECK-SAME: !range
+    // CHECK-SAME: !noundef
+    // CHECK: %[[RET:.+]].0 = trunc i32 %[[RAW_STORE_DISCRIM]] to i1
+    // CHECK: %[[RAW_STORE_T:.+]] = getelementptr inbounds i8, ptr %store, i64 4
+    // CHECK: %[[RET]].1 = load i32, ptr %[[RAW_STORE_T]], align 4
+    // CHECK: %[[IMM:.+]] = insertvalue { i1, i32 } poison, i1 %[[RET]].0, 0
+    // CHECK: %[[R:.+]] = insertvalue { i1, i32 } %[[IMM]], i32 %[[RET]].1, 1
+    // CHECK: ret { i1, i32 } %[[R]]
+    *store
+}

--- a/tests/codegen/enum/two-variant-fieldless-enum-repr-uint.rs
+++ b/tests/codegen/enum/two-variant-fieldless-enum-repr-uint.rs
@@ -1,0 +1,52 @@
+// Check that two-variant fieldless enum with unsigned integer representations don't get represented
+// as `i1` except for the bool special case.
+//
+//@ compile-flags: -C no-prepopulate-passes
+#![crate_type = "lib"]
+#![feature(repr128)]
+
+#[repr(u8)]
+pub enum FakeBoolU8 { True, False }
+
+// CHECK: define void @fake_bool_u8(i1 noundef zeroext %_x)
+#[no_mangle]
+pub fn fake_bool_u8(_x: FakeBoolU8) {}
+
+#[repr(u16)]
+pub enum FakeBoolU16 { True, False }
+
+// CHECK: define void @fake_bool_u16(i16 noundef %_x)
+#[no_mangle]
+pub fn fake_bool_u16(_x: FakeBoolU16) {}
+
+#[repr(u32)]
+pub enum FakeBoolU32 { True, False }
+
+// CHECK: define void @fake_bool_u32(i32 noundef %_x)
+#[no_mangle]
+pub fn fake_bool_u32(_x: FakeBoolU32) {}
+
+#[repr(u64)]
+pub enum FakeBoolU64 { True, False }
+
+// CHECK: define void @fake_bool_u64(i64 noundef %_x)
+#[no_mangle]
+pub fn fake_bool_u64(_x: FakeBoolU64) {}
+
+#[repr(u128)]
+pub enum FakeBoolU128 { True, False }
+
+// CHECK: define void @fake_bool_u128(i128 noundef %_x)
+#[no_mangle]
+pub fn fake_bool_u128(_x: FakeBoolU128) {}
+
+// Check that `zeroext` is present when `extern "C"`.
+// CHECK: define void @repr_c_fake_bool_u16(i16 noundef zeroext %_x)
+#[no_mangle]
+pub extern "C" fn repr_c_fake_bool_u16(_x: FakeBoolU16) {}
+
+pub enum RustFakeBoolU16 { True, False }
+
+// CHECK: define void @repr_rust_fake_bool_u16(i1 noundef zeroext %_x)
+#[no_mangle]
+pub fn repr_rust_fake_bool_u16(_x: RustFakeBoolU16) {}

--- a/tests/codegen/intrinsics/transmute.rs
+++ b/tests/codegen/intrinsics/transmute.rs
@@ -192,6 +192,15 @@ pub unsafe fn check_byte_from_bool(x: bool) -> u8 {
 pub unsafe fn check_to_pair(x: u64) -> Option<i32> {
     // CHECK: %_0 = alloca %"core::option::Option<i32>", align 4
     // CHECK: store i64 %x, ptr %_0, align 4
+    // CHECK-NEXT: load i32, ptr %_0, align 4
+    // CHECK-SAME: !range
+    // CHECK-SAME: !noundef
+    // CHECK-NEXT: trunc i32 %0 to i1
+    // CHECK-NEXT: getelementptr inbounds i8, ptr %_0, i64 4
+    // CHECK-NEXT: load i32, ptr %2, align 4
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: ret { i1, i32 }
     transmute(x)
 }
 
@@ -203,8 +212,10 @@ pub unsafe fn check_from_pair(x: Option<i32>) -> u64 {
     const { assert!(std::mem::align_of::<Option<i32>>() == 4) };
 
     // CHECK: %_0 = alloca i64, align 8
-    // CHECK: store i32 %x.0, ptr %_0, align 8
-    // CHECK: store i32 %x.1, ptr %0, align 4
+    // CHECK: %0 = zext i1 %x.0 to i32
+    // CHECK: store i32 %0, ptr %_0, align 8
+    // CHECK: %1 = getelementptr inbounds i8, ptr %_0, i64 4
+    // CHECK: store i32 %x.1, ptr %1, align 4
     // CHECK: %[[R:.+]] = load i64, ptr %_0, align 8
     // CHECK: ret i64 %[[R]]
     transmute(x)

--- a/tests/codegen/iter-repeat-n-trivial-drop.rs
+++ b/tests/codegen/iter-repeat-n-trivial-drop.rs
@@ -20,8 +20,8 @@ pub fn iter_repeat_n_next(it: &mut std::iter::RepeatN<NotCopy>) -> Option<NotCop
     // CHECK-NEXT: start:
     // CHECK-NOT: br
     // CHECK: %[[COUNT:.+]] = load i64
-    // CHECK-NEXT: %[[COUNT_ZERO:.+]] = icmp eq i64 %[[COUNT]], 0
-    // CHECK-NEXT: br i1 %[[COUNT_ZERO]], label %[[EMPTY:.+]], label %[[NOT_EMPTY:.+]]
+    // CHECK-NEXT: %0 = icmp ne i64 %[[COUNT]], 0
+    // CHECK-NEXT: br i1 %0, label %[[NOT_EMPTY:.+]], label %[[EMPTY:.+]]
 
     // CHECK: [[NOT_EMPTY]]:
     // CHECK-NEXT: %[[DEC:.+]] = add i64 %[[COUNT]], -1

--- a/tests/codegen/overaligned-constant.rs
+++ b/tests/codegen/overaligned-constant.rs
@@ -16,8 +16,8 @@ fn main() {
     // CHECK-LABEL: @_ZN20overaligned_constant4main
     // CHECK: [[full:%_.*]] = alloca %SmallStruct, align 8
     // CHECK: call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[full]], ptr align 8 @0, i64 32, i1 false)
-    // CHECK: %b.0 = load i32, ptr @0, align 4,
-    // CHECK: %b.1 = load i32, ptr getelementptr inbounds ({{.*}}), align 4
+    // CHECK: %b.0 = trunc i32 %0 to i1
+    // CHECK: %b.1 = load i32, ptr getelementptr inbounds (i8, ptr @0, i64 4), align 4
     let mut s = S(1);
 
     s.0 = 3;

--- a/tests/codegen/try_question_mark_nop.rs
+++ b/tests/codegen/try_question_mark_nop.rs
@@ -11,9 +11,9 @@ use std::ptr::NonNull;
 #[no_mangle]
 pub fn option_nop_match_32(x: Option<u32>) -> Option<u32> {
     // CHECK: start:
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: ret { i32, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: ret { i1, i32 } %3
     match x {
         Some(x) => Some(x),
         None => None,
@@ -24,9 +24,9 @@ pub fn option_nop_match_32(x: Option<u32>) -> Option<u32> {
 #[no_mangle]
 pub fn option_nop_traits_32(x: Option<u32>) -> Option<u32> {
     // CHECK: start:
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: ret { i32, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: ret { i1, i32 } %3
     try {
         x?
     }
@@ -36,9 +36,9 @@ pub fn option_nop_traits_32(x: Option<u32>) -> Option<u32> {
 #[no_mangle]
 pub fn result_nop_match_32(x: Result<i32, u32>) -> Result<i32, u32> {
     // CHECK: start:
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: ret { i32, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: ret { i1, i32 }
     match x {
         Ok(x) => Ok(x),
         Err(x) => Err(x),
@@ -49,9 +49,9 @@ pub fn result_nop_match_32(x: Result<i32, u32>) -> Result<i32, u32> {
 #[no_mangle]
 pub fn result_nop_traits_32(x: Result<i32, u32>) -> Result<i32, u32> {
     // CHECK: start:
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: ret { i32, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: ret { i1, i32 }
     try {
         x?
     }
@@ -61,9 +61,9 @@ pub fn result_nop_traits_32(x: Result<i32, u32>) -> Result<i32, u32> {
 #[no_mangle]
 pub fn result_nop_match_64(x: Result<i64, u64>) -> Result<i64, u64> {
     // CHECK: start:
-    // CHECK-NEXT: insertvalue { i64, i64 }
-    // CHECK-NEXT: insertvalue { i64, i64 }
-    // CHECK-NEXT: ret { i64, i64 }
+    // CHECK-NEXT: insertvalue { i1, i64 }
+    // CHECK-NEXT: insertvalue { i1, i64 }
+    // CHECK-NEXT: ret { i1, i64 }
     match x {
         Ok(x) => Ok(x),
         Err(x) => Err(x),
@@ -74,9 +74,9 @@ pub fn result_nop_match_64(x: Result<i64, u64>) -> Result<i64, u64> {
 #[no_mangle]
 pub fn result_nop_traits_64(x: Result<i64, u64>) -> Result<i64, u64> {
     // CHECK: start:
-    // CHECK-NEXT: insertvalue { i64, i64 }
-    // CHECK-NEXT: insertvalue { i64, i64 }
-    // CHECK-NEXT: ret { i64, i64 }
+    // CHECK-NEXT: insertvalue { i1, i64 }
+    // CHECK-NEXT: insertvalue { i1, i64 }
+    // CHECK-NEXT: ret { i1, i64 }
     try {
         x?
     }
@@ -86,9 +86,9 @@ pub fn result_nop_traits_64(x: Result<i64, u64>) -> Result<i64, u64> {
 #[no_mangle]
 pub fn result_nop_match_ptr(x: Result<usize, Box<()>>) -> Result<usize, Box<()>> {
     // CHECK: start:
-    // CHECK-NEXT: insertvalue { i{{[0-9]+}}, ptr }
-    // CHECK-NEXT: insertvalue { i{{[0-9]+}}, ptr }
-    // CHECK-NEXT: ret
+    // CHECK-NEXT: insertvalue { i1, ptr }
+    // CHECK-NEXT: insertvalue { i1, ptr }
+    // CHECK-NEXT: ret { i1, ptr }
     match x {
         Ok(x) => Ok(x),
         Err(x) => Err(x),
@@ -99,9 +99,9 @@ pub fn result_nop_match_ptr(x: Result<usize, Box<()>>) -> Result<usize, Box<()>>
 #[no_mangle]
 pub fn result_nop_traits_ptr(x: Result<u64, NonNull<()>>) -> Result<u64, NonNull<()>> {
     // CHECK: start:
-    // CHECK-NEXT: insertvalue { i{{[0-9]+}}, ptr }
-    // CHECK-NEXT: insertvalue { i{{[0-9]+}}, ptr }
-    // CHECK-NEXT: ret
+    // CHECK-NEXT: insertvalue { i1, ptr }
+    // CHECK-NEXT: insertvalue { i1, ptr }
+    // CHECK-NEXT: ret { i1, ptr }
     try {
         x?
     }
@@ -111,9 +111,9 @@ pub fn result_nop_traits_ptr(x: Result<u64, NonNull<()>>) -> Result<u64, NonNull
 #[no_mangle]
 pub fn control_flow_nop_match_32(x: ControlFlow<i32, u32>) -> ControlFlow<i32, u32> {
     // CHECK: start:
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: ret { i32, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: ret { i1, i32 }
     match x {
         Continue(x) => Continue(x),
         Break(x) => Break(x),
@@ -124,9 +124,9 @@ pub fn control_flow_nop_match_32(x: ControlFlow<i32, u32>) -> ControlFlow<i32, u
 #[no_mangle]
 pub fn control_flow_nop_traits_32(x: ControlFlow<i32, u32>) -> ControlFlow<i32, u32> {
     // CHECK: start:
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: ret { i32, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: insertvalue { i1, i32 }
+    // CHECK-NEXT: ret { i1, i32 }
     try {
         x?
     }


### PR DESCRIPTION
Currently, non-niche-optimized bivariant `#[repr(Rust)]` enums passed as immediates as arguments or return values have full-sized discriminants. For example:

- `pub fn ret() -> Option<u32>` is `define { i32, i32 } @ret()`
- `pub fn arg(_x: Option<u32>)` is `define void @arg(i32 noundef %x.0, i32 %x.1)`

Returning like this loses range metadata, and similarly the discriminant could be passed as `i1` in the argument instead.

This PR changes the "in-register" format of `#[repr(Rust)]` enum immediates to become

- `define { i1, i32 } @ret()`, and
- `define void @arg(i1 noundef %_x.0, i32 %_x.1)`

respectively.

This change is intentionally restricted to enums which satisfies all three conditions:

1. **Bivariant**: only affects discriminant if the discriminant can fit in `i1`.
2. **Immediates**: non-immediates (e.g. loads/stores) do not use `i1` discriminant representation.
3. **`#[repr(Rust)]`**: other `repr`s such as packed, C, `repr(iN/uN)`, etc. prevents using the `i1` discriminant representation for ABI correctness. Notably, bivariant `repr(u8)/repr(i8)` enums (them as a scalar or their discriminant) apparently are... special, because they or their discriminant are affected by the bool hack.