### PR TITLE
Add some tests for public-private dependencies.

### DIFF
--- a/tests/ui/privacy/pub-priv-dep/auxiliary/diamond_priv_dep.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/diamond_priv_dep.rs
@@ -1,0 +1,9 @@
+//@ aux-crate:shared=shared.rs
+
+extern crate shared;
+
+pub use shared::Shared;
+
+pub struct SharedInType {
+    pub f: Shared
+}

--- a/tests/ui/privacy/pub-priv-dep/auxiliary/diamond_pub_dep.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/diamond_pub_dep.rs
@@ -1,0 +1,9 @@
+//@ aux-crate:shared=shared.rs
+
+extern crate shared;
+
+pub use shared::Shared;
+
+pub struct SharedInType {
+    pub f: Shared
+}

--- a/tests/ui/privacy/pub-priv-dep/auxiliary/indirect1.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/indirect1.rs
@@ -1,0 +1,4 @@
+//@ aux-crate:priv:indirect2=indirect2.rs
+//@ compile-flags: -Zunstable-options
+
+extern crate indirect2;

--- a/tests/ui/privacy/pub-priv-dep/auxiliary/indirect2.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/indirect2.rs
@@ -1,0 +1,4 @@
+//@ aux-crate:shared=shared.rs
+
+// This is public.
+extern crate shared;

--- a/tests/ui/privacy/pub-priv-dep/auxiliary/pm.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/pm.rs
@@ -1,0 +1,22 @@
+//@ force-host
+//@ no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn fn_like(input: TokenStream) -> TokenStream {
+    "".parse().unwrap()
+}
+
+#[proc_macro_derive(PmDerive)]
+pub fn pm_derive(item: TokenStream) -> TokenStream {
+    "".parse().unwrap()
+}
+
+#[proc_macro_attribute]
+pub fn pm_attr(attr: TokenStream, item: TokenStream) -> TokenStream {
+    "".parse().unwrap()
+}

--- a/tests/ui/privacy/pub-priv-dep/auxiliary/priv_dep.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/priv_dep.rs
@@ -1,2 +1,11 @@
 pub struct OtherType;
 pub trait OtherTrait {}
+
+#[macro_export]
+macro_rules! m {
+    () => {};
+}
+
+pub enum E {
+    V1
+}

--- a/tests/ui/privacy/pub-priv-dep/auxiliary/reexport.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/reexport.rs
@@ -1,0 +1,5 @@
+//@ aux-crate:shared=shared.rs
+
+extern crate shared;
+
+pub use shared::Shared;

--- a/tests/ui/privacy/pub-priv-dep/auxiliary/shared.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/shared.rs
@@ -1,0 +1,1 @@
+pub struct Shared;

--- a/tests/ui/privacy/pub-priv-dep/diamond_deps.rs
+++ b/tests/ui/privacy/pub-priv-dep/diamond_deps.rs
@@ -1,0 +1,48 @@
+//@ aux-crate:priv:diamond_priv_dep=diamond_priv_dep.rs
+//@ aux-crate:diamond_pub_dep=diamond_pub_dep.rs
+//@ compile-flags: -Zunstable-options
+
+// A diamond dependency:
+//
+//           diamond_reepxort
+//                  /\
+//        (public) /  \ (PRIVATE)
+//                /    \
+//   diamond_pub_dep  diamond_priv_dep
+//                \    /
+//        (public) \  /  (public)
+//                  \/
+//                shared
+//
+// Where the pub and private crates reexport something from the shared crate.
+//
+// Checks the behavior when the same shared item appears in the public API,
+// depending on whether it comes from the public side or the private side.
+//
+// NOTE: compiletest does not support deduplicating shared dependencies.
+// However, it should work well enough for this test, the only downside is
+// that diamond_shared gets built twice.
+
+#![crate_type = "lib"]
+#![deny(exported_private_dependencies)]
+
+extern crate diamond_priv_dep;
+extern crate diamond_pub_dep;
+
+// FIXME: This should trigger.
+pub fn leaks_priv() -> diamond_priv_dep::Shared {
+    diamond_priv_dep::Shared
+}
+
+pub fn leaks_pub() -> diamond_pub_dep::Shared {
+    diamond_pub_dep::Shared
+}
+
+pub struct PrivInStruct {
+    pub f: diamond_priv_dep::SharedInType
+//~^ ERROR type `diamond_priv_dep::SharedInType` from private dependency 'diamond_priv_dep' in public interface
+}
+
+pub struct PubInStruct {
+    pub f: diamond_pub_dep::SharedInType
+}

--- a/tests/ui/privacy/pub-priv-dep/diamond_deps.stderr
+++ b/tests/ui/privacy/pub-priv-dep/diamond_deps.stderr
@@ -1,0 +1,14 @@
+error: type `diamond_priv_dep::SharedInType` from private dependency 'diamond_priv_dep' in public interface
+  --> $DIR/diamond_deps.rs:42:5
+   |
+LL |     pub f: diamond_priv_dep::SharedInType
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/diamond_deps.rs:27:9
+   |
+LL | #![deny(exported_private_dependencies)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -1,12 +1,20 @@
 //@ aux-crate:priv:priv_dep=priv_dep.rs
 //@ aux-build:pub_dep.rs
+//@ aux-crate:priv:pm=pm.rs
 //@ compile-flags: -Zunstable-options
+
+// Basic behavior check of exported_private_dependencies from either a public
+// dependency or a private one.
+
 #![deny(exported_private_dependencies)]
 
 // This crate is a private dependency
-extern crate priv_dep;
+// FIXME: This should trigger.
+pub extern crate priv_dep;
 // This crate is a public dependency
 extern crate pub_dep;
+// This crate is a private dependency
+extern crate pm;
 
 use priv_dep::{OtherTrait, OtherType};
 use pub_dep::PubType;
@@ -25,7 +33,10 @@ pub struct PublicType {
 }
 
 impl PublicType {
-    pub fn pub_fn(param: OtherType) {}
+    pub fn pub_fn_param(param: OtherType) {}
+    //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+
+    pub fn pub_fn_return() -> OtherType { OtherType }
     //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
 
     fn priv_fn(param: OtherType) {}
@@ -36,9 +47,61 @@ pub trait MyPubTrait {
 }
 //~^^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
 
+pub trait WithSuperTrait: OtherTrait {}
+//~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
+
+pub trait PubLocalTraitWithAssoc {
+    type X;
+}
+
+pub struct PrivateAssoc;
+impl PubLocalTraitWithAssoc for PrivateAssoc {
+    type X = OtherType;
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+}
+
+pub fn in_bounds<T: OtherTrait>(x: T) { unimplemented!() }
+//~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
+
+pub fn private_in_generic() -> std::num::Saturating<OtherType> { unimplemented!() }
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+
+pub static STATIC: OtherType = OtherType;
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+
+pub const CONST: OtherType = OtherType;
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+
+pub type Alias = OtherType;
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+
+pub struct PublicWithPrivateImpl;
+
+// FIXME: This should trigger.
+// See https://github.com/rust-lang/rust/issues/71043
+impl OtherTrait for PublicWithPrivateImpl {}
+
+pub trait PubTraitOnPrivate {}
+
+// FIXME: This should trigger.
+// See https://github.com/rust-lang/rust/issues/71043
+impl PubTraitOnPrivate for OtherType {}
+
 pub struct AllowedPrivType {
     #[allow(exported_private_dependencies)]
     pub allowed: OtherType,
 }
+
+// FIXME: This should trigger.
+pub use priv_dep::m;
+// FIXME: This should trigger.
+pub use pm::fn_like;
+// FIXME: This should trigger.
+pub use pm::PmDerive;
+// FIXME: This should trigger.
+pub use pm::pm_attr;
+
+// FIXME: This should trigger.
+pub use priv_dep::E::V1;
 
 fn main() {}

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
@@ -1,26 +1,74 @@
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:21:5
+  --> $DIR/pub-priv1.rs:29:5
    |
 LL |     pub field: OtherType,
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/pub-priv1.rs:4:9
+  --> $DIR/pub-priv1.rs:9:9
    |
 LL | #![deny(exported_private_dependencies)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:28:5
+  --> $DIR/pub-priv1.rs:36:5
    |
-LL |     pub fn pub_fn(param: OtherType) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     pub fn pub_fn_param(param: OtherType) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:39:5
+   |
+LL |     pub fn pub_fn_return() -> OtherType { OtherType }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:35:5
+  --> $DIR/pub-priv1.rs:46:5
    |
 LL |     type Foo: OtherTrait;
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:50:1
+   |
+LL | pub trait WithSuperTrait: OtherTrait {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:59:5
+   |
+LL |     type X = OtherType;
+   |     ^^^^^^
+
+error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:63:1
+   |
+LL | pub fn in_bounds<T: OtherTrait>(x: T) { unimplemented!() }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:66:1
+   |
+LL | pub fn private_in_generic() -> std::num::Saturating<OtherType> { unimplemented!() }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:69:1
+   |
+LL | pub static STATIC: OtherType = OtherType;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:72:1
+   |
+LL | pub const CONST: OtherType = OtherType;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:75:1
+   |
+LL | pub type Alias = OtherType;
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/privacy/pub-priv-dep/reexport_from_priv.rs
+++ b/tests/ui/privacy/pub-priv-dep/reexport_from_priv.rs
@@ -1,0 +1,15 @@
+//@ aux-crate:priv:reexport=reexport.rs
+//@ compile-flags: -Zunstable-options
+//@ check-pass
+
+// Checks the behavior of a reexported item from a private dependency.
+
+#![crate_type = "lib"]
+#![deny(exported_private_dependencies)]
+
+extern crate reexport;
+
+// FIXME: This should trigger.
+pub fn leaks_priv() -> reexport::Shared {
+    reexport::Shared
+}

--- a/tests/ui/privacy/pub-priv-dep/shared_both_private.rs
+++ b/tests/ui/privacy/pub-priv-dep/shared_both_private.rs
@@ -1,0 +1,32 @@
+//@ aux-crate:priv:shared=shared.rs
+//@ aux-crate:reexport=reexport.rs
+//@ compile-flags: -Zunstable-options
+//@ check-pass
+
+// A shared dependency, where a private dependency reexports a public dependency.
+//
+//         shared_both_private
+//                  /\
+//       (PRIVATE) /  | (PRIVATE)
+//                /   |
+//        reexport    |
+//                \   |
+//        (public) \  /
+//                  \/
+//                shared
+
+#![crate_type = "lib"]
+#![deny(exported_private_dependencies)]
+
+extern crate shared;
+extern crate reexport;
+
+// FIXME: This should trigger.
+pub fn leaks_priv() -> shared::Shared {
+    shared::Shared
+}
+
+// FIXME: This should trigger.
+pub fn leaks_priv_reexport() -> reexport::Shared {
+    reexport::Shared
+}

--- a/tests/ui/privacy/pub-priv-dep/shared_direct_private.rs
+++ b/tests/ui/privacy/pub-priv-dep/shared_direct_private.rs
@@ -1,0 +1,39 @@
+//@ aux-crate:priv:shared=shared.rs
+//@ aux-crate:reexport=reexport.rs
+//@ compile-flags: -Zunstable-options
+//@ check-pass
+
+// A shared dependency, where the public side reexports the same item as a
+// direct private dependency.
+//
+//          shared_direct_private
+//                  /\
+//        (public) /  | (PRIVATE)
+//                /   |
+//        reexport    |
+//                \   |
+//        (public) \  /
+//                  \/
+//                shared
+//
+
+#![crate_type = "lib"]
+#![deny(exported_private_dependencies)]
+
+extern crate shared;
+extern crate reexport;
+
+// FIXME: Should this trigger?
+//
+// One could make an argument that I said I want "reexport" to be public, and
+// since "reexport" says "shared_direct_private" is public, then it should
+// transitively be public for me. However, as written, this is explicitly
+// referring to a dependency that is marked "private", which I think is
+// confusing.
+pub fn leaks_priv() -> shared::Shared {
+    shared::Shared
+}
+
+pub fn leaks_pub() -> reexport::Shared {
+    reexport::Shared
+}

--- a/tests/ui/privacy/pub-priv-dep/shared_indirect.rs
+++ b/tests/ui/privacy/pub-priv-dep/shared_indirect.rs
@@ -1,0 +1,29 @@
+//@ aux-crate:priv:shared=shared.rs
+//@ aux-crate:priv:indirect1=indirect1.rs
+//@ compile-flags: -Zunstable-options
+//@ check-pass
+
+// A shared dependency, where it is only indirectly public.
+//
+//            shared_indirect
+//                  /\
+//       (PRIVATE) /  | (PRIVATE)
+//                /   |
+//     indirect1 |    |
+//     (PRIVATE) |    |
+//     indirect2 |    |
+//                \   |
+//        (public) \  /
+//                  \/
+//                shared
+
+#![crate_type = "lib"]
+#![deny(exported_private_dependencies)]
+
+extern crate shared;
+extern crate indirect1;
+
+// FIXME: This should trigger.
+pub fn leaks_priv() -> shared::Shared {
+    shared::Shared
+}


### PR DESCRIPTION
This adds some tests to show more scenarios for the `exported_private_dependencies` lint. Several of these illustrate that the lint is not working as expected, and I have annotated those places with `FIXME`. 

Note also that this includes some diamond dependency structures which compiletest doesn't exactly support. However, I don't think it should be a problem, it just results in the common dependency being built twice.
