### PR TITLE
core: document default attribute stabilization

### DIFF
--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -71,6 +71,8 @@ use crate::ascii::Char as AsciiChar;
 ///
 /// You cannot use the `#[default]` attribute on non-unit or non-exhaustive variants.
 ///
+/// The `#[default]` attribute was stabilized in Rust 1.62.0.
+///
 /// ## How can I implement `Default`?
 ///
 /// Provide an implementation for the `default()` method that returns the value of


### PR DESCRIPTION
As of now, the first release which stabilized the `#[default]` macro for the deriving the `Default` trait for enus is not documented.
I have had to search the [`RELEASES.md`](https://github.com/rust-lang/rust/blob/master/RELEASES.md) when making sure my code would be accepted by an older Rust compiler.

I just added a line in the doc comment since, as far as I know, there's no option to pass to the `#[stable()]` attribute.

I am open to improvements in the wording.