### PR TITLE
Fix incorrect mutable suggestion information for binding in ref pattern.

### DIFF
--- a/src/tools/tidy/src/issues.txt
+++ b/src/tools/tidy/src/issues.txt
@@ -3463,7 +3463,6 @@
 "ui/pattern/issue-106552.rs",
 "ui/pattern/issue-106862.rs",
 "ui/pattern/issue-110508.rs",
-"ui/pattern/issue-114896.rs",
 "ui/pattern/issue-115599.rs",
 "ui/pattern/issue-11577.rs",
 "ui/pattern/issue-117626.rs",

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.fixed
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.fixed
@@ -1,6 +1,9 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
 fn main() {
     fn x(a: &char) {
-        let &b = a;
+        let &(mut b) = a;
         b.make_ascii_uppercase();
 //~^ cannot borrow `b` as mutable, as it is not declared as mutable
     }

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.rs
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.rs
@@ -1,0 +1,10 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
+fn main() {
+    fn x(a: &char) {
+        let &b = a;
+        b.make_ascii_uppercase();
+//~^ cannot borrow `b` as mutable, as it is not declared as mutable
+    }
+}

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
@@ -1,5 +1,5 @@
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
-  --> $DIR/issue-114896.rs:4:9
+  --> $DIR/patkind-ref-binding-issue-114896.rs:7:9
    |
 LL |         let &b = a;
    |             -- help: consider changing this to be mutable: `&(mut b)`

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.fixed
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.fixed
@@ -1,0 +1,11 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
+fn mutate(_y: &mut i32) {}
+
+fn foo(&(mut x): &i32) {
+    mutate(&mut x);
+    //~^ ERROR cannot borrow `x` as mutable
+}
+
+fn main() {}

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.rs
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.rs
@@ -1,0 +1,11 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
+fn mutate(_y: &mut i32) {}
+
+fn foo(&x: &i32) {
+    mutate(&mut x);
+    //~^ ERROR cannot borrow `x` as mutable
+}
+
+fn main() {}

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
@@ -1,0 +1,11 @@
+error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/patkind-ref-binding-issue-122415.rs:7:12
+   |
+LL | fn foo(&x: &i32) {
+   |        -- help: consider changing this to be mutable: `&(mut x)`
+LL |     mutate(&mut x);
+   |            ^^^^^^ cannot borrow as mutable
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0596`.


### PR DESCRIPTION
For ref pattern in func param, the mutability suggestion has to apply to the binding.

For example: `fn foo(&x: &i32)` -> `fn foo(&(mut x): &i32)`

fixes #122415