### PR TITLE
Do not eat nested expressions' results in `MayContainYieldPoint` format args visitor

### DIFF
--- a/compiler/rustc_ast_lowering/src/format.rs
+++ b/compiler/rustc_ast_lowering/src/format.rs
@@ -604,8 +604,7 @@ fn may_contain_yield_point(e: &ast::Expr) -> bool {
             if let ast::ExprKind::Await(_, _) | ast::ExprKind::Yield(_) = e.kind {
                 ControlFlow::Break(())
             } else {
-                visit::walk_expr(self, e);
-                ControlFlow::Continue(())
+                visit::walk_expr(self, e)
             }
         }
 

--- a/tests/ui/fmt/nested-awaits-issue-122674.rs
+++ b/tests/ui/fmt/nested-awaits-issue-122674.rs
@@ -1,0 +1,22 @@
+// Non-regression test for issue #122674: a change in the format args visitor missed nested awaits.
+
+//@ edition: 2021
+//@ check-pass
+
+pub fn f1() -> impl std::future::Future<Output = Result<(), String>> + Send {
+    async {
+        should_work().await?;
+        Ok(())
+    }
+}
+
+async fn should_work() -> Result<String, String> {
+    let x = 1;
+    Err(format!("test: {}: {}", x, inner().await?))
+}
+
+async fn inner() -> Result<String, String> {
+    Ok("test".to_string())
+}
+
+fn main() {}


### PR DESCRIPTION
#121563 unintentionally changed the `MayContainYieldPoint` format args visitor behavior, now missing yield points in nested expressions, as seen in #122674.

The walk can find a yield point in an expression but it was ignored.

r? @petrochenkov as the reviewer of #121563
cc @Jarcho as the author

Fixes #122674.
We're in the 1.77 release week. #121563 will land on 1.78 but beta is still 1.77.9: this PR will likely need to be backported soon after beta is cut.
