### PR TITLE
Fix ICE: `global_asm!()` Don't Panic When Unable to Evaluate Constant

### DIFF
--- a/tests/ui/asm/fail-const-eval-issue-121099.rs
+++ b/tests/ui/asm/fail-const-eval-issue-121099.rs
@@ -1,4 +1,5 @@
 //@ build-fail
+//@ needs-asm-support
 #![feature(asm_const)]
 
 use std::arch::global_asm;

--- a/tests/ui/asm/fail-const-eval-issue-121099.rs
+++ b/tests/ui/asm/fail-const-eval-issue-121099.rs
@@ -1,0 +1,10 @@
+//@ build-fail 
+#![feature(asm_const)]
+
+use std::arch::global_asm;
+
+fn main() {}
+
+global_asm!("/* {} */", const 1 << 500); //~ ERROR evaluation of constant value failed [E0080]
+
+global_asm!("/* {} */", const 1 / 0); //~ ERROR evaluation of constant value failed [E0080]

--- a/tests/ui/asm/fail-const-eval-issue-121099.rs
+++ b/tests/ui/asm/fail-const-eval-issue-121099.rs
@@ -1,4 +1,4 @@
-//@ build-fail 
+//@ build-fail
 #![feature(asm_const)]
 
 use std::arch::global_asm;

--- a/tests/ui/asm/fail-const-eval-issue-121099.stderr
+++ b/tests/ui/asm/fail-const-eval-issue-121099.stderr
@@ -1,0 +1,15 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/fail-const-eval-issue-121099.rs:8:31
+   |
+LL | global_asm!("/* {} */", const 1 << 500);
+   |                               ^^^^^^^^ attempt to shift left by `500_i32`, which would overflow
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/fail-const-eval-issue-121099.rs:10:31
+   |
+LL | global_asm!("/* {} */", const 1 / 0);
+   |                               ^^^^^ attempt to divide `1_i32` by zero
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/asm/fail-const-eval-issue-121099.stderr
+++ b/tests/ui/asm/fail-const-eval-issue-121099.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/fail-const-eval-issue-121099.rs:8:31
+  --> $DIR/fail-const-eval-issue-121099.rs:9:31
    |
 LL | global_asm!("/* {} */", const 1 << 500);
    |                               ^^^^^^^^ attempt to shift left by `500_i32`, which would overflow
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/fail-const-eval-issue-121099.rs:10:31
+  --> $DIR/fail-const-eval-issue-121099.rs:11:31
    |
 LL | global_asm!("/* {} */", const 1 / 0);
    |                               ^^^^^ attempt to divide `1_i32` by zero


### PR DESCRIPTION
Fixes #121099 

A bit of an inelegant fix but given that the error is created only
after call to `const_eval_poly()` and that the calling function
cannot propagate the error anywhere else, the error has to be
explicitly handled inside `mono_item.rs`.

r? @Amanieu 