### PR TITLE
Detect allocator for box in `must_not_suspend` lint

### DIFF
--- a/tests/ui/lint/must_not_suspend/allocator.rs
+++ b/tests/ui/lint/must_not_suspend/allocator.rs
@@ -1,0 +1,30 @@
+//@ edition: 2021
+
+#![feature(must_not_suspend, allocator_api)]
+#![deny(must_not_suspend)]
+
+use std::alloc::*;
+use std::ptr::NonNull;
+
+#[must_not_suspend]
+struct MyAllocatorWhichMustNotSuspend;
+
+unsafe impl Allocator for MyAllocatorWhichMustNotSuspend {
+    fn allocate(&self, l: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        Global.allocate(l)
+    }
+    unsafe fn deallocate(&self, p: NonNull<u8>, l: Layout) {
+        Global.deallocate(p, l)
+    }
+}
+
+async fn suspend() {}
+
+async fn foo() {
+    let x = Box::new_in(1i32, MyAllocatorWhichMustNotSuspend);
+    //~^ ERROR allocator `MyAllocatorWhichMustNotSuspend` held across a suspend point, but should not be
+    suspend().await;
+    drop(x);
+}
+
+fn main() {}

--- a/tests/ui/lint/must_not_suspend/allocator.stderr
+++ b/tests/ui/lint/must_not_suspend/allocator.stderr
@@ -1,0 +1,22 @@
+error: allocator `MyAllocatorWhichMustNotSuspend` held across a suspend point, but should not be
+  --> $DIR/allocator.rs:24:9
+   |
+LL |     let x = Box::new_in(1i32, MyAllocatorWhichMustNotSuspend);
+   |         ^
+LL |
+LL |     suspend().await;
+   |               ----- the value is held across this suspend point
+   |
+help: consider using a block (`{ ... }`) to shrink the value's scope, ending before the suspend point
+  --> $DIR/allocator.rs:24:9
+   |
+LL |     let x = Box::new_in(1i32, MyAllocatorWhichMustNotSuspend);
+   |         ^
+note: the lint level is defined here
+  --> $DIR/allocator.rs:4:9
+   |
+LL | #![deny(must_not_suspend)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
I don't expect this to happen in practice, but better to check than not.

Fixes #122643