### PR TITLE
[WIP] Use assume rather than range metadata

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1017,6 +1017,7 @@ extern "C" {
 
     // Operations on instructions
     pub fn LLVMIsAInstruction(Val: &Value) -> Option<&Value>;
+    pub fn LLVMIsALoadInst(Val: &Value) -> Option<&Value>;
     pub fn LLVMGetFirstBasicBlock(Fn: &Value) -> &BasicBlock;
 
     // Operations on call sites


### PR DESCRIPTION
Fixes #122726.

Currently, range can only be used in load, call and invoke instructions. Due to SROA being run before other passes, even in the simplest IR, LLVM cannot infer that `%i1` is 0. Most of the range metadata will be dropped before they work.

```llvm
define noundef i32 @src(i32 noundef %arg) {
  %i = alloca i32, align 4
  store i32 %arg, ptr %i, align 4
  %i1 = load i32, ptr %i, align 4, !range !0
  ret i32 %i1
}
```

https://alive2.llvm.org/ce/z/MjsH9b

r? @ghost