### PR TITLE
Expose `ucred::peer_cred` on QNX targets to enable dist builds

### DIFF
--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -8,7 +8,8 @@
     target_os = "macos",
     target_os = "watchos",
     target_os = "netbsd",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "nto"
 ))]
 use super::{peer_cred, UCred};
 #[cfg(any(doc, target_os = "android", target_os = "linux"))]
@@ -234,7 +235,8 @@ impl UnixStream {
         target_os = "macos",
         target_os = "watchos",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "nto"
     ))]
     pub fn peer_cred(&self) -> io::Result<UCred> {
         peer_cred(self)

--- a/library/std/src/os/unix/net/ucred.rs
+++ b/library/std/src/os/unix/net/ucred.rs
@@ -30,7 +30,8 @@ pub(super) use self::impl_linux::peer_cred;
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "openbsd",
-    target_os = "netbsd"
+    target_os = "netbsd",
+    target_os = "nto"
 ))]
 pub(super) use self::impl_bsd::peer_cred;
 


### PR DESCRIPTION
After following https://doc.rust-lang.org/rustc/platform-support/nto-qnx.html I attempted to run the following `x.py` command:

```bash
export build_env='
    CC_aarch64-unknown-nto-qnx710=qcc
    CFLAGS_aarch64-unknown-nto-qnx710=-Vgcc_ntoaarch64le_cxx
    CXX_aarch64-unknown-nto-qnx710=qcc
    AR_aarch64_unknown_nto_qnx710=ntoaarch64-ar
    CC_x86_64-pc-nto-qnx710=qcc
    CFLAGS_x86_64-pc-nto-qnx710=-Vgcc_ntox86_64_cxx
    CXX_x86_64-pc-nto-qnx710=qcc
    AR_x86_64_pc_nto_qnx710=ntox86_64-ar'
env $build_env ./x.py --stage 2 dist rust-std  --target aarch64-unknown-nto-qnx710,x86_64-pc-nto-qnx710,x86_64-unknown-linux-gnu
```

The result was the following error:

```
   Compiling object v0.32.2
   Compiling std_detect v0.1.5 (/home/ana/git/rust-lang/rust/library/stdarch/crates/std_detect)
   Compiling addr2line v0.21.0
error: function `peer_cred` is never used
  --> library/std/src/os/unix/net/ucred.rs:89:12
   |
89 |     pub fn peer_cred(socket: &UnixStream) -> io::Result<UCred> {
   |            ^^^^^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`

error: could not compile `std` (lib) due to 1 previous error
Build completed unsuccessfully in 0:06:25
```

I contacted @flba-eb and @gh-tr over email and we confirmed that `peer_cred` here should be flagged on `nto` targets. This should enable the clean `x.py --stage 2 dist rust-std` command on these platforms.