### PR TITLE
Strip placeholders from hidden types before remapping generic parameter

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -192,6 +192,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                         .find(|ur_vid| self.eval_equal(vid, **ur_vid))
                         .and_then(|ur_vid| self.definitions[*ur_vid].external_name)
                         .unwrap_or(infcx.tcx.lifetimes.re_erased),
+                    ty::RePlaceholder(_) => ty::Region::new_error_with_message(
+                        infcx.tcx,
+                        concrete_type.span,
+                        "hidden type contains placeholders, we don't support higher kinded opaques yet",
+                    ),
                     _ => region,
                 });
             debug!(?universal_concrete_type);

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden4.rs
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden4.rs
@@ -1,0 +1,25 @@
+//! This test used to ICE because, while an error was emitted,
+//! we still tried to remap generic params used in the hidden type
+//! to the ones of the opaque type definition.
+
+//@ edition: 2021
+
+#![feature(type_alias_impl_trait)]
+use std::future::Future;
+
+type FutNothing<'a> = impl 'a + Future<Output = ()>;
+//~^ ERROR: unconstrained opaque type
+
+async fn operation(_: &mut ()) -> () {
+    //~^ ERROR: concrete type differs from previous
+    call(operation).await
+}
+
+async fn call<F>(_f: F)
+where
+    for<'any> F: FnMut(&'any mut ()) -> FutNothing<'any>,
+{
+    //~^ ERROR: expected generic lifetime parameter, found `'any`
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden4.stderr
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden4.stderr
@@ -1,0 +1,34 @@
+error: unconstrained opaque type
+  --> $DIR/hkl_forbidden4.rs:10:23
+   |
+LL | type FutNothing<'a> = impl 'a + Future<Output = ()>;
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `FutNothing` must be used in combination with a concrete type within the same module
+
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/hkl_forbidden4.rs:13:1
+   |
+LL | async fn operation(_: &mut ()) -> () {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `FutNothing<'_>`, got `{async fn body@$DIR/hkl_forbidden4.rs:13:38: 16:2}`
+   |
+note: previous use here
+  --> $DIR/hkl_forbidden4.rs:15:5
+   |
+LL |     call(operation).await
+   |     ^^^^^^^^^^^^^^^
+
+error[E0792]: expected generic lifetime parameter, found `'any`
+  --> $DIR/hkl_forbidden4.rs:21:1
+   |
+LL |   type FutNothing<'a> = impl 'a + Future<Output = ()>;
+   |                   -- this generic parameter must be used with a generic lifetime parameter
+...
+LL | / {
+LL | |
+LL | | }
+   | |_^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0792`.


### PR DESCRIPTION
When remapping generic parameters in the hidden type to the generic parameters of the definition of the opaque, we assume that placeholders cannot exist. Instead of just patching that site, I decided to handle it earlier, directly in `infer_opaque_types`, where we are already doing all the careful lifetime handling.

fixes #122694

the reason that ICE now occurred was that we stopped treating `operation` as being in the defining scope, so the TAIT became part of the hidden type of the `async fn`'s opaque type instead of just bailing out as ambiguos

I think

```rust
use std::future::Future;

mod foo {
    type FutNothing<'a> = impl 'a + Future<Output = ()>;
    //~^ ERROR: unconstrained opaque type
}

async fn operation(_: &mut ()) -> () {
    //~^ ERROR: concrete type differs from previous
    call(operation).await
    //~^ ERROR: concrete type differs from previous
}

async fn call<F>(_f: F)
where
    for<'any> F: FnMut(&'any mut ()) -> foo::FutNothing<'any>,
{
    //~^ ERROR: expected generic lifetime parameter, found `'any`
}
```

would have already had the same ICE before https://github.com/rust-lang/rust/pull/121796