### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/index.rs
+++ b/compiler/rustc_ast_lowering/src/index.rs
@@ -55,7 +55,7 @@ pub(super) fn index_hir<'hir>(
         OwnerNode::TraitItem(item) => collector.visit_trait_item(item),
         OwnerNode::ImplItem(item) => collector.visit_impl_item(item),
         OwnerNode::ForeignItem(item) => collector.visit_foreign_item(item),
-        OwnerNode::AssocOpaqueTy(..) => unreachable!(),
+        OwnerNode::Synthetic => unreachable!(),
     };
 
     for (local_id, node) in collector.nodes.iter_enumerated() {

--- a/compiler/rustc_const_eval/src/interpret/intern.rs
+++ b/compiler/rustc_const_eval/src/interpret/intern.rs
@@ -111,6 +111,8 @@ fn intern_as_new_static<'tcx>(
     feed.generics_of(tcx.generics_of(static_id).clone());
     feed.def_ident_span(tcx.def_ident_span(static_id));
     feed.explicit_predicates_of(tcx.explicit_predicates_of(static_id));
+
+    feed.feed_hir()
 }
 
 /// How a constant value should be interned.

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -124,7 +124,7 @@ pub fn find_feature_issue(feature: Symbol, issue: GateIssue) -> Option<NonZero<u
 pub use accepted::ACCEPTED_FEATURES;
 pub use builtin_attrs::AttributeDuplicates;
 pub use builtin_attrs::{
-    deprecated_attributes, find_gated_cfg, is_builtin_attr_name, is_builtin_only_local,
+    deprecated_attributes, encode_cross_crate, find_gated_cfg, is_builtin_attr_name,
     is_valid_for_get_attr, AttributeGate, AttributeTemplate, AttributeType, BuiltinAttribute,
     GatedCfg, BUILTIN_ATTRIBUTES, BUILTIN_ATTRIBUTE_MAP,
 };

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -196,7 +196,7 @@ fn check_well_formed(tcx: TyCtxt<'_>, def_id: hir::OwnerId) -> Result<(), ErrorG
         hir::OwnerNode::TraitItem(item) => check_trait_item(tcx, item),
         hir::OwnerNode::ImplItem(item) => check_impl_item(tcx, item),
         hir::OwnerNode::ForeignItem(item) => check_foreign_item(tcx, item),
-        hir::OwnerNode::AssocOpaqueTy(..) => unreachable!(),
+        hir::OwnerNode::Synthetic => unreachable!(),
     };
 
     if let Some(generics) = node.generics() {

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -262,7 +262,7 @@ fn resolve_bound_vars(tcx: TyCtxt<'_>, local_def_id: hir::OwnerId) -> ResolveBou
             visitor.visit_impl_item(item)
         }
         hir::OwnerNode::Crate(_) => {}
-        hir::OwnerNode::AssocOpaqueTy(..) => unreachable!(),
+        hir::OwnerNode::Synthetic => unreachable!(),
     }
 
     let mut rl = ResolveBoundVars::default();

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -121,7 +121,7 @@ impl<'a> State<'a> {
                 self.print_bounds(":", pred.bounds);
             }
             Node::ArrayLenInfer(_) => self.word("_"),
-            Node::AssocOpaqueTy(..) => unreachable!(),
+            Node::Synthetic => unreachable!(),
             Node::Err(_) => self.word("/*ERROR*/"),
         }
     }

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2553,7 +2553,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             hir::OwnerNode::ImplItem(i) => visitor.visit_impl_item(i),
             hir::OwnerNode::TraitItem(i) => visitor.visit_trait_item(i),
             hir::OwnerNode::Crate(_) => bug!("OwnerNode::Crate doesn't not have generics"),
-            hir::OwnerNode::AssocOpaqueTy(..) => unreachable!(),
+            hir::OwnerNode::Synthetic => unreachable!(),
         }
 
         let ast_generics = self.tcx.hir().get_generics(lifetime_scope).unwrap();

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -191,7 +191,7 @@ fn shallow_lint_levels_on(tcx: TyCtxt<'_>, owner: hir::OwnerId) -> ShallowLintLe
                 levels.add_id(hir::CRATE_HIR_ID);
                 levels.visit_mod(mod_, mod_.spans.inner_span, hir::CRATE_HIR_ID)
             }
-            hir::OwnerNode::AssocOpaqueTy(..) => unreachable!(),
+            hir::OwnerNode::Synthetic => unreachable!(),
         },
     }
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -817,8 +817,8 @@ struct AnalyzeAttrState {
 #[inline]
 fn analyze_attr(attr: &Attribute, state: &mut AnalyzeAttrState) -> bool {
     let mut should_encode = false;
-    if rustc_feature::is_builtin_only_local(attr.name_or_empty()) {
-        // Attributes marked local-only don't need to be encoded for downstream crates.
+    if !rustc_feature::encode_cross_crate(attr.name_or_empty()) {
+        // Attributes not marked encode-cross-crate don't need to be encoded for downstream crates.
     } else if attr.doc_str().is_some() {
         // We keep all doc comments reachable to rustdoc because they might be "imported" into
         // downstream crates if they use `#[doc(inline)]` to copy an item's documentation into

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -954,7 +954,7 @@ impl<'hir> Map<'hir> {
             Node::Crate(item) => item.spans.inner_span,
             Node::WhereBoundPredicate(pred) => pred.span,
             Node::ArrayLenInfer(inf) => inf.span,
-            Node::AssocOpaqueTy(..) => unreachable!(),
+            Node::Synthetic => unreachable!(),
             Node::Err(span) => *span,
         }
     }
@@ -1219,7 +1219,7 @@ fn hir_id_to_string(map: Map<'_>, id: HirId) -> String {
         Node::Crate(..) => String::from("(root_crate)"),
         Node::WhereBoundPredicate(_) => node_str("where bound predicate"),
         Node::ArrayLenInfer(_) => node_str("array len infer"),
-        Node::AssocOpaqueTy(..) => unreachable!(),
+        Node::Synthetic => unreachable!(),
         Node::Err(_) => node_str("error"),
     }
 }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -596,6 +596,27 @@ impl<'tcx> TyCtxtFeed<'tcx, LocalDefId> {
     pub fn feed_owner_id(&self) -> TyCtxtFeed<'tcx, hir::OwnerId> {
         TyCtxtFeed { tcx: self.tcx, key: hir::OwnerId { def_id: self.key } }
     }
+
+    // Fills in all the important parts needed by HIR queries
+    pub fn feed_hir(&self) {
+        self.local_def_id_to_hir_id(HirId::make_owner(self.def_id()));
+
+        let node = hir::OwnerNode::Synthetic;
+        let bodies = Default::default();
+        let attrs = hir::AttributeMap::EMPTY;
+
+        let (opt_hash_including_bodies, _) = self.tcx.hash_owner_nodes(node, &bodies, &attrs.map);
+        let node = node.into();
+        self.opt_hir_owner_nodes(Some(self.tcx.arena.alloc(hir::OwnerNodes {
+            opt_hash_including_bodies,
+            nodes: IndexVec::from_elem_n(
+                hir::ParentedNode { parent: hir::ItemLocalId::INVALID, node },
+                1,
+            ),
+            bodies,
+        })));
+        self.feed_owner_id().hir_attrs(attrs);
+    }
 }
 
 /// The central data structure of the compiler. It stores references

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1752,9 +1752,8 @@ impl<'tcx> TyCtxt<'tcx> {
         let filter_fn = move |a: &&ast::Attribute| a.has_name(attr);
         if let Some(did) = did.as_local() {
             self.hir().attrs(self.local_def_id_to_hir_id(did)).iter().filter(filter_fn)
-        } else if cfg!(debug_assertions) && rustc_feature::is_builtin_only_local(attr) {
-            bug!("tried to access the `only_local` attribute `{}` from an extern crate", attr);
         } else {
+            debug_assert!(rustc_feature::encode_cross_crate(attr));
             self.item_attrs(did).iter().filter(filter_fn)
         }
     }
@@ -1786,12 +1785,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
     /// Determines whether an item is annotated with an attribute.
     pub fn has_attr(self, did: impl Into<DefId>, attr: Symbol) -> bool {
-        let did: DefId = did.into();
-        if cfg!(debug_assertions) && !did.is_local() && rustc_feature::is_builtin_only_local(attr) {
-            bug!("tried to access the `only_local` attribute `{}` from an extern crate", attr);
-        } else {
-            self.get_attrs(did, attr).next().is_some()
-        }
+        self.get_attrs(did, attr).next().is_some()
     }
 
     /// Returns `true` if this is an `auto trait`.

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -943,7 +943,10 @@ impl<'a> Parser<'a> {
         // Stitch the list of outer attributes onto the return value.
         // A little bit ugly, but the best way given the current code
         // structure
-        let res = self.parse_expr_dot_or_call_with_(e0, lo);
+        let res = ensure_sufficient_stack(
+            // this expr demonstrates the recursion it guards against
+            || self.parse_expr_dot_or_call_with_(e0, lo),
+        );
         if attrs.is_empty() {
             res
         } else {

--- a/compiler/rustc_passes/src/reachable.rs
+++ b/compiler/rustc_passes/src/reachable.rs
@@ -247,7 +247,7 @@ impl<'tcx> ReachableContext<'tcx> {
             | Node::Field(_)
             | Node::Ty(_)
             | Node::Crate(_)
-            | Node::AssocOpaqueTy(..) => {}
+            | Node::Synthetic => {}
             _ => {
                 bug!(
                     "found unexpected node kind in worklist: {} ({:?})",

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4645,6 +4645,13 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
     }
 
     fn lint_unused_qualifications(&mut self, path: &[Segment], ns: Namespace, finalize: Finalize) {
+        // Don't lint on global paths because the user explicitly wrote out the full path.
+        if let Some(seg) = path.first()
+            && seg.ident.name == kw::PathRoot
+        {
+            return;
+        }
+
         if path.iter().any(|seg| seg.ident.span.from_expansion()) {
             return;
         }

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -241,18 +241,16 @@ fn associated_types_for_impl_traits_in_associated_fn(
 fn feed_hir(feed: &TyCtxtFeed<'_, LocalDefId>) {
     feed.local_def_id_to_hir_id(HirId::make_owner(feed.def_id()));
 
-    let node = hir::OwnerNode::AssocOpaqueTy(&hir::AssocOpaqueTy {});
+    let node = hir::OwnerNode::Synthetic;
     let bodies = Default::default();
     let attrs = hir::AttributeMap::EMPTY;
 
     let (opt_hash_including_bodies, _) = feed.tcx.hash_owner_nodes(node, &bodies, &attrs.map);
+    let node = node.into();
     feed.opt_hir_owner_nodes(Some(feed.tcx.arena.alloc(hir::OwnerNodes {
         opt_hash_including_bodies,
         nodes: IndexVec::from_elem_n(
-            hir::ParentedNode {
-                parent: hir::ItemLocalId::INVALID,
-                node: hir::Node::AssocOpaqueTy(&hir::AssocOpaqueTy {}),
-            },
+            hir::ParentedNode { parent: hir::ItemLocalId::INVALID, node },
             1,
         ),
         bodies,

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1337,7 +1337,7 @@ impl<T> SizedTypeProperties for T {}
 /// type B = Wrapper<u8, i8>;
 ///
 /// // Not necessarily identical even though `u8` and `i8` have the same layout!
-/// // assert!(mem::offset_of!(A, 1), mem::offset_of!(B, 1));
+/// // assert_eq!(mem::offset_of!(A, 1), mem::offset_of!(B, 1));
 ///
 /// #[repr(transparent)]
 /// struct U8(u8);
@@ -1345,12 +1345,12 @@ impl<T> SizedTypeProperties for T {}
 /// type C = Wrapper<u8, U8>;
 ///
 /// // Not necessarily identical even though `u8` and `U8` have the same layout!
-/// // assert!(mem::offset_of!(A, 1), mem::offset_of!(C, 1));
+/// // assert_eq!(mem::offset_of!(A, 1), mem::offset_of!(C, 1));
 ///
 /// struct Empty<T>(core::marker::PhantomData<T>);
 ///
 /// // Not necessarily identical even though `PhantomData` always has the same layout!
-/// // assert!(mem::offset_of!(Empty<u8>, 0), mem::offset_of!(Empty<i8>, 0));
+/// // assert_eq!(mem::offset_of!(Empty<u8>, 0), mem::offset_of!(Empty<i8>, 0));
 /// ```
 ///
 /// [explicit `repr` attribute]: https://doc.rust-lang.org/reference/type-layout.html#representations

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -36,6 +36,7 @@ impl HeadersCache {
 #[derive(Default)]
 pub struct EarlyProps {
     pub aux: Vec<String>,
+    pub aux_bin: Vec<String>,
     pub aux_crate: Vec<(String, String)>,
     pub revisions: Vec<String>,
 }
@@ -59,6 +60,12 @@ impl EarlyProps {
                 config.push_name_value_directive(ln, directives::AUX_BUILD, &mut props.aux, |r| {
                     r.trim().to_string()
                 });
+                config.push_name_value_directive(
+                    ln,
+                    directives::AUX_BIN,
+                    &mut props.aux_bin,
+                    |r| r.trim().to_string(),
+                );
                 config.push_name_value_directive(
                     ln,
                     directives::AUX_CRATE,
@@ -95,6 +102,8 @@ pub struct TestProps {
     // directory as the test, but for backwards compatibility reasons
     // we also check the auxiliary directory)
     pub aux_builds: Vec<String>,
+    // Auxiliary crates that should be compiled as `#![crate_type = "bin"]`.
+    pub aux_bins: Vec<String>,
     // Similar to `aux_builds`, but a list of NAME=somelib.rs of dependencies
     // to build and pass with the `--extern` flag.
     pub aux_crates: Vec<(String, String)>,
@@ -217,6 +226,7 @@ mod directives {
     pub const PRETTY_EXPANDED: &'static str = "pretty-expanded";
     pub const PRETTY_MODE: &'static str = "pretty-mode";
     pub const PRETTY_COMPARE_ONLY: &'static str = "pretty-compare-only";
+    pub const AUX_BIN: &'static str = "aux-bin";
     pub const AUX_BUILD: &'static str = "aux-build";
     pub const AUX_CRATE: &'static str = "aux-crate";
     pub const EXEC_ENV: &'static str = "exec-env";
@@ -252,6 +262,7 @@ impl TestProps {
             run_flags: None,
             pp_exact: None,
             aux_builds: vec![],
+            aux_bins: vec![],
             aux_crates: vec![],
             revisions: vec![],
             rustc_env: vec![("RUSTC_ICE".to_string(), "0".to_string())],
@@ -415,6 +426,9 @@ impl TestProps {
                         &mut self.pretty_compare_only,
                     );
                     config.push_name_value_directive(ln, AUX_BUILD, &mut self.aux_builds, |r| {
+                        r.trim().to_string()
+                    });
+                    config.push_name_value_directive(ln, AUX_BIN, &mut self.aux_bins, |r| {
                         r.trim().to_string()
                     });
                     config.push_name_value_directive(
@@ -683,6 +697,7 @@ pub fn line_directive<'line>(
 const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     // tidy-alphabetical-start
     "assembly-output",
+    "aux-bin",
     "aux-build",
     "aux-crate",
     "build-aux-docs",

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -82,22 +82,21 @@ fn disable_error_reporting<F: FnOnce() -> R, R>(f: F) -> R {
 }
 
 /// The platform-specific library name
-fn get_lib_name(lib: &str, aux_type: AuxType) -> String {
+fn get_lib_name(lib: &str, aux_type: AuxType) -> Option<String> {
     match aux_type {
+        AuxType::Bin => None,
         // In some cases (e.g. MUSL), we build a static
         // library, rather than a dynamic library.
         // In this case, the only path we can pass
         // with '--extern-meta' is the '.rlib' file
-        AuxType::Lib => format!("lib{}.rlib", lib),
-        AuxType::Dylib => {
-            if cfg!(windows) {
-                format!("{}.dll", lib)
-            } else if cfg!(target_os = "macos") {
-                format!("lib{}.dylib", lib)
-            } else {
-                format!("lib{}.so", lib)
-            }
-        }
+        AuxType::Lib => Some(format!("lib{}.rlib", lib)),
+        AuxType::Dylib => Some(if cfg!(windows) {
+            format!("{}.dll", lib)
+        } else if cfg!(target_os = "macos") {
+            format!("lib{}.dylib", lib)
+        } else {
+            format!("lib{}.so", lib)
+        }),
     }
 }
 
@@ -2099,19 +2098,36 @@ impl<'test> TestCx<'test> {
             create_dir_all(&aux_dir).unwrap();
         }
 
+        if !self.props.aux_bins.is_empty() {
+            let aux_bin_dir = self.aux_bin_output_dir_name();
+            let _ = fs::remove_dir_all(&aux_bin_dir);
+            create_dir_all(&aux_bin_dir).unwrap();
+        }
+
         aux_dir
     }
 
     fn build_all_auxiliary(&self, of: &TestPaths, aux_dir: &Path, rustc: &mut Command) {
         for rel_ab in &self.props.aux_builds {
-            self.build_auxiliary(of, rel_ab, &aux_dir);
+            self.build_auxiliary(of, rel_ab, &aux_dir, false /* is_bin */);
+        }
+
+        for rel_ab in &self.props.aux_bins {
+            self.build_auxiliary(of, rel_ab, &aux_dir, true /* is_bin */);
         }
 
         for (aux_name, aux_path) in &self.props.aux_crates {
-            let aux_type = self.build_auxiliary(of, &aux_path, &aux_dir);
+            let aux_type = self.build_auxiliary(of, &aux_path, &aux_dir, false /* is_bin */);
             let lib_name =
                 get_lib_name(&aux_path.trim_end_matches(".rs").replace('-', "_"), aux_type);
-            rustc.arg("--extern").arg(format!("{}={}/{}", aux_name, aux_dir.display(), lib_name));
+            if let Some(lib_name) = lib_name {
+                rustc.arg("--extern").arg(format!(
+                    "{}={}/{}",
+                    aux_name,
+                    aux_dir.display(),
+                    lib_name
+                ));
+            }
         }
     }
 
@@ -2130,12 +2146,23 @@ impl<'test> TestCx<'test> {
     }
 
     /// Builds an aux dependency.
-    ///
-    /// Returns whether or not it is a dylib.
-    fn build_auxiliary(&self, of: &TestPaths, source_path: &str, aux_dir: &Path) -> AuxType {
+    fn build_auxiliary(
+        &self,
+        of: &TestPaths,
+        source_path: &str,
+        aux_dir: &Path,
+        is_bin: bool,
+    ) -> AuxType {
         let aux_testpaths = self.compute_aux_test_paths(of, source_path);
         let aux_props = self.props.from_aux_file(&aux_testpaths.file, self.revision, self.config);
-        let aux_output = TargetLocation::ThisDirectory(aux_dir.to_path_buf());
+        let mut aux_dir = aux_dir.to_path_buf();
+        if is_bin {
+            // On unix, the binary of `auxiliary/foo.rs` will be named
+            // `auxiliary/foo` which clashes with the _dir_ `auxiliary/foo`, so
+            // put bins in a `bin` subfolder.
+            aux_dir.push("bin");
+        }
+        let aux_output = TargetLocation::ThisDirectory(aux_dir.clone());
         let aux_cx = TestCx {
             config: self.config,
             props: &aux_props,
@@ -2153,14 +2180,16 @@ impl<'test> TestCx<'test> {
             LinkToAux::No,
             Vec::new(),
         );
-        aux_cx.build_all_auxiliary(of, aux_dir, &mut aux_rustc);
+        aux_cx.build_all_auxiliary(of, &aux_dir, &mut aux_rustc);
 
         for key in &aux_props.unset_rustc_env {
             aux_rustc.env_remove(key);
         }
         aux_rustc.envs(aux_props.rustc_env.clone());
 
-        let (aux_type, crate_type) = if aux_props.no_prefer_dynamic {
+        let (aux_type, crate_type) = if is_bin {
+            (AuxType::Bin, Some("bin"))
+        } else if aux_props.no_prefer_dynamic {
             (AuxType::Dylib, None)
         } else if self.config.target.contains("emscripten")
             || (self.config.target.contains("musl")
@@ -2676,6 +2705,12 @@ impl<'test> TestCx<'test> {
         self.output_base_dir()
             .join("auxiliary")
             .with_extra_extension(self.config.mode.aux_dir_disambiguator())
+    }
+
+    /// Gets the directory where auxiliary binaries are written.
+    /// E.g., `/.../testname.revision.mode/auxiliary/bin`.
+    fn aux_bin_output_dir_name(&self) -> PathBuf {
+        self.aux_output_dir_name().join("bin")
     }
 
     /// Generates a unique name for the test, such as `testname.revision.mode`.
@@ -4829,6 +4864,7 @@ enum LinkToAux {
 }
 
 enum AuxType {
+    Bin,
     Lib,
     Dylib,
 }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -82,7 +82,7 @@ fn disable_error_reporting<F: FnOnce() -> R, R>(f: F) -> R {
 }
 
 /// The platform-specific library name
-pub fn get_lib_name(lib: &str, dylib: bool) -> String {
+fn get_lib_name(lib: &str, dylib: bool) -> String {
     // In some casess (e.g. MUSL), we build a static
     // library, rather than a dynamic library.
     // In this case, the only path we can pass

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -83,10 +83,10 @@ fn disable_error_reporting<F: FnOnce() -> R, R>(f: F) -> R {
 
 /// The platform-specific library name
 fn get_lib_name(lib: &str, dylib: bool) -> String {
-    // In some casess (e.g. MUSL), we build a static
+    // In some cases (e.g. MUSL), we build a static
     // library, rather than a dynamic library.
     // In this case, the only path we can pass
-    // with '--extern-meta' is the '.lib' file
+    // with '--extern-meta' is the '.rlib' file
     if !dylib {
         return format!("lib{}.rlib", lib);
     }

--- a/src/tools/tidy/src/issues.txt
+++ b/src/tools/tidy/src/issues.txt
@@ -3463,7 +3463,6 @@
 "ui/pattern/issue-106552.rs",
 "ui/pattern/issue-106862.rs",
 "ui/pattern/issue-110508.rs",
-"ui/pattern/issue-114896.rs",
 "ui/pattern/issue-115599.rs",
 "ui/pattern/issue-11577.rs",
 "ui/pattern/issue-117626.rs",

--- a/tests/ui/asm/fail-const-eval-issue-121099.rs
+++ b/tests/ui/asm/fail-const-eval-issue-121099.rs
@@ -1,4 +1,5 @@
 //@ build-fail
+//@ needs-asm-support
 #![feature(asm_const)]
 
 use std::arch::global_asm;

--- a/tests/ui/asm/fail-const-eval-issue-121099.rs
+++ b/tests/ui/asm/fail-const-eval-issue-121099.rs
@@ -1,0 +1,10 @@
+//@ build-fail 
+#![feature(asm_const)]
+
+use std::arch::global_asm;
+
+fn main() {}
+
+global_asm!("/* {} */", const 1 << 500); //~ ERROR evaluation of constant value failed [E0080]
+
+global_asm!("/* {} */", const 1 / 0); //~ ERROR evaluation of constant value failed [E0080]

--- a/tests/ui/asm/fail-const-eval-issue-121099.rs
+++ b/tests/ui/asm/fail-const-eval-issue-121099.rs
@@ -1,4 +1,4 @@
-//@ build-fail 
+//@ build-fail
 #![feature(asm_const)]
 
 use std::arch::global_asm;

--- a/tests/ui/asm/fail-const-eval-issue-121099.stderr
+++ b/tests/ui/asm/fail-const-eval-issue-121099.stderr
@@ -1,0 +1,15 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/fail-const-eval-issue-121099.rs:8:31
+   |
+LL | global_asm!("/* {} */", const 1 << 500);
+   |                               ^^^^^^^^ attempt to shift left by `500_i32`, which would overflow
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/fail-const-eval-issue-121099.rs:10:31
+   |
+LL | global_asm!("/* {} */", const 1 / 0);
+   |                               ^^^^^ attempt to divide `1_i32` by zero
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/asm/fail-const-eval-issue-121099.stderr
+++ b/tests/ui/asm/fail-const-eval-issue-121099.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/fail-const-eval-issue-121099.rs:8:31
+  --> $DIR/fail-const-eval-issue-121099.rs:9:31
    |
 LL | global_asm!("/* {} */", const 1 << 500);
    |                               ^^^^^^^^ attempt to shift left by `500_i32`, which would overflow
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/fail-const-eval-issue-121099.rs:10:31
+  --> $DIR/fail-const-eval-issue-121099.rs:11:31
    |
 LL | global_asm!("/* {} */", const 1 / 0);
    |                               ^^^^^ attempt to divide `1_i32` by zero

--- a/tests/ui/cast/unsized-union-ice.rs
+++ b/tests/ui/cast/unsized-union-ice.rs
@@ -1,0 +1,14 @@
+// Regression test for https://github.com/rust-lang/rust/issues/122581
+// This used to ICE, because the union was unsized and the pointer casting code
+// assumed that non-struct ADTs must be sized.
+
+union Union {
+    val: std::mem::ManuallyDrop<[u8]>,
+    //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+}
+
+fn cast(ptr: *const ()) -> *const Union {
+    ptr as _
+}
+
+fn main() {}

--- a/tests/ui/cast/unsized-union-ice.stderr
+++ b/tests/ui/cast/unsized-union-ice.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/unsized-union-ice.rs:6:10
+   |
+LL |     val: std::mem::ManuallyDrop<[u8]>,
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `ManuallyDrop<[u8]>`, the trait `Sized` is not implemented for `[u8]`, which is required by `ManuallyDrop<[u8]>: Sized`
+note: required because it appears within the type `ManuallyDrop<[u8]>`
+  --> $SRC_DIR/core/src/mem/manually_drop.rs:LL:COL
+   = note: no field of a union may have a dynamically sized type
+   = help: change the field's type to have a statically known size
+help: borrowed types always have a statically known size
+   |
+LL |     val: &std::mem::ManuallyDrop<[u8]>,
+   |          +
+help: the `Box` type always has a statically known size and allocates its contents in the heap
+   |
+LL |     val: Box<std::mem::ManuallyDrop<[u8]>>,
+   |          ++++                            +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/compiletest-self-test/auxiliary/print-it-works.rs
+++ b/tests/ui/compiletest-self-test/auxiliary/print-it-works.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("it works");
+}

--- a/tests/ui/compiletest-self-test/test-aux-bin.rs
+++ b/tests/ui/compiletest-self-test/test-aux-bin.rs
@@ -1,0 +1,9 @@
+//@ ignore-cross-compile because we run the compiled code
+//@ aux-bin: print-it-works.rs
+//@ run-pass
+
+fn main() {
+    let stdout =
+        std::process::Command::new("auxiliary/bin/print-it-works").output().unwrap().stdout;
+    assert_eq!(stdout, b"it works\n");
+}

--- a/tests/ui/fmt/format-args-non-identifier-diagnostics.fixed
+++ b/tests/ui/fmt/format-args-non-identifier-diagnostics.fixed
@@ -1,0 +1,10 @@
+// Checks that there is a suggestion for simple tuple index access expression (used where an
+// identifier is expected in a format arg) to use positional arg instead.
+// Issue: <https://github.com/rust-lang/rust/issues/122535>.
+//@ run-rustfix
+
+fn main() {
+    let x = (1,);
+    println!("{0}", x.0);
+    //~^ ERROR invalid format string
+}

--- a/tests/ui/fmt/format-args-non-identifier-diagnostics.rs
+++ b/tests/ui/fmt/format-args-non-identifier-diagnostics.rs
@@ -1,0 +1,10 @@
+// Checks that there is a suggestion for simple tuple index access expression (used where an
+// identifier is expected in a format arg) to use positional arg instead.
+// Issue: <https://github.com/rust-lang/rust/issues/122535>.
+//@ run-rustfix
+
+fn main() {
+    let x = (1,);
+    println!("{x.0}");
+    //~^ ERROR invalid format string
+}

--- a/tests/ui/fmt/format-args-non-identifier-diagnostics.stderr
+++ b/tests/ui/fmt/format-args-non-identifier-diagnostics.stderr
@@ -1,0 +1,13 @@
+error: invalid format string: tuple index access isn't supported
+  --> $DIR/format-args-non-identifier-diagnostics.rs:8:16
+   |
+LL |     println!("{x.0}");
+   |                ^^^ not supported in format string
+   |
+help: consider using a positional formatting argument instead
+   |
+LL |     println!("{0}", x.0);
+   |                ~  +++++
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/lint-qualification.fixed
+++ b/tests/ui/lint/lint-qualification.fixed
@@ -16,7 +16,6 @@ fn main() {
     let _ = || -> Result<(), ()> { try!(Ok(())); Ok(()) }; // issue #37345
 
     let _ = String::new(); //~ ERROR: unnecessary qualification
-    let _ = std::env::current_dir(); //~ ERROR: unnecessary qualification
 
     let _: Vec<String> = Vec::<String>::new();
     //~^ ERROR: unnecessary qualification
@@ -27,7 +26,7 @@ fn main() {
     let _: std::fmt::Result = Ok(());
     // don't report unnecessary qualification because fix(#122373) for issue #121331
 
-    let _ = <bool as Default>::default(); // issue #121999
+    let _ = <bool as Default>::default(); // issue #121999 (modified)
     //~^ ERROR: unnecessary qualification
 
     macro_rules! m { ($a:ident, $b:ident) => {

--- a/tests/ui/lint/lint-qualification.rs
+++ b/tests/ui/lint/lint-qualification.rs
@@ -16,7 +16,6 @@ fn main() {
     let _ = || -> Result<(), ()> { try!(Ok(())); Ok(()) }; // issue #37345
 
     let _ = std::string::String::new(); //~ ERROR: unnecessary qualification
-    let _ = ::std::env::current_dir(); //~ ERROR: unnecessary qualification
 
     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
     //~^ ERROR: unnecessary qualification
@@ -27,7 +26,7 @@ fn main() {
     let _: std::fmt::Result = Ok(());
     // don't report unnecessary qualification because fix(#122373) for issue #121331
 
-    let _ = <bool as ::std::default::Default>::default(); // issue #121999
+    let _ = <bool as std::default::Default>::default(); // issue #121999 (modified)
     //~^ ERROR: unnecessary qualification
 
     macro_rules! m { ($a:ident, $b:ident) => {

--- a/tests/ui/lint/lint-qualification.stderr
+++ b/tests/ui/lint/lint-qualification.stderr
@@ -40,19 +40,7 @@ LL +     let _ = String::new();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:19:13
-   |
-LL |     let _ = ::std::env::current_dir();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: remove the unnecessary path segments
-   |
-LL -     let _ = ::std::env::current_dir();
-LL +     let _ = std::env::current_dir();
-   |
-
-error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:21:12
+  --> $DIR/lint-qualification.rs:20:12
    |
 LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
    |            ^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +52,7 @@ LL +     let _: Vec<String> = std::vec::Vec::<String>::new();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:21:36
+  --> $DIR/lint-qualification.rs:20:36
    |
 LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,7 +64,7 @@ LL +     let _: std::vec::Vec<String> = Vec::<String>::new();
    |
 
 error: unused import: `std::fmt`
-  --> $DIR/lint-qualification.rs:25:9
+  --> $DIR/lint-qualification.rs:24:9
    |
 LL |     use std::fmt;
    |         ^^^^^^^^
@@ -88,16 +76,16 @@ LL | #![deny(unused_imports)]
    |         ^^^^^^^^^^^^^^
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:30:13
+  --> $DIR/lint-qualification.rs:29:13
    |
-LL |     let _ = <bool as ::std::default::Default>::default(); // issue #121999
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = <bool as std::default::Default>::default(); // issue #121999 (modified)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the unnecessary path segments
    |
-LL -     let _ = <bool as ::std::default::Default>::default(); // issue #121999
-LL +     let _ = <bool as Default>::default(); // issue #121999
+LL -     let _ = <bool as std::default::Default>::default(); // issue #121999 (modified)
+LL +     let _ = <bool as Default>::default(); // issue #121999 (modified)
    |
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/lint/unused-qualifications-global-paths.rs
+++ b/tests/ui/lint/unused-qualifications-global-paths.rs
@@ -1,0 +1,12 @@
+// Checks that `unused_qualifications` don't fire on explicit global paths.
+// Issue: <https://github.com/rust-lang/rust/issues/122374>.
+
+//@ check-pass
+
+#![deny(unused_qualifications)]
+
+pub fn bar() -> u64 {
+    ::std::default::Default::default()
+}
+
+fn main() {}

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.fixed
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.fixed
@@ -1,6 +1,9 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
 fn main() {
     fn x(a: &char) {
-        let &b = a;
+        let &(mut b) = a;
         b.make_ascii_uppercase();
 //~^ cannot borrow `b` as mutable, as it is not declared as mutable
     }

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.rs
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.rs
@@ -1,0 +1,10 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
+fn main() {
+    fn x(a: &char) {
+        let &b = a;
+        b.make_ascii_uppercase();
+//~^ cannot borrow `b` as mutable, as it is not declared as mutable
+    }
+}

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
@@ -1,5 +1,5 @@
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
-  --> $DIR/issue-114896.rs:4:9
+  --> $DIR/patkind-ref-binding-issue-114896.rs:7:9
    |
 LL |         let &b = a;
    |             -- help: consider changing this to be mutable: `&(mut b)`

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.fixed
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.fixed
@@ -1,0 +1,11 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
+fn mutate(_y: &mut i32) {}
+
+fn foo(&(mut x): &i32) {
+    mutate(&mut x);
+    //~^ ERROR cannot borrow `x` as mutable
+}
+
+fn main() {}

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.rs
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.rs
@@ -1,0 +1,11 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
+fn mutate(_y: &mut i32) {}
+
+fn foo(&x: &i32) {
+    mutate(&mut x);
+    //~^ ERROR cannot borrow `x` as mutable
+}
+
+fn main() {}

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
@@ -1,0 +1,11 @@
+error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/patkind-ref-binding-issue-122415.rs:7:12
+   |
+LL | fn foo(&x: &i32) {
+   |        -- help: consider changing this to be mutable: `&(mut x)`
+LL |     mutate(&mut x);
+   |            ^^^^^^ cannot borrow as mutable
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0596`.


### PR DESCRIPTION
Successful merges:

 - #122435 (Don't trigger `unused_qualifications` on global paths)
 - #122556 (Extend format arg help for simple tuple index access expression)
 - #122634 (compiletest: Add support for `//@ aux-bin: foo.rs`)
 - #122677 (Fix incorrect mutable suggestion information for binding in ref pattern.)
 - #122691 (Fix ICE: `global_asm!()` Don't Panic When Unable to Evaluate Constant)
 - #122695 (Change only_local to a enum type.)
 - #122717 (Ensure stack before parsing dot-or-call)
 - #122719 (Ensure nested statics have a HIR node to prevent various queries from ICEing)
 - #122720 ([doc]:fix error code example)
 - #122724 (add test for casting pointer to union with unsized tail)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=122435,122556,122634,122677,122691,122695,122717,122719,122720,122724)
<!-- homu-ignore:end -->