### PR TITLE
use more accurate terminology

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -915,6 +915,6 @@
 # Available options: fast, balanced, best
 #compression-profile = "fast"
 
-# Copy the linker, DLLs, and various libraries from MinGW into the rustc toolchain.
+# Copy the linker, DLLs, and various libraries from MinGW into the Rust toolchain.
 # Only applies when the host or target is pc-windows-gnu.
 #include-mingw-linker = true


### PR DESCRIPTION
rustc is just one tool/executable, even if at the center of the toolchain