### PR TITLE
Reduce `pub` usage in `rustc_session`.

### DIFF
--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -12,9 +12,9 @@ use rustc_target::spec::{SplitDebuginfo, StackProtector, TargetTriple};
 
 use crate::{config::CrateType, parse::ParseSess};
 
-pub struct FeatureGateError {
-    pub span: MultiSpan,
-    pub explain: DiagMessage,
+pub(crate) struct FeatureGateError {
+    pub(crate) span: MultiSpan,
+    pub(crate) explain: DiagMessage,
 }
 
 impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for FeatureGateError {
@@ -26,22 +26,22 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for FeatureGateError {
 
 #[derive(Subdiagnostic)]
 #[note(session_feature_diagnostic_for_issue)]
-pub struct FeatureDiagnosticForIssue {
-    pub n: NonZero<u32>,
+pub(crate) struct FeatureDiagnosticForIssue {
+    pub(crate) n: NonZero<u32>,
 }
 
 #[derive(Subdiagnostic)]
 #[note(session_feature_suggest_upgrade_compiler)]
-pub struct SuggestUpgradeCompiler {
+pub(crate) struct SuggestUpgradeCompiler {
     date: &'static str,
 }
 
 impl SuggestUpgradeCompiler {
-    pub fn ui_testing() -> Self {
+    pub(crate) fn ui_testing() -> Self {
         Self { date: "YYYY-MM-DD" }
     }
 
-    pub fn new() -> Option<Self> {
+    pub(crate) fn new() -> Option<Self> {
         let date = option_env!("CFG_VER_DATE")?;
 
         Some(Self { date })
@@ -50,108 +50,108 @@ impl SuggestUpgradeCompiler {
 
 #[derive(Subdiagnostic)]
 #[help(session_feature_diagnostic_help)]
-pub struct FeatureDiagnosticHelp {
-    pub feature: Symbol,
+pub(crate) struct FeatureDiagnosticHelp {
+    pub(crate) feature: Symbol,
 }
 
 #[derive(Subdiagnostic)]
 #[help(session_cli_feature_diagnostic_help)]
-pub struct CliFeatureDiagnosticHelp {
-    pub feature: Symbol,
+pub(crate) struct CliFeatureDiagnosticHelp {
+    pub(crate) feature: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_not_circumvent_feature)]
-pub struct NotCircumventFeature;
+pub(crate) struct NotCircumventFeature;
 
 #[derive(Diagnostic)]
 #[diag(session_linker_plugin_lto_windows_not_supported)]
-pub struct LinkerPluginToWindowsNotSupported;
+pub(crate) struct LinkerPluginToWindowsNotSupported;
 
 #[derive(Diagnostic)]
 #[diag(session_profile_use_file_does_not_exist)]
-pub struct ProfileUseFileDoesNotExist<'a> {
-    pub path: &'a std::path::Path,
+pub(crate) struct ProfileUseFileDoesNotExist<'a> {
+    pub(crate) path: &'a std::path::Path,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_profile_sample_use_file_does_not_exist)]
-pub struct ProfileSampleUseFileDoesNotExist<'a> {
-    pub path: &'a std::path::Path,
+pub(crate) struct ProfileSampleUseFileDoesNotExist<'a> {
+    pub(crate) path: &'a std::path::Path,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_target_requires_unwind_tables)]
-pub struct TargetRequiresUnwindTables;
+pub(crate) struct TargetRequiresUnwindTables;
 
 #[derive(Diagnostic)]
 #[diag(session_instrumentation_not_supported)]
-pub struct InstrumentationNotSupported {
-    pub us: String,
+pub(crate) struct InstrumentationNotSupported {
+    pub(crate) us: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_not_supported)]
-pub struct SanitizerNotSupported {
-    pub us: String,
+pub(crate) struct SanitizerNotSupported {
+    pub(crate) us: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizers_not_supported)]
-pub struct SanitizersNotSupported {
-    pub us: String,
+pub(crate) struct SanitizersNotSupported {
+    pub(crate) us: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_cannot_mix_and_match_sanitizers)]
-pub struct CannotMixAndMatchSanitizers {
-    pub first: String,
-    pub second: String,
+pub(crate) struct CannotMixAndMatchSanitizers {
+    pub(crate) first: String,
+    pub(crate) second: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_cannot_enable_crt_static_linux)]
-pub struct CannotEnableCrtStaticLinux;
+pub(crate) struct CannotEnableCrtStaticLinux;
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_cfi_requires_lto)]
-pub struct SanitizerCfiRequiresLto;
+pub(crate) struct SanitizerCfiRequiresLto;
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_cfi_requires_single_codegen_unit)]
-pub struct SanitizerCfiRequiresSingleCodegenUnit;
+pub(crate) struct SanitizerCfiRequiresSingleCodegenUnit;
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_cfi_canonical_jump_tables_requires_cfi)]
-pub struct SanitizerCfiCanonicalJumpTablesRequiresCfi;
+pub(crate) struct SanitizerCfiCanonicalJumpTablesRequiresCfi;
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_cfi_generalize_pointers_requires_cfi)]
-pub struct SanitizerCfiGeneralizePointersRequiresCfi;
+pub(crate) struct SanitizerCfiGeneralizePointersRequiresCfi;
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_cfi_normalize_integers_requires_cfi)]
-pub struct SanitizerCfiNormalizeIntegersRequiresCfi;
+pub(crate) struct SanitizerCfiNormalizeIntegersRequiresCfi;
 
 #[derive(Diagnostic)]
 #[diag(session_split_lto_unit_requires_lto)]
-pub struct SplitLtoUnitRequiresLto;
+pub(crate) struct SplitLtoUnitRequiresLto;
 
 #[derive(Diagnostic)]
 #[diag(session_unstable_virtual_function_elimination)]
-pub struct UnstableVirtualFunctionElimination;
+pub(crate) struct UnstableVirtualFunctionElimination;
 
 #[derive(Diagnostic)]
 #[diag(session_unsupported_dwarf_version)]
-pub struct UnsupportedDwarfVersion {
-    pub dwarf_version: u32,
+pub(crate) struct UnsupportedDwarfVersion {
+    pub(crate) dwarf_version: u32,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_target_stack_protector_not_supported)]
-pub struct StackProtectorNotSupportedForTarget<'a> {
-    pub stack_protector: StackProtector,
-    pub target_triple: &'a TargetTriple,
+pub(crate) struct StackProtectorNotSupportedForTarget<'a> {
+    pub(crate) stack_protector: StackProtector,
+    pub(crate) target_triple: &'a TargetTriple,
 }
 
 #[derive(Diagnostic)]
@@ -160,58 +160,58 @@ pub(crate) struct BranchProtectionRequiresAArch64;
 
 #[derive(Diagnostic)]
 #[diag(session_split_debuginfo_unstable_platform)]
-pub struct SplitDebugInfoUnstablePlatform {
-    pub debuginfo: SplitDebuginfo,
+pub(crate) struct SplitDebugInfoUnstablePlatform {
+    pub(crate) debuginfo: SplitDebuginfo,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_file_is_not_writeable)]
-pub struct FileIsNotWriteable<'a> {
-    pub file: &'a std::path::Path,
+pub(crate) struct FileIsNotWriteable<'a> {
+    pub(crate) file: &'a std::path::Path,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_file_write_fail)]
 pub(crate) struct FileWriteFail<'a> {
-    pub path: &'a std::path::Path,
-    pub err: String,
+    pub(crate) path: &'a std::path::Path,
+    pub(crate) err: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_crate_name_does_not_match)]
-pub struct CrateNameDoesNotMatch {
+pub(crate) struct CrateNameDoesNotMatch {
     #[primary_span]
-    pub span: Span,
-    pub s: Symbol,
-    pub name: Symbol,
+    pub(crate) span: Span,
+    pub(crate) s: Symbol,
+    pub(crate) name: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_crate_name_invalid)]
-pub struct CrateNameInvalid<'a> {
-    pub s: &'a str,
+pub(crate) struct CrateNameInvalid<'a> {
+    pub(crate) s: &'a str,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_crate_name_empty)]
-pub struct CrateNameEmpty {
+pub(crate) struct CrateNameEmpty {
     #[primary_span]
-    pub span: Option<Span>,
+    pub(crate) span: Option<Span>,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_invalid_character_in_create_name)]
-pub struct InvalidCharacterInCrateName {
+pub(crate) struct InvalidCharacterInCrateName {
     #[primary_span]
-    pub span: Option<Span>,
-    pub character: char,
-    pub crate_name: Symbol,
+    pub(crate) span: Option<Span>,
+    pub(crate) character: char,
+    pub(crate) crate_name: Symbol,
     #[subdiagnostic]
-    pub crate_name_help: Option<InvalidCrateNameHelp>,
+    pub(crate) crate_name_help: Option<InvalidCrateNameHelp>,
 }
 
 #[derive(Subdiagnostic)]
-pub enum InvalidCrateNameHelp {
+pub(crate) enum InvalidCrateNameHelp {
     #[help(session_invalid_character_in_create_name_help)]
     AddCrateName,
 }
@@ -220,9 +220,9 @@ pub enum InvalidCrateNameHelp {
 #[multipart_suggestion(session_expr_parentheses_needed, applicability = "machine-applicable")]
 pub struct ExprParenthesesNeeded {
     #[suggestion_part(code = "(")]
-    pub left: Span,
+    left: Span,
     #[suggestion_part(code = ")")]
-    pub right: Span,
+    right: Span,
 }
 
 impl ExprParenthesesNeeded {
@@ -233,13 +233,13 @@ impl ExprParenthesesNeeded {
 
 #[derive(Diagnostic)]
 #[diag(session_skipping_const_checks)]
-pub struct SkippingConstChecks {
+pub(crate) struct SkippingConstChecks {
     #[subdiagnostic]
-    pub unleashed_features: Vec<UnleashedFeatureHelp>,
+    pub(crate) unleashed_features: Vec<UnleashedFeatureHelp>,
 }
 
 #[derive(Subdiagnostic)]
-pub enum UnleashedFeatureHelp {
+pub(crate) enum UnleashedFeatureHelp {
     #[help(session_unleashed_feature_help_named)]
     Named {
         #[primary_span]
@@ -255,101 +255,101 @@ pub enum UnleashedFeatureHelp {
 
 #[derive(Diagnostic)]
 #[diag(session_invalid_literal_suffix)]
-pub(crate) struct InvalidLiteralSuffix<'a> {
+struct InvalidLiteralSuffix<'a> {
     #[primary_span]
     #[label]
-    pub span: Span,
+    span: Span,
     // FIXME(#100717)
-    pub kind: &'a str,
-    pub suffix: Symbol,
+    kind: &'a str,
+    suffix: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_invalid_int_literal_width)]
 #[help]
-pub(crate) struct InvalidIntLiteralWidth {
+struct InvalidIntLiteralWidth {
     #[primary_span]
-    pub span: Span,
-    pub width: String,
+    span: Span,
+    width: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_invalid_num_literal_base_prefix)]
 #[note]
-pub(crate) struct InvalidNumLiteralBasePrefix {
+struct InvalidNumLiteralBasePrefix {
     #[primary_span]
     #[suggestion(applicability = "maybe-incorrect", code = "{fixed}")]
-    pub span: Span,
-    pub fixed: String,
+    span: Span,
+    fixed: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_invalid_num_literal_suffix)]
 #[help]
-pub(crate) struct InvalidNumLiteralSuffix {
+struct InvalidNumLiteralSuffix {
     #[primary_span]
     #[label]
-    pub span: Span,
-    pub suffix: String,
+    span: Span,
+    suffix: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_invalid_float_literal_width)]
 #[help]
-pub(crate) struct InvalidFloatLiteralWidth {
+struct InvalidFloatLiteralWidth {
     #[primary_span]
-    pub span: Span,
-    pub width: String,
+    span: Span,
+    width: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_invalid_float_literal_suffix)]
 #[help]
-pub(crate) struct InvalidFloatLiteralSuffix {
+struct InvalidFloatLiteralSuffix {
     #[primary_span]
     #[label]
-    pub span: Span,
-    pub suffix: String,
+    span: Span,
+    suffix: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_int_literal_too_large)]
 #[note]
-pub(crate) struct IntLiteralTooLarge {
+struct IntLiteralTooLarge {
     #[primary_span]
-    pub span: Span,
-    pub limit: String,
+    span: Span,
+    limit: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_hexadecimal_float_literal_not_supported)]
-pub(crate) struct HexadecimalFloatLiteralNotSupported {
+struct HexadecimalFloatLiteralNotSupported {
     #[primary_span]
     #[label(session_not_supported)]
-    pub span: Span,
+    span: Span,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_octal_float_literal_not_supported)]
-pub(crate) struct OctalFloatLiteralNotSupported {
+struct OctalFloatLiteralNotSupported {
     #[primary_span]
     #[label(session_not_supported)]
-    pub span: Span,
+    span: Span,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_binary_float_literal_not_supported)]
-pub(crate) struct BinaryFloatLiteralNotSupported {
+struct BinaryFloatLiteralNotSupported {
     #[primary_span]
     #[label(session_not_supported)]
-    pub span: Span,
+    span: Span,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_unsupported_crate_type_for_target)]
-pub struct UnsupportedCrateTypeForTarget<'a> {
-    pub crate_type: CrateType,
-    pub target_triple: &'a TargetTriple,
+pub(crate) struct UnsupportedCrateTypeForTarget<'a> {
+    pub(crate) crate_type: CrateType,
+    pub(crate) target_triple: &'a TargetTriple,
 }
 
 pub fn report_lit_error(
@@ -431,16 +431,16 @@ pub fn report_lit_error(
 
 #[derive(Diagnostic)]
 #[diag(session_optimization_fuel_exhausted)]
-pub struct OptimisationFuelExhausted {
-    pub msg: String,
+pub(crate) struct OptimisationFuelExhausted {
+    pub(crate) msg: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_incompatible_linker_flavor)]
 #[note]
-pub struct IncompatibleLinkerFlavor {
-    pub flavor: &'static str,
-    pub compatible_list: String,
+pub(crate) struct IncompatibleLinkerFlavor {
+    pub(crate) flavor: &'static str,
+    pub(crate) compatible_list: String,
 }
 
 #[derive(Diagnostic)]
@@ -453,6 +453,6 @@ pub(crate) struct FunctionReturnThunkExternRequiresNonLargeCodeModel;
 
 #[derive(Diagnostic)]
 #[diag(session_failed_to_create_profiler)]
-pub struct FailedToCreateProfiler {
-    pub err: String,
+pub(crate) struct FailedToCreateProfiler {
+    pub(crate) err: String,
 }


### PR DESCRIPTION
In particular, almost none of the errors in `errors.rs` are used outside the crate.

r? @jackh726 