### PR TITLE
make `type_flags(ReError) & HAS_ERROR`

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -434,10 +434,6 @@ fn check_opaque_type_parameter_valid(
     // Only check the parent generics, which will ignore any of the
     // duplicated lifetime args that come from reifying late-bounds.
     for (i, arg) in opaque_type_key.args.iter().take(parent_generics.count()).enumerate() {
-        if let Err(guar) = arg.error_reported() {
-            return Err(guar);
-        }
-
         let arg_is_param = match arg.unpack() {
             GenericArgKind::Type(ty) => matches!(ty.kind(), ty::Param(_)),
             GenericArgKind::Lifetime(lt) if is_ty_alias => {

--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -94,9 +94,6 @@ impl<'tcx> InferCtxt<'tcx> {
         cause: &ObligationCause<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
     ) -> InferResult<'tcx, ()> {
-        if a.references_error() || b.references_error() {
-            return Ok(InferOk { value: (), obligations: vec![] });
-        }
         let process = |a: Ty<'tcx>, b: Ty<'tcx>| match *a.kind() {
             ty::Alias(ty::Opaque, ty::AliasTy { def_id, args, .. }) if def_id.is_local() => {
                 let def_id = def_id.expect_local();

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -251,6 +251,7 @@ impl<'tcx> Region<'tcx> {
             }
             ty::ReError(_) => {
                 flags = flags | TypeFlags::HAS_FREE_REGIONS;
+                flags = flags | TypeFlags::HAS_ERROR;
             }
         }
 

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -85,7 +85,7 @@ bitflags! {
                                           | TypeFlags::HAS_TY_INHERENT.bits()
                                           | TypeFlags::HAS_CT_PROJECTION.bits();
 
-        /// Is an error type/const reachable?
+        /// Is an error type/lifetime/const reachable?
         const HAS_ERROR                   = 1 << 15;
 
         /// Does this have any region that "appears free" in the type?

--- a/tests/ui/async-await/in-trait/return-not-existing-pair.rs
+++ b/tests/ui/async-await/in-trait/return-not-existing-pair.rs
@@ -9,8 +9,7 @@ trait MyTrait<'a, 'b, T> {
 impl<'a, 'b, T, U> MyTrait<T> for U {
     //~^ ERROR: implicit elided lifetime not allowed here [E0726]
     async fn foo(_: T) -> (&'a U, &'b T) {}
-    //~^ ERROR: method `foo` has a `&self` declaration in the trait, but not in the impl [E0186]
-    //~| ERROR: mismatched types [E0308]
+    //~^ ERROR: mismatched types [E0308]
 }
 
 fn main() {}

--- a/tests/ui/async-await/in-trait/return-not-existing-pair.stderr
+++ b/tests/ui/async-await/in-trait/return-not-existing-pair.stderr
@@ -15,15 +15,6 @@ error[E0412]: cannot find type `ConnImpl` in this scope
 LL |     async fn foo(&'a self, key: &'b T) -> (&'a ConnImpl, &'b T);
    |                                                ^^^^^^^^ not found in this scope
 
-error[E0186]: method `foo` has a `&self` declaration in the trait, but not in the impl
-  --> $DIR/return-not-existing-pair.rs:11:5
-   |
-LL |     async fn foo(&'a self, key: &'b T) -> (&'a ConnImpl, &'b T);
-   |     ------------------------------------------------------------ `&self` used in trait
-...
-LL |     async fn foo(_: T) -> (&'a U, &'b T) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&self` in impl
-
 error[E0308]: mismatched types
   --> $DIR/return-not-existing-pair.rs:11:42
    |
@@ -33,7 +24,7 @@ LL |     async fn foo(_: T) -> (&'a U, &'b T) {}
    = note:  expected tuple `(&'a U, &'b T)`
            found unit type `()`
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0186, E0308, E0412, E0726.
-For more information about an error, try `rustc --explain E0186`.
+Some errors have detailed explanations: E0308, E0412, E0726.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/in-trait/unconstrained-impl-region.rs
+++ b/tests/ui/async-await/in-trait/unconstrained-impl-region.rs
@@ -14,6 +14,7 @@ impl<'a> Actor for () {
 //~^ ERROR the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
     type Message = &'a ();
     async fn on_mount(self, _: impl Inbox<&'a ()>) {}
+    //~^ ERROR the trait bound `impl Inbox<&'a ()>: Inbox<&'a ()>` is not satisfied
 }
 
 fn main() {}

--- a/tests/ui/async-await/in-trait/unconstrained-impl-region.stderr
+++ b/tests/ui/async-await/in-trait/unconstrained-impl-region.stderr
@@ -1,9 +1,26 @@
+error[E0277]: the trait bound `impl Inbox<&'a ()>: Inbox<&'a ()>` is not satisfied
+  --> $DIR/unconstrained-impl-region.rs:16:5
+   |
+LL |     async fn on_mount(self, _: impl Inbox<&'a ()>) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Inbox<&'a ()>` is not implemented for `impl Inbox<&'a ()>`
+   |
+note: required by a bound in `<() as Actor>::on_mount`
+  --> $DIR/unconstrained-impl-region.rs:16:37
+   |
+LL |     async fn on_mount(self, _: impl Inbox<&'a ()>) {}
+   |                                     ^^^^^^^^^^^^^ required by this bound in `<() as Actor>::on_mount`
+help: consider further restricting this bound
+   |
+LL |     async fn on_mount(self, _: impl Inbox<&'a ()> + Inbox<&'a ()>) {}
+   |                                                   +++++++++++++++
+
 error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
   --> $DIR/unconstrained-impl-region.rs:13:6
    |
 LL | impl<'a> Actor for () {
    |      ^^ unconstrained lifetime parameter
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0207`.
+Some errors have detailed explanations: E0207, E0277.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.rs
@@ -4,6 +4,7 @@
 impl EntriesBuffer {
     fn a(&self) -> impl Iterator {
         self.0.iter_mut() //~ ERROR: cannot borrow `*self.0` as mutable, as it is behind a `&` reference
+                          //~| ERROR captures lifetime that does not appear in bounds
     }
 }
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `HashesEntryLEN` in this scope
-  --> $DIR/issue-109141.rs:10:32
+  --> $DIR/issue-109141.rs:11:32
    |
 LL | struct EntriesBuffer(Box<[[u8; HashesEntryLEN]; 5]>);
    |                                ^^^^^^^^^^^^^^ not found in this scope
@@ -20,7 +20,22 @@ help: consider changing this to be a mutable reference
 LL |     fn a(&mut self) -> impl Iterator {
    |          ~~~~~~~~~
 
-error: aborting due to 2 previous errors
+error[E0700]: hidden type for `impl Iterator` captures lifetime that does not appear in bounds
+  --> $DIR/issue-109141.rs:6:9
+   |
+LL |     fn a(&self) -> impl Iterator {
+   |          -----     ------------- opaque type defined here
+   |          |
+   |          hidden type `std::slice::IterMut<'_, [u8; {const error}]>` captures the anonymous lifetime defined here
+LL |         self.0.iter_mut()
+   |         ^^^^^^^^^^^^^^^^^
+   |
+help: to declare that `impl Iterator` captures `'_`, you can add an explicit `'_` lifetime bound
+   |
+LL |     fn a(&self) -> impl Iterator + '_ {
+   |                                  ++++
 
-Some errors have detailed explanations: E0425, E0596.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0425, E0596, E0700.
 For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
+++ b/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
@@ -4,46 +4,5 @@ error: cannot capture late-bound lifetime in constant
 LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
    |        -- lifetime defined here                     ^^
 
-error: overly complex generic constant
-  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
-   |
-LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^ blocks are not supported in generic constants
-   |
-   = help: consider moving this anonymous constant into a `const` function
-   = note: this operation may be supported in the future
+error: aborting due to 1 previous error
 
-error[E0391]: cycle detected when evaluating type-level constant
-  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
-   |
-LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: ...which requires const-evaluating + checking `bug::{constant#0}`...
-  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
-   |
-LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires caching mir of `bug::{constant#0}` for CTFE...
-  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
-   |
-LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires elaborating drops for `bug::{constant#0}`...
-  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
-   |
-LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires borrow-checking `bug::{constant#0}`...
-  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
-   |
-LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which requires normalizing `Binder { value: ConstEvaluatable(UnevaluatedConst { def: DefId(0:8 ~ late_bound_in_return_issue_77357[9394]::bug::{constant#0}), args: [T/#0] }: usize), bound_vars: [] }`...
-   = note: ...which again requires evaluating type-level constant, completing the cycle
-   = note: cycle used when normalizing `&dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]>`
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
-
-error: aborting due to 3 previous errors
-
-For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/error-codes/E0637.rs
+++ b/tests/ui/error-codes/E0637.rs
@@ -2,9 +2,9 @@ fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
     //~^ ERROR: `'_` cannot be used here [E0637]
     //~| ERROR: missing lifetime specifier
     if str1.len() > str2.len() {
-        str1 //~ ERROR: lifetime may not live long enough
+        str1
     } else {
-        str2 //~ ERROR: lifetime may not live long enough
+        str2
     }
 }
 

--- a/tests/ui/error-codes/E0637.stderr
+++ b/tests/ui/error-codes/E0637.stderr
@@ -27,25 +27,7 @@ help: consider introducing a higher-ranked lifetime here
 LL |     T: for<'a> Into<&'a u32>,
    |        +++++++       ++
 
-error: lifetime may not live long enough
-  --> $DIR/E0637.rs:5:9
-   |
-LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
-   |                                  - let's call the lifetime of this reference `'1`
-...
-LL |         str1
-   |         ^^^^ returning this value requires that `'1` must outlive `'static`
-
-error: lifetime may not live long enough
-  --> $DIR/E0637.rs:7:9
-   |
-LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
-   |                                                 - let's call the lifetime of this reference `'2`
-...
-LL |         str2
-   |         ^^^^ returning this value requires that `'2` must outlive `'static`
-
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0106, E0637.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/generic-associated-types/issue-80433.rs
+++ b/tests/ui/generic-associated-types/issue-80433.rs
@@ -29,5 +29,5 @@ fn test_simpler<'a>(dst: &'a mut impl TestMut<Output = &'a mut f32>)
 
 fn main() {
     let mut t1: E<f32> = Default::default();
-    test_simpler(&mut t1); //~ ERROR does not live long enough
+    test_simpler(&mut t1);
 }

--- a/tests/ui/generic-associated-types/issue-80433.stderr
+++ b/tests/ui/generic-associated-types/issue-80433.stderr
@@ -48,20 +48,7 @@ LL |         *dst.test_mut() = n.into();
    |          `dst` escapes the function body here
    |          argument requires that `'a` must outlive `'static`
 
-error[E0597]: `t1` does not live long enough
-  --> $DIR/issue-80433.rs:32:18
-   |
-LL |     let mut t1: E<f32> = Default::default();
-   |         ------ binding `t1` declared here
-LL |     test_simpler(&mut t1);
-   |     -------------^^^^^^^-
-   |     |            |
-   |     |            borrowed value does not live long enough
-   |     argument requires that `t1` is borrowed for `'static`
-LL | }
-   | - `t1` dropped here while still borrowed
+error: aborting due to 4 previous errors
 
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0107, E0499, E0521, E0597.
+Some errors have detailed explanations: E0107, E0499, E0521.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.rs
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.rs
@@ -4,19 +4,16 @@ use std::fmt::Debug;
 fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
     //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
     |x| x
-    //~^ ERROR lifetime may not live long enough
 }
 
 fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
     //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
     |x| x
-    //~^ ERROR lifetime may not live long enough
 }
 
 fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
     //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
     |x| x
-    //~^ ERROR lifetime may not live long enough
 }
 
 fn d() -> impl Fn() -> (impl Debug + '_) {

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-fn-hrtb-bounds.rs:22:38
+  --> $DIR/impl-fn-hrtb-bounds.rs:19:38
    |
 LL | fn d() -> impl Fn() -> (impl Debug + '_) {
    |                                      ^^ expected named lifetime parameter
@@ -22,58 +22,31 @@ note: lifetime declared here
 LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
    |                   ^
 
-error: lifetime may not live long enough
-  --> $DIR/impl-fn-hrtb-bounds.rs:6:9
-   |
-LL |     |x| x
-   |      -- ^ returning this value requires that `'1` must outlive `'2`
-   |      ||
-   |      |return type of closure is impl Debug + '2
-   |      has type `&'1 u8`
-
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/impl-fn-hrtb-bounds.rs:10:52
+  --> $DIR/impl-fn-hrtb-bounds.rs:9:52
    |
 LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
    |                                                    ^^
    |
 note: lifetime declared here
-  --> $DIR/impl-fn-hrtb-bounds.rs:10:20
+  --> $DIR/impl-fn-hrtb-bounds.rs:9:20
    |
 LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
    |                    ^^
 
-error: lifetime may not live long enough
-  --> $DIR/impl-fn-hrtb-bounds.rs:12:9
-   |
-LL |     |x| x
-   |      -- ^ returning this value requires that `'1` must outlive `'2`
-   |      ||
-   |      |return type of closure is impl Debug + '2
-   |      has type `&'1 u8`
-
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/impl-fn-hrtb-bounds.rs:16:52
+  --> $DIR/impl-fn-hrtb-bounds.rs:14:52
    |
 LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
    |                                                    ^^
    |
 note: lifetime declared here
-  --> $DIR/impl-fn-hrtb-bounds.rs:16:20
+  --> $DIR/impl-fn-hrtb-bounds.rs:14:20
    |
 LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
    |                    ^^
 
-error: lifetime may not live long enough
-  --> $DIR/impl-fn-hrtb-bounds.rs:18:9
-   |
-LL |     |x| x
-   |      -- ^ returning this value requires that `'1` must outlive `'2`
-   |      ||
-   |      |return type of closure is impl Debug + '2
-   |      has type `&'1 u8`
-
-error: aborting due to 7 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0106, E0657.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/impl-trait/impl-fn-parsing-ambiguities.rs
+++ b/tests/ui/impl-trait/impl-fn-parsing-ambiguities.rs
@@ -5,7 +5,6 @@ fn a() -> impl Fn(&u8) -> impl Debug + '_ {
     //~^ ERROR ambiguous `+` in a type
     //~| ERROR cannot capture higher-ranked lifetime from outer `impl Trait`
     |x| x
-    //~^ ERROR lifetime may not live long enough
 }
 
 fn b() -> impl Fn() -> impl Debug + Send {

--- a/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
+++ b/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
@@ -5,7 +5,7 @@ LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
    |                           ^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + '_)`
 
 error: ambiguous `+` in a type
-  --> $DIR/impl-fn-parsing-ambiguities.rs:11:24
+  --> $DIR/impl-fn-parsing-ambiguities.rs:10:24
    |
 LL | fn b() -> impl Fn() -> impl Debug + Send {
    |                        ^^^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + Send)`
@@ -22,15 +22,6 @@ note: lifetime declared here
 LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
    |                   ^
 
-error: lifetime may not live long enough
-  --> $DIR/impl-fn-parsing-ambiguities.rs:7:9
-   |
-LL |     |x| x
-   |      -- ^ returning this value requires that `'1` must outlive `'2`
-   |      ||
-   |      |return type of closure is impl Debug + '2
-   |      has type `&'1 u8`
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/impl-trait/nested-rpit-hrtb.rs
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.rs
@@ -31,11 +31,9 @@ fn one_hrtb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl Qux<'a>> {}
 
 fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
 //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-//~| ERROR implementation of `Bar` is not general enough
 
 fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
 //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-//~| ERROR: the trait bound `for<'a> &'a (): Qux<'_>` is not satisfied
 
 // This should resolve.
 fn one_hrtb_mention_fn_trait_param<'b>() -> impl for<'a> Foo<'a, Assoc = impl Qux<'b>> {}

--- a/tests/ui/impl-trait/nested-rpit-hrtb.rs
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.rs
@@ -31,6 +31,7 @@ fn one_hrtb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl Qux<'a>> {}
 
 fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
 //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
+//~| ERROR implementation of `Bar` is not general enough
 
 fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
 //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
@@ -43,7 +44,7 @@ fn one_hrtb_mention_fn_outlives<'b>() -> impl for<'a> Foo<'a, Assoc = impl Sized
 
 // This should resolve.
 fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
-//~^ ERROR: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
+//~^ ERROR type annotations needed: cannot satisfy `for<'a> &'a (): Qux<'b>`
 
 // This should resolve.
 fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}

--- a/tests/ui/impl-trait/nested-rpit-hrtb.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:58:77
+  --> $DIR/nested-rpit-hrtb.rs:56:77
    |
 LL | fn two_htrb_outlives() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                             ^^ undeclared lifetime
@@ -15,7 +15,7 @@ LL | fn two_htrb_outlives<'b>() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Siz
    |                     ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:66:82
+  --> $DIR/nested-rpit-hrtb.rs:64:82
    |
 LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                                  ^^ undeclared lifetime
@@ -65,38 +65,20 @@ note: lifetime declared here
 LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
    |                                         ^^
 
-error: implementation of `Bar` is not general enough
-  --> $DIR/nested-rpit-hrtb.rs:32:78
-   |
-LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
-   |                                                                              ^^ implementation of `Bar` is not general enough
-   |
-   = note: `()` must implement `Bar<'a>`
-   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
-
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/nested-rpit-hrtb.rs:36:73
+  --> $DIR/nested-rpit-hrtb.rs:35:73
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                                                         ^^
    |
 note: lifetime declared here
-  --> $DIR/nested-rpit-hrtb.rs:36:44
+  --> $DIR/nested-rpit-hrtb.rs:35:44
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                            ^^
 
-error[E0277]: the trait bound `for<'a> &'a (): Qux<'_>` is not satisfied
-  --> $DIR/nested-rpit-hrtb.rs:36:64
-   |
-LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
-   |                                                                ^^^^^^^^^^^^ the trait `for<'a> Qux<'_>` is not implemented for `&'a ()`
-   |
-   = help: the trait `Qux<'_>` is implemented for `()`
-   = help: for that trait implementation, expected `()`, found `&'a ()`
-
 error[E0277]: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
-  --> $DIR/nested-rpit-hrtb.rs:47:79
+  --> $DIR/nested-rpit-hrtb.rs:45:79
    |
 LL | fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
    |                                                                               ^^^^^^^^^^^^ the trait `for<'a> Qux<'b>` is not implemented for `&'a ()`
@@ -105,7 +87,7 @@ LL | fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
 error: implementation of `Bar` is not general enough
-  --> $DIR/nested-rpit-hrtb.rs:51:93
+  --> $DIR/nested-rpit-hrtb.rs:49:93
    |
 LL | fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}
    |                                                                                             ^^ implementation of `Bar` is not general enough
@@ -114,7 +96,7 @@ LL | fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = 
    = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
 
 error[E0277]: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
-  --> $DIR/nested-rpit-hrtb.rs:62:64
+  --> $DIR/nested-rpit-hrtb.rs:60:64
    |
 LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
    |                                                                ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Qux<'b>` is not implemented for `&'a ()`
@@ -123,7 +105,7 @@ LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b>
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
 error: implementation of `Bar` is not general enough
-  --> $DIR/nested-rpit-hrtb.rs:66:86
+  --> $DIR/nested-rpit-hrtb.rs:64:86
    |
 LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                                      ^^ implementation of `Bar` is not general enough
@@ -131,7 +113,7 @@ LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Si
    = note: `()` must implement `Bar<'a>`
    = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
 
-error: aborting due to 12 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0261, E0277, E0657.
 For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/impl-trait/nested-rpit-hrtb.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:56:77
+  --> $DIR/nested-rpit-hrtb.rs:57:77
    |
 LL | fn two_htrb_outlives() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                             ^^ undeclared lifetime
@@ -15,7 +15,7 @@ LL | fn two_htrb_outlives<'b>() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Siz
    |                     ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:64:82
+  --> $DIR/nested-rpit-hrtb.rs:65:82
    |
 LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                                  ^^ undeclared lifetime
@@ -65,29 +65,39 @@ note: lifetime declared here
 LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
    |                                         ^^
 
+error: implementation of `Bar` is not general enough
+  --> $DIR/nested-rpit-hrtb.rs:32:78
+   |
+LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
+   |                                                                              ^^ implementation of `Bar` is not general enough
+   |
+   = note: `()` must implement `Bar<'a>`
+   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
+
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/nested-rpit-hrtb.rs:35:73
+  --> $DIR/nested-rpit-hrtb.rs:36:73
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                                                         ^^
    |
 note: lifetime declared here
-  --> $DIR/nested-rpit-hrtb.rs:35:44
+  --> $DIR/nested-rpit-hrtb.rs:36:44
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                            ^^
 
-error[E0277]: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
-  --> $DIR/nested-rpit-hrtb.rs:45:79
+error[E0283]: type annotations needed: cannot satisfy `for<'a> &'a (): Qux<'b>`
+  --> $DIR/nested-rpit-hrtb.rs:46:79
    |
 LL | fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
-   |                                                                               ^^^^^^^^^^^^ the trait `for<'a> Qux<'b>` is not implemented for `&'a ()`
+   |                                                                               ^^^^^^^^^^^^
    |
+   = note: cannot satisfy `for<'a> &'a (): Qux<'b>`
    = help: the trait `Qux<'_>` is implemented for `()`
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
 error: implementation of `Bar` is not general enough
-  --> $DIR/nested-rpit-hrtb.rs:49:93
+  --> $DIR/nested-rpit-hrtb.rs:50:93
    |
 LL | fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}
    |                                                                                             ^^ implementation of `Bar` is not general enough
@@ -96,7 +106,7 @@ LL | fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = 
    = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
 
 error[E0277]: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
-  --> $DIR/nested-rpit-hrtb.rs:60:64
+  --> $DIR/nested-rpit-hrtb.rs:61:64
    |
 LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
    |                                                                ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Qux<'b>` is not implemented for `&'a ()`
@@ -105,7 +115,7 @@ LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b>
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
 error: implementation of `Bar` is not general enough
-  --> $DIR/nested-rpit-hrtb.rs:64:86
+  --> $DIR/nested-rpit-hrtb.rs:65:86
    |
 LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                                      ^^ implementation of `Bar` is not general enough
@@ -113,7 +123,7 @@ LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Si
    = note: `()` must implement `Bar<'a>`
    = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
 
-error: aborting due to 10 previous errors
+error: aborting due to 11 previous errors
 
-Some errors have detailed explanations: E0261, E0277, E0657.
+Some errors have detailed explanations: E0261, E0277, E0283, E0657.
 For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/inference/issue-107090.rs
+++ b/tests/ui/inference/issue-107090.rs
@@ -19,7 +19,7 @@ impl<'long: 'short, 'short, T> Convert<'long, 'b> for Foo<'short, 'out, T> {
 
 fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ Foo<'short, 'out, T>) -> &'out T {
     //~^ ERROR use of undeclared lifetime name
-    sadness.cast() //~ ERROR: mismatched types
+    sadness.cast()
 }
 
 fn main() {}

--- a/tests/ui/inference/issue-107090.stderr
+++ b/tests/ui/inference/issue-107090.stderr
@@ -66,19 +66,6 @@ LL | fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ Foo<'short, 
    |           |
    |           help: consider introducing lifetime `'short` here: `'short,`
 
-error[E0308]: mismatched types
-  --> $DIR/issue-107090.rs:22:5
-   |
-LL | fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ Foo<'short, 'out, T>) -> &'out T {
-   |                       - expected this type parameter                                    ------- expected `&'out T` because of return type
-LL |
-LL |     sadness.cast()
-   |     ^^^^^^^^^^^^^^ expected `&T`, found `&Foo<'_, '_, T>`
-   |
-   = note: expected reference `&'out T`
-              found reference `&Foo<'_, '_, T>`
+error: aborting due to 6 previous errors
 
-error: aborting due to 7 previous errors
-
-Some errors have detailed explanations: E0261, E0308.
-For more information about an error, try `rustc --explain E0261`.
+For more information about this error, try `rustc --explain E0261`.

--- a/tests/ui/issues/issue-10412.rs
+++ b/tests/ui/issues/issue-10412.rs
@@ -8,7 +8,6 @@ impl<'self> Serializable<str> for &'self str {
     //~^ ERROR lifetimes cannot use keyword names
     //~| ERROR lifetimes cannot use keyword names
     //~| ERROR implicit elided lifetime not allowed here
-    //~| ERROR the size for values of type `str` cannot be known at compilation time [E0277]
     fn serialize(val: &'self str) -> Vec<u8> {
         //~^ ERROR lifetimes cannot use keyword names
         vec![1]

--- a/tests/ui/issues/issue-10412.stderr
+++ b/tests/ui/issues/issue-10412.stderr
@@ -29,13 +29,13 @@ LL | impl<'self> Serializable<str> for &'self str {
    |                                    ^^^^^
 
 error: lifetimes cannot use keyword names
-  --> $DIR/issue-10412.rs:12:24
+  --> $DIR/issue-10412.rs:11:24
    |
 LL |     fn serialize(val: &'self str) -> Vec<u8> {
    |                        ^^^^^
 
 error: lifetimes cannot use keyword names
-  --> $DIR/issue-10412.rs:16:37
+  --> $DIR/issue-10412.rs:15:37
    |
 LL |     fn deserialize(repr: &[u8]) -> &'self str {
    |                                     ^^^^^
@@ -51,24 +51,6 @@ help: indicate the anonymous lifetime
 LL | impl<'self> Serializable<'_, str> for &'self str {
    |                          +++
 
-error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/issue-10412.rs:7:13
-   |
-LL | impl<'self> Serializable<str> for &'self str {
-   |             ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `str`
-note: required by an implicit `Sized` bound in `Serializable`
-  --> $DIR/issue-10412.rs:1:27
-   |
-LL | trait Serializable<'self, T> {
-   |                           ^ required by the implicit `Sized` requirement on this type parameter in `Serializable`
-help: consider relaxing the implicit `Sized` restriction
-   |
-LL | trait Serializable<'self, T: ?Sized> {
-   |                            ++++++++
+error: aborting due to 8 previous errors
 
-error: aborting due to 9 previous errors
-
-Some errors have detailed explanations: E0277, E0726.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0726`.

--- a/tests/ui/lifetimes/could-not-resolve-issue-121503.rs
+++ b/tests/ui/lifetimes/could-not-resolve-issue-121503.rs
@@ -4,8 +4,7 @@
 struct Struct;
 impl Struct {
     async fn box_ref_Struct(self: Box<Self, impl FnMut(&mut Self)>) -> &u32 {
-    //~^ ERROR the trait bound `impl FnMut(&mut Self): Allocator` is not satisfied
-    //~| ERROR Box<Struct, impl FnMut(&mut Self)>` cannot be used as the type of `self` without
+    //~^ ERROR Box<Struct, impl FnMut(&mut Self)>` cannot be used as the type of `self` without
         &1
     }
 }

--- a/tests/ui/lifetimes/could-not-resolve-issue-121503.stderr
+++ b/tests/ui/lifetimes/could-not-resolve-issue-121503.stderr
@@ -1,16 +1,3 @@
-error[E0277]: the trait bound `impl FnMut(&mut Self): Allocator` is not satisfied
-  --> $DIR/could-not-resolve-issue-121503.rs:6:5
-   |
-LL |     async fn box_ref_Struct(self: Box<Self, impl FnMut(&mut Self)>) -> &u32 {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Allocator` is not implemented for `impl FnMut(&mut Self)`
-   |
-note: required by a bound in `Box`
-  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
-help: consider further restricting this bound
-   |
-LL |     async fn box_ref_Struct(self: Box<Self, impl FnMut(&mut Self) + std::alloc::Allocator>) -> &u32 {
-   |                                                                   +++++++++++++++++++++++
-
 error[E0658]: `Box<Struct, impl FnMut(&mut Self)>` cannot be used as the type of `self` without the `arbitrary_self_types` feature
   --> $DIR/could-not-resolve-issue-121503.rs:6:35
    |
@@ -22,7 +9,6 @@ LL |     async fn box_ref_Struct(self: Box<Self, impl FnMut(&mut Self)>) -> &u32
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0277, E0658.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/lifetimes/issue-26638.rs
+++ b/tests/ui/lifetimes/issue-26638.rs
@@ -1,6 +1,5 @@
 fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.next() }
 //~^ ERROR missing lifetime specifier [E0106]
-//~| ERROR mismatched types
 
 fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
 //~^ ERROR missing lifetime specifier [E0106]

--- a/tests/ui/lifetimes/issue-26638.stderr
+++ b/tests/ui/lifetimes/issue-26638.stderr
@@ -11,7 +11,7 @@ LL | fn parse_type<'a>(iter: Box<dyn Iterator<Item=&'a str>+'static>) -> &'a str
    |              ++++                              ++                    ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/issue-26638.rs:5:40
+  --> $DIR/issue-26638.rs:4:40
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
    |                                        ^ expected named lifetime parameter
@@ -31,7 +31,7 @@ LL | fn parse_type_2(iter: fn(&u8)->&u8) -> String { iter() }
    |                                        ~~~~~~
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/issue-26638.rs:10:22
+  --> $DIR/issue-26638.rs:9:22
    |
 LL | fn parse_type_3() -> &str { unimplemented!() }
    |                      ^ expected named lifetime parameter
@@ -46,23 +46,8 @@ help: instead, you are more likely to want to return an owned value
 LL | fn parse_type_3() -> String { unimplemented!() }
    |                      ~~~~~~
 
-error[E0308]: mismatched types
-  --> $DIR/issue-26638.rs:1:69
-   |
-LL | fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.next() }
-   |                                                              ----   ^^^^^^^^^^^ expected `&str`, found `Option<&str>`
-   |                                                              |
-   |                                                              expected `&str` because of return type
-   |
-   = note: expected reference `&str`
-                   found enum `Option<&str>`
-help: consider using `Option::expect` to unwrap the `Option<&str>` value, panicking if the value is an `Option::None`
-   |
-LL | fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.next().expect("REASON") }
-   |                                                                                +++++++++++++++++
-
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> $DIR/issue-26638.rs:5:47
+  --> $DIR/issue-26638.rs:4:47
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
    |                                               ^^^^-- an argument of type `&u8` is missing
@@ -73,7 +58,7 @@ LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter(/* &u8 */) }
    |                                                   ~~~~~~~~~~~
 
 error[E0308]: mismatched types
-  --> $DIR/issue-26638.rs:5:47
+  --> $DIR/issue-26638.rs:4:47
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
    |                                        ----   ^^^^^^ expected `&str`, found `&u8`
@@ -83,7 +68,7 @@ LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
    = note: expected reference `&'static str`
               found reference `&u8`
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0061, E0106, E0308.
 For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.rs
+++ b/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.rs
@@ -1,7 +1,5 @@
 fn foo(x: &i32, y: &i32) -> &i32 { //~ ERROR missing lifetime
     if x > y { x } else { y }
-    //~^ ERROR: lifetime may not live long enough
-    //~| ERROR: lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
@@ -10,22 +10,6 @@ help: consider introducing a named lifetime parameter
 LL | fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
    |       ++++     ++          ++          ++
 
-error: lifetime may not live long enough
-  --> $DIR/ex1b-return-no-names-if-else.rs:2:16
-   |
-LL | fn foo(x: &i32, y: &i32) -> &i32 {
-   |           - let's call the lifetime of this reference `'1`
-LL |     if x > y { x } else { y }
-   |                ^ returning this value requires that `'1` must outlive `'static`
-
-error: lifetime may not live long enough
-  --> $DIR/ex1b-return-no-names-if-else.rs:2:27
-   |
-LL | fn foo(x: &i32, y: &i32) -> &i32 {
-   |                    - let's call the lifetime of this reference `'2`
-LL |     if x > y { x } else { y }
-   |                           ^ returning this value requires that `'2` must outlive `'static`
-
-error: aborting due to 3 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/nll/user-annotations/region-error-ice-109072.rs
+++ b/tests/ui/nll/user-annotations/region-error-ice-109072.rs
@@ -11,4 +11,5 @@ impl Lt<'missing> for () { //~ ERROR undeclared lifetime
 
 fn main() {
     let _: <() as Lt<'_>>::T = &();
+    //~^ ERROR the trait bound `(): Lt<'_>` is not satisfied
 }

--- a/tests/ui/nll/user-annotations/region-error-ice-109072.stderr
+++ b/tests/ui/nll/user-annotations/region-error-ice-109072.stderr
@@ -21,6 +21,13 @@ help: consider introducing lifetime `'missing` here
 LL | impl<'missing> Lt<'missing> for () {
    |     ++++++++++
 
-error: aborting due to 2 previous errors
+error[E0277]: the trait bound `(): Lt<'_>` is not satisfied
+  --> $DIR/region-error-ice-109072.rs:13:13
+   |
+LL |     let _: <() as Lt<'_>>::T = &();
+   |             ^^ the trait `Lt<'_>` is not implemented for `()`
 
-For more information about this error, try `rustc --explain E0261`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0261, E0277.
+For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.rs
+++ b/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.rs
@@ -15,7 +15,6 @@ fn is_static<T>(_: T) where T: 'static { }
 // code forces us into a conservative, hacky path.
 fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
 //~^ ERROR please supply an explicit bound
-//~| ERROR `(): Foo<'_>` is not satisfied
 
 fn main() {
     let s = format!("foo");

--- a/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.stderr
+++ b/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.stderr
@@ -4,20 +4,6 @@ error[E0228]: the lifetime bound for this object type cannot be deduced from con
 LL | fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
    |                                    ^^^^^^^
 
-error[E0277]: the trait bound `(): Foo<'_>` is not satisfied
-  --> $DIR/object-lifetime-default-dyn-binding-nonstatic3.rs:16:47
-   |
-LL | fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
-   |                                               ^^^ the trait `Foo<'_>` is not implemented for `()`
-   |
-help: this trait has no implementations, consider adding one
-  --> $DIR/object-lifetime-default-dyn-binding-nonstatic3.rs:4:1
-   |
-LL | trait Foo<'a> {
-   | ^^^^^^^^^^^^^
-   = note: required for the cast from `&()` to `&dyn Foo<'_, Item = dyn Bar>`
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0228, E0277.
-For more information about an error, try `rustc --explain E0228`.
+For more information about this error, try `rustc --explain E0228`.

--- a/tests/ui/suggestions/issue-86667.rs
+++ b/tests/ui/suggestions/issue-86667.rs
@@ -6,13 +6,11 @@
 async fn a(s1: &str, s2: &str) -> &str {
     //~^ ERROR: missing lifetime specifier [E0106]
     s1
-    //~^ ERROR: lifetime may not live long enough
 }
 
 fn b(s1: &str, s2: &str) -> &str {
     //~^ ERROR: missing lifetime specifier [E0106]
     s1
-    //~^ ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/suggestions/issue-86667.stderr
+++ b/tests/ui/suggestions/issue-86667.stderr
@@ -11,7 +11,7 @@ LL | async fn a<'a>(s1: &'a str, s2: &'a str) -> &'a str {
    |           ++++      ++           ++          ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/issue-86667.rs:12:29
+  --> $DIR/issue-86667.rs:11:29
    |
 LL | fn b(s1: &str, s2: &str) -> &str {
    |          ----      ----     ^ expected named lifetime parameter
@@ -22,24 +22,6 @@ help: consider introducing a named lifetime parameter
 LL | fn b<'a>(s1: &'a str, s2: &'a str) -> &'a str {
    |     ++++      ++           ++          ++
 
-error: lifetime may not live long enough
-  --> $DIR/issue-86667.rs:8:5
-   |
-LL | async fn a(s1: &str, s2: &str) -> &str {
-   |                - let's call the lifetime of this reference `'1`
-LL |
-LL |     s1
-   |     ^^ returning this value requires that `'1` must outlive `'static`
-
-error: lifetime may not live long enough
-  --> $DIR/issue-86667.rs:14:5
-   |
-LL | fn b(s1: &str, s2: &str) -> &str {
-   |          - let's call the lifetime of this reference `'1`
-LL |
-LL |     s1
-   |     ^^ returning this value requires that `'1` must outlive `'static`
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/missing-lifetime-specifier.rs
+++ b/tests/ui/suggestions/missing-lifetime-specifier.rs
@@ -20,31 +20,21 @@ pub union Qux<'t, 'k, I> {
 trait Tar<'t, 'k, I> {}
 
 thread_local! {
-    //~^ ERROR lifetime may not live long enough
-    //~| ERROR lifetime may not live long enough
     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
       //~^ ERROR missing lifetime specifiers
       //~| ERROR missing lifetime specifiers
 }
 thread_local! {
-    //~^ ERROR lifetime may not live long enough
-    //~| ERROR lifetime may not live long enough
-    //~| ERROR lifetime may not live long enough
     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
       //~^ ERROR missing lifetime specifiers
       //~| ERROR missing lifetime specifiers
 }
 thread_local! {
-    //~^ ERROR lifetime may not live long enough
-    //~| ERROR lifetime may not live long enough
     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
     //~^ ERROR missing lifetime specifiers
     //~| ERROR missing lifetime specifiers
 }
 thread_local! {
-    //~^ ERROR lifetime may not live long enough
-    //~| ERROR lifetime may not live long enough
-    //~| ERROR lifetime may not live long enough
     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
     //~^ ERROR missing lifetime specifiers
     //~| ERROR missing lifetime specifiers

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:25:44
+  --> $DIR/missing-lifetime-specifier.rs:23:44
    |
 LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ expected 2 lifetime parameters
@@ -11,11 +11,9 @@ LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo<'static, 'static>>>>> = RefC
    |                                               ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:25:44
+  --> $DIR/missing-lifetime-specifier.rs:23:44
    |
 LL | / thread_local! {
-LL | |
-LL | |
 LL | |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
    | |                                            ^^^ expected 2 lifetime parameters
 LL | |
@@ -26,7 +24,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:33:44
+  --> $DIR/missing-lifetime-specifier.rs:28:44
    |
 LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
    |                                            ^^^^ expected 2 lifetime parameters
@@ -40,12 +38,9 @@ LL |     static b: RefCell<HashMap<i32, Vec<Vec<&'static Bar<'static, 'static>>>
    |                                             +++++++    ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:33:44
+  --> $DIR/missing-lifetime-specifier.rs:28:44
    |
 LL | / thread_local! {
-LL | |
-LL | |
-LL | |
 LL | |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
    | |                                            ^^^^ expected 2 lifetime parameters
    | |                                            |
@@ -58,7 +53,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:40:47
+  --> $DIR/missing-lifetime-specifier.rs:33:47
    |
 LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
    |                                               ^ expected 2 lifetime parameters
@@ -70,11 +65,9 @@ LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:40:47
+  --> $DIR/missing-lifetime-specifier.rs:33:47
    |
 LL | / thread_local! {
-LL | |
-LL | |
 LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
    | |                                               ^ expected 2 lifetime parameters
 LL | |
@@ -85,7 +78,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:48:44
+  --> $DIR/missing-lifetime-specifier.rs:38:44
    |
 LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^   ^ expected 2 lifetime parameters
@@ -99,12 +92,9 @@ LL |     static d: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, 'static, i
    |                                             +++++++     +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:48:44
+  --> $DIR/missing-lifetime-specifier.rs:38:44
    |
 LL | / thread_local! {
-LL | |
-LL | |
-LL | |
 LL | |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
    | |                                            ^   ^ expected 2 lifetime parameters
    | |                                            |
@@ -117,7 +107,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:58:44
+  --> $DIR/missing-lifetime-specifier.rs:48:44
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^ expected named lifetime parameter
@@ -129,7 +119,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> =
    |                                             +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:58:44
+  --> $DIR/missing-lifetime-specifier.rs:48:44
    |
 LL | / thread_local! {
 LL | |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -143,7 +133,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:54:44
+  --> $DIR/missing-lifetime-specifier.rs:44:44
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ ------- supplied 1 lifetime argument
@@ -161,7 +151,7 @@ LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                       +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:58:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -178,199 +168,7 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        +++++++++
 
-error: lifetime may not live long enough
-  --> $DIR/missing-lifetime-specifier.rs:22:1
-   |
-LL | / thread_local! {
-LL | |
-LL | |
-LL | |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
-LL | |
-LL | |
-LL | | }
-   | | ^
-   | | |
-   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Foo<'1, '_>>>>>>>`
-   |   returning this value requires that `'1` must outlive `'static`
-   |
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: lifetime may not live long enough
-  --> $DIR/missing-lifetime-specifier.rs:22:1
-   |
-LL | / thread_local! {
-LL | |
-LL | |
-LL | |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
-LL | |
-LL | |
-LL | | }
-   | | ^
-   | | |
-   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Foo<'_, '2>>>>>>>`
-   |   returning this value requires that `'2` must outlive `'static`
-   |
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: lifetime may not live long enough
-  --> $DIR/missing-lifetime-specifier.rs:29:1
-   |
-LL | / thread_local! {
-LL | |
-LL | |
-LL | |
-LL | |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
-   | |                                            - let's call the lifetime of this reference `'1`
-LL | |
-LL | |
-LL | | }
-   | |_^ returning this value requires that `'1` must outlive `'static`
-   |
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
-   |
-LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar + '_>>>> = RefCell::new(HashMap::new());
-   |                                                 ++++
-
-error: lifetime may not live long enough
-  --> $DIR/missing-lifetime-specifier.rs:29:1
-   |
-LL | / thread_local! {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | | ^
-   | | |
-   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Bar<'2, '_>>>>>>>`
-   |   returning this value requires that `'2` must outlive `'static`
-   |
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
-   |
-LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar + '_>>>> = RefCell::new(HashMap::new());
-   |                                                 ++++
-
-error: lifetime may not live long enough
-  --> $DIR/missing-lifetime-specifier.rs:29:1
-   |
-LL | / thread_local! {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | | ^
-   | | |
-   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Bar<'_, '3>>>>>>>`
-   |   returning this value requires that `'3` must outlive `'static`
-   |
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
-   |
-LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar + '_>>>> = RefCell::new(HashMap::new());
-   |                                                 ++++
-
-error: lifetime may not live long enough
-  --> $DIR/missing-lifetime-specifier.rs:37:1
-   |
-LL | / thread_local! {
-LL | |
-LL | |
-LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
-LL | |
-LL | |
-LL | | }
-   | | ^
-   | | |
-   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Qux<'1, '_, i32>>>>>>>`
-   |   returning this value requires that `'1` must outlive `'static`
-   |
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: lifetime may not live long enough
-  --> $DIR/missing-lifetime-specifier.rs:37:1
-   |
-LL | / thread_local! {
-LL | |
-LL | |
-LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
-LL | |
-LL | |
-LL | | }
-   | | ^
-   | | |
-   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Qux<'_, '2, i32>>>>>>>`
-   |   returning this value requires that `'2` must outlive `'static`
-   |
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: lifetime may not live long enough
-  --> $DIR/missing-lifetime-specifier.rs:44:1
-   |
-LL | / thread_local! {
-LL | |
-LL | |
-LL | |
-LL | |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
-   | |                                            - let's call the lifetime of this reference `'1`
-LL | |
-LL | |
-LL | | }
-   | |_^ returning this value requires that `'1` must outlive `'static`
-   |
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
-   |
-LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32> + '_>>>> = RefCell::new(HashMap::new());
-   |                                                      ++++
-
-error: lifetime may not live long enough
-  --> $DIR/missing-lifetime-specifier.rs:44:1
-   |
-LL | / thread_local! {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | | ^
-   | | |
-   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Tar<'2, '_, i32>>>>>>>`
-   |   returning this value requires that `'2` must outlive `'static`
-   |
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
-   |
-LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32> + '_>>>> = RefCell::new(HashMap::new());
-   |                                                      ++++
-
-error: lifetime may not live long enough
-  --> $DIR/missing-lifetime-specifier.rs:44:1
-   |
-LL | / thread_local! {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | | ^
-   | | |
-   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Tar<'_, '3, i32>>>>>>>`
-   |   returning this value requires that `'3` must outlive `'static`
-   |
-   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
-   |
-LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32> + '_>>>> = RefCell::new(HashMap::new());
-   |                                                      ++++
-
-error: aborting due to 22 previous errors
+error: aborting due to 12 previous errors
 
 Some errors have detailed explanations: E0106, E0107.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/traits/span-bug-issue-121414.rs
+++ b/tests/ui/traits/span-bug-issue-121414.rs
@@ -6,7 +6,8 @@ impl<'a> Bar for Foo<'f> { //~ ERROR undeclared lifetime
     type Type = u32;
 }
 
-fn test() //~ ERROR implementation of `Bar` is not general enough
+fn test() //~ ERROR the trait bound `for<'a> Foo<'a>: Bar` is not satisfied
+          //~| ERROR the trait bound `for<'a> Foo<'a>: Bar` is not satisfied
 where
     for<'a> <Foo<'a> as Bar>::Type: Sized,
 {

--- a/tests/ui/traits/span-bug-issue-121414.stderr
+++ b/tests/ui/traits/span-bug-issue-121414.stderr
@@ -6,15 +6,22 @@ LL | impl<'a> Bar for Foo<'f> {
    |      |
    |      help: consider introducing lifetime `'f` here: `'f,`
 
-error: implementation of `Bar` is not general enough
+error[E0277]: the trait bound `for<'a> Foo<'a>: Bar` is not satisfied
+  --> $DIR/span-bug-issue-121414.rs:9:1
+   |
+LL | / fn test()
+LL | |
+LL | | where
+LL | |     for<'a> <Foo<'a> as Bar>::Type: Sized,
+   | |__________________________________________^ the trait `for<'a> Bar` is not implemented for `Foo<'a>`
+
+error[E0277]: the trait bound `for<'a> Foo<'a>: Bar` is not satisfied
   --> $DIR/span-bug-issue-121414.rs:9:4
    |
 LL | fn test()
-   |    ^^^^ implementation of `Bar` is not general enough
-   |
-   = note: `Bar` would have to be implemented for the type `Foo<'0>`, for any lifetime `'0`...
-   = note: ...but `Bar` is actually implemented for the type `Foo<'1>`, for some specific lifetime `'1`
+   |    ^^^^ the trait `for<'a> Bar` is not implemented for `Foo<'a>`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0261`.
+Some errors have detailed explanations: E0261, E0277.
+For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/type-alias-impl-trait/escaping-bound-var.rs
+++ b/tests/ui/type-alias-impl-trait/escaping-bound-var.rs
@@ -8,6 +8,7 @@ trait Test<'a> {}
 
 pub type Foo = impl for<'a> Trait<'a, Assoc = impl Test<'a>>;
 //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
+//~| ERROR unconstrained opaque type
 
 impl Trait<'_> for () {
     type Assoc = ();

--- a/tests/ui/type-alias-impl-trait/escaping-bound-var.rs
+++ b/tests/ui/type-alias-impl-trait/escaping-bound-var.rs
@@ -8,7 +8,6 @@ trait Test<'a> {}
 
 pub type Foo = impl for<'a> Trait<'a, Assoc = impl Test<'a>>;
 //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-//~| ERROR unconstrained opaque type
 
 impl Trait<'_> for () {
     type Assoc = ();

--- a/tests/ui/type-alias-impl-trait/escaping-bound-var.stderr
+++ b/tests/ui/type-alias-impl-trait/escaping-bound-var.stderr
@@ -10,6 +10,14 @@ note: lifetime declared here
 LL | pub type Foo = impl for<'a> Trait<'a, Assoc = impl Test<'a>>;
    |                         ^^
 
-error: aborting due to 1 previous error
+error: unconstrained opaque type
+  --> $DIR/escaping-bound-var.rs:9:47
+   |
+LL | pub type Foo = impl for<'a> Trait<'a, Assoc = impl Test<'a>>;
+   |                                               ^^^^^^^^^^^^^
+   |
+   = note: `Foo` must be used in combination with a concrete type within the same module
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/type-alias-impl-trait/escaping-bound-var.stderr
+++ b/tests/ui/type-alias-impl-trait/escaping-bound-var.stderr
@@ -10,14 +10,6 @@ note: lifetime declared here
 LL | pub type Foo = impl for<'a> Trait<'a, Assoc = impl Test<'a>>;
    |                         ^^
 
-error: unconstrained opaque type
-  --> $DIR/escaping-bound-var.rs:9:47
-   |
-LL | pub type Foo = impl for<'a> Trait<'a, Assoc = impl Test<'a>>;
-   |                                               ^^^^^^^^^^^^^
-   |
-   = note: `Foo` must be used in combination with a concrete type within the same module
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/typeck/escaping_bound_vars.rs
+++ b/tests/ui/typeck/escaping_bound_vars.rs
@@ -11,9 +11,6 @@ where
     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
     //~^ ERROR cannot capture late-bound lifetime in constant
     //~| ERROR associated type bindings are not allowed here
-    //~| ERROR the trait bound `(): Elide<(&(),)>` is not satisfied
-    //~| ERROR the trait bound `(): Elide<(&(),)>` is not satisfied
-    //~| ERROR cannot add
 {
 }
 

--- a/tests/ui/typeck/escaping_bound_vars.stderr
+++ b/tests/ui/typeck/escaping_bound_vars.stderr
@@ -12,49 +12,6 @@ error[E0229]: associated type bindings are not allowed here
 LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
    |                            ^^^^^^^^^^ associated type not allowed here
 
-error[E0277]: the trait bound `(): Elide<(&(),)>` is not satisfied
-  --> $DIR/escaping_bound_vars.rs:11:22
-   |
-LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
-   |                      ^^ the trait `Elide<(&(),)>` is not implemented for `()`
-   |
-help: this trait has no implementations, consider adding one
-  --> $DIR/escaping_bound_vars.rs:5:1
-   |
-LL | trait Elide<T> {
-   | ^^^^^^^^^^^^^^
+error: aborting due to 2 previous errors
 
-error[E0277]: cannot add `fn() {<() as Elide<(&(),)>>::call}` to `{integer}`
-  --> $DIR/escaping_bound_vars.rs:11:18
-   |
-LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
-   |                  ^ no implementation for `{integer} + fn() {<() as Elide<(&(),)>>::call}`
-   |
-   = help: the trait `Add<fn() {<() as Elide<(&(),)>>::call}>` is not implemented for `{integer}`
-   = help: the following other types implement trait `Add<Rhs>`:
-             <isize as Add>
-             <isize as Add<&isize>>
-             <i8 as Add>
-             <i8 as Add<&i8>>
-             <i16 as Add>
-             <i16 as Add<&i16>>
-             <i32 as Add>
-             <i32 as Add<&i32>>
-           and 48 others
-
-error[E0277]: the trait bound `(): Elide<(&(),)>` is not satisfied
-  --> $DIR/escaping_bound_vars.rs:11:18
-   |
-LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
-   |                  ^ the trait `Elide<(&(),)>` is not implemented for `()`
-   |
-help: this trait has no implementations, consider adding one
-  --> $DIR/escaping_bound_vars.rs:5:1
-   |
-LL | trait Elide<T> {
-   | ^^^^^^^^^^^^^^
-
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0229, E0277.
-For more information about an error, try `rustc --explain E0229`.
+For more information about this error, try `rustc --explain E0229`.

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
@@ -33,7 +33,6 @@ fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {
     //~^ ERROR trait takes 1 lifetime argument but 0 lifetime arguments were supplied
     // Here, the omitted lifetimes are expanded to distinct things.
     same_type(x, y)
-    //~^ ERROR borrowed data escapes outside of function
 }
 
 fn main() { }

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
@@ -34,22 +34,6 @@ note: trait defined here, with 1 lifetime parameter: `'a`
 LL | trait Foo<'a,T> {
    |       ^^^ --
 
-error[E0521]: borrowed data escapes outside of function
-  --> $DIR/unboxed-closure-sugar-region.rs:35:5
-   |
-LL | fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {
-   |          -                                - `y` declared here, outside of the function body
-   |          |
-   |          `x` is a reference that is only valid in the function body
-   |          has type `&dyn Foo<'1, (isize,), Output = ()>`
-...
-LL |     same_type(x, y)
-   |     ^^^^^^^^^^^^^^^
-   |     |
-   |     `x` escapes the function body here
-   |     argument requires that `'1` must outlive `'static`
+error: aborting due to 3 previous errors
 
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0107, E0521.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/underscore-lifetime/underscore-lifetime-binders.rs
+++ b/tests/ui/underscore-lifetime/underscore-lifetime-binders.rs
@@ -14,7 +14,6 @@ fn meh() -> Box<dyn for<'_> Meh<'_>> //~ ERROR cannot be used here
 }
 
 fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y } //~ ERROR missing lifetime specifier
-//~^ ERROR lifetime may not live long enough
 
 fn main() {
     let x = 5;

--- a/tests/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/tests/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -45,15 +45,7 @@ help: consider introducing a named lifetime parameter
 LL | fn foo2<'a>(_: &'a u8, y: &'a u8) -> &'a u8 { y }
    |        ++++     ~~         ~~         ~~
 
-error: lifetime may not live long enough
-  --> $DIR/underscore-lifetime-binders.rs:16:43
-   |
-LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
-   |                       -                   ^ returning this value requires that `'1` must outlive `'static`
-   |                       |
-   |                       let's call the lifetime of this reference `'1`
-
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0106, E0637.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/wf/wf-in-foreign-fn-decls-issue-80468.rs
+++ b/tests/ui/wf/wf-in-foreign-fn-decls-issue-80468.rs
@@ -14,4 +14,5 @@ impl Trait for Ref {} //~ ERROR:  implicit elided lifetime not allowed here
 
 extern "C" {
     pub fn repro(_: Wrapper<Ref>);
+    //~^ ERROR the trait bound `Ref<'_>: Trait` is not satisfied
 }

--- a/tests/ui/wf/wf-in-foreign-fn-decls-issue-80468.stderr
+++ b/tests/ui/wf/wf-in-foreign-fn-decls-issue-80468.stderr
@@ -9,6 +9,19 @@ help: indicate the anonymous lifetime
 LL | impl Trait for Ref<'_> {}
    |                   ++++
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `Ref<'_>: Trait` is not satisfied
+  --> $DIR/wf-in-foreign-fn-decls-issue-80468.rs:16:21
+   |
+LL |     pub fn repro(_: Wrapper<Ref>);
+   |                     ^^^^^^^^^^^^ the trait `Trait` is not implemented for `Ref<'_>`
+   |
+note: required by a bound in `Wrapper`
+  --> $DIR/wf-in-foreign-fn-decls-issue-80468.rs:8:23
+   |
+LL | pub struct Wrapper<T: Trait>(T);
+   |                       ^^^^^ required by this bound in `Wrapper`
 
-For more information about this error, try `rustc --explain E0726`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0726.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Self-explanatory. `TypeVisitableExt::references_error(ReError)` incorrectly returned `false`.