### PR TITLE
Fixed the `private-dependency` bug

### DIFF
--- a/tests/ui/privacy/pub-priv-dep/auxiliary/bar.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/bar.rs
@@ -1,0 +1,6 @@
+//@ aux-crate:priv:foo=foo.rs
+//@ compile-flags: -Zunstable-options
+
+#![crate_type = "rlib"]
+extern crate foo;
+pub struct Bar(pub i32);

--- a/tests/ui/privacy/pub-priv-dep/auxiliary/foo.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/foo.rs
@@ -1,0 +1,2 @@
+#![crate_type = "rlib"]
+pub struct Foo(pub i32);

--- a/tests/ui/privacy/pub-priv-dep/priv-dep-issue-122756.rs
+++ b/tests/ui/privacy/pub-priv-dep/priv-dep-issue-122756.rs
@@ -1,0 +1,12 @@
+//@ aux-build: bar.rs
+//@ aux-build: foo.rs
+//@ build-pass
+
+#![deny(exported_private_dependencies)]
+
+// Ensure the libbar.rlib is loaded first. If the command line parameter `--extern foo` does not
+// exist, previus version would fail to compile
+#![crate_type = "rlib"]
+extern crate bar;
+extern crate foo;
+pub fn baz() -> (Option<foo::Foo>, Option<bar::Bar>) { (None, None) }


### PR DESCRIPTION
Fixed the private-dependency bug: If the directly dependent crate is loaded last and is not configured with `--extern`, it may be incorrectly set to `private-dependency`

Fixes #122756