### PR TITLE
coverage: Remove incorrect assertions from counter allocation

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/counters.rs
+++ b/compiler/rustc_mir_transform/src/coverage/counters.rs
@@ -1,12 +1,12 @@
+use std::fmt::{self, Debug};
+
 use rustc_data_structures::captures::Captures;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::graph::WithNumNodes;
 use rustc_index::IndexVec;
-use rustc_middle::mir::coverage::*;
+use rustc_middle::mir::coverage::{CounterId, CovTerm, Expression, ExpressionId, Op};
 
-use super::graph::{BasicCoverageBlock, CoverageGraph, TraverseCoverageGraphWithLoops};
-
-use std::fmt::{self, Debug};
+use crate::coverage::graph::{BasicCoverageBlock, CoverageGraph, TraverseCoverageGraphWithLoops};
 
 /// The coverage counter or counter expression associated with a particular
 /// BCB node or BCB edge.

--- a/tests/coverage/let_else_loop.cov-map
+++ b/tests/coverage/let_else_loop.cov-map
@@ -1,0 +1,30 @@
+Function name: let_else_loop::_if (unused)
+Raw bytes (19): 0x[01, 01, 00, 03, 00, 16, 01, 01, 0c, 00, 02, 09, 00, 10, 00, 02, 09, 00, 10]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Zero) at (prev + 22, 1) to (start + 1, 12)
+- Code(Zero) at (prev + 2, 9) to (start + 0, 16)
+- Code(Zero) at (prev + 2, 9) to (start + 0, 16)
+
+Function name: let_else_loop::_loop_either_way (unused)
+Raw bytes (19): 0x[01, 01, 00, 03, 00, 0f, 01, 01, 14, 00, 01, 1c, 00, 23, 00, 01, 05, 00, 0c]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Zero) at (prev + 15, 1) to (start + 1, 20)
+- Code(Zero) at (prev + 1, 28) to (start + 0, 35)
+- Code(Zero) at (prev + 1, 5) to (start + 0, 12)
+
+Function name: let_else_loop::loopy
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 09, 01, 01, 14, 00, 01, 1c, 00, 23, 05, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 9, 1) to (start + 1, 20)
+- Code(Zero) at (prev + 1, 28) to (start + 0, 35)
+- Code(Counter(1)) at (prev + 1, 1) to (start + 0, 2)
+

--- a/tests/coverage/let_else_loop.coverage
+++ b/tests/coverage/let_else_loop.coverage
@@ -1,6 +1,6 @@
    LL|       |#![feature(coverage_attribute)]
    LL|       |//@ edition: 2021
-   LL|       |//@ ignore-test
+   LL|       |
    LL|       |// Regression test for <https://github.com/rust-lang/rust/issues/122738>.
    LL|       |// These code patterns should not trigger an ICE when allocating a physical
    LL|       |// counter to a node and also one of its in-edges, because that is allowed

--- a/tests/coverage/let_else_loop.coverage
+++ b/tests/coverage/let_else_loop.coverage
@@ -1,0 +1,35 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2021
+   LL|       |//@ ignore-test
+   LL|       |// Regression test for <https://github.com/rust-lang/rust/issues/122738>.
+   LL|       |// These code patterns should not trigger an ICE when allocating a physical
+   LL|       |// counter to a node and also one of its in-edges, because that is allowed
+   LL|       |// when the node contains a tight loop to itself.
+   LL|       |
+   LL|      1|fn loopy(cond: bool) {
+   LL|      1|    let true = cond else { loop {} };
+                                         ^0
+   LL|      1|}
+   LL|       |
+   LL|       |// Variant that also has `loop {}` on the success path.
+   LL|       |// This isn't needed to catch the original ICE, but might help detect regressions.
+   LL|      0|fn _loop_either_way(cond: bool) {
+   LL|      0|    let true = cond else { loop {} };
+   LL|      0|    loop {}
+   LL|       |}
+   LL|       |
+   LL|       |// Variant using regular `if` instead of let-else.
+   LL|       |// This doesn't trigger the original ICE, but might help detect regressions.
+   LL|      0|fn _if(cond: bool) {
+   LL|      0|    if cond {
+   LL|      0|        loop {}
+   LL|       |    } else {
+   LL|      0|        loop {}
+   LL|       |    }
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    loopy(true);
+   LL|       |}
+

--- a/tests/coverage/let_else_loop.rs
+++ b/tests/coverage/let_else_loop.rs
@@ -1,0 +1,33 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+//@ ignore-test
+// Regression test for <https://github.com/rust-lang/rust/issues/122738>.
+// These code patterns should not trigger an ICE when allocating a physical
+// counter to a node and also one of its in-edges, because that is allowed
+// when the node contains a tight loop to itself.
+
+fn loopy(cond: bool) {
+    let true = cond else { loop {} };
+}
+
+// Variant that also has `loop {}` on the success path.
+// This isn't needed to catch the original ICE, but might help detect regressions.
+fn _loop_either_way(cond: bool) {
+    let true = cond else { loop {} };
+    loop {}
+}
+
+// Variant using regular `if` instead of let-else.
+// This doesn't trigger the original ICE, but might help detect regressions.
+fn _if(cond: bool) {
+    if cond {
+        loop {}
+    } else {
+        loop {}
+    }
+}
+
+#[coverage(off)]
+fn main() {
+    loopy(true);
+}

--- a/tests/coverage/let_else_loop.rs
+++ b/tests/coverage/let_else_loop.rs
@@ -1,6 +1,6 @@
 #![feature(coverage_attribute)]
 //@ edition: 2021
-//@ ignore-test
+
 // Regression test for <https://github.com/rust-lang/rust/issues/122738>.
 // These code patterns should not trigger an ICE when allocating a physical
 // counter to a node and also one of its in-edges, because that is allowed


### PR DESCRIPTION
These assertions detect situations where a BCB node (in the coverage graph) would have both a physical counter and one or more in-edge counters/expressions.

For most BCBs that situation would indicate an implementation bug. However, it's perfectly fine in the case of a BCB having an edge that loops back to itself.

Given the complexity and risk involved in fixing the assertions, and the fact that nothing relies on them actually being true, this patch just removes them instead.

Fixes #122738.

@rustbot label +A-code-coverage