### PR TITLE
experiment: remove value-based reasoning for interior mutability

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -415,7 +415,7 @@ impl<'tcx> NonConstOp<'tcx> for LiveDrop<'tcx> {
 pub struct TransientCellBorrow;
 impl<'tcx> NonConstOp<'tcx> for TransientCellBorrow {
     fn status_in_item(&self, _: &ConstCx<'_, 'tcx>) -> Status {
-        Status::Unstable(sym::const_refs_to_cell)
+        Status::Allowed
     }
     fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> Diag<'tcx> {
         ccx.tcx

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -196,7 +196,6 @@ pub struct BorrowCheckResult<'tcx> {
 /// `Qualif`.
 #[derive(Clone, Copy, Debug, Default, TyEncodable, TyDecodable, HashStable)]
 pub struct ConstQualifs {
-    pub has_mut_interior: bool,
     pub needs_drop: bool,
     pub needs_non_const_drop: bool,
     pub tainted_by_errors: Option<ErrorGuaranteed>,

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![allow(rustc::untranslatable_diagnostic)]
 #![allow(rustc::diagnostic_outside_of_impl)]
+#![feature(freeze)]
 
 pub mod constructor;
 #[cfg(feature = "rustc")]
@@ -90,9 +91,9 @@ pub trait PatCx: Sized + fmt::Debug {
     /// Errors that can abort analysis.
     type Error: fmt::Debug;
     /// The index of an enum variant.
-    type VariantIdx: Clone + index::Idx + fmt::Debug;
+    type VariantIdx: Clone + index::Idx + fmt::Debug + std::marker::Freeze;
     /// A string literal
-    type StrLit: Clone + PartialEq + fmt::Debug;
+    type StrLit: Clone + PartialEq + fmt::Debug + std::marker::Freeze;
     /// Extra data to store in a match arm.
     type ArmData: Copy + Clone + fmt::Debug;
     /// Extra data to store in a pattern.


### PR DESCRIPTION
This also stabilizes `const_refs_to_cell` as it's just a crater experiment anyway and that reduces the amount of regressions.