### PR TITLE
Replace closures with `_` when suggesting fully qualified path for method call

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/bounds.rs
@@ -565,7 +565,7 @@ fn check_assoc_const_binding_type<'tcx>(
     let mut guar = ty.visit_with(&mut collector).break_value();
 
     let ty_note = ty
-        .make_suggestable(tcx, false)
+        .make_suggestable(tcx, false, None)
         .map(|ty| crate::errors::TyOfAssocConstBindingNote { assoc_const, ty });
 
     let enclosing_item_owner_id = tcx

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1364,7 +1364,7 @@ fn infer_return_ty_for_fn_sig<'tcx>(
             // recursive function definition to leak out into the fn sig.
             let mut should_recover = false;
 
-            if let Some(ret_ty) = ret_ty.make_suggestable(tcx, false) {
+            if let Some(ret_ty) = ret_ty.make_suggestable(tcx, false, None) {
                 diag.span_suggestion(
                     ty.span,
                     "replace with the correct return type",
@@ -1442,7 +1442,7 @@ fn suggest_impl_trait<'tcx>(
             let ty::Tuple(types) = *args_tuple.kind() else {
                 return None;
             };
-            let types = types.make_suggestable(tcx, false)?;
+            let types = types.make_suggestable(tcx, false, None)?;
             let maybe_ret =
                 if item_ty.is_unit() { String::new() } else { format!(" -> {item_ty}") };
             Some(format!(
@@ -1500,7 +1500,7 @@ fn suggest_impl_trait<'tcx>(
         // FIXME(compiler-errors): We may benefit from resolving regions here.
         if ocx.select_where_possible().is_empty()
             && let item_ty = infcx.resolve_vars_if_possible(item_ty)
-            && let Some(item_ty) = item_ty.make_suggestable(tcx, false)
+            && let Some(item_ty) = item_ty.make_suggestable(tcx, false, None)
             && let Some(sugg) = formatter(
                 tcx,
                 infcx.resolve_vars_if_possible(args),

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -47,7 +47,7 @@ fn anon_const_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
             let ty = tcx.fold_regions(ty, |r, _| {
                 if r.is_erased() { ty::Region::new_error_misc(tcx) } else { r }
             });
-            let (ty, opt_sugg) = if let Some(ty) = ty.make_suggestable(tcx, false) {
+            let (ty, opt_sugg) = if let Some(ty) = ty.make_suggestable(tcx, false, None) {
                 (ty, Some((span, Applicability::MachineApplicable)))
             } else {
                 (ty, None)
@@ -587,7 +587,7 @@ fn infer_placeholder_type<'a>(
                     suggestions.clear();
                 }
 
-                if let Some(ty) = ty.make_suggestable(tcx, false) {
+                if let Some(ty) = ty.make_suggestable(tcx, false, None) {
                     err.span_suggestion(
                         span,
                         format!("provide a type for the {kind}"),
@@ -606,7 +606,7 @@ fn infer_placeholder_type<'a>(
             let mut diag = bad_placeholder(tcx, vec![span], kind);
 
             if !ty.references_error() {
-                if let Some(ty) = ty.make_suggestable(tcx, false) {
+                if let Some(ty) = ty.make_suggestable(tcx, false, None) {
                     diag.span_suggestion(
                         span,
                         "replace with the correct type",

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -809,7 +809,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 return true;
             }
             &hir::FnRetTy::DefaultReturn(span) if expected.is_unit() => {
-                if let Some(found) = found.make_suggestable(self.tcx, false) {
+                if let Some(found) = found.make_suggestable(self.tcx, false, None) {
                     err.subdiagnostic(
                         self.dcx(),
                         errors::AddReturnTypeSuggestion::Add { span, found: found.to_string() },

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -601,8 +601,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                             if let Some(output_def_id) = output_def_id
                                                 && let Some(trait_def_id) = trait_def_id
                                                 && self.tcx.parent(output_def_id) == trait_def_id
-                                                && let Some(output_ty) =
-                                                    output_ty.make_suggestable(self.tcx, false)
+                                                && let Some(output_ty) = output_ty
+                                                    .make_suggestable(self.tcx, false, None)
                                             {
                                                 Some(("Output", output_ty))
                                             } else {

--- a/src/tools/clippy/clippy_lints/src/box_default.rs
+++ b/src/tools/clippy/clippy_lints/src/box_default.rs
@@ -70,7 +70,9 @@ impl LateLintPass<'_> for BoxDefault {
                 "try",
                 if is_plain_default(cx, arg_path) || given_type(cx, expr) {
                     "Box::default()".into()
-                } else if let Some(arg_ty) = cx.typeck_results().expr_ty(arg).make_suggestable(cx.tcx, true) {
+                } else if let Some(arg_ty) =
+                    cx.typeck_results().expr_ty(arg).make_suggestable(cx.tcx, true, None)
+                {
                     // Check if we can copy from the source expression in the replacement.
                     // We need the call to have no argument (see `explicit_default_type`).
                     if inner_call_args.is_empty()

--- a/tests/ui/suggestions/types/into-inference-needs-type.rs
+++ b/tests/ui/suggestions/types/into-inference-needs-type.rs
@@ -1,0 +1,15 @@
+#[derive(Debug)]
+enum MyError {
+    MainError
+}
+
+fn main() -> Result<(), MyError> {
+    let vec = vec!["one", "two", "three"];
+    let list = vec
+        .iter()
+        .map(|s| s.strip_prefix("t"))
+        .filter_map(Option::Some)
+        .into()?; //~ ERROR type annotations needed
+
+    return Ok(());
+}

--- a/tests/ui/suggestions/types/into-inference-needs-type.stderr
+++ b/tests/ui/suggestions/types/into-inference-needs-type.stderr
@@ -1,0 +1,19 @@
+error[E0283]: type annotations needed
+  --> $DIR/into-inference-needs-type.rs:12:10
+   |
+LL |         .into()?;
+   |          ^^^^
+   |
+   = note: cannot satisfy `_: From<FilterMap<Map<std::slice::Iter<'_, &str>, {closure@$DIR/into-inference-needs-type.rs:10:14: 10:17}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>>`
+   = note: required for `FilterMap<Map<std::slice::Iter<'_, &str>, {closure@$DIR/into-inference-needs-type.rs:10:14: 10:17}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>` to implement `Into<_>`
+help: try using a fully qualified path to specify the expected types
+   |
+LL ~     let list = <FilterMap<Map<std::slice::Iter<'_, &str>, _>, _> as Into<T>>::into(vec
+LL |         .iter()
+LL |         .map(|s| s.strip_prefix("t"))
+LL ~         .filter_map(Option::Some))?;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/suggest-fully-qualified-closure.rs
+++ b/tests/ui/traits/suggest-fully-qualified-closure.rs
@@ -1,7 +1,5 @@
 //@ check-fail
 //@ known-bug: #103705
-//@ normalize-stderr-test "\{closure@.*\}" -> "{closure@}"
-//@ normalize-stderr-test "\+* ~" -> "+++ ~"
 
 // The output of this currently suggests writing a closure in the qualified path.
 

--- a/tests/ui/traits/suggest-fully-qualified-closure.stderr
+++ b/tests/ui/traits/suggest-fully-qualified-closure.stderr
@@ -1,11 +1,11 @@
 error[E0283]: type annotations needed
-  --> $DIR/suggest-fully-qualified-closure.rs:23:7
+  --> $DIR/suggest-fully-qualified-closure.rs:21:7
    |
 LL |     q.lol(||());
    |       ^^^
    |
 note: multiple `impl`s satisfying `Qqq: MyTrait<_>` found
-  --> $DIR/suggest-fully-qualified-closure.rs:14:1
+  --> $DIR/suggest-fully-qualified-closure.rs:12:1
    |
 LL | impl MyTrait<u32> for Qqq{
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -14,8 +14,8 @@ LL | impl MyTrait<u64> for Qqq{
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 help: try using a fully qualified path to specify the expected types
    |
-LL |     <Qqq as MyTrait<T>>::lol::<{closure@}>(&q, ||());
-   |     +++ ~
+LL |     <Qqq as MyTrait<T>>::lol::<_>(&q, ||());
+   |     +++++++++++++++++++++++++++++++ ~
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
```
error[E0283]: type annotations needed
  --> $DIR/into-inference-needs-type.rs:12:10
   |
LL |         .into()?;
   |          ^^^^
   |
   = note: cannot satisfy `_: From<...>`
   = note: required for `FilterMap<...>` to implement `Into<_>`
help: try using a fully qualified path to specify the expected types
   |
LL ~     let list = <FilterMap<Map<std::slice::Iter<'_, &str>, _>, _> as Into<T>>::into(vec
LL |         .iter()
LL |         .map(|s| s.strip_prefix("t"))
LL ~         .filter_map(Option::Some))?;
   |
```

Fix #122569.