### PR TITLE
Remove `target_override`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -21,7 +21,6 @@ use rustc_session::{
 };
 use rustc_span::symbol::Symbol;
 use rustc_target::abi::call::FnAbi;
-use rustc_target::spec::Target;
 
 use std::fmt;
 
@@ -69,12 +68,6 @@ pub trait CodegenBackend {
     }
     fn print_passes(&self) {}
     fn print_version(&self) {}
-
-    /// If this plugin provides additional builtin targets, provide the one enabled by the options here.
-    /// Be careful: this is called *before* init() is called.
-    fn target_override(&self, _opts: &config::Options) -> Option<Target> {
-        None
-    }
 
     /// The metadata loader used to load rlib and dylib metadata.
     ///

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -890,7 +890,7 @@ pub fn version_at_macro_invocation(
         let backend_name = debug_flags.iter().find_map(|x| x.strip_prefix("codegen-backend="));
         let opts = config::Options::default();
         let sysroot = filesearch::materialize_sysroot(opts.maybe_sysroot.clone());
-        let target = config::build_target_config(early_dcx, &opts, None, &sysroot);
+        let target = config::build_target_config(early_dcx, &opts, &sysroot);
 
         get_codegen_backend(early_dcx, &sysroot, backend_name, &target).print_version();
     }
@@ -1100,7 +1100,7 @@ pub fn describe_flag_categories(early_dcx: &EarlyDiagCtxt, matches: &Matches) ->
 
         let opts = config::Options::default();
         let sysroot = filesearch::materialize_sysroot(opts.maybe_sysroot.clone());
-        let target = config::build_target_config(early_dcx, &opts, None, &sysroot);
+        let target = config::build_target_config(early_dcx, &opts, &sysroot);
 
         get_codegen_backend(early_dcx, &sysroot, backend_name, &target).print_passes();
         return true;

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -41,7 +41,7 @@ fn mk_session(matches: getopts::Matches) -> (Session, Cfg) {
 
     let sysroot = filesearch::materialize_sysroot(sessopts.maybe_sysroot.clone());
 
-    let target_cfg = rustc_session::config::build_target_config(&early_dcx, &sessopts, &sysroot);
+    let target = rustc_session::config::build_target_config(&early_dcx, &sessopts, &sysroot);
 
     let sess = build_session(
         early_dcx,
@@ -52,7 +52,7 @@ fn mk_session(matches: getopts::Matches) -> (Session, Cfg) {
         vec![],
         Default::default(),
         None,
-        target_cfg,
+        target,
         sysroot,
         "",
         None,

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -41,8 +41,7 @@ fn mk_session(matches: getopts::Matches) -> (Session, Cfg) {
 
     let sysroot = filesearch::materialize_sysroot(sessopts.maybe_sysroot.clone());
 
-    let target_cfg =
-        rustc_session::config::build_target_config(&early_dcx, &sessopts, None, &sysroot);
+    let target_cfg = rustc_session::config::build_target_config(&early_dcx, &sessopts, &sysroot);
 
     let sess = build_session(
         early_dcx,

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1008,7 +1008,7 @@ pub fn build_session(
     fluent_resources: Vec<&'static str>,
     driver_lint_caps: FxHashMap<lint::LintId, lint::Level>,
     file_loader: Option<Box<dyn FileLoader + Send + Sync + 'static>>,
-    target_cfg: Target,
+    target: Target,
     sysroot: PathBuf,
     cfg_version: &'static str,
     ice_file: Option<PathBuf>,
@@ -1036,7 +1036,7 @@ pub fn build_session(
 
     let loader = file_loader.unwrap_or_else(|| Box::new(RealFileLoader));
     let hash_kind = sopts.unstable_opts.src_hash_algorithm.unwrap_or_else(|| {
-        if target_cfg.is_like_msvc {
+        if target.is_like_msvc {
             SourceFileHashAlgorithm::Sha256
         } else {
             SourceFileHashAlgorithm::Md5
@@ -1117,11 +1117,10 @@ pub fn build_session(
         _ => CtfeBacktrace::Disabled,
     });
 
-    let asm_arch =
-        if target_cfg.allow_asm { InlineAsmArch::from_str(&target_cfg.arch).ok() } else { None };
+    let asm_arch = if target.allow_asm { InlineAsmArch::from_str(&target.arch).ok() } else { None };
 
     let sess = Session {
-        target: target_cfg,
+        target,
         host,
         opts: sopts,
         host_tlib_path,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2091,6 +2091,9 @@ pub struct TargetOptions {
     /// compiling `rustc` will be used instead (or llvm if it is not set).
     ///
     /// N.B. when *using* the compiler, backend can always be overridden with `-Zcodegen-backend`.
+    ///
+    /// This was added by WaffleLapkin in #116793. The motivation is a rustc fork that requires a
+    /// custom codegen backend for a particular target.
     pub default_codegen_backend: Option<StaticCow<str>>,
 
     /// Whether to generate trap instructions in places where optimization would


### PR DESCRIPTION
Because the "target can override the backend" and "backend can override the target" situation is a mess. Details in the individual commits.

r? @WaffleLapkin 