### PR TITLE
Add tests for shortcomings of associated type bounds

### DIFF
--- a/tests/ui/associated-type-bounds/cant-see-copy-bound-from-child-rigid-2.rs
+++ b/tests/ui/associated-type-bounds/cant-see-copy-bound-from-child-rigid-2.rs
@@ -1,0 +1,18 @@
+trait Id {
+    type This: ?Sized;
+}
+impl<T: ?Sized> Id for T {
+    type This = T;
+}
+
+trait Trait {
+    type Assoc: Id<This: Copy>;
+}
+
+// We can't see use the `T::Assoc::This: Copy` bound to prove `T::Assoc: Copy`
+fn foo<T: Trait>(x: T::Assoc) -> (T::Assoc, T::Assoc) {
+    (x, x)
+    //~^ ERROR use of moved value
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/cant-see-copy-bound-from-child-rigid-2.stderr
+++ b/tests/ui/associated-type-bounds/cant-see-copy-bound-from-child-rigid-2.stderr
@@ -1,0 +1,13 @@
+error[E0382]: use of moved value: `x`
+  --> $DIR/cant-see-copy-bound-from-child-rigid-2.rs:14:9
+   |
+LL | fn foo<T: Trait>(x: T::Assoc) -> (T::Assoc, T::Assoc) {
+   |                  - move occurs because `x` has type `<T as Trait>::Assoc`, which does not implement the `Copy` trait
+LL |     (x, x)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/associated-type-bounds/cant-see-copy-bound-from-child-rigid.rs
+++ b/tests/ui/associated-type-bounds/cant-see-copy-bound-from-child-rigid.rs
@@ -1,0 +1,18 @@
+trait Id {
+    type This: ?Sized;
+}
+
+trait Trait {
+    type Assoc: Id<This: Copy>;
+}
+
+// We can't see use the `T::Assoc::This: Copy` bound to prove `T::Assoc: Copy`
+fn foo<T: Trait>(x: T::Assoc) -> (T::Assoc, T::Assoc)
+where
+    T::Assoc: Id<This = T::Assoc>,
+{
+    (x, x)
+    //~^ ERROR use of moved value
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/cant-see-copy-bound-from-child-rigid.stderr
+++ b/tests/ui/associated-type-bounds/cant-see-copy-bound-from-child-rigid.stderr
@@ -1,0 +1,14 @@
+error[E0382]: use of moved value: `x`
+  --> $DIR/cant-see-copy-bound-from-child-rigid.rs:14:9
+   |
+LL | fn foo<T: Trait>(x: T::Assoc) -> (T::Assoc, T::Assoc)
+   |                  - move occurs because `x` has type `<T as Trait>::Assoc`, which does not implement the `Copy` trait
+...
+LL |     (x, x)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.


### PR DESCRIPTION
Adds the test in https://github.com/rust-lang/rust/pull/122791#issuecomment-2011433015

Turns out that #121123 is what breaks `tests/ui/associated-type-bounds/cant-see-copy-bound-from-child-rigid.rs` (passes on nightly), but given that associated type bounds haven't landed anywhere yet, I'm happy with breaking it.

This is unrelated to #122791, which just needed that original commit e6b64c61941120f734657106ae2479d05b463197 stacked on top of it so that it wouldn't have tests failing.

r? lcnr