### PR TITLE
make failure logs less verbose

### DIFF
--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1009,15 +1009,23 @@ impl Build {
         let result = if !output.status.success() {
             if print_error {
                 println!(
-                    "\n\ncommand did not execute successfully: {:?}\n\
-                    expected success, got: {}\n\n\
-                    stdout ----\n{}\n\
-                    stderr ----\n{}\n\n",
-                    command.command,
+                    "\n\nCommand did not execute successfully.\
+                    \nExpected success, got: {}",
                     output.status,
-                    String::from_utf8_lossy(&output.stdout),
-                    String::from_utf8_lossy(&output.stderr)
                 );
+
+                if !self.is_verbose() {
+                    println!("Add `-v` to see more details.\n");
+                }
+
+                self.verbose(|| {
+                    println!(
+                        "\nSTDOUT ----\n{}\n\
+                        STDERR ----\n{}\n",
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr)
+                    )
+                });
             }
             Err(())
         } else {


### PR DESCRIPTION
Resolves #122706

Logs without verbose flag:

![image](https://github.com/rust-lang/rust/assets/39852038/f2fc2d35-0954-44b0-bedc-045afedaabe8)

Logs with verbose flag:

![image](https://github.com/rust-lang/rust/assets/39852038/b9308655-ad31-4527-a1be-5a62a78ac469)


I decided to exclude command from the log since it's already included in verbose mode.

cc @Nilstrieb 