### PR TITLE
collector: always consider all monomorphic functions to be 'mentioned'

### DIFF
--- a/tests/incremental/callee_caller_cross_crate/b.rs
+++ b/tests/incremental/callee_caller_cross_crate/b.rs
@@ -6,7 +6,7 @@
 
 extern crate a;
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck,optimized_mir", cfg="rpass2")]
 pub fn call_function0() {
     a::function0(77);
 }

--- a/tests/incremental/dirty_clean.rs
+++ b/tests/incremental/dirty_clean.rs
@@ -36,6 +36,7 @@ mod y {
         //[cfail2]~| ERROR `type_of(y)` should be dirty but is not
         //[cfail2]~| ERROR `fn_sig(y)` should be dirty but is not
         //[cfail2]~| ERROR `typeck(y)` should be clean but is not
+        //[cfail2]~| ERROR `optimized_mir(y)` should be clean but is not
         x::x();
     }
 }

--- a/tests/incremental/hashes/call_expressions.rs
+++ b/tests/incremental/hashes/call_expressions.rs
@@ -62,9 +62,9 @@ mod change_callee_indirectly_function {
     #[cfg(not(any(cfail1,cfail4)))]
     use super::callee2 as callee;
 
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail2")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail5")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]
     pub fn change_callee_indirectly_function() {
         callee(1, 2)

--- a/tests/incremental/hashes/indexing_expressions.rs
+++ b/tests/incremental/hashes/indexing_expressions.rs
@@ -23,9 +23,9 @@ fn change_simple_index(slice: &[u32]) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn change_simple_index(slice: &[u32]) -> u32 {
     slice[4]
@@ -40,9 +40,9 @@ fn change_lower_bound(slice: &[u32]) -> &[u32] {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn change_lower_bound(slice: &[u32]) -> &[u32] {
     &slice[2..5]
@@ -57,9 +57,9 @@ fn change_upper_bound(slice: &[u32]) -> &[u32] {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn change_upper_bound(slice: &[u32]) -> &[u32] {
     &slice[3..7]
@@ -74,9 +74,9 @@ fn add_lower_bound(slice: &[u32]) -> &[u32] {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn add_lower_bound(slice: &[u32]) -> &[u32] {
     &slice[3..4]
@@ -91,9 +91,9 @@ fn add_upper_bound(slice: &[u32]) -> &[u32] {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn add_upper_bound(slice: &[u32]) -> &[u32] {
     &slice[3..7]
@@ -108,9 +108,9 @@ fn change_mutability(slice: &mut [u32]) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn change_mutability(slice: &mut [u32]) -> u32 {
     (&    slice[3..5])[0]
@@ -125,9 +125,9 @@ fn exclusive_to_inclusive_range(slice: &[u32]) -> &[u32] {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn exclusive_to_inclusive_range(slice: &[u32]) -> &[u32] {
     &slice[3..=7]

--- a/tests/incremental/ich_method_call_trait_scope.rs
+++ b/tests/incremental/ich_method_call_trait_scope.rs
@@ -26,7 +26,7 @@ mod mod3 {
     #[cfg(rpass2)]
     use Trait2;
 
-    #[rustc_clean(except="typeck", cfg="rpass2")]
+    #[rustc_clean(except="typeck,optimized_mir", cfg="rpass2")]
     fn bar() {
         ().method();
     }

--- a/tests/incremental/ich_resolve_results.rs
+++ b/tests/incremental/ich_resolve_results.rs
@@ -36,7 +36,7 @@ mod mod3 {
     }
 
     #[rustc_clean(cfg="rpass2")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="rpass3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="rpass3")]
     fn in_type() {
         test::<Foo>();
     }

--- a/tests/incremental/struct_add_field.rs
+++ b/tests/incremental/struct_add_field.rs
@@ -21,12 +21,12 @@ pub struct Y {
     pub y: char
 }
 
-#[rustc_clean(except="fn_sig,typeck", cfg="rpass2")]
+#[rustc_clean(except="fn_sig,typeck,optimized_mir", cfg="rpass2")]
 pub fn use_X(x: X) -> u32 {
     x.x as u32
 }
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck,optimized_mir", cfg="rpass2")]
 pub fn use_EmbedX(embed: EmbedX) -> u32 {
     embed.x.x as u32
 }

--- a/tests/incremental/struct_change_field_type.rs
+++ b/tests/incremental/struct_change_field_type.rs
@@ -24,13 +24,13 @@ pub struct Y {
     pub y: char
 }
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck,optimized_mir", cfg="rpass2")]
 pub fn use_X() -> u32 {
     let x: X = X { x: 22 };
     x.x as u32
 }
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck,optimized_mir", cfg="rpass2")]
 pub fn use_EmbedX(x: EmbedX) -> u32 {
     let x: X = X { x: 22 };
     x.x as u32

--- a/tests/incremental/struct_change_field_type_cross_crate/b.rs
+++ b/tests/incremental/struct_change_field_type_cross_crate/b.rs
@@ -8,13 +8,13 @@ extern crate a;
 
 use a::*;
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck,optimized_mir", cfg="rpass2")]
 pub fn use_X() -> u32 {
     let x: X = X { x: 22 };
     x.x as u32
 }
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck,optimized_mir", cfg="rpass2")]
 pub fn use_EmbedX(embed: EmbedX) -> u32 {
     embed.x.x as u32
 }

--- a/tests/incremental/struct_remove_field.rs
+++ b/tests/incremental/struct_remove_field.rs
@@ -25,12 +25,12 @@ pub struct Y {
     pub y: char
 }
 
-#[rustc_clean(except="typeck,fn_sig", cfg="rpass2")]
+#[rustc_clean(except="typeck,fn_sig,optimized_mir", cfg="rpass2")]
 pub fn use_X(x: X) -> u32 {
     x.x as u32
 }
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck,optimized_mir", cfg="rpass2")]
 pub fn use_EmbedX(embed: EmbedX) -> u32 {
     embed.x.x as u32
 }

--- a/tests/incremental/struct_remove_field.rs
+++ b/tests/incremental/struct_remove_field.rs
@@ -1,4 +1,4 @@
-// Test incremental compilation tracking where we change field names
+// Test incremental compilation tracking where we remove a field
 // in between revisions (hashing should be stable).
 
 //@ revisions:rpass1 rpass2

--- a/tests/incremental/type_alias_cross_crate/b.rs
+++ b/tests/incremental/type_alias_cross_crate/b.rs
@@ -6,7 +6,7 @@
 
 extern crate a;
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck,optimized_mir", cfg="rpass2")]
 #[rustc_clean(cfg="rpass3")]
 pub fn use_X() -> u32 {
     let x: a::X = 22;

--- a/tests/ui/consts/required-consts/collect-roots-dead-fn1.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-roots-dead-fn1.noopt.stderr
@@ -1,0 +1,23 @@
+error[E0080]: evaluation of `Fail::<i32>::C` failed
+  --> $DIR/collect-roots-dead-fn1.rs:15:19
+   |
+LL |     const C: () = panic!();
+   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-roots-dead-fn1.rs:15:19
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/collect-roots-dead-fn1.rs:31:5
+   |
+LL |     Fail::<T>::C;
+   |     ^^^^^^^^^^^^
+
+note: the above error was encountered while instantiating `fn h::<i32>`
+  --> $DIR/collect-roots-dead-fn1.rs:24:5
+   |
+LL |     h::<i32>()
+   |     ^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/required-consts/collect-roots-dead-fn1.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-roots-dead-fn1.opt.stderr
@@ -1,0 +1,23 @@
+error[E0080]: evaluation of `Fail::<i32>::C` failed
+  --> $DIR/collect-roots-dead-fn1.rs:15:19
+   |
+LL |     const C: () = panic!();
+   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-roots-dead-fn1.rs:15:19
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/collect-roots-dead-fn1.rs:31:5
+   |
+LL |     Fail::<T>::C;
+   |     ^^^^^^^^^^^^
+
+note: the above error was encountered while instantiating `fn h::<i32>`
+  --> $DIR/collect-roots-dead-fn1.rs:24:5
+   |
+LL |     h::<i32>()
+   |     ^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/required-consts/collect-roots-dead-fn1.rs
+++ b/tests/ui/consts/required-consts/collect-roots-dead-fn1.rs
@@ -1,0 +1,32 @@
+//@revisions: noopt opt
+//@ build-fail
+//@[noopt] compile-flags: -Copt-level=0
+//@[opt] compile-flags: -O
+
+//! This used to fail in optimized builds but pass in unoptimized builds. The reason is that in
+//! optimized builds, `f` gets marked as cross-crate-inlineable, so the functions it calls become
+//! reachable, and therefore `g` becomes a collection root. But in unoptimized builds, `g` is no
+//! root, and the call to `g` disappears in an early `SimplifyCfg` before "mentioned items" are
+//! gathered, so we never reach `g`.
+#![crate_type = "lib"]
+
+struct Fail<T>(T);
+impl<T> Fail<T> {
+    const C: () = panic!(); //~ERROR: evaluation of `Fail::<i32>::C` failed
+}
+
+pub fn f() {
+    loop {}; g()
+}
+
+#[inline(never)]
+fn g() {
+    h::<i32>()
+}
+
+// Make sure we only use the faulty const in a generic function, or
+// else it gets evaluated by some MIR pass.
+#[inline(never)]
+fn h<T>() {
+    Fail::<T>::C;
+}

--- a/tests/ui/consts/required-consts/collect-roots-dead-fn2.rs
+++ b/tests/ui/consts/required-consts/collect-roots-dead-fn2.rs
@@ -1,0 +1,23 @@
+//@revisions: noopt opt
+//@ build-pass
+//@[noopt] compile-flags: -Copt-level=0
+//@[opt] compile-flags: -O
+
+//! A slight variant of `collect-roots-in-dead-fn` where the dead call is itself generic. Now this
+//! *passes* in both optimized and unoptimized builds: the call to `h` always disappears in an early
+//! `SimplifyCfg`, and `h` is generic so it can never be a root.
+#![crate_type = "lib"]
+
+struct Fail<T>(T);
+impl<T> Fail<T> {
+    const C: () = panic!();
+}
+
+pub fn f() {
+    loop {}; h::<i32>()
+}
+
+#[inline(never)]
+fn h<T>() {
+    Fail::<T>::C;
+}

--- a/tests/ui/consts/required-consts/collect-roots-dead-fn3.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-roots-dead-fn3.noopt.stderr
@@ -1,0 +1,23 @@
+error[E0080]: evaluation of `fail::<()>::{constant#0}` failed
+  --> $DIR/collect-roots-dead-fn3.rs:35:13
+   |
+LL |     const { panic!(); }
+   |             ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-roots-dead-fn3.rs:35:13
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/collect-roots-dead-fn3.rs:35:5
+   |
+LL |     const { panic!(); }
+   |     ^^^^^^^^^^^^^^^^^^^
+
+note: the above error was encountered while instantiating `fn fail::<()>`
+  --> $DIR/collect-roots-dead-fn3.rs:28:5
+   |
+LL |     fail::<()>();
+   |     ^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/required-consts/collect-roots-dead-fn3.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-roots-dead-fn3.opt.stderr
@@ -1,0 +1,23 @@
+error[E0080]: evaluation of `fail::<()>::{constant#0}` failed
+  --> $DIR/collect-roots-dead-fn3.rs:35:13
+   |
+LL |     const { panic!(); }
+   |             ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-roots-dead-fn3.rs:35:13
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/collect-roots-dead-fn3.rs:35:5
+   |
+LL |     const { panic!(); }
+   |     ^^^^^^^^^^^^^^^^^^^
+
+note: the above error was encountered while instantiating `fn fail::<()>`
+  --> $DIR/collect-roots-dead-fn3.rs:28:5
+   |
+LL |     fail::<()>();
+   |     ^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/required-consts/collect-roots-dead-fn3.rs
+++ b/tests/ui/consts/required-consts/collect-roots-dead-fn3.rs
@@ -1,0 +1,36 @@
+//@revisions: noopt opt
+//@ build-fail
+//@[noopt] compile-flags: -Copt-level=0
+//@[opt] compile-flags: -O
+
+#![crate_type = "lib"]
+#![feature(inline_const)]
+
+// Will be `inline` with optimizations, so then `g::<()>` becomes reachable. At the same time `g` is
+// not "mentioned" in `f` since it is only called inside an inline `const` and hence never appears
+// in its MIR! This fundamentally is an issue caused by reachability walking the HIR (before inline
+// `const` are extracted) and collection being based on MIR.
+pub fn f() {
+    loop {}; const { g::<()>() }
+}
+
+// When this comes reachable (for any `T`), so does `hidden_root`.
+// And `hidden_root` is monomorphic so it can become a root!
+const fn g<T>() {
+    match std::mem::size_of::<T>() {
+        0 => (),
+        _ => hidden_root(),
+    }
+}
+
+#[inline(never)]
+const fn hidden_root() {
+    fail::<()>();
+}
+
+#[inline(never)]
+const fn fail<T>() {
+    // Hiding this in a generic fn so that it doesn't get evaluated by
+    // MIR passes.
+    const { panic!(); } //~ERROR: evaluation of `fail::<()>::{constant#0}` failed
+}

--- a/tests/ui/consts/required-consts/collect-roots-inline-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-roots-inline-fn.noopt.stderr
@@ -1,0 +1,23 @@
+error[E0080]: evaluation of `Zst::<u32>::ASSERT` failed
+  --> $DIR/collect-roots-inline-fn.rs:13:9
+   |
+LL |         panic!();
+   |         ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-roots-inline-fn.rs:13:9
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/collect-roots-inline-fn.rs:18:5
+   |
+LL |     Zst::<T>::ASSERT;
+   |     ^^^^^^^^^^^^^^^^
+
+note: the above error was encountered while instantiating `fn f::<u32>`
+  --> $DIR/collect-roots-inline-fn.rs:22:5
+   |
+LL |     f::<u32>()
+   |     ^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/required-consts/collect-roots-inline-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-roots-inline-fn.opt.stderr
@@ -1,0 +1,17 @@
+error[E0080]: evaluation of `Zst::<u32>::ASSERT` failed
+  --> $DIR/collect-roots-inline-fn.rs:13:9
+   |
+LL |         panic!();
+   |         ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-roots-inline-fn.rs:13:9
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/collect-roots-inline-fn.rs:18:5
+   |
+LL |     Zst::<T>::ASSERT;
+   |     ^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/required-consts/collect-roots-inline-fn.rs
+++ b/tests/ui/consts/required-consts/collect-roots-inline-fn.rs
@@ -1,0 +1,23 @@
+//@revisions: noopt opt
+//@ build-fail
+//@[noopt] compile-flags: -Copt-level=0
+//@[opt] compile-flags: -O
+
+//! In optimized builds, the functions in this crate are all marked "inline" so none of them become
+//! collector roots. Ensure that we still evaluate the constants.
+#![crate_type = "lib"]
+
+struct Zst<T>(T);
+impl<T> Zst<T> {
+    const ASSERT: () = if std::mem::size_of::<T>() != 0 {
+        panic!(); //~ERROR: evaluation of `Zst::<u32>::ASSERT` failed
+    };
+}
+
+fn f<T>() {
+    Zst::<T>::ASSERT;
+}
+
+pub fn g() {
+    f::<u32>()
+}


### PR DESCRIPTION
This would fix https://github.com/rust-lang/rust/issues/122814. But it's probably not going to be cheap...

Ideally we'd avoid building the optimized MIR for these new roots, and only request `mir_drops_elaborated_and_const_checked` -- but that MIR is often getting stolen so I don't see a way to do that. ([Zulip](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Use.20unoptimized.20MIR.20for.20.22mentioned.22.20items.20collection))

r? @oli-obk @tmiasko 