### PR TITLE
[rustdoc] Detect and resolve ambiguities in fn parameters type names

### DIFF
--- a/src/librustdoc/html/ambiguity.rs
+++ b/src/librustdoc/html/ambiguity.rs
@@ -1,0 +1,190 @@
+#![allow(warnings)]
+use rustc_data_structures::fx::FxHashMap;
+use rustc_hir::def_id::DefId;
+use rustc_span::Symbol;
+
+use crate::clean::{self, FnDecl, Function};
+
+#[derive(Debug, Clone)]
+pub struct PathLike<'a> {
+    path: &'a clean::Path,
+    suffix_len: usize,
+}
+
+impl<'a> PathLike<'a> {
+    pub fn make_longer(self) -> Self {
+        let Self { path, suffix_len } = self;
+        assert!(suffix_len < path.segments.len());
+        Self { path, suffix_len: suffix_len + 1 }
+    }
+
+    pub fn iter_from_end(&self) -> impl DoubleEndedIterator<Item = &'a Symbol> {
+        self.path.segments.iter().map(|seg| &seg.name).rev().take(self.suffix_len)
+    }
+}
+
+impl<'a> Eq for PathLike<'a> {}
+impl<'a> PartialEq for PathLike<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.suffix_len != other.suffix_len {
+            return false;
+        }
+        let self_suffix = self.iter_from_end();
+        let other_suffix = self.iter_from_end();
+        self_suffix.zip(other_suffix).all(|(s, o)| s.eq(o))
+    }
+}
+
+impl<'a> std::hash::Hash for PathLike<'a> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for sym in self.iter_from_end() {
+            sym.hash(state)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AmbiguityTable<'a> {
+    inner: FxHashMap<DefId, PathLike<'a>>,
+}
+
+impl<'a> AmbiguityTable<'a> {
+    pub fn empty() -> Self {
+        Self { inner: FxHashMap::default() }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn build() -> AmbiguityTableBuilder<'a> {
+        AmbiguityTableBuilder { inner: FxHashMap::default() }
+    }
+
+    pub fn get(&self, x: &DefId) -> Option<&PathLike<'a>> {
+        self.inner.get(x)
+    }
+}
+
+enum AmbiguityTableBuilderEntry {
+    MapsToOne(DefId),
+    IsAmbiguous,
+}
+
+pub struct AmbiguityTableBuilder<'a> {
+    inner: FxHashMap<PathLike<'a>, AmbiguityTableBuilderEntry>,
+}
+
+impl<'a> AmbiguityTableBuilder<'a> {
+    // Invariant: must start with length 1 path view
+    fn add_path_view(&mut self, p: PathLike<'a>, did: DefId) {
+        use std::collections::hash_map::Entry::*;
+        // TODO: clone
+        match self.inner.entry(p.clone()) {
+            Occupied(entry) => {
+                let v =
+                    std::mem::replace(entry.into_mut(), AmbiguityTableBuilderEntry::IsAmbiguous);
+                let p = p.make_longer();
+                match v {
+                    AmbiguityTableBuilderEntry::MapsToOne(other_did) => {
+                        self.add_path_view(p.clone(), other_did)
+                    }
+                    AmbiguityTableBuilderEntry::IsAmbiguous => (),
+                }
+                self.add_path_view(p.clone(), did)
+            }
+            Vacant(entry) => {
+                entry.insert(AmbiguityTableBuilderEntry::MapsToOne(did));
+            }
+        }
+    }
+
+    fn add_path(&mut self, path: &'a clean::Path) {
+        let pv = PathLike { path, suffix_len: 1 };
+        self.add_path_view(pv, path.def_id())
+    }
+
+    fn add_generic_bound(&mut self, generic_bound: &'a clean::GenericBound) {
+        match generic_bound {
+            clean::GenericBound::TraitBound(poly_trait, _) => self.add_poly_trait(poly_trait),
+            clean::GenericBound::Outlives(_) => (),
+        }
+    }
+
+    fn add_poly_trait(&mut self, poly_trait: &'a clean::PolyTrait) {
+        // TODO: also add potential bounds on trait parameters
+        self.add_path(&poly_trait.trait_);
+        for gen_param in &poly_trait.generic_params {
+            use clean::GenericParamDefKind::*;
+            match &gen_param.kind {
+                Type { bounds, .. } => {
+                    for bnd in bounds {
+                        self.add_generic_bound(bnd)
+                    }
+                }
+                Lifetime { .. } | Const { .. } => (),
+            }
+        }
+    }
+
+    fn add_type(&mut self, ty: &'a clean::Type) {
+        match ty {
+            clean::Type::Path { path } => self.add_path(path),
+            clean::Type::Tuple(tys) => {
+                for ty in tys {
+                    self.add_type(ty)
+                }
+            }
+            clean::Type::RawPointer(_, ty)
+            | clean::Type::Slice(ty)
+            | clean::Type::BorrowedRef { type_: ty, .. }
+            | clean::Type::Array(ty, _) => self.add_type(ty),
+
+            clean::Type::DynTrait(poly_trait, _) => {
+                for trai in poly_trait {
+                    self.add_poly_trait(trai)
+                }
+            }
+
+            clean::Type::BareFunction(bare_func_decl) => {
+                let clean::FnDecl { output, inputs, .. } = &bare_func_decl.decl;
+                self.add_type(output);
+                for inpt in &inputs.values {
+                    self.add_type(&inpt.type_)
+                }
+            }
+            clean::Type::ImplTrait(bnds) => {
+                for bnd in bnds {
+                    self.add_generic_bound(bnd)
+                }
+            }
+            clean::Type::Infer
+            | clean::Type::QPath(_)
+            | clean::Type::Primitive(_)
+            | clean::Type::Generic(_) => (),
+        }
+    }
+
+    fn add_fndecl(&mut self, decl: &'a FnDecl) {
+        for arg in &decl.inputs.values {
+            self.add_type(&arg.type_);
+        }
+        self.add_type(&decl.output);
+    }
+
+    pub fn add_fn(mut self, f: &'a Function) -> Self{
+        self.add_fndecl(&f.decl);
+        self
+    }
+
+    pub fn finnish(self) -> AmbiguityTable<'a> {
+        let mut inner = FxHashMap::default();
+        for (path_view, did) in self.inner {
+            if let AmbiguityTableBuilderEntry::MapsToOne(did) = did {
+                let hopefully_none = inner.insert(did, path_view);
+                assert!(hopefully_none.is_none());
+            }
+        }
+        AmbiguityTable { inner }
+    }
+}

--- a/src/librustdoc/html/mod.rs
+++ b/src/librustdoc/html/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod escape;
 pub(crate) mod format;
+mod ambiguity;
 pub(crate) mod highlight;
 pub(crate) mod layout;
 mod length_limit;

--- a/src/librustdoc/html/mod.rs
+++ b/src/librustdoc/html/mod.rs
@@ -1,6 +1,6 @@
+mod ambiguity;
 pub(crate) mod escape;
 pub(crate) mod format;
-mod ambiguity;
 pub(crate) mod highlight;
 pub(crate) mod layout;
 mod length_limit;

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -533,8 +533,8 @@ fn scrape_examples_help(shared: &SharedContext<'_>) -> String {
     )
 }
 
-fn document<'a, 'cx: 'a>(
-    cx: &'a mut Context<'cx>,
+fn document<'a, 'cx: 'a, 'at: 'a>(
+    cx: &'a mut Context<'cx, 'at>,
     item: &'a clean::Item,
     parent: Option<&'a clean::Item>,
     heading_offset: HeadingOffset,
@@ -1443,7 +1443,7 @@ fn should_render_item(item: &clean::Item, deref_mut_: bool, tcx: TyCtxt<'_>) -> 
     }
 }
 
-pub(crate) fn notable_traits_button(ty: &clean::Type, cx: &mut Context<'_>) -> Option<String> {
+pub(crate) fn notable_traits_button(ty: &clean::Type, cx: &mut Context<'_, '_>) -> Option<String> {
     let mut has_notable_trait = false;
 
     if ty.is_unit() {

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -8,7 +8,7 @@ use rustc_middle::ty::{self, TyCtxt};
 use crate::{
     clean,
     formats::{item_type::ItemType, Impl},
-    html::{format::Buffer, markdown::IdMap},
+    html::{ambiguity::AmbiguityTable, format::Buffer, markdown::IdMap},
 };
 
 use super::{item_ty_to_section, Context, ItemSection};
@@ -423,10 +423,11 @@ fn sidebar_deref_methods<'a>(
                 } else {
                     Cow::Borrowed("deref-methods")
                 };
+                let at = AmbiguityTable::empty();
                 let title = format!(
                     "Methods from {:#}<Target={:#}>",
-                    impl_.inner_impl().trait_.as_ref().unwrap().print(cx),
-                    real_target.print(cx),
+                    impl_.inner_impl().trait_.as_ref().unwrap().print(cx, &at),
+                    real_target.print(cx, &at),
                 );
                 // We want links' order to be reproducible so we don't use unstable sort.
                 ret.sort();
@@ -530,7 +531,8 @@ fn sidebar_render_assoc_items(
                     ty::ImplPolarity::Positive | ty::ImplPolarity::Reservation => "",
                     ty::ImplPolarity::Negative => "!",
                 };
-                let generated = Link::new(encoded, format!("{prefix}{:#}", trait_.print(cx)));
+                let at = AmbiguityTable::empty();
+                let generated = Link::new(encoded, format!("{prefix}{:#}", trait_.print(cx, &at)));
                 if links.insert(generated.clone()) { Some(generated) } else { None }
             })
             .collect::<Vec<Link<'static>>>();

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -23,6 +23,7 @@ use crate::error::Error;
 use crate::formats::cache::Cache;
 use crate::formats::item_type::ItemType;
 use crate::formats::Impl;
+use crate::html::ambiguity::AmbiguityTable;
 use crate::html::format::Buffer;
 use crate::html::render::{AssocItemLink, ImplRenderingParameters};
 use crate::html::{layout, static_files};
@@ -534,11 +535,12 @@ else if (window.initSearch) window.initSearch(searchIndex);
             .values()
             .flat_map(|AliasedTypeImpl { impl_, type_aliases }| {
                 let mut ret = Vec::new();
+                let at = AmbiguityTable::empty();
                 let trait_ = impl_
                     .inner_impl()
                     .trait_
                     .as_ref()
-                    .map(|trait_| format!("{:#}", trait_.print(cx)));
+                    .map(|trait_| format!("{:#}", trait_.print(cx, &at)));
                 // render_impl will filter out "impossible-to-call" methods
                 // to make that functionality work here, it needs to be called with
                 // each type alias, and if it gives a different result, split the impl
@@ -692,8 +694,10 @@ else if (window.initSearch) window.initSearch(searchIndex);
                 if imp.impl_item.item_id.krate() == did.krate || !imp.impl_item.item_id.is_local() {
                     None
                 } else {
+                    let at = AmbiguityTable::empty();
+                    let text = imp.inner_impl().print(false, cx, &at).to_string();
                     Some(Implementor {
-                        text: imp.inner_impl().print(false, cx).to_string(),
+                        text,
                         synthetic: imp.inner_impl().kind.is_auto(),
                         types: collect_paths_for_type(imp.inner_impl().for_.clone(), cache),
                     })

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -10,6 +10,7 @@
 #![feature(iter_intersperse)]
 #![feature(lazy_cell)]
 #![feature(let_chains)]
+#![feature(map_entry_replace)]
 #![feature(never_type)]
 #![feature(round_char_boundary)]
 #![feature(test)]

--- a/tests/rustdoc/fn_param_ambiguities.rs
+++ b/tests/rustdoc/fn_param_ambiguities.rs
@@ -1,0 +1,13 @@
+pub mod X {
+    pub enum A {}
+    pub enum B {}
+    pub enum C {}
+}
+
+pub mod Y {
+    pub enum A {}
+    pub enum B {}
+}
+
+// @has fn_param_ambiguities/fn.f.html //pre 'pub fn f(xa: fn_param_ambiguities::X::A, ya: fn_param_ambiguities::Y::A, yb: B, xc: C)'
+pub fn f(xa: X::A, ya: Y::A, yb : Y::B, xc: X::C) {}

--- a/tests/rustdoc/fn_param_ambiguities.rs
+++ b/tests/rustdoc/fn_param_ambiguities.rs
@@ -9,5 +9,5 @@ pub mod Y {
     pub enum B {}
 }
 
-// @has fn_param_ambiguities/fn.f.html //pre 'pub fn f(xa: fn_param_ambiguities::X::A, ya: fn_param_ambiguities::Y::A, yb: B, xc: C)'
+// @has fn_param_ambiguities/fn.f.html //pre 'pub fn f(xa: X::A, ya: Y::A, yb: B, xc: C)'
 pub fn f(xa: X::A, ya: Y::A, yb : Y::B, xc: X::C) {}


### PR DESCRIPTION
Possible improvements could be 

1. Be more clever regarding the size of the full path suffix that must be kept to be unambiguous. This would be better looking, but add code in more places and be more complex algorithmically and at runtime as well I guess. 
2. To use a similar disambiguation wherever else is needed. Off of the top of my head I'd say every time we print a tuple.

A more general way of doing it would add a notion of context to the formatting which keeps track of what symbols are currently being rendered and need disambiguation, but this is a much more ambitious work. EDIT: actually, a simple notion of context is not enough. This needs to be done in two passes. The first one identifies for each symbol its shorter non ambiguous path suffix, and the second does the actual printing.

Closes:  #122673

r? @GuillaumeGomez 