### PR TITLE
Use `arch::wasm::unreachable` instead of `arch::wasm32::unreachable`

### DIFF
--- a/library/unwind/src/wasm.rs
+++ b/library/unwind/src/wasm.rs
@@ -59,7 +59,7 @@ pub unsafe fn _Unwind_RaiseException(exception: *mut _Unwind_Exception) -> _Unwi
             wasm_throw(0, exception.cast())
         } else {
             let _ = exception;
-            core::arch::wasm32::unreachable()
+            core::arch::wasm::unreachable()
         }
     }
 }


### PR DESCRIPTION
Closes #122877