### PR TITLE
Unix: Support more platforms with `preadv` and `pwritev`

### DIFF
--- a/library/std/src/sys/pal/unix/fd.rs
+++ b/library/std/src/sys/pal/unix/fd.rs
@@ -167,6 +167,8 @@ impl FileDesc {
     }
 
     #[cfg(any(
+        target_os = "aix",
+        target_os = "dragonfly", // DragonFly 1.5
         target_os = "emscripten",
         target_os = "freebsd",
         target_os = "fuchsia",
@@ -174,6 +176,7 @@ impl FileDesc {
         target_os = "illumos",
         target_os = "linux",
         target_os = "netbsd",
+        target_os = "openbsd", // OpenBSD 2.7
     ))]
     pub fn read_vectored_at(&self, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
         let ret = cvt(unsafe {
@@ -188,7 +191,9 @@ impl FileDesc {
     }
 
     #[cfg(not(any(
+        target_os = "aix",
         target_os = "android",
+        target_os = "dragonfly",
         target_os = "emscripten",
         target_os = "freebsd",
         target_os = "fuchsia",
@@ -199,6 +204,8 @@ impl FileDesc {
         target_os = "linux",
         target_os = "macos",
         target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "watchos",
     )))]
     pub fn read_vectored_at(&self, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
         io::default_read_vectored(|b| self.read_at(b, offset), bufs)
@@ -236,9 +243,10 @@ impl FileDesc {
     // no `syscall` possible in these platform.
     #[cfg(any(
         all(target_os = "android", target_pointer_width = "32"),
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "macos",
+        target_os = "ios", // ios 14.0
+        target_os = "tvos", // tvos 14.0
+        target_os = "macos", // macos 11.0
+        target_os = "watchos", // watchos 7.0
     ))]
     pub fn read_vectored_at(&self, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
         super::weak::weak!(fn preadv64(libc::c_int, *const libc::iovec, libc::c_int, off64_t) -> isize);
@@ -318,6 +326,8 @@ impl FileDesc {
     }
 
     #[cfg(any(
+        target_os = "aix",
+        target_os = "dragonfly", // DragonFly 1.5
         target_os = "emscripten",
         target_os = "freebsd",
         target_os = "fuchsia",
@@ -325,6 +335,7 @@ impl FileDesc {
         target_os = "illumos",
         target_os = "linux",
         target_os = "netbsd",
+        target_os = "openbsd", // OpenBSD 2.7
     ))]
     pub fn write_vectored_at(&self, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
         let ret = cvt(unsafe {
@@ -339,7 +350,9 @@ impl FileDesc {
     }
 
     #[cfg(not(any(
+        target_os = "aix",
         target_os = "android",
+        target_os = "dragonfly",
         target_os = "emscripten",
         target_os = "freebsd",
         target_os = "fuchsia",
@@ -350,6 +363,8 @@ impl FileDesc {
         target_os = "linux",
         target_os = "macos",
         target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "watchos",
     )))]
     pub fn write_vectored_at(&self, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
         io::default_write_vectored(|b| self.write_at(b, offset), bufs)
@@ -387,9 +402,10 @@ impl FileDesc {
     // no `syscall` possible in these platform.
     #[cfg(any(
         all(target_os = "android", target_pointer_width = "32"),
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "macos",
+        target_os = "ios", // ios 14.0
+        target_os = "tvos", // tvos 14.0
+        target_os = "macos", // macos 11.0
+        target_os = "watchos", // watchos 7.0
     ))]
     pub fn write_vectored_at(&self, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
         super::weak::weak!(fn pwritev64(libc::c_int, *const libc::iovec, libc::c_int, off64_t) -> isize);


### PR DESCRIPTION
- `aix`, `dragonfly` and `openbsd` with direct call 
- `watchos` with weak linkage

cc #89517 