### PR TITLE
Delegation: fix ICE on `bound_vars` divergence

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2494,13 +2494,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         hir_ty: Option<&hir::Ty<'_>>,
     ) -> ty::PolyFnSig<'tcx> {
         let tcx = self.tcx();
-        let bound_vars = if let hir::FnRetTy::Return(ret_ty) = decl.output
-            && let hir::TyKind::InferDelegation(sig_id, _) = ret_ty.kind
-        {
-            tcx.fn_sig(sig_id).skip_binder().bound_vars()
-        } else {
-            tcx.late_bound_vars(hir_id)
-        };
+        let bound_vars = tcx.late_bound_vars(hir_id);
         debug!(?bound_vars);
 
         // We proactively collect all the inferred type params to emit a single error per fn def.

--- a/tests/ui/delegation/ice-issue-122550.rs
+++ b/tests/ui/delegation/ice-issue-122550.rs
@@ -1,0 +1,18 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    fn description(&self) -> &str {}
+    //~^ ERROR mismatched types
+}
+
+struct F;
+struct S(F);
+
+impl S {
+    reuse <S as Trait>::description { &self.0 }
+    //~^ ERROR mismatched types
+    //~| ERROR the trait bound `S: Trait` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/delegation/ice-issue-122550.stderr
+++ b/tests/ui/delegation/ice-issue-122550.stderr
@@ -1,0 +1,31 @@
+error[E0308]: mismatched types
+  --> $DIR/ice-issue-122550.rs:5:35
+   |
+LL |     fn description(&self) -> &str {}
+   |                                   ^^ expected `&str`, found `()`
+
+error[E0308]: mismatched types
+  --> $DIR/ice-issue-122550.rs:13:39
+   |
+LL |     reuse <S as Trait>::description { &self.0 }
+   |                                       ^^^^^^^ expected `&S`, found `&F`
+   |
+   = note: expected reference `&S`
+              found reference `&F`
+
+error[E0277]: the trait bound `S: Trait` is not satisfied
+  --> $DIR/ice-issue-122550.rs:13:12
+   |
+LL |     reuse <S as Trait>::description { &self.0 }
+   |            ^ the trait `Trait` is not implemented for `S`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-issue-122550.rs:4:1
+   |
+LL | trait Trait {
+   | ^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/122550.

Bug was caused by divergence  between lowered type and corresponding `bound_vars` in `late_bound_vars_map`. In this patch `bound_vars` calculation for delegation item is moved from `lower_fn_ty` to `resolve_bound_vars` query.

r? @petrochenkov