### PR TITLE
fix(bootstrap/dist): use versioned dirs when vendoring

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1003,6 +1003,7 @@ impl Step for PlainSourceTarball {
             // Vendor all Cargo dependencies
             let mut cmd = Command::new(&builder.initial_cargo);
             cmd.arg("vendor")
+                .arg("--versioned-dirs")
                 .arg("--sync")
                 .arg(builder.src.join("./src/tools/cargo/Cargo.toml"))
                 .arg("--sync")


### PR DESCRIPTION
Currently, if you attempt to run ui tests in a vendored build, you will
see this failure

```
---- [ui] tests/ui/issues/issue-21763.rs stdout ----
diff of stderr:

8          = note: required because it appears within the type `(Rc<()>, Rc<()>)`
9          = note: required for `hashbrown::raw::RawTable<(Rc<()>, Rc<()>)>` to implement `Send`
10      note: required because it appears within the type `hashbrown::map::HashMap<Rc<()>, Rc<()>, RandomState>`
-         --> $HASHBROWN_SRC_LOCATION
+         --> /rust/deps/hashbrown/src/map.rs:190:12
12      note: required because it appears within the type `HashMap<Rc<()>, Rc<()>>`
13        --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
14      note: required by a bound in `foo`
```

This happens because the code that attempts to remap
`HASHBROWN_SRC_LOCATION` expects it to be under `hashbrown-$version`,
which is the case in a normal cargo registry, but not when vendoring, where
by default crates may not have the version in their directory name.

This change passes `--versioned-dirs` to `cargo vendor` to enforce that
every crate includes the version in the subdir name, which fixes the ui
test and brings `--enable-vendor` builds closer to normal ones.
