### PR TITLE
Move check for error in impl header outside of reporting

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -402,10 +402,6 @@ fn report_conflicting_impls<'tcx>(
         impl_span: Span,
         err: &mut Diag<'_, G>,
     ) {
-        if (overlap.trait_ref, overlap.self_ty).references_error() {
-            err.downgrade_to_delayed_bug();
-        }
-
         match tcx.span_of_impl(overlap.with_impl) {
             Ok(span) => {
                 err.span_label(span, "first implementation here");
@@ -457,6 +453,11 @@ fn report_conflicting_impls<'tcx>(
             }
         )
     });
+
+    // Don't report overlap errors if the header references error
+    if let Err(err) = (overlap.trait_ref, overlap.self_ty).error_reported() {
+        return Err(err);
+    }
 
     match used_to_be_allowed {
         None => {

--- a/tests/ui/coherence/skip-reporting-if-references-err.current.stderr
+++ b/tests/ui/coherence/skip-reporting-if-references-err.current.stderr
@@ -1,0 +1,27 @@
+error[E0726]: implicit elided lifetime not allowed here
+  --> $DIR/skip-reporting-if-references-err.rs:10:9
+   |
+LL | impl<T> ToUnit for T {}
+   |         ^^^^^^ expected lifetime parameter
+   |
+help: indicate the anonymous lifetime
+   |
+LL | impl<T> ToUnit<'_> for T {}
+   |               ++++
+
+error[E0277]: the trait bound `for<'a> (): ToUnit<'a>` is not satisfied
+  --> $DIR/skip-reporting-if-references-err.rs:15:29
+   |
+LL | impl Overlap for for<'a> fn(<() as ToUnit<'a>>::Unit) {}
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> ToUnit<'a>` is not implemented for `()`
+
+error[E0277]: the trait bound `for<'a> (): ToUnit<'a>` is not satisfied
+  --> $DIR/skip-reporting-if-references-err.rs:15:18
+   |
+LL | impl Overlap for for<'a> fn(<() as ToUnit<'a>>::Unit) {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> ToUnit<'a>` is not implemented for `()`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0726.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/coherence/skip-reporting-if-references-err.next.stderr
+++ b/tests/ui/coherence/skip-reporting-if-references-err.next.stderr
@@ -1,0 +1,14 @@
+error[E0726]: implicit elided lifetime not allowed here
+  --> $DIR/skip-reporting-if-references-err.rs:10:9
+   |
+LL | impl<T> ToUnit for T {}
+   |         ^^^^^^ expected lifetime parameter
+   |
+help: indicate the anonymous lifetime
+   |
+LL | impl<T> ToUnit<'_> for T {}
+   |               ++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0726`.

--- a/tests/ui/coherence/skip-reporting-if-references-err.rs
+++ b/tests/ui/coherence/skip-reporting-if-references-err.rs
@@ -1,0 +1,19 @@
+// Regression test for #121006.
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+trait ToUnit<'a> {
+    type Unit;
+}
+
+impl<T> ToUnit for T {}
+//~^ ERROR implicit elided lifetime not allowed here
+
+trait Overlap {}
+impl<U> Overlap for fn(U) {}
+impl Overlap for for<'a> fn(<() as ToUnit<'a>>::Unit) {}
+//[current]~^ ERROR the trait bound `for<'a> (): ToUnit<'a>` is not satisfied
+//[current]~| ERROR the trait bound `for<'a> (): ToUnit<'a>` is not satisfied
+
+fn main() {}


### PR DESCRIPTION
Fixes #121006

r? lcnr

test location kinda sucks, can move it if needed