### PR TITLE
Validate that we're only matching on unit struct for path pattern

### DIFF
--- a/tests/ui/parser/issues/issue-70549-resolve-after-recovered-self-ctor.rs
+++ b/tests/ui/parser/issues/issue-70549-resolve-after-recovered-self-ctor.rs
@@ -4,12 +4,12 @@ impl S {
     fn foo(&mur Self) {}
     //~^ ERROR expected identifier, found keyword `Self`
     //~| ERROR expected one of `:`, `@`
-    //~| ERROR the `Self` constructor can only be used with
+    //~| ERROR expected unit struct, found self constructor `Self`
     fn bar(&'static mur Self) {}
     //~^ ERROR unexpected lifetime
     //~| ERROR expected identifier, found keyword `Self`
     //~| ERROR expected one of `:`, `@`
-    //~| ERROR the `Self` constructor can only be used with
+    //~| ERROR expected unit struct, found self constructor `Self`
 
     fn baz(&mur Self @ _) {}
     //~^ ERROR expected one of `:`, `@`

--- a/tests/ui/parser/issues/issue-70549-resolve-after-recovered-self-ctor.stderr
+++ b/tests/ui/parser/issues/issue-70549-resolve-after-recovered-self-ctor.stderr
@@ -40,17 +40,18 @@ error: expected one of `:`, `@`, or `|`, found keyword `Self`
 LL |     fn baz(&mur Self @ _) {}
    |                 ^^^^ expected one of `:`, `@`, or `|`
 
-error: the `Self` constructor can only be used with tuple or unit structs
+error[E0533]: expected unit struct, found self constructor `Self`
   --> $DIR/issue-70549-resolve-after-recovered-self-ctor.rs:4:17
    |
 LL |     fn foo(&mur Self) {}
-   |                 ^^^^ help: use curly brackets: `Self { /* fields */ }`
+   |                 ^^^^ not a unit struct
 
-error: the `Self` constructor can only be used with tuple or unit structs
+error[E0533]: expected unit struct, found self constructor `Self`
   --> $DIR/issue-70549-resolve-after-recovered-self-ctor.rs:8:25
    |
 LL |     fn bar(&'static mur Self) {}
-   |                         ^^^^ help: use curly brackets: `Self { /* fields */ }`
+   |                         ^^^^ not a unit struct
 
 error: aborting due to 8 previous errors
 
+For more information about this error, try `rustc --explain E0533`.

--- a/tests/ui/pattern/no-match-tuple-variant-self-ctor.rs
+++ b/tests/ui/pattern/no-match-tuple-variant-self-ctor.rs
@@ -1,0 +1,37 @@
+//@ revisions: tuple unit struct_
+//@[unit] check-pass
+
+#[cfg(unit)]
+mod unit {
+    struct S;
+    impl S {
+        fn foo() {
+            let Self = S;
+        }
+    }
+}
+
+#[cfg(tuple)]
+mod tuple {
+    struct S(());
+    impl S {
+        fn foo() {
+            let Self = S;
+            //[tuple]~^ ERROR expected unit struct
+        }
+    }
+}
+
+#[cfg(struct_)]
+mod struct_ {
+    struct S {}
+    impl S {
+        fn foo() {
+            let Self = S;
+            //[struct_]~^ ERROR expected value, found struct `S`
+            //[struct_]~| ERROR expected unit struct, found self constructor `Self`
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/pattern/no-match-tuple-variant-self-ctor.struct_.stderr
+++ b/tests/ui/pattern/no-match-tuple-variant-self-ctor.struct_.stderr
@@ -1,0 +1,19 @@
+error[E0423]: expected value, found struct `S`
+  --> $DIR/no-match-tuple-variant-self-ctor.rs:30:24
+   |
+LL |     struct S {}
+   |     ----------- `S` defined here
+...
+LL |             let Self = S;
+   |                        ^ help: use struct literal syntax instead: `S {}`
+
+error[E0533]: expected unit struct, found self constructor `Self`
+  --> $DIR/no-match-tuple-variant-self-ctor.rs:30:17
+   |
+LL |             let Self = S;
+   |                 ^^^^ not a unit struct
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0423, E0533.
+For more information about an error, try `rustc --explain E0423`.

--- a/tests/ui/pattern/no-match-tuple-variant-self-ctor.tuple.stderr
+++ b/tests/ui/pattern/no-match-tuple-variant-self-ctor.tuple.stderr
@@ -1,0 +1,9 @@
+error[E0533]: expected unit struct, found self constructor `Self`
+  --> $DIR/no-match-tuple-variant-self-ctor.rs:19:17
+   |
+LL |             let Self = S;
+   |                 ^^^^ not a unit struct
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0533`.


### PR DESCRIPTION
Resolution doesn't validate that we only really take `CtorKind::Unit` in path patterns, since all it sees is `Res::SelfCtor(def_id)`. Check this instead during pattern typeck.

r? petrochenkov

Fixes #122809