### PR TITLE
docs(sync): normalize dot in fn summaries

### DIFF
--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -396,7 +396,7 @@ impl<T: ?Sized> Mutex<T> {
         self.poison.get()
     }
 
-    /// Clear the poisoned state from a mutex
+    /// Clear the poisoned state from a mutex.
     ///
     /// If the mutex is poisoned, it will remain poisoned until this function is called. This
     /// allows recovering from a poisoned state and marking that it has recovered. For example, if

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -439,7 +439,7 @@ impl<T: ?Sized> RwLock<T> {
         self.poison.get()
     }
 
-    /// Clear the poisoned state from a lock
+    /// Clear the poisoned state from a lock.
     ///
     /// If the lock is poisoned, it will remain poisoned until this function is called. This allows
     /// recovering from a poisoned state and marking that it has recovered. For example, if the


### PR DESCRIPTION
All other functions in e.g. [`Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) have a dot at the end of their first doc line, except for the newly stabilized [`Mutex::clear_poison`](https://doc.rust-lang.org/std/sync/struct.Mutex.html#method.clear_poison) (and its friend [`RwLock::clear_poison`](https://doc.rust-lang.org/std/sync/struct.RwLock.html#method.clear_poison)).

This PR remedies that by adding a normalizing dot.