### PR TITLE
Replace unstable `Waker::noop()` with `Waker::NOOP`.

### DIFF
--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -247,7 +247,7 @@ fn raw_waker<W: Wake + Send + Sync + 'static>(waker: Arc<W>) -> RawWaker {
 ///         // cast the Rc<Task> into a `LocalWaker`
 ///         let local_waker: LocalWaker = task.clone().into();
 ///         // Build the context using `ContextBuilder`
-///         let mut cx = ContextBuilder::from_waker(Waker::noop())
+///         let mut cx = ContextBuilder::from_waker(Waker::NOOP)
 ///             .local_waker(&local_waker)
 ///             .build();
 ///

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -284,7 +284,7 @@ impl fmt::Debug for Context<'_> {
 /// use std::future::Future;
 ///
 /// let local_waker = LocalWaker::noop();
-/// let waker = Waker::noop();
+/// let waker = Waker::NOOP;
 ///
 /// let mut cx = ContextBuilder::from_waker(&waker)
 ///     .local_waker(&local_waker)
@@ -465,7 +465,7 @@ impl Waker {
         Waker { waker }
     }
 
-    /// Returns a reference to a `Waker` that does nothing when used.
+    /// A reference to a `Waker` that does nothing when used.
     ///
     /// This is mostly useful for writing tests that need a [`Context`] to poll
     /// some futures, but are not expecting those futures to wake the waker or
@@ -481,18 +481,13 @@ impl Waker {
     /// use std::future::Future;
     /// use std::task;
     ///
-    /// let mut cx = task::Context::from_waker(task::Waker::noop());
+    /// let mut cx = task::Context::from_waker(task::Waker::NOOP);
     ///
     /// let mut future = Box::pin(async { 10 });
     /// assert_eq!(future.as_mut().poll(&mut cx), task::Poll::Ready(10));
     /// ```
-    #[inline]
-    #[must_use]
     #[unstable(feature = "noop_waker", issue = "98286")]
-    pub const fn noop() -> &'static Waker {
-        const WAKER: &Waker = &Waker { waker: RawWaker::NOOP };
-        WAKER
-    }
+    pub const NOOP: &'static Waker = &Waker { waker: RawWaker::NOOP };
 
     /// Get a reference to the underlying [`RawWaker`].
     #[inline]
@@ -697,7 +692,7 @@ impl LocalWaker {
     /// use std::future::Future;
     /// use std::task::{ContextBuilder, LocalWaker, Waker, Poll};
     ///
-    /// let mut cx = ContextBuilder::from_waker(Waker::noop())
+    /// let mut cx = ContextBuilder::from_waker(Waker::NOOP)
     ///     .local_waker(LocalWaker::noop())
     ///     .build();
     ///

--- a/library/core/tests/async_iter/mod.rs
+++ b/library/core/tests/async_iter/mod.rs
@@ -7,7 +7,7 @@ fn into_async_iter() {
     let async_iter = async_iter::from_iter(0..3);
     let mut async_iter = pin!(async_iter.into_async_iter());
 
-    let mut cx = &mut core::task::Context::from_waker(core::task::Waker::noop());
+    let mut cx = &mut core::task::Context::from_waker(core::task::Waker::NOOP);
 
     assert_eq!(async_iter.as_mut().poll_next(&mut cx), Poll::Ready(Some(0)));
     assert_eq!(async_iter.as_mut().poll_next(&mut cx), Poll::Ready(Some(1)));

--- a/src/tools/miri/tests/pass/async-closure.rs
+++ b/src/tools/miri/tests/pass/async-closure.rs
@@ -6,7 +6,7 @@ use std::task::*;
 
 pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
     let mut fut = pin!(fut);
-    let ctx = &mut Context::from_waker(Waker::noop());
+    let ctx = &mut Context::from_waker(Waker::NOOP);
 
     loop {
         match fut.as_mut().poll(ctx) {

--- a/src/tools/miri/tests/pass/async-fn.rs
+++ b/src/tools/miri/tests/pass/async-fn.rs
@@ -76,7 +76,7 @@ async fn uninhabited_variant() {
 fn run_fut<T>(fut: impl Future<Output = T>) -> T {
     use std::task::{Context, Poll, Waker};
 
-    let mut context = Context::from_waker(Waker::noop());
+    let mut context = Context::from_waker(Waker::NOOP);
 
     let mut pinned = Box::pin(fut);
     loop {

--- a/src/tools/miri/tests/pass/dyn-star.rs
+++ b/src/tools/miri/tests/pass/dyn-star.rs
@@ -93,7 +93,7 @@ fn dispatch_on_pin_mut() {
     let mut fut = async_main();
 
     // Poll loop, just to test the future...
-    let ctx = &mut Context::from_waker(Waker::noop());
+    let ctx = &mut Context::from_waker(Waker::NOOP);
 
     loop {
         match unsafe { Pin::new_unchecked(&mut fut).poll(ctx) } {

--- a/src/tools/miri/tests/pass/future-self-referential.rs
+++ b/src/tools/miri/tests/pass/future-self-referential.rs
@@ -77,7 +77,7 @@ impl Future for DoStuff {
 }
 
 fn run_fut<T>(fut: impl Future<Output = T>) -> T {
-    let mut context = Context::from_waker(Waker::noop());
+    let mut context = Context::from_waker(Waker::NOOP);
 
     let mut pinned = pin!(fut);
     loop {
@@ -89,7 +89,7 @@ fn run_fut<T>(fut: impl Future<Output = T>) -> T {
 }
 
 fn self_referential_box() {
-    let cx = &mut Context::from_waker(Waker::noop());
+    let cx = &mut Context::from_waker(Waker::NOOP);
 
     async fn my_fut() -> i32 {
         let val = 10;

--- a/src/tools/miri/tests/pass/issues/issue-miri-2068.rs
+++ b/src/tools/miri/tests/pass/issues/issue-miri-2068.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll, Waker};
 
 pub fn fuzzing_block_on<O, F: Future<Output = O>>(fut: F) -> O {
     let mut fut = std::pin::pin!(fut);
-    let mut context = Context::from_waker(Waker::noop());
+    let mut context = Context::from_waker(Waker::NOOP);
     loop {
         match fut.as_mut().poll(&mut context) {
             Poll::Ready(v) => return v,

--- a/src/tools/miri/tests/pass/move-data-across-await-point.rs
+++ b/src/tools/miri/tests/pass/move-data-across-await-point.rs
@@ -56,7 +56,7 @@ fn data_moved() {
 fn run_fut<T>(fut: impl Future<Output = T>) -> T {
     use std::task::{Context, Poll, Waker};
 
-    let mut context = Context::from_waker(Waker::noop());
+    let mut context = Context::from_waker(Waker::NOOP);
 
     let mut pinned = Box::pin(fut);
     loop {

--- a/tests/coverage/async.coverage
+++ b/tests/coverage/async.coverage
@@ -119,7 +119,7 @@
    LL|       |    #[coverage(off)]
    LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
    LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
+   LL|       |        let mut context = Context::from_waker(Waker::NOOP);
    LL|       |
    LL|       |        loop {
    LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/async.rs
+++ b/tests/coverage/async.rs
@@ -112,7 +112,7 @@ mod executor {
     #[coverage(off)]
     pub fn block_on<F: Future>(mut future: F) -> F::Output {
         let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
+        let mut context = Context::from_waker(Waker::NOOP);
 
         loop {
             if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/async2.coverage
+++ b/tests/coverage/async2.coverage
@@ -41,7 +41,7 @@
    LL|       |    #[coverage(off)]
    LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
    LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
+   LL|       |        let mut context = Context::from_waker(Waker::NOOP);
    LL|       |
    LL|       |        loop {
    LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/async2.rs
+++ b/tests/coverage/async2.rs
@@ -39,7 +39,7 @@ mod executor {
     #[coverage(off)]
     pub fn block_on<F: Future>(mut future: F) -> F::Output {
         let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
+        let mut context = Context::from_waker(Waker::NOOP);
 
         loop {
             if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/async_block.coverage
+++ b/tests/coverage/async_block.coverage
@@ -24,7 +24,7 @@
    LL|       |    #[coverage(off)]
    LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
    LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
+   LL|       |        let mut context = Context::from_waker(Waker::NOOP);
    LL|       |
    LL|       |        loop {
    LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/async_block.rs
+++ b/tests/coverage/async_block.rs
@@ -23,7 +23,7 @@ mod executor {
     #[coverage(off)]
     pub fn block_on<F: Future>(mut future: F) -> F::Output {
         let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
+        let mut context = Context::from_waker(Waker::NOOP);
 
         loop {
             if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/closure_macro_async.coverage
+++ b/tests/coverage/closure_macro_async.coverage
@@ -55,7 +55,7 @@
    LL|       |    #[coverage(off)]
    LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
    LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
+   LL|       |        let mut context = Context::from_waker(Waker::NOOP);
    LL|       |
    LL|       |        loop {
    LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/closure_macro_async.rs
+++ b/tests/coverage/closure_macro_async.rs
@@ -54,7 +54,7 @@ mod executor {
     #[coverage(off)]
     pub fn block_on<F: Future>(mut future: F) -> F::Output {
         let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
+        let mut context = Context::from_waker(Waker::NOOP);
 
         loop {
             if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/mir-opt/async_closure_shims.rs
+++ b/tests/mir-opt/async_closure_shims.rs
@@ -11,7 +11,7 @@ use std::task::*;
 
 pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
     let mut fut = pin!(fut);
-    let ctx = &mut Context::from_waker(Waker::noop());
+    let ctx = &mut Context::from_waker(Waker::NOOP);
 
     loop {
         match fut.as_mut().poll(ctx) {

--- a/tests/ui/async-await/async-closures/auxiliary/block-on.rs
+++ b/tests/ui/async-await/async-closures/auxiliary/block-on.rs
@@ -9,7 +9,7 @@ use std::task::*;
 pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
     let mut fut = pin!(fut);
     // Poll loop, just to test the future...
-    let ctx = &mut Context::from_waker(Waker::noop());
+    let ctx = &mut Context::from_waker(Waker::NOOP);
 
     loop {
         match unsafe { fut.as_mut().poll(ctx) } {

--- a/tests/ui/async-await/async-fn/auxiliary/block-on.rs
+++ b/tests/ui/async-await/async-fn/auxiliary/block-on.rs
@@ -9,7 +9,7 @@ use std::task::*;
 pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
     let mut fut = pin!(fut);
     // Poll loop, just to test the future...
-    let ctx = &mut Context::from_waker(Waker::noop());
+    let ctx = &mut Context::from_waker(Waker::NOOP);
 
     loop {
         match unsafe { fut.as_mut().poll(ctx) } {

--- a/tests/ui/async-await/for-await-passthrough.rs
+++ b/tests/ui/async-await/for-await-passthrough.rs
@@ -23,7 +23,7 @@ async fn real_main() {
 
 fn main() {
     let future = real_main();
-    let mut cx = &mut core::task::Context::from_waker(std::task::Waker::noop());
+    let mut cx = &mut core::task::Context::from_waker(std::task::Waker::NOOP);
     let mut future = core::pin::pin!(future);
     while let core::task::Poll::Pending = future.as_mut().poll(&mut cx) {}
 }

--- a/tests/ui/async-await/for-await.rs
+++ b/tests/ui/async-await/for-await.rs
@@ -17,7 +17,7 @@ async fn real_main() {
 
 fn main() {
     let future = real_main();
-    let mut cx = &mut core::task::Context::from_waker(std::task::Waker::noop());
+    let mut cx = &mut core::task::Context::from_waker(std::task::Waker::NOOP);
     let mut future = core::pin::pin!(future);
     while let core::task::Poll::Pending = future.as_mut().poll(&mut cx) {}
 }

--- a/tests/ui/async-await/in-trait/async-default-fn-overridden.rs
+++ b/tests/ui/async-await/in-trait/async-default-fn-overridden.rs
@@ -40,7 +40,7 @@ fn main() {
     let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let ctx = &mut Context::from_waker(Waker::noop());
+    let ctx = &mut Context::from_waker(Waker::NOOP);
 
     loop {
         match fut.as_mut().poll(ctx) {

--- a/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.rs
+++ b/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.rs
@@ -43,7 +43,7 @@ fn main() {
     let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let ctx = &mut Context::from_waker(Waker::noop());
+    let ctx = &mut Context::from_waker(Waker::NOOP);
 
     loop {
         match fut.as_mut().poll(ctx) {

--- a/tests/ui/coroutine/async-gen-yield-ty-is-unit.rs
+++ b/tests/ui/coroutine/async-gen-yield-ty-is-unit.rs
@@ -11,6 +11,6 @@ async gen fn gen_fn() -> &'static str {
 
 pub fn main() {
     let async_iterator = pin!(gen_fn());
-    let ctx = &mut Context::from_waker(Waker::noop());
+    let ctx = &mut Context::from_waker(Waker::NOOP);
     async_iterator.poll_next(ctx);
 }

--- a/tests/ui/coroutine/async_gen_fn_iter.rs
+++ b/tests/ui/coroutine/async_gen_fn_iter.rs
@@ -73,7 +73,7 @@ fn main() {
     let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let ctx = &mut Context::from_waker(Waker::noop());
+    let ctx = &mut Context::from_waker(Waker::NOOP);
 
     loop {
         match fut.as_mut().poll(ctx) {

--- a/tests/ui/dyn-star/dispatch-on-pin-mut.rs
+++ b/tests/ui/dyn-star/dispatch-on-pin-mut.rs
@@ -26,7 +26,7 @@ fn main() {
     let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let ctx = &mut Context::from_waker(Waker::noop());
+    let ctx = &mut Context::from_waker(Waker::NOOP);
 
     loop {
         match fut.as_mut().poll(ctx) {


### PR DESCRIPTION
[As discussed on Zulip](
https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Associated.20constants.20vs.2E.20functions.20in.20std.20API), across `std`, outside of argumentless `new()` constructor functions, stable constant values are generally provided using `const` items rather than `const fn`s. Therefore, this change is more consistent API design.

Further, [WG-async writes](https://github.com/rust-lang/rust/issues/98286#issuecomment-1940085340):

> WG-async is in favor of this being an associated constant of type `&Waker`.

This PR implements that decision.