### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -42,7 +42,7 @@ jobs:
 
           # Exit with error if open and S-waiting-on-bors
           if [[ "$STATE" == "OPEN" && "$WAITING_ON_BORS" == "true" ]]; then
-            exit 1
+            gh run cancel ${{ github.run_id }}
           fi
 
   update:
@@ -65,7 +65,10 @@ jobs:
 
       - name: cargo update
         # Remove first line that always just says "Updating crates.io index"
-        run: cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
+        # If there are no changes, cancel the job here
+        run: |
+          cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
+          git status --porcelain | grep -q Cargo.lock || gh run cancel ${{ github.run_id }}
       - name: upload Cargo.lock artifact for use in PR
         uses: actions/upload-artifact@v3
         with:
@@ -131,7 +134,7 @@ jobs:
           # Exit with error if PR is closed
           STATE=$(gh pr view cargo_update --repo $GITHUB_REPOSITORY --json state --jq '.state')
           if [[ "$STATE" != "OPEN" ]]; then
-            exit 1
+            gh run cancel ${{ github.run_id }}
           fi
 
           gh pr edit cargo_update --title "${PR_TITLE}" --body-file body.md --repo $GITHUB_REPOSITORY

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -639,10 +639,9 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
         }
     }
 
-    if !unnormalized_trait_sig.output().references_error() {
-        debug_assert!(
-            !collector.types.is_empty(),
-            "expect >0 RPITITs in call to `collect_return_position_impl_trait_in_trait_tys`"
+    if !unnormalized_trait_sig.output().references_error() && collector.types.is_empty() {
+        tcx.dcx().delayed_bug(
+            "expect >0 RPITITs in call to `collect_return_position_impl_trait_in_trait_tys`",
         );
     }
 

--- a/compiler/rustc_session/src/code_stats.rs
+++ b/compiler/rustc_session/src/code_stats.rs
@@ -44,6 +44,10 @@ pub struct FieldInfo {
     pub offset: u64,
     pub size: u64,
     pub align: u64,
+    /// Name of the type of this field.
+    /// Present only if the creator thought that this would be important for identifying the field,
+    /// typically because the field name is uninformative.
+    pub type_name: Option<Symbol>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
@@ -192,7 +196,7 @@ impl CodeStats {
                 fields.sort_by_key(|f| (f.offset, f.size));
 
                 for field in fields {
-                    let FieldInfo { kind, ref name, offset, size, align } = field;
+                    let FieldInfo { kind, ref name, offset, size, align, type_name } = field;
 
                     if offset > min_offset {
                         let pad = offset - min_offset;
@@ -201,19 +205,25 @@ impl CodeStats {
 
                     if offset < min_offset {
                         // If this happens it's probably a union.
-                        println!(
+                        print!(
                             "print-type-size {indent}{kind} `.{name}`: {size} bytes, \
                                   offset: {offset} bytes, \
                                   alignment: {align} bytes"
                         );
                     } else if info.packed || offset == min_offset {
-                        println!("print-type-size {indent}{kind} `.{name}`: {size} bytes");
+                        print!("print-type-size {indent}{kind} `.{name}`: {size} bytes");
                     } else {
                         // Include field alignment in output only if it caused padding injection
-                        println!(
+                        print!(
                             "print-type-size {indent}{kind} `.{name}`: {size} bytes, \
                                   alignment: {align} bytes"
                         );
+                    }
+
+                    if let Some(type_name) = type_name {
+                        println!(", type: {type_name}");
+                    } else {
+                        println!();
                     }
 
                     min_offset = offset + size;

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1726,20 +1726,28 @@ pub(crate) mod builtin {
         builtin # deref($pat)
     }
 
-    /// Unstable implementation detail of the `rustc` compiler, do not use.
+    /// Derive macro for `rustc-serialize`. Should not be used in new code.
     #[rustc_builtin_macro]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics, libstd_sys_internals, rt)]
+    #[unstable(
+        feature = "rustc_encodable_decodable",
+        issue = "none",
+        soft,
+        reason = "derive macro for `rustc-serialize`; should not be used in new code"
+    )]
     #[deprecated(since = "1.52.0", note = "rustc-serialize is deprecated and no longer supported")]
     #[doc(hidden)] // While technically stable, using it is unstable, and deprecated. Hide it.
     pub macro RustcDecodable($item:item) {
         /* compiler built-in */
     }
 
-    /// Unstable implementation detail of the `rustc` compiler, do not use.
+    /// Derive macro for `rustc-serialize`. Should not be used in new code.
     #[rustc_builtin_macro]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics, rt)]
+    #[unstable(
+        feature = "rustc_encodable_decodable",
+        issue = "none",
+        soft,
+        reason = "derive macro for `rustc-serialize`; should not be used in new code"
+    )]
     #[deprecated(since = "1.52.0", note = "rustc-serialize is deprecated and no longer supported")]
     #[doc(hidden)] // While technically stable, using it is unstable, and deprecated. Hide it.
     pub macro RustcEncodable($item:item) {

--- a/library/core/src/prelude/common.rs
+++ b/library/core/src/prelude/common.rs
@@ -1,8 +1,6 @@
-//! The first version of the core prelude.
+//! Items common to the prelude of all editions.
 //!
 //! See the [module-level documentation](super) for more.
-
-#![stable(feature = "core_prelude", since = "1.4.0")]
 
 // Re-exported core operators
 #[stable(feature = "core_prelude", since = "1.4.0")]
@@ -67,16 +65,6 @@ pub use crate::{
 )]
 #[doc(no_inline)]
 pub use crate::concat_bytes;
-
-// Do not `doc(inline)` these `doc(hidden)` items.
-#[unstable(
-    feature = "rustc_encodable_decodable",
-    issue = "none",
-    soft,
-    reason = "unstable implementation detail of the `rustc` compiler, do not use"
-)]
-#[allow(deprecated)]
-pub use crate::macros::builtin::{RustcDecodable, RustcEncodable};
 
 // Do not `doc(no_inline)` so that they become doc items on their own
 // (no public module for them to be re-exported from).

--- a/library/core/src/prelude/mod.rs
+++ b/library/core/src/prelude/mod.rs
@@ -6,7 +6,26 @@
 
 #![stable(feature = "core_prelude", since = "1.4.0")]
 
-pub mod v1;
+mod common;
+
+/// The first version of the prelude of The Rust Standard Library.
+///
+/// See the [module-level documentation](self) for more.
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod v1 {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::common::*;
+
+    // Do not `doc(inline)` these `doc(hidden)` items.
+    #[unstable(
+        feature = "rustc_encodable_decodable",
+        issue = "none",
+        soft,
+        reason = "derive macro for `rustc-serialize`; should not be used in new code"
+    )]
+    #[allow(deprecated)]
+    pub use crate::macros::builtin::{RustcDecodable, RustcEncodable};
+}
 
 /// The 2015 version of the core prelude.
 ///
@@ -46,14 +65,21 @@ pub mod rust_2021 {
     pub use crate::convert::{TryFrom, TryInto};
 }
 
-/// The 2024 edition of the core prelude.
+/// The 2024 version of the core prelude.
 ///
 /// See the [module-level documentation](self) for more.
 #[unstable(feature = "prelude_2024", issue = "121042")]
 pub mod rust_2024 {
-    #[unstable(feature = "prelude_2024", issue = "121042")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::common::*;
+
+    #[stable(feature = "prelude_2021", since = "1.55.0")]
     #[doc(no_inline)]
-    pub use super::rust_2021::*;
+    pub use crate::iter::FromIterator;
+
+    #[stable(feature = "prelude_2021", since = "1.55.0")]
+    #[doc(no_inline)]
+    pub use crate::convert::{TryFrom, TryInto};
 
     #[unstable(feature = "prelude_2024", issue = "121042")]
     #[doc(no_inline)]

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -69,7 +69,12 @@ pub use crate::{
 pub use crate::concat_bytes;
 
 // Do not `doc(inline)` these `doc(hidden)` items.
-#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[unstable(
+    feature = "rustc_encodable_decodable",
+    issue = "none",
+    soft,
+    reason = "unstable implementation detail of the `rustc` compiler, do not use"
+)]
 #[allow(deprecated)]
 pub use crate::macros::builtin::{RustcDecodable, RustcEncodable};
 

--- a/library/std/src/prelude/common.rs
+++ b/library/std/src/prelude/common.rs
@@ -1,8 +1,6 @@
-//! The first version of the prelude of The Rust Standard Library.
+//! Items common to the prelude of all editions.
 //!
 //! See the [module-level documentation](super) for more.
-
-#![stable(feature = "rust1", since = "1.0.0")]
 
 // Re-exported core operators
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -51,16 +49,6 @@ pub use core::prelude::v1::{
 )]
 #[doc(no_inline)]
 pub use core::prelude::v1::concat_bytes;
-
-// Do not `doc(inline)` these `doc(hidden)` items.
-#[unstable(
-    feature = "rustc_encodable_decodable",
-    issue = "none",
-    soft,
-    reason = "unstable implementation detail of the `rustc` compiler, do not use"
-)]
-#[allow(deprecated)]
-pub use core::prelude::v1::{RustcDecodable, RustcEncodable};
 
 // Do not `doc(no_inline)` so that they become doc items on their own
 // (no public module for them to be re-exported from).

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -93,7 +93,26 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-pub mod v1;
+mod common;
+
+/// The first version of the prelude of The Rust Standard Library.
+///
+/// See the [module-level documentation](self) for more.
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod v1 {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::common::*;
+
+    // Do not `doc(inline)` these `doc(hidden)` items.
+    #[unstable(
+        feature = "rustc_encodable_decodable",
+        issue = "none",
+        soft,
+        reason = "derive macro for `rustc-serialize`; should not be used in new code"
+    )]
+    #[allow(deprecated)]
+    pub use core::prelude::v1::{RustcDecodable, RustcEncodable};
+}
 
 /// The 2015 version of the prelude of The Rust Standard Library.
 ///
@@ -134,9 +153,8 @@ pub mod rust_2021 {
 /// See the [module-level documentation](self) for more.
 #[unstable(feature = "prelude_2024", issue = "121042")]
 pub mod rust_2024 {
-    #[unstable(feature = "prelude_2024", issue = "121042")]
-    #[doc(no_inline)]
-    pub use super::v1::*;
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::common::*;
 
     #[unstable(feature = "prelude_2024", issue = "121042")]
     #[doc(no_inline)]

--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -53,7 +53,12 @@ pub use core::prelude::v1::{
 pub use core::prelude::v1::concat_bytes;
 
 // Do not `doc(inline)` these `doc(hidden)` items.
-#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[unstable(
+    feature = "rustc_encodable_decodable",
+    issue = "none",
+    soft,
+    reason = "unstable implementation detail of the `rustc` compiler, do not use"
+)]
 #[allow(deprecated)]
 pub use core::prelude::v1::{RustcDecodable, RustcEncodable};
 

--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -396,7 +396,7 @@ impl<T: ?Sized> Mutex<T> {
         self.poison.get()
     }
 
-    /// Clear the poisoned state from a mutex
+    /// Clear the poisoned state from a mutex.
     ///
     /// If the mutex is poisoned, it will remain poisoned until this function is called. This
     /// allows recovering from a poisoned state and marking that it has recovered. For example, if

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -439,7 +439,7 @@ impl<T: ?Sized> RwLock<T> {
         self.poison.get()
     }
 
-    /// Clear the poisoned state from a lock
+    /// Clear the poisoned state from a lock.
     ///
     /// If the lock is poisoned, it will remain poisoned until this function is called. This allows
     /// recovering from a poisoned state and marking that it has recovered. For example, if the

--- a/library/unwind/src/wasm.rs
+++ b/library/unwind/src/wasm.rs
@@ -59,7 +59,7 @@ pub unsafe fn _Unwind_RaiseException(exception: *mut _Unwind_Exception) -> _Unwi
             wasm_throw(0, exception.cast())
         } else {
             let _ = exception;
-            core::arch::wasm32::unreachable()
+            core::arch::wasm::unreachable()
         }
     }
 }

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+GIT_REPO="https://github.com/antoyo/gcc"
+
+# This commit hash needs to be updated to use a more recent gcc fork version.
+GIT_COMMIT="78dc50f0e50e6cd1433149520bd512a4e0eaa1bc"
+
 set -ex
 
 cd $1
@@ -7,13 +12,11 @@ cd $1
 source shared.sh
 
 # Setting up folders for GCC
-git clone https://github.com/antoyo/gcc gcc-src
-cd gcc-src
-# This commit hash needs to be updated to use a more recent gcc fork version.
-git checkout 78dc50f0e50e6cd1433149520bd512a4e0eaa1bc
+curl -L "$GIT_REPO/archive/$GIT_COMMIT.tar.gz" |
+    tar -xz --transform "s/gcc-$GIT_COMMIT/gcc-src/"
 
-mkdir ../gcc-build ../gcc-install
-cd ../gcc-build
+mkdir gcc-build gcc-install
+cd gcc-build
 
 # Building GCC.
 hide_output \
@@ -28,6 +31,7 @@ hide_output \
 hide_output make -j$(nproc)
 hide_output make install
 
-rm -rf ../gcc-src
+cd ..
+rm -rf gcc-src gcc-build
 ln -s /scripts/gcc-install/lib/libgccjit.so /usr/lib/x86_64-linux-gnu/libgccjit.so
 ln -s /scripts/gcc-install/lib/libgccjit.so /usr/lib/x86_64-linux-gnu/libgccjit.so.0

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
@@ -16,7 +16,7 @@ curl -L "$GIT_REPO/archive/$GIT_COMMIT.tar.gz" |
     tar -xz --transform "s/gcc-$GIT_COMMIT/gcc-src/"
 
 mkdir gcc-build gcc-install
-cd gcc-build
+pushd gcc-build
 
 # Building GCC.
 hide_output \
@@ -31,7 +31,7 @@ hide_output \
 hide_output make -j$(nproc)
 hide_output make install
 
-cd ..
+popd
 rm -rf gcc-src gcc-build
 ln -s /scripts/gcc-install/lib/libgccjit.so /usr/lib/x86_64-linux-gnu/libgccjit.so
 ln -s /scripts/gcc-install/lib/libgccjit.so /usr/lib/x86_64-linux-gnu/libgccjit.so.0

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GIT_REPO="https://github.com/antoyo/gcc"
+GIT_REPO="https://github.com/rust-lang/gcc"
 
 # This commit hash needs to be updated to use a more recent gcc fork version.
 GIT_COMMIT="78dc50f0e50e6cd1433149520bd512a4e0eaa1bc"

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -1,8 +1,12 @@
+pub mod run;
+
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 pub use wasmparser;
+
+pub use run::{run, run_fail};
 
 pub fn out_dir() -> PathBuf {
     env::var_os("TMPDIR").unwrap().into()
@@ -24,65 +28,122 @@ fn handle_failed_output(cmd: &str, output: Output, caller_line_number: u32) -> !
     std::process::exit(1)
 }
 
-pub fn rustc() -> RustcInvocationBuilder {
-    RustcInvocationBuilder::new()
+/// Construct a new `rustc` invocation.
+pub fn rustc() -> Rustc {
+    Rustc::new()
 }
 
-pub fn aux_build() -> AuxBuildInvocationBuilder {
-    AuxBuildInvocationBuilder::new()
+/// Construct a new `rustc` aux-build invocation.
+pub fn aux_build() -> Rustc {
+    Rustc::new_aux_build()
 }
 
+/// A `rustc` invocation builder.
 #[derive(Debug)]
-pub struct RustcInvocationBuilder {
+pub struct Rustc {
     cmd: Command,
 }
 
-impl RustcInvocationBuilder {
-    fn new() -> Self {
+impl Rustc {
+    // `rustc` invocation constructor methods
+
+    /// Construct a new `rustc` invocation.
+    pub fn new() -> Self {
         let cmd = setup_common_build_cmd();
         Self { cmd }
     }
 
-    pub fn arg(&mut self, arg: &str) -> &mut RustcInvocationBuilder {
-        self.cmd.arg(arg);
-        self
-    }
-
-    pub fn args(&mut self, args: &[&str]) -> &mut RustcInvocationBuilder {
-        self.cmd.args(args);
-        self
-    }
-
-    #[track_caller]
-    pub fn run(&mut self) -> Output {
-        let caller_location = std::panic::Location::caller();
-        let caller_line_number = caller_location.line();
-
-        let output = self.cmd.output().unwrap();
-        if !output.status.success() {
-            handle_failed_output(&format!("{:#?}", self.cmd), output, caller_line_number);
-        }
-        output
-    }
-}
-
-#[derive(Debug)]
-pub struct AuxBuildInvocationBuilder {
-    cmd: Command,
-}
-
-impl AuxBuildInvocationBuilder {
-    fn new() -> Self {
+    /// Construct a new `rustc` invocation with `aux_build` preset (setting `--crate-type=lib`).
+    pub fn new_aux_build() -> Self {
         let mut cmd = setup_common_build_cmd();
         cmd.arg("--crate-type=lib");
         Self { cmd }
     }
 
-    pub fn arg(&mut self, arg: &str) -> &mut AuxBuildInvocationBuilder {
+    // Argument provider methods
+
+    /// Configure the compilation environment.
+    pub fn cfg(&mut self, s: &str) -> &mut Self {
+        self.cmd.arg("--cfg");
+        self.cmd.arg(s);
+        self
+    }
+
+    /// Specify default optimization level `-O` (alias for `-C opt-level=2`).
+    pub fn opt(&mut self) -> &mut Self {
+        self.cmd.arg("-O");
+        self
+    }
+
+    /// Specify type(s) of output files to generate.
+    pub fn emit(&mut self, kinds: &str) -> &mut Self {
+        self.cmd.arg(format!("--emit={kinds}"));
+        self
+    }
+
+    /// Specify where an external library is located.
+    pub fn extern_<P: AsRef<Path>>(&mut self, crate_name: &str, path: P) -> &mut Self {
+        assert!(
+            !crate_name.contains(|c: char| c.is_whitespace() || c == '\\' || c == '/'),
+            "crate name cannot contain whitespace or path separators"
+        );
+
+        let path = path.as_ref().to_string_lossy();
+
+        self.cmd.arg("--extern");
+        self.cmd.arg(format!("{crate_name}={path}"));
+
+        self
+    }
+
+    /// Specify path to the input file.
+    pub fn input<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+        self.cmd.arg(path.as_ref());
+        self
+    }
+
+    /// Specify target triple.
+    pub fn target(&mut self, target: &str) -> &mut Self {
+        assert!(!target.contains(char::is_whitespace), "target triple cannot contain spaces");
+        self.cmd.arg(format!("--target={target}"));
+        self
+    }
+
+    /// Generic command argument provider. Use `.arg("-Zname")` over `.arg("-Z").arg("arg")`.
+    /// This method will panic if a plain `-Z` or `-C` is passed, or if `-Z <name>` or `-C <name>`
+    /// is passed (note the space).
+    pub fn arg(&mut self, arg: &str) -> &mut Self {
+        assert!(
+            !(["-Z", "-C"].contains(&arg) || arg.starts_with("-Z ") || arg.starts_with("-C ")),
+            "use `-Zarg` or `-Carg` over split `-Z` `arg` or `-C` `arg`"
+        );
         self.cmd.arg(arg);
         self
     }
 
+    /// Generic command arguments provider. Use `.arg("-Zname")` over `.arg("-Z").arg("arg")`.
+    /// This method will panic if a plain `-Z` or `-C` is passed, or if `-Z <name>` or `-C <name>`
+    /// is passed (note the space).
+    pub fn args(&mut self, args: &[&str]) -> &mut Self {
+        for arg in args {
+            assert!(
+                !(["-Z", "-C"].contains(&arg) || arg.starts_with("-Z ") || arg.starts_with("-C ")),
+                "use `-Zarg` or `-Carg` over split `-Z` `arg` or `-C` `arg`"
+            );
+        }
+
+        self.cmd.args(args);
+        self
+    }
+
+    // Command inspection, output and running helper methods
+
+    /// Get the [`Output`][std::process::Output] of the finished `rustc` process.
+    pub fn output(&mut self) -> Output {
+        self.cmd.output().unwrap()
+    }
+
+    /// Run the constructed `rustc` command and assert that it is successfully run.
     #[track_caller]
     pub fn run(&mut self) -> Output {
         let caller_location = std::panic::Location::caller();
@@ -94,66 +155,10 @@ impl AuxBuildInvocationBuilder {
         }
         output
     }
-}
 
-fn run_common(bin_name: &str) -> (Command, Output) {
-    let target = env::var("TARGET").unwrap();
-
-    let bin_name =
-        if target.contains("windows") { format!("{}.exe", bin_name) } else { bin_name.to_owned() };
-
-    let mut bin_path = PathBuf::new();
-    bin_path.push(env::var("TMPDIR").unwrap());
-    bin_path.push(&bin_name);
-    let ld_lib_path_envvar = env::var("LD_LIB_PATH_ENVVAR").unwrap();
-    let mut cmd = Command::new(bin_path);
-    cmd.env(&ld_lib_path_envvar, {
-        let mut paths = vec![];
-        paths.push(PathBuf::from(env::var("TMPDIR").unwrap()));
-        for p in env::split_paths(&env::var("TARGET_RPATH_ENV").unwrap()) {
-            paths.push(p.to_path_buf());
-        }
-        for p in env::split_paths(&env::var(&ld_lib_path_envvar).unwrap()) {
-            paths.push(p.to_path_buf());
-        }
-        env::join_paths(paths.iter()).unwrap()
-    });
-
-    if target.contains("windows") {
-        let mut paths = vec![];
-        for p in env::split_paths(&std::env::var("PATH").unwrap_or(String::new())) {
-            paths.push(p.to_path_buf());
-        }
-        paths.push(Path::new(&std::env::var("TARGET_RPATH_DIR").unwrap()).to_path_buf());
-        cmd.env("PATH", env::join_paths(paths.iter()).unwrap());
+    /// Inspect what the underlying [`Command`] is up to the current construction.
+    pub fn inspect(&mut self, f: impl FnOnce(&Command)) -> &mut Self {
+        f(&self.cmd);
+        self
     }
-
-    let output = cmd.output().unwrap();
-    (cmd, output)
-}
-
-/// Run a built binary and make sure it succeeds.
-#[track_caller]
-pub fn run(bin_name: &str) -> Output {
-    let caller_location = std::panic::Location::caller();
-    let caller_line_number = caller_location.line();
-
-    let (cmd, output) = run_common(bin_name);
-    if !output.status.success() {
-        handle_failed_output(&format!("{:#?}", cmd), output, caller_line_number);
-    }
-    output
-}
-
-/// Run a built binary and make sure it fails.
-#[track_caller]
-pub fn run_fail(bin_name: &str) -> Output {
-    let caller_location = std::panic::Location::caller();
-    let caller_line_number = caller_location.line();
-
-    let (cmd, output) = run_common(bin_name);
-    if output.status.success() {
-        handle_failed_output(&format!("{:#?}", cmd), output, caller_line_number);
-    }
-    output
 }

--- a/src/tools/run-make-support/src/run.rs
+++ b/src/tools/run-make-support/src/run.rs
@@ -1,0 +1,67 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use super::handle_failed_output;
+
+fn run_common(bin_name: &str) -> (Command, Output) {
+    let target = env::var("TARGET").unwrap();
+
+    let bin_name =
+        if target.contains("windows") { format!("{}.exe", bin_name) } else { bin_name.to_owned() };
+
+    let mut bin_path = PathBuf::new();
+    bin_path.push(env::var("TMPDIR").unwrap());
+    bin_path.push(&bin_name);
+    let ld_lib_path_envvar = env::var("LD_LIB_PATH_ENVVAR").unwrap();
+    let mut cmd = Command::new(bin_path);
+    cmd.env(&ld_lib_path_envvar, {
+        let mut paths = vec![];
+        paths.push(PathBuf::from(env::var("TMPDIR").unwrap()));
+        for p in env::split_paths(&env::var("TARGET_RPATH_ENV").unwrap()) {
+            paths.push(p.to_path_buf());
+        }
+        for p in env::split_paths(&env::var(&ld_lib_path_envvar).unwrap()) {
+            paths.push(p.to_path_buf());
+        }
+        env::join_paths(paths.iter()).unwrap()
+    });
+
+    if target.contains("windows") {
+        let mut paths = vec![];
+        for p in env::split_paths(&std::env::var("PATH").unwrap_or(String::new())) {
+            paths.push(p.to_path_buf());
+        }
+        paths.push(Path::new(&std::env::var("TARGET_RPATH_DIR").unwrap()).to_path_buf());
+        cmd.env("PATH", env::join_paths(paths.iter()).unwrap());
+    }
+
+    let output = cmd.output().unwrap();
+    (cmd, output)
+}
+
+/// Run a built binary and make sure it succeeds.
+#[track_caller]
+pub fn run(bin_name: &str) -> Output {
+    let caller_location = std::panic::Location::caller();
+    let caller_line_number = caller_location.line();
+
+    let (cmd, output) = run_common(bin_name);
+    if !output.status.success() {
+        handle_failed_output(&format!("{:#?}", cmd), output, caller_line_number);
+    }
+    output
+}
+
+/// Run a built binary and make sure it fails.
+#[track_caller]
+pub fn run_fail(bin_name: &str) -> Output {
+    let caller_location = std::panic::Location::caller();
+    let caller_line_number = caller_location.line();
+
+    let (cmd, output) = run_common(bin_name);
+    if output.status.success() {
+        handle_failed_output(&format!("{:#?}", cmd), output, caller_line_number);
+    }
+    output
+}

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -1,6 +1,5 @@
 //@ unit-test: DataflowConstProp
 //@ compile-flags: -Zmir-enable-passes=+GVN,+Inline
-//@ ignore-debug assertions change the output MIR
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/funky_arms.rs
+++ b/tests/mir-opt/funky_arms.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ compile-flags: --crate-type lib -Cdebug-assertions=no
 
 #![feature(flt2dec)]
 

--- a/tests/mir-opt/inline/unchecked_shifts.rs
+++ b/tests/mir-opt/inline/unchecked_shifts.rs
@@ -2,7 +2,6 @@
 #![crate_type = "lib"]
 #![feature(unchecked_shifts)]
 
-//@ ignore-debug: the debug assertions prevent the inlining we are testing for
 //@ compile-flags: -Zmir-opt-level=2 -Zinline-mir
 
 // EMIT_MIR unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.diff

--- a/tests/mir-opt/inline/unwrap_unchecked.rs
+++ b/tests/mir-opt/inline/unwrap_unchecked.rs
@@ -1,8 +1,7 @@
 #![crate_type = "lib"]
 
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ ignore-debug: the debug assertions prevent the inlining we are testing for
-//@ compile-flags: -Zmir-opt-level=2 -Zinline-mir -Cdebug-assertions=no
+//@ compile-flags: -Zmir-opt-level=2 -Zinline-mir
 
 // EMIT_MIR unwrap_unchecked.unwrap_unchecked.Inline.diff
 // EMIT_MIR unwrap_unchecked.unwrap_unchecked.PreCodegen.after.mir

--- a/tests/mir-opt/pre-codegen/duplicate_switch_targets.rs
+++ b/tests/mir-opt/pre-codegen/duplicate_switch_targets.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=0
-//@ ignore-debug: standard library debug assertions add a panic that breaks this optimization
 
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/pre-codegen/mem_replace.rs
+++ b/tests/mir-opt/pre-codegen/mem_replace.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2 -Zinline-mir
-//@ ignore-debug the standard library debug assertions leak into this test
+//@ ignore-debug: precondition checks on ptr::read/write are under cfg(debug_assertions)
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![crate_type = "lib"]

--- a/tests/mir-opt/pre-codegen/slice_index.rs
+++ b/tests/mir-opt/pre-codegen/slice_index.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ ignore-debug the standard library debug assertions leak into this test
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![crate_type = "lib"]

--- a/tests/mir-opt/pre-codegen/slice_iter.rs
+++ b/tests/mir-opt/pre-codegen/slice_iter.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
-//@ ignore-debug the standard library debug assertions leak into this test
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![crate_type = "lib"]

--- a/tests/run-make-fulldeps/pretty-expanded/input.rs
+++ b/tests/run-make-fulldeps/pretty-expanded/input.rs
@@ -1,12 +1,8 @@
-#[crate_type="lib"]
-
 // #13544
 
-extern crate rustc_serialize;
-
-#[derive(RustcEncodable)] pub struct A;
-#[derive(RustcEncodable)] pub struct B(isize);
-#[derive(RustcEncodable)] pub struct C { x: isize }
-#[derive(RustcEncodable)] pub enum D {}
-#[derive(RustcEncodable)] pub enum E { y }
-#[derive(RustcEncodable)] pub enum F { z(isize) }
+#[derive(Debug)] pub struct A;
+#[derive(Debug)] pub struct B(isize);
+#[derive(Debug)] pub struct C { x: isize }
+#[derive(Debug)] pub enum D {}
+#[derive(Debug)] pub enum E { y }
+#[derive(Debug)] pub enum F { z(isize) }

--- a/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
+++ b/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
@@ -1,24 +1,25 @@
 // ignore-tidy-linelength
 
+// Check that the `CURRENT_RUSTC_VERSION` placeholder is correctly replaced by the current
+// `rustc` version and the `since` property in feature stability gating is properly respected.
+
 extern crate run_make_support;
 
 use std::path::PathBuf;
 
-use run_make_support::{aux_build, rustc};
+use run_make_support::{rustc, aux_build};
 
 fn main() {
-    aux_build()
-        .arg("--emit=metadata")
-        .arg("stable.rs")
-        .run();
+    aux_build().input("stable.rs").emit("metadata").run();
+
     let mut stable_path = PathBuf::from(env!("TMPDIR"));
     stable_path.push("libstable.rmeta");
+
     let output = rustc()
-        .arg("--emit=metadata")
-        .arg("--extern")
-        .arg(&format!("stable={}", &stable_path.to_string_lossy()))
-        .arg("main.rs")
-        .run();
+        .input("main.rs")
+        .emit("metadata")
+        .extern_("stable", &stable_path)
+        .output();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     let version = include_str!(concat!(env!("S"), "/src/version"));

--- a/tests/run-make/a-b-a-linker-guard/rmake.rs
+++ b/tests/run-make/a-b-a-linker-guard/rmake.rs
@@ -1,44 +1,36 @@
 // ignore-tidy-linelength
 
+// Test that if we build `b` against a version of `a` that has one set of types, it will not run
+// with a dylib that has a different set of types.
+
 extern crate run_make_support;
 
 use run_make_support::{run, run_fail, rustc};
 
 fn main() {
     rustc()
-        .arg("a.rs")
-        .arg("--cfg")
-        .arg("x")
-        .arg("-C")
-        .arg("prefer-dynamic")
-        .arg("-Z")
-        .arg("unstable-options")
-        .arg("-C")
-        .arg("symbol-mangling-version=legacy")
+        .input("a.rs")
+        .cfg("x")
+        .arg("-Zunstable-options")
+        .arg("-Cprefer-dynamic")
+        .arg("-Csymbol-mangling-version=legacy")
         .run();
 
     rustc()
-       .arg("b.rs")
-       .arg("-C")
-       .arg("prefer-dynamic")
-       .arg("-Z")
-       .arg("unstable-options")
-       .arg("-C")
-       .arg("symbol-mangling-version=legacy")
-       .run();
+        .input("b.rs")
+        .arg("-Zunstable-options")
+        .arg("-Cprefer-dynamic")
+        .arg("-Csymbol-mangling-version=legacy")
+        .run();
 
     run("b");
 
     rustc()
-        .arg("a.rs")
-        .arg("--cfg")
-        .arg("y")
-        .arg("-C")
-        .arg("prefer-dynamic")
-        .arg("-Z")
-        .arg("unstable-options")
-        .arg("-C")
-        .arg("symbol-mangling-version=legacy")
+        .input("a.rs")
+        .cfg("y")
+        .arg("-Zunstable-options")
+        .arg("-Cprefer-dynamic")
+        .arg("-Csymbol-mangling-version=legacy")
         .run();
 
     run_fail("b");

--- a/tests/run-make/wasm-abi/rmake.rs
+++ b/tests/run-make/wasm-abi/rmake.rs
@@ -9,7 +9,8 @@ fn main() {
         return;
     }
 
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").run();
+    rustc().input("foo.rs").target("wasm32-wasip1").run();
+
     let file = out_dir().join("foo.wasm");
 
     let has_wasmtime = match Command::new("wasmtime").arg("--version").output() {

--- a/tests/run-make/wasm-custom-section/rmake.rs
+++ b/tests/run-make/wasm-custom-section/rmake.rs
@@ -1,6 +1,6 @@
 extern crate run_make_support;
 
-use run_make_support::{out_dir, rustc, wasmparser};
+use run_make_support::{out_dir, wasmparser, rustc};
 use std::collections::HashMap;
 
 fn main() {
@@ -8,8 +8,9 @@ fn main() {
         return;
     }
 
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").run();
-    rustc().arg("bar.rs").arg("--target=wasm32-wasip1").arg("-Clto").arg("-O").run();
+    rustc().input("foo.rs").target("wasm32-wasip1").run();
+
+    rustc().input("bar.rs").target("wasm32-wasip1").opt().run();
 
     let file = std::fs::read(&out_dir().join("bar.wasm")).unwrap();
 

--- a/tests/run-make/wasm-custom-sections-opt/rmake.rs
+++ b/tests/run-make/wasm-custom-sections-opt/rmake.rs
@@ -1,6 +1,6 @@
 extern crate run_make_support;
 
-use run_make_support::{out_dir, rustc, wasmparser};
+use run_make_support::{out_dir, wasmparser, rustc};
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -9,7 +9,8 @@ fn main() {
         return;
     }
 
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").arg("-O").run();
+    rustc().input("foo.rs").target("wasm32-wasip1").opt().run();
+
     verify(&out_dir().join("foo.wasm"));
 }
 

--- a/tests/run-make/wasm-export-all-symbols/rmake.rs
+++ b/tests/run-make/wasm-export-all-symbols/rmake.rs
@@ -1,6 +1,6 @@
 extern crate run_make_support;
 
-use run_make_support::{out_dir, rustc, wasmparser};
+use run_make_support::{out_dir, wasmparser, rustc};
 use std::collections::HashMap;
 use std::path::Path;
 use wasmparser::ExternalKind::*;
@@ -17,9 +17,10 @@ fn main() {
 
 fn test(args: &[&str]) {
     eprintln!("running with {args:?}");
-    rustc().arg("bar.rs").arg("--target=wasm32-wasip1").args(args).run();
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").args(args).run();
-    rustc().arg("main.rs").arg("--target=wasm32-wasip1").args(args).run();
+
+    rustc().input("bar.rs").target("wasm32-wasip1").args(args).run();
+    rustc().input("foo.rs").target("wasm32-wasip1").args(args).run();
+    rustc().input("main.rs").target("wasm32-wasip1").args(args).run();
 
     verify_exports(
         &out_dir().join("foo.wasm"),

--- a/tests/run-make/wasm-import-module/rmake.rs
+++ b/tests/run-make/wasm-import-module/rmake.rs
@@ -1,6 +1,6 @@
 extern crate run_make_support;
 
-use run_make_support::{out_dir, rustc, wasmparser};
+use run_make_support::{out_dir, wasmparser, rustc};
 use std::collections::HashMap;
 use wasmparser::TypeRef::Func;
 
@@ -9,8 +9,13 @@ fn main() {
         return;
     }
 
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").run();
-    rustc().arg("bar.rs").arg("--target=wasm32-wasip1").arg("-Clto").arg("-O").run();
+    rustc().input("foo.rs").target("wasm32-wasip1").run();
+    rustc()
+        .input("bar.rs")
+        .target("wasm32-wasip1")
+        .arg("-Clto")
+        .opt()
+        .run();
 
     let file = std::fs::read(&out_dir().join("bar.wasm")).unwrap();
 

--- a/tests/run-make/wasm-panic-small/rmake.rs
+++ b/tests/run-make/wasm-panic-small/rmake.rs
@@ -17,13 +17,13 @@ fn main() {
 
 fn test(cfg: &str) {
     eprintln!("running cfg {cfg:?}");
+
     rustc()
-        .arg("foo.rs")
-        .arg("--target=wasm32-wasip1")
+        .input("foo.rs")
+        .target("wasm32-wasip1")
         .arg("-Clto")
-        .arg("-O")
-        .arg("--cfg")
-        .arg(cfg)
+        .opt()
+        .cfg(cfg)
         .run();
 
     let bytes = std::fs::read(&out_dir().join("foo.wasm")).unwrap();

--- a/tests/run-make/wasm-spurious-import/rmake.rs
+++ b/tests/run-make/wasm-spurious-import/rmake.rs
@@ -1,8 +1,7 @@
 extern crate run_make_support;
 
-use run_make_support::{out_dir, rustc, wasmparser};
+use run_make_support::{out_dir, wasmparser, rustc};
 use std::collections::HashMap;
-use wasmparser::TypeRef::Func;
 
 fn main() {
     if std::env::var("TARGET").unwrap() != "wasm32-wasip1" {
@@ -10,9 +9,9 @@ fn main() {
     }
 
     rustc()
-        .arg("main.rs")
-        .arg("--target=wasm32-wasip1")
-        .arg("-Coverflow-checks=yes")
+        .input("main.rs")
+        .target("wasm32-wasip1")
+        .arg("-Coverflow-checks")
         .arg("-Cpanic=abort")
         .arg("-Clto")
         .arg("-Copt-level=z")

--- a/tests/run-make/wasm-stringify-ints-small/rmake.rs
+++ b/tests/run-make/wasm-stringify-ints-small/rmake.rs
@@ -9,7 +9,12 @@ fn main() {
         return;
     }
 
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").arg("-Clto").arg("-O").run();
+    rustc()
+        .input("foo.rs")
+        .target("wasm32-wasip1")
+        .arg("-Clto")
+        .opt()
+        .run();
 
     let bytes = std::fs::read(&out_dir().join("foo.wasm")).unwrap();
     println!("{}", bytes.len());

--- a/tests/run-make/wasm-symbols-different-module/rmake.rs
+++ b/tests/run-make/wasm-symbols-different-module/rmake.rs
@@ -1,6 +1,6 @@
 extern crate run_make_support;
 
-use run_make_support::{out_dir, rustc, wasmparser};
+use run_make_support::{out_dir, wasmparser, rustc};
 use std::collections::{HashMap, HashSet};
 
 fn main() {
@@ -24,7 +24,7 @@ fn test_file(file: &str, expected_imports: &[(&str, &[&str])]) {
 fn test(file: &str, args: &[&str], expected_imports: &[(&str, &[&str])]) {
     println!("test {file:?} {args:?} for {expected_imports:?}");
 
-    rustc().arg(file).arg("--target=wasm32-wasip1").args(args).run();
+    rustc().input(file).target("wasm32-wasip1").args(args).run();
 
     let file = std::fs::read(&out_dir().join(file).with_extension("wasm")).unwrap();
 

--- a/tests/run-make/wasm-symbols-not-exported/rmake.rs
+++ b/tests/run-make/wasm-symbols-not-exported/rmake.rs
@@ -1,6 +1,6 @@
 extern crate run_make_support;
 
-use run_make_support::{out_dir, rustc, wasmparser};
+use run_make_support::{out_dir, wasmparser, rustc};
 use std::path::Path;
 
 fn main() {
@@ -8,14 +8,14 @@ fn main() {
         return;
     }
 
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").run();
+    rustc().input("foo.rs").target("wasm32-wasip1").run();
     verify_symbols(&out_dir().join("foo.wasm"));
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").arg("-O").run();
+    rustc().input("foo.rs").target("wasm32-wasip1").opt().run();
     verify_symbols(&out_dir().join("foo.wasm"));
 
-    rustc().arg("bar.rs").arg("--target=wasm32-wasip1").run();
+    rustc().input("bar.rs").target("wasm32-wasip1").run();
     verify_symbols(&out_dir().join("bar.wasm"));
-    rustc().arg("bar.rs").arg("--target=wasm32-wasip1").arg("-O").run();
+    rustc().input("bar.rs").target("wasm32-wasip1").opt().run();
     verify_symbols(&out_dir().join("bar.wasm"));
 }
 

--- a/tests/run-make/wasm-symbols-not-imported/rmake.rs
+++ b/tests/run-make/wasm-symbols-not-imported/rmake.rs
@@ -1,6 +1,6 @@
 extern crate run_make_support;
 
-use run_make_support::{out_dir, rustc, wasmparser};
+use run_make_support::{out_dir, wasmparser, rustc};
 use std::path::Path;
 
 fn main() {
@@ -8,13 +8,13 @@ fn main() {
         return;
     }
 
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").run();
+    rustc().input("foo.rs").target("wasm32-wasip1").run();
     verify_symbols(&out_dir().join("foo.wasm"));
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").arg("-Clto").run();
+    rustc().input("foo.rs").target("wasm32-wasip1").arg("-Clto").run();
     verify_symbols(&out_dir().join("foo.wasm"));
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").arg("-O").run();
+    rustc().input("foo.rs").target("wasm32-wasip1").opt().run();
     verify_symbols(&out_dir().join("foo.wasm"));
-    rustc().arg("foo.rs").arg("--target=wasm32-wasip1").arg("-Clto").arg("-O").run();
+    rustc().input("foo.rs").target("wasm32-wasip1").arg("-Clto").opt().run();
     verify_symbols(&out_dir().join("foo.wasm"));
 }
 

--- a/tests/ui/async-await/future-sizes/async-awaiting-fut.stdout
+++ b/tests/ui/async-await/future-sizes/async-awaiting-fut.stdout
@@ -2,7 +2,7 @@ print-type-size type: `{async fn body@$DIR/async-awaiting-fut.rs:21:21: 24:2}`: 
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 0 bytes
 print-type-size     variant `Suspend0`: 3077 bytes
-print-type-size         local `.__awaitee`: 3077 bytes
+print-type-size         local `.__awaitee`: 3077 bytes, type: {async fn body@$DIR/async-awaiting-fut.rs:10:64: 19:2}
 print-type-size     variant `Returned`: 0 bytes
 print-type-size     variant `Panicked`: 0 bytes
 print-type-size type: `std::mem::ManuallyDrop<{async fn body@$DIR/async-awaiting-fut.rs:10:64: 19:2}>`: 3077 bytes, alignment: 1 bytes
@@ -19,19 +19,19 @@ print-type-size     variant `Suspend0`: 2052 bytes
 print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
 print-type-size         padding: 1 bytes
 print-type-size         local `.fut`: 1025 bytes, alignment: 1 bytes
-print-type-size         local `..coroutine_field4`: 1 bytes
-print-type-size         local `.__awaitee`: 1 bytes
+print-type-size         local `..coroutine_field4`: 1 bytes, type: bool
+print-type-size         local `.__awaitee`: 1 bytes, type: {async fn body@$DIR/async-awaiting-fut.rs:6:17: 6:19}
 print-type-size     variant `Suspend1`: 3076 bytes
 print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
 print-type-size         padding: 1026 bytes
-print-type-size         local `..coroutine_field4`: 1 bytes, alignment: 1 bytes
-print-type-size         local `.__awaitee`: 1025 bytes
+print-type-size         local `..coroutine_field4`: 1 bytes, alignment: 1 bytes, type: bool
+print-type-size         local `.__awaitee`: 1025 bytes, type: {async fn body@$DIR/async-awaiting-fut.rs:8:35: 8:37}
 print-type-size     variant `Suspend2`: 2052 bytes
 print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
 print-type-size         padding: 1 bytes
 print-type-size         local `.fut`: 1025 bytes, alignment: 1 bytes
-print-type-size         local `..coroutine_field4`: 1 bytes
-print-type-size         local `.__awaitee`: 1 bytes
+print-type-size         local `..coroutine_field4`: 1 bytes, type: bool
+print-type-size         local `.__awaitee`: 1 bytes, type: {async fn body@$DIR/async-awaiting-fut.rs:6:17: 6:19}
 print-type-size     variant `Returned`: 1025 bytes
 print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
 print-type-size     variant `Panicked`: 1025 bytes

--- a/tests/ui/async-await/future-sizes/large-arg.stdout
+++ b/tests/ui/async-await/future-sizes/large-arg.stdout
@@ -2,7 +2,7 @@ print-type-size type: `{async fn body@$DIR/large-arg.rs:6:21: 8:2}`: 3076 bytes,
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 0 bytes
 print-type-size     variant `Suspend0`: 3075 bytes
-print-type-size         local `.__awaitee`: 3075 bytes
+print-type-size         local `.__awaitee`: 3075 bytes, type: {async fn body@$DIR/large-arg.rs:10:30: 12:2}
 print-type-size     variant `Returned`: 0 bytes
 print-type-size     variant `Panicked`: 0 bytes
 print-type-size type: `std::mem::ManuallyDrop<{async fn body@$DIR/large-arg.rs:10:30: 12:2}>`: 3075 bytes, alignment: 1 bytes
@@ -17,7 +17,7 @@ print-type-size     variant `Unresumed`: 1024 bytes
 print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Suspend0`: 3074 bytes
 print-type-size         upvar `.t`: 1024 bytes
-print-type-size         local `.__awaitee`: 2050 bytes
+print-type-size         local `.__awaitee`: 2050 bytes, type: {async fn body@$DIR/large-arg.rs:13:26: 15:2}
 print-type-size     variant `Returned`: 1024 bytes
 print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Panicked`: 1024 bytes
@@ -34,7 +34,7 @@ print-type-size     variant `Unresumed`: 1024 bytes
 print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Suspend0`: 2049 bytes
 print-type-size         upvar `.t`: 1024 bytes
-print-type-size         local `.__awaitee`: 1025 bytes
+print-type-size         local `.__awaitee`: 1025 bytes, type: {async fn body@$DIR/large-arg.rs:16:26: 18:2}
 print-type-size     variant `Returned`: 1024 bytes
 print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Panicked`: 1024 bytes

--- a/tests/ui/feature-gates/feature-gate-rustc_encodable_decodable.rs
+++ b/tests/ui/feature-gates/feature-gate-rustc_encodable_decodable.rs
@@ -1,0 +1,16 @@
+#![crate_type = "lib"]
+
+// This isn't intended to compile, so it's easiest to just ignore this error.
+extern crate rustc_serialize; //~ERROR can't find crate for `rustc_serialize`
+
+#[derive(
+    RustcEncodable,
+    //~^   ERROR   use of unstable library feature 'rustc_encodable_decodable'
+    //~^^  WARNING this was previously accepted by the compiler
+    //~^^^ WARNING use of deprecated macro `RustcEncodable`
+    RustcDecodable,
+    //~^   ERROR   use of unstable library feature 'rustc_encodable_decodable'
+    //~^^  WARNING this was previously accepted by the compiler
+    //~^^^ WARNING use of deprecated macro `RustcDecodable`
+)]
+struct S;

--- a/tests/ui/feature-gates/feature-gate-rustc_encodable_decodable.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc_encodable_decodable.stderr
@@ -1,0 +1,66 @@
+error[E0463]: can't find crate for `rustc_serialize`
+  --> $DIR/feature-gate-rustc_encodable_decodable.rs:4:1
+   |
+LL | extern crate rustc_serialize;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate
+   |
+   = help: maybe you need to install the missing components with: `rustup component add rust-src rustc-dev llvm-tools-preview`
+
+error: use of unstable library feature 'rustc_encodable_decodable': derive macro for `rustc-serialize`; should not be used in new code
+  --> $DIR/feature-gate-rustc_encodable_decodable.rs:7:5
+   |
+LL |     RustcEncodable,
+   |     ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+   = note: `#[deny(soft_unstable)]` on by default
+
+warning: use of deprecated macro `RustcEncodable`: rustc-serialize is deprecated and no longer supported
+  --> $DIR/feature-gate-rustc_encodable_decodable.rs:7:5
+   |
+LL |     RustcEncodable,
+   |     ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+error: use of unstable library feature 'rustc_encodable_decodable': derive macro for `rustc-serialize`; should not be used in new code
+  --> $DIR/feature-gate-rustc_encodable_decodable.rs:11:5
+   |
+LL |     RustcDecodable,
+   |     ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+
+warning: use of deprecated macro `RustcDecodable`: rustc-serialize is deprecated and no longer supported
+  --> $DIR/feature-gate-rustc_encodable_decodable.rs:11:5
+   |
+LL |     RustcDecodable,
+   |     ^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors; 2 warnings emitted
+
+For more information about this error, try `rustc --explain E0463`.
+Future incompatibility report: Future breakage diagnostic:
+error: use of unstable library feature 'rustc_encodable_decodable': derive macro for `rustc-serialize`; should not be used in new code
+  --> $DIR/feature-gate-rustc_encodable_decodable.rs:7:5
+   |
+LL |     RustcEncodable,
+   |     ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+   = note: `#[deny(soft_unstable)]` on by default
+
+Future breakage diagnostic:
+error: use of unstable library feature 'rustc_encodable_decodable': derive macro for `rustc-serialize`; should not be used in new code
+  --> $DIR/feature-gate-rustc_encodable_decodable.rs:11:5
+   |
+LL |     RustcDecodable,
+   |     ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+   = note: `#[deny(soft_unstable)]` on by default
+

--- a/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.rs
+++ b/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.rs
@@ -1,5 +1,4 @@
-struct Wrapper<'rom>(T);
-//~^ ERROR cannot find type `T` in this scope
+struct Wrapper<'rom>(&'rom ());
 
 trait Foo {
     fn bar() -> Wrapper<impl Sized>;
@@ -12,6 +11,20 @@ impl Foo for () {
         //~^ ERROR method `bar` has an incompatible type for trait
         //~| ERROR method `bar` has an incompatible return type for trait
         0
+    }
+}
+
+trait Bar {
+    fn foo() -> Wrapper<impl Sized>;
+    //~^ ERROR missing lifetime specifier
+    //~| ERROR struct takes 0 generic arguments but 1 generic argument was supplied
+}
+
+impl Bar for () {
+    fn foo() -> Wrapper<impl Sized> {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR struct takes 0 generic arguments but 1 generic argument was supplied
+        Wrapper(&())
     }
 }
 

--- a/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
+++ b/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/opaque-and-lifetime-mismatch.rs:5:24
+  --> $DIR/opaque-and-lifetime-mismatch.rs:4:24
    |
 LL |     fn bar() -> Wrapper<impl Sized>;
    |                        ^ expected named lifetime parameter
@@ -10,19 +10,32 @@ help: consider using the `'static` lifetime, but this is uncommon unless you're 
 LL |     fn bar() -> Wrapper<'static, impl Sized>;
    |                         ++++++++
 
-error[E0412]: cannot find type `T` in this scope
-  --> $DIR/opaque-and-lifetime-mismatch.rs:1:22
+error[E0106]: missing lifetime specifier
+  --> $DIR/opaque-and-lifetime-mismatch.rs:18:24
    |
-LL | struct Wrapper<'rom>(T);
-   |                      ^ not found in this scope
+LL |     fn foo() -> Wrapper<impl Sized>;
+   |                        ^ expected named lifetime parameter
    |
-help: you might be missing a type parameter
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
    |
-LL | struct Wrapper<'rom, T>(T);
-   |                    +++
+LL |     fn foo() -> Wrapper<'static, impl Sized>;
+   |                         ++++++++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/opaque-and-lifetime-mismatch.rs:24:24
+   |
+LL |     fn foo() -> Wrapper<impl Sized> {
+   |                        ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
+   |
+LL |     fn foo() -> Wrapper<'static, impl Sized> {
+   |                         ++++++++
 
 error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/opaque-and-lifetime-mismatch.rs:5:17
+  --> $DIR/opaque-and-lifetime-mismatch.rs:4:17
    |
 LL |     fn bar() -> Wrapper<impl Sized>;
    |                 ^^^^^^^ ---------- help: remove this generic argument
@@ -32,11 +45,25 @@ LL |     fn bar() -> Wrapper<impl Sized>;
 note: struct defined here, with 0 generic parameters
   --> $DIR/opaque-and-lifetime-mismatch.rs:1:8
    |
-LL | struct Wrapper<'rom>(T);
+LL | struct Wrapper<'rom>(&'rom ());
+   |        ^^^^^^^
+
+error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/opaque-and-lifetime-mismatch.rs:18:17
+   |
+LL |     fn foo() -> Wrapper<impl Sized>;
+   |                 ^^^^^^^ ---------- help: remove this generic argument
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: struct defined here, with 0 generic parameters
+  --> $DIR/opaque-and-lifetime-mismatch.rs:1:8
+   |
+LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
 
 error[E0053]: method `bar` has an incompatible return type for trait
-  --> $DIR/opaque-and-lifetime-mismatch.rs:11:17
+  --> $DIR/opaque-and-lifetime-mismatch.rs:10:17
    |
 LL |     fn bar() -> i32 {
    |                 ^^^
@@ -45,7 +72,7 @@ LL |     fn bar() -> i32 {
    |                 return type in trait
 
 error[E0053]: method `bar` has an incompatible type for trait
-  --> $DIR/opaque-and-lifetime-mismatch.rs:11:17
+  --> $DIR/opaque-and-lifetime-mismatch.rs:10:17
    |
 LL |     fn bar() -> i32 {
    |                 ^^^
@@ -54,14 +81,28 @@ LL |     fn bar() -> i32 {
    |                 help: change the output type to match the trait: `Wrapper<'static>`
    |
 note: type in trait
-  --> $DIR/opaque-and-lifetime-mismatch.rs:5:17
+  --> $DIR/opaque-and-lifetime-mismatch.rs:4:17
    |
 LL |     fn bar() -> Wrapper<impl Sized>;
    |                 ^^^^^^^^^^^^^^^^^^^
    = note: expected signature `fn() -> Wrapper<'static>`
               found signature `fn() -> i32`
 
-error: aborting due to 5 previous errors
+error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/opaque-and-lifetime-mismatch.rs:24:17
+   |
+LL |     fn foo() -> Wrapper<impl Sized> {
+   |                 ^^^^^^^ ---------- help: remove this generic argument
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: struct defined here, with 0 generic parameters
+  --> $DIR/opaque-and-lifetime-mismatch.rs:1:8
+   |
+LL | struct Wrapper<'rom>(&'rom ());
+   |        ^^^^^^^
 
-Some errors have detailed explanations: E0053, E0106, E0107, E0412.
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0053, E0106, E0107.
 For more information about an error, try `rustc --explain E0053`.

--- a/tests/ui/print_type_sizes/async.stdout
+++ b/tests/ui/print_type_sizes/async.stdout
@@ -5,7 +5,7 @@ print-type-size         upvar `.arg`: 8192 bytes
 print-type-size     variant `Suspend0`: 16385 bytes
 print-type-size         upvar `.arg`: 8192 bytes
 print-type-size         local `.arg`: 8192 bytes
-print-type-size         local `.__awaitee`: 1 bytes
+print-type-size         local `.__awaitee`: 1 bytes, type: {async fn body@$DIR/async.rs:8:17: 8:19}
 print-type-size     variant `Returned`: 8192 bytes
 print-type-size         upvar `.arg`: 8192 bytes
 print-type-size     variant `Panicked`: 8192 bytes


### PR DESCRIPTION
Successful merges:

 - #116016 (Soft-destabilize `RustcEncodable` & `RustcDecodable`, remove from prelude in next edition)
 - #122460 (Rework rmake support library API)
 - #122658 (ci: Build gccjit from a git archive)
 - #122698 (Cancel `cargo update` job if there's no updates)
 - #122878 (Use `arch::wasm::unreachable` instead of `arch::wasm32::unreachable`)
 - #122915 (Delay a bug if no RPITITs were found)
 - #122916 (docs(sync): normalize dot in fn summaries)
 - #122921 (Enable more mir-opt tests in debug builds)
 - #122922 (-Zprint-type-sizes: print the types of awaitees and unnamed coroutine locals.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=116016,122460,122658,122698,122878,122915,122916,122921,122922)
<!-- homu-ignore:end -->