### PR TITLE
Add a regression test for #117310

### DIFF
--- a/tests/ui/type-alias-impl-trait/tait-param-inference-issue-117310.rs
+++ b/tests/ui/type-alias-impl-trait/tait-param-inference-issue-117310.rs
@@ -1,0 +1,28 @@
+//@ check-pass
+
+#![feature(type_alias_impl_trait)]
+#![allow(dead_code)]
+
+use std::ops::Deref;
+
+trait Trait {}
+impl<A, B> Trait for (A, B, u8) where A: Deref, B: Deref<Target = A::Target>, {}
+impl<A, B> Trait for (A, B, i8) {}
+
+type TaitSized = impl Sized;
+fn def_tait1() -> TaitSized {}
+
+type TaitCopy = impl Copy;
+fn def_tait2() -> TaitCopy {}
+
+fn impl_trait<T: Trait> () {}
+
+fn test() {
+    impl_trait::<(&TaitSized, &TaitCopy, _)>();
+    impl_trait::<(&TaitCopy, &TaitSized, _)>();
+
+    impl_trait::<(&TaitCopy, &String, _)>();
+    impl_trait::<(&TaitSized, &String, _)>();
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #117310

It seems to have been fixed in `rustc 1.79.0-nightly (1388d7a06 2024-03-20)` or before, so just adding a regression test for it.