### PR TITLE
Update upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         run: src/ci/scripts/create-doc-artifacts.sh
         if: success() && !env.SKIP_JOB
       - name: upload artifacts to github
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ env.DOC_ARTIFACT_NAME }}"
           path: obj/artifacts/doc
@@ -576,7 +576,7 @@ jobs:
         run: src/ci/scripts/create-doc-artifacts.sh
         if: success() && !env.SKIP_JOB
       - name: upload artifacts to github
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ env.DOC_ARTIFACT_NAME }}"
           path: obj/artifacts/doc
@@ -715,7 +715,7 @@ jobs:
         run: src/ci/scripts/create-doc-artifacts.sh
         if: success() && !env.SKIP_JOB
       - name: upload artifacts to github
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ env.DOC_ARTIFACT_NAME }}"
           path: obj/artifacts/doc

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -67,13 +67,13 @@ jobs:
         # Remove first line that always just says "Updating crates.io index"
         run: cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
       - name: upload Cargo.lock artifact for use in PR
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Cargo-lock
           path: Cargo.lock
           retention-days: 1
       - name: upload cargo-update log artifact for use in PR
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cargo-updates
           path: cargo_update.log

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -261,7 +261,7 @@ x--expand-yaml-anchors--remove:
         <<: *step
 
       - name: upload artifacts to github
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # name is set in previous step
           name: ${{ env.DOC_ARTIFACT_NAME }}


### PR DESCRIPTION
This contains a breaking change around artifact merging no longer being done. This was not relied on, so it's fine.