### PR TITLE
Be more specific when flagging imports as redundant due to the extern prelude

### DIFF
--- a/compiler/rustc_lint/src/context/diagnostics.rs
+++ b/compiler/rustc_lint/src/context/diagnostics.rs
@@ -105,7 +105,7 @@ pub(super) fn builtin(sess: &Session, diagnostic: BuiltinLintDiag, diag: &mut Di
         BuiltinLintDiag::RedundantImport(spans, ident) => {
             for (span, is_imported) in spans {
                 let introduced = if is_imported { "imported" } else { "defined" };
-                let span_msg = if span.is_dummy() { "by prelude" } else { "here" };
+                let span_msg = if span.is_dummy() { "by the extern prelude" } else { "here" };
                 diag.span_label(
                     span,
                     format!("the item `{ident}` is already {introduced} {span_msg}"),

--- a/tests/ui/imports/redundant-import-extern-prelude.rs
+++ b/tests/ui/imports/redundant-import-extern-prelude.rs
@@ -1,0 +1,17 @@
+// Check that we detect imports that are redundant due to the extern prelude
+// and that we emit a reasonable diagnostic.
+// issue: rust-lang/rust#121915
+//~^^^ NOTE the item `aux_issue_121915` is already defined by the extern prelude
+
+// See also the discussion in <https://github.com/rust-lang/rust/pull/122954>.
+
+//@ compile-flags: --extern aux_issue_121915 --edition 2018
+//@ aux-build: aux-issue-121915.rs
+
+#[deny(unused_imports)]
+//~^ NOTE the lint level is defined here
+fn main() {
+    use aux_issue_121915;
+    //~^ ERROR the item `aux_issue_121915` is imported redundantly
+    aux_issue_121915::item();
+}

--- a/tests/ui/imports/redundant-import-extern-prelude.stderr
+++ b/tests/ui/imports/redundant-import-extern-prelude.stderr
@@ -1,11 +1,11 @@
 error: the item `aux_issue_121915` is imported redundantly
-  --> $DIR/redundant-import-issue-121915.rs:6:9
+  --> $DIR/redundant-import-extern-prelude.rs:14:9
    |
 LL |     use aux_issue_121915;
-   |         ^^^^^^^^^^^^^^^^ the item `aux_issue_121915` is already defined by prelude
+   |         ^^^^^^^^^^^^^^^^ the item `aux_issue_121915` is already defined by the extern prelude
    |
 note: the lint level is defined here
-  --> $DIR/redundant-import-issue-121915.rs:4:8
+  --> $DIR/redundant-import-extern-prelude.rs:11:8
    |
 LL | #[deny(unused_imports)]
    |        ^^^^^^^^^^^^^^

--- a/tests/ui/imports/redundant-import-issue-121915.rs
+++ b/tests/ui/imports/redundant-import-issue-121915.rs
@@ -1,9 +1,0 @@
-//@ compile-flags: --extern aux_issue_121915 --edition 2018
-//@ aux-build: aux-issue-121915.rs
-
-#[deny(unused_imports)]
-fn main() {
-    use aux_issue_121915;
-    //~^ ERROR the item `aux_issue_121915` is imported redundantly
-    aux_issue_121915::item();
-}

--- a/tests/ui/imports/redundant-import-lang-prelude-attr.rs
+++ b/tests/ui/imports/redundant-import-lang-prelude-attr.rs
@@ -1,0 +1,18 @@
+// Check that we detect imports (of built-in attributes) that are redundant due to
+// the language prelude and that we emit a reasonable diagnostic.
+//~^^ NOTE the item `allow` is already defined by the extern prelude
+
+// Note that we use the term "extern prelude" in the label even though "language prelude"
+// would be more correct. However, it's not worth special-casing this.
+
+// See also the discussion in <https://github.com/rust-lang/rust/pull/122954>.
+
+//@ edition: 2018
+
+#![deny(unused_imports)]
+//~^ NOTE the lint level is defined here
+
+use allow; //~ ERROR the item `allow` is imported redundantly
+
+#[allow(unused)]
+fn main() {}

--- a/tests/ui/imports/redundant-import-lang-prelude-attr.stderr
+++ b/tests/ui/imports/redundant-import-lang-prelude-attr.stderr
@@ -1,0 +1,14 @@
+error: the item `allow` is imported redundantly
+  --> $DIR/redundant-import-lang-prelude-attr.rs:15:5
+   |
+LL | use allow;
+   |     ^^^^^ the item `allow` is already defined by the extern prelude
+   |
+note: the lint level is defined here
+  --> $DIR/redundant-import-lang-prelude-attr.rs:12:9
+   |
+LL | #![deny(unused_imports)]
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/imports/redundant-import-lang-prelude.rs
+++ b/tests/ui/imports/redundant-import-lang-prelude.rs
@@ -1,0 +1,18 @@
+// Check that we detect imports that are redundant due to the language prelude
+// and that we emit a reasonable diagnostic.
+//~^^ NOTE the item `u8` is already defined by the extern prelude
+
+// Note that we use the term "extern prelude" in the label even though "language prelude"
+// would be more correct. However, it's not worth special-casing this.
+
+// See also the discussion in <https://github.com/rust-lang/rust/pull/122954>.
+
+#![deny(unused_imports)]
+//~^ NOTE the lint level is defined here
+
+use std::primitive::u8;
+//~^ ERROR the item `u8` is imported redundantly
+
+const _: u8 = 0;
+
+fn main() {}

--- a/tests/ui/imports/redundant-import-lang-prelude.stderr
+++ b/tests/ui/imports/redundant-import-lang-prelude.stderr
@@ -1,0 +1,14 @@
+error: the item `u8` is imported redundantly
+  --> $DIR/redundant-import-lang-prelude.rs:13:5
+   |
+LL | use std::primitive::u8;
+   |     ^^^^^^^^^^^^^^^^^^ the item `u8` is already defined by the extern prelude
+   |
+note: the lint level is defined here
+  --> $DIR/redundant-import-lang-prelude.rs:10:9
+   |
+LL | #![deny(unused_imports)]
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/imports/redundant-import-undetected-macro-use-prelude.rs
+++ b/tests/ui/imports/redundant-import-undetected-macro-use-prelude.rs
@@ -1,0 +1,23 @@
+// This test demonstrates that we currently don't make an effort to detect
+// imports made redundant by the `#[macro_use]` prelude.
+// See also the discussion in <https://github.com/rust-lang/rust/pull/122954>.
+
+//@ check-pass
+//@ aux-build:two_macros.rs
+#![deny(unused_imports)]
+
+#[macro_use]
+extern crate two_macros;
+
+// This import is actually redundant due to the `#[macro_use]` above.
+use two_macros::n;
+
+// We intentionally reference two items from the `#[macro_use]`'d crate because
+// if we were to reference only item `n`, we would flag the `#[macro_use]`
+// attribute as redundant which would be correct of course.
+// That's interesting on its own -- we prefer "blaming" the `#[macro_use]`
+// over the import (here, `use two_macros::n`) when it comes to redundancy.
+n!();
+m!();
+
+fn main() {}


### PR DESCRIPTION
There are multiple distinct kinds of [preludes](https://doc.rust-lang.org/reference/names/preludes.html). Be more specific when flagging imports as redundant due to the [extern prelude](https://doc.rust-lang.org/reference/names/preludes.html#extern-prelude).

r? Nilstrieb or compiler