### PR TITLE
Silence unnecessary "missing `dyn`" errors and tweak E0746 suggestions

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1984,6 +1984,14 @@ impl<'hir> QPath<'hir> {
             QPath::LangItem(_, span) => span,
         }
     }
+
+    pub fn res(&self) -> Option<Res> {
+        match self {
+            QPath::LangItem(..) => None,
+            QPath::Resolved(_, path) => Some(path.res),
+            QPath::TypeRelative(_, path_segment) => Some(path_segment.res),
+        }
+    }
 }
 
 /// Hints at the original code for a let statement.

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
@@ -204,7 +204,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             diag.multipart_suggestion_verbose(msg, impl_sugg, Applicability::MachineApplicable);
             if is_object_safe {
                 diag.multipart_suggestion_verbose(
-                    "alternatively, you can return an owned trait object",
+                    "alternatively, you can return a boxed trait object",
                     vec![
                         (ty.span.shrink_to_lo(), "Box<dyn ".to_string()),
                         (ty.span.shrink_to_hi(), ">".to_string()),

--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -86,7 +86,7 @@ pub(super) fn check_fn<'a, 'tcx>(
         if !params_can_be_unsized {
             fcx.require_type_is_sized(
                 param_ty,
-                param.pat.span,
+                param.ty_span,
                 // ty.span == binding_span iff this is a closure parameter with no type ascription,
                 // or if it's an implicit `self` parameter
                 traits::SizedArgumentType(

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -688,7 +688,12 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
 
                 // Object safety violations or miscellaneous.
                 Err(err) => {
-                    self.err_ctxt().report_selection_error(obligation.clone(), &obligation, &err);
+                    self.err_ctxt().report_selection_error(
+                        obligation.clone(),
+                        &obligation,
+                        &err,
+                        obligation.cause.span,
+                    );
                     // Treat this like an obligation and follow through
                     // with the unsizing - the lack of a coercion should
                     // be silent, as it causes a type mismatch later.

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -688,12 +688,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
 
                 // Object safety violations or miscellaneous.
                 Err(err) => {
-                    self.err_ctxt().report_selection_error(
-                        obligation.clone(),
-                        &obligation,
-                        &err,
-                        obligation.cause.span,
-                    );
+                    self.err_ctxt().report_selection_error(obligation.clone(), &obligation, &err);
                     // Treat this like an obligation and follow through
                     // with the unsizing - the lack of a coercion should
                     // be silent, as it causes a type mismatch later.

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -600,7 +600,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.require_type_is_sized_deferred(
                 output,
                 call.map_or(expr.span, |e| e.span),
-                traits::SizedCallReturnType,
+                traits::SizedCallReturnType(call.map(|e| e.hir_id)),
             );
         }
 

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -582,7 +582,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.require_type_is_sized_deferred(
                         input,
                         span,
-                        traits::SizedArgumentType(None),
+                        traits::SizedArgumentType(args.get(i).map(|e| e.hir_id)),
                     );
                 }
             }

--- a/compiler/rustc_hir_typeck/src/gather_locals.rs
+++ b/compiler/rustc_hir_typeck/src/gather_locals.rs
@@ -147,7 +147,7 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
                 if !self.fcx.tcx.features().unsized_fn_params {
                     self.fcx.require_type_is_sized(
                         var_ty,
-                        p.span,
+                        ty_span,
                         // ty_span == ident.span iff this is a closure parameter with no type
                         // ascription, or if it's an implicit `self` parameter
                         traits::SizedArgumentType(

--- a/compiler/rustc_infer/src/traits/mod.rs
+++ b/compiler/rustc_infer/src/traits/mod.rs
@@ -17,7 +17,7 @@ use rustc_middle::traits::query::NoSolution;
 use rustc_middle::traits::solve::Certainty;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{self, Const, ToPredicate, Ty, TyCtxt};
-use rustc_span::{DesugaringKind, ExpnKind, Span};
+use rustc_span::Span;
 
 pub use self::ImplSource::*;
 pub use self::SelectionError::*;
@@ -205,19 +205,6 @@ impl<'tcx> FulfillmentError<'tcx> {
         root_obligation: PredicateObligation<'tcx>,
     ) -> FulfillmentError<'tcx> {
         FulfillmentError { obligation, code, root_obligation }
-    }
-
-    pub fn span(&self) -> Span {
-        let mut span = self.obligation.cause.span;
-        // We want to ignore desugarings here: spans are equivalent even
-        // if one is the result of a desugaring and the other is not.
-        let expn_data = span.ctxt().outer_expn_data();
-        if let ExpnKind::Desugaring(desugaring) = expn_data.kind
-            && DesugaringKind::QuestionMark != desugaring
-        {
-            span = expn_data.call_site;
-        }
-        span
     }
 }
 

--- a/compiler/rustc_infer/src/traits/mod.rs
+++ b/compiler/rustc_infer/src/traits/mod.rs
@@ -207,39 +207,8 @@ impl<'tcx> FulfillmentError<'tcx> {
         FulfillmentError { obligation, code, root_obligation }
     }
 
-    pub fn span(&self, tcx: TyCtxt<'tcx>) -> Span {
+    pub fn span(&self) -> Span {
         let mut span = self.obligation.cause.span;
-        if let ObligationCauseCode::SizedArgumentType(Some(hir_id)) = self.obligation.cause.code()
-            && let Some(ty_span) = {
-                match tcx.hir_node(*hir_id) {
-                    hir::Node::Ty(hir::Ty { span, .. }) => Some(*span),
-                    hir::Node::Param(hir::Param { ty_span, .. }) => {
-                        // We use `contains` because the type might be surrounded by parentheses,
-                        // which makes `ty_span` and `t.span` disagree with each other, but one
-                        // fully contains the other: `foo: (dyn Foo + Bar)`
-                        //                                 ^-------------^
-                        //                                 ||
-                        //                                 |t.span
-                        //                                 param._ty_span
-                        // Otherwise we'd use `ty_span` directly.
-                        // If we don't do this a case like `fn foo(_: (dyn A + B))` would emit two
-                        // unsized errors one for `(dyn A + B)` and one for `dyn A + B`, because the
-                        // dedup logic would consdider them different.
-                        if let Some(decl) = tcx.parent_hir_node(*hir_id).fn_decl()
-                            && let Some(t) = decl.inputs.iter().find(|t| ty_span.contains(t.span))
-                        {
-                            Some(t.span)
-                        } else {
-                            Some(*ty_span)
-                        }
-                    }
-                    _ => None,
-                }
-            }
-        {
-            // On implicit `Sized` on arguments, we want to point at the type and not the pattern.
-            span = ty_span;
-        }
         // We want to ignore desugarings here: spans are equivalent even
         // if one is the result of a desugaring and the other is not.
         let expn_data = span.ctxt().outer_expn_data();

--- a/compiler/rustc_infer/src/traits/mod.rs
+++ b/compiler/rustc_infer/src/traits/mod.rs
@@ -17,7 +17,7 @@ use rustc_middle::traits::query::NoSolution;
 use rustc_middle::traits::solve::Certainty;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{self, Const, ToPredicate, Ty, TyCtxt};
-use rustc_span::Span;
+use rustc_span::{DesugaringKind, ExpnKind, Span};
 
 pub use self::ImplSource::*;
 pub use self::SelectionError::*;
@@ -205,6 +205,18 @@ impl<'tcx> FulfillmentError<'tcx> {
         root_obligation: PredicateObligation<'tcx>,
     ) -> FulfillmentError<'tcx> {
         FulfillmentError { obligation, code, root_obligation }
+    }
+    pub fn span(&self) -> Span {
+        let mut span = self.obligation.cause.span;
+        // We want to ignore desugarings here: spans are equivalent even
+        // if one is the result of a desugaring and the other is not.
+        let expn_data = span.ctxt().outer_expn_data();
+        if let ExpnKind::Desugaring(desugaring) = expn_data.kind
+            && DesugaringKind::QuestionMark != desugaring
+        {
+            span = expn_data.call_site;
+        }
+        span
     }
 }
 

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -293,7 +293,7 @@ pub enum ObligationCauseCode<'tcx> {
     /// Return type must be `Sized`.
     SizedReturnType,
     /// Return type of a call expression must be `Sized`.
-    SizedCallReturnType,
+    SizedCallReturnType(Option<hir::HirId>),
     /// Yield type must be `Sized`.
     SizedYieldType,
     /// Inline asm operand type must be `Sized`.

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -17,8 +17,8 @@ use crate::ty::{GenericArgsRef, TyCtxt};
 
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::{Applicability, Diag, EmissionGuarantee};
-use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
+use rustc_hir::{HirId, MatchSource};
 use rustc_span::def_id::{LocalDefId, CRATE_DEF_ID};
 use rustc_span::symbol::Symbol;
 use rustc_span::{Span, DUMMY_SP};
@@ -262,10 +262,10 @@ pub enum ObligationCauseCode<'tcx> {
     /// expression that caused the obligation, and the `usize`
     /// indicates exactly which predicate it is in the list of
     /// instantiated predicates.
-    ExprItemObligation(DefId, rustc_hir::HirId, usize),
+    ExprItemObligation(DefId, HirId, usize),
 
     /// Combines `ExprItemObligation` and `BindingObligation`.
-    ExprBindingObligation(DefId, Span, rustc_hir::HirId, usize),
+    ExprBindingObligation(DefId, Span, HirId, usize),
 
     /// A type like `&'a T` is WF only if `T: 'a`.
     ReferenceOutlivesReferent(Ty<'tcx>),
@@ -287,13 +287,13 @@ pub enum ObligationCauseCode<'tcx> {
     /// `S { ... }` must be `Sized`.
     StructInitializerSized,
     /// Type of each variable must be `Sized`.
-    VariableType(hir::HirId),
+    VariableType(HirId),
     /// Argument type must be `Sized`.
-    SizedArgumentType(Option<hir::HirId>),
+    SizedArgumentType(Option<HirId>),
     /// Return type must be `Sized`.
     SizedReturnType,
     /// Return type of a call expression must be `Sized`.
-    SizedCallReturnType(Option<hir::HirId>),
+    SizedCallReturnType(Option<HirId>),
     /// Yield type must be `Sized`.
     SizedYieldType,
     /// Inline asm operand type must be `Sized`.
@@ -335,9 +335,9 @@ pub enum ObligationCauseCode<'tcx> {
 
     FunctionArgumentObligation {
         /// The node of the relevant argument in the function call.
-        arg_hir_id: hir::HirId,
+        arg_hir_id: HirId,
         /// The node of the function call.
-        call_hir_id: hir::HirId,
+        call_hir_id: HirId,
         /// The obligation introduced by this argument.
         parent_code: InternedObligationCauseCode<'tcx>,
     },
@@ -402,18 +402,18 @@ pub enum ObligationCauseCode<'tcx> {
     ReturnNoExpression,
 
     /// `return` with an expression
-    ReturnValue(hir::HirId),
+    ReturnValue(HirId),
 
     /// Opaque return type of this function
     OpaqueReturnType(Option<(Ty<'tcx>, Span)>),
 
     /// Block implicit return
-    BlockTailExpression(hir::HirId, hir::MatchSource),
+    BlockTailExpression(HirId, MatchSource),
 
     /// #[feature(trivial_bounds)] is not enabled
     TrivialBound,
 
-    AwaitableExpr(hir::HirId),
+    AwaitableExpr(HirId),
 
     ForLoopIterator,
 
@@ -431,8 +431,8 @@ pub enum ObligationCauseCode<'tcx> {
     MatchImpl(ObligationCause<'tcx>, DefId),
 
     BinOp {
-        lhs_hir_id: hir::HirId,
-        rhs_hir_id: Option<hir::HirId>,
+        lhs_hir_id: HirId,
+        rhs_hir_id: Option<HirId>,
         rhs_span: Option<Span>,
         rhs_is_lit: bool,
         output_ty: Option<Ty<'tcx>>,
@@ -562,14 +562,14 @@ pub enum StatementAsExpression {
 #[derive(Clone, Debug, PartialEq, Eq, HashStable, TyEncodable, TyDecodable)]
 #[derive(TypeVisitable, TypeFoldable)]
 pub struct MatchExpressionArmCause<'tcx> {
-    pub arm_block_id: Option<hir::HirId>,
+    pub arm_block_id: Option<HirId>,
     pub arm_ty: Ty<'tcx>,
     pub arm_span: Span,
-    pub prior_arm_block_id: Option<hir::HirId>,
+    pub prior_arm_block_id: Option<HirId>,
     pub prior_arm_ty: Ty<'tcx>,
     pub prior_arm_span: Span,
     pub scrut_span: Span,
-    pub source: hir::MatchSource,
+    pub source: MatchSource,
     pub prior_non_diverging_arms: Vec<Span>,
     // Is the expectation of this match expression an RPIT?
     pub tail_defines_return_position_impl_trait: Option<LocalDefId>,
@@ -578,8 +578,8 @@ pub struct MatchExpressionArmCause<'tcx> {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[derive(TypeFoldable, TypeVisitable, HashStable, TyEncodable, TyDecodable)]
 pub struct IfExpressionCause<'tcx> {
-    pub then_id: hir::HirId,
-    pub else_id: hir::HirId,
+    pub then_id: HirId,
+    pub else_id: HirId,
     pub then_ty: Ty<'tcx>,
     pub else_ty: Ty<'tcx>,
     pub outer_span: Option<Span>,

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -266,8 +266,9 @@ pub fn suggest_constraining_type_params<'a>(
                 constraints.extract_if(|(_, def_id)| *def_id == tcx.lang_items().sized_trait());
             if let Some((_, def_id)) = sized_constraints.next() {
                 applicability = Applicability::MaybeIncorrect;
-
-                err.span_label(param.span, "this type parameter needs to be `Sized`");
+                if !param.name.ident().as_str().starts_with("impl ") {
+                    err.span_label(param.span, "this type parameter needs to be `Sized`");
+                }
                 suggest_changing_unsized_bound(generics, &mut suggestions, param, def_id);
             }
         }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3257,7 +3257,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     err.help("unsized fn params are gated as an unstable feature");
                 }
             }
-            ObligationCauseCode::SizedReturnType | ObligationCauseCode::SizedCallReturnType => {
+            ObligationCauseCode::SizedReturnType | ObligationCauseCode::SizedCallReturnType(_) => {
                 err.note("the return type of a function must have a statically known size");
             }
             ObligationCauseCode::SizedYieldType => {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2002,6 +2002,11 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 },
                 Applicability::MachineApplicable,
             );
+        } else {
+            err.help(
+                "if the returned value came from a borrowed argument that implements the trait, \
+                 then you could return `&dyn Trait`",
+            );
         }
 
         true

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -167,8 +167,6 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         for from_expansion in [false, true] {
             for (error, suppressed) in iter::zip(&errors, &is_suppressed) {
                 if !suppressed && error.obligation.cause.span.from_expansion() == from_expansion {
-                    info!(?error.obligation);
-                    info!(?error.obligation.cause);
                     let guar = self.report_fulfillment_error(error);
                     reported = Some(guar);
                     self.reported_trait_errors

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -46,7 +46,7 @@ use rustc_session::config::DumpSolverProofTree;
 use rustc_session::Limit;
 use rustc_span::def_id::LOCAL_CRATE;
 use rustc_span::symbol::sym;
-use rustc_span::{BytePos, Span, Symbol, DUMMY_SP};
+use rustc_span::{BytePos, ExpnKind, Span, Symbol, DUMMY_SP};
 use std::borrow::Cow;
 use std::fmt;
 use std::iter;
@@ -94,6 +94,52 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             predicate: ty::Predicate<'tcx>,
             index: Option<usize>, // None if this is an old error
         }
+        let dedup_span = |obligation: &Obligation<'_, ty::Predicate<'_>>| {
+            // We want to ignore desugarings here: spans are equivalent even
+            // if one is the result of a desugaring and the other is not.
+            let mut span = obligation.cause.span;
+            if let ty::PredicateKind::Clause(ty::ClauseKind::Trait(pred)) =
+                obligation.predicate.kind().skip_binder()
+                && Some(pred.def_id()) == self.tcx.lang_items().sized_trait()
+            {
+                // For `Sized` bounds exclusively, we deduplicate based on `let` binding origin.
+                // We could do this for other traits, but in cases like the tests at
+                // `tests/ui/coroutine/clone-impl-async.rs` we'd end up with fewer errors than we do
+                // now, because different `fn` calls might have different sources of the obligation,
+                // which are unrelated between calls. FIXME: We could rework the dedup logic below
+                // to go further from evaluating only a single span, instead grouping multiple
+                // errors associated to the same binding and emitting a single error with *all* the
+                // appropriate context.
+                match obligation.cause.code() {
+                    ObligationCauseCode::VariableType(hir_id) => {
+                        if let hir::Node::Pat(pat) = self.tcx.hir_node(*hir_id) {
+                            // `let` binding obligations will not necessarily point at the
+                            // identifier, so point at it.
+                            span = pat.span;
+                        }
+                    }
+                    ObligationCauseCode::FunctionArgumentObligation { arg_hir_id, .. } => {
+                        if let hir::Node::Expr(expr) = self.tcx.hir_node(*arg_hir_id)
+                            && let hir::ExprKind::Path(hir::QPath::Resolved(
+                                None,
+                                hir::Path { res: hir::def::Res::Local(hir_id), .. },
+                            )) = expr.peel_borrows().kind
+                            && let hir::Node::Pat(pat) = self.tcx.hir_node(*hir_id)
+                        {
+                            // When we have a call argument that is a `!Sized` `let` binding,
+                            // deduplicate all the `!Sized` errors referencing that binding.
+                            span = pat.span;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let expn_data = span.ctxt().outer_expn_data();
+            if let ExpnKind::Desugaring(_) = expn_data.kind {
+                span = expn_data.call_site;
+            }
+            span
+        };
 
         let mut error_map: FxIndexMap<_, Vec<_>> = self
             .reported_trait_errors
@@ -125,7 +171,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         });
 
         for (index, error) in errors.iter().enumerate() {
-            error_map.entry(error.obligation.cause.span).or_default().push(ErrorDescriptor {
+            error_map.entry(dedup_span(&error.obligation)).or_default().push(ErrorDescriptor {
                 predicate: error.obligation.predicate,
                 index: Some(index),
             });
@@ -171,7 +217,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     reported = Some(guar);
                     self.reported_trait_errors
                         .borrow_mut()
-                        .entry(error.obligation.cause.span)
+                        .entry(dedup_span(&error.obligation))
                         .or_insert_with(|| (vec![], guar))
                         .0
                         .push(error.obligation.predicate);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -135,13 +135,13 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         // This is a special case: when `fn foo() -> dyn Trait` and we call `foo()`
                         // in the init of a `let` binding, we will already emit an unsized local
                         // error, so we check for this case and unify the errors.
-                        if let hir::Node::Local(local) = self.tcx.parent_hir_node(*hir_id) {
+                        if let hir::Node::LetStmt(local) = self.tcx.parent_hir_node(*hir_id) {
                             span = local.pat.span;
                         }
                     }
                     ObligationCauseCode::ExprBindingObligation(_, _, hir_id, _) => {
                         // For method calls like `let x = y.foo();` that are `?Sized`, we also dedup
-                        if let hir::Node::Local(local) = self.tcx.parent_hir_node(*hir_id) {
+                        if let hir::Node::LetStmt(local) = self.tcx.parent_hir_node(*hir_id) {
                             span = local.pat.span;
                         }
                     }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -125,7 +125,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         });
 
         for (index, error) in errors.iter().enumerate() {
-            error_map.entry(error.span(self.tcx)).or_default().push(ErrorDescriptor {
+            error_map.entry(error.span()).or_default().push(ErrorDescriptor {
                 predicate: error.obligation.predicate,
                 index: Some(index),
             });
@@ -171,7 +171,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     reported = Some(guar);
                     self.reported_trait_errors
                         .borrow_mut()
-                        .entry(error.span(self.tcx))
+                        .entry(error.span())
                         .or_insert_with(|| (vec![], guar))
                         .0
                         .push(error.obligation.predicate);
@@ -628,15 +628,14 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
 
                         if let ObligationCauseCode::Coercion { source, target } =
                             *obligation.cause.code().peel_derives()
+                            && Some(trait_ref.def_id()) == self.tcx.lang_items().sized_trait()
                         {
-                            if Some(trait_ref.def_id()) == self.tcx.lang_items().sized_trait() {
-                                self.suggest_borrowing_for_object_cast(
-                                    &mut err,
-                                    root_obligation,
-                                    source,
-                                    target,
-                                );
-                            }
+                            self.suggest_borrowing_for_object_cast(
+                                &mut err,
+                                root_obligation,
+                                source,
+                                target,
+                            );
                         }
 
                         let UnsatisfiedConst(unsatisfied_const) = self
@@ -1490,7 +1489,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     error.obligation.clone(),
                     &error.root_obligation,
                     selection_error,
-                    error.span(self.tcx),
+                    error.span(),
                 ),
             FulfillmentErrorCode::ProjectionError(ref e) => {
                 self.report_projection_error(&error.obligation, e)

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -125,7 +125,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         });
 
         for (index, error) in errors.iter().enumerate() {
-            error_map.entry(error.span()).or_default().push(ErrorDescriptor {
+            error_map.entry(error.obligation.cause.span).or_default().push(ErrorDescriptor {
                 predicate: error.obligation.predicate,
                 index: Some(index),
             });
@@ -171,7 +171,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     reported = Some(guar);
                     self.reported_trait_errors
                         .borrow_mut()
-                        .entry(error.span())
+                        .entry(error.obligation.cause.span)
                         .or_insert_with(|| (vec![], guar))
                         .0
                         .push(error.obligation.predicate);
@@ -1489,7 +1489,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     error.obligation.clone(),
                     &error.root_obligation,
                     selection_error,
-                    error.span(),
+                    error.obligation.cause.span,
                 ),
             FulfillmentErrorCode::ProjectionError(ref e) => {
                 self.report_projection_error(&error.obligation, e)

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -348,9 +348,9 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         mut obligation: PredicateObligation<'tcx>,
         root_obligation: &PredicateObligation<'tcx>,
         error: &SelectionError<'tcx>,
-        mut span: Span,
     ) -> ErrorGuaranteed {
         let tcx = self.tcx;
+        let mut span = obligation.cause.span;
 
         if tcx.sess.opts.unstable_opts.next_solver.map(|c| c.dump_tree).unwrap_or_default()
             == DumpSolverProofTree::OnError
@@ -1489,7 +1489,6 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     error.obligation.clone(),
                     &error.root_obligation,
                     selection_error,
-                    error.obligation.cause.span,
                 ),
             FulfillmentErrorCode::ProjectionError(ref e) => {
                 self.report_projection_error(&error.obligation, e)

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -139,6 +139,12 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             span = local.pat.span;
                         }
                     }
+                    ObligationCauseCode::ExprBindingObligation(_, _, hir_id, _) => {
+                        // For method calls like `let x = y.foo();` that are `?Sized`, we also dedup
+                        if let hir::Node::Local(local) = self.tcx.parent_hir_node(*hir_id) {
+                            span = local.pat.span;
+                        }
+                    }
                     _ => {}
                 }
             }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -125,7 +125,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         });
 
         for (index, error) in errors.iter().enumerate() {
-            error_map.entry(error.span()).or_default().push(ErrorDescriptor {
+            error_map.entry(error.span(self.tcx)).or_default().push(ErrorDescriptor {
                 predicate: error.obligation.predicate,
                 index: Some(index),
             });
@@ -167,11 +167,13 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         for from_expansion in [false, true] {
             for (error, suppressed) in iter::zip(&errors, &is_suppressed) {
                 if !suppressed && error.obligation.cause.span.from_expansion() == from_expansion {
+                    info!(?error.obligation);
+                    info!(?error.obligation.cause);
                     let guar = self.report_fulfillment_error(error);
                     reported = Some(guar);
                     self.reported_trait_errors
                         .borrow_mut()
-                        .entry(error.span())
+                        .entry(error.span(self.tcx))
                         .or_insert_with(|| (vec![], guar))
                         .0
                         .push(error.obligation.predicate);
@@ -1490,7 +1492,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     error.obligation.clone(),
                     &error.root_obligation,
                     selection_error,
-                    error.span(),
+                    error.span(self.tcx),
                 ),
             FulfillmentErrorCode::ProjectionError(ref e) => {
                 self.report_projection_error(&error.obligation, e)

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -131,6 +131,14 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             span = pat.span;
                         }
                     }
+                    ObligationCauseCode::SizedCallReturnType(Some(hir_id)) => {
+                        // This is a special case: when `fn foo() -> dyn Trait` and we call `foo()`
+                        // in the init of a `let` binding, we will already emit an unsized local
+                        // error, so we check for this case and unify the errors.
+                        if let hir::Node::Local(local) = self.tcx.parent_hir_node(*hir_id) {
+                            span = local.pat.span;
+                        }
+                    }
                     _ => {}
                 }
             }

--- a/src/tools/clippy/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -137,7 +137,6 @@ fn assert_len_expr<'hir>(
     if let Some(higher::If { cond, then, .. }) = higher::If::hir(expr)
         && let ExprKind::Unary(UnOp::Not, condition) = &cond.kind
         && let ExprKind::Binary(bin_op, left, right) = &condition.kind
-
         && let Some((cmp, asserted_len, slice_len)) = len_comparison(*bin_op, left, right)
         && let ExprKind::MethodCall(method, recv, ..) = &slice_len.kind
         && cx.typeck_results().expr_ty_adjusted(recv).peel_refs().is_slice()

--- a/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui/crashes/ice-6251.rs:4:45
+  --> tests/ui/crashes/ice-6251.rs:4:48
    |
 LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: [u8]| x }]> {
-   |                                             ^ doesn't have a size known at compile-time
+   |                                                ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = help: unsized fn params are gated as an unstable feature

--- a/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
@@ -5,7 +5,7 @@ LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: [u8]| x }]> {
    |                                                ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed slices always have a known size
    |
 LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: &[u8]| x }]> {

--- a/tests/ui/associated-types/associated-types-unsized.stderr
+++ b/tests/ui/associated-types/associated-types-unsized.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `<T as Get>::Value` cannot be known at compilation time
-  --> $DIR/associated-types-unsized.rs:10:9
+  --> $DIR/associated-types-unsized.rs:10:13
    |
 LL |     let x = t.get();
-   |         ^ doesn't have a size known at compile-time
+   |             ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `<T as Get>::Value`
    = note: all local variables must have a statically known size

--- a/tests/ui/associated-types/associated-types-unsized.stderr
+++ b/tests/ui/associated-types/associated-types-unsized.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `<T as Get>::Value` cannot be known at compilation time
-  --> $DIR/associated-types-unsized.rs:10:13
+  --> $DIR/associated-types-unsized.rs:10:15
    |
 LL |     let x = t.get();
-   |             ^^^^^^^ doesn't have a size known at compile-time
+   |               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `<T as Get>::Value`
    = note: all local variables must have a statically known size

--- a/tests/ui/associated-types/associated-types-unsized.stderr
+++ b/tests/ui/associated-types/associated-types-unsized.stderr
@@ -5,8 +5,7 @@ LL |     let x = t.get();
    |               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `<T as Get>::Value`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 help: consider further restricting the associated type
    |
 LL | fn foo<T:Get>(t: T) where <T as Get>::Value: Sized {

--- a/tests/ui/associated-types/issue-20005.rs
+++ b/tests/ui/associated-types/issue-20005.rs
@@ -9,6 +9,7 @@ trait To {
         self //~ ERROR the size for values of type
     ) -> <Dst as From<Self>>::Result where Dst: From<Self> { //~ ERROR the size for values of type
         From::from(self) //~ ERROR the size for values of type
+        //~^ ERROR the size for values of type
     }
 }
 

--- a/tests/ui/associated-types/issue-20005.stderr
+++ b/tests/ui/associated-types/issue-20005.stderr
@@ -54,6 +54,19 @@ help: consider relaxing the implicit `Sized` restriction
 LL | trait From<Src: ?Sized> {
    |               ++++++++
 
-error: aborting due to 3 previous errors
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-20005.rs:11:20
+   |
+LL |         From::from(self)
+   |                    ^^^^ doesn't have a size known at compile-time
+   |
+   = note: all function arguments must have a statically known size
+   = help: unsized fn params are gated as an unstable feature
+help: consider further restricting `Self`
+   |
+LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self>, Self: Sized {
+   |                                                           +++++++++++++
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/issue-20005.stderr
+++ b/tests/ui/associated-types/issue-20005.stderr
@@ -24,7 +24,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |         self
    |         ^^^^ doesn't have a size known at compile-time
    |
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider further restricting `Self`
    |
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self>, Self: Sized {
@@ -60,8 +60,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |         From::from(self)
    |                    ^^^^ doesn't have a size known at compile-time
    |
-   = note: all function arguments must have a statically known size
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider further restricting `Self`
    |
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self>, Self: Sized {

--- a/tests/ui/associated-types/issue-59324.stderr
+++ b/tests/ui/associated-types/issue-59324.stderr
@@ -79,10 +79,10 @@ LL | pub trait Foo: NotFoo {
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `(dyn ThriftService<(), AssocType = _> + 'static)` cannot be known at compilation time
-  --> $DIR/issue-59324.rs:23:20
+  --> $DIR/issue-59324.rs:23:29
    |
 LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
-   |                    ^^^^^^^ doesn't have a size known at compile-time
+   |                             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn ThriftService<(), AssocType = _> + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/associated-types/issue-59324.stderr
+++ b/tests/ui/associated-types/issue-59324.stderr
@@ -85,7 +85,7 @@ LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
    |                             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn ThriftService<(), AssocType = _> + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | fn with_factory<H>(factory: impl ThriftService<()>) {}

--- a/tests/ui/async-await/issue-72590-type-error-sized.stderr
+++ b/tests/ui/async-await/issue-72590-type-error-sized.stderr
@@ -22,7 +22,7 @@ note: required because it appears within the type `Foo`
    |
 LL | struct Foo {
    |        ^^^
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL |     async fn frob(&self) {}

--- a/tests/ui/closures/cannot-call-unsized-via-ptr-2.stderr
+++ b/tests/ui/closures/cannot-call-unsized-via-ptr-2.stderr
@@ -5,7 +5,6 @@ LL |     let f = if true { |_a| {} } else { |_b| {} };
    |                        ^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all function arguments must have a statically known size
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/cannot-call-unsized-via-ptr-2.rs:5:41
@@ -14,7 +13,6 @@ LL |     let f = if true { |_a| {} } else { |_b| {} };
    |                                         ^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all function arguments must have a statically known size
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/closures/cannot-call-unsized-via-ptr.stderr
+++ b/tests/ui/closures/cannot-call-unsized-via-ptr.stderr
@@ -5,7 +5,6 @@ LL |     let f: fn([u8]) = |_result| {};
    |                        ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all function arguments must have a statically known size
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/issue-111932.rs
+++ b/tests/ui/closures/issue-111932.rs
@@ -2,7 +2,7 @@ trait Foo: std::fmt::Debug {}
 
 fn print_foos(foos: impl Iterator<Item = dyn Foo>) {
     foos.for_each(|foo| { //~ ERROR [E0277]
-        println!("{:?}", foo); //~ ERROR [E0277]
+        println!("{:?}", foo); // no `!Sized` error, already reported above
     });
 }
 

--- a/tests/ui/closures/issue-111932.stderr
+++ b/tests/ui/closures/issue-111932.stderr
@@ -8,19 +8,6 @@ LL |     foos.for_each(|foo| {
    = note: all function arguments must have a statically known size
    = help: unsized fn params are gated as an unstable feature
 
-error[E0277]: the size for values of type `dyn Foo` cannot be known at compilation time
-  --> $DIR/issue-111932.rs:5:26
-   |
-LL |         println!("{:?}", foo);
-   |                   ----   ^^^ doesn't have a size known at compile-time
-   |                   |
-   |                   required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `dyn Foo`
-note: required by an implicit `Sized` bound in `core::fmt::rt::Argument::<'a>::new_debug`
-  --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
-   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/closures/issue-111932.stderr
+++ b/tests/ui/closures/issue-111932.stderr
@@ -5,8 +5,7 @@ LL |     foos.for_each(|foo| {
    |                    ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
-   = note: all function arguments must have a statically known size
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/issue-78720.stderr
+++ b/tests/ui/closures/issue-78720.stderr
@@ -43,7 +43,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn map2<F>(self, f: F) -> Map2<F> {}
    |                ^^^^ doesn't have a size known at compile-time
    |
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider further restricting `Self`
    |
 LL |     fn map2<F>(self, f: F) -> Map2<F> where Self: Sized {}

--- a/tests/ui/coherence/occurs-check/opaques.next.stderr
+++ b/tests/ui/coherence/occurs-check/opaques.next.stderr
@@ -8,10 +8,10 @@ LL | impl<T> Trait<T> for defining_scope::Alias<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
 
 error[E0282]: type annotations needed
-  --> $DIR/opaques.rs:13:20
+  --> $DIR/opaques.rs:13:23
    |
 LL |     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
-   |                    ^ cannot infer type for struct `Container<T, T>`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for struct `Container<T, T>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/coroutine/issue-88653.rs
+++ b/tests/ui/coroutine/issue-88653.rs
@@ -6,11 +6,13 @@
 use std::ops::Coroutine;
 
 fn foo(bar: bool) -> impl Coroutine<(bool,)> {
-    //~^ ERROR: type mismatch in coroutine arguments [E0631]
-    //~| NOTE: expected due to this
-    //~| NOTE: expected coroutine signature `fn((bool,)) -> _`
+    //~^ ERROR type mismatch in coroutine arguments [E0631]
+    //~| NOTE expected due to this
+    //~| NOTE expected coroutine signature `fn((bool,)) -> _`
+    //~| NOTE in this expansion of desugaring of `impl Trait`
+    //~| NOTE in this expansion of desugaring of `impl Trait`
     |bar| {
-        //~^ NOTE: found signature defined here
+        //~^ NOTE found signature defined here
         if bar {
             yield bar;
         }

--- a/tests/ui/coroutine/issue-88653.rs
+++ b/tests/ui/coroutine/issue-88653.rs
@@ -9,8 +9,6 @@ fn foo(bar: bool) -> impl Coroutine<(bool,)> {
     //~^ ERROR: type mismatch in coroutine arguments [E0631]
     //~| NOTE: expected due to this
     //~| NOTE: expected coroutine signature `fn((bool,)) -> _`
-    //~| NOTE: in this expansion of desugaring of `impl Trait`
-    //~| NOTE: in this expansion of desugaring of `impl Trait`
     |bar| {
         //~^ NOTE: found signature defined here
         if bar {

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
@@ -14,10 +14,10 @@ LL |     fn bar(i: i32, t: usize, s: &()) -> (usize, i32) {
    |               ~~~     ~~~~~     ~~~     ~~~~~~~~~~~~
 
 error[E0282]: type annotations needed
-  --> $DIR/replace-impl-infer-ty-from-trait.rs:9:12
+  --> $DIR/replace-impl-infer-ty-from-trait.rs:9:15
    |
 LL |     fn bar(i: _, t: _, s: _) -> _ {
-   |            ^ cannot infer type
+   |               ^ cannot infer type
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0038.stderr
+++ b/tests/ui/error-codes/E0038.stderr
@@ -29,10 +29,10 @@ LL |     fn foo(&self) -> Self;
    = help: consider moving `foo` to another trait
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
-  --> $DIR/E0038.rs:7:13
+  --> $DIR/E0038.rs:7:15
    |
 LL |     let y = x.foo();
-   |             ^^^^^^^ doesn't have a size known at compile-time
+   |               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
    = note: all local variables must have a statically known size

--- a/tests/ui/error-codes/E0038.stderr
+++ b/tests/ui/error-codes/E0038.stderr
@@ -29,10 +29,10 @@ LL |     fn foo(&self) -> Self;
    = help: consider moving `foo` to another trait
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
-  --> $DIR/E0038.rs:7:9
+  --> $DIR/E0038.rs:7:13
    |
 LL |     let y = x.foo();
-   |         ^ doesn't have a size known at compile-time
+   |             ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
    = note: all local variables must have a statically known size

--- a/tests/ui/error-codes/E0038.stderr
+++ b/tests/ui/error-codes/E0038.stderr
@@ -35,8 +35,7 @@ LL |     let y = x.foo();
    |               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/error-codes/E0277.stderr
+++ b/tests/ui/error-codes/E0277.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/E0277.rs:11:6
+  --> $DIR/E0277.rs:11:9
    |
 LL | fn f(p: Path) { }
-   |      ^ doesn't have a size known at compile-time
+   |         ^^^^ doesn't have a size known at compile-time
    |
    = help: within `Path`, the trait `Sized` is not implemented for `[u8]`, which is required by `Path: Sized`
 note: required because it appears within the type `Path`

--- a/tests/ui/error-codes/E0277.stderr
+++ b/tests/ui/error-codes/E0277.stderr
@@ -7,7 +7,7 @@ LL | fn f(p: Path) { }
    = help: within `Path`, the trait `Sized` is not implemented for `[u8]`, which is required by `Path: Sized`
 note: required because it appears within the type `Path`
   --> $SRC_DIR/std/src/path.rs:LL:COL
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn f(p: &Path) { }

--- a/tests/ui/error-codes/E0746.stderr
+++ b/tests/ui/error-codes/E0746.stderr
@@ -4,6 +4,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn foo() -> dyn Trait { Struct }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn foo() -> impl Trait { Struct }
@@ -19,6 +20,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bar() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn bar() -> impl Trait {

--- a/tests/ui/error-codes/E0746.stderr
+++ b/tests/ui/error-codes/E0746.stderr
@@ -4,11 +4,11 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn foo() -> dyn Trait { Struct }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn foo() -> impl Trait { Struct }
    |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL | fn foo() -> Box<dyn Trait> { Box::new(Struct) }
    |             ++++         +   +++++++++      +
@@ -19,11 +19,11 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bar() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn bar() -> impl Trait {
    |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bar() -> Box<dyn Trait> {
 LL |     if true {

--- a/tests/ui/feature-gates/feature-gate-unsized_fn_params.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_fn_params.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_fn_params.rs:17:8
+  --> $DIR/feature-gate-unsized_fn_params.rs:17:11
    |
 LL | fn foo(x: dyn Foo) {
-   |        ^ doesn't have a size known at compile-time
+   |           ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
    = help: unsized fn params are gated as an unstable feature
@@ -16,10 +16,10 @@ LL | fn foo(x: &dyn Foo) {
    |           +
 
 error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_fn_params.rs:21:8
+  --> $DIR/feature-gate-unsized_fn_params.rs:21:11
    |
 LL | fn bar(x: Foo) {
-   |        ^ doesn't have a size known at compile-time
+   |           ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
    = help: unsized fn params are gated as an unstable feature
@@ -33,10 +33,10 @@ LL | fn bar(x: &dyn Foo) {
    |           ++++
 
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_fn_params.rs:25:8
+  --> $DIR/feature-gate-unsized_fn_params.rs:25:11
    |
 LL | fn qux(_: [()]) {}
-   |        ^ doesn't have a size known at compile-time
+   |           ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[()]`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/feature-gates/feature-gate-unsized_fn_params.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_fn_params.stderr
@@ -5,7 +5,7 @@ LL | fn foo(x: dyn Foo) {
    |           ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | fn foo(x: impl Foo) {
@@ -22,7 +22,7 @@ LL | fn bar(x: Foo) {
    |           ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | fn bar(x: impl Foo) {
@@ -39,7 +39,7 @@ LL | fn qux(_: [()]) {}
    |           ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[()]`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed slices always have a known size
    |
 LL | fn qux(_: &[()]) {}
@@ -52,8 +52,7 @@ LL |     foo(*x);
    |         ^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
-   = note: all function arguments must have a statically known size
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-unsized_locals.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_locals.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn FnOnce() + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_locals.rs:1:6
+  --> $DIR/feature-gate-unsized_locals.rs:1:9
    |
 LL | fn f(f: dyn FnOnce()) {}
-   |      ^ doesn't have a size known at compile-time
+   |         ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn FnOnce() + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/feature-gates/feature-gate-unsized_locals.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_locals.stderr
@@ -5,7 +5,7 @@ LL | fn f(f: dyn FnOnce()) {}
    |         ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn FnOnce() + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | fn f(f: impl FnOnce()) {}

--- a/tests/ui/for/for-c-in-str.rs
+++ b/tests/ui/for/for-c-in-str.rs
@@ -6,9 +6,6 @@ fn main() {
         //~| NOTE `&str` is not an iterator
         //~| HELP the trait `Iterator` is not implemented for `&str`
         //~| NOTE required for `&str` to implement `IntoIterator`
-        //~| NOTE in this expansion of desugaring of `for` loop
-        //~| NOTE in this expansion of desugaring of `for` loop
-        //~| NOTE in this expansion of desugaring of `for` loop
         println!();
     }
 }

--- a/tests/ui/for/for-c-in-str.rs
+++ b/tests/ui/for/for-c-in-str.rs
@@ -6,6 +6,9 @@ fn main() {
         //~| NOTE `&str` is not an iterator
         //~| HELP the trait `Iterator` is not implemented for `&str`
         //~| NOTE required for `&str` to implement `IntoIterator`
+        //~| NOTE in this expansion of desugaring of `for` loop
+        //~| NOTE in this expansion of desugaring of `for` loop
+        //~| NOTE in this expansion of desugaring of `for` loop
         println!();
     }
 }

--- a/tests/ui/generic-associated-types/issue-79636-1.stderr
+++ b/tests/ui/generic-associated-types/issue-79636-1.stderr
@@ -20,7 +20,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn bind<B, F>(self, f: F) -> Self::Wrapped<B> {
    |                   ^^^^ doesn't have a size known at compile-time
    |
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider further restricting `Self`
    |
 LL |     fn bind<B, F>(self, f: F) -> Self::Wrapped<B> where Self: Sized {

--- a/tests/ui/impl-trait/dyn-impl-type-mismatch.rs
+++ b/tests/ui/impl-trait/dyn-impl-type-mismatch.rs
@@ -10,7 +10,7 @@ fn main() {
     } else {
         foo() //~ ERROR E0308
     };
-    let a: dyn Trait = if true {
+    let a: dyn Trait = if true { //~ ERROR E0277
         Struct //~ ERROR E0308
     } else {
         foo() //~ ERROR E0308

--- a/tests/ui/impl-trait/dyn-impl-type-mismatch.stderr
+++ b/tests/ui/impl-trait/dyn-impl-type-mismatch.stderr
@@ -1,3 +1,17 @@
+error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
+  --> $DIR/dyn-impl-type-mismatch.rs:13:12
+   |
+LL |     let a: dyn Trait = if true {
+   |            ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn Trait`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+help: consider borrowing here
+   |
+LL |     let a: &dyn Trait = if true {
+   |            +
+
 error[E0308]: mismatched types
   --> $DIR/dyn-impl-type-mismatch.rs:11:9
    |
@@ -38,6 +52,7 @@ LL |         foo()
                found opaque type `impl Trait`
    = help: you can box the `impl Trait` to coerce it to `Box<dyn Trait>`, but you'll have to change the expected type as well
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/dyn-impl-type-mismatch.stderr
+++ b/tests/ui/impl-trait/dyn-impl-type-mismatch.stderr
@@ -5,9 +5,8 @@ LL |     let a: dyn Trait = if true {
    |            ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-help: consider borrowing here
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
+help: borrowed types have a statically known size
    |
 LL |     let a: &dyn Trait = if true {
    |            +

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
@@ -48,10 +48,14 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bap() -> Trait { Struct }
    |             ^^^^^ doesn't have a size known at compile-time
    |
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: return an `impl Trait` instead of a `dyn Trait`
    |
-LL | fn bap() -> Box<Trait> { Box::new(Struct) }
-   |             ++++     +   +++++++++      +
+LL | fn bap() -> impl Trait { Struct }
+   |             ++++
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
+   |
+LL | fn bap() -> Box<dyn Trait> { Box::new(Struct) }
+   |             +++++++      +   +++++++++      +
 
 error[E0746]: return type cannot have an unboxed trait object
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:13
@@ -59,11 +63,11 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn ban() -> dyn Trait { Struct }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn ban() -> impl Trait { Struct }
    |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL | fn ban() -> Box<dyn Trait> { Box::new(Struct) }
    |             ++++         +   +++++++++      +
@@ -74,11 +78,11 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bak() -> dyn Trait { unimplemented!() }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn bak() -> impl Trait { unimplemented!() }
    |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL | fn bak() -> Box<dyn Trait> { Box::new(unimplemented!()) }
    |             ++++         +   +++++++++                +
@@ -89,11 +93,15 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bal() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: the returned values do not all have the same type, so `impl Trait` can't be used
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:21:16
    |
-LL | fn bal() -> impl Trait {
-   |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+LL |         return Struct;
+   |                ^^^^^^ this returned value has type `Struct`
+LL |     }
+LL |     42
+   |     ^^ this returned value has type `{integer}`
+help: box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bal() -> Box<dyn Trait> {
 LL |     if true {
@@ -108,11 +116,15 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bax() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: the returned values do not all have the same type, so `impl Trait` can't be used
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:27:9
    |
-LL | fn bax() -> impl Trait {
-   |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+LL |         Struct
+   |         ^^^^^^ this returned value has type `Struct`
+LL |     } else {
+LL |         42
+   |         ^^ this returned value has type `{integer}`
+help: box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bax() -> Box<dyn Trait> {
 LL |     if true {
@@ -263,11 +275,11 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bat() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn bat() -> impl Trait {
    |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bat() -> Box<dyn Trait> {
 LL |     if true {
@@ -282,11 +294,11 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bay() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn bay() -> impl Trait {
    |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bay() -> Box<dyn Trait> {
 LL |     if true {

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
@@ -48,6 +48,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bap() -> Trait { Struct }
    |             ^^^^^ doesn't have a size known at compile-time
    |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn bap() -> impl Trait { Struct }
@@ -63,6 +64,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn ban() -> dyn Trait { Struct }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn ban() -> impl Trait { Struct }
@@ -78,6 +80,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bak() -> dyn Trait { unimplemented!() }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn bak() -> impl Trait { unimplemented!() }
@@ -101,6 +104,7 @@ LL |         return Struct;
 LL |     }
 LL |     42
    |     ^^ this returned value has type `{integer}`
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bal() -> Box<dyn Trait> {
@@ -124,6 +128,7 @@ LL |         Struct
 LL |     } else {
 LL |         42
    |         ^^ this returned value has type `{integer}`
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bax() -> Box<dyn Trait> {
@@ -275,6 +280,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bat() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn bat() -> impl Trait {
@@ -294,6 +300,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn bay() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn bay() -> impl Trait {

--- a/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.rs
+++ b/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.rs
@@ -33,4 +33,10 @@ fn cat() -> Box<dyn NotObjectSafe> { //~ ERROR the trait `NotObjectSafe` cannot 
     Box::new(B) //~ ERROR cannot be made into an object
 }
 
+fn can(x: &A) -> dyn NotObjectSafe { //~ ERROR the trait `NotObjectSafe` cannot be made into an object
+//~^ ERROR return type cannot have an unboxed trait object
+    x
+}
+
+
 fn main() {}

--- a/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
+++ b/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
@@ -48,25 +48,50 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
+error[E0038]: the trait `NotObjectSafe` cannot be made into an object
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:36:18
+   |
+LL | fn can(x: &A) -> dyn NotObjectSafe {
+   |                  ^^^^^^^^^^^^^^^^^ `NotObjectSafe` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:3:8
+   |
+LL | trait NotObjectSafe {
+   |       ------------- this trait cannot be made into an object...
+LL |     fn foo() -> Self;
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `NotObjectSafe` for this new enum and using it instead:
+             A
+             B
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self) -> Self;
+   |            +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo() -> Self where Self: Sized;
+   |                      +++++++++++++++++
+
 error[E0746]: return type cannot have an unboxed trait object
   --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:21:13
    |
 LL | fn car() -> dyn NotObjectSafe {
    |             ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: the returned values do not all have the same type, so `impl Trait` can't be used
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:24:16
    |
-LL | fn car() -> impl NotObjectSafe {
-   |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
-   |
-LL ~ fn car() -> Box<dyn NotObjectSafe> {
-LL |
-LL |     if true {
-LL ~         return Box::new(A);
+LL |         return A;
+   |                ^ this returned value has type `A`
 LL |     }
-LL ~     Box::new(B)
+LL |     B
+   |     ^ this returned value has type `B`
+help: trait `NotObjectSafe` is not object safe, so you can't return a boxed trait object `Box<dyn NotObjectSafe>`
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:21:17
    |
+LL | fn car() -> dyn NotObjectSafe {
+   |                 ^^^^^^^^^^^^^
 
 error[E0038]: the trait `NotObjectSafe` cannot be made into an object
   --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:31:16
@@ -120,7 +145,27 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
-error: aborting due to 5 previous errors
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:36:18
+   |
+LL | fn can(x: &A) -> dyn NotObjectSafe {
+   |                  ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: trait `NotObjectSafe` is not object safe, so you can't return a boxed trait object `Box<dyn NotObjectSafe>`
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:36:22
+   |
+LL | fn can(x: &A) -> dyn NotObjectSafe {
+   |                      ^^^^^^^^^^^^^
+help: return an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn can(x: &A) -> impl NotObjectSafe {
+   |                  ~~~~
+help: alternatively, you might be able to borrow from the function's argument
+   |
+LL | fn can(x: &A) -> &dyn NotObjectSafe {
+   |                  +
+
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0038, E0746.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
+++ b/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
@@ -92,6 +92,7 @@ help: trait `NotObjectSafe` is not object safe, so you can't return a boxed trai
    |
 LL | fn car() -> dyn NotObjectSafe {
    |                 ^^^^^^^^^^^^^
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 
 error[E0038]: the trait `NotObjectSafe` cannot be made into an object
   --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:31:16

--- a/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
+++ b/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
@@ -171,11 +171,11 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn hat() -> dyn std::fmt::Display {
    |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn hat() -> impl std::fmt::Display {
    |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn hat() -> Box<dyn std::fmt::Display> {
 LL |     match 13 {
@@ -192,11 +192,11 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn pug() -> dyn std::fmt::Display {
    |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn pug() -> impl std::fmt::Display {
    |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn pug() -> Box<dyn std::fmt::Display> {
 LL |     match 13 {
@@ -211,11 +211,15 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn man() -> dyn std::fmt::Display {
    |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: the returned values do not all have the same type, so `impl Trait` can't be used
+  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:87:9
    |
-LL | fn man() -> impl std::fmt::Display {
-   |             ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+LL |         0i32
+   |         ^^^^ this returned value has type `i32`
+LL |     } else {
+LL |         1u32
+   |         ^^^^ this returned value has type `u32`
+help: box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn man() -> Box<dyn std::fmt::Display> {
 LL |     if false {

--- a/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
+++ b/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
@@ -171,6 +171,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn hat() -> dyn std::fmt::Display {
    |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn hat() -> impl std::fmt::Display {
@@ -192,6 +193,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn pug() -> dyn std::fmt::Display {
    |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn pug() -> impl std::fmt::Display {
@@ -219,6 +221,7 @@ LL |         0i32
 LL |     } else {
 LL |         1u32
    |         ^^^^ this returned value has type `u32`
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn man() -> Box<dyn std::fmt::Display> {

--- a/tests/ui/inference/ice-ifer-var-leaked-out-of-rollback-122098.stderr
+++ b/tests/ui/inference/ice-ifer-var-leaked-out-of-rollback-122098.stderr
@@ -36,10 +36,10 @@ LL | struct Query<'q> {}
    = help: consider removing `'q`, referring to it in a field, or using a marker such as `PhantomData`
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/ice-ifer-var-leaked-out-of-rollback-122098.rs:7:17
+  --> $DIR/ice-ifer-var-leaked-out-of-rollback-122098.rs:7:21
    |
 LL |     fn for_each(mut self, mut f: Box<dyn FnMut(Self::Item<'_>) + 'static>) {}
-   |                 ^^^^^^^^ doesn't have a size known at compile-time
+   |                     ^^^^ doesn't have a size known at compile-time
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider further restricting `Self`

--- a/tests/ui/inference/ice-ifer-var-leaked-out-of-rollback-122098.stderr
+++ b/tests/ui/inference/ice-ifer-var-leaked-out-of-rollback-122098.stderr
@@ -41,7 +41,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn for_each(mut self, mut f: Box<dyn FnMut(Self::Item<'_>) + 'static>) {}
    |                     ^^^^ doesn't have a size known at compile-time
    |
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider further restricting `Self`
    |
 LL |     fn for_each(mut self, mut f: Box<dyn FnMut(Self::Item<'_>) + 'static>) where Self: Sized {}

--- a/tests/ui/issues/issue-15756.stderr
+++ b/tests/ui/issues/issue-15756.stderr
@@ -5,8 +5,7 @@ LL |     &mut something
    |          ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[T]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-18107.stderr
+++ b/tests/ui/issues/issue-18107.stderr
@@ -4,11 +4,11 @@ error[E0746]: return type cannot have an unboxed trait object
 LL |     dyn AbstractRenderer
    |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL |     impl AbstractRenderer
    |     ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~     Box<dyn AbstractRenderer>
 LL |
@@ -16,6 +16,10 @@ LL | {
 LL |     match 0 {
 LL ~         _ => Box::new(unimplemented!())
    |
+help: finally, you might be able to borrow from the function's argument
+   |
+LL |     &dyn AbstractRenderer
+   |     +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-27078.stderr
+++ b/tests/ui/issues/issue-27078.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn foo(self) -> &'static i32 {
    |            ^^^^ doesn't have a size known at compile-time
    |
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider further restricting `Self`
    |
 LL |     fn foo(self) -> &'static i32 where Self: Sized {

--- a/tests/ui/issues/issue-38954.stderr
+++ b/tests/ui/issues/issue-38954.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/issue-38954.rs:1:10
+  --> $DIR/issue-38954.rs:1:18
    |
 LL | fn _test(ref _p: str) {}
-   |          ^^^^^^ doesn't have a size known at compile-time
+   |                  ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/issues/issue-38954.stderr
+++ b/tests/ui/issues/issue-38954.stderr
@@ -5,7 +5,7 @@ LL | fn _test(ref _p: str) {}
    |                  ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn _test(ref _p: &str) {}

--- a/tests/ui/issues/issue-41229-ref-str.stderr
+++ b/tests/ui/issues/issue-41229-ref-str.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/issue-41229-ref-str.rs:1:16
+  --> $DIR/issue-41229-ref-str.rs:1:23
    |
 LL | pub fn example(ref s: str) {}
-   |                ^^^^^ doesn't have a size known at compile-time
+   |                       ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/issues/issue-41229-ref-str.stderr
+++ b/tests/ui/issues/issue-41229-ref-str.stderr
@@ -5,7 +5,7 @@ LL | pub fn example(ref s: str) {}
    |                       ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | pub fn example(ref s: &str) {}

--- a/tests/ui/issues/issue-42312.stderr
+++ b/tests/ui/issues/issue-42312.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `<Self as Deref>::Target` cannot be known at compilation time
-  --> $DIR/issue-42312.rs:4:12
+  --> $DIR/issue-42312.rs:4:15
    |
 LL |     fn baz(_: Self::Target) where Self: Deref {}
-   |            ^ doesn't have a size known at compile-time
+   |               ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `<Self as Deref>::Target`
    = help: unsized fn params are gated as an unstable feature
@@ -16,10 +16,10 @@ LL |     fn baz(_: &Self::Target) where Self: Deref {}
    |               +
 
 error[E0277]: the size for values of type `(dyn ToString + 'static)` cannot be known at compilation time
-  --> $DIR/issue-42312.rs:8:10
+  --> $DIR/issue-42312.rs:8:13
    |
 LL | pub fn f(_: dyn ToString) {}
-   |          ^ doesn't have a size known at compile-time
+   |             ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn ToString + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/issues/issue-42312.stderr
+++ b/tests/ui/issues/issue-42312.stderr
@@ -5,7 +5,7 @@ LL |     fn baz(_: Self::Target) where Self: Deref {}
    |               ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `<Self as Deref>::Target`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider further restricting the associated type
    |
 LL |     fn baz(_: Self::Target) where Self: Deref, <Self as Deref>::Target: Sized {}
@@ -22,7 +22,7 @@ LL | pub fn f(_: dyn ToString) {}
    |             ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn ToString + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | pub fn f(_: impl ToString) {}

--- a/tests/ui/issues/issue-5883.stderr
+++ b/tests/ui/issues/issue-5883.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
-  --> $DIR/issue-5883.rs:8:5
+  --> $DIR/issue-5883.rs:8:8
    |
 LL |     r: dyn A + 'static
-   |     ^ doesn't have a size known at compile-time
+   |        ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/issues/issue-5883.stderr
+++ b/tests/ui/issues/issue-5883.stderr
@@ -5,7 +5,7 @@ LL |     r: dyn A + 'static
    |        ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL |     r: impl A + 'static

--- a/tests/ui/issues/issue-66706.stderr
+++ b/tests/ui/issues/issue-66706.stderr
@@ -29,10 +29,10 @@ LL |     [0; match [|f @ &ref _| () ] {} ]
    |         while parsing this `match` expression
 
 error[E0282]: type annotations needed
-  --> $DIR/issue-66706.rs:2:11
+  --> $DIR/issue-66706.rs:2:14
    |
 LL |     [0; [|_: _ &_| ()].len()]
-   |           ^ cannot infer type
+   |              ^ cannot infer type
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/iterators/collect-into-slice.rs
+++ b/tests/ui/iterators/collect-into-slice.rs
@@ -5,13 +5,10 @@ fn process_slice(data: &[i32]) {
 fn main() {
     let some_generated_vec = (0..10).collect();
     //~^ ERROR the size for values of type `[i32]` cannot be known at compilation time
-    //~| ERROR the size for values of type `[i32]` cannot be known at compilation time
     //~| ERROR a slice of type `[i32]` cannot be built since `[i32]` has no definite size
     //~| NOTE try explicitly collecting into a `Vec<{integer}>`
-    //~| NOTE required by an implicit `Sized` bound in `collect`
     //~| NOTE required by a bound in `collect`
     //~| NOTE all local variables must have a statically known size
-    //~| NOTE doesn't have a size known at compile-time
     //~| NOTE doesn't have a size known at compile-time
     process_slice(&some_generated_vec);
 

--- a/tests/ui/iterators/collect-into-slice.rs
+++ b/tests/ui/iterators/collect-into-slice.rs
@@ -8,7 +8,6 @@ fn main() {
     //~| ERROR a slice of type `[i32]` cannot be built since `[i32]` has no definite size
     //~| NOTE try explicitly collecting into a `Vec<{integer}>`
     //~| NOTE required by a bound in `collect`
-    //~| NOTE all local variables must have a statically known size
     //~| NOTE doesn't have a size known at compile-time
     process_slice(&some_generated_vec);
 

--- a/tests/ui/iterators/collect-into-slice.stderr
+++ b/tests/ui/iterators/collect-into-slice.stderr
@@ -9,10 +9,10 @@ note: required by a bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
-  --> $DIR/collect-into-slice.rs:6:9
+  --> $DIR/collect-into-slice.rs:6:30
    |
 LL |     let some_generated_vec = (0..10).collect();
-   |         ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                              ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
    = note: all local variables must have a statically known size

--- a/tests/ui/iterators/collect-into-slice.stderr
+++ b/tests/ui/iterators/collect-into-slice.stderr
@@ -9,27 +9,17 @@ note: required by a bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
-  --> $DIR/collect-into-slice.rs:6:30
-   |
-LL |     let some_generated_vec = (0..10).collect();
-   |                              ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[i32]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-
-error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
   --> $DIR/collect-into-slice.rs:6:38
    |
 LL |     let some_generated_vec = (0..10).collect();
    |                                      ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-note: required by an implicit `Sized` bound in `collect`
-  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
 error[E0277]: a slice of type `&[i32]` cannot be built since we need to store the elements somewhere
-  --> $DIR/collect-into-slice.rs:18:38
+  --> $DIR/collect-into-slice.rs:15:38
    |
 LL |     let some_generated_vec = (0..10).collect();
    |                                      ^^^^^^^ try explicitly collecting into a `Vec<{integer}>`
@@ -38,6 +28,6 @@ LL |     let some_generated_vec = (0..10).collect();
 note: required by a bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/iterators/collect-into-slice.stderr
+++ b/tests/ui/iterators/collect-into-slice.stderr
@@ -15,11 +15,10 @@ LL |     let some_generated_vec = (0..10).collect();
    |                                      ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 
 error[E0277]: a slice of type `&[i32]` cannot be built since we need to store the elements somewhere
-  --> $DIR/collect-into-slice.rs:15:38
+  --> $DIR/collect-into-slice.rs:14:38
    |
 LL |     let some_generated_vec = (0..10).collect();
    |                                      ^^^^^^^ try explicitly collecting into a `Vec<{integer}>`

--- a/tests/ui/iterators/float_iterator_hint.rs
+++ b/tests/ui/iterators/float_iterator_hint.rs
@@ -4,10 +4,6 @@ fn main() {
     for i in 0.2 {
         //~^ ERROR `{float}` is not an iterator
         //~| `{float}` is not an iterator
-        //~| NOTE in this expansion of desugaring of `for` loop
-        //~| NOTE in this expansion of desugaring of `for` loop
-        //~| NOTE in this expansion of desugaring of `for` loop
-        //~| NOTE in this expansion of desugaring of `for` loop
         //~| NOTE if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
         //~| NOTE required for `{float}` to implement `IntoIterator`
         println!();

--- a/tests/ui/iterators/float_iterator_hint.rs
+++ b/tests/ui/iterators/float_iterator_hint.rs
@@ -6,6 +6,10 @@ fn main() {
         //~| `{float}` is not an iterator
         //~| NOTE if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
         //~| NOTE required for `{float}` to implement `IntoIterator`
+        //~| NOTE in this expansion of desugaring of `for` loop
+        //~| NOTE in this expansion of desugaring of `for` loop
+        //~| NOTE in this expansion of desugaring of `for` loop
+        //~| NOTE in this expansion of desugaring of `for` loop
         println!();
     }
 }

--- a/tests/ui/kinds-of-primitive-impl.stderr
+++ b/tests/ui/kinds-of-primitive-impl.stderr
@@ -38,7 +38,7 @@ LL |     fn bar(self) {}
    |            ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL |     fn bar(&self) {}

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
@@ -33,7 +33,6 @@ LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a
    | |__________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
    = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:1

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
@@ -33,6 +33,7 @@ LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a
    | |__________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
    = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:1

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
@@ -19,10 +19,10 @@ LL |     f()
    |     call expression requires function
 
 error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known at compilation time
-  --> $DIR/avoid-ice-on-warning-2.rs:4:10
+  --> $DIR/avoid-ice-on-warning-2.rs:4:13
    |
 LL | fn id<F>(f: Copy) -> usize {
-   |          ^ doesn't have a size known at compile-time
+   |             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
@@ -25,7 +25,7 @@ LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | fn id<F>(f: impl Copy) -> usize {

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
@@ -47,10 +47,10 @@ LL |     f()
    |     call expression requires function
 
 error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known at compilation time
-  --> $DIR/avoid-ice-on-warning-2.rs:4:10
+  --> $DIR/avoid-ice-on-warning-2.rs:4:13
    |
 LL | fn id<F>(f: Copy) -> usize {
-   |          ^ doesn't have a size known at compile-time
+   |             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
@@ -53,7 +53,7 @@ LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | fn id<F>(f: impl Copy) -> usize {

--- a/tests/ui/resolve/issue-3907-2.stderr
+++ b/tests/ui/resolve/issue-3907-2.stderr
@@ -11,10 +11,10 @@ LL |     fn bar();
    |        ^^^ the trait cannot be made into an object because associated function `bar` has no `self` parameter
 
 error[E0277]: the size for values of type `(dyn issue_3907::Foo + 'static)` cannot be known at compilation time
-  --> $DIR/issue-3907-2.rs:11:8
+  --> $DIR/issue-3907-2.rs:11:12
    |
 LL | fn bar(_x: Foo) {}
-   |        ^^ doesn't have a size known at compile-time
+   |            ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn issue_3907::Foo + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/resolve/issue-3907-2.stderr
+++ b/tests/ui/resolve/issue-3907-2.stderr
@@ -17,7 +17,7 @@ LL | fn bar(_x: Foo) {}
    |            ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn issue_3907::Foo + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn bar(_x: &Foo) {}

--- a/tests/ui/resolve/issue-5035-2.stderr
+++ b/tests/ui/resolve/issue-5035-2.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn I + 'static)` cannot be known at compilation time
-  --> $DIR/issue-5035-2.rs:4:8
+  --> $DIR/issue-5035-2.rs:4:12
    |
 LL | fn foo(_x: K) {}
-   |        ^^ doesn't have a size known at compile-time
+   |            ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn I + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/resolve/issue-5035-2.stderr
+++ b/tests/ui/resolve/issue-5035-2.stderr
@@ -5,7 +5,7 @@ LL | fn foo(_x: K) {}
    |            ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn I + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn foo(_x: &K) {}

--- a/tests/ui/sized/let-ref-pat-unsized-works.rs
+++ b/tests/ui/sized/let-ref-pat-unsized-works.rs
@@ -1,0 +1,11 @@
+//@ build-pass
+#![allow(unused)]
+
+fn main() {
+    let ref x: str = *"";
+}
+
+fn foo(r: &(usize, str)) -> usize {
+    let (x, _): (usize, str) = *r;
+    x
+}

--- a/tests/ui/sized/unsized-binding.rs
+++ b/tests/ui/sized/unsized-binding.rs
@@ -1,5 +1,17 @@
+struct Foo<T: ?Sized>(i32, T);
+trait T {}
+
+fn bar() -> dyn T { //~ ERROR E0746
+    panic!()
+}
+
 fn main() {
     let x = *""; //~ ERROR E0277
     println!("{}", x);
     println!("{}", x);
+    let Foo(a, b) = Foo(1, bar());
+    //~^ ERROR E0277
+    //~| ERROR E0277
+    // The second error above could be deduplicated if we remove or unify the additional `note`
+    // explaining unsized locals and fn arguments.
 }

--- a/tests/ui/sized/unsized-binding.stderr
+++ b/tests/ui/sized/unsized-binding.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized-binding.rs:2:9
+  --> $DIR/unsized-binding.rs:2:13
    |
 LL |     let x = *"";
-   |         ^ doesn't have a size known at compile-time
+   |             ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: all local variables must have a statically known size

--- a/tests/ui/sized/unsized-binding.stderr
+++ b/tests/ui/sized/unsized-binding.stderr
@@ -1,5 +1,22 @@
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/unsized-binding.rs:4:13
+   |
+LL | fn bar() -> dyn T {
+   |             ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
+help: return an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn bar() -> impl T {
+   |             ~~~~
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn bar() -> Box<dyn T> {
+LL ~     Box::new(panic!())
+   |
+
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized-binding.rs:2:13
+  --> $DIR/unsized-binding.rs:9:13
    |
 LL |     let x = *"";
    |             ^^^ doesn't have a size known at compile-time
@@ -8,6 +25,27 @@ LL |     let x = *"";
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `dyn T` cannot be known at compilation time
+  --> $DIR/unsized-binding.rs:12:28
+   |
+LL |     let Foo(a, b) = Foo(1, bar());
+   |                            ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn T`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
-For more information about this error, try `rustc --explain E0277`.
+error[E0277]: the size for values of type `dyn T` cannot be known at compilation time
+  --> $DIR/unsized-binding.rs:12:28
+   |
+LL |     let Foo(a, b) = Foo(1, bar());
+   |                            ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn T`
+   = note: all function arguments must have a statically known size
+   = help: unsized fn params are gated as an unstable feature
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0746.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/sized/unsized-binding.stderr
+++ b/tests/ui/sized/unsized-binding.stderr
@@ -22,8 +22,7 @@ LL |     let x = *"";
    |             ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 
 error[E0277]: the size for values of type `dyn T` cannot be known at compilation time
   --> $DIR/unsized-binding.rs:12:28
@@ -32,8 +31,7 @@ LL |     let Foo(a, b) = Foo(1, bar());
    |                            ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn T`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 
 error[E0277]: the size for values of type `dyn T` cannot be known at compilation time
   --> $DIR/unsized-binding.rs:12:28
@@ -42,8 +40,7 @@ LL |     let Foo(a, b) = Foo(1, bar());
    |                            ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn T`
-   = note: all function arguments must have a statically known size
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/sized/unsized-return.rs
+++ b/tests/ui/sized/unsized-return.rs
@@ -6,6 +6,5 @@ fn foo() -> dyn T { //~ E0746
 
 fn main() {
     let x = foo(); //~ ERROR E0277
-    //~^ ERROR E0277
     let x: dyn T = foo(); //~ ERROR E0277
 }

--- a/tests/ui/sized/unsized-return.rs
+++ b/tests/ui/sized/unsized-return.rs
@@ -1,0 +1,11 @@
+trait T {}
+
+fn foo() -> dyn T { //~ E0746
+   todo!()
+}
+
+fn main() {
+    let x = foo(); //~ ERROR E0277
+    //~^ ERROR E0277
+    let x: dyn T = foo(); //~ ERROR E0277
+}

--- a/tests/ui/sized/unsized-return.stderr
+++ b/tests/ui/sized/unsized-return.stderr
@@ -16,7 +16,7 @@ LL ~    Box::new(todo!())
    |
 
 error[E0277]: the size for values of type `dyn T` cannot be known at compilation time
-  --> $DIR/unsized-return.rs:10:12
+  --> $DIR/unsized-return.rs:9:12
    |
 LL |     let x: dyn T = foo();
    |            ^^^^^ doesn't have a size known at compile-time
@@ -39,16 +39,7 @@ LL |     let x = foo();
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
 
-error[E0277]: the size for values of type `(dyn T + 'static)` cannot be known at compilation time
-  --> $DIR/unsized-return.rs:8:13
-   |
-LL |     let x = foo();
-   |             ^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `(dyn T + 'static)`
-   = note: the return type of a function must have a statically known size
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0277, E0746.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/sized/unsized-return.stderr
+++ b/tests/ui/sized/unsized-return.stderr
@@ -1,0 +1,54 @@
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/unsized-return.rs:3:13
+   |
+LL | fn foo() -> dyn T {
+   |             ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
+help: return an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn foo() -> impl T {
+   |             ~~~~
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn foo() -> Box<dyn T> {
+LL ~    Box::new(todo!())
+   |
+
+error[E0277]: the size for values of type `dyn T` cannot be known at compilation time
+  --> $DIR/unsized-return.rs:10:12
+   |
+LL |     let x: dyn T = foo();
+   |            ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn T`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+help: consider borrowing here
+   |
+LL |     let x: &dyn T = foo();
+   |            +
+
+error[E0277]: the size for values of type `dyn T` cannot be known at compilation time
+  --> $DIR/unsized-return.rs:8:13
+   |
+LL |     let x = foo();
+   |             ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn T`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+
+error[E0277]: the size for values of type `(dyn T + 'static)` cannot be known at compilation time
+  --> $DIR/unsized-return.rs:8:13
+   |
+LL |     let x = foo();
+   |             ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn T + 'static)`
+   = note: the return type of a function must have a statically known size
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0746.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/sized/unsized-return.stderr
+++ b/tests/ui/sized/unsized-return.stderr
@@ -22,9 +22,8 @@ LL |     let x: dyn T = foo();
    |            ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn T`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-help: consider borrowing here
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
+help: borrowed types have a statically known size
    |
 LL |     let x: &dyn T = foo();
    |            +
@@ -36,8 +35,7 @@ LL |     let x = foo();
    |             ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn T`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/str/str-array-assignment.stderr
+++ b/tests/ui/str/str-array-assignment.stderr
@@ -18,10 +18,10 @@ LL |   let u: &str = if true { &s[..2] } else { s };
    |                           +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/str-array-assignment.rs:7:7
+  --> $DIR/str-array-assignment.rs:7:11
    |
 LL |   let v = s[..2];
-   |       ^ doesn't have a size known at compile-time
+   |           ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: all local variables must have a statically known size

--- a/tests/ui/str/str-array-assignment.stderr
+++ b/tests/ui/str/str-array-assignment.stderr
@@ -24,9 +24,8 @@ LL |   let v = s[..2];
    |           ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-help: consider borrowing here
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
+help: borrowed values have a statically known size
    |
 LL |   let v = &s[..2];
    |           +

--- a/tests/ui/suggestions/object-unsafe-trait-references-self.stderr
+++ b/tests/ui/suggestions/object-unsafe-trait-references-self.stderr
@@ -32,10 +32,10 @@ LL | trait Other: Sized {}
    |       this trait cannot be made into an object...
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/object-unsafe-trait-references-self.rs:2:19
+  --> $DIR/object-unsafe-trait-references-self.rs:2:22
    |
 LL |     fn baz(&self, _: Self) {}
-   |                   ^ doesn't have a size known at compile-time
+   |                      ^^^^ doesn't have a size known at compile-time
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider further restricting `Self`

--- a/tests/ui/suggestions/object-unsafe-trait-references-self.stderr
+++ b/tests/ui/suggestions/object-unsafe-trait-references-self.stderr
@@ -37,7 +37,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn baz(&self, _: Self) {}
    |                      ^^^^ doesn't have a size known at compile-time
    |
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider further restricting `Self`
    |
 LL |     fn baz(&self, _: Self) where Self: Sized {}

--- a/tests/ui/suggestions/path-by-value.stderr
+++ b/tests/ui/suggestions/path-by-value.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/path-by-value.rs:3:6
+  --> $DIR/path-by-value.rs:3:9
    |
 LL | fn f(p: Path) { }
-   |      ^ doesn't have a size known at compile-time
+   |         ^^^^ doesn't have a size known at compile-time
    |
    = help: within `Path`, the trait `Sized` is not implemented for `[u8]`, which is required by `Path: Sized`
 note: required because it appears within the type `Path`

--- a/tests/ui/suggestions/path-by-value.stderr
+++ b/tests/ui/suggestions/path-by-value.stderr
@@ -7,7 +7,7 @@ LL | fn f(p: Path) { }
    = help: within `Path`, the trait `Sized` is not implemented for `[u8]`, which is required by `Path: Sized`
 note: required because it appears within the type `Path`
   --> $SRC_DIR/std/src/path.rs:LL:COL
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn f(p: &Path) { }

--- a/tests/ui/suggestions/unsized-function-parameter.fixed
+++ b/tests/ui/suggestions/unsized-function-parameter.fixed
@@ -5,19 +5,19 @@
 fn foo1(bar: &str) {}
 //~^ ERROR the size for values of type `str` cannot be known at compilation time
 //~| HELP the trait `Sized` is not implemented for `str`
-//~| HELP unsized fn params are gated as an unstable feature
+//~| HELP unsized fn params are gated as unstable feature
 //~| HELP function arguments must have a statically known size, borrowed types always have a known size
 
 fn foo2(_bar: &str) {}
 //~^ ERROR the size for values of type `str` cannot be known at compilation time
 //~| HELP the trait `Sized` is not implemented for `str`
-//~| HELP unsized fn params are gated as an unstable feature
+//~| HELP unsized fn params are gated as unstable feature
 //~| HELP function arguments must have a statically known size, borrowed types always have a known size
 
 fn foo3(_: &str) {}
 //~^ ERROR the size for values of type `str` cannot be known at compilation time
 //~| HELP the trait `Sized` is not implemented for `str`
-//~| HELP unsized fn params are gated as an unstable feature
+//~| HELP unsized fn params are gated as unstable feature
 //~| HELP function arguments must have a statically known size, borrowed types always have a known size
 
 fn main() {}

--- a/tests/ui/suggestions/unsized-function-parameter.rs
+++ b/tests/ui/suggestions/unsized-function-parameter.rs
@@ -5,19 +5,19 @@
 fn foo1(bar: str) {}
 //~^ ERROR the size for values of type `str` cannot be known at compilation time
 //~| HELP the trait `Sized` is not implemented for `str`
-//~| HELP unsized fn params are gated as an unstable feature
+//~| HELP unsized fn params are gated as unstable feature
 //~| HELP function arguments must have a statically known size, borrowed types always have a known size
 
 fn foo2(_bar: str) {}
 //~^ ERROR the size for values of type `str` cannot be known at compilation time
 //~| HELP the trait `Sized` is not implemented for `str`
-//~| HELP unsized fn params are gated as an unstable feature
+//~| HELP unsized fn params are gated as unstable feature
 //~| HELP function arguments must have a statically known size, borrowed types always have a known size
 
 fn foo3(_: str) {}
 //~^ ERROR the size for values of type `str` cannot be known at compilation time
 //~| HELP the trait `Sized` is not implemented for `str`
-//~| HELP unsized fn params are gated as an unstable feature
+//~| HELP unsized fn params are gated as unstable feature
 //~| HELP function arguments must have a statically known size, borrowed types always have a known size
 
 fn main() {}

--- a/tests/ui/suggestions/unsized-function-parameter.stderr
+++ b/tests/ui/suggestions/unsized-function-parameter.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized-function-parameter.rs:5:9
+  --> $DIR/unsized-function-parameter.rs:5:14
    |
 LL | fn foo1(bar: str) {}
-   |         ^^^ doesn't have a size known at compile-time
+   |              ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: unsized fn params are gated as an unstable feature
@@ -12,10 +12,10 @@ LL | fn foo1(bar: &str) {}
    |              +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized-function-parameter.rs:11:9
+  --> $DIR/unsized-function-parameter.rs:11:15
    |
 LL | fn foo2(_bar: str) {}
-   |         ^^^^ doesn't have a size known at compile-time
+   |               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: unsized fn params are gated as an unstable feature
@@ -25,10 +25,10 @@ LL | fn foo2(_bar: &str) {}
    |               +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized-function-parameter.rs:17:9
+  --> $DIR/unsized-function-parameter.rs:17:12
    |
 LL | fn foo3(_: str) {}
-   |         ^ doesn't have a size known at compile-time
+   |            ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/suggestions/unsized-function-parameter.stderr
+++ b/tests/ui/suggestions/unsized-function-parameter.stderr
@@ -5,7 +5,7 @@ LL | fn foo1(bar: str) {}
    |              ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn foo1(bar: &str) {}
@@ -18,7 +18,7 @@ LL | fn foo2(_bar: str) {}
    |               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn foo2(_bar: &str) {}
@@ -31,7 +31,7 @@ LL | fn foo3(_: str) {}
    |            ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn foo3(_: &str) {}

--- a/tests/ui/trait-bounds/apit-unsized.stderr
+++ b/tests/ui/trait-bounds/apit-unsized.stderr
@@ -1,10 +1,11 @@
 error[E0277]: the size for values of type `impl Iterator<Item = i32> + ?Sized` cannot be known at compilation time
-  --> $DIR/apit-unsized.rs:1:8
+  --> $DIR/apit-unsized.rs:1:11
    |
 LL | fn foo(_: impl Iterator<Item = i32> + ?Sized) {}
-   |        ^  ---------------------------------- this type parameter needs to be `Sized`
-   |        |
-   |        doesn't have a size known at compile-time
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           |
+   |           doesn't have a size known at compile-time
+   |           this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -18,12 +19,13 @@ LL | fn foo(_: &impl Iterator<Item = i32> + ?Sized) {}
    |           +
 
 error[E0277]: the size for values of type `impl ?Sized` cannot be known at compilation time
-  --> $DIR/apit-unsized.rs:2:8
+  --> $DIR/apit-unsized.rs:2:11
    |
 LL | fn bar(_: impl ?Sized) {}
-   |        ^  ----------- this type parameter needs to be `Sized`
-   |        |
-   |        doesn't have a size known at compile-time
+   |           ^^^^^^^^^^^
+   |           |
+   |           doesn't have a size known at compile-time
+   |           this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider replacing `?Sized` with `Sized`

--- a/tests/ui/trait-bounds/apit-unsized.stderr
+++ b/tests/ui/trait-bounds/apit-unsized.stderr
@@ -2,10 +2,7 @@ error[E0277]: the size for values of type `impl Iterator<Item = i32> + ?Sized` c
   --> $DIR/apit-unsized.rs:1:11
    |
 LL | fn foo(_: impl Iterator<Item = i32> + ?Sized) {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |           |
-   |           doesn't have a size known at compile-time
-   |           this type parameter needs to be `Sized`
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -22,10 +19,7 @@ error[E0277]: the size for values of type `impl ?Sized` cannot be known at compi
   --> $DIR/apit-unsized.rs:2:11
    |
 LL | fn bar(_: impl ?Sized) {}
-   |           ^^^^^^^^^^^
-   |           |
-   |           doesn't have a size known at compile-time
-   |           this type parameter needs to be `Sized`
+   |           ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider replacing `?Sized` with `Sized`

--- a/tests/ui/trait-bounds/apit-unsized.stderr
+++ b/tests/ui/trait-bounds/apit-unsized.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `impl Iterator<Item = i32> + ?Sized` c
 LL | fn foo(_: impl Iterator<Item = i32> + ?Sized) {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn foo(_: impl Iterator<Item = i32> + ?Sized) {}
@@ -21,7 +21,7 @@ error[E0277]: the size for values of type `impl ?Sized` cannot be known at compi
 LL | fn bar(_: impl ?Sized) {}
    |           ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider replacing `?Sized` with `Sized`
    |
 LL - fn bar(_: impl ?Sized) {}

--- a/tests/ui/traits/alias/dont-elaborate-non-self.stderr
+++ b/tests/ui/traits/alias/dont-elaborate-non-self.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn Fn() -> Fut + 'static)` cannot be known at compilation time
-  --> $DIR/dont-elaborate-non-self.rs:7:11
+  --> $DIR/dont-elaborate-non-self.rs:7:14
    |
 LL | fn f<Fut>(a: dyn F<Fut>) {}
-   |           ^ doesn't have a size known at compile-time
+   |              ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() -> Fut + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/traits/alias/dont-elaborate-non-self.stderr
+++ b/tests/ui/traits/alias/dont-elaborate-non-self.stderr
@@ -5,7 +5,7 @@ LL | fn f<Fut>(a: dyn F<Fut>) {}
    |              ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() -> Fut + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | fn f<Fut>(a: impl F<Fut>) {}

--- a/tests/ui/traits/bound/not-on-bare-trait-2021.rs
+++ b/tests/ui/traits/bound/not-on-bare-trait-2021.rs
@@ -6,14 +6,25 @@ trait Foo {
 // This should emit the less confusing error, not the more confusing one.
 
 fn foo(_x: Foo + Send) {
-    //~^ ERROR trait objects must include the `dyn` keyword
-    //~| ERROR size for values of type
+    //~^ ERROR size for values of type
 }
 fn bar(x: Foo) -> Foo {
+    //~^ ERROR size for values of type
+    x
+}
+fn bat(x: &Foo) -> Foo {
+    //~^ ERROR return type cannot have an unboxed trait object
+    //~| ERROR trait objects must include the `dyn` keyword
+    x
+}
+fn bae(x: &Foo) -> &Foo {
     //~^ ERROR trait objects must include the `dyn` keyword
     //~| ERROR trait objects must include the `dyn` keyword
-    //~| ERROR size for values of type
     x
+}
+fn qux() -> Foo {
+    //~^ ERROR return type cannot have an unboxed trait object
+    todo!()
 }
 
 fn main() {}

--- a/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
-  --> $DIR/not-on-bare-trait-2021.rs:8:8
+  --> $DIR/not-on-bare-trait-2021.rs:8:12
    |
 LL | fn foo(_x: Foo + Send) {
-   |        ^^ doesn't have a size known at compile-time
+   |            ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
    = help: unsized fn params are gated as an unstable feature
@@ -16,10 +16,10 @@ LL | fn foo(_x: &(dyn Foo + Send)) {
    |            +++++           +
 
 error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
-  --> $DIR/not-on-bare-trait-2021.rs:12:8
+  --> $DIR/not-on-bare-trait-2021.rs:12:11
    |
 LL | fn bar(x: Foo) -> Foo {
-   |        ^ doesn't have a size known at compile-time
+   |           ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
@@ -16,7 +16,7 @@ LL | fn foo(_x: &(dyn Foo + Send)) {
    |            +++++           +
 
 error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
-  --> $DIR/not-on-bare-trait-2021.rs:12:11
+  --> $DIR/not-on-bare-trait-2021.rs:11:11
    |
 LL | fn bar(x: Foo) -> Foo {
    |           ^^^ doesn't have a size known at compile-time
@@ -32,60 +32,79 @@ help: function arguments must have a statically known size, borrowed types alway
 LL | fn bar(x: &dyn Foo) -> Foo {
    |           ++++
 
-error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/not-on-bare-trait-2021.rs:8:12
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/not-on-bare-trait-2021.rs:15:20
    |
-LL | fn foo(_x: Foo + Send) {
-   |            ^^^^^^^^^^
+LL | fn bat(x: &Foo) -> Foo {
+   |                    ^^^ doesn't have a size known at compile-time
    |
-help: use a new generic type parameter, constrained by `Foo + Send`
+help: return an `impl Trait` instead of a `dyn Trait`
    |
-LL | fn foo<T: Foo + Send>(_x: T) {
-   |       +++++++++++++++     ~
-help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
+LL | fn bat(x: &Foo) -> impl Foo {
+   |                    ++++
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
-LL | fn foo(_x: impl Foo + Send) {
-   |            ++++
-help: alternatively, use a trait object to accept any type that implements `Foo + Send`, accessing its methods at runtime using dynamic dispatch
+LL ~ fn bat(x: &Foo) -> Box<dyn Foo> {
+LL |
+LL |
+LL ~     Box::new(x)
    |
-LL | fn foo(_x: &(dyn Foo + Send)) {
-   |            +++++           +
+help: finally, you might be able to borrow from the function's argument
+   |
+LL | fn bat(x: &Foo) -> &dyn Foo {
+   |                    ++++
+
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/not-on-bare-trait-2021.rs:25:13
+   |
+LL | fn qux() -> Foo {
+   |             ^^^ doesn't have a size known at compile-time
+   |
+help: return an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn qux() -> impl Foo {
+   |             ++++
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn qux() -> Box<dyn Foo> {
+LL |
+LL ~     Box::new(todo!())
+   |
 
 error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/not-on-bare-trait-2021.rs:12:11
+  --> $DIR/not-on-bare-trait-2021.rs:15:12
    |
-LL | fn bar(x: Foo) -> Foo {
-   |           ^^^
+LL | fn bat(x: &Foo) -> Foo {
+   |            ^^^
    |
-help: use a new generic type parameter, constrained by `Foo`
+help: add `dyn` keyword before this trait
    |
-LL | fn bar<T: Foo>(x: T) -> Foo {
-   |       ++++++++    ~
-help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
-   |
-LL | fn bar(x: impl Foo) -> Foo {
-   |           ++++
-help: alternatively, use a trait object to accept any type that implements `Foo`, accessing its methods at runtime using dynamic dispatch
-   |
-LL | fn bar(x: &dyn Foo) -> Foo {
-   |           ++++
+LL | fn bat(x: &dyn Foo) -> Foo {
+   |            +++
 
 error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/not-on-bare-trait-2021.rs:12:19
+  --> $DIR/not-on-bare-trait-2021.rs:20:12
    |
-LL | fn bar(x: Foo) -> Foo {
-   |                   ^^^
+LL | fn bae(x: &Foo) -> &Foo {
+   |            ^^^
    |
-help: use `impl Foo` to return an opaque type, as long as you return a single underlying type
+help: add `dyn` keyword before this trait
    |
-LL | fn bar(x: Foo) -> impl Foo {
-   |                   ++++
-help: alternatively, you can return a boxed trait object
-   |
-LL | fn bar(x: Foo) -> Box<dyn Foo> {
-   |                   +++++++    +
+LL | fn bae(x: &dyn Foo) -> &Foo {
+   |            +++
 
-error: aborting due to 5 previous errors
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/not-on-bare-trait-2021.rs:20:21
+   |
+LL | fn bae(x: &Foo) -> &Foo {
+   |                     ^^^
+   |
+help: add `dyn` keyword before this trait
+   |
+LL | fn bae(x: &Foo) -> &dyn Foo {
+   |                     +++
 
-Some errors have detailed explanations: E0277, E0782.
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0277, E0746, E0782.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
@@ -80,7 +80,7 @@ help: use `impl Foo` to return an opaque type, as long as you return a single un
    |
 LL | fn bar(x: Foo) -> impl Foo {
    |                   ++++
-help: alternatively, you can return an owned trait object
+help: alternatively, you can return a boxed trait object
    |
 LL | fn bar(x: Foo) -> Box<dyn Foo> {
    |                   +++++++    +

--- a/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
@@ -60,6 +60,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn qux() -> Foo {
    |             ^^^ doesn't have a size known at compile-time
    |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn qux() -> impl Foo {

--- a/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
@@ -5,7 +5,7 @@ LL | fn foo(_x: Foo + Send) {
    |            ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | fn foo(_x: impl Foo + Send) {
@@ -22,7 +22,7 @@ LL | fn bar(x: Foo) -> Foo {
    |           ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | fn bar(x: impl Foo) -> Foo {

--- a/tests/ui/traits/bound/not-on-bare-trait.rs
+++ b/tests/ui/traits/bound/not-on-bare-trait.rs
@@ -12,5 +12,28 @@ fn foo(_x: Foo + Send) {
 fn bar(_x: (dyn Foo + Send)) {
     //~^ ERROR the size for values of type
 }
+fn bat(x: &Foo) -> Foo {
+    //~^ ERROR return type cannot have an unboxed trait object
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
+    //~| WARN this is accepted in the current edition
+    //~| WARN this is accepted in the current edition
+    x
+}
+fn bae(x: &Foo) -> &Foo {
+    //~^ WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
+    //~| WARN this is accepted in the current edition
+    x
+}
+fn qux() -> Foo {
+    //~^ ERROR return type cannot have an unboxed trait object
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
+    todo!()
+}
 
 fn main() {}

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -154,6 +154,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn qux() -> Foo {
    |             ^^^ doesn't have a size known at compile-time
    |
+   = help: if the returned value came from a borrowed argument that implements the trait, then you could return `&dyn Trait`
 help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn qux() -> impl Foo {

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -13,10 +13,10 @@ LL | fn foo(_x: dyn Foo + Send) {
    |            +++
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
-  --> $DIR/not-on-bare-trait.rs:7:8
+  --> $DIR/not-on-bare-trait.rs:7:12
    |
 LL | fn foo(_x: Foo + Send) {
-   |        ^^ doesn't have a size known at compile-time
+   |            ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
    = help: unsized fn params are gated as an unstable feature
@@ -30,10 +30,10 @@ LL | fn foo(_x: &(dyn Foo + Send)) {
    |            +++++           +
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
-  --> $DIR/not-on-bare-trait.rs:12:8
+  --> $DIR/not-on-bare-trait.rs:12:13
    |
 LL | fn bar(_x: (dyn Foo + Send)) {
-   |        ^^ doesn't have a size known at compile-time
+   |             ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -12,6 +12,71 @@ help: if this is an object-safe trait, use `dyn`
 LL | fn foo(_x: dyn Foo + Send) {
    |            +++
 
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/not-on-bare-trait.rs:15:12
+   |
+LL | fn bat(x: &Foo) -> Foo {
+   |            ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: if this is an object-safe trait, use `dyn`
+   |
+LL | fn bat(x: &dyn Foo) -> Foo {
+   |            +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/not-on-bare-trait.rs:15:20
+   |
+LL | fn bat(x: &Foo) -> Foo {
+   |                    ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: if this is an object-safe trait, use `dyn`
+   |
+LL | fn bat(x: &Foo) -> dyn Foo {
+   |                    +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/not-on-bare-trait.rs:25:12
+   |
+LL | fn bae(x: &Foo) -> &Foo {
+   |            ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: if this is an object-safe trait, use `dyn`
+   |
+LL | fn bae(x: &dyn Foo) -> &Foo {
+   |            +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/not-on-bare-trait.rs:25:21
+   |
+LL | fn bae(x: &Foo) -> &Foo {
+   |                     ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: if this is an object-safe trait, use `dyn`
+   |
+LL | fn bae(x: &Foo) -> &dyn Foo {
+   |                     +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/not-on-bare-trait.rs:32:13
+   |
+LL | fn qux() -> Foo {
+   |             ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: if this is an object-safe trait, use `dyn`
+   |
+LL | fn qux() -> dyn Foo {
+   |             +++
+
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
   --> $DIR/not-on-bare-trait.rs:7:12
    |
@@ -46,6 +111,63 @@ help: function arguments must have a statically known size, borrowed types alway
 LL | fn bar(_x: (&(dyn Foo + Send))) {
    |             ++              +
 
-error: aborting due to 2 previous errors; 1 warning emitted
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/not-on-bare-trait.rs:15:20
+   |
+LL | fn bat(x: &Foo) -> Foo {
+   |                    ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: if this is an object-safe trait, use `dyn`
+   |
+LL | fn bat(x: &Foo) -> dyn Foo {
+   |                    +++
 
-For more information about this error, try `rustc --explain E0277`.
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/not-on-bare-trait.rs:15:20
+   |
+LL | fn bat(x: &Foo) -> Foo {
+   |                    ^^^ doesn't have a size known at compile-time
+   |
+help: return an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn bat(x: &Foo) -> impl Foo {
+   |                    ++++
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn bat(x: &Foo) -> Box<dyn Foo> {
+LL |
+ ...
+LL |
+LL ~     Box::new(x)
+   |
+help: finally, you might be able to borrow from the function's argument
+   |
+LL | fn bat(x: &Foo) -> &dyn Foo {
+   |                    ++++
+
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/not-on-bare-trait.rs:32:13
+   |
+LL | fn qux() -> Foo {
+   |             ^^^ doesn't have a size known at compile-time
+   |
+help: return an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn qux() -> impl Foo {
+   |             ++++
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn qux() -> Box<dyn Foo> {
+LL |
+LL |
+LL |
+LL ~     Box::new(todo!())
+   |
+
+error: aborting due to 4 previous errors; 7 warnings emitted
+
+Some errors have detailed explanations: E0277, E0746.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -95,10 +95,10 @@ LL | fn foo(_x: &(dyn Foo + Send)) {
    |            +++++           +
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
-  --> $DIR/not-on-bare-trait.rs:12:13
+  --> $DIR/not-on-bare-trait.rs:12:12
    |
 LL | fn bar(_x: (dyn Foo + Send)) {
-   |             ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |            ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -84,7 +84,7 @@ LL | fn foo(_x: Foo + Send) {
    |            ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | fn foo(_x: impl Foo + Send) {
@@ -101,7 +101,7 @@ LL | fn bar(_x: (dyn Foo + Send)) {
    |            ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: you can use `impl Trait` as the argument type
    |
 LL | fn bar(_x: (impl Foo + Send)) {

--- a/tests/ui/type/type-check/unknown_type_for_closure.stderr
+++ b/tests/ui/type/type-check/unknown_type_for_closure.stderr
@@ -16,10 +16,10 @@ LL |     let x = |_: /* Type */| {};
    |               ++++++++++++
 
 error[E0282]: type annotations needed
-  --> $DIR/unknown_type_for_closure.rs:10:14
+  --> $DIR/unknown_type_for_closure.rs:10:17
    |
 LL |     let x = |k: _| {};
-   |              ^ cannot infer type
+   |                 ^ cannot infer type
 
 error[E0282]: type annotations needed
   --> $DIR/unknown_type_for_closure.rs:14:28

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -358,10 +358,10 @@ LL ~         b: (T, T),
    |
 
 error[E0282]: type annotations needed
-  --> $DIR/typeck_type_placeholder_item.rs:128:18
+  --> $DIR/typeck_type_placeholder_item.rs:128:21
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
-   |                  ^ cannot infer type
+   |                     ^ cannot infer type
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:128:28

--- a/tests/ui/unsized-locals/issue-30276-feature-flagged.stderr
+++ b/tests/ui/unsized-locals/issue-30276-feature-flagged.stderr
@@ -14,8 +14,7 @@ LL |     let _x: fn(_) -> Test = Test;
    |                             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-   = note: all function arguments must have a statically known size
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/unsized-locals/issue-30276.stderr
+++ b/tests/ui/unsized-locals/issue-30276.stderr
@@ -5,8 +5,7 @@ LL |     let _x: fn(_) -> Test = Test;
    |                             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-   = note: all function arguments must have a statically known size
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unsized-locals/issue-50940.stderr
+++ b/tests/ui/unsized-locals/issue-50940.stderr
@@ -5,8 +5,7 @@ LL |     A as fn(str) -> A<str>;
    |     ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = note: all function arguments must have a statically known size
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unsized-locals/issue-67981.stderr
+++ b/tests/ui/unsized-locals/issue-67981.stderr
@@ -5,7 +5,6 @@ LL |     let f: fn([u8]) = |_| {};
    |                        ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all function arguments must have a statically known size
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unsized-locals/suggest-borrow.stderr
+++ b/tests/ui/unsized-locals/suggest-borrow.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/suggest-borrow.rs:2:9
+  --> $DIR/suggest-borrow.rs:2:12
    |
 LL |     let x: [u8] = vec!(1, 2, 3)[..];
-   |         ^ doesn't have a size known at compile-time
+   |            ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: all local variables must have a statically known size
@@ -44,10 +44,10 @@ LL |     let x: &[u8] = &vec!(1, 2, 3)[..];
    |            +
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/suggest-borrow.rs:4:9
+  --> $DIR/suggest-borrow.rs:4:19
    |
 LL |     let x: [u8] = &vec!(1, 2, 3)[..];
-   |         ^ doesn't have a size known at compile-time
+   |                   ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: all local variables must have a statically known size

--- a/tests/ui/unsized-locals/suggest-borrow.stderr
+++ b/tests/ui/unsized-locals/suggest-borrow.stderr
@@ -5,9 +5,8 @@ LL |     let x: [u8] = vec!(1, 2, 3)[..];
    |            ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-help: consider borrowing here
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
+help: borrowed types have a statically known size
    |
 LL |     let x: &[u8] = vec!(1, 2, 3)[..];
    |            +
@@ -50,9 +49,8 @@ LL |     let x: [u8] = &vec!(1, 2, 3)[..];
    |                   ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-help: consider borrowing here
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
+help: borrowed types have a statically known size
    |
 LL |     let x: &[u8] = &vec!(1, 2, 3)[..];
    |            +

--- a/tests/ui/unsized-locals/unsized-exprs3.stderr
+++ b/tests/ui/unsized-locals/unsized-exprs3.stderr
@@ -5,8 +5,7 @@ LL |     udrop as fn([u8]);
    |     ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all function arguments must have a statically known size
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unsized-locals/unsized-locals-using-unsized-fn-params.stderr
+++ b/tests/ui/unsized-locals/unsized-locals-using-unsized-fn-params.stderr
@@ -19,10 +19,10 @@ LL | fn f2((_x, _y): (i32, [i32])) {}
    = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/unsized-locals-using-unsized-fn-params.rs:13:9
+  --> $DIR/unsized-locals-using-unsized-fn-params.rs:13:15
    |
 LL |     let _foo: [u8] = *foo;
-   |         ^^^^ doesn't have a size known at compile-time
+   |               ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: all local variables must have a statically known size

--- a/tests/ui/unsized-locals/unsized-locals-using-unsized-fn-params.stderr
+++ b/tests/ui/unsized-locals/unsized-locals-using-unsized-fn-params.stderr
@@ -5,8 +5,7 @@ LL | fn f1(box box _b: Box<Box<[u8]>>) {}
    |               ^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
   --> $DIR/unsized-locals-using-unsized-fn-params.rs:8:12
@@ -15,8 +14,7 @@ LL | fn f2((_x, _y): (i32, [i32])) {}
    |            ^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/unsized-locals-using-unsized-fn-params.rs:13:15
@@ -25,9 +23,8 @@ LL |     let _foo: [u8] = *foo;
    |               ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-help: consider borrowing here
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
+help: borrowed types have a statically known size
    |
 LL |     let _foo: &[u8] = *foo;
    |               +

--- a/tests/ui/unsized/box-instead-of-dyn-fn.stderr
+++ b/tests/ui/unsized/box-instead-of-dyn-fn.stderr
@@ -4,17 +4,21 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> dyn Fn() + 'a {
    |                                                        ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> impl Fn() + 'a {
    |                                                        ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> Box<dyn Fn() + 'a> {
 LL |
 LL |     if a % 2 == 0 {
 LL ~         Box::new(move || println!("{a}"))
    |
+help: finally, you might be able to borrow from the function's argument
+   |
+LL | fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> &dyn Fn() + 'a {
+   |                                                        +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unsized/issue-30355.stderr
+++ b/tests/ui/unsized/issue-30355.stderr
@@ -5,8 +5,7 @@ LL |     &X(*Y)
    |        ^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all function arguments must have a statically known size
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unsized/issue-91801.stderr
+++ b/tests/ui/unsized/issue-91801.stderr
@@ -4,10 +4,7 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Validator<'a> {
    |                                                                             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: box the return type, and wrap all of the returned values in `Box::new`
-   |
-LL | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Box<Validator<'a>> {
-   |                                                                             ++++             +
+   = note: the return type of a function must have a statically known size
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unsized/issue-91801.stderr
+++ b/tests/ui/unsized/issue-91801.stderr
@@ -4,7 +4,14 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Validator<'a> {
    |                                                                             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = note: the return type of a function must have a statically known size
+help: box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
+   |
+LL | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Box<Validator<'a>> {
+   |                                                                             ++++             +
+help: alternatively, you might be able to borrow from one of the function's arguments
+   |
+LL | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> &Validator<'a> {
+   |                                                                             +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unsized/issue-91803.stderr
+++ b/tests/ui/unsized/issue-91803.stderr
@@ -4,14 +4,18 @@ error[E0746]: return type cannot have an unboxed trait object
 LL | fn or<'a>(first: &'static dyn Foo<'a>) -> dyn Foo<'a> {
    |                                           ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+help: return an `impl Trait` instead of a `dyn Trait`
    |
 LL | fn or<'a>(first: &'static dyn Foo<'a>) -> impl Foo<'a> {
    |                                           ~~~~
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
    |
 LL | fn or<'a>(first: &'static dyn Foo<'a>) -> Box<dyn Foo<'a>> {
    |                                           ++++           +
+help: finally, you might be able to borrow from the function's argument
+   |
+LL | fn or<'a>(first: &'static dyn Foo<'a>) -> &dyn Foo<'a> {
+   |                                           +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unsized/unsized-fn-arg.stderr
+++ b/tests/ui/unsized/unsized-fn-arg.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/unsized-fn-arg.rs:5:17
+  --> $DIR/unsized-fn-arg.rs:5:20
    |
 LL | fn f<T: ?Sized>(t: T) {}
-   |      -          ^ doesn't have a size known at compile-time
+   |      -             ^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `Sized`
    |

--- a/tests/ui/unsized/unsized-fn-arg.stderr
+++ b/tests/ui/unsized/unsized-fn-arg.stderr
@@ -6,7 +6,7 @@ LL | fn f<T: ?Sized>(t: T) {}
    |      |
    |      this type parameter needs to be `Sized`
    |
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f<T: ?Sized>(t: T) {}

--- a/tests/ui/unsized/unsized6.stderr
+++ b/tests/ui/unsized/unsized6.stderr
@@ -196,10 +196,10 @@ LL + fn f4<X: T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:38:18
+  --> $DIR/unsized6.rs:38:21
    |
 LL | fn g1<X: ?Sized>(x: X) {}
-   |       -          ^ doesn't have a size known at compile-time
+   |       -             ^ doesn't have a size known at compile-time
    |       |
    |       this type parameter needs to be `Sized`
    |
@@ -215,10 +215,10 @@ LL | fn g1<X: ?Sized>(x: &X) {}
    |                     +
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:40:22
+  --> $DIR/unsized6.rs:40:25
    |
 LL | fn g2<X: ?Sized + T>(x: X) {}
-   |       -              ^ doesn't have a size known at compile-time
+   |       -                 ^ doesn't have a size known at compile-time
    |       |
    |       this type parameter needs to be `Sized`
    |

--- a/tests/ui/unsized/unsized6.stderr
+++ b/tests/ui/unsized/unsized6.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the size for values of type `Y` cannot be known at compilation time
-  --> $DIR/unsized6.rs:9:9
+  --> $DIR/unsized6.rs:9:12
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
    |                             - this type parameter needs to be `Sized`
 ...
 LL |     let y: Y;
-   |         ^ doesn't have a size known at compile-time
+   |            ^ doesn't have a size known at compile-time
    |
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -52,12 +52,12 @@ LL + fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z>(x: &X) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:15:9
+  --> $DIR/unsized6.rs:15:12
    |
 LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
    |       - this type parameter needs to be `Sized`
 LL |     let y: X;
-   |         ^ doesn't have a size known at compile-time
+   |            ^ doesn't have a size known at compile-time
    |
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -88,12 +88,12 @@ LL + fn f2<X: ?Sized, Y>(x: &X) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:22:9
+  --> $DIR/unsized6.rs:22:12
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |       - this type parameter needs to be `Sized`
 LL |     let y: X = *x1;
-   |         ^ doesn't have a size known at compile-time
+   |            ^ doesn't have a size known at compile-time
    |
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -108,13 +108,13 @@ LL |     let y: &X = *x1;
    |            +
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:24:9
+  --> $DIR/unsized6.rs:24:13
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |       - this type parameter needs to be `Sized`
 ...
 LL |     let y = *x2;
-   |         ^ doesn't have a size known at compile-time
+   |             ^^^ doesn't have a size known at compile-time
    |
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -142,12 +142,12 @@ LL + fn f3<X>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:30:9
+  --> $DIR/unsized6.rs:30:12
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |       - this type parameter needs to be `Sized`
 LL |     let y: X = *x1;
-   |         ^ doesn't have a size known at compile-time
+   |            ^ doesn't have a size known at compile-time
    |
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -162,13 +162,13 @@ LL |     let y: &X = *x1;
    |            +
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:32:9
+  --> $DIR/unsized6.rs:32:13
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |       - this type parameter needs to be `Sized`
 ...
 LL |     let y = *x2;
-   |         ^ doesn't have a size known at compile-time
+   |             ^^^ doesn't have a size known at compile-time
    |
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature

--- a/tests/ui/unsized/unsized6.stderr
+++ b/tests/ui/unsized/unsized6.stderr
@@ -7,14 +7,13 @@ LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
 LL |     let y: Y;
    |            ^ doesn't have a size known at compile-time
    |
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
 LL + fn f1<W: ?Sized, X: ?Sized, Y, Z: ?Sized>(x: &X) {
    |
-help: consider borrowing here
+help: borrowed types have a statically known size
    |
 LL |     let y: &Y;
    |            +
@@ -59,14 +58,13 @@ LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
 LL |     let y: X;
    |            ^ doesn't have a size known at compile-time
    |
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
 LL + fn f2<X, Y: ?Sized>(x: &X) {
    |
-help: consider borrowing here
+help: borrowed types have a statically known size
    |
 LL |     let y: &X;
    |            +
@@ -95,14 +93,13 @@ LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let y: X = *x1;
    |            ^ doesn't have a size known at compile-time
    |
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL + fn f3<X>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |
-help: consider borrowing here
+help: borrowed types have a statically known size
    |
 LL |     let y: &X = *x1;
    |            +
@@ -116,8 +113,7 @@ LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let y = *x2;
    |             ^^^ doesn't have a size known at compile-time
    |
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
@@ -133,8 +129,7 @@ LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let (y, z) = (*x3, 4);
    |                   ^^^ doesn't have a size known at compile-time
    |
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
@@ -149,14 +144,13 @@ LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let y: X = *x1;
    |            ^ doesn't have a size known at compile-time
    |
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL + fn f4<X: T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |
-help: consider borrowing here
+help: borrowed types have a statically known size
    |
 LL |     let y: &X = *x1;
    |            +
@@ -170,8 +164,7 @@ LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let y = *x2;
    |             ^^^ doesn't have a size known at compile-time
    |
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
@@ -187,8 +180,7 @@ LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL |     let (y, z) = (*x3, 4);
    |                   ^^^ doesn't have a size known at compile-time
    |
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
+   = help: unsized locals are gated as unstable feature `#[feature(unsized_locals)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
@@ -203,7 +195,7 @@ LL | fn g1<X: ?Sized>(x: X) {}
    |       |
    |       this type parameter needs to be `Sized`
    |
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn g1<X: ?Sized>(x: X) {}
@@ -222,7 +214,7 @@ LL | fn g2<X: ?Sized + T>(x: X) {}
    |       |
    |       this type parameter needs to be `Sized`
    |
-   = help: unsized fn params are gated as an unstable feature
+   = help: unsized fn params are gated as unstable feature `#[feature(unsized_fn_params)]`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn g2<X: ?Sized + T>(x: X) {}

--- a/tests/ui/unsized/unsized6.stderr
+++ b/tests/ui/unsized/unsized6.stderr
@@ -125,13 +125,13 @@ LL + fn f3<X>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:26:10
+  --> $DIR/unsized6.rs:26:19
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |       - this type parameter needs to be `Sized`
 ...
 LL |     let (y, z) = (*x3, 4);
-   |          ^ doesn't have a size known at compile-time
+   |                   ^^^ doesn't have a size known at compile-time
    |
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
@@ -179,13 +179,13 @@ LL + fn f4<X: T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:34:10
+  --> $DIR/unsized6.rs:34:19
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |       - this type parameter needs to be `Sized`
 ...
 LL |     let (y, z) = (*x3, 4);
-   |          ^ doesn't have a size known at compile-time
+   |                   ^^^ doesn't have a size known at compile-time
    |
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/122957)*
<!-- homu-ignore:end -->

Rework impl Trait and Box<dyn Trait> return type suggestions in E0746

* If the return value types diverge, mention it and do not suggest `impl Trait`
* If the returned `dyn Trait` is not object safe, mention it and do not suggest `Box<dyn Trait>` and boxing the returned values
* If the function has arguments with borrowed types, suggest `&dyn Trait`
* Tweak wording of `E0782`

```
error[E0746]: return type cannot have an unboxed trait object
  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:13:13
   |
LL | fn bap() -> Trait { Struct }
   |             ^^^^^ doesn't have a size known at compile-time
   |
help: return an `impl Trait` instead of a `dyn Trait`
   |
LL | fn bap() -> impl Trait { Struct }
   |             ++++
help: alternatively, box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
   |
LL | fn bap() -> Box<dyn Trait> { Box::new(Struct) }
   |             +++++++      +   +++++++++      +
```
```
error[E0746]: return type cannot have an unboxed trait object
  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:36:18
   |
LL | fn can(x: &A) -> dyn NotObjectSafe {
   |                  ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
   |
help: trait `NotObjectSafe` is not object safe, so you can't return a boxed trait object `Box<dyn NotObjectSafe>`
  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:36:22
   |
LL | fn can(x: &A) -> dyn NotObjectSafe {
   |                      ^^^^^^^^^^^^^
help: return an `impl Trait` instead of a `dyn Trait`
   |
LL | fn can(x: &A) -> impl NotObjectSafe {
   |                  ~~~~
help: alternatively, you might be able to borrow from the function's argument
   |
LL | fn can(x: &A) -> &dyn NotObjectSafe {
   |                  +
```
```
error[E0782]: trait objects must include the `dyn` keyword
  --> $DIR/not-on-bare-trait-2021.rs:12:19
   |
LL | fn bar(x: Foo) -> Foo {
   |                   ^^^
   |
help: use `impl Foo` to return an opaque type, as long as you return a single underlying type
   |
LL | fn bar(x: Foo) -> impl Foo {
   |                   ++++
help: alternatively, you can return a boxed trait object
   |
LL | fn bar(x: Foo) -> Box<dyn Foo> {
   |                   +++++++    +
```

Silence "missing dyn" error if "?Sized type" error is already emitted.

Account for `type Alias = dyn Trait;` in unsized return suggestion:

```
error[E0746]: return type cannot have an unboxed trait object
 --> tests/ui/unsized/issue-91801.rs:8:77
  |
8 | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Validator<'a> {
  |                                                                             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
-Ztrack-diagnostics: created at compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs:566:39
  |
help: box the return type to make a boxed trait object, and wrap all of the returned values in `Box::new`
  |
8 | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Box<Validator<'a>> {
  |                                                                             ++++             +
help: alternatively, you might be able to borrow from one of the function's arguments
  |
8 | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> &Validator<'a> {
  |                                                                             +
```

Use more complex logic for E0277 deduplication of `FullfillmentError`s, accounting and customizing the span for `SizedArgument` obligations and functions with unsized return types. We only emit one unsized local error whenever possible.

Point at the let binding type or init expression instead of the pattern when possible for `?Sized` errors.

```
error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
  --> $DIR/unsized-locals-using-unsized-fn-params.rs:13:15
   |
LL |     let _foo: [u8] = *foo;
   |               ^^^^ doesn't have a size known at compile-time
   |
   = help: the trait `Sized` is not implemented for `[u8]`
   = note: all local variables must have a statically known size
```

Fix rust-lang/rust#121037. Fix rust-lang/rust#105753.