### PR TITLE
Track run-make-support lib in common inputs stamp

### DIFF
--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -609,6 +609,8 @@ fn common_inputs_stamp(config: &Config) -> Stamp {
         stamp.add_path(&rust_src_dir.join("src/etc/htmldocck.py"));
     }
 
+    stamp.add_dir(&rust_src_dir.join("src/tools/run-make-support"));
+
     // Compiletest itself.
     stamp.add_dir(&rust_src_dir.join("src/tools/compiletest/"));
 


### PR DESCRIPTION
So that when the support library gets modified, `run-make` tests are forced to re-run instead of being still ignored as if nothing changed.

Fixes #122961.