### PR TITLE
Remove len argument from RawVec::reserve_for_push

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2087,7 +2087,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
         // buffer without it being full emerge
         debug_assert!(self.is_full());
         let old_cap = self.capacity();
-        self.buf.reserve_for_push();
+        self.buf.grow_one();
         unsafe {
             self.handle_capacity_increase(old_cap);
         }

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2086,9 +2086,10 @@ impl<T, A: Allocator> VecDeque<T, A> {
         // Extend or possibly remove this assertion when valid use-cases for growing the
         // buffer without it being full emerge
         debug_assert!(self.is_full());
+        let old_cap = self.capacity();
         self.buf.reserve_for_push();
         unsafe {
-            self.handle_capacity_increase(self.capacity());
+            self.handle_capacity_increase(old_cap);
         }
         debug_assert!(!self.is_full());
     }

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2086,10 +2086,9 @@ impl<T, A: Allocator> VecDeque<T, A> {
         // Extend or possibly remove this assertion when valid use-cases for growing the
         // buffer without it being full emerge
         debug_assert!(self.is_full());
-        let old_cap = self.capacity();
-        self.buf.reserve_for_push(old_cap);
+        self.buf.reserve_for_push();
         unsafe {
-            self.handle_capacity_increase(old_cap);
+            self.handle_capacity_increase(self.capacity());
         }
         debug_assert!(!self.is_full());
     }

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -349,8 +349,8 @@ impl<T, A: Allocator> RawVec<T, A> {
     /// oft-instantiated `Vec::push()`, which does its own capacity check.
     #[cfg(not(no_global_oom_handling))]
     #[inline(never)]
-    pub fn reserve_for_push(&mut self, len: usize) {
-        if let Err(err) = self.grow_amortized(len, 1) {
+    pub fn reserve_for_push(&mut self) {
+        if let Err(err) = self.grow_amortized(self.cap.0, 1) {
             handle_error(err);
         }
     }

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -345,11 +345,11 @@ impl<T, A: Allocator> RawVec<T, A> {
         }
     }
 
-    /// A specialized version of `reserve()` used only by the hot and
-    /// oft-instantiated `Vec::push()`, which does its own capacity check.
+    /// A specialized version of `self.reserve(len, 1)` which requires the
+    /// caller to ensure `len == self.capacity()`.
     #[cfg(not(no_global_oom_handling))]
     #[inline(never)]
-    pub fn reserve_for_push(&mut self) {
+    pub fn grow_one(&mut self) {
         if let Err(err) = self.grow_amortized(self.cap.0, 1) {
             handle_error(err);
         }

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1547,7 +1547,7 @@ impl<T, A: Allocator> Vec<T, A> {
 
         // space for the new element
         if len == self.buf.capacity() {
-            self.reserve(1);
+            self.buf.reserve_for_push();
         }
 
         unsafe {
@@ -1967,7 +1967,7 @@ impl<T, A: Allocator> Vec<T, A> {
         // This will panic or abort if we would allocate > isize::MAX bytes
         // or if the length increment would overflow for zero-sized types.
         if self.len == self.buf.capacity() {
-            self.buf.reserve_for_push(self.len);
+            self.buf.reserve_for_push();
         }
         unsafe {
             let end = self.as_mut_ptr().add(self.len);

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1547,7 +1547,7 @@ impl<T, A: Allocator> Vec<T, A> {
 
         // space for the new element
         if len == self.buf.capacity() {
-            self.buf.reserve_for_push();
+            self.buf.grow_one();
         }
 
         unsafe {
@@ -1967,7 +1967,7 @@ impl<T, A: Allocator> Vec<T, A> {
         // This will panic or abort if we would allocate > isize::MAX bytes
         // or if the length increment would overflow for zero-sized types.
         if self.len == self.buf.capacity() {
-            self.buf.reserve_for_push();
+            self.buf.grow_one();
         }
         unsafe {
             let end = self.as_mut_ptr().add(self.len);

--- a/tests/codegen/vec_pop_push_noop.rs
+++ b/tests/codegen/vec_pop_push_noop.rs
@@ -5,10 +5,10 @@
 #[no_mangle]
 // CHECK-LABEL: @noop(
 pub fn noop(v: &mut Vec<u8>) {
-    // CHECK-NOT: reserve_for_push
+    // CHECK-NOT: grow_one
     // CHECK-NOT: call
     // CHECK: tail call void @llvm.assume
-    // CHECK-NOT: reserve_for_push
+    // CHECK-NOT: grow_one
     // CHECK-NOT: call
     // CHECK: ret
     if let Some(x) = v.pop() {
@@ -19,6 +19,6 @@ pub fn noop(v: &mut Vec<u8>) {
 #[no_mangle]
 // CHECK-LABEL: @push_byte(
 pub fn push_byte(v: &mut Vec<u8>) {
-    // CHECK: call {{.*}}reserve_for_push
+    // CHECK: call {{.*}}grow_one
     v.push(3);
 }


### PR DESCRIPTION
Removes `RawVec::reserve_for_push`'s `len` argument since it's always the same as capacity.
Also makes `Vec::insert` use `RawVec::reserve_for_push`.