### PR TITLE
Fix build failure on ARM/AArch64/PowerPC/RISC-V FreeBSD/NetBSD

### DIFF
--- a/library/std/src/sys/pal/unix/net.rs
+++ b/library/std/src/sys/pal/unix/net.rs
@@ -459,7 +459,7 @@ impl Socket {
             const AF_NAME_MAX: usize = 16;
             let mut buf = [0; AF_NAME_MAX];
             for (src, dst) in name.to_bytes().iter().zip(&mut buf[..AF_NAME_MAX - 1]) {
-                *dst = *src as i8;
+                *dst = *src as libc::c_char;
             }
             let mut arg: libc::accept_filter_arg = unsafe { mem::zeroed() };
             arg.af_name = buf;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/pull/121881#discussion_r1536764650

Checked targets: aarch64-unknown-freebsd, powerpc64-unknown-freebsd, armv7-unknown-freebsd, riscv64gc-unknown-freebsd, aarch64-unknown-netbsd.

r? @Amanieu
cc @devnexen