### PR TITLE
panic-in-panic-hook: formatting a message that's just a string is risk-free

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -328,6 +328,7 @@
 #![feature(float_gamma)]
 #![feature(float_minimum_maximum)]
 #![feature(float_next_up_down)]
+#![feature(fmt_internals)]
 #![feature(generic_nonzero)]
 #![feature(hasher_prefixfree_extras)]
 #![feature(hashmap_internals)]

--- a/tests/ui/panics/panic-in-message-fmt.run.stderr
+++ b/tests/ui/panics/panic-in-message-fmt.run.stderr
@@ -1,2 +1,3 @@
 panicked at $DIR/panic-in-message-fmt.rs:18:9:
+not yet implemented
 thread panicked while processing panic. aborting.


### PR DESCRIPTION
This slightly improves the output in the 'panic while processing panic' case if the panic message does not involve any formatting. Follow-up to https://github.com/rust-lang/rust/pull/122930.

r? @Amanieu 