### PR TITLE
std::thread: refine available_parallelism for solaris/illumos.

### DIFF
--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -483,6 +483,12 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
                         .ok_or(io::const_io_error!(io::ErrorKind::NotFound, "The number of hardware threads is not known for the target platform"))
                 }
             }
+        } else if #[cfg(any(target_os = "solaris", target_os = "illumos"))] {
+            let mut cpus = 0u32;
+            if unsafe { libc::pset_info(libc::PS_MYID, core::ptr::null_mut(), &mut cpus, core::ptr::null_mut()) } == 0 {
+                NonZero::new(cpus as usize)
+                    .ok_or(io::const_io_error!(io::ErrorKind::NotFound, "The number of hardware threads is not known for the target platform"))
+            }
         } else if #[cfg(target_os = "haiku")] {
             // system_info cpu_count field gets the static data set at boot time with `smp_set_num_cpus`
             // `get_system_info` calls then `smp_get_num_cpus`

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -355,8 +355,6 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             target_os = "tvos",
             target_os = "linux",
             target_os = "macos",
-            target_os = "solaris",
-            target_os = "illumos",
             target_os = "aix",
         ))] {
             #[allow(unused_assignments)]
@@ -485,10 +483,10 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             }
         } else if #[cfg(any(target_os = "solaris", target_os = "illumos"))] {
             let mut cpus = 0u32;
-            if unsafe { libc::pset_info(libc::PS_MYID, core::ptr::null_mut(), &mut cpus, core::ptr::null_mut()) } == 0 {
-                NonZero::new(cpus as usize)
-                    .ok_or(io::const_io_error!(io::ErrorKind::NotFound, "The number of hardware threads is not known for the target platform"))
+            if unsafe { libc::pset_info(libc::PS_MYID, core::ptr::null_mut(), &mut cpus, core::ptr::null_mut()) } != 0 {
+                return Err(io::const_io_error!(io::ErrorKind::NotFound, "The number of hardware threads is not known for the target platform"));
             }
+            Ok(unsafe { NonZero::new_unchecked(cpus as usize) })
         } else if #[cfg(target_os = "haiku")] {
             // system_info cpu_count field gets the static data set at boot time with `smp_set_num_cpus`
             // `get_system_info` calls then `smp_get_num_cpus`


### PR DESCRIPTION
Rather than the system-wide available cpus fallback solution, we fetch the cpus bound to the current process.