### PR TITLE
give rustc_driver users a chance to overwrite the default sysroot

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -642,10 +642,6 @@ fn test_top_level_options_tracked_no_crate() {
 
     // Make sure that changing a [TRACKED_NO_CRATE_HASH] option leaves the crate hash unchanged but changes the incremental hash.
     // tidy-alphabetical-start
-    tracked!(
-        real_rust_source_base_dir,
-        Some("/home/bors/rust/.rustup/toolchains/nightly/lib/rustlib/src/rust".into())
-    );
     tracked!(remap_path_prefix, vec![("/home/bors/rust".into(), "src".into())]);
     // tidy-alphabetical-end
 }

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -197,14 +197,6 @@ top_level_options!(
 
         /// Remap source path prefixes in all output (messages, object files, debug, etc.).
         remap_path_prefix: Vec<(PathBuf, PathBuf)> [TRACKED_NO_CRATE_HASH],
-        /// Base directory containing the `src/` for the Rust standard library, and
-        /// potentially `rustc` as well, if we can find it. Right now it's always
-        /// `$sysroot/lib/rustlib/src/rust` (i.e. the `rustup` `rust-src` component).
-        ///
-        /// This directory is what the virtual `/rustc/$hash` is translated back to,
-        /// if Rust was built with path remapping to `/rustc/$hash` enabled
-        /// (the `rust.remap-debuginfo` option in `config.toml`).
-        real_rust_source_base_dir: Option<PathBuf> [TRACKED_NO_CRATE_HASH],
 
         edition: Edition [TRACKED],
 


### PR DESCRIPTION
and then use that in Miri.

This lets us get rid of an annoying arg-patching hack, and may help with https://github.com/rust-lang/miri/issues/3404.

Unfortunately the computation of `real_rust_source_base_dir` depended on knowing the default sysroot, so I had to move that around a bit. I have no idea how all this `Session` and `Options` stuff works  so I hope this makes sense.