### PR TITLE
Fix unpretty UI test when /tmp does not exist

### DIFF
--- a/tests/ui/unpretty/avoid-crash.rs
+++ b/tests/ui/unpretty/avoid-crash.rs
@@ -1,4 +1,4 @@
 //@ normalize-stderr-test "error `.*`" -> "$$ERROR_MESSAGE"
-//@ compile-flags: -o/tmp/ -Zunpretty=ast-tree
+//@ compile-flags: -o. -Zunpretty=ast-tree
 
 fn main() {}

--- a/tests/ui/unpretty/avoid-crash.stderr
+++ b/tests/ui/unpretty/avoid-crash.stderr
@@ -1,4 +1,4 @@
-error: failed to write `/tmp/` due to $ERROR_MESSAGE
+error: failed to write `.` due to $ERROR_MESSAGE
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
On Windows this test fails if e.g. `C:\tmp` is created successfully