### PR TITLE
Reduce enabled features for llvm-bitcode-linker

### DIFF
--- a/src/tools/llvm-bitcode-linker/Cargo.toml
+++ b/src/tools/llvm-bitcode-linker/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 tracing = "0.1"
-tracing-subscriber = {version = "0.3.0", features = ["std"] }
+tracing-subscriber = { version = "0.3.3", default-features = false, features = ["fmt", "env-filter", "ansi"] }
 clap = { version = "4.3", features = ["derive"] }
 thiserror = "1.0.24"


### PR DESCRIPTION
This hopefully reduces compile times. See [perf results] which show a +60% increase in tracing-subscriber and syn compile times, which I'm guessing are due to this.

[perf results]: https://perf.rust-lang.org/compare.html?start=65cd843ae06ad00123c131a431ed5304e4cd577a&end=6554a5645a13e4d9331fd028960d69be91d7492d&tab=bootstrap

r? @Mark-Simulacrum (perf first)