### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4634,6 +4634,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
+ "rustc_trait_selection",
  "tracing",
  "twox-hash",
 ]

--- a/compiler/rustc_symbol_mangling/Cargo.toml
+++ b/compiler/rustc_symbol_mangling/Cargo.toml
@@ -15,6 +15,7 @@ rustc_middle = { path = "../rustc_middle" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
+rustc_trait_selection = { path = "../rustc_trait_selection" }
 tracing = "0.1"
 twox-hash = "1.6.3"
 # tidy-alphabetical-end

--- a/compiler/rustc_symbol_mangling/src/lib.rs
+++ b/compiler/rustc_symbol_mangling/src/lib.rs
@@ -90,6 +90,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(rustdoc_internals)]
+#![feature(let_chains)]
 #![allow(internal_features)]
 
 #[macro_use]

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1356,7 +1356,7 @@ extern "rust-intrinsic" {
     /// let v_clone = v_orig.clone();
     ///
     /// // This is the suggested, safe way.
-    /// // It does copy the entire vector, though, into a new array.
+    /// // It may copy the entire vector into a new one though, but also may not.
     /// let v_collected = v_clone.into_iter()
     ///                          .map(Some)
     ///                          .collect::<Vec<Option<&i32>>>();

--- a/src/etc/lldb_commands
+++ b/src/etc/lldb_commands
@@ -16,4 +16,7 @@ type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)R
 type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)RefMut<.+>$" --category Rust
 type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)RefCell<.+>$" --category Rust
 type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)NonZero<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^core::num::([a-z_]+::)*NonZero.+$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(std::([a-z_]+::)+)PathBuf$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^&(mut )?(std::([a-z_]+::)+)Path$" --category Rust
 type category enable Rust

--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -58,6 +58,11 @@ def summary_lookup(valobj, dict):
     if rust_type == RustType.STD_NONZERO_NUMBER:
         return StdNonZeroNumberSummaryProvider(valobj, dict)
 
+    if rust_type == RustType.STD_PATHBUF:
+        return StdPathBufSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_PATH:
+        return StdPathSummaryProvider(valobj, dict)
+
     return ""
 
 

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -173,6 +173,35 @@ def StdStrSummaryProvider(valobj, dict):
     return '"%s"' % data
 
 
+def StdPathBufSummaryProvider(valobj, dict):
+    # type: (SBValue, dict) -> str
+    # logger = Logger.Logger()
+    # logger >> "[StdPathBufSummaryProvider] for " + str(valobj.GetName())
+    return StdOsStringSummaryProvider(valobj.GetChildMemberWithName("inner"), dict)
+
+
+def StdPathSummaryProvider(valobj, dict):
+    # type: (SBValue, dict) -> str
+    # logger = Logger.Logger()
+    # logger >> "[StdPathSummaryProvider] for " + str(valobj.GetName())
+    length = valobj.GetChildMemberWithName("length").GetValueAsUnsigned()
+    if length == 0:
+        return '""'
+
+    data_ptr = valobj.GetChildMemberWithName("data_ptr")
+
+    start = data_ptr.GetValueAsUnsigned()
+    error = SBError()
+    process = data_ptr.GetProcess()
+    data = process.ReadMemory(start, length, error)
+    if PY3:
+        try:
+            data = data.decode(encoding='UTF-8')
+        except UnicodeDecodeError:
+            return '%r' % data
+    return '"%s"' % data
+
+
 class StructSyntheticProvider:
     """Pretty-printer for structs and struct enum variants"""
 

--- a/src/etc/rust_types.py
+++ b/src/etc/rust_types.py
@@ -32,6 +32,8 @@ class RustType(object):
     STD_REF_MUT = "StdRefMut"
     STD_REF_CELL = "StdRefCell"
     STD_NONZERO_NUMBER = "StdNonZeroNumber"
+    STD_PATH = "StdPath"
+    STD_PATHBUF = "StdPathBuf"
 
 
 STD_STRING_REGEX = re.compile(r"^(alloc::([a-z_]+::)+)String$")
@@ -51,6 +53,8 @@ STD_REF_REGEX = re.compile(r"^(core::([a-z_]+::)+)Ref<.+>$")
 STD_REF_MUT_REGEX = re.compile(r"^(core::([a-z_]+::)+)RefMut<.+>$")
 STD_REF_CELL_REGEX = re.compile(r"^(core::([a-z_]+::)+)RefCell<.+>$")
 STD_NONZERO_NUMBER_REGEX = re.compile(r"^(core::([a-z_]+::)+)NonZero<.+>$")
+STD_PATHBUF_REGEX = re.compile(r"^(std::([a-z_]+::)+)PathBuf$")
+STD_PATH_REGEX =  re.compile(r"^&(mut )?(std::([a-z_]+::)+)Path$")
 
 TUPLE_ITEM_REGEX = re.compile(r"__\d+$")
 
@@ -75,6 +79,8 @@ STD_TYPE_TO_REGEX = {
     RustType.STD_REF_CELL: STD_REF_CELL_REGEX,
     RustType.STD_CELL: STD_CELL_REGEX,
     RustType.STD_NONZERO_NUMBER: STD_NONZERO_NUMBER_REGEX,
+    RustType.STD_PATHBUF: STD_PATHBUF_REGEX,
+    RustType.STD_PATH: STD_PATH_REGEX,
 }
 
 def is_tuple_fields(fields):

--- a/tests/debuginfo/path.rs
+++ b/tests/debuginfo/path.rs
@@ -1,0 +1,31 @@
+//@ ignore-gdb
+
+//@ compile-flags:-g
+
+// === LLDB TESTS =================================================================================
+
+// lldb-command:run
+
+// lldb-command:print pathbuf
+// lldb-check:[...]$0 = "/some/path" { inner = "/some/path" { inner = { inner = size=10 { [0] = '/'
+//     [1] = 's' [2] = 'o' [3] = 'm' [4] = 'e' [5] = '/' [6] = 'p' [7] = 'a' [8] = 't' [9] = 'h' }
+// } } }
+// lldb-command:po pathbuf
+// lldb-check:"/some/path"
+// lldb-command:print path
+// lldb-check:[...]$1 = "/some/path" { data_ptr = [...] length = 10 }
+// lldb-command:po path
+// lldb-check:"/some/path"
+
+use std::path::Path;
+
+fn main() {
+    let path = Path::new("/some/path");
+    let pathbuf = path.to_path_buf();
+
+    zzz(); // #break
+}
+
+fn zzz() {
+    ()
+}

--- a/tests/mir-opt/instrument_coverage.bar.InstrumentCoverage.diff
+++ b/tests/mir-opt/instrument_coverage.bar.InstrumentCoverage.diff
@@ -4,7 +4,7 @@
   fn bar() -> bool {
       let mut _0: bool;
   
-+     coverage Code(Counter(0)) => /the/src/instrument_coverage.rs:21:1 - 23:2;
++     coverage Code(Counter(0)) => $DIR/instrument_coverage.rs:19:1 - 21:2;
 + 
       bb0: {
 +         Coverage::CounterIncrement(0);

--- a/tests/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
+++ b/tests/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
@@ -9,11 +9,11 @@
   
 +     coverage ExpressionId(0) => Expression { lhs: Counter(0), op: Add, rhs: Counter(1) };
 +     coverage ExpressionId(1) => Expression { lhs: Expression(0), op: Subtract, rhs: Counter(1) };
-+     coverage Code(Counter(0)) => /the/src/instrument_coverage.rs:12:1 - 12:11;
-+     coverage Code(Expression(0)) => /the/src/instrument_coverage.rs:13:5 - 14:17;
-+     coverage Code(Expression(1)) => /the/src/instrument_coverage.rs:15:13 - 15:18;
-+     coverage Code(Counter(1)) => /the/src/instrument_coverage.rs:16:10 - 16:11;
-+     coverage Code(Expression(1)) => /the/src/instrument_coverage.rs:18:1 - 18:2;
++     coverage Code(Counter(0)) => $DIR/instrument_coverage.rs:10:1 - 10:11;
++     coverage Code(Expression(0)) => $DIR/instrument_coverage.rs:11:5 - 12:17;
++     coverage Code(Expression(1)) => $DIR/instrument_coverage.rs:13:13 - 13:18;
++     coverage Code(Counter(1)) => $DIR/instrument_coverage.rs:14:10 - 14:11;
++     coverage Code(Expression(1)) => $DIR/instrument_coverage.rs:16:1 - 16:2;
 + 
       bb0: {
 +         Coverage::CounterIncrement(0);

--- a/tests/mir-opt/instrument_coverage.rs
+++ b/tests/mir-opt/instrument_coverage.rs
@@ -1,11 +1,9 @@
-// skip-filecheck
-// Test that `-C instrument-coverage` injects Coverage statements. The Coverage Counter statements
-// are later converted into LLVM instrprof.increment intrinsics, during codegen.
+// Test that `-C instrument-coverage` injects Coverage statements.
+// The Coverage::CounterIncrement statements are later converted into LLVM
+// instrprof.increment intrinsics, during codegen.
 
 //@ unit-test: InstrumentCoverage
-//@ needs-profiler-support
-//@ ignore-windows
-//@ compile-flags: -C instrument-coverage --remap-path-prefix={{src-base}}=/the/src
+//@ compile-flags: -Cinstrument-coverage -Zno-profiler-runtime
 
 // EMIT_MIR instrument_coverage.main.InstrumentCoverage.diff
 // EMIT_MIR instrument_coverage.bar.InstrumentCoverage.diff
@@ -22,17 +20,9 @@ fn bar() -> bool {
     true
 }
 
-// Note that the MIR with injected coverage intrinsics includes references to source locations,
-// including the source file absolute path. Typically, MIR pretty print output with file
-// references are safe because the file prefixes are substituted with `$DIR`, but in this case
-// the file references are encoded as function arguments, with an `Operand` type representation
-// (`Slice` `Allocation` interned byte array) that cannot be normalized by simple substitution.
-//
-// The first workaround is to use the `SourceMap`-supported `--remap-path-prefix` option; however,
-// the implementation of the `--remap-path-prefix` option currently joins the new prefix and the
-// remaining source path with an OS-specific path separator (`\` on Windows). This difference still
-// shows up in the byte array representation of the path, causing Windows tests to fail to match
-// blessed results baselined with a `/` path separator.
-//
-// Since this `mir-opt` test does not have any significant platform dependencies, other than the
-// path separator differences, the final workaround is to disable testing on Windows.
+// CHECK:     coverage ExpressionId({{[0-9]+}}) =>
+// CHECK-DAG: coverage Code(Counter({{[0-9]+}})) =>
+// CHECK-DAG: coverage Code(Expression({{[0-9]+}})) =>
+// CHECK:     bb0:
+// CHECK-DAG: Coverage::ExpressionUsed({{[0-9]+}})
+// CHECK-DAG: Coverage::CounterIncrement({{[0-9]+}})

--- a/tests/mir-opt/instrument_coverage_cleanup.main.CleanupPostBorrowck.diff
+++ b/tests/mir-opt/instrument_coverage_cleanup.main.CleanupPostBorrowck.diff
@@ -5,15 +5,15 @@
       let mut _0: ();
       let mut _1: bool;
   
-      coverage branch { true: BlockMarkerId(0), false: BlockMarkerId(1) } => /the/src/instrument_coverage_cleanup.rs:15:8: 15:36 (#0)
+      coverage branch { true: BlockMarkerId(0), false: BlockMarkerId(1) } => $DIR/instrument_coverage_cleanup.rs:14:8: 14:36 (#0)
   
       coverage ExpressionId(0) => Expression { lhs: Counter(0), op: Subtract, rhs: Counter(1) };
       coverage ExpressionId(1) => Expression { lhs: Counter(1), op: Add, rhs: Expression(0) };
-      coverage Code(Counter(0)) => /the/src/instrument_coverage_cleanup.rs:14:1 - 15:36;
-      coverage Code(Expression(0)) => /the/src/instrument_coverage_cleanup.rs:15:37 - 15:39;
-      coverage Code(Counter(1)) => /the/src/instrument_coverage_cleanup.rs:15:39 - 15:40;
-      coverage Code(Expression(1)) => /the/src/instrument_coverage_cleanup.rs:16:1 - 16:2;
-      coverage Branch { true_term: Expression(0), false_term: Counter(1) } => /the/src/instrument_coverage_cleanup.rs:15:8 - 15:36;
+      coverage Code(Counter(0)) => $DIR/instrument_coverage_cleanup.rs:13:1 - 14:36;
+      coverage Code(Expression(0)) => $DIR/instrument_coverage_cleanup.rs:14:37 - 14:39;
+      coverage Code(Counter(1)) => $DIR/instrument_coverage_cleanup.rs:14:39 - 14:40;
+      coverage Code(Expression(1)) => $DIR/instrument_coverage_cleanup.rs:15:1 - 15:2;
+      coverage Branch { true_term: Expression(0), false_term: Counter(1) } => $DIR/instrument_coverage_cleanup.rs:14:8 - 14:36;
   
       bb0: {
           Coverage::CounterIncrement(0);

--- a/tests/mir-opt/instrument_coverage_cleanup.main.InstrumentCoverage.diff
+++ b/tests/mir-opt/instrument_coverage_cleanup.main.InstrumentCoverage.diff
@@ -5,15 +5,15 @@
       let mut _0: ();
       let mut _1: bool;
   
-      coverage branch { true: BlockMarkerId(0), false: BlockMarkerId(1) } => /the/src/instrument_coverage_cleanup.rs:15:8: 15:36 (#0)
+      coverage branch { true: BlockMarkerId(0), false: BlockMarkerId(1) } => $DIR/instrument_coverage_cleanup.rs:14:8: 14:36 (#0)
   
 +     coverage ExpressionId(0) => Expression { lhs: Counter(0), op: Subtract, rhs: Counter(1) };
 +     coverage ExpressionId(1) => Expression { lhs: Counter(1), op: Add, rhs: Expression(0) };
-+     coverage Code(Counter(0)) => /the/src/instrument_coverage_cleanup.rs:14:1 - 15:36;
-+     coverage Code(Expression(0)) => /the/src/instrument_coverage_cleanup.rs:15:37 - 15:39;
-+     coverage Code(Counter(1)) => /the/src/instrument_coverage_cleanup.rs:15:39 - 15:40;
-+     coverage Code(Expression(1)) => /the/src/instrument_coverage_cleanup.rs:16:1 - 16:2;
-+     coverage Branch { true_term: Expression(0), false_term: Counter(1) } => /the/src/instrument_coverage_cleanup.rs:15:8 - 15:36;
++     coverage Code(Counter(0)) => $DIR/instrument_coverage_cleanup.rs:13:1 - 14:36;
++     coverage Code(Expression(0)) => $DIR/instrument_coverage_cleanup.rs:14:37 - 14:39;
++     coverage Code(Counter(1)) => $DIR/instrument_coverage_cleanup.rs:14:39 - 14:40;
++     coverage Code(Expression(1)) => $DIR/instrument_coverage_cleanup.rs:15:1 - 15:2;
++     coverage Branch { true_term: Expression(0), false_term: Counter(1) } => $DIR/instrument_coverage_cleanup.rs:14:8 - 14:36;
 + 
       bb0: {
 +         Coverage::CounterIncrement(0);

--- a/tests/mir-opt/instrument_coverage_cleanup.rs
+++ b/tests/mir-opt/instrument_coverage_cleanup.rs
@@ -7,7 +7,6 @@
 
 //@ unit-test: InstrumentCoverage
 //@ compile-flags: -Cinstrument-coverage -Zcoverage-options=branch -Zno-profiler-runtime
-//@ compile-flags: --remap-path-prefix={{src-base}}=/the/src
 
 // EMIT_MIR instrument_coverage_cleanup.main.InstrumentCoverage.diff
 // EMIT_MIR instrument_coverage_cleanup.main.CleanupPostBorrowck.diff

--- a/tests/ui/const-generics/const-argument-if-length.full.stderr
+++ b/tests/ui/const-generics/const-argument-if-length.full.stderr
@@ -4,7 +4,10 @@ error: unconstrained generic constant
 LL |     pad: [u8; is_zst::<T>()],
    |          ^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); is_zst::<T>()]:`
+help: try adding a `where` bound
+   |
+LL | pub struct AtLeastByte<T: ?Sized> where [(); is_zst::<T>()]: {
+   |                                   ++++++++++++++++++++++++++
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/const-argument-if-length.rs:16:12

--- a/tests/ui/const-generics/defaults/generic-expr-default.stderr
+++ b/tests/ui/const-generics/defaults/generic-expr-default.stderr
@@ -4,7 +4,10 @@ error: unconstrained generic constant
 LL | pub fn needs_evaluatable_bound<const N1: usize>() -> Foo<N1> {
    |                                                      ^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { N + 1 }]:`
+help: try adding a `where` bound
+   |
+LL | pub fn needs_evaluatable_bound<const N1: usize>() -> Foo<N1> where [(); { N + 1 }]: {
+   |                                                              ++++++++++++++++++++++
 
 error: unconstrained generic constant
   --> $DIR/generic-expr-default.rs:14:58
@@ -12,7 +15,10 @@ error: unconstrained generic constant
 LL | fn needs_evaluatable_bound_alias<T, const N: usize>() -> FooAlias<N>
    |                                                          ^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { N + 1 }]:`
+help: try adding a `where` bound
+   |
+LL | fn needs_evaluatable_bound_alias<T, const N: usize>() -> FooAlias<N> where [(); { N + 1 }]:
+   |                                                                      ++++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/ensure_is_evaluatable.stderr
+++ b/tests/ui/const-generics/ensure_is_evaluatable.stderr
@@ -4,7 +4,6 @@ error: unconstrained generic constant
 LL |     bar()
    |     ^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); N + 1]:`
 note: required by a bound in `bar`
   --> $DIR/ensure_is_evaluatable.rs:15:10
    |
@@ -13,6 +12,10 @@ LL | fn bar<const N: usize>() -> [(); N]
 LL | where
 LL |     [(); N + 1]:,
    |          ^^^^^ required by this bound in `bar`
+help: try adding a `where` bound
+   |
+LL |     [(); M + 1]:, [(); N + 1]:
+   |                 ~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/fn_with_two_const_inputs.stderr
+++ b/tests/ui/const-generics/fn_with_two_const_inputs.stderr
@@ -4,7 +4,6 @@ error: unconstrained generic constant
 LL |     bar()
    |     ^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); N + 1]:`
 note: required by a bound in `bar`
   --> $DIR/fn_with_two_const_inputs.rs:18:10
    |
@@ -13,6 +12,10 @@ LL | fn bar<const N: usize>() -> [(); N]
 LL | where
 LL |     [(); N + 1]:,
    |          ^^^^^ required by this bound in `bar`
+help: try adding a `where` bound
+   |
+LL |     [(); both(N + 1, M + 1)]:, [(); N + 1]:
+   |                              ~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-2.fixed
+++ b/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-2.fixed
@@ -7,14 +7,14 @@ struct Evaluatable<const N: u128> {}
 struct Foo<const N: u8>([u8; N as usize])
 //~^ ERROR unconstrained generic constant
 where
-    Evaluatable<{N as u128}>:;
+    Evaluatable<{N as u128}>:, [(); N as usize]:;
 //~^ HELP try adding a `where` bound
 
-struct Foo2<const N: u8>(Evaluatable::<{N as u128}>) where Evaluatable<{N as usize as u128 }>:;
+struct Foo2<const N: u8>(Evaluatable::<{N as u128}>) where Evaluatable<{N as usize as u128 }>:, [(); {N as u128} as usize]:;
 //~^ ERROR unconstrained generic constant
 //~| HELP try adding a `where` bound
 
-struct Bar<const N: u8>([u8; (N + 2) as usize]) where [(); (N + 1) as usize]:;
+struct Bar<const N: u8>([u8; (N + 2) as usize]) where [(); (N + 1) as usize]:, [(); (N + 2) as usize]:;
 //~^ ERROR unconstrained generic constant
 //~| HELP try adding a `where` bound
 

--- a/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-2.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-2.stderr
@@ -1,26 +1,35 @@
 error: unconstrained generic constant
-  --> $DIR/abstract-const-as-cast-2.rs:6:25
+  --> $DIR/abstract-const-as-cast-2.rs:7:25
    |
 LL | struct Foo<const N: u8>([u8; N as usize])
    |                         ^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); N as usize]:`
+help: try adding a `where` bound
+   |
+LL |     Evaluatable<{N as u128}>:, [(); N as usize]:;
+   |                              +++++++++++++++++++
 
 error: unconstrained generic constant
-  --> $DIR/abstract-const-as-cast-2.rs:12:26
+  --> $DIR/abstract-const-as-cast-2.rs:13:26
    |
 LL | struct Foo2<const N: u8>(Evaluatable::<{N as u128}>) where Evaluatable<{N as usize as u128 }>:;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); {N as u128}]:`
+help: try adding a `where` bound
+   |
+LL | struct Foo2<const N: u8>(Evaluatable::<{N as u128}>) where Evaluatable<{N as usize as u128 }>:, [(); {N as u128} as usize]:;
+   |                                                                                               +++++++++++++++++++++++++++++
 
 error: unconstrained generic constant
-  --> $DIR/abstract-const-as-cast-2.rs:16:25
+  --> $DIR/abstract-const-as-cast-2.rs:17:25
    |
 LL | struct Bar<const N: u8>([u8; (N + 2) as usize]) where [(); (N + 1) as usize]:;
    |                         ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); (N + 2) as usize]:`
+help: try adding a `where` bound
+   |
+LL | struct Bar<const N: u8>([u8; (N + 2) as usize]) where [(); (N + 1) as usize]:, [(); (N + 2) as usize]:;
+   |                                                                              +++++++++++++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
@@ -4,7 +4,6 @@ error: unconstrained generic constant
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as u128 }>>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { O as u128 }]:`
 note: required for `HasCastInTraitImpl<{ N + 1 }, { N as u128 }>` to implement `Trait`
   --> $DIR/abstract-const-as-cast-3.rs:8:22
    |
@@ -15,6 +14,10 @@ note: required by a bound in `use_trait_impl::assert_impl`
    |
 LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
+help: try adding a `where` bound
+   |
+LL |     EvaluatableU128<{N as u128}>:, [(); { O as u128 } as usize]: {
+   |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:17:5
@@ -36,7 +39,6 @@ error: unconstrained generic constant
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as _ }>>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { O as u128 }]:`
 note: required for `HasCastInTraitImpl<{ N + 1 }, { N as _ }>` to implement `Trait`
   --> $DIR/abstract-const-as-cast-3.rs:8:22
    |
@@ -47,6 +49,10 @@ note: required by a bound in `use_trait_impl::assert_impl`
    |
 LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
+help: try adding a `where` bound
+   |
+LL |     EvaluatableU128<{N as u128}>:, [(); { O as u128 } as usize]: {
+   |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:20:5
@@ -96,7 +102,6 @@ error: unconstrained generic constant
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as u128 }>>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { O as u128 }]:`
 note: required for `HasCastInTraitImpl<{ N + 1 }, { N as u128 }>` to implement `Trait`
   --> $DIR/abstract-const-as-cast-3.rs:8:22
    |
@@ -107,6 +112,10 @@ note: required by a bound in `use_trait_impl_2::assert_impl`
    |
 LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
+help: try adding a `where` bound
+   |
+LL |     EvaluatableU128<{N as _}>:, [(); { O as u128 } as usize]: {
+   |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:35:5
@@ -128,7 +137,6 @@ error: unconstrained generic constant
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as _ }>>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { O as u128 }]:`
 note: required for `HasCastInTraitImpl<{ N + 1 }, { N as _ }>` to implement `Trait`
   --> $DIR/abstract-const-as-cast-3.rs:8:22
    |
@@ -139,6 +147,10 @@ note: required by a bound in `use_trait_impl_2::assert_impl`
    |
 LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
+help: try adding a `where` bound
+   |
+LL |     EvaluatableU128<{N as _}>:, [(); { O as u128 } as usize]: {
+   |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:38:5

--- a/tests/ui/const-generics/generic_const_exprs/abstract-consts-as-cast-5.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/abstract-consts-as-cast-5.stderr
@@ -4,7 +4,10 @@ error: unconstrained generic constant
 LL |     bar::<{ N as usize as usize }>();
    |           ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { N as usize as usize }]:`
+help: try adding a `where` bound
+   |
+LL | fn foo<const N: u8>(a: [(); N as usize]) where [(); { N as usize as usize }]: {
+   |                                          ++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.full.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.full.stderr
@@ -4,7 +4,10 @@ error: unconstrained generic constant
 LL | struct ArithArrayLen<const N: usize>([u32; 0 + N]);
    |                                      ^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); 0 + N]:`
+help: try adding a `where` bound
+   |
+LL | struct ArithArrayLen<const N: usize>([u32; 0 + N]) where [(); 0 + N]:;
+   |                                                    ++++++++++++++++++
 
 error: overly complex generic constant
   --> $DIR/array-size-in-generic-struct-param.rs:23:15

--- a/tests/ui/const-generics/generic_const_exprs/assoc_const_unification/doesnt_unify_evaluatable.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/assoc_const_unification/doesnt_unify_evaluatable.stderr
@@ -4,7 +4,10 @@ error: unconstrained generic constant
 LL |     bar::<{ T::ASSOC }>();
    |           ^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { T::ASSOC }]:`
+help: try adding a `where` bound
+   |
+LL | fn foo<T: Trait, U: Trait>() where [(); U::ASSOC]:, [(); { T::ASSOC }]: {
+   |                                                   ~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
@@ -24,7 +24,10 @@ error: unconstrained generic constant
 LL |     foo::<_, L>([(); L + 1 + L]);
    |                      ^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); L + 1 + L]:`
+help: try adding a `where` bound
+   |
+LL |     [(); (L - 1) + 1 + L]:, [(); L + 1 + L]:
+   |                           ~~~~~~~~~~~~~~~~~~
 
 error: unconstrained generic constant
   --> $DIR/issue_114151.rs:17:17
@@ -34,11 +37,6 @@ LL |     foo::<_, L>([(); L + 1 + L]);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: try adding a `where` bound using this expression: `where [(); {
-                   {
-                       N
-                   }
-               }]:`
 note: required by a bound in `foo`
   --> $DIR/issue_114151.rs:5:13
    |
@@ -51,6 +49,14 @@ LL | |             N
 LL | |         }
 LL | |     }],
    | |_____^ required by this bound in `foo`
+help: try adding a `where` bound
+   |
+LL ~     [(); (L - 1) + 1 + L]:, [(); {
+LL +         {
+LL +             N
+LL +         }
+LL +     }]:
+   |
 
 error: unconstrained generic constant `L + 1 + L`
   --> $DIR/issue_114151.rs:17:5

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_binop_arg_tys.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_binop_arg_tys.stderr
@@ -13,7 +13,10 @@ error: unconstrained generic constant
 LL |     Bar::<{ make_generic(N, 1_u8 == 0_u8) }>
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { make_generic(N, 1_u8 == 0_u8) }]:`
+help: try adding a `where` bound
+   |
+LL | fn foo<const N: usize>() -> Bar<{ make_generic(N, true == false) }> where [(); { make_generic(N, 1_u8 == 0_u8) } as usize]: {
+   |                                                                     +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_cast_arg_ty.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/relate_cast_arg_ty.stderr
@@ -13,7 +13,10 @@ error: unconstrained generic constant
 LL |     [(); (1_u8 as usize) + N]
    |          ^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); (1_u8 as usize) + N]:`
+help: try adding a `where` bound
+   |
+LL | fn foo<const N: usize>() -> [(); (true as usize) + N] where [(); (1_u8 as usize) + N]: {
+   |                                                       ++++++++++++++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/wf_obligation.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/wf_obligation.stderr
@@ -13,7 +13,10 @@ error: unconstrained generic constant
 LL |     foo::<_, L>([(); L + 1 + L]);
    |                      ^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); L + 1 + L]:`
+help: try adding a `where` bound
+   |
+LL |     [(); (L - 1) + 1 + L]:, [(); L + 1 + L]:
+   |                           ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/cross_crate_predicate.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/cross_crate_predicate.stderr
@@ -4,7 +4,6 @@ error: unconstrained generic constant
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |                                            ^
    |
-   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
 note: required by a bound in `test1`
   --> $DIR/auxiliary/const_evaluatable_lib.rs:5:10
    |
@@ -13,6 +12,10 @@ LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
 LL | where
 LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test1`
+help: try adding a `where` bound
+   |
+LL | fn user<T>() where [(); std::mem::size_of::<T>() - 1]: {
+   |              +++++++++++++++++++++++++++++++++++++++++
 
 error: unconstrained generic constant
   --> $DIR/cross_crate_predicate.rs:7:44
@@ -20,12 +23,15 @@ error: unconstrained generic constant
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |                                            ^
    |
-   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
 note: required by a bound in `test1`
   --> $DIR/auxiliary/const_evaluatable_lib.rs:3:27
    |
 LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test1`
+help: try adding a `where` bound
+   |
+LL | fn user<T>() where [(); std::mem::size_of::<T>() - 1]: {
+   |              +++++++++++++++++++++++++++++++++++++++++
 
 error: unconstrained generic constant
   --> $DIR/cross_crate_predicate.rs:7:13
@@ -33,7 +39,6 @@ error: unconstrained generic constant
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
 note: required by a bound in `test1`
   --> $DIR/auxiliary/const_evaluatable_lib.rs:5:10
    |
@@ -42,6 +47,10 @@ LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
 LL | where
 LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test1`
+help: try adding a `where` bound
+   |
+LL | fn user<T>() where [(); std::mem::size_of::<T>() - 1]: {
+   |              +++++++++++++++++++++++++++++++++++++++++
 
 error: unconstrained generic constant
   --> $DIR/cross_crate_predicate.rs:7:13
@@ -49,12 +58,15 @@ error: unconstrained generic constant
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
 note: required by a bound in `test1`
   --> $DIR/auxiliary/const_evaluatable_lib.rs:3:27
    |
 LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test1`
+help: try adding a `where` bound
+   |
+LL | fn user<T>() where [(); std::mem::size_of::<T>() - 1]: {
+   |              +++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/dependence_lint.gce.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dependence_lint.gce.stderr
@@ -20,7 +20,10 @@ error: unconstrained generic constant
 LL |     let _: [u8; size_of::<*mut T>()]; // error on stable, error with gce
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); size_of::<*mut T>()]:`
+help: try adding a `where` bound
+   |
+LL | fn foo<T>() where [(); size_of::<*mut T>()]: {
+   |             ++++++++++++++++++++++++++++++++
 
 error: unconstrained generic constant
   --> $DIR/dependence_lint.rs:10:9
@@ -28,7 +31,10 @@ error: unconstrained generic constant
 LL |     [0; size_of::<*mut T>()]; // lint on stable, error with `generic_const_exprs`
    |         ^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); size_of::<*mut T>()]:`
+help: try adding a `where` bound
+   |
+LL | fn foo<T>() where [(); size_of::<*mut T>()]: {
+   |             ++++++++++++++++++++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/different-fn.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/different-fn.stderr
@@ -13,7 +13,10 @@ error: unconstrained generic constant
 LL |     [0; size_of::<Foo<T>>()]
    |         ^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); size_of::<Foo<T>>()]:`
+help: try adding a `where` bound
+   |
+LL | fn test<T>() -> [u8; size_of::<T>()] where [(); size_of::<Foo<T>>()]: {
+   |                                      ++++++++++++++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-62504.full.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-62504.full.stderr
@@ -13,7 +13,10 @@ error: unconstrained generic constant
 LL |         ArrayHolder([0; Self::SIZE])
    |                         ^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); Self::SIZE]:`
+help: try adding a `where` bound
+   |
+LL |     pub const fn new() -> Self where [(); Self::SIZE]: {
+   |                                +++++++++++++++++++++++
 
 error[E0282]: type annotations needed for `ArrayHolder<X>`
   --> $DIR/issue-62504.rs:26:9

--- a/tests/ui/const-generics/generic_const_exprs/issue-83765.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-83765.stderr
@@ -13,12 +13,15 @@ error: unconstrained generic constant
 LL |         self.reference.size()
    |                        ^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); Self::DIM]:`
 note: required by a bound in `TensorSize::size`
   --> $DIR/issue-83765.rs:9:31
    |
 LL |     fn size(&self) -> [usize; Self::DIM];
    |                               ^^^^^^^^^ required by this bound in `TensorSize::size`
+help: try adding a `where` bound
+   |
+LL |     fn size(&self) -> [usize; DIM] where [(); Self::DIM]: {
+   |                                    ++++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/issue-83765.rs:32:9

--- a/tests/ui/const-generics/generic_const_exprs/issue-85848.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-85848.stderr
@@ -35,7 +35,6 @@ LL |     writes_to_specific_path(&cap);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: try adding a `where` bound using this expression: `where [(); { contains::<T, U>() }]:`
 note: required for `&C` to implement `Contains<(), true>`
   --> $DIR/issue-85848.rs:21:12
    |
@@ -53,6 +52,10 @@ note: required by a bound in `writes_to_specific_path`
    |
 LL | fn writes_to_specific_path<C: Delegates<()>>(cap: &C) {}
    |                               ^^^^^^^^^^^^^ required by this bound in `writes_to_specific_path`
+help: try adding a `where` bound
+   |
+LL | fn writes_to_path<C>(cap: &C) where [(); { contains::<T, U>() } as usize]: {
+   |                               ++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/issue-85848.rs:24:5

--- a/tests/ui/const-generics/generic_const_exprs/needs_where_clause.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/needs_where_clause.stderr
@@ -4,7 +4,10 @@ error: unconstrained generic constant
 LL |   b: [f32; complex_maths::<T>(N)],
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); complex_maths::<T>(N)]:`
+help: try adding a `where` bound
+   |
+LL | struct Example<T, const N: usize> where [(); complex_maths::<T>(N)]: {
+   |                                   ++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/no_where_clause.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/no_where_clause.stderr
@@ -4,7 +4,10 @@ error: unconstrained generic constant
 LL |   b: [f32; complex_maths(N)],
    |      ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); complex_maths(N)]:`
+help: try adding a `where` bound
+   |
+LL | pub struct Example<const N: usize> where [(); complex_maths(N)]: {
+   |                                    +++++++++++++++++++++++++++++
 
 error: unconstrained generic constant
   --> $DIR/no_where_clause.rs:18:15
@@ -12,7 +15,10 @@ error: unconstrained generic constant
 LL |       b: [0.; complex_maths(N)],
    |               ^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); complex_maths(N)]:`
+help: try adding a `where` bound
+   |
+LL |   pub fn new() -> Self where [(); complex_maths(N)]: {
+   |                        +++++++++++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/unify-op-with-fn-call.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unify-op-with-fn-call.stderr
@@ -40,7 +40,10 @@ error: unconstrained generic constant
 LL |     bar2::<{ std::ops::Add::add(N, N) }>();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { std::ops::Add::add(N, N) }]:`
+help: try adding a `where` bound
+   |
+LL | fn foo2<const N: usize>(a: Evaluatable2<{ N + N }>) where [(); { std::ops::Add::add(N, N) }]: {
+   |                                                     +++++++++++++++++++++++++++++++++++++++++
 
 error[E0015]: cannot call non-const operator in constants
   --> $DIR/unify-op-with-fn-call.rs:20:39

--- a/tests/ui/const-generics/issues/issue-67739.full.stderr
+++ b/tests/ui/const-generics/issues/issue-67739.full.stderr
@@ -4,7 +4,10 @@ error: unconstrained generic constant
 LL |         [0u8; mem::size_of::<Self::Associated>()];
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); mem::size_of::<Self::Associated>()]:`
+help: try adding a `where` bound
+   |
+LL |     fn associated_size(&self) -> usize where [(); mem::size_of::<Self::Associated>()]: {
+   |                                        +++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-71202.stderr
+++ b/tests/ui/const-generics/issues/issue-71202.stderr
@@ -10,24 +10,27 @@ LL | |         <IsCopy<T>>::VALUE
 LL | |     } as usize] = [];
    | |_____________________^
    |
-   = help: try adding a `where` bound using this expression: `where [(); 1 - {
-                   trait NotCopy {
-                       const VALUE: bool = false;
-                   }
-           
-                   impl<__Type: ?Sized> NotCopy for __Type {}
-           
-                   struct IsCopy<__Type: ?Sized>(PhantomData<__Type>);
-           
-                   impl<__Type> IsCopy<__Type>
-                   where
-                       __Type: Sized + Copy,
-                   {
-                       const VALUE: bool = true;
-                   }
-           
-                   <IsCopy<T>>::VALUE
-               } as usize]:`
+help: try adding a `where` bound
+   |
+LL ~     } as usize] where [(); 1 - {
+LL +         trait NotCopy {
+LL +             const VALUE: bool = false;
+LL +         }
+LL + 
+LL +         impl<__Type: ?Sized> NotCopy for __Type {}
+LL + 
+LL +         struct IsCopy<__Type: ?Sized>(PhantomData<__Type>);
+LL + 
+LL +         impl<__Type> IsCopy<__Type>
+LL +         where
+LL +             __Type: Sized + Copy,
+LL +         {
+LL +             const VALUE: bool = true;
+LL +         }
+LL + 
+LL +         <IsCopy<T>>::VALUE
+LL ~     } as usize]: = [];
+   |
 
 error: unconstrained generic constant
   --> $DIR/issue-71202.rs:28:19
@@ -35,24 +38,27 @@ error: unconstrained generic constant
 LL |     } as usize] = [];
    |                   ^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); 1 - {
-                   trait NotCopy {
-                       const VALUE: bool = false;
-                   }
-           
-                   impl<__Type: ?Sized> NotCopy for __Type {}
-           
-                   struct IsCopy<__Type: ?Sized>(PhantomData<__Type>);
-           
-                   impl<__Type> IsCopy<__Type>
-                   where
-                       __Type: Sized + Copy,
-                   {
-                       const VALUE: bool = true;
-                   }
-           
-                   <IsCopy<T>>::VALUE
-               } as usize]:`
+help: try adding a `where` bound
+   |
+LL ~     } as usize] where [(); 1 - {
+LL +         trait NotCopy {
+LL +             const VALUE: bool = false;
+LL +         }
+LL + 
+LL +         impl<__Type: ?Sized> NotCopy for __Type {}
+LL + 
+LL +         struct IsCopy<__Type: ?Sized>(PhantomData<__Type>);
+LL + 
+LL +         impl<__Type> IsCopy<__Type>
+LL +         where
+LL +             __Type: Sized + Copy,
+LL +         {
+LL +             const VALUE: bool = true;
+LL +         }
+LL + 
+LL +         <IsCopy<T>>::VALUE
+LL ~     } as usize]: = [];
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-84659.fixed
+++ b/tests/ui/const-generics/issues/issue-84659.fixed
@@ -6,7 +6,7 @@ trait Bar<const N: usize> {}
 
 trait Foo<'a> {
     const N: usize;
-    type Baz: Bar<{ Self::N }>;
+    type Baz: Bar<{ Self::N }> where [(); { Self::N }]:;
     //~^ ERROR: unconstrained generic constant
 }
 

--- a/tests/ui/const-generics/issues/issue-84659.stderr
+++ b/tests/ui/const-generics/issues/issue-84659.stderr
@@ -1,10 +1,13 @@
 error: unconstrained generic constant
-  --> $DIR/issue-84659.rs:8:15
+  --> $DIR/issue-84659.rs:9:15
    |
 LL |     type Baz: Bar<{ Self::N }>;
    |               ^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { Self::N }]:`
+help: try adding a `where` bound
+   |
+LL |     type Baz: Bar<{ Self::N }> where [(); { Self::N }]:;
+   |                                ++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-90455.fixed
+++ b/tests/ui/const-generics/issues/issue-90455.fixed
@@ -2,7 +2,7 @@
 #![feature(generic_const_exprs, adt_const_params)]
 #![allow(incomplete_features, dead_code)]
 
-struct FieldElement<const N: &'static str> {
+struct FieldElement<const N: &'static str> where [(); num_limbs(N)]: {
     n: [u64; num_limbs(N)],
     //~^ ERROR unconstrained generic constant
 }

--- a/tests/ui/const-generics/issues/issue-90455.stderr
+++ b/tests/ui/const-generics/issues/issue-90455.stderr
@@ -1,10 +1,13 @@
 error: unconstrained generic constant
-  --> $DIR/issue-90455.rs:5:8
+  --> $DIR/issue-90455.rs:6:8
    |
 LL |     n: [u64; num_limbs(N)],
    |        ^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); num_limbs(N)]:`
+help: try adding a `where` bound
+   |
+LL | struct FieldElement<const N: &'static str> where [(); num_limbs(N)]: {
+   |                                            +++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-needs_drop-monomorphic.stderr
+++ b/tests/ui/consts/const-needs_drop-monomorphic.stderr
@@ -13,7 +13,10 @@ error: unconstrained generic constant
 LL |     Bool::<{ std::mem::needs_drop::<T>() }>::assert();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { std::mem::needs_drop::<T>() }]:`
+help: try adding a `where` bound
+   |
+LL | fn f<T>() where [(); { std::mem::needs_drop::<T>() } as usize]: {
+   |           +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generic-const-items/evaluatable-bounds.fixed
+++ b/tests/ui/generic-const-items/evaluatable-bounds.fixed
@@ -11,7 +11,7 @@
 trait Trait {
     const LEN: usize;
 
-    const ARRAY: [i32; Self::LEN]; //~ ERROR unconstrained generic constant
+    const ARRAY: [i32; Self::LEN] where [(); Self::LEN]:; //~ ERROR unconstrained generic constant
 
 }
 

--- a/tests/ui/generic-const-items/evaluatable-bounds.stderr
+++ b/tests/ui/generic-const-items/evaluatable-bounds.stderr
@@ -1,5 +1,5 @@
 error: unconstrained generic constant
-  --> $DIR/evaluatable-bounds.rs:16:5
+  --> $DIR/evaluatable-bounds.rs:14:5
    |
 LL |     const ARRAY: [i32; Self::LEN];
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/sanitizer/cfi-complex-receiver.rs
+++ b/tests/ui/sanitizer/cfi-complex-receiver.rs
@@ -1,0 +1,42 @@
+// Check that more complex receivers work:
+// * Arc<dyn Foo> as for custom receivers
+// * &dyn Bar<T=Baz> for type constraints
+
+//@ needs-sanitizer-cfi
+// FIXME(#122848) Remove only-linux once OSX CFI binaries work
+//@ only-linux
+//@ compile-flags: --crate-type=bin -Cprefer-dynamic=off -Clto -Zsanitizer=cfi
+//@ compile-flags: -C target-feature=-crt-static -C codegen-units=1 -C opt-level=0
+//@ run-pass
+
+use std::sync::Arc;
+
+trait Foo {
+    fn foo(self: Arc<Self>);
+}
+
+struct FooImpl;
+
+impl Foo for FooImpl {
+    fn foo(self: Arc<Self>) {}
+}
+
+trait Bar {
+    type T;
+    fn bar(&self) -> Self::T;
+}
+
+struct BarImpl;
+
+impl Bar for BarImpl {
+    type T = i32;
+    fn bar(&self) -> Self::T { 7 }
+}
+
+fn main() {
+    let foo: Arc<dyn Foo> = Arc::new(FooImpl);
+    foo.foo();
+
+    let bar: &dyn Bar<T=i32> = &BarImpl;
+    assert_eq!(bar.bar(), 7);
+}

--- a/tests/ui/sanitizer/cfi-drop-no-principal.rs
+++ b/tests/ui/sanitizer/cfi-drop-no-principal.rs
@@ -1,0 +1,21 @@
+// Check that dropping a trait object without a principal trait succeeds
+
+//@ needs-sanitizer-cfi
+// FIXME(#122848) Remove only-linux once OSX CFI binaries works
+//@ only-linux
+//@ compile-flags: --crate-type=bin -Cprefer-dynamic=off -Clto -Zsanitizer=cfi
+//@ compile-flags: -C target-feature=-crt-static -C codegen-units=1 -C opt-level=0
+// FIXME(#118761) Should be run-pass once the labels on drop are compatible.
+// This test is being landed ahead of that to test that the compiler doesn't ICE while labeling the
+// callsite for a drop, but the vtable doesn't have the correct label yet.
+//@ build-pass
+
+struct CustomDrop;
+
+impl Drop for CustomDrop {
+    fn drop(&mut self) {}
+}
+
+fn main() {
+    let _ = Box::new(CustomDrop) as Box<dyn Send>;
+}

--- a/tests/ui/simd/array-trait.stderr
+++ b/tests/ui/simd/array-trait.stderr
@@ -4,7 +4,10 @@ error: unconstrained generic constant
 LL | pub struct T<S: Simd>([S::Lane; S::SIZE]);
    |                       ^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); S::SIZE]:`
+help: try adding a `where` bound
+   |
+LL | pub struct T<S: Simd>([S::Lane; S::SIZE]) where [(); S::SIZE]:;
+   |                                           ++++++++++++++++++++
 
 error[E0077]: SIMD vector element type should be a primitive scalar (integer/float/pointer) type
   --> $DIR/array-trait.rs:23:1
@@ -20,7 +23,6 @@ LL | #[derive(Copy, Clone)]
 LL | pub struct T<S: Simd>([S::Lane; S::SIZE]);
    |                       ^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); S::SIZE]:`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/tests/ui/specialization/issue-51892.stderr
+++ b/tests/ui/specialization/issue-51892.stderr
@@ -4,7 +4,10 @@ error: unconstrained generic constant
 LL |     type Type = [u8; std::mem::size_of::<<T as Trait>::Type>()];
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<<T as Trait>::Type>()]:`
+help: try adding a `where` bound
+   |
+LL |     type Type = [u8; std::mem::size_of::<<T as Trait>::Type>()] where [(); std::mem::size_of::<<T as Trait>::Type>()]:;
+   |                                                                 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/variance/variance-associated-consts.stderr
+++ b/tests/ui/variance/variance-associated-consts.stderr
@@ -4,7 +4,10 @@ error: unconstrained generic constant
 LL |     field: [u8; <T as Trait>::Const]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); <T as Trait>::Const]:`
+help: try adding a `where` bound
+   |
+LL | struct Foo<T: Trait> where [(); <T as Trait>::Const]: {
+   |                      ++++++++++++++++++++++++++++++++
 
 error: [o]
   --> $DIR/variance-associated-consts.rs:13:1

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -775,7 +775,6 @@ compiler-team = [
 compiler-team-contributors = [
     "@TaKO8Ki",
     "@Nadrieril",
-    "@nnethercote",
     "@fmease",
     "@fee1-dead",
 ]
@@ -831,17 +830,14 @@ parser = [
     "@compiler-errors",
     "@davidtwco",
     "@estebank",
-    "@nnethercote",
     "@petrochenkov",
     "@spastorino",
 ]
 lexer = [
-    "@nnethercote",
     "@petrochenkov",
     "@estebank",
 ]
 arena = [
-    "@nnethercote",
     "@spastorino",
 ]
 mir = [


### PR DESCRIPTION
Successful merges:

 - #120557 (Add rust-lldb pretty printing for Path and PathBuf)
 - #122802 (Provide structured suggestion for unconstrained generic constant)
 - #122858 (Tweak `parse_dot_suffix_expr`)
 - #122990 (Clarify transmute example)
 - #122995 (Clean up unnecessary headers/flags in coverage mir-opt tests)
 - #123003 (CFI: Handle dyn with no principal)
 - #123005 (CFI: Support complex receivers)
 - #123020 (Temporarily remove nnethercote from the review rotation.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=120557,122802,122858,122990,122995,123003,123005,123020)
<!-- homu-ignore:end -->