### PR TITLE
Generate pdb file when strip=debuginfo

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -924,7 +924,7 @@ impl<'a> Linker for MsvcLinker<'a> {
 
     fn debuginfo(&mut self, strip: Strip, natvis_debugger_visualizers: &[PathBuf]) {
         match strip {
-            Strip::None => {
+            Strip::None | Strip::Debuginfo => {
                 // This will cause the Microsoft linker to generate a PDB file
                 // from the CodeView line tables in the object files.
                 self.cmd.arg("/DEBUG");
@@ -965,7 +965,7 @@ impl<'a> Linker for MsvcLinker<'a> {
                     self.cmd.arg(arg);
                 }
             }
-            Strip::Debuginfo | Strip::Symbols => {
+            Strip::Symbols => {
                 self.cmd.arg("/DEBUG:NONE");
             }
         }

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -552,8 +552,7 @@ Supported values for this option are:
   binary or separate files depending on the target (e.g. `.pdb` files in case
   of MSVC).
 - `debuginfo` - debuginfo sections and debuginfo symbols from the symbol table
-  section are stripped at link time and are not copied to the produced binary
-  or separate files.
+  section are stripped at link time and are not copied to the produced binary.
 - `symbols` - same as `debuginfo`, but the rest of the symbol table section is
   stripped as well if the linker supports it.
 


### PR DESCRIPTION
For msvc targets, treat `strip=debuginfo` the same as `strip=none`. See #122857 for why this is important. We should definitely not be stripping symbol names from external debug files in this case.

This is a much more minimal version of #115120. It only affects `strip=debuginfo` and nothing else.