### PR TITLE
Try shrinking RawVec::grow_amortized

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -146,6 +146,7 @@
 #![feature(non_null_convenience)]
 #![feature(panic_internals)]
 #![feature(pattern)]
+#![feature(ptr_alignment_type)]
 #![feature(ptr_internals)]
 #![feature(ptr_metadata)]
 #![feature(ptr_sub_ptr)]


### PR DESCRIPTION
Opening for perf evaluation.

r? @Mark-Simulacrum 