### PR TITLE
Add a bunch of needs-unwind annotations to tests

### DIFF
--- a/compiler/rustc_codegen_cranelift/scripts/test_rustc_tests.sh
+++ b/compiler/rustc_codegen_cranelift/scripts/test_rustc_tests.sh
@@ -41,12 +41,6 @@ rm tests/ui/parser/unclosed-delimiter-in-dep.rs # submodule contains //~ERROR
 # missing features
 # ================
 
-# requires stack unwinding
-# FIXME add needs-unwind to these tests
-rm -r tests/run-make/libtest-junit
-rm tests/ui/asm/may_unwind.rs
-rm tests/ui/stable-mir-print/basic_function.rs
-
 # extra warning about -Cpanic=abort for proc macros
 rm tests/ui/proc-macro/crt-static.rs
 rm tests/ui/proc-macro/proc-macro-deprecated-attr.rs

--- a/compiler/rustc_codegen_cranelift/scripts/test_rustc_tests.sh
+++ b/compiler/rustc_codegen_cranelift/scripts/test_rustc_tests.sh
@@ -41,15 +41,6 @@ rm tests/ui/parser/unclosed-delimiter-in-dep.rs # submodule contains //~ERROR
 # missing features
 # ================
 
-# extra warning about -Cpanic=abort for proc macros
-rm tests/ui/proc-macro/crt-static.rs
-rm tests/ui/proc-macro/proc-macro-deprecated-attr.rs
-rm tests/ui/proc-macro/quote-debug.rs
-rm tests/ui/proc-macro/no-missing-docs.rs
-rm tests/ui/rust-2018/proc-macro-crate-in-paths.rs
-rm tests/ui/proc-macro/allowed-signatures.rs
-rm tests/ui/proc-macro/no-mangle-in-proc-macro-issue-111888.rs
-
 # vendor intrinsics
 rm tests/ui/simd/array-type.rs # "Index argument for `simd_insert` is not a constant"
 rm tests/ui/asm/x86_64/evex512-implicit-feature.rs # unimplemented AVX512 x86 vendor intrinsic

--- a/tests/run-make/libtest-junit/Makefile
+++ b/tests/run-make/libtest-junit/Makefile
@@ -1,4 +1,5 @@
 # ignore-cross-compile
+# needs-unwind contains should_panic test
 include ../tools.mk
 
 # Test expected libtest's junit output

--- a/tests/ui/asm/may_unwind.rs
+++ b/tests/ui/asm/may_unwind.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-asm-support
+//@ needs-unwind
 
 #![feature(asm_unwind)]
 

--- a/tests/ui/proc-macro/allowed-signatures.rs
+++ b/tests/ui/proc-macro/allowed-signatures.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 //@ force-host
 //@ no-prefer-dynamic
+//@ needs-unwind compiling proc macros with panic=abort causes a warning
 
 #![crate_type = "proc-macro"]
 #![allow(private_interfaces)]
@@ -9,7 +10,7 @@ use proc_macro::TokenStream;
 
 #[proc_macro]
 pub fn foo<T>(t: T) -> TokenStream {
-  TokenStream::new()
+    TokenStream::new()
 }
 
 trait Project {

--- a/tests/ui/proc-macro/crt-static.rs
+++ b/tests/ui/proc-macro/crt-static.rs
@@ -7,6 +7,7 @@
 //@ force-host
 //@ no-prefer-dynamic
 //@ needs-dynamic-linking
+//@ needs-unwind compiling proc macros with panic=abort causes a warning
 
 #![crate_type = "proc-macro"]
 

--- a/tests/ui/proc-macro/no-mangle-in-proc-macro-issue-111888.rs
+++ b/tests/ui/proc-macro/no-mangle-in-proc-macro-issue-111888.rs
@@ -1,6 +1,7 @@
 //@ build-pass
 //@ force-host
 //@ no-prefer-dynamic
+//@ needs-unwind compiling proc macros with panic=abort causes a warning
 //@ aux-build:exports_no_mangle.rs
 #![crate_type = "proc-macro"]
 

--- a/tests/ui/proc-macro/no-missing-docs.rs
+++ b/tests/ui/proc-macro/no-missing-docs.rs
@@ -4,6 +4,7 @@
 //@ build-pass (FIXME(62277): could be check-pass?)
 //@ force-host
 //@ no-prefer-dynamic
+//@ needs-unwind compiling proc macros with panic=abort causes a warning
 
 #![crate_type = "proc-macro"]
 #![deny(missing_docs)]

--- a/tests/ui/proc-macro/proc-macro-deprecated-attr.rs
+++ b/tests/ui/proc-macro/proc-macro-deprecated-attr.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 //@ force-host
 //@ no-prefer-dynamic
+//@ needs-unwind compiling proc macros with panic=abort causes a warning
 
 #![deny(deprecated)]
 

--- a/tests/ui/proc-macro/quote-debug.rs
+++ b/tests/ui/proc-macro/quote-debug.rs
@@ -2,6 +2,7 @@
 //@ force-host
 //@ no-prefer-dynamic
 //@ compile-flags: -Z unpretty=expanded
+//@ needs-unwind compiling proc macros with panic=abort causes a warning
 //
 // This file is not actually used as a proc-macro - instead,
 // it's just used to show the output of the `quote!` macro

--- a/tests/ui/proc-macro/quote-debug.stdout
+++ b/tests/ui/proc-macro/quote-debug.stdout
@@ -4,6 +4,7 @@
 //@ force-host
 //@ no-prefer-dynamic
 //@ compile-flags: -Z unpretty=expanded
+//@ needs-unwind compiling proc macros with panic=abort causes a warning
 //
 // This file is not actually used as a proc-macro - instead,
 // it's just used to show the output of the `quote!` macro

--- a/tests/ui/rust-2018/proc-macro-crate-in-paths.rs
+++ b/tests/ui/rust-2018/proc-macro-crate-in-paths.rs
@@ -1,6 +1,7 @@
 //@ build-pass (FIXME(62277): could be check-pass?)
 //@ force-host
 //@ no-prefer-dynamic
+//@ needs-unwind compiling proc macros with panic=abort causes a warning
 
 #![crate_type = "proc-macro"]
 #![deny(rust_2018_compatibility)]

--- a/tests/ui/stable-mir-print/basic_function.rs
+++ b/tests/ui/stable-mir-print/basic_function.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Z unpretty=stable-mir -Z mir-opt-level=3
 //@ check-pass
 //@ only-x86_64
+//@ needs-unwind unwind edges are different with panic=abort
 
 fn foo(i: i32) -> i32 {
     i + 1


### PR DESCRIPTION
To filter out tests that fail with cg_clif due to missing panic=unwind support.