### PR TITLE
 Correctly register lifetime constraints from opaque types from canonical queries called from nll

### DIFF
--- a/tests/ui/impl-trait/nested-hkl-lifetime.rs
+++ b/tests/ui/impl-trait/nested-hkl-lifetime.rs
@@ -1,0 +1,32 @@
+//@ check-pass
+
+use std::iter::FromIterator;
+
+struct DynamicAlt<P>(P);
+
+impl<P> FromIterator<P> for DynamicAlt<P> {
+    fn from_iter<T: IntoIterator<Item = P>>(_iter: T) -> Self {
+        loop {}
+    }
+}
+
+fn owned_context<I, F>(_: F) -> impl FnMut(I) -> I {
+    |i| i
+}
+
+trait Parser<I> {}
+
+impl<T, I> Parser<I> for T where T: FnMut(I) -> I {}
+
+fn alt<I, P: Parser<I>>(_: DynamicAlt<P>) -> impl FnMut(I) -> I {
+    |i| i
+}
+
+fn rule_to_parser<'c>() -> impl Parser<&'c str> {
+    move |input| {
+        let v: Vec<()> = vec![];
+        alt(v.iter().map(|()| owned_context(rule_to_parser())).collect::<DynamicAlt<_>>())(input)
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Unblocks https://github.com/rust-lang/rust/pull/122077

in #122077 we had the fun situation where a `Opaque<'1, '2>` got a hidden type `Opaque<'3, '4>` registered (before that situation just didn't occur). Since `query_response_instantiation_guess` always equated opaque types with their hidden type (to let the type relation logic reregister the hidden type if applicable), during #122077 that started registering lifetime relations in the InferCtxt. Nll needs to take them out and tell borrowck about them, but that never happened, so borrowck started ICEing.

My next step was to stop equating opaque types to their hidden type, as we now always know that we can just register the hidden type in the query caller's InferCtxt. But then the opaque type's lifetimes never got resolved, even though the hidden type's lifetimes got resolved. That then errors out because there's an opaque type whose generic params do not refer to generic params of the item currently being borrowcked.

So my solution for now is to explicitly register lifetime relations in nll.