### PR TITLE
panic_str only exists for the migration to 2021 panic macros

### DIFF
--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -53,7 +53,7 @@ impl<'tcx> LateLintPass<'tcx> for NonPanicFmt {
 
                 if Some(def_id) == cx.tcx.lang_items().begin_panic_fn()
                     || Some(def_id) == cx.tcx.lang_items().panic_fn()
-                    || f_diagnostic_name == Some(sym::panic_str)
+                    || f_diagnostic_name == Some(sym::panic_str_2015)
                 {
                     if let Some(id) = f.span.ctxt().outer_expn_data().macro_def_id {
                         if matches!(

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1306,7 +1306,7 @@ symbols! {
         panic_misaligned_pointer_dereference,
         panic_nounwind,
         panic_runtime,
-        panic_str,
+        panic_str_2015,
         panic_unwind,
         panicking,
         param_attrs,

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -554,7 +554,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::iter::{self, FusedIterator, TrustedLen};
-use crate::panicking::{panic, panic_str};
+use crate::panicking::{panic, panic_display};
 use crate::pin::Pin;
 use crate::{
     cmp, convert, hint, mem,
@@ -1991,7 +1991,7 @@ const fn unwrap_failed() -> ! {
 #[track_caller]
 #[rustc_const_unstable(feature = "const_option", issue = "67441")]
 const fn expect_failed(msg: &str) -> ! {
-    panic_str(msg)
+    panic_display(&msg)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -27,9 +27,9 @@ pub macro panic_2015 {
     ($msg:literal $(,)?) => (
         $crate::panicking::panic($msg)
     ),
-    // Use `panic_str` instead of `panic_display::<&str>` for non_fmt_panic lint.
+    // Use `panic_str_2015` instead of `panic_display::<&str>` for non_fmt_panic lint.
     ($msg:expr $(,)?) => ({
-        $crate::panicking::panic_str($msg);
+        $crate::panicking::panic_str_2015($msg);
     }),
     // Special-case the single-argument case for const_panic.
     ("{}", $arg:expr $(,)?) => ({

--- a/tests/ui-fulldeps/stable-mir/check_transform.rs
+++ b/tests/ui-fulldeps/stable-mir/check_transform.rs
@@ -137,9 +137,9 @@ fn generate_input(path: &str) -> std::io::Result<()> {
     write!(
         file,
         r#"
-        #![feature(panic_internals)]
+        fn panic_str(msg: &str) {{ panic!("{{}}", msg); }}
         pub fn dummy() {{
-            core::panicking::panic_str("oops");
+            panic_str("oops");
         }}
         "#
     )?;


### PR DESCRIPTION
The only caller is `expect_failed`, which is already a cold inline(never) function, so inlining into that function should be fine. (And indeed `panic_str` was `#[inline]` anyway.)

The existence of panic_str risks someone calling it when they should call `panic` instead, and I can't see a reason why this footgun should exist.

I also extended the comment in `panic` to explain why it needs a `'static` string -- I know I've wondered about this in the past and it took me quite a while to understand.