### PR TITLE
match lowering: consistently merge simple or-patterns

### DIFF
--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1293,8 +1293,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // At least one of the candidates has been split into subcandidates.
                 // We need to change the candidate list to include those.
                 let mut new_candidates = Vec::new();
-
-                for candidate in candidates {
+                for candidate in candidates.iter_mut() {
                     candidate.visit_leaves(|leaf_candidate| new_candidates.push(leaf_candidate));
                 }
                 self.match_simplified_candidates(
@@ -1304,6 +1303,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     otherwise_block,
                     &mut *new_candidates,
                 );
+
+                for candidate in candidates {
+                    self.merge_trivial_subcandidates(candidate);
+                }
             } else {
                 self.match_simplified_candidates(
                     span,

--- a/compiler/rustc_mir_build/src/build/matches/simplify.rs
+++ b/compiler/rustc_mir_build/src/build/matches/simplify.rs
@@ -82,7 +82,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     &*candidate.match_pairs
                 {
                     candidate.subcandidates = self.create_or_subcandidates(pats, has_guard);
-                    candidate.match_pairs.pop();
+                    let first_match_pair = candidate.match_pairs.pop().unwrap();
+                    candidate.or_span = Some(first_match_pair.pattern.span);
                 }
                 candidate
             })

--- a/tests/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/tests/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -26,18 +26,20 @@
           _3 = _1;
           _2 = move _3 as [u32; 4] (Transmute);
           StorageDead(_3);
-          switchInt(_2[0 of 4]) -> [0: bb1, otherwise: bb6];
+          switchInt(_2[0 of 4]) -> [0: bb1, otherwise: bb4];
       }
   
       bb1: {
-          switchInt(_2[1 of 4]) -> [0: bb2, otherwise: bb6];
+          switchInt(_2[1 of 4]) -> [0: bb2, otherwise: bb4];
       }
   
       bb2: {
-          switchInt(_2[2 of 4]) -> [0: bb4, 4294901760: bb5, otherwise: bb6];
+          switchInt(_2[2 of 4]) -> [0: bb3, 4294901760: bb3, otherwise: bb4];
       }
   
       bb3: {
+          StorageLive(_4);
+          _4 = _2[3 of 4];
           StorageLive(_5);
           StorageLive(_6);
           _6 = _4;
@@ -46,27 +48,15 @@
           _0 = Option::<[u8; 4]>::Some(move _5);
           StorageDead(_5);
           StorageDead(_4);
-          goto -> bb7;
+          goto -> bb5;
       }
   
       bb4: {
-          StorageLive(_4);
-          _4 = _2[3 of 4];
-          goto -> bb3;
+          _0 = Option::<[u8; 4]>::None;
+          goto -> bb5;
       }
   
       bb5: {
-          StorageLive(_4);
-          _4 = _2[3 of 4];
-          goto -> bb3;
-      }
-  
-      bb6: {
-          _0 = Option::<[u8; 4]>::None;
-          goto -> bb7;
-      }
-  
-      bb7: {
           StorageDead(_2);
           return;
       }


### PR DESCRIPTION
There are two places where we expand or-patterns in match lowering: the main one is `test_candidates_with_or`, and there's one in `match_candidates` that's an optimization for the simple case where the whole pattern is just one or-pattern.

To reduce duplication, we merge or-pattern alternatives into a single block when possible, but we only to that in `test_candidates_with_or`. This PR fixes this oversight and merges them in `match_candidates` too.

This is a part of splitting up https://github.com/rust-lang/rust/pull/122046 into smaller bits.