### PR TITLE
CFI: Fix drop and drop_in_place

### DIFF
--- a/tests/codegen/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-drop-in-place.rs
+++ b/tests/codegen/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-drop-in-place.rs
@@ -1,0 +1,27 @@
+// Verifies that type metadata identifiers for drop functions are emitted correctly.
+//
+//@ needs-sanitizer-cfi
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static
+
+#![crate_type="lib"]
+
+// CHECK-LABEL: define{{.*}}4core3ptr47drop_in_place$LT$dyn$u20$core..marker..Send$GT$
+// CHECK-SAME:  {{.*}}!type ![[TYPE1:[0-9]+]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+// CHECK:       call i1 @llvm.type.test(ptr {{%.+}}, metadata !"_ZTSFvPu3dynIu{{[0-9]+}}NtNtNtC{{[[:print:]]+}}_4core3ops4drop4Dropu6regionEE")
+
+struct EmptyDrop;
+// CHECK: define{{.*}}4core3ptr{{[0-9]+}}drop_in_place$LT${{.*}}EmptyDrop$GT${{.*}}!type ![[TYPE1]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+
+struct NonEmptyDrop;
+
+impl Drop for NonEmptyDrop {
+    fn drop(&mut self) {}
+    // CHECK: define{{.*}}4core3ptr{{[0-9]+}}drop_in_place$LT${{.*}}NonEmptyDrop$GT${{.*}}!type ![[TYPE1]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+}
+
+pub fn foo() {
+    let _ = Box::new(EmptyDrop) as Box<dyn Send>;
+    let _ = Box::new(NonEmptyDrop) as Box<dyn Send>;
+}
+
+// CHECK: ![[TYPE1]] = !{i64 0, !"_ZTSFvPu3dynIu{{[0-9]+}}NtNtNtC{{[[:print:]]+}}_4core3ops4drop4Dropu6regionEE"}

--- a/tests/codegen/sanitizer/kcfi/emit-type-metadata-trait-objects.rs
+++ b/tests/codegen/sanitizer/kcfi/emit-type-metadata-trait-objects.rs
@@ -29,6 +29,8 @@ impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b 
 trait Freeze { }
 #[lang="drop_in_place"]
 fn drop_in_place_fn<T>() { }
+#[lang="drop"]
+trait Drop { fn drop(&mut self); }
 
 pub trait Trait1 {
     fn foo(&self);

--- a/tests/ui/sanitizer/cfi-drop-in-place.rs
+++ b/tests/ui/sanitizer/cfi-drop-in-place.rs
@@ -1,0 +1,20 @@
+// Verifies that drops can be called on arbitrary trait objects.
+//
+// FIXME(#122848): Remove only-linux when fixed.
+//@ only-linux
+//@ needs-sanitizer-cfi
+//@ compile-flags: -Clto -Copt-level=0 -Cprefer-dynamic=off -Ctarget-feature=-crt-static -Zsanitizer=cfi
+//@ run-pass
+
+struct EmptyDrop;
+
+struct NonEmptyDrop;
+
+impl Drop for NonEmptyDrop {
+    fn drop(&mut self) {}
+}
+
+fn main() {
+    let _ = Box::new(EmptyDrop) as Box<dyn Send>;
+    let _ = Box::new(NonEmptyDrop) as Box<dyn Send>;
+}


### PR DESCRIPTION
Fix drop and drop_in_place by transforming self of drop and drop_in_place methods into a Drop trait objects.

This was split off from https://github.com/rust-lang/rust/pull/116404.

cc @compiler-errors @workingjubilee