### PR TITLE
Add basic trait impls for `f16` and `f128`

### DIFF
--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -227,7 +227,7 @@ mod impls {
     impl_clone! {
         usize u8 u16 u32 u64 u128
         isize i8 i16 i32 i64 i128
-        f32 f64
+        f16 f32 f64 f128
         bool char
     }
 

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1486,7 +1486,7 @@ mod impls {
     }
 
     partial_eq_impl! {
-        bool char usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64
+        bool char usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128
     }
 
     macro_rules! eq_impl {
@@ -1539,7 +1539,7 @@ mod impls {
         }
     }
 
-    partial_ord_impl! { f32 f64 }
+    partial_ord_impl! { f16 f32 f64 f128 }
 
     macro_rules! ord_impl {
         ($($t:ty)*) => ($(

--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -178,5 +178,9 @@ default_impl! { i32, 0, "Returns the default value of `0`" }
 default_impl! { i64, 0, "Returns the default value of `0`" }
 default_impl! { i128, 0, "Returns the default value of `0`" }
 
+#[cfg(not(bootstrap))]
+default_impl! { f16, 0.0f16, "Returns the default value of `0.0`" }
 default_impl! { f32, 0.0f32, "Returns the default value of `0.0`" }
 default_impl! { f64, 0.0f64, "Returns the default value of `0.0`" }
+#[cfg(not(bootstrap))]
+default_impl! { f128, 0.0f128, "Returns the default value of `0.0`" }

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -229,6 +229,8 @@
 #![feature(doc_notable_trait)]
 #![feature(effects)]
 #![feature(extern_types)]
+#![feature(f128)]
+#![feature(f16)]
 #![feature(freeze_impls)]
 #![feature(fundamental)]
 #![feature(generic_arg_infer)]

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -422,7 +422,7 @@ marker_impls! {
     Copy for
         usize, u8, u16, u32, u64, u128,
         isize, i8, i16, i32, i64, i128,
-        f32, f64,
+        f16, f32, f64, f128,
         bool, char,
         {T: ?Sized} *const T,
         {T: ?Sized} *mut T,

--- a/tests/ui/binop/binary-op-suggest-deref.stderr
+++ b/tests/ui/binop/binary-op-suggest-deref.stderr
@@ -247,15 +247,15 @@ LL |     _ = &&0 == Foo;
    |
    = help: the trait `PartialEq<Foo>` is not implemented for `&&{integer}`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             f128
+             f16
              f32
              f64
              i128
              i16
              i32
              i64
-             i8
-             isize
-           and 6 others
+           and 8 others
 
 error[E0369]: binary operation `==` cannot be applied to type `Foo`
   --> $DIR/binary-op-suggest-deref.rs:60:13

--- a/tests/ui/mismatched_types/binops.stderr
+++ b/tests/ui/mismatched_types/binops.stderr
@@ -73,15 +73,15 @@ LL |     5 < String::new();
    |
    = help: the trait `PartialOrd<String>` is not implemented for `{integer}`
    = help: the following other types implement trait `PartialOrd<Rhs>`:
+             f128
+             f16
              f32
              f64
              i128
              i16
              i32
              i64
-             i8
-             isize
-           and 6 others
+           and 8 others
 
 error[E0277]: can't compare `{integer}` with `Result<{integer}, _>`
   --> $DIR/binops.rs:7:7
@@ -91,15 +91,15 @@ LL |     6 == Ok(1);
    |
    = help: the trait `PartialEq<Result<{integer}, _>>` is not implemented for `{integer}`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             f128
+             f16
              f32
              f64
              i128
              i16
              i32
              i64
-             i8
-             isize
-           and 6 others
+           and 8 others
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Split off part of <https://github.com/rust-lang/rust/pull/122470> so the compiler doesn't ICE because it expects primitives to have some minimal traits.

Fixes <https://github.com/rust-lang/rust/issues/123074>