### PR TITLE
Fix doc link to BufWriter in std::fs::File documentation

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -97,7 +97,7 @@ use crate::time::SystemTime;
 /// have been opened for asynchronous I/O (e.g. by using `FILE_FLAG_OVERLAPPED`).
 ///
 /// [`BufReader`]: io::BufReader
-/// [`BufWriter`]: io::BufReader
+/// [`BufWriter`]: io::BufWriter
 /// [`sync_all`]: File::sync_all
 /// [`write`]: File::write
 /// [`read`]: File::read


### PR DESCRIPTION
It seems that doc link to `BufWriter` in `std::fs::File` doc leads to `BufReader`, not `BufWriter`.
See https://doc.rust-lang.org/std/fs/struct.File.html