### PR TITLE
Replace `f16` and `f128` pattern matching stubs with real implementations

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -1047,6 +1047,12 @@ impl<'tcx> PatRangeBoundary<'tcx> {
         let b = other.eval_bits(ty, tcx, param_env);
 
         match ty.kind() {
+            ty::Float(ty::FloatTy::F16) => {
+                use rustc_apfloat::Float;
+                let a = rustc_apfloat::ieee::Half::from_bits(a);
+                let b = rustc_apfloat::ieee::Half::from_bits(b);
+                a.partial_cmp(&b)
+            }
             ty::Float(ty::FloatTy::F32) => {
                 use rustc_apfloat::Float;
                 let a = rustc_apfloat::ieee::Single::from_bits(a);
@@ -1057,6 +1063,12 @@ impl<'tcx> PatRangeBoundary<'tcx> {
                 use rustc_apfloat::Float;
                 let a = rustc_apfloat::ieee::Double::from_bits(a);
                 let b = rustc_apfloat::ieee::Double::from_bits(b);
+                a.partial_cmp(&b)
+            }
+            ty::Float(ty::FloatTy::F128) => {
+                use rustc_apfloat::Float;
+                let a = rustc_apfloat::ieee::Quad::from_bits(a);
+                let b = rustc_apfloat::ieee::Quad::from_bits(b);
                 a.partial_cmp(&b)
             }
             ty::Int(ity) => {

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1196,7 +1196,7 @@ impl<'tcx> Ty<'tcx> {
     /// Returns the minimum and maximum values for the given numeric type (including `char`s) or
     /// returns `None` if the type is not numeric.
     pub fn numeric_min_and_max_as_bits(self, tcx: TyCtxt<'tcx>) -> Option<(u128, u128)> {
-        use rustc_apfloat::ieee::{Double, Single};
+        use rustc_apfloat::ieee::{Double, Half, Quad, Single};
         Some(match self.kind() {
             ty::Int(_) | ty::Uint(_) => {
                 let (size, signed) = self.int_size_and_signed(tcx);
@@ -1206,12 +1206,14 @@ impl<'tcx> Ty<'tcx> {
                 (min, max)
             }
             ty::Char => (0, std::char::MAX as u128),
+            ty::Float(ty::FloatTy::F16) => ((-Half::INFINITY).to_bits(), Half::INFINITY.to_bits()),
             ty::Float(ty::FloatTy::F32) => {
                 ((-Single::INFINITY).to_bits(), Single::INFINITY.to_bits())
             }
             ty::Float(ty::FloatTy::F64) => {
                 ((-Double::INFINITY).to_bits(), Double::INFINITY.to_bits())
             }
+            ty::Float(ty::FloatTy::F128) => ((-Quad::INFINITY).to_bits(), Quad::INFINITY.to_bits()),
             _ => return None,
         })
     }

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -369,10 +369,10 @@ impl<'tcx> ConstToPat<'tcx> {
             ty::Float(flt) => {
                 let v = cv.unwrap_leaf();
                 let is_nan = match flt {
-                    ty::FloatTy::F16 => unimplemented!("f16_f128"),
+                    ty::FloatTy::F16 => v.to_f16().is_nan(),
                     ty::FloatTy::F32 => v.to_f32().is_nan(),
                     ty::FloatTy::F64 => v.to_f64().is_nan(),
-                    ty::FloatTy::F128 => unimplemented!("f16_f128"),
+                    ty::FloatTy::F128 => v.to_f128().is_nan(),
                 };
                 if is_nan {
                     // NaNs are not ever equal to anything so they make no sense as patterns.

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -247,8 +247,9 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                 }
                 _ => bug!("bad slice pattern {:?} {:?}", ctor, ty),
             },
-            Bool(..) | IntRange(..) | F32Range(..) | F64Range(..) | Str(..) | Opaque(..)
-            | Never | NonExhaustive | Hidden | Missing | PrivateUninhabited | Wildcard => &[],
+            Bool(..) | IntRange(..) | F16Range(..) | F32Range(..) | F64Range(..)
+            | F128Range(..) | Str(..) | Opaque(..) | Never | NonExhaustive | Hidden | Missing
+            | PrivateUninhabited | Wildcard => &[],
             Or => {
                 bug!("called `Fields::wildcards` on an `Or` ctor")
             }
@@ -275,8 +276,9 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
             },
             Ref => 1,
             Slice(slice) => slice.arity(),
-            Bool(..) | IntRange(..) | F32Range(..) | F64Range(..) | Str(..) | Opaque(..)
-            | Never | NonExhaustive | Hidden | Missing | PrivateUninhabited | Wildcard => 0,
+            Bool(..) | IntRange(..) | F16Range(..) | F32Range(..) | F64Range(..)
+            | F128Range(..) | Str(..) | Opaque(..) | Never | NonExhaustive | Hidden | Missing
+            | PrivateUninhabited | Wildcard => 0,
             Or => bug!("The `Or` constructor doesn't have a fixed arity"),
         }
     }
@@ -546,6 +548,18 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                         fields = vec![];
                         arity = 0;
                     }
+                    ty::Float(ty::FloatTy::F16) => {
+                        ctor = match value.try_eval_bits(cx.tcx, cx.param_env) {
+                            Some(bits) => {
+                                use rustc_apfloat::Float;
+                                let value = rustc_apfloat::ieee::Half::from_bits(bits);
+                                F16Range(value, value, RangeEnd::Included)
+                            }
+                            None => Opaque(OpaqueId::new()),
+                        };
+                        fields = vec![];
+                        arity = 0;
+                    }
                     ty::Float(ty::FloatTy::F32) => {
                         ctor = match value.try_eval_bits(cx.tcx, cx.param_env) {
                             Some(bits) => {
@@ -564,6 +578,18 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                                 use rustc_apfloat::Float;
                                 let value = rustc_apfloat::ieee::Double::from_bits(bits);
                                 F64Range(value, value, RangeEnd::Included)
+                            }
+                            None => Opaque(OpaqueId::new()),
+                        };
+                        fields = vec![];
+                        arity = 0;
+                    }
+                    ty::Float(ty::FloatTy::F128) => {
+                        ctor = match value.try_eval_bits(cx.tcx, cx.param_env) {
+                            Some(bits) => {
+                                use rustc_apfloat::Float;
+                                let value = rustc_apfloat::ieee::Quad::from_bits(bits);
+                                F128Range(value, value, RangeEnd::Included)
                             }
                             None => Opaque(OpaqueId::new()),
                         };
@@ -611,7 +637,12 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                         let lo = lo.as_finite().map(|c| c.eval_bits(cx.tcx, cx.param_env));
                         let hi = hi.as_finite().map(|c| c.eval_bits(cx.tcx, cx.param_env));
                         match fty {
-                            ty::FloatTy::F16 => unimplemented!("f16_f128"),
+                            ty::FloatTy::F16 => {
+                                use rustc_apfloat::ieee::Half;
+                                let lo = lo.map(Half::from_bits).unwrap_or(-Half::INFINITY);
+                                let hi = hi.map(Half::from_bits).unwrap_or(Half::INFINITY);
+                                F16Range(lo, hi, end)
+                            }
                             ty::FloatTy::F32 => {
                                 use rustc_apfloat::ieee::Single;
                                 let lo = lo.map(Single::from_bits).unwrap_or(-Single::INFINITY);
@@ -624,7 +655,12 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                                 let hi = hi.map(Double::from_bits).unwrap_or(Double::INFINITY);
                                 F64Range(lo, hi, end)
                             }
-                            ty::FloatTy::F128 => unimplemented!("f16_f128"),
+                            ty::FloatTy::F128 => {
+                                use rustc_apfloat::ieee::Quad;
+                                let lo = lo.map(Quad::from_bits).unwrap_or(-Quad::INFINITY);
+                                let hi = hi.map(Quad::from_bits).unwrap_or(Quad::INFINITY);
+                                F128Range(lo, hi, end)
+                            }
                         }
                     }
                     _ => bug!("invalid type for range pattern: {}", ty.inner()),
@@ -837,7 +873,7 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                 "trying to convert a `Missing` constructor into a `Pat`; this is probably a bug,
                 `Missing` should have been processed in `apply_constructors`"
             ),
-            F32Range(..) | F64Range(..) | Opaque(..) | Or => {
+            F16Range(..) | F32Range(..) | F64Range(..) | F128Range(..) | Opaque(..) | Or => {
                 bug!("can't convert to pattern: {:?}", pat)
             }
         };

--- a/tests/crashes/122587-1.rs
+++ b/tests/crashes/122587-1.rs
@@ -1,5 +1,0 @@
-//@ known-bug: #122587
-const b: f16 = 0.0f16;
-pub fn main() {
-   let b = 0.0f16;
-}

--- a/tests/ui/consts/const_in_pattern/f16-f128-const-reassign.rs
+++ b/tests/ui/consts/const_in_pattern/f16-f128-const-reassign.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+// issue: rust-lang/rust#122587
+
+#![feature(f128)]
+#![feature(f16)]
+#![allow(non_upper_case_globals)]
+
+const h: f16 = 0.0f16;
+const q: f128 = 0.0f128;
+
+pub fn main() {
+    let h = 0.0f16 else { unreachable!() };
+    let q = 0.0f128 else { unreachable!() };
+}

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-semantics.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-semantics.rs
@@ -4,6 +4,8 @@
 // via `.contains(...)` and make sure the dynamic semantics match.
 
 #![allow(unreachable_patterns)]
+#![feature(f128)]
+#![feature(f16)]
 
 macro_rules! yes {
     ($scrutinee:expr, $($t:tt)+) => {
@@ -39,6 +41,17 @@ fn range_to_inclusive() {
     assert!(yes!('a', ..='a'));
     assert!(!yes!('b', ..='a'));
 
+    // f16; `..=X`
+    // FIXME(f16_f128): remove gate when ABI issues are resolved
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        // FIXME(f16_f128): enable infinity tests when constants are available
+        // assert!(yes!(f16::NEG_INFINITY, ..=f16::NEG_INFINITY));
+        // assert!(yes!(f16::NEG_INFINITY, ..=1.0f16));
+        assert!(yes!(1.5f16, ..=1.5f16));
+        assert!(!yes!(1.6f16, ..=-1.5f16));
+    }
+
     // f32; `..=X`
     assert!(yes!(f32::NEG_INFINITY, ..=f32::NEG_INFINITY));
     assert!(yes!(f32::NEG_INFINITY, ..=1.0f32));
@@ -50,6 +63,17 @@ fn range_to_inclusive() {
     assert!(yes!(f64::NEG_INFINITY, ..=1.0f64));
     assert!(yes!(1.5f64, ..=1.5f64));
     assert!(!yes!(1.6f64, ..=-1.5f64));
+
+    // f128; `..=X`
+    // FIXME(f16_f128): remove gate when ABI issues are resolved
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        // FIXME(f16_f128): enable infinity tests when constants are available
+        // assert!(yes!(f128::NEG_INFINITY, ..=f128::NEG_INFINITY));
+        // assert!(yes!(f128::NEG_INFINITY, ..=1.0f128));
+        assert!(yes!(1.5f128, ..=1.5f128));
+        assert!(!yes!(1.6f128, ..=-1.5f128));
+    }
 }
 
 fn range_to() {
@@ -83,6 +107,18 @@ fn range_to() {
     assert!(!yes!('a', ..'a'));
     assert!(!yes!('b', ..'a'));
 
+    // f16; `..X`
+    // FIXME(f16_f128): remove gate when ABI issues are resolved
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        // FIXME(f16_f128): enable infinity tests when constants are available
+        // assert!(yes!(f16::NEG_INFINITY, ..1.0f16));
+        assert!(!yes!(1.5f16, ..1.5f16));
+        const E16: f16 = 1.5f16 + f16::EPSILON;
+        assert!(yes!(1.5f16, ..E16));
+        assert!(!yes!(1.6f16, ..1.5f16));
+    }
+
     // f32; `..X`
     assert!(yes!(f32::NEG_INFINITY, ..1.0f32));
     assert!(!yes!(1.5f32, ..1.5f32));
@@ -96,6 +132,18 @@ fn range_to() {
     const E64: f64 = 1.5f64 + f64::EPSILON;
     assert!(yes!(1.5f64, ..E64));
     assert!(!yes!(1.6f64, ..1.5f64));
+
+    // f128; `..X`
+    // FIXME(f16_f128): remove gate when ABI issues are resolved
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        // FIXME(f16_f128): enable infinity tests when constants are available
+        // assert!(yes!(f128::NEG_INFINITY, ..1.0f128));
+        assert!(!yes!(1.5f128, ..1.5f128));
+        const E128: f128 = 1.5f128 + f128::EPSILON;
+        assert!(yes!(1.5f128, ..E128));
+        assert!(!yes!(1.6f128, ..1.5f128));
+    }
 }
 
 fn range_from() {
@@ -129,6 +177,21 @@ fn range_from() {
     assert!(!yes!('a', 'b'..));
     assert!(yes!(core::char::MAX, core::char::MAX..));
 
+    // f16; `X..`
+    // FIXME(f16_f128): remove gate when ABI issues are resolved
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        // FIXME(f16_f128): enable infinity tests when constants are available
+        // assert!(yes!(f16::NEG_INFINITY, f16::NEG_INFINITY..));
+        // assert!(yes!(f16::INFINITY, f16::NEG_INFINITY..));
+        // assert!(!yes!(f16::NEG_INFINITY, 1.0f16..));
+        // assert!(yes!(f16::INFINITY, 1.0f16..));
+        assert!(!yes!(1.0f16 - f16::EPSILON, 1.0f16..));
+        assert!(yes!(1.0f16, 1.0f16..));
+        // assert!(yes!(f16::INFINITY, 1.0f16..));
+        // assert!(yes!(f16::INFINITY, f16::INFINITY..));
+    }
+
     // f32; `X..`
     assert!(yes!(f32::NEG_INFINITY, f32::NEG_INFINITY..));
     assert!(yes!(f32::INFINITY, f32::NEG_INFINITY..));
@@ -148,6 +211,21 @@ fn range_from() {
     assert!(yes!(1.0f64, 1.0f64..));
     assert!(yes!(f64::INFINITY, 1.0f64..));
     assert!(yes!(f64::INFINITY, f64::INFINITY..));
+
+    // f128; `X..`
+    // FIXME(f16_f128): remove gate when ABI issues are resolved
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        // FIXME(f16_f128): enable infinity tests when constants are available
+        // assert!(yes!(f128::NEG_INFINITY, f128::NEG_INFINITY..));
+        // assert!(yes!(f128::INFINITY, f128::NEG_INFINITY..));
+        // assert!(!yes!(f128::NEG_INFINITY, 1.0f128..));
+        // assert!(yes!(f128::INFINITY, 1.0f128..));
+        assert!(!yes!(1.0f128 - f128::EPSILON, 1.0f128..));
+        assert!(yes!(1.0f128, 1.0f128..));
+        // assert!(yes!(f128::INFINITY, 1.0f128..));
+        // assert!(yes!(f128::INFINITY, f128::INFINITY..));
+    }
 }
 
 fn main() {

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.rs
@@ -27,6 +27,7 @@ fn main() {
     m!(0, ..i128::MIN);
     //~^ ERROR lower range bound must be less than upper
 
+    // FIXME(f16_f128): add tests when NEG_INFINITY is available
     m!(0f32, ..f32::NEG_INFINITY);
     //~^ ERROR lower range bound must be less than upper
     m!(0f64, ..f64::NEG_INFINITY);

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.stderr
@@ -59,19 +59,19 @@ LL |     m!(0, ..i128::MIN);
    |           ^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:30:14
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:31:14
    |
 LL |     m!(0f32, ..f32::NEG_INFINITY);
    |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:32:14
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:33:14
    |
 LL |     m!(0f64, ..f64::NEG_INFINITY);
    |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:35:13
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:36:13
    |
 LL |     m!('a', ..'\u{0}');
    |             ^^^^^^^^^

--- a/tests/ui/match/match-float.rs
+++ b/tests/ui/match/match-float.rs
@@ -1,11 +1,54 @@
 //@ run-pass
 // Makes sure we use `==` (not bitwise) semantics for float comparison.
 
-fn main() {
+#![feature(f128)]
+#![feature(f16)]
+
+// FIXME(f16_f128): remove gates when ABI issues are resolved
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+fn check_f16() {
+    const F1: f16 = 0.0;
+    const F2: f16 = -0.0;
+    assert_eq!(F1, F2);
+    assert_ne!(F1.to_bits(), F2.to_bits());
+    assert!(matches!(F1, F2));
+    assert!(matches!(F2, F1));
+}
+
+fn check_f32() {
     const F1: f32 = 0.0;
     const F2: f32 = -0.0;
     assert_eq!(F1, F2);
     assert_ne!(F1.to_bits(), F2.to_bits());
     assert!(matches!(F1, F2));
     assert!(matches!(F2, F1));
+}
+
+fn check_f64() {
+    const F1: f64 = 0.0;
+    const F2: f64 = -0.0;
+    assert_eq!(F1, F2);
+    assert_ne!(F1.to_bits(), F2.to_bits());
+    assert!(matches!(F1, F2));
+    assert!(matches!(F2, F1));
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+fn check_f128() {
+    const F1: f128 = 0.0;
+    const F2: f128 = -0.0;
+    assert_eq!(F1, F2);
+    assert_ne!(F1.to_bits(), F2.to_bits());
+    assert!(matches!(F1, F2));
+    assert!(matches!(F2, F1));
+}
+
+fn main() {
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    check_f16();
+    check_f32();
+    check_f64();
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    check_f128();
 }

--- a/tests/ui/pattern/usefulness/floats.rs
+++ b/tests/ui/pattern/usefulness/floats.rs
@@ -1,4 +1,6 @@
 #![deny(unreachable_patterns)]
+#![feature(f128)]
+#![feature(f16)]
 
 fn main() {
     match 0.0 {
@@ -10,6 +12,32 @@ fn main() {
         //~^ ERROR non-exhaustive patterns
         0.0..=1.0 => {}
     }
+
+    match 1.0f16 {
+        0.01f16..=6.5f16 => {}
+        0.01f16 => {} //~ ERROR unreachable pattern
+        0.02f16 => {} //~ ERROR unreachable pattern
+        6.5f16 => {}  //~ ERROR unreachable pattern
+        _ => {}
+    };
+    match 1.0f16 {
+        0.01f16..6.5f16 => {}
+        6.5f16 => {} // this is reachable
+        _ => {}
+    };
+
+    match 1.0f32 {
+        0.01f32..=6.5f32 => {}
+        0.01f32 => {} //~ ERROR unreachable pattern
+        0.02f32 => {} //~ ERROR unreachable pattern
+        6.5f32 => {}  //~ ERROR unreachable pattern
+        _ => {}
+    };
+    match 1.0f32 {
+        0.01f32..6.5f32 => {}
+        6.5f32 => {} // this is reachable
+        _ => {}
+    };
 
     match 1.0f64 {
         0.01f64..=6.5f64 => {}
@@ -28,16 +56,20 @@ fn main() {
         _ => {}
     };
 
-    match 1.0f32 {
-        0.01f32..=6.5f32 => {}
-        0.01f32 => {} //~ ERROR unreachable pattern
-        0.02f32 => {} //~ ERROR unreachable pattern
-        6.5f32 => {}  //~ ERROR unreachable pattern
+    match 1.0f128 {
+        0.01f128..=6.5f128 => {}
+        0.005f128 => {}
+        0.01f128 => {} //~ ERROR unreachable pattern
+        0.02f128 => {} //~ ERROR unreachable pattern
+        6.5f128 => {}  //~ ERROR unreachable pattern
+        6.6f128 => {}
+        1.0f128..=4.0f128 => {} //~ ERROR unreachable pattern
+        5.0f128..=7.0f128 => {}
         _ => {}
     };
-    match 1.0f32 {
-        0.01f32..6.5f32 => {}
-        6.5f32 => {} // this is reachable
+    match 1.0f128 {
+        0.01f128..6.5f128 => {}
+        6.5f128 => {} // this is reachable
         _ => {}
     };
 }

--- a/tests/ui/pattern/usefulness/floats.stderr
+++ b/tests/ui/pattern/usefulness/floats.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/floats.rs:9:11
+  --> $DIR/floats.rs:11:11
    |
 LL |     match 0.0 {
    |           ^^^ pattern `_` not covered
@@ -12,9 +12,9 @@ LL +         _ => todo!()
    |
 
 error: unreachable pattern
-  --> $DIR/floats.rs:17:9
+  --> $DIR/floats.rs:18:9
    |
-LL |         0.01f64 => {}
+LL |         0.01f16 => {}
    |         ^^^^^^^
    |
 note: the lint level is defined here
@@ -24,41 +24,83 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/floats.rs:18:9
+  --> $DIR/floats.rs:19:9
    |
-LL |         0.02f64 => {}
+LL |         0.02f16 => {}
    |         ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/floats.rs:19:9
+  --> $DIR/floats.rs:20:9
    |
-LL |         6.5f64 => {}
+LL |         6.5f16 => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/floats.rs:21:9
-   |
-LL |         1.0f64..=4.0f64 => {}
-   |         ^^^^^^^^^^^^^^^
-
-error: unreachable pattern
-  --> $DIR/floats.rs:33:9
+  --> $DIR/floats.rs:31:9
    |
 LL |         0.01f32 => {}
    |         ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/floats.rs:34:9
+  --> $DIR/floats.rs:32:9
    |
 LL |         0.02f32 => {}
    |         ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/floats.rs:35:9
+  --> $DIR/floats.rs:33:9
    |
 LL |         6.5f32 => {}
    |         ^^^^^^
 
-error: aborting due to 8 previous errors
+error: unreachable pattern
+  --> $DIR/floats.rs:45:9
+   |
+LL |         0.01f64 => {}
+   |         ^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:46:9
+   |
+LL |         0.02f64 => {}
+   |         ^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:47:9
+   |
+LL |         6.5f64 => {}
+   |         ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:49:9
+   |
+LL |         1.0f64..=4.0f64 => {}
+   |         ^^^^^^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:62:9
+   |
+LL |         0.01f128 => {}
+   |         ^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:63:9
+   |
+LL |         0.02f128 => {}
+   |         ^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:64:9
+   |
+LL |         6.5f128 => {}
+   |         ^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/floats.rs:66:9
+   |
+LL |         1.0f128..=4.0f128 => {}
+   |         ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
This section of code depends on `rustc_apfloat` rather than our internal types, so this is one potential ICE that we should be able to melt now.

r? @Nadrieril