### PR TITLE
Delegation: fix ICE on wrong `self` resolution

### DIFF
--- a/tests/ui/delegation/target-expr.rs
+++ b/tests/ui/delegation/target-expr.rs
@@ -1,0 +1,38 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    fn static_method(x: i32) -> i32 { x }
+}
+
+struct F;
+
+struct S(F);
+impl Trait for S {}
+
+fn foo(x: i32) -> i32 { x }
+
+fn bar<T: Default>(_: T) {
+    reuse Trait::static_method {
+        //~^ ERROR delegation with early bound generics is not supported yet
+        //~| ERROR mismatched types
+        let _ = T::Default();
+        //~^ ERROR can't use generic parameters from outer item
+    }
+}
+
+fn main() {
+    let y = 0;
+    reuse <S as Trait>::static_method {
+        let x = y;
+        //~^ ERROR can't capture dynamic environment in a fn item
+        foo(self);
+
+        let reuse_ptr: fn(i32) -> i32  = static_method;
+        reuse_ptr(0)
+    }
+    self.0;
+    //~^ ERROR expected value, found module `self`
+    let z = x;
+    //~^ ERROR cannot find value `x` in this scope
+}

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -1,0 +1,65 @@
+error[E0401]: can't use generic parameters from outer item
+  --> $DIR/target-expr.rs:19:17
+   |
+LL | fn bar<T: Default>(_: T) {
+   |        - type parameter from outer item
+LL |     reuse Trait::static_method {
+   |                               - help: try introducing a local generic parameter here: `T,`
+...
+LL |         let _ = T::Default();
+   |                 ^^^^^^^^^^ use of generic parameter from outer item
+
+error[E0434]: can't capture dynamic environment in a fn item
+  --> $DIR/target-expr.rs:27:17
+   |
+LL |         let x = y;
+   |                 ^
+   |
+   = help: use the `|| { ... }` closure form instead
+
+error[E0424]: expected value, found module `self`
+  --> $DIR/target-expr.rs:34:5
+   |
+LL | fn main() {
+   |    ---- this function can't have a `self` parameter
+...
+LL |     self.0;
+   |     ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/target-expr.rs:36:13
+   |
+LL |     let z = x;
+   |             ^
+   |
+help: the binding `x` is available in a different scope in the same function
+  --> $DIR/target-expr.rs:27:13
+   |
+LL |         let x = y;
+   |             ^
+
+error: delegation with early bound generics is not supported yet
+  --> $DIR/target-expr.rs:16:18
+   |
+LL |     fn static_method(x: i32) -> i32 { x }
+   |     ------------------------------- callee defined here
+...
+LL |     reuse Trait::static_method {
+   |                  ^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr.rs:16:32
+   |
+LL |       reuse Trait::static_method {
+   |  ________________________________^
+LL | |
+LL | |
+LL | |         let _ = T::Default();
+LL | |
+LL | |     }
+   | |_____^ expected `i32`, found `()`
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0308, E0401, E0424, E0425, E0434.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/122874

Delegation item should be wrapped in a `rib` to behave like a regular function during name resolution.

r? @petrochenkov