### PR TITLE
Add a nice header to our README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ If you wish to _contribute_ to the compiler, you should read
 
 </details>
 
+## Why Rust?
+
+- **Performance:** Fast and memory-efficient, suitable for critical services, embedded devices, and easily integrate with other languages.
+
+- **Reliability:** Our rich type system and ownership model ensure memory and thread safety, reducing bugs at compile-time.
+
+- **Productivity:** Comprehensive documentation, a compiler committed to providing great diagnostics, and advanced tooling including package manager and build tool ([Cargo]), auto-formatter ([rustfmt]), linter ([Clippy]) and editor support ([rust-analyzer]).
+
+[Cargo]: https://github.com/rust-lang/cargo
+[rustfmt]: https://github.com/rust-lang/rustfmt
+[Clippy]: https://github.com/rust-lang/rust-clippy
+[rust-analyzer]: https://github.com/rust-lang/rust-analyzer
+
 ## Quick Start
 
 Read ["Installation"] from [The Book].

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <div align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/Urgau/rust/assets/3616612/526538d1-450c-4709-b597-27b7dd83c794">
-    <source media="(prefers-color-scheme: light)" srcset="https://www.rust-lang.org/static/images/rust-social-wide.jpg">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rust-lang/www.rust-lang.org/master/static/images/rust-social-wide-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/rust-lang/www.rust-lang.org/master/static/images/rust-social-wide-light.svg">
     <img alt="The Rust Programming Language: A language empowering everyone to build reliable and efficient software"
-         src="https://www.rust-lang.org/static/images/rust-social-wide.jpg"
+         src="https://raw.githubusercontent.com/rust-lang/www.rust-lang.org/master/static/images/rust-social-wide-light.svg"
          width="50%">
   </picture>
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,23 @@
-# The Rust Programming Language
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/Urgau/rust/assets/3616612/526538d1-450c-4709-b597-27b7dd83c794">
+    <source media="(prefers-color-scheme: light)" srcset="https://www.rust-lang.org/static/images/rust-social-wide.jpg">
+    <img alt="The Rust Programming Language: A language empowering everyone to build reliable and efficient software"
+         src="https://www.rust-lang.org/static/images/rust-social-wide.jpg"
+         width="50%">
+  </picture>
 
-[![Rust Community](https://img.shields.io/badge/Rust_Community%20-Join_us-brightgreen?style=plastic&logo=rust)](https://www.rust-lang.org/community)
+[Website][Rust] | [Getting started] | [Learn] | [Documentation] | [Contributing]
+</div>
 
 This is the main source code repository for [Rust]. It contains the compiler,
 standard library, and documentation.
 
 [Rust]: https://www.rust-lang.org/
-
-**Note: this README is for _users_ rather than _contributors_.**
-If you wish to _contribute_ to the compiler, you should read
-[CONTRIBUTING.md](CONTRIBUTING.md) instead.
-
-<details>
-<summary>Table of Contents</summary>
-
-- [Quick Start](#quick-start)
-- [Installing from Source](#installing-from-source)
-- [Getting Help](#getting-help)
-- [Contributing](#contributing)
-- [License](#license)
-- [Trademark](#trademark)
-
-</details>
+[Getting Started]: https://www.rust-lang.org/learn/get-started
+[Learn]: https://www.rust-lang.org/learn
+[Documentation]: https://www.rust-lang.org/learn#learn-use
+[Contributing]: CONTRIBUTING.md
 
 ## Why Rust?
 


### PR DESCRIPTION
This PR improves our README, it is greatly inspired by [esbuild](https://github.com/evanw/esbuild/blob/9d1777f23d9b64c186345223d92f319e59388d8b/README.md) README.

Context: As was reading https://johnjago.com/great-docs/ I though we could greatly improve ours. So that's what I did.

It provides direct "quick-access" links to pages in rust-lang.org.

The "Why Rust?" section is ~~a direct copy/paste of the same~~ modified version of section in [rust-lang.org](https://www.rust-lang.org/).

| Before | After |
|--------|-------|
| ![before](https://github.com/rust-lang/rust/assets/3616612/4afb6753-18a9-4881-919e-2a79328beb5a) | ![after](https://github.com/rust-lang/rust/assets/3616612/408dea7b-5d97-4bb8-a77e-35541ddd50cb) <details> ![after](https://github.com/rust-lang/rust/assets/3616612/76e4a8c6-b61c-46e8-b5ba-4f09c13cfc94) </details> <details> ![after -1](https://github.com/rust-lang/rust/assets/3616612/ed50675c-8301-457c-8b9a-a1199c515fb7) </details> |

Note: I removed the manual TOC, since GitHub provides it's own at the top right corner and I don't think it's needed anymore.
Same for the notice about the readme being for users, it's now clear enough and that notice was distracting anyway.