### PR TITLE
Don't check match scrutinee of postfix match for unused parens

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -865,7 +865,9 @@ trait UnusedDelimLint {
                 (iter, UnusedDelimsCtx::ForIterExpr, true, None, Some(body.span.lo()), true)
             }
 
-            Match(ref head, ..) if Self::LINT_EXPR_IN_PATTERN_MATCHING_CTX => {
+            Match(ref head, _, ast::MatchKind::Prefix)
+                if Self::LINT_EXPR_IN_PATTERN_MATCHING_CTX =>
+            {
                 let left = e.span.lo() + rustc_span::BytePos(5);
                 (head, UnusedDelimsCtx::MatchScrutineeExpr, true, Some(left), None, true)
             }

--- a/tests/ui/match/postfix-match/no-unused-parens.rs
+++ b/tests/ui/match/postfix-match/no-unused-parens.rs
@@ -1,0 +1,8 @@
+//@ check-pass
+
+#![feature(postfix_match)]
+
+fn main() {
+    (&1).match { a => a };
+    (1 + 2).match { b => b };
+}


### PR DESCRIPTION
We only check the scrutinees of block-like constructs and a few others (return/index/assign/method calls). Just don't do it for postfix match at all.

Fixes #123064

r? fmease