### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -6,8 +6,6 @@ on:
   schedule:
     # Run weekly
     - cron: '0 0 * * Sun'
-    # Re-bump deps every 4 hours
-    - cron: '0 */4 * * *'
   workflow_dispatch:
     # Needed so we can run it manually
 permissions:
@@ -42,7 +40,7 @@ jobs:
 
           # Exit with error if open and S-waiting-on-bors
           if [[ "$STATE" == "OPEN" && "$WAITING_ON_BORS" == "true" ]]; then
-            gh run cancel ${{ github.run_id }}
+            exit 1
           fi
 
   update:
@@ -65,10 +63,7 @@ jobs:
 
       - name: cargo update
         # Remove first line that always just says "Updating crates.io index"
-        # If there are no changes, cancel the job here
-        run: |
-          cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
-          git status --porcelain | grep -q Cargo.lock || gh run cancel ${{ github.run_id }}
+        run: cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
       - name: upload Cargo.lock artifact for use in PR
         uses: actions/upload-artifact@v4
         with:
@@ -95,11 +90,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: download Cargo.lock from update job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Cargo-lock
       - name: download cargo-update log from update job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cargo-updates
 
@@ -134,14 +129,14 @@ jobs:
           # Exit with error if PR is closed
           STATE=$(gh pr view cargo_update --repo $GITHUB_REPOSITORY --json state --jq '.state')
           if [[ "$STATE" != "OPEN" ]]; then
-            gh run cancel ${{ github.run_id }}
+            exit 1
           fi
 
           gh pr edit cargo_update --title "${PR_TITLE}" --body-file body.md --repo $GITHUB_REPOSITORY
 
       - name: open new pull request
-        # Only run if there wasn't an existing PR and if this is the weekly run
-        if: steps.edit.outcome != 'success' && github.event.schedule == '0 0 * * Sun'
+        # Only run if there wasn't an existing PR
+        if: steps.edit.outcome != 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr create --title "${PR_TITLE}" --body-file body.md --repo $GITHUB_REPOSITORY

--- a/.mailmap
+++ b/.mailmap
@@ -324,6 +324,7 @@ Katze <binary@benary.org>
 Keegan McAllister <mcallister.keegan@gmail.com> <kmcallister@mozilla.com>
 Kerem Kat <keremkat@gmail.com>
 Kevin Butler <haqkrs@gmail.com>
+Kevin Reid <kpreid@switchb.org> <kpreid@google.com>
 Kevin Jiang <kwj2104@columbia.edu>
 Kornel Lesiński <kornel@geekhood.net>
 Krishna Sai Veera Reddy <veerareddy@email.arizona.edu>

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -73,7 +73,7 @@ use rustc_hir::lang_items::{LangItem, LanguageItems};
 use rustc_hir::{Crate, ItemLocalId, ItemLocalMap, TraitCandidate};
 use rustc_index::IndexVec;
 use rustc_query_system::ich::StableHashingContext;
-use rustc_query_system::query::{try_get_cached, CacheSelector, QueryCache, QueryMode, QueryState};
+use rustc_query_system::query::{try_get_cached, QueryCache, QueryMode, QueryState};
 use rustc_session::config::{EntryFnType, OptLevel, OutputFilenames, SymbolManglingVersion};
 use rustc_session::cstore::{CrateDepKind, CrateSource};
 use rustc_session::cstore::{ExternCrate, ForeignModule, LinkagePreference, NativeLib};

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -336,9 +336,7 @@ macro_rules! define_callbacks {
                     ))
                 }
 
-                pub type Storage<'tcx> = <
-                    <$($K)* as keys::Key>::CacheSelector as CacheSelector<'tcx, Erase<$V>>
-                >::Cache;
+                pub type Storage<'tcx> = <$($K)* as keys::Key>::Cache<Erase<$V>>;
 
                 // Ensure that keys grow no larger than 64 bytes
                 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1293,8 +1293,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // At least one of the candidates has been split into subcandidates.
                 // We need to change the candidate list to include those.
                 let mut new_candidates = Vec::new();
-
-                for candidate in candidates {
+                for candidate in candidates.iter_mut() {
                     candidate.visit_leaves(|leaf_candidate| new_candidates.push(leaf_candidate));
                 }
                 self.match_simplified_candidates(
@@ -1304,6 +1303,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     otherwise_block,
                     &mut *new_candidates,
                 );
+
+                for candidate in candidates {
+                    self.merge_trivial_subcandidates(candidate);
+                }
             } else {
                 self.match_simplified_candidates(
                     span,

--- a/compiler/rustc_mir_build/src/build/matches/simplify.rs
+++ b/compiler/rustc_mir_build/src/build/matches/simplify.rs
@@ -82,7 +82,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     &*candidate.match_pairs
                 {
                     candidate.subcandidates = self.create_or_subcandidates(pats, has_guard);
-                    candidate.match_pairs.pop();
+                    let first_match_pair = candidate.match_pairs.pop().unwrap();
+                    candidate.or_span = Some(first_match_pair.pattern.span);
                 }
                 candidate
             })

--- a/compiler/rustc_mir_transform/src/simplify_branches.rs
+++ b/compiler/rustc_mir_transform/src/simplify_branches.rs
@@ -19,6 +19,7 @@ impl<'tcx> MirPass<'tcx> for SimplifyConstCondition {
         let param_env = tcx.param_env_reveal_all_normalized(body.source.def_id());
         'blocks: for block in body.basic_blocks_mut() {
             for stmt in block.statements.iter_mut() {
+                // Simplify `assume` of a known value: either a NOP or unreachable.
                 if let StatementKind::Intrinsic(box ref intrinsic) = stmt.kind
                     && let NonDivergingIntrinsic::Assume(discr) = intrinsic
                     && let Operand::Constant(ref c) = discr

--- a/compiler/rustc_query_system/src/query/caches.rs
+++ b/compiler/rustc_query_system/src/query/caches.rs
@@ -9,13 +9,6 @@ use rustc_span::def_id::DefId;
 use rustc_span::def_id::DefIndex;
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::marker::PhantomData;
-
-pub trait CacheSelector<'tcx, V> {
-    type Cache
-    where
-        V: Copy;
-}
 
 pub trait QueryCache: Sized {
     type Key: Hash + Eq + Copy + Debug;
@@ -27,14 +20,6 @@ pub trait QueryCache: Sized {
     fn complete(&self, key: Self::Key, value: Self::Value, index: DepNodeIndex);
 
     fn iter(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex));
-}
-
-pub struct DefaultCacheSelector<K>(PhantomData<K>);
-
-impl<'tcx, K: Eq + Hash, V: 'tcx> CacheSelector<'tcx, V> for DefaultCacheSelector<K> {
-    type Cache = DefaultCache<K, V>
-    where
-        V: Copy;
 }
 
 pub struct DefaultCache<K, V> {
@@ -81,14 +66,6 @@ where
     }
 }
 
-pub struct SingleCacheSelector;
-
-impl<'tcx, V: 'tcx> CacheSelector<'tcx, V> for SingleCacheSelector {
-    type Cache = SingleCache<V>
-    where
-        V: Copy;
-}
-
 pub struct SingleCache<V> {
     cache: OnceLock<(V, DepNodeIndex)>,
 }
@@ -121,14 +98,6 @@ where
             f(&(), &value.0, value.1)
         }
     }
-}
-
-pub struct VecCacheSelector<K>(PhantomData<K>);
-
-impl<'tcx, K: Idx, V: 'tcx> CacheSelector<'tcx, V> for VecCacheSelector<K> {
-    type Cache = VecCache<K, V>
-    where
-        V: Copy;
 }
 
 pub struct VecCache<K: Idx, V> {
@@ -172,14 +141,6 @@ where
             }
         }
     }
-}
-
-pub struct DefIdCacheSelector;
-
-impl<'tcx, V: 'tcx> CacheSelector<'tcx, V> for DefIdCacheSelector {
-    type Cache = DefIdCache<V>
-    where
-        V: Copy;
 }
 
 pub struct DefIdCache<V> {

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -9,10 +9,7 @@ pub use self::job::{
 };
 
 mod caches;
-pub use self::caches::{
-    CacheSelector, DefIdCacheSelector, DefaultCacheSelector, QueryCache, SingleCacheSelector,
-    VecCacheSelector,
-};
+pub use self::caches::{DefIdCache, DefaultCache, QueryCache, SingleCache, VecCache};
 
 mod config;
 pub use self::config::{HashResult, QueryConfig};

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -415,6 +415,19 @@ enum PathResult<'a> {
         label: String,
         suggestion: Option<Suggestion>,
         is_error_from_last_segment: bool,
+        /// The final module being resolved, for instance:
+        ///
+        /// ```compile_fail
+        /// mod a {
+        ///     mod b {
+        ///         mod c {}
+        ///     }
+        /// }
+        ///
+        /// use a::not_exist::c;
+        /// ```
+        ///
+        /// In this case, `module` will point to `a`.
         module: Option<ModuleOrUniformRoot<'a>>,
         /// The segment name of target
         segment_name: Symbol,

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -97,7 +97,7 @@ use crate::time::SystemTime;
 /// have been opened for asynchronous I/O (e.g. by using `FILE_FLAG_OVERLAPPED`).
 ///
 /// [`BufReader`]: io::BufReader
-/// [`BufWriter`]: io::BufReader
+/// [`BufWriter`]: io::BufWriter
 /// [`sync_all`]: File::sync_all
 /// [`write`]: File::write
 /// [`read`]: File::read

--- a/tests/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/tests/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -26,18 +26,20 @@
           _3 = _1;
           _2 = move _3 as [u32; 4] (Transmute);
           StorageDead(_3);
-          switchInt(_2[0 of 4]) -> [0: bb1, otherwise: bb6];
+          switchInt(_2[0 of 4]) -> [0: bb1, otherwise: bb4];
       }
   
       bb1: {
-          switchInt(_2[1 of 4]) -> [0: bb2, otherwise: bb6];
+          switchInt(_2[1 of 4]) -> [0: bb2, otherwise: bb4];
       }
   
       bb2: {
-          switchInt(_2[2 of 4]) -> [0: bb4, 4294901760: bb5, otherwise: bb6];
+          switchInt(_2[2 of 4]) -> [0: bb3, 4294901760: bb3, otherwise: bb4];
       }
   
       bb3: {
+          StorageLive(_4);
+          _4 = _2[3 of 4];
           StorageLive(_5);
           StorageLive(_6);
           _6 = _4;
@@ -46,27 +48,15 @@
           _0 = Option::<[u8; 4]>::Some(move _5);
           StorageDead(_5);
           StorageDead(_4);
-          goto -> bb7;
+          goto -> bb5;
       }
   
       bb4: {
-          StorageLive(_4);
-          _4 = _2[3 of 4];
-          goto -> bb3;
+          _0 = Option::<[u8; 4]>::None;
+          goto -> bb5;
       }
   
       bb5: {
-          StorageLive(_4);
-          _4 = _2[3 of 4];
-          goto -> bb3;
-      }
-  
-      bb6: {
-          _0 = Option::<[u8; 4]>::None;
-          goto -> bb7;
-      }
-  
-      bb7: {
           StorageDead(_2);
           return;
       }

--- a/tests/ui/cfg/diagnostics-same-crate.rs
+++ b/tests/ui/cfg/diagnostics-same-crate.rs
@@ -4,8 +4,12 @@ pub mod inner {
     //~^ NOTE found an item that was configured out
 
     #[cfg(FALSE)]
-    pub mod doesnt_exist { //~ NOTE found an item that was configured out
+    pub mod doesnt_exist {
+        //~^ NOTE found an item that was configured out
+        //~| NOTE found an item that was configured out
+        //~| NOTE found an item that was configured out
         pub fn hello() {}
+        pub mod hi {}
     }
 
     pub mod wrong {
@@ -18,6 +22,15 @@ pub mod inner {
         pub fn meow() {}
         //~^ NOTE found an item that was configured out
     }
+}
+
+mod placeholder {
+    use super::inner::doesnt_exist;
+    //~^ ERROR unresolved import `super::inner::doesnt_exist`
+    //~| NOTE no `doesnt_exist` in `inner`
+    use super::inner::doesnt_exist::hi;
+    //~^ ERROR unresolved import `super::inner::doesnt_exist`
+    //~| NOTE could not find `doesnt_exist` in `inner`
 }
 
 #[cfg(i_dont_exist_and_you_can_do_nothing_about_it)]

--- a/tests/ui/cfg/diagnostics-same-crate.stderr
+++ b/tests/ui/cfg/diagnostics-same-crate.stderr
@@ -1,5 +1,29 @@
+error[E0432]: unresolved import `super::inner::doesnt_exist`
+  --> $DIR/diagnostics-same-crate.rs:28:9
+   |
+LL |     use super::inner::doesnt_exist;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ no `doesnt_exist` in `inner`
+   |
+note: found an item that was configured out
+  --> $DIR/diagnostics-same-crate.rs:7:13
+   |
+LL |     pub mod doesnt_exist {
+   |             ^^^^^^^^^^^^
+
+error[E0432]: unresolved import `super::inner::doesnt_exist`
+  --> $DIR/diagnostics-same-crate.rs:31:23
+   |
+LL |     use super::inner::doesnt_exist::hi;
+   |                       ^^^^^^^^^^^^ could not find `doesnt_exist` in `inner`
+   |
+note: found an item that was configured out
+  --> $DIR/diagnostics-same-crate.rs:7:13
+   |
+LL |     pub mod doesnt_exist {
+   |             ^^^^^^^^^^^^
+
 error[E0433]: failed to resolve: could not find `doesnt_exist` in `inner`
-  --> $DIR/diagnostics-same-crate.rs:37:12
+  --> $DIR/diagnostics-same-crate.rs:50:12
    |
 LL |     inner::doesnt_exist::hello();
    |            ^^^^^^^^^^^^ could not find `doesnt_exist` in `inner`
@@ -11,7 +35,7 @@ LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
 
 error[E0425]: cannot find function `uwu` in module `inner`
-  --> $DIR/diagnostics-same-crate.rs:32:12
+  --> $DIR/diagnostics-same-crate.rs:45:12
    |
 LL |     inner::uwu();
    |            ^^^ not found in `inner`
@@ -23,31 +47,31 @@ LL |     pub fn uwu() {}
    |            ^^^
 
 error[E0425]: cannot find function `meow` in module `inner::right`
-  --> $DIR/diagnostics-same-crate.rs:41:19
+  --> $DIR/diagnostics-same-crate.rs:54:19
    |
 LL |     inner::right::meow();
    |                   ^^^^ not found in `inner::right`
    |
 note: found an item that was configured out
-  --> $DIR/diagnostics-same-crate.rs:18:16
+  --> $DIR/diagnostics-same-crate.rs:22:16
    |
 LL |         pub fn meow() {}
    |                ^^^^
    = note: the item is gated behind the `what-a-cool-feature` feature
 
 error[E0425]: cannot find function `uwu` in this scope
-  --> $DIR/diagnostics-same-crate.rs:28:5
+  --> $DIR/diagnostics-same-crate.rs:41:5
    |
 LL |     uwu();
    |     ^^^ not found in this scope
 
 error[E0425]: cannot find function `vanished` in this scope
-  --> $DIR/diagnostics-same-crate.rs:48:5
+  --> $DIR/diagnostics-same-crate.rs:61:5
    |
 LL |     vanished();
    |     ^^^^^^^^ not found in this scope
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0425, E0433.
+Some errors have detailed explanations: E0425, E0432, E0433.
 For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/delegation/target-expr.rs
+++ b/tests/ui/delegation/target-expr.rs
@@ -1,0 +1,38 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    fn static_method(x: i32) -> i32 { x }
+}
+
+struct F;
+
+struct S(F);
+impl Trait for S {}
+
+fn foo(x: i32) -> i32 { x }
+
+fn bar<T: Default>(_: T) {
+    reuse Trait::static_method {
+        //~^ ERROR delegation with early bound generics is not supported yet
+        //~| ERROR mismatched types
+        let _ = T::Default();
+        //~^ ERROR can't use generic parameters from outer item
+    }
+}
+
+fn main() {
+    let y = 0;
+    reuse <S as Trait>::static_method {
+        let x = y;
+        //~^ ERROR can't capture dynamic environment in a fn item
+        foo(self);
+
+        let reuse_ptr: fn(i32) -> i32  = static_method;
+        reuse_ptr(0)
+    }
+    self.0;
+    //~^ ERROR expected value, found module `self`
+    let z = x;
+    //~^ ERROR cannot find value `x` in this scope
+}

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -1,0 +1,65 @@
+error[E0401]: can't use generic parameters from outer item
+  --> $DIR/target-expr.rs:19:17
+   |
+LL | fn bar<T: Default>(_: T) {
+   |        - type parameter from outer item
+LL |     reuse Trait::static_method {
+   |                               - help: try introducing a local generic parameter here: `T,`
+...
+LL |         let _ = T::Default();
+   |                 ^^^^^^^^^^ use of generic parameter from outer item
+
+error[E0434]: can't capture dynamic environment in a fn item
+  --> $DIR/target-expr.rs:27:17
+   |
+LL |         let x = y;
+   |                 ^
+   |
+   = help: use the `|| { ... }` closure form instead
+
+error[E0424]: expected value, found module `self`
+  --> $DIR/target-expr.rs:34:5
+   |
+LL | fn main() {
+   |    ---- this function can't have a `self` parameter
+...
+LL |     self.0;
+   |     ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/target-expr.rs:36:13
+   |
+LL |     let z = x;
+   |             ^
+   |
+help: the binding `x` is available in a different scope in the same function
+  --> $DIR/target-expr.rs:27:13
+   |
+LL |         let x = y;
+   |             ^
+
+error: delegation with early bound generics is not supported yet
+  --> $DIR/target-expr.rs:16:18
+   |
+LL |     fn static_method(x: i32) -> i32 { x }
+   |     ------------------------------- callee defined here
+...
+LL |     reuse Trait::static_method {
+   |                  ^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr.rs:16:32
+   |
+LL |       reuse Trait::static_method {
+   |  ________________________________^
+LL | |
+LL | |
+LL | |         let _ = T::Default();
+LL | |
+LL | |     }
+   | |_____^ expected `i32`, found `()`
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0308, E0401, E0424, E0425, E0434.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/sanitizer/cfi-assoc-ty-lifetime-issue-123053.rs
+++ b/tests/ui/sanitizer/cfi-assoc-ty-lifetime-issue-123053.rs
@@ -1,0 +1,38 @@
+// Regression test for issue 123053, where associated types with lifetimes caused generation of the
+// trait object type to fail, causing an ICE.
+//
+//@ needs-sanitizer-cfi
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi --edition=2021
+//@ no-prefer-dynamic
+//@ only-x86_64-unknown-linux-gnu
+//@ build-pass
+
+trait Iterable {
+    type Item<'a>
+    where
+        Self: 'a;
+    type Iter<'a>: Iterator<Item = Self::Item<'a>>
+    where
+        Self: 'a;
+
+    fn iter<'a>(&'a self) -> Self::Iter<'a>;
+}
+
+impl<T> Iterable for [T] {
+    type Item<'a> = <std::slice::Iter<'a, T> as Iterator>::Item where T: 'a;
+    type Iter<'a> = std::slice::Iter<'a, T> where T: 'a;
+
+    fn iter<'a>(&'a self) -> Self::Iter<'a> {
+        self.iter()
+    }
+}
+
+fn get_first<'a, I: Iterable + ?Sized>(it: &'a I) -> Option<I::Item<'a>> {
+    it.iter().next()
+}
+
+fn main() {
+    let v = vec![1, 2, 3];
+
+    assert_eq!(Some(&1), get_first(&*v));
+}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -424,7 +424,15 @@ message_on_reopen = "Issue #{number} has been reopened. Pinging @*T-types*."
 
 [notify-zulip."A-edition-2021"]
 required_labels = ["C-bug"]
-zulip_stream = 268952 # #edition 2021
+zulip_stream = 268952 # #edition
+topic = "Edition Bugs"
+message_on_add = """\
+Issue #{number} "{title}" has been added (previous edition 2021).
+"""
+
+[notify-zulip."A-edition-2024"]
+required_labels = ["C-bug"]
+zulip_stream = 268952 # #edition
 topic = "Edition Bugs"
 message_on_add = """\
 Issue #{number} "{title}" has been added.


### PR DESCRIPTION
Successful merges:

 - #122766 (store segment and module in `UnresolvedImportError`)
 - #122996 (simplify_branches: add comment)
 - #123047 (triagebot: Add notification of 2024 issues)
 - #123066 (CFI: (actually) check that methods are object-safe before projecting their receivers to `dyn Trait` in CFI)
 - #123067 (match lowering: consistently merge simple or-patterns)
 - #123069 (Revert `cargo update` changes and bump `download-artifact` to v4)
 - #123070 (Add my former address to .mailmap)
 - #123086 (Fix doc link to BufWriter in std::fs::File documentation)
 - #123090 (Remove `CacheSelector` trait now that we can use GATs)
 - #123091 (Delegation: fix ICE on wrong `self` resolution)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=122766,122996,123047,123066,123067,123069,123070,123086,123090,123091)
<!-- homu-ignore:end -->