### PR TITLE
Replace some `CrateStore` trait methods with hooks. 

### DIFF
--- a/compiler/rustc_middle/src/hooks/mod.rs
+++ b/compiler/rustc_middle/src/hooks/mod.rs
@@ -6,7 +6,7 @@
 use crate::mir;
 use crate::query::TyCtxtAt;
 use crate::ty::{Ty, TyCtxt};
-use rustc_span::def_id::LocalDefId;
+use rustc_span::def_id::{CrateNum, LocalDefId};
 use rustc_span::DUMMY_SP;
 
 macro_rules! declare_hooks {
@@ -16,7 +16,6 @@ macro_rules! declare_hooks {
             $(
             $(#[$attr])*
             #[inline(always)]
-            #[must_use]
             pub fn $name(self, $($arg: $K,)*) -> $V
             {
                 self.at(DUMMY_SP).$name($($arg,)*)
@@ -28,7 +27,6 @@ macro_rules! declare_hooks {
             $(
             $(#[$attr])*
             #[inline(always)]
-            #[must_use]
             #[instrument(level = "debug", skip(self), ret)]
             pub fn $name(self, $($arg: $K,)*) -> $V
             {
@@ -83,4 +81,11 @@ declare_hooks! {
     /// You do not want to call this yourself, instead use the cached version
     /// via `mir_built`
     hook build_mir(key: LocalDefId) -> mir::Body<'tcx>;
+
+
+    /// Imports all `SourceFile`s from the given crate into the current session.
+    /// This normally happens automatically when we decode a `Span` from
+    /// that crate's metadata - however, the incr comp cache needs
+    /// to trigger this manually when decoding a foreign `Span`
+    hook import_source_files(key: CrateNum) -> ();
 }

--- a/compiler/rustc_middle/src/hooks/mod.rs
+++ b/compiler/rustc_middle/src/hooks/mod.rs
@@ -7,7 +7,7 @@ use crate::mir;
 use crate::query::TyCtxtAt;
 use crate::ty::{Ty, TyCtxt};
 use rustc_span::def_id::{CrateNum, LocalDefId};
-use rustc_span::DUMMY_SP;
+use rustc_span::{ExpnHash, ExpnId, DUMMY_SP};
 
 macro_rules! declare_hooks {
     ($($(#[$attr:meta])*hook $name:ident($($arg:ident: $K:ty),*) -> $V:ty;)*) => {
@@ -88,4 +88,10 @@ declare_hooks! {
     /// that crate's metadata - however, the incr comp cache needs
     /// to trigger this manually when decoding a foreign `Span`
     hook import_source_files(key: CrateNum) -> ();
+
+    hook expn_hash_to_expn_id(
+        cnum: CrateNum,
+        index_guess: u32,
+        hash: ExpnHash
+    ) -> ExpnId;
 }

--- a/compiler/rustc_middle/src/hooks/mod.rs
+++ b/compiler/rustc_middle/src/hooks/mod.rs
@@ -6,6 +6,8 @@
 use crate::mir;
 use crate::query::TyCtxtAt;
 use crate::ty::{Ty, TyCtxt};
+use rustc_hir::def_id::{DefId, DefPathHash};
+use rustc_session::StableCrateId;
 use rustc_span::def_id::{CrateNum, LocalDefId};
 use rustc_span::{ExpnHash, ExpnId, DUMMY_SP};
 
@@ -94,4 +96,10 @@ declare_hooks! {
         index_guess: u32,
         hash: ExpnHash
     ) -> ExpnId;
+
+    /// Converts a `DefPathHash` to its corresponding `DefId` in the current compilation
+    /// session, if it still exists. This is used during incremental compilation to
+    /// turn a deserialized `DefPathHash` into its current `DefId`.
+    /// Will fetch a DefId from a DefPathHash for a foreign crate.
+    hook def_path_hash_to_def_id_extern(hash: DefPathHash, stable_crate_id: StableCrateId) -> DefId;
 }

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -632,12 +632,7 @@ impl<'a, 'tcx> SpanDecoder for CacheDecoder<'a, 'tcx> {
             expn_id
         } else {
             let index_guess = self.foreign_expn_data[&hash];
-            self.tcx.cstore_untracked().expn_hash_to_expn_id(
-                self.tcx.sess,
-                krate,
-                index_guess,
-                hash,
-            )
+            self.tcx.expn_hash_to_expn_id(krate, index_guess, hash)
         };
 
         debug_assert_eq!(expn_id.krate, krate);

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -492,9 +492,7 @@ impl<'a, 'tcx> CacheDecoder<'a, 'tcx> {
                 // expansion, so we use `import_source_files` to ensure that the foreign
                 // source files are actually imported before we call `source_file_by_stable_id`.
                 if source_file_cnum != LOCAL_CRATE {
-                    self.tcx
-                        .cstore_untracked()
-                        .import_source_files(self.tcx.sess, source_file_cnum);
+                    self.tcx.import_source_files(source_file_cnum);
                 }
 
                 source_map

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1073,11 +1073,7 @@ impl<'tcx> TyCtxt<'tcx> {
         if stable_crate_id == self.stable_crate_id(LOCAL_CRATE) {
             self.untracked.definitions.read().local_def_path_hash_to_def_id(hash, err).to_def_id()
         } else {
-            // If this is a DefPathHash from an upstream crate, let the CrateStore map
-            // it to a DefId.
-            let cstore = &*self.cstore_untracked();
-            let cnum = cstore.stable_crate_id_to_crate_num(stable_crate_id);
-            cstore.def_path_hash_to_def_id(cnum, hash)
+            self.def_path_hash_to_def_id_extern(hash, stable_crate_id)
         }
     }
 

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -4,12 +4,10 @@
 
 use crate::search_paths::PathKind;
 use crate::utils::NativeLibKind;
-use crate::Session;
 use rustc_ast as ast;
 use rustc_data_structures::sync::{self, AppendOnlyIndexVec, FreezeLock};
 use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, StableCrateId, LOCAL_CRATE};
 use rustc_hir::definitions::{DefKey, DefPath, DefPathHash, Definitions};
-use rustc_span::hygiene::{ExpnHash, ExpnId};
 use rustc_span::symbol::Symbol;
 use rustc_span::Span;
 use rustc_target::spec::abi::Abi;
@@ -223,13 +221,6 @@ pub trait CrateStore: std::fmt::Debug {
 
     /// Fetch a DefId from a DefPathHash for a foreign crate.
     fn def_path_hash_to_def_id(&self, cnum: CrateNum, hash: DefPathHash) -> DefId;
-    fn expn_hash_to_expn_id(
-        &self,
-        sess: &Session,
-        cnum: CrateNum,
-        index_guess: u32,
-        hash: ExpnHash,
-    ) -> ExpnId;
 }
 
 pub type CrateStoreDyn = dyn CrateStore + sync::DynSync + sync::DynSend;

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -218,9 +218,6 @@ pub trait CrateStore: std::fmt::Debug {
     fn crate_name(&self, cnum: CrateNum) -> Symbol;
     fn stable_crate_id(&self, cnum: CrateNum) -> StableCrateId;
     fn stable_crate_id_to_crate_num(&self, stable_crate_id: StableCrateId) -> CrateNum;
-
-    /// Fetch a DefId from a DefPathHash for a foreign crate.
-    fn def_path_hash_to_def_id(&self, cnum: CrateNum, hash: DefPathHash) -> DefId;
 }
 
 pub type CrateStoreDyn = dyn CrateStore + sync::DynSync + sync::DynSend;

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -230,12 +230,6 @@ pub trait CrateStore: std::fmt::Debug {
         index_guess: u32,
         hash: ExpnHash,
     ) -> ExpnId;
-
-    /// Imports all `SourceFile`s from the given crate into the current session.
-    /// This normally happens automatically when we decode a `Span` from
-    /// that crate's metadata - however, the incr comp cache needs
-    /// to trigger this manually when decoding a foreign `Span`
-    fn import_source_files(&self, sess: &Session, cnum: CrateNum);
 }
 
 pub type CrateStoreDyn = dyn CrateStore + sync::DynSync + sync::DynSend;


### PR DESCRIPTION
Just like with the `CrateStore` trait, this avoids the cyclic definition issues with `CStore` being
defined after TyCtxt, but needing to be used in TyCtxt.