### PR TITLE
Fix run make tests when it can't find dynamically linked librustc

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3784,6 +3784,7 @@ impl<'test> TestCx<'test> {
             .env("TMPDIR", &tmpdir)
             .env("LD_LIB_PATH_ENVVAR", dylib_env_var())
             .env("HOST_RPATH_DIR", cwd.join(&self.config.compile_lib_path))
+            .env("LD_LIBRARY_PATH", cwd.join(&self.config.compile_lib_path))
             .env("TARGET_RPATH_DIR", cwd.join(&self.config.run_lib_path))
             .env("LLVM_COMPONENTS", &self.config.llvm_components)
             // We for sure don't want these tests to run in parallel, so make
@@ -3838,6 +3839,7 @@ impl<'test> TestCx<'test> {
             .env("RUSTC", cwd.join(&self.config.rustc_path))
             .env("TMPDIR", &tmpdir)
             .env("HOST_RPATH_DIR", cwd.join(&self.config.compile_lib_path))
+            .env("LD_LIBRARY_PATH", cwd.join(&self.config.compile_lib_path))
             .env("TARGET_RPATH_DIR", cwd.join(&self.config.run_lib_path))
             .env("LLVM_COMPONENTS", &self.config.llvm_components)
             // We for sure don't want these tests to run in parallel, so make


### PR DESCRIPTION
The recent updates to run make support caused the following tests to break on sgx i.e. target  `x86_64-fortanix-unknown-sgx` : 
```
11:22:48 failures:
11:22:48     [run-make] tests/run-make/CURRENT_RUSTC_VERSION
11:22:48     [run-make] tests/run-make/a-b-a-linker-guard
11:22:48     [run-make] tests/run-make/rustdoc-test-args
11:22:48     [run-make] tests/run-make/wasm-abi
11:22:48     [run-make] tests/run-make/wasm-custom-section
11:22:48     [run-make] tests/run-make/wasm-custom-sections-opt
11:22:48     [run-make] tests/run-make/wasm-export-all-symbols
11:22:48     [run-make] tests/run-make/wasm-import-module
11:22:48     [run-make] tests/run-make/wasm-panic-small
11:22:48     [run-make] tests/run-make/wasm-spurious-import
11:22:48     [run-make] tests/run-make/wasm-stringify-ints-small
11:22:48     [run-make] tests/run-make/wasm-symbols-different-module
11:22:48     [run-make] tests/run-make/wasm-symbols-not-exported
11:22:48     [run-make] tests/run-make/wasm-symbols-not-imported
```
The error observed was:
``` 
rust/build/x86_64-unknown-linux-gnu/stage1/bin/rustc: error while loading shared libraries: librustc_driver-8fd070a3dbd486b2.so: cannot open shared object file: No such file or directory
```

Providing the LD_LIBRARY_PATH for compiling and running the tests fixes the issue. Similar fix from the past - https://github.com/rust-lang/rust/pull/113889 for a similar error.

@jethrogb @raoulstrackx 