### PR TITLE
rustdoc: Swap fields and variant documentations

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1728,6 +1728,8 @@ fn item_variants(
         }
         w.write_str("</h3></section>");
 
+        write!(w, "{}", document(cx, variant, Some(it), HeadingOffset::H4));
+
         let heading_and_fields = match &variant_data.kind {
             clean::VariantKind::Struct(s) => {
                 // If there is no field to display, no need to add the heading.
@@ -1789,8 +1791,6 @@ fn item_variants(
             }
             w.write_str("</div>");
         }
-
-        write!(w, "{}", document(cx, variant, Some(it), HeadingOffset::H4));
     }
     write!(w, "</div>");
 }


### PR DESCRIPTION
Previously, the documentation for a variant appeared after the documentation for each of its fields. This was inconsistent with structs and unions, and made little sense on its own; fields are subordinate to variants and should therefore appear later in the documentation.

Before:

![Screenshot of rendered documentation before this patch.](https://github.com/rust-lang/rust/assets/50083900/4c98258e-bdf7-4507-9cf1-fe601407ff11)

After:

![Screenshot of rendered documentation after this patch.](https://github.com/rust-lang/rust/assets/50083900/bd223f92-9b06-4b5a-820e-7a8501bdc0e2)
