### PR TITLE
Optimize `upgrade` method of `alloc::sync::Weak`

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -28,7 +28,7 @@ use core::ptr::{self, NonNull};
 #[cfg(not(no_global_oom_handling))]
 use core::slice::from_raw_parts_mut;
 use core::sync::atomic;
-use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+use core::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
@@ -354,7 +354,7 @@ impl<T: ?Sized> fmt::Debug for Weak<T> {
 // inner types.
 #[repr(C)]
 struct ArcInner<T: ?Sized> {
-    strong: atomic::AtomicUsize,
+    strong: StickyCounter,
 
     // the value usize::MAX acts as a sentinel for temporarily "locking" the
     // ability to upgrade weak pointers or downgrade strong ones; this is used
@@ -393,7 +393,7 @@ impl<T> Arc<T> {
         // Start the weak pointer count as 1 which is the weak pointer that's
         // held by all the strong pointers (kinda), see std/rc.rs for more info
         let x: Box<_> = Box::new(ArcInner {
-            strong: atomic::AtomicUsize::new(1),
+            strong: StickyCounter(atomic::AtomicUsize::new(1)),
             weak: atomic::AtomicUsize::new(1),
             data,
         });
@@ -461,7 +461,7 @@ impl<T> Arc<T> {
         // Construct the inner in the "uninitialized" state with a single
         // weak reference.
         let uninit_ptr: NonNull<_> = Box::leak(Box::new(ArcInner {
-            strong: atomic::AtomicUsize::new(0),
+            strong: StickyCounter(atomic::AtomicUsize::new(StickyCounter::ZERO_BIT)),
             weak: atomic::AtomicUsize::new(1),
             data: mem::MaybeUninit::<T>::uninit(),
         }))
@@ -496,8 +496,11 @@ impl<T> Arc<T> {
             //
             // These side effects do not impact us in any way, and no other side effects are
             // possible with safe code alone.
-            let prev_value = (*inner).strong.fetch_add(1, Release);
-            debug_assert_eq!(prev_value, 0, "No prior strong references should exist");
+            let prev_value = (*inner).strong.0.swap(1, Release);
+            debug_assert!(
+                StickyCounter::is_zero(prev_value),
+                "No prior strong references should exist"
+            );
 
             Arc::from_inner(init_ptr)
         };
@@ -608,7 +611,7 @@ impl<T> Arc<T> {
         // Start the weak pointer count as 1 which is the weak pointer that's
         // held by all the strong pointers (kinda), see std/rc.rs for more info
         let x: Box<_> = Box::try_new(ArcInner {
-            strong: atomic::AtomicUsize::new(1),
+            strong: StickyCounter(atomic::AtomicUsize::new(1)),
             weak: atomic::AtomicUsize::new(1),
             data,
         })?;
@@ -713,7 +716,7 @@ impl<T, A: Allocator> Arc<T, A> {
         // held by all the strong pointers (kinda), see std/rc.rs for more info
         let x = Box::new_in(
             ArcInner {
-                strong: atomic::AtomicUsize::new(1),
+                strong: StickyCounter(atomic::AtomicUsize::new(1)),
                 weak: atomic::AtomicUsize::new(1),
                 data,
             },
@@ -840,7 +843,7 @@ impl<T, A: Allocator> Arc<T, A> {
         // held by all the strong pointers (kinda), see std/rc.rs for more info
         let x = Box::try_new_in(
             ArcInner {
-                strong: atomic::AtomicUsize::new(1),
+                strong: StickyCounter(atomic::AtomicUsize::new(1)),
                 weak: atomic::AtomicUsize::new(1),
                 data,
             },
@@ -961,7 +964,7 @@ impl<T, A: Allocator> Arc<T, A> {
     #[inline]
     #[stable(feature = "arc_unique", since = "1.4.0")]
     pub fn try_unwrap(this: Self) -> Result<T, Self> {
-        if this.inner().strong.compare_exchange(1, 0, Relaxed, Relaxed).is_err() {
+        if this.inner().strong.set_zero_if_one(Relaxed, Relaxed).is_err() {
             return Err(this);
         }
 
@@ -1080,7 +1083,7 @@ impl<T, A: Allocator> Arc<T, A> {
         let mut this = mem::ManuallyDrop::new(this);
 
         // Following the implementation of `drop` and `drop_slow`
-        if this.inner().strong.fetch_sub(1, Release) != 1 {
+        if this.inner().strong.decrement(SeqCst) != 1 {
             return None;
         }
 
@@ -1883,7 +1886,7 @@ impl<T: ?Sized> Arc<T> {
         debug_assert_eq!(unsafe { Layout::for_value_raw(inner) }, layout);
 
         unsafe {
-            ptr::addr_of_mut!((*inner).strong).write(atomic::AtomicUsize::new(1));
+            ptr::addr_of_mut!((*inner).strong).write(StickyCounter(atomic::AtomicUsize::new(1)));
             ptr::addr_of_mut!((*inner).weak).write(atomic::AtomicUsize::new(1));
         }
 
@@ -2072,7 +2075,7 @@ impl<T: ?Sized, A: Allocator + Clone> Clone for Arc<T, A> {
         // another must already provide any required synchronization.
         //
         // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
-        let old_size = self.inner().strong.fetch_add(1, Relaxed);
+        let old_size = self.inner().strong.try_increment(SeqCst).unwrap();
 
         // However we need to guard against massive refcounts in case someone is `mem::forget`ing
         // Arcs. If we don't do this the count can overflow and users will use-after free. This
@@ -2176,7 +2179,7 @@ impl<T: Clone, A: Allocator + Clone> Arc<T, A> {
         // before release writes (i.e., decrements) to `strong`. Since we hold a
         // weak count, there's no chance the ArcInner itself could be
         // deallocated.
-        if this.inner().strong.compare_exchange(1, 0, Acquire, Relaxed).is_err() {
+        if this.inner().strong.set_zero_if_one(Acquire, Relaxed).is_err() {
             // Another strong pointer exists, so we must clone.
             // Pre-allocate memory to allow writing the cloned value directly.
             let mut arc = Self::new_uninit_in(this.alloc.clone());
@@ -2212,7 +2215,7 @@ impl<T: Clone, A: Allocator + Clone> Arc<T, A> {
         } else {
             // We were the sole reference of either kind; bump back up the
             // strong ref count.
-            this.inner().strong.store(1, Release);
+            this.inner().strong.0.store(1, Release);
         }
 
         // As with `get_mut()`, the unsafety is ok because our reference was
@@ -2424,7 +2427,7 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Arc<T, A> {
         // Because `fetch_sub` is already atomic, we do not need to synchronize
         // with other threads unless we are going to delete the object. This
         // same logic applies to the below `fetch_sub` to the `weak` count.
-        if self.inner().strong.fetch_sub(1, Release) != 1 {
+        if self.inner().strong.decrement(SeqCst) != 1 {
             return;
         }
 
@@ -2600,7 +2603,7 @@ impl<T, A: Allocator> Weak<T, A> {
 /// making any assertions about the data field.
 struct WeakInner<'a> {
     weak: &'a atomic::AtomicUsize,
-    strong: &'a atomic::AtomicUsize,
+    strong: &'a StickyCounter,
 }
 
 impl<T: ?Sized> Weak<T> {
@@ -2825,6 +2828,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     where
         A: Clone,
     {
+        /*
         #[inline]
         fn checked_increment(n: usize) -> Option<usize> {
             // Any write of 0 we can observe leaves the field in permanently zero state.
@@ -2835,7 +2839,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
             assert!(n <= MAX_REFCOUNT, "{}", INTERNAL_OVERFLOW_ERROR);
             Some(n + 1)
         }
-
+        */
         // We use a CAS loop to increment the strong count instead of a
         // fetch_add as this function should never take the reference count
         // from zero to one.
@@ -2844,7 +2848,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
         // Acquire is necessary for the success case to synchronise with `Arc::new_cyclic`, when the inner
         // value can be initialized after `Weak` references have already been created. In that case, we
         // expect to observe the fully initialized value.
-        if self.inner()?.strong.fetch_update(Acquire, Relaxed, checked_increment).is_ok() {
+        if self.inner()?.strong.try_increment(SeqCst).is_ok() {
             // SAFETY: pointer is not null, verified in checked_increment
             unsafe { Some(Arc::from_inner_in(self.ptr, self.alloc.clone())) }
         } else {
@@ -3649,5 +3653,70 @@ impl<T: core::error::Error + ?Sized> core::error::Error for Arc<T> {
 
     fn provide<'a>(&'a self, req: &mut core::error::Request<'a>) {
         core::error::Error::provide(&**self, req);
+    }
+}
+
+/// A counter that implements the wait-free "increment-if-not-zero" mechanism, as described in:
+/// https://dl.acm.org/doi/10.1145/3519939.3523730, section 4.3. The "help bit" and associated
+/// logic is omitted.
+///
+/// We assume that overflow to the zero bit will never occur, nor will any decrements past zero.
+struct StickyCounter(atomic::AtomicUsize);
+
+impl StickyCounter {
+    const ZERO_BIT: usize = 1 << (usize::BITS - 1);
+
+    /// Attempts a fetch_add with value 1 and returns a `Result` indicating whether it succeeded.
+    fn try_increment(&self, order: atomic::Ordering) -> Result<usize, usize> {
+        let before = self.0.fetch_add(1, order);
+        if Self::is_zero(before) {
+            // The user might attempt a lot of upgrades; we should undo them to prevent overflow.
+            self.0.fetch_sub(1, Relaxed);
+            Err(0)
+        } else if before == 0 {
+            // The stored value is zero, but the zero bit is not set, so a decrement is occurring.
+            // They will act as if our increment occurred before their decrement, so we should too.
+            Ok(1)
+        } else {
+            Ok(before)
+        }
+    }
+
+    // Performs a fetch_sub with value 1.
+    fn decrement(&self, order: atomic::Ordering) -> usize {
+        let before = self.0.fetch_sub(1, order);
+        if before == 1 {
+            match self.0.compare_exchange(0, Self::ZERO_BIT, SeqCst, SeqCst) {
+                Ok(_) => 1,
+                Err(val) => {
+                    // Someone else set the zero bit or an increment occurred first.
+                    // In the latter case, we simply act as if we never hit zero.
+                    if Self::is_zero(val) { 0 } else { val + 1 }
+                }
+            }
+        } else {
+            before
+        }
+    }
+
+    fn load(&self, order: atomic::Ordering) -> usize {
+        let mut val = self.0.load(order);
+        if val == 0 {
+            // We are racing with a decrement, so we try to help set the zero bit.
+            val = self.0.compare_exchange(0, Self::ZERO_BIT, SeqCst, SeqCst).unwrap_or_else(|x| x)
+        }
+        if Self::is_zero(val) { 0 } else { val }
+    }
+
+    fn set_zero_if_one(
+        &self,
+        success: atomic::Ordering,
+        failure: atomic::Ordering,
+    ) -> Result<usize, usize> {
+        self.0.compare_exchange(1, Self::ZERO_BIT, success, failure)
+    }
+
+    fn is_zero(val: usize) -> bool {
+        (val & Self::ZERO_BIT) != 0
     }
 }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -3656,11 +3656,13 @@ impl<T: core::error::Error + ?Sized> core::error::Error for Arc<T> {
     }
 }
 
-/// A counter that implements the wait-free "increment-if-not-zero" mechanism, as described in:
-/// https://dl.acm.org/doi/10.1145/3519939.3523730, section 4.3. The "help bit" and associated
+/// A counter that implements the wait-free "increment-if-not-zero" mechanism, as described in
+/// section 4.3 of this paper [1]. The "help bit" and associated
 /// logic is omitted.
 ///
 /// We assume that overflow to the zero bit will never occur, nor will any decrements past zero.
+///
+/// [1]: (https://dl.acm.org/doi/10.1145/3519939.3523730)
 struct StickyCounter(atomic::AtomicUsize);
 
 impl StickyCounter {

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -4,7 +4,7 @@ use std::clone::Clone;
 use std::mem::MaybeUninit;
 use std::option::Option::None;
 use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::SeqCst;
+//use std::sync::atomic::Ordering::SeqCst;
 use std::sync::mpsc::channel;
 use std::sync::Mutex;
 use std::thread;

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -4,7 +4,7 @@ use std::clone::Clone;
 use std::mem::MaybeUninit;
 use std::option::Option::None;
 use std::sync::atomic::AtomicUsize;
-//use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::Ordering::SeqCst;
 use std::sync::mpsc::channel;
 use std::sync::Mutex;
 use std::thread;


### PR DESCRIPTION
This is my first time contributing to Rust, so apologies if I’ve broken any rules or tagged the wrong people.

### Background

The `upgrade` method on `Weak` is currently implemented using a CAS loop, to ensure that the increment to the strong count cannot occur if it is zero. This quickly becomes inefficient if other threads attempt to upgrade the `Weak`, clone or drop the `Arc`, or otherwise update the strong count. The CAS will fail every time the strong count changes, even if it’s nowhere near zero. In theory, it may never succeed.

Consider a basic doubly linked list with strong next pointers and weak prev pointers. Given N nodes, M threads, and just 1 update to the strong count per thread, a simple backward iteration could end up being N*M operations in the worst case.

### Solution

We can utilize a “sticky counter” mechanism, which I encountered in section 4.3 of [this paper](https://dl.acm.org/doi/10.1145/3519939.3523730). This eliminates the CAS loop and replaces it with an “increment-if-not-zero” mechanism. ~~I propose a modified version of the counter described in the paper, which only steals a single high bit (indicating whether the count is zero).~~ That actually fits nicely with the current `MAX_REFCOUNT`, as the weak count is already effectively using its high bit as a spinlock flag. The algorithm has no additional overhead; all increments and decrements will succeed or fail in a single atomic operation (until the counter reaches zero). This would make the list iteration example O(N) in all cases.

### Considerations

* ~~The authors of the paper also used a second “help bit” in their formulation, to allow a single decrement operation to “take credit” for bringing the counter to zero in some edge cases. I could not think of a reason why we would need that, so I omitted it. If it turns out that I made a mistake, then 2 bits would be required, and that may or may not be a dealbreaker.~~
* ~~The correct memory orderings need to be hammered out - right now I have many of them set to `SeqCst` as a proof of concept.~~
* If we go forward with this, I’m guessing we’ll want a Crater test at some point to make sure that this doesn’t nuke everything that uses `Arc` / `Weak`.

Edit 1:
* The "help bit" is needed, so I added it. However, the second bit being used actually isn't a concern after all w.r.t MAX_REFCOUNT since it isn't used until the counter reaches zero.

Edit 2:
Closing the PR - it turns out that the counter cannot be used in this context (it only works if there also exists a memory reclamation mechanism, which is not the case with Arc / Weak).