### PR TITLE
Fix target-cpu fpu features on Arm R/M-profile

### DIFF
--- a/compiler/rustc_target/src/spec/targets/armebv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armebv7r_none_eabihf.rs
@@ -22,7 +22,7 @@ pub fn target() -> Target {
             linker: Some("rust-lld".into()),
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
-            features: "+vfp3,-d32,-fp16".into(),
+            features: "+vfp3d16".into(),
             max_atomic_width: Some(64),
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.

--- a/compiler/rustc_target/src/spec/targets/armv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7r_none_eabihf.rs
@@ -21,7 +21,7 @@ pub fn target() -> Target {
             linker: Some("rust-lld".into()),
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
-            features: "+vfp3,-d32,-fp16".into(),
+            features: "+vfp3d16".into(),
             max_atomic_width: Some(64),
             emit_debug_gdb_scripts: false,
             // GCC defaults to 8 for arm-none here.

--- a/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabihf.rs
@@ -25,16 +25,15 @@ pub fn target() -> Target {
 
         options: TargetOptions {
             abi: "eabihf".into(),
-            // `+vfp4` is the lowest common denominator between the Cortex-M4 (vfp4-16) and the
-            // Cortex-M7 (vfp5)
-            // `-d32` both the Cortex-M4 and the Cortex-M7 only have 16 double-precision registers
-            // available
-            // `-fp64` The Cortex-M4 only supports single precision floating point operations
-            // whereas in the Cortex-M7 double precision is optional
+            // vfp4 is the lowest common denominator between the Cortex-M4F (vfp4) and the
+            // Cortex-M7 (vfp5).
+            // Both the Cortex-M4 and the Cortex-M7 only have 16 double-precision registers
+            // available, and the Cortex-M4 only supports single-precision floating point operations
+            // whereas in the Cortex-M7 double-precision is optional.
             //
             // Reference:
             // ARMv7-M Architecture Reference Manual - A2.5 The optional floating-point extension
-            features: "+vfp4,-d32,-fp64".into(),
+            features: "+vfp4d16sp".into(),
             max_atomic_width: Some(32),
             ..base::thumb::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/thumbv8m_main_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv8m_main_none_eabihf.rs
@@ -22,8 +22,7 @@ pub fn target() -> Target {
             // processor, the Cortex-M33 Technical Reference Manual states that
             // the FPU uses the FPv5 architecture, single-precision instructions
             // and 16 D registers.
-            // These parameters map to the following LLVM features.
-            features: "+fp-armv8,-fp64,-d32".into(),
+            features: "+fp-armv8d16sp".into(),
             max_atomic_width: Some(32),
             ..base::thumb::opts()
         },


### PR DESCRIPTION
This is achieved by converting `+<fpu>,-d32,{,-fp64}` to `+<fpu>d16{,sp}`.

By using a single additive feature that captures `d16` vs `d32` and `sp` vs
`dp`, we prevent `-<feature>` from overriding `-C target-cpu` at build time.

Remove extraneous `-fp16` from `armv7r` targets, as this is not included in
`vfp3` anyway, but was preventing `fp16` from being enabled by e.g.,
`-C target-cpu=cortex-r7`, which does support `fp16`.
