### PR TITLE
Correctly get complete intra-doc link data

### DIFF
--- a/tests/rustdoc-ui/invalid-redundant-explicit-link.rs
+++ b/tests/rustdoc-ui/invalid-redundant-explicit-link.rs
@@ -1,0 +1,8 @@
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/123158>. It
+// should not emit any warning.
+
+//! [**`SomeTrait`**](SomeTrait):
+
+pub trait SomeTrait {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/123158.

The problem was that we didn't take into account cases where there would be content other than backticks into the intra doc link definition.

r? @notriddle