### PR TITLE
skip known panics lint for impossible items

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -2116,6 +2116,13 @@ rustc_queries! {
         }
     }
 
+    query is_impossible_item(def_id: DefId) -> bool {
+        desc { |tcx|
+            "checking if `{}` has predicates that are impossible to satisfy",
+            tcx.def_path_str(def_id),
+        }
+    }
+
     query is_impossible_associated_item(key: (DefId, DefId)) -> bool {
         desc { |tcx|
             "checking if `{}` is impossible to reference within `{}`",

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -51,6 +51,11 @@ impl<'tcx> MirLint<'tcx> for KnownPanicsLint {
             return;
         }
 
+        if tcx.is_impossible_item(def_id) {
+            trace!("KnownPanicsLint skipped for impossible item {:?}", def_id);
+            return;
+        }
+
         trace!("KnownPanicsLint starting for {:?}", def_id);
 
         let mut linter = ConstPropagator::new(body, tcx);

--- a/tests/ui/mir/lint/known-panics-impossible-pred-ice.rs
+++ b/tests/ui/mir/lint/known-panics-impossible-pred-ice.rs
@@ -1,0 +1,43 @@
+//@ build-pass
+// Regression test for an ICE: https://github.com/rust-lang/rust/issues/123134
+
+trait Api: Sized {
+    type Device: ?Sized;
+}
+
+struct OpenDevice<A: Api>
+where
+    A::Device: Sized,
+{
+    device: A::Device,
+    queue: (),
+}
+
+trait Adapter {
+    type A: Api;
+
+    fn open() -> OpenDevice<Self::A>
+    where
+        <Self::A as Api>::Device: Sized;
+}
+
+struct ApiS;
+
+impl Api for ApiS {
+    type Device = [u8];
+}
+
+impl<T> Adapter for T
+{
+    type A = ApiS;
+
+    // This function has the impossible predicate `[u8]: Sized`.
+    fn open() -> OpenDevice<Self::A>
+    where
+        <Self::A as Api>::Device: Sized,
+    {
+        unreachable!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/123134

For items with impossible predicates like `[u8]: Sized` it's possible to have locals that are "Sized", but cannot be const-propped in any meaningful way. To avoid this issue, we can just skip the known panics lint for items that have impossible predicates.