### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_ast_lowering/src/format.rs
+++ b/compiler/rustc_ast_lowering/src/format.rs
@@ -604,8 +604,7 @@ fn may_contain_yield_point(e: &ast::Expr) -> bool {
             if let ast::ExprKind::Await(_, _) | ast::ExprKind::Yield(_) = e.kind {
                 ControlFlow::Break(())
             } else {
-                visit::walk_expr(self, e);
-                ControlFlow::Continue(())
+                visit::walk_expr(self, e)
             }
         }
 

--- a/compiler/rustc_trait_selection/messages.ftl
+++ b/compiler/rustc_trait_selection/messages.ftl
@@ -19,6 +19,9 @@ trait_selection_closure_kind_mismatch = expected a closure that implements the `
 
 trait_selection_closure_kind_requirement = the requirement to implement `{$trait_prefix}{$expected}` derives from here
 
+trait_selection_disallowed_positional_argument = positional format arguments are not allowed here
+    .help = only named format arguments with the name of one of the generic types are allowed in this context
+
 trait_selection_dump_vtable_entries = vtable entries for `{$trait_ref}`: {$entries}
 
 trait_selection_empty_on_clause_in_rustc_on_unimplemented = empty `on`-clause in `#[rustc_on_unimplemented]`
@@ -29,6 +32,9 @@ trait_selection_ignored_diagnostic_option = `{$option_name}` is ignored due to p
     .label = `{$option_name}` is already declared here
 
 trait_selection_inherent_projection_normalization_overflow = overflow evaluating associated type `{$ty}`
+
+trait_selection_invalid_format_specifier = invalid format specifier
+    .help = no format specifier are supported in this position
 
 trait_selection_invalid_on_clause_in_rustc_on_unimplemented = invalid `on`-clause in `#[rustc_on_unimplemented]`
     .label = invalid on-clause here
@@ -60,3 +66,6 @@ trait_selection_unable_to_construct_constant_value = unable to construct a const
 
 trait_selection_unknown_format_parameter_for_on_unimplemented_attr = there is no parameter `{$argument_name}` on trait `{$trait_name}`
     .help = expect either a generic argument name or {"`{Self}`"} as format argument
+
+trait_selection_wrapped_parser_error = {$description}
+    .label = {$label}

--- a/src/ci/scripts/install-ninja.sh
+++ b/src/ci/scripts/install-ninja.sh
@@ -8,7 +8,7 @@ source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 if isWindows; then
     mkdir ninja
-    curl -o ninja.zip "${MIRRORS_BASE}/2017-03-15-ninja-win.zip"
+    curl -o ninja.zip "${MIRRORS_BASE}/2024-03-28-v1.11.1-ninja-win.zip"
     7z x -oninja ninja.zip
     rm ninja.zip
     ciCommandSetEnv "RUST_CONFIGURE_ARGS" "${RUST_CONFIGURE_ARGS} --enable-ninja"

--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -136,6 +136,28 @@ h1 a:link, h1 a:visited, h2 a:link, h2 a:visited,
 h3 a:link, h3 a:visited, h4 a:link, h4 a:visited,
 h5 a:link, h5 a:visited {color: black;}
 
+h1, h2, h3, h4, h5 {
+	/* This is needed to be able to position the doc-anchor. Ideally there
+	   would be a <div> around the whole document, but we don't have that. */
+	position: relative;
+}
+
+a.doc-anchor {
+	color: black;
+	display: none;
+	position: absolute;
+	left: -20px;
+	/* We add this padding so that when the cursor moves from the heading's text to the anchor,
+	   the anchor doesn't disappear. */
+	padding-right: 5px;
+	/* And this padding is used to make the anchor larger and easier to click on. */
+	padding-left: 3px;
+}
+*:hover > .doc-anchor {
+	display: block;
+}
+
+
 /* Code */
 
 pre, code {

--- a/tests/ui/diagnostic_namespace/on_unimplemented/broken_format.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/broken_format.rs
@@ -1,0 +1,45 @@
+#[diagnostic::on_unimplemented(message = "{{Test } thing")]
+//~^WARN unmatched `}` found
+//~|WARN unmatched `}` found
+trait ImportantTrait1 {}
+
+#[diagnostic::on_unimplemented(message = "Test {}")]
+//~^WARN positional format arguments are not allowed here
+//~|WARN positional format arguments are not allowed here
+trait ImportantTrait2 {}
+
+#[diagnostic::on_unimplemented(message = "Test {1:}")]
+//~^WARN positional format arguments are not allowed here
+//~|WARN positional format arguments are not allowed here
+trait ImportantTrait3 {}
+
+#[diagnostic::on_unimplemented(message = "Test {Self:123}")]
+//~^WARN invalid format specifier
+//~|WARN invalid format specifier
+trait ImportantTrait4 {}
+
+#[diagnostic::on_unimplemented(message = "Test {Self:!}")]
+//~^WARN expected `'}'`, found `'!'`
+//~|WARN expected `'}'`, found `'!'`
+//~|WARN unmatched `}` found
+//~|WARN unmatched `}` found
+trait ImportantTrait5 {}
+
+fn check_1(_: impl ImportantTrait1) {}
+fn check_2(_: impl ImportantTrait2) {}
+fn check_3(_: impl ImportantTrait3) {}
+fn check_4(_: impl ImportantTrait4) {}
+fn check_5(_: impl ImportantTrait5) {}
+
+fn main() {
+    check_1(());
+    //~^ERROR {{Test } thing
+    check_2(());
+    //~^ERROR Test {}
+    check_3(());
+    //~^ERROR Test {1}
+    check_4(());
+    //~^ERROR Test ()
+    check_5(());
+    //~^ERROR Test {Self:!}
+}

--- a/tests/ui/diagnostic_namespace/on_unimplemented/broken_format.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/broken_format.stderr
@@ -1,0 +1,193 @@
+warning: unmatched `}` found
+  --> $DIR/broken_format.rs:1:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "{{Test } thing")]
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unknown_or_malformed_diagnostic_attributes)]` on by default
+
+warning: positional format arguments are not allowed here
+  --> $DIR/broken_format.rs:6:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "Test {}")]
+   |                                ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: only named format arguments with the name of one of the generic types are allowed in this context
+
+warning: positional format arguments are not allowed here
+  --> $DIR/broken_format.rs:11:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "Test {1:}")]
+   |                                ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: only named format arguments with the name of one of the generic types are allowed in this context
+
+warning: invalid format specifier
+  --> $DIR/broken_format.rs:16:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "Test {Self:123}")]
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: no format specifier are supported in this position
+
+warning: expected `'}'`, found `'!'`
+  --> $DIR/broken_format.rs:21:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "Test {Self:!}")]
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unmatched `}` found
+  --> $DIR/broken_format.rs:21:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "Test {Self:!}")]
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unmatched `}` found
+  --> $DIR/broken_format.rs:1:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "{{Test } thing")]
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: {{Test } thing
+  --> $DIR/broken_format.rs:35:13
+   |
+LL |     check_1(());
+   |     ------- ^^ the trait `ImportantTrait1` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/broken_format.rs:4:1
+   |
+LL | trait ImportantTrait1 {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `check_1`
+  --> $DIR/broken_format.rs:28:20
+   |
+LL | fn check_1(_: impl ImportantTrait1) {}
+   |                    ^^^^^^^^^^^^^^^ required by this bound in `check_1`
+
+warning: positional format arguments are not allowed here
+  --> $DIR/broken_format.rs:6:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "Test {}")]
+   |                                ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: only named format arguments with the name of one of the generic types are allowed in this context
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: Test {}
+  --> $DIR/broken_format.rs:37:13
+   |
+LL |     check_2(());
+   |     ------- ^^ the trait `ImportantTrait2` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/broken_format.rs:9:1
+   |
+LL | trait ImportantTrait2 {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `check_2`
+  --> $DIR/broken_format.rs:29:20
+   |
+LL | fn check_2(_: impl ImportantTrait2) {}
+   |                    ^^^^^^^^^^^^^^^ required by this bound in `check_2`
+
+warning: positional format arguments are not allowed here
+  --> $DIR/broken_format.rs:11:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "Test {1:}")]
+   |                                ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: only named format arguments with the name of one of the generic types are allowed in this context
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: Test {1}
+  --> $DIR/broken_format.rs:39:13
+   |
+LL |     check_3(());
+   |     ------- ^^ the trait `ImportantTrait3` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/broken_format.rs:14:1
+   |
+LL | trait ImportantTrait3 {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `check_3`
+  --> $DIR/broken_format.rs:30:20
+   |
+LL | fn check_3(_: impl ImportantTrait3) {}
+   |                    ^^^^^^^^^^^^^^^ required by this bound in `check_3`
+
+warning: invalid format specifier
+  --> $DIR/broken_format.rs:16:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "Test {Self:123}")]
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: no format specifier are supported in this position
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: Test ()
+  --> $DIR/broken_format.rs:41:13
+   |
+LL |     check_4(());
+   |     ------- ^^ the trait `ImportantTrait4` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/broken_format.rs:19:1
+   |
+LL | trait ImportantTrait4 {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `check_4`
+  --> $DIR/broken_format.rs:31:20
+   |
+LL | fn check_4(_: impl ImportantTrait4) {}
+   |                    ^^^^^^^^^^^^^^^ required by this bound in `check_4`
+
+warning: expected `'}'`, found `'!'`
+  --> $DIR/broken_format.rs:21:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "Test {Self:!}")]
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: unmatched `}` found
+  --> $DIR/broken_format.rs:21:32
+   |
+LL | #[diagnostic::on_unimplemented(message = "Test {Self:!}")]
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: Test {Self:!}
+  --> $DIR/broken_format.rs:43:13
+   |
+LL |     check_5(());
+   |     ------- ^^ the trait `ImportantTrait5` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/broken_format.rs:26:1
+   |
+LL | trait ImportantTrait5 {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `check_5`
+  --> $DIR/broken_format.rs:32:20
+   |
+LL | fn check_5(_: impl ImportantTrait5) {}
+   |                    ^^^^^^^^^^^^^^^ required by this bound in `check_5`
+
+error: aborting due to 5 previous errors; 12 warnings emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/fmt/nested-awaits-issue-122674.rs
+++ b/tests/ui/fmt/nested-awaits-issue-122674.rs
@@ -1,0 +1,22 @@
+// Non-regression test for issue #122674: a change in the format args visitor missed nested awaits.
+
+//@ edition: 2021
+//@ check-pass
+
+pub fn f1() -> impl std::future::Future<Output = Result<(), String>> + Send {
+    async {
+        should_work().await?;
+        Ok(())
+    }
+}
+
+async fn should_work() -> Result<String, String> {
+    let x = 1;
+    Err(format!("test: {}: {}", x, inner().await?))
+}
+
+async fn inner() -> Result<String, String> {
+    Ok("test".to_string())
+}
+
+fn main() {}


### PR DESCRIPTION
- Do not eat nested expressions' results in `MayContainYieldPoint` format args visitor #122680
- Fix heading anchors in doc pages. #122693
- Make `#[diagnostic::on_unimplemented]` format string parsing more robust #122402
-  Update ninja on Windows #123178 

r? cuviper