### PR TITLE
Update ninja on Windows

### DIFF
--- a/src/ci/scripts/install-ninja.sh
+++ b/src/ci/scripts/install-ninja.sh
@@ -8,7 +8,7 @@ source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 if isWindows; then
     mkdir ninja
-    curl -o ninja.zip "${MIRRORS_BASE}/2017-03-15-ninja-win.zip"
+    curl -o ninja.zip "${MIRRORS_BASE}/2024-03-28-v1.11.1-ninja-win.zip"
     7z x -oninja ninja.zip
     rm ninja.zip
     ciCommandSetEnv "RUST_CONFIGURE_ARGS" "${RUST_CONFIGURE_ARGS} --enable-ninja"


### PR DESCRIPTION
Errors started showing up, and I read somewhere that this might be because of old ninja versions. This ninja version is indeed *ancient*.

```
multiple outputs aren't (yet?) supported by depslog; bring this up on the mailing list if it affects you
```

This requires someone uploading https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-win.zip as `2024-03-28-v1.11.1-ninja-win.zip`.

should end https://github.com/rust-lang/rust/pull/122671#issuecomment-2026178791