### PR TITLE
Avoid expanding to unstable internal method

### DIFF
--- a/tests/ui/derives/auxiliary/rustc-serialize.rs
+++ b/tests/ui/derives/auxiliary/rustc-serialize.rs
@@ -1,0 +1,16 @@
+#![crate_type = "lib"]
+
+pub trait Decoder {
+    type Error;
+
+    fn read_enum<T, F>(&mut self, name: &str, f: F) -> Result<T, Self::Error>
+        where F: FnOnce(&mut Self) -> Result<T, Self::Error>;
+    fn read_enum_variant<T, F>(&mut self, names: &[&str], f: F)
+                               -> Result<T, Self::Error>
+        where F: FnMut(&mut Self, usize) -> Result<T, Self::Error>;
+
+}
+
+pub trait Decodable: Sized {
+    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error>;
+}

--- a/tests/ui/derives/rustc-decodable-issue-123156.rs
+++ b/tests/ui/derives/rustc-decodable-issue-123156.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+//@ edition:2021
+//@ aux-build:rustc-serialize.rs
+
+#![crate_type = "lib"]
+#![allow(deprecated, soft_unstable)]
+
+extern crate rustc_serialize;
+
+#[derive(RustcDecodable)]
+pub enum Foo {}

--- a/tests/ui/derives/rustc-decodable-issue-123156.stderr
+++ b/tests/ui/derives/rustc-decodable-issue-123156.stderr
@@ -1,0 +1,10 @@
+Future incompatibility report: Future breakage diagnostic:
+warning: use of unstable library feature 'rustc_encodable_decodable': derive macro for `rustc-serialize`; should not be used in new code
+  --> $DIR/rustc-decodable-issue-123156.rs:10:10
+   |
+LL | #[derive(RustcDecodable)]
+   |          ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+


### PR DESCRIPTION
Fixes #123156

Rather than expanding to `std::rt::begin_panic`, the expansion is now to `unreachable!()`. The resulting behavior is identical. A test that previously triggered the same error as #123156 has been added to ensure it does not regress.

r? compiler