### PR TITLE
copy any file from stage0/lib to stage0-sysroot/lib

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -643,13 +643,13 @@ impl Step for StdLink {
             t!(fs::create_dir_all(&sysroot_bin_dir));
             builder.cp_link_r(&stage0_bin_dir, &sysroot_bin_dir);
 
-            // Copy all *.so files from stage0/lib to stage0-sysroot/lib
+            // Copy all files from stage0/lib to stage0-sysroot/lib
             let stage0_lib_dir = builder.out.join(host).join("stage0/lib");
             if let Ok(files) = fs::read_dir(stage0_lib_dir) {
                 for file in files {
                     let file = t!(file);
                     let path = file.path();
-                    if path.is_file() && is_dylib(&file.file_name().into_string().unwrap()) {
+                    if path.is_file() {
                         builder
                             .copy_link(&path, &sysroot.join("lib").join(path.file_name().unwrap()));
                     }


### PR DESCRIPTION
With the LLVM 18 upgrade, the name of the LLVM library has been changed to something like `libLLVM.so.18.1-rust-1.78.0-beta`, which `is_dylib` function cannot determine as it only looks whether files are ending with ".so" or not.
This change resolves this problem by no longer doing that ".so" check, as we need all files from the stage0/lib as they are all dependency of rustc anyway.

Fixes #122913