### PR TITLE
Do not attempt to write `ty::Err` on binding that isn't from current HIR Owner

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1916,18 +1916,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         pat: &'tcx hir::Pat<'tcx>,
         ty: Ty<'tcx>,
     ) {
-        struct V<'tcx> {
-            tcx: TyCtxt<'tcx>,
+        struct V {
             pat_hir_ids: Vec<hir::HirId>,
         }
 
-        impl<'tcx> Visitor<'tcx> for V<'tcx> {
-            type NestedFilter = rustc_middle::hir::nested_filter::All;
-
-            fn nested_visit_map(&mut self) -> Self::Map {
-                self.tcx.hir()
-            }
-
+        impl<'tcx> Visitor<'tcx> for V {
             fn visit_pat(&mut self, p: &'tcx hir::Pat<'tcx>) {
                 self.pat_hir_ids.push(p.hir_id);
                 hir::intravisit::walk_pat(self, p);
@@ -1938,7 +1931,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let err = Ty::new_error(self.tcx, guar);
             self.write_ty(hir_id, err);
             self.write_ty(pat.hir_id, err);
-            let mut visitor = V { tcx: self.tcx, pat_hir_ids: vec![] };
+            let mut visitor = V { pat_hir_ids: vec![] };
             hir::intravisit::walk_pat(&mut visitor, pat);
             // Mark all the subpatterns as `{type error}` as well. This allows errors for specific
             // subpatterns to be silenced.

--- a/tests/ui/sized/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.rs
+++ b/tests/ui/sized/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let str::<{fn str() { let str::T>>::as_bytes; }}, T>::as_bytes;
+//~^ ERROR expected a pattern, found an expression
+//~| ERROR cannot find type `T` in this scope
+//~| ERROR type and const arguments are not allowed on builtin type `str`
+//~| ERROR expected unit struct, unit variant or constant, found associated function `str<, T>::as_bytes`
+}

--- a/tests/ui/sized/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.stderr
+++ b/tests/ui/sized/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.stderr
@@ -1,0 +1,36 @@
+error: expected a pattern, found an expression
+  --> $DIR/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.rs:2:31
+   |
+LL |     let str::<{fn str() { let str::T>>::as_bytes; }}, T>::as_bytes;
+   |                               ^^^^^^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.rs:2:55
+   |
+LL |     let str::<{fn str() { let str::T>>::as_bytes; }}, T>::as_bytes;
+   |                                                       ^ not found in this scope
+
+error[E0109]: type and const arguments are not allowed on builtin type `str`
+  --> $DIR/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.rs:2:15
+   |
+LL |     let str::<{fn str() { let str::T>>::as_bytes; }}, T>::as_bytes;
+   |         ---   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^ type and const arguments not allowed
+   |         |
+   |         not allowed on builtin type `str`
+   |
+help: primitive type `str` doesn't have generic parameters
+   |
+LL -     let str::<{fn str() { let str::T>>::as_bytes; }}, T>::as_bytes;
+LL +     let str::as_bytes;
+   |
+
+error[E0533]: expected unit struct, unit variant or constant, found associated function `str<, T>::as_bytes`
+  --> $DIR/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.rs:2:9
+   |
+LL |     let str::<{fn str() { let str::T>>::as_bytes; }}, T>::as_bytes;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a unit struct, unit variant or constant
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0109, E0412, E0533.
+For more information about an error, try `rustc --explain E0109`.


### PR DESCRIPTION
Fix #123009. Follow up to #122119.