### PR TITLE
Add support for `NonNull`s in the `ambiguous_wide_ptr_comparisions` lint

### DIFF
--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -243,6 +243,7 @@ where
     T: Tag,
 {
     #[inline]
+    #[allow(ambiguous_wide_pointer_comparisons)]
     fn eq(&self, other: &Self) -> bool {
         self.packed == other.packed
     }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1632,11 +1632,13 @@ pub struct AmbiguousWidePointerComparisonsAddrMetadataSuggestion<'a> {
     pub ne: &'a str,
     pub deref_left: &'a str,
     pub deref_right: &'a str,
+    pub l_modifiers: &'a str,
+    pub r_modifiers: &'a str,
     #[suggestion_part(code = "{ne}std::ptr::eq({deref_left}")]
     pub left: Span,
-    #[suggestion_part(code = ", {deref_right}")]
+    #[suggestion_part(code = "{l_modifiers}, {deref_right}")]
     pub middle: Span,
-    #[suggestion_part(code = ")")]
+    #[suggestion_part(code = "{r_modifiers})")]
     pub right: Span,
 }
 
@@ -1652,11 +1654,13 @@ pub enum AmbiguousWidePointerComparisonsAddrSuggestion<'a> {
         ne: &'a str,
         deref_left: &'a str,
         deref_right: &'a str,
+        l_modifiers: &'a str,
+        r_modifiers: &'a str,
         #[suggestion_part(code = "{ne}std::ptr::addr_eq({deref_left}")]
         left: Span,
-        #[suggestion_part(code = ", {deref_right}")]
+        #[suggestion_part(code = "{l_modifiers}, {deref_right}")]
         middle: Span,
-        #[suggestion_part(code = ")")]
+        #[suggestion_part(code = "{r_modifiers})")]
         right: Span,
     },
     #[multipart_suggestion(
@@ -1670,13 +1674,15 @@ pub enum AmbiguousWidePointerComparisonsAddrSuggestion<'a> {
         deref_right: &'a str,
         paren_left: &'a str,
         paren_right: &'a str,
+        l_modifiers: &'a str,
+        r_modifiers: &'a str,
         #[suggestion_part(code = "({deref_left}")]
         left_before: Option<Span>,
-        #[suggestion_part(code = "{paren_left}.cast::<()>()")]
+        #[suggestion_part(code = "{l_modifiers}{paren_left}.cast::<()>()")]
         left_after: Span,
         #[suggestion_part(code = "({deref_right}")]
         right_before: Option<Span>,
-        #[suggestion_part(code = "{paren_right}.cast::<()>()")]
+        #[suggestion_part(code = "{r_modifiers}{paren_right}.cast::<()>()")]
         right_after: Span,
     },
 }

--- a/tests/ui/lint/wide_pointer_comparisons.rs
+++ b/tests/ui/lint/wide_pointer_comparisons.rs
@@ -3,6 +3,7 @@
 use std::rc::Rc;
 use std::sync::Arc;
 use std::cmp::PartialEq;
+use std::ptr::NonNull;
 
 struct A;
 struct B;
@@ -49,6 +50,17 @@ fn main() {
     //~^ WARN ambiguous wide pointer comparison
     let _ = a.gt(&b);
     //~^ WARN ambiguous wide pointer comparison
+
+    {
+        let a = NonNull::<dyn T>::new(a as *mut _).unwrap();
+        let b = NonNull::<dyn T>::new(b as *mut _).unwrap();
+        let _ = a == b;
+        //~^ WARN ambiguous wide pointer comparison
+        let _ = a >= b;
+        //~^ WARN ambiguous wide pointer comparison
+        let _ = &a == &b;
+        //~^ WARN ambiguous wide pointer comparison
+    }
 
     {
         // &*const ?Sized

--- a/tests/ui/lint/wide_pointer_comparisons.stderr
+++ b/tests/ui/lint/wide_pointer_comparisons.stderr
@@ -1,5 +1,5 @@
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:19:13
+  --> $DIR/wide_pointer_comparisons.rs:20:13
    |
 LL |     let _ = a == b;
    |             ^^^^^^
@@ -11,7 +11,7 @@ LL |     let _ = std::ptr::addr_eq(a, b);
    |             ++++++++++++++++++ ~  +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:21:13
+  --> $DIR/wide_pointer_comparisons.rs:22:13
    |
 LL |     let _ = a != b;
    |             ^^^^^^
@@ -22,7 +22,7 @@ LL |     let _ = !std::ptr::addr_eq(a, b);
    |             +++++++++++++++++++ ~  +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:23:13
+  --> $DIR/wide_pointer_comparisons.rs:24:13
    |
 LL |     let _ = a < b;
    |             ^^^^^
@@ -33,7 +33,7 @@ LL |     let _ = a.cast::<()>() < b.cast::<()>();
    |              +++++++++++++    +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:25:13
+  --> $DIR/wide_pointer_comparisons.rs:26:13
    |
 LL |     let _ = a <= b;
    |             ^^^^^^
@@ -44,7 +44,7 @@ LL |     let _ = a.cast::<()>() <= b.cast::<()>();
    |              +++++++++++++     +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:27:13
+  --> $DIR/wide_pointer_comparisons.rs:28:13
    |
 LL |     let _ = a > b;
    |             ^^^^^
@@ -55,7 +55,7 @@ LL |     let _ = a.cast::<()>() > b.cast::<()>();
    |              +++++++++++++    +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:29:13
+  --> $DIR/wide_pointer_comparisons.rs:30:13
    |
 LL |     let _ = a >= b;
    |             ^^^^^^
@@ -66,7 +66,7 @@ LL |     let _ = a.cast::<()>() >= b.cast::<()>();
    |              +++++++++++++     +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:32:13
+  --> $DIR/wide_pointer_comparisons.rs:33:13
    |
 LL |     let _ = PartialEq::eq(&a, &b);
    |             ^^^^^^^^^^^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     let _ = std::ptr::addr_eq(a, b);
    |             ~~~~~~~~~~~~~~~~~~ ~  ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:34:13
+  --> $DIR/wide_pointer_comparisons.rs:35:13
    |
 LL |     let _ = PartialEq::ne(&a, &b);
    |             ^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ LL |     let _ = !std::ptr::addr_eq(a, b);
    |             ~~~~~~~~~~~~~~~~~~~ ~  ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:36:13
+  --> $DIR/wide_pointer_comparisons.rs:37:13
    |
 LL |     let _ = a.eq(&b);
    |             ^^^^^^^^
@@ -99,7 +99,7 @@ LL |     let _ = std::ptr::addr_eq(a, b);
    |             ++++++++++++++++++ ~  ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:38:13
+  --> $DIR/wide_pointer_comparisons.rs:39:13
    |
 LL |     let _ = a.ne(&b);
    |             ^^^^^^^^
@@ -110,7 +110,7 @@ LL |     let _ = !std::ptr::addr_eq(a, b);
    |             +++++++++++++++++++ ~  ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:40:13
+  --> $DIR/wide_pointer_comparisons.rs:41:13
    |
 LL |     let _ = a.cmp(&b);
    |             ^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     let _ = a.cast::<()>().cmp(&b.cast::<()>());
    |              +++++++++++++       +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:42:13
+  --> $DIR/wide_pointer_comparisons.rs:43:13
    |
 LL |     let _ = a.partial_cmp(&b);
    |             ^^^^^^^^^^^^^^^^^
@@ -132,7 +132,7 @@ LL |     let _ = a.cast::<()>().partial_cmp(&b.cast::<()>());
    |              +++++++++++++               +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:44:13
+  --> $DIR/wide_pointer_comparisons.rs:45:13
    |
 LL |     let _ = a.le(&b);
    |             ^^^^^^^^
@@ -143,7 +143,7 @@ LL |     let _ = a.cast::<()>().le(&b.cast::<()>());
    |              +++++++++++++      +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:46:13
+  --> $DIR/wide_pointer_comparisons.rs:47:13
    |
 LL |     let _ = a.lt(&b);
    |             ^^^^^^^^
@@ -154,7 +154,7 @@ LL |     let _ = a.cast::<()>().lt(&b.cast::<()>());
    |              +++++++++++++      +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:48:13
+  --> $DIR/wide_pointer_comparisons.rs:49:13
    |
 LL |     let _ = a.ge(&b);
    |             ^^^^^^^^
@@ -165,7 +165,7 @@ LL |     let _ = a.cast::<()>().ge(&b.cast::<()>());
    |              +++++++++++++      +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:50:13
+  --> $DIR/wide_pointer_comparisons.rs:51:13
    |
 LL |     let _ = a.gt(&b);
    |             ^^^^^^^^
@@ -176,7 +176,40 @@ LL |     let _ = a.cast::<()>().gt(&b.cast::<()>());
    |              +++++++++++++      +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:58:17
+  --> $DIR/wide_pointer_comparisons.rs:57:17
+   |
+LL |         let _ = a == b;
+   |                 ^^^^^^
+   |
+help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+   |
+LL |         let _ = std::ptr::addr_eq(a.as_ptr(), b.as_ptr());
+   |                 ++++++++++++++++++ ~~~~~~~~~~  ++++++++++
+
+warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
+  --> $DIR/wide_pointer_comparisons.rs:59:17
+   |
+LL |         let _ = a >= b;
+   |                 ^^^^^^
+   |
+help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+   |
+LL |         let _ = a.as_ptr().cast::<()>() >= b.as_ptr().cast::<()>();
+   |                  ++++++++++++++++++++++     ++++++++++++++++++++++
+
+warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
+  --> $DIR/wide_pointer_comparisons.rs:61:17
+   |
+LL |         let _ = &a == &b;
+   |                 ^^^^^^^^
+   |
+help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+   |
+LL |         let _ = std::ptr::addr_eq(a.as_ptr(), b.as_ptr());
+   |                 ~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~  ++++++++++
+
+warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
+  --> $DIR/wide_pointer_comparisons.rs:70:17
    |
 LL |         let _ = a == b;
    |                 ^^^^^^
@@ -187,7 +220,7 @@ LL |         let _ = std::ptr::addr_eq(*a, *b);
    |                 +++++++++++++++++++ ~~~ +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:60:17
+  --> $DIR/wide_pointer_comparisons.rs:72:17
    |
 LL |         let _ = a != b;
    |                 ^^^^^^
@@ -198,7 +231,7 @@ LL |         let _ = !std::ptr::addr_eq(*a, *b);
    |                 ++++++++++++++++++++ ~~~ +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:62:17
+  --> $DIR/wide_pointer_comparisons.rs:74:17
    |
 LL |         let _ = a < b;
    |                 ^^^^^
@@ -209,7 +242,7 @@ LL |         let _ = (*a).cast::<()>() < (*b).cast::<()>();
    |                 ++ ++++++++++++++   ++ ++++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:64:17
+  --> $DIR/wide_pointer_comparisons.rs:76:17
    |
 LL |         let _ = a <= b;
    |                 ^^^^^^
@@ -220,7 +253,7 @@ LL |         let _ = (*a).cast::<()>() <= (*b).cast::<()>();
    |                 ++ ++++++++++++++    ++ ++++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:66:17
+  --> $DIR/wide_pointer_comparisons.rs:78:17
    |
 LL |         let _ = a > b;
    |                 ^^^^^
@@ -231,7 +264,7 @@ LL |         let _ = (*a).cast::<()>() > (*b).cast::<()>();
    |                 ++ ++++++++++++++   ++ ++++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:68:17
+  --> $DIR/wide_pointer_comparisons.rs:80:17
    |
 LL |         let _ = a >= b;
    |                 ^^^^^^
@@ -242,7 +275,7 @@ LL |         let _ = (*a).cast::<()>() >= (*b).cast::<()>();
    |                 ++ ++++++++++++++    ++ ++++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:71:17
+  --> $DIR/wide_pointer_comparisons.rs:83:17
    |
 LL |         let _ = PartialEq::eq(a, b);
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -253,7 +286,7 @@ LL |         let _ = std::ptr::addr_eq(*a, *b);
    |                 ~~~~~~~~~~~~~~~~~~~ ~~~ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:73:17
+  --> $DIR/wide_pointer_comparisons.rs:85:17
    |
 LL |         let _ = PartialEq::ne(a, b);
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -264,7 +297,7 @@ LL |         let _ = !std::ptr::addr_eq(*a, *b);
    |                 ~~~~~~~~~~~~~~~~~~~~ ~~~ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:75:17
+  --> $DIR/wide_pointer_comparisons.rs:87:17
    |
 LL |         let _ = PartialEq::eq(&a, &b);
    |                 ^^^^^^^^^^^^^^^^^^^^^
@@ -275,7 +308,7 @@ LL |         let _ = std::ptr::addr_eq(*a, *b);
    |                 ~~~~~~~~~~~~~~~~~~~ ~~~ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:77:17
+  --> $DIR/wide_pointer_comparisons.rs:89:17
    |
 LL |         let _ = PartialEq::ne(&a, &b);
    |                 ^^^^^^^^^^^^^^^^^^^^^
@@ -286,7 +319,7 @@ LL |         let _ = !std::ptr::addr_eq(*a, *b);
    |                 ~~~~~~~~~~~~~~~~~~~~ ~~~ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:79:17
+  --> $DIR/wide_pointer_comparisons.rs:91:17
    |
 LL |         let _ = a.eq(b);
    |                 ^^^^^^^
@@ -297,7 +330,7 @@ LL |         let _ = std::ptr::addr_eq(*a, *b);
    |                 +++++++++++++++++++ ~~~ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:81:17
+  --> $DIR/wide_pointer_comparisons.rs:93:17
    |
 LL |         let _ = a.ne(b);
    |                 ^^^^^^^
@@ -308,7 +341,7 @@ LL |         let _ = !std::ptr::addr_eq(*a, *b);
    |                 ++++++++++++++++++++ ~~~ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:83:17
+  --> $DIR/wide_pointer_comparisons.rs:95:17
    |
 LL |         let _ = a.cmp(&b);
    |                 ^^^^^^^^^
@@ -319,7 +352,7 @@ LL |         let _ = (*a).cast::<()>().cmp(&(*b).cast::<()>());
    |                 ++ ++++++++++++++      ++ ++++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:85:17
+  --> $DIR/wide_pointer_comparisons.rs:97:17
    |
 LL |         let _ = a.partial_cmp(&b);
    |                 ^^^^^^^^^^^^^^^^^
@@ -330,7 +363,7 @@ LL |         let _ = (*a).cast::<()>().partial_cmp(&(*b).cast::<()>());
    |                 ++ ++++++++++++++              ++ ++++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:87:17
+  --> $DIR/wide_pointer_comparisons.rs:99:17
    |
 LL |         let _ = a.le(&b);
    |                 ^^^^^^^^
@@ -341,7 +374,7 @@ LL |         let _ = (*a).cast::<()>().le(&(*b).cast::<()>());
    |                 ++ ++++++++++++++     ++ ++++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:89:17
+  --> $DIR/wide_pointer_comparisons.rs:101:17
    |
 LL |         let _ = a.lt(&b);
    |                 ^^^^^^^^
@@ -352,7 +385,7 @@ LL |         let _ = (*a).cast::<()>().lt(&(*b).cast::<()>());
    |                 ++ ++++++++++++++     ++ ++++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:91:17
+  --> $DIR/wide_pointer_comparisons.rs:103:17
    |
 LL |         let _ = a.ge(&b);
    |                 ^^^^^^^^
@@ -363,7 +396,7 @@ LL |         let _ = (*a).cast::<()>().ge(&(*b).cast::<()>());
    |                 ++ ++++++++++++++     ++ ++++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:93:17
+  --> $DIR/wide_pointer_comparisons.rs:105:17
    |
 LL |         let _ = a.gt(&b);
    |                 ^^^^^^^^
@@ -374,7 +407,7 @@ LL |         let _ = (*a).cast::<()>().gt(&(*b).cast::<()>());
    |                 ++ ++++++++++++++     ++ ++++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:98:13
+  --> $DIR/wide_pointer_comparisons.rs:110:13
    |
 LL |     let _ = s == s;
    |             ^^^^^^
@@ -389,7 +422,7 @@ LL |     let _ = std::ptr::eq(s, s);
    |             +++++++++++++ ~  +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:102:13
+  --> $DIR/wide_pointer_comparisons.rs:114:13
    |
 LL |     let _ = s == s;
    |             ^^^^^^
@@ -404,7 +437,7 @@ LL |     let _ = std::ptr::eq(s, s);
    |             +++++++++++++ ~  +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:106:17
+  --> $DIR/wide_pointer_comparisons.rs:118:17
    |
 LL |         let _ = a == b;
    |                 ^^^^^^
@@ -419,7 +452,7 @@ LL |         let _ = std::ptr::eq(a, b);
    |                 +++++++++++++ ~  +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:108:17
+  --> $DIR/wide_pointer_comparisons.rs:120:17
    |
 LL |         let _ = a != b;
    |                 ^^^^^^
@@ -434,7 +467,7 @@ LL |         let _ = !std::ptr::eq(a, b);
    |                 ++++++++++++++ ~  +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:110:17
+  --> $DIR/wide_pointer_comparisons.rs:122:17
    |
 LL |         let _ = a < b;
    |                 ^^^^^
@@ -445,7 +478,7 @@ LL |         let _ = a.cast::<()>() < b.cast::<()>();
    |                  +++++++++++++    +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:112:17
+  --> $DIR/wide_pointer_comparisons.rs:124:17
    |
 LL |         let _ = a <= b;
    |                 ^^^^^^
@@ -456,7 +489,7 @@ LL |         let _ = a.cast::<()>() <= b.cast::<()>();
    |                  +++++++++++++     +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:114:17
+  --> $DIR/wide_pointer_comparisons.rs:126:17
    |
 LL |         let _ = a > b;
    |                 ^^^^^
@@ -467,7 +500,7 @@ LL |         let _ = a.cast::<()>() > b.cast::<()>();
    |                  +++++++++++++    +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:116:17
+  --> $DIR/wide_pointer_comparisons.rs:128:17
    |
 LL |         let _ = a >= b;
    |                 ^^^^^^
@@ -478,7 +511,7 @@ LL |         let _ = a.cast::<()>() >= b.cast::<()>();
    |                  +++++++++++++     +++++++++++++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:119:17
+  --> $DIR/wide_pointer_comparisons.rs:131:17
    |
 LL |         let _ = PartialEq::eq(&a, &b);
    |                 ^^^^^^^^^^^^^^^^^^^^^
@@ -493,7 +526,7 @@ LL |         let _ = std::ptr::eq(a, b);
    |                 ~~~~~~~~~~~~~ ~  ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:121:17
+  --> $DIR/wide_pointer_comparisons.rs:133:17
    |
 LL |         let _ = PartialEq::ne(&a, &b);
    |                 ^^^^^^^^^^^^^^^^^^^^^
@@ -508,7 +541,7 @@ LL |         let _ = !std::ptr::eq(a, b);
    |                 ~~~~~~~~~~~~~~ ~  ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:123:17
+  --> $DIR/wide_pointer_comparisons.rs:135:17
    |
 LL |         let _ = a.eq(&b);
    |                 ^^^^^^^^
@@ -523,7 +556,7 @@ LL |         let _ = std::ptr::eq(a, b);
    |                 +++++++++++++ ~  ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:125:17
+  --> $DIR/wide_pointer_comparisons.rs:137:17
    |
 LL |         let _ = a.ne(&b);
    |                 ^^^^^^^^
@@ -538,7 +571,7 @@ LL |         let _ = !std::ptr::eq(a, b);
    |                 ++++++++++++++ ~  ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:130:9
+  --> $DIR/wide_pointer_comparisons.rs:142:9
    |
 LL |         &*a == &*b
    |         ^^^^^^^^^^
@@ -553,7 +586,7 @@ LL |         std::ptr::eq(*a, *b)
    |         ~~~~~~~~~~~~~  ~   +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:141:14
+  --> $DIR/wide_pointer_comparisons.rs:153:14
    |
 LL |         cmp!(a, b);
    |              ^^^^
@@ -564,7 +597,7 @@ LL |         cmp!(std::ptr::addr_eq(a, b));
    |              ++++++++++++++++++ ~  +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:147:39
+  --> $DIR/wide_pointer_comparisons.rs:159:39
    |
 LL |             ($a:ident, $b:ident) => { $a == $b }
    |                                       ^^^^^^^^
@@ -579,7 +612,7 @@ LL |             ($a:ident, $b:ident) => { std::ptr::addr_eq($a, $b) }
    |                                       ++++++++++++++++++  ~   +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:157:37
+  --> $DIR/wide_pointer_comparisons.rs:169:37
    |
 LL |             ($a:expr, $b:expr) => { $a == $b }
    |                                     ^^
@@ -591,5 +624,5 @@ LL |         cmp!(&a, &b);
    = help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    = note: this warning originates in the macro `cmp` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: 50 warnings emitted
+warning: 53 warnings emitted
 


### PR DESCRIPTION
This PR add support for `NonNull` pointers in the `ambiguous_wide_ptr_comparisions` lint.

Fixes https://github.com/rust-lang/rust/issues/121264
r? @Nadrieril (since you just reviewed #121268, feel free to reassign)  