### PR TITLE
Don't use `#[note] note: ()` as a field in diagnostics

### DIFF
--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -849,7 +849,6 @@ pub fn find_deprecation(
                                         session_diagnostics::DeprecatedItemSuggestion {
                                             span: mi.span,
                                             is_nightly: sess.is_nightly_build().then_some(()),
-                                            details: (),
                                         },
                                     );
                                 }

--- a/compiler/rustc_attr/src/session_diagnostics.rs
+++ b/compiler/rustc_attr/src/session_diagnostics.rs
@@ -337,15 +337,13 @@ pub(crate) struct CfgPredicateIdentifier {
 
 #[derive(Diagnostic)]
 #[diag(attr_deprecated_item_suggestion)]
+#[note]
 pub(crate) struct DeprecatedItemSuggestion {
     #[primary_span]
     pub span: Span,
 
     #[help]
     pub is_nightly: Option<()>,
-
-    #[note]
-    pub details: (),
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -1432,12 +1432,7 @@ fn report_ice(
         && system_datetime.checked_sub(36.hours()).is_some_and(|d| d > ver_datetime)
         && !using_internal_features.load(std::sync::atomic::Ordering::Relaxed)
     {
-        dcx.emit_note(session_diagnostics::IceBugReportOutdated {
-            version,
-            bug_report_url,
-            note_update: (),
-            note_url: (),
-        });
+        dcx.emit_note(session_diagnostics::IceBugReportOutdated { version, bug_report_url });
     } else {
         if using_internal_features.load(std::sync::atomic::Ordering::Relaxed) {
             dcx.emit_note(session_diagnostics::IceBugReportInternalFeature);

--- a/compiler/rustc_driver_impl/src/session_diagnostics.rs
+++ b/compiler/rustc_driver_impl/src/session_diagnostics.rs
@@ -48,13 +48,11 @@ pub(crate) struct IceBugReportInternalFeature;
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_ice_bug_report_outdated)]
+#[note(driver_impl_update)]
+#[note(driver_impl_url)]
 pub(crate) struct IceBugReportOutdated<'a> {
     pub version: &'a str,
     pub bug_report_url: &'a str,
-    #[note(driver_impl_update)]
-    pub note_update: (),
-    #[note(driver_impl_url)]
-    pub note_url: (),
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -198,7 +198,6 @@ fn check_union_fields(tcx: TyCtxt<'_>, span: Span, item_def_id: LocalDefId) -> b
                         lo: ty_span.shrink_to_lo(),
                         hi: ty_span.shrink_to_hi(),
                     },
-                    note: (),
                 });
                 return false;
             } else if field_ty.needs_drop(tcx, param_env) {

--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -373,7 +373,6 @@ fn emit_orphan_check_error<'tcx>(
             let err_struct = match self_ty.kind() {
                 ty::Adt(..) => errors::OnlyCurrentTraits::Outside {
                     span: sp,
-                    note: (),
                     opaque,
                     foreign,
                     name,
@@ -383,7 +382,6 @@ fn emit_orphan_check_error<'tcx>(
                 },
                 _ if self_ty.is_primitive() => errors::OnlyCurrentTraits::Primitive {
                     span: sp,
-                    note: (),
                     opaque,
                     foreign,
                     name,
@@ -393,7 +391,6 @@ fn emit_orphan_check_error<'tcx>(
                 },
                 _ => errors::OnlyCurrentTraits::Arbitrary {
                     span: sp,
-                    note: (),
                     opaque,
                     foreign,
                     name,
@@ -413,13 +410,10 @@ fn emit_orphan_check_error<'tcx>(
             }
 
             match local_type {
-                Some(local_type) => tcx.dcx().emit_err(errors::TyParamFirstLocal {
-                    span: sp,
-                    note: (),
-                    param_ty,
-                    local_type,
-                }),
-                None => tcx.dcx().emit_err(errors::TyParamSome { span: sp, note: (), param_ty }),
+                Some(local_type) => {
+                    tcx.dcx().emit_err(errors::TyParamFirstLocal { span: sp, param_ty, local_type })
+                }
+                None => tcx.dcx().emit_err(errors::TyParamSome { span: sp, param_ty }),
             }
         }
     })

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1590,8 +1590,6 @@ fn check_impl_constness(
         trait_name,
         local_trait_span:
             trait_def_id.as_local().map(|_| tcx.def_span(trait_def_id).shrink_to_lo()),
-        marking: (),
-        adding: (),
     }))
 }
 

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -429,9 +429,8 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<Ty
             ItemKind::TyAlias(self_ty, _) => icx.lower_ty(self_ty),
             ItemKind::Impl(hir::Impl { self_ty, .. }) => match self_ty.find_self_aliases() {
                 spans if spans.len() > 0 => {
-                    let guar = tcx
-                        .dcx()
-                        .emit_err(crate::errors::SelfInImplSelf { span: spans.into(), note: () });
+                    let guar =
+                        tcx.dcx().emit_err(crate::errors::SelfInImplSelf { span: spans.into() });
                     Ty::new_error(tcx, guar)
                 }
                 _ => icx.lower_ty(*self_ty),

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -470,16 +470,14 @@ pub struct GenericArgsOnOverriddenImpl {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_const_impl_for_non_const_trait)]
+#[note]
+#[note(hir_analysis_adding)]
 pub struct ConstImplForNonConstTrait {
     #[primary_span]
     pub trait_ref_span: Span,
     pub trait_name: String,
     #[suggestion(applicability = "machine-applicable", code = "#[const_trait]")]
     pub local_trait_span: Option<Span>,
-    #[note]
-    pub marking: (),
-    #[note(hir_analysis_adding)]
-    pub adding: (),
 }
 
 #[derive(Diagnostic)]
@@ -492,11 +490,10 @@ pub struct ConstBoundForNonConstTrait {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_self_in_impl_self)]
+#[note]
 pub struct SelfInImplSelf {
     #[primary_span]
     pub span: MultiSpan,
-    #[note]
-    pub note: (),
 }
 
 #[derive(Diagnostic)]
@@ -690,13 +687,12 @@ pub(crate) struct CastThinPointerToFatPointer<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_invalid_union_field, code = E0740)]
+#[note]
 pub(crate) struct InvalidUnionField {
     #[primary_span]
     pub field_span: Span,
     #[subdiagnostic]
     pub sugg: InvalidUnionFieldSuggestion,
-    #[note]
-    pub note: (),
 }
 
 #[derive(Diagnostic)]
@@ -708,14 +704,13 @@ pub struct InvalidUnnamedFieldTy {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_return_type_notation_on_non_rpitit)]
+#[note]
 pub(crate) struct ReturnTypeNotationOnNonRpitit<'tcx> {
     #[primary_span]
     pub span: Span,
     pub ty: Ty<'tcx>,
     #[label]
     pub fn_span: Option<Span>,
-    #[note]
-    pub note: (),
 }
 
 #[derive(Subdiagnostic)]
@@ -1353,12 +1348,11 @@ pub struct CrossCrateTraitsDefined {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_ty_param_first_local, code = E0210)]
 #[note]
+#[note(hir_analysis_case_note)]
 pub struct TyParamFirstLocal<'a> {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[note(hir_analysis_case_note)]
-    pub note: (),
     pub param_ty: Ty<'a>,
     pub local_type: Ty<'a>,
 }
@@ -1366,24 +1360,22 @@ pub struct TyParamFirstLocal<'a> {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_ty_param_some, code = E0210)]
 #[note]
+#[note(hir_analysis_only_note)]
 pub struct TyParamSome<'a> {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[note(hir_analysis_only_note)]
-    pub note: (),
     pub param_ty: Ty<'a>,
 }
 
 #[derive(Diagnostic)]
 pub enum OnlyCurrentTraits<'a> {
     #[diag(hir_analysis_only_current_traits_outside, code = E0117)]
+    #[note(hir_analysis_only_current_traits_note)]
     Outside {
         #[primary_span]
         #[label(hir_analysis_only_current_traits_label)]
         span: Span,
-        #[note(hir_analysis_only_current_traits_note)]
-        note: (),
         #[subdiagnostic]
         opaque: Vec<OnlyCurrentTraitsOpaque>,
         #[subdiagnostic]
@@ -1398,12 +1390,11 @@ pub enum OnlyCurrentTraits<'a> {
         sugg: Option<OnlyCurrentTraitsPointerSugg<'a>>,
     },
     #[diag(hir_analysis_only_current_traits_primitive, code = E0117)]
+    #[note(hir_analysis_only_current_traits_note)]
     Primitive {
         #[primary_span]
         #[label(hir_analysis_only_current_traits_label)]
         span: Span,
-        #[note(hir_analysis_only_current_traits_note)]
-        note: (),
         #[subdiagnostic]
         opaque: Vec<OnlyCurrentTraitsOpaque>,
         #[subdiagnostic]
@@ -1418,12 +1409,11 @@ pub enum OnlyCurrentTraits<'a> {
         sugg: Option<OnlyCurrentTraitsPointerSugg<'a>>,
     },
     #[diag(hir_analysis_only_current_traits_arbitrary, code = E0117)]
+    #[note(hir_analysis_only_current_traits_note)]
     Arbitrary {
         #[primary_span]
         #[label(hir_analysis_only_current_traits_label)]
         span: Span,
-        #[note(hir_analysis_only_current_traits_note)]
-        note: (),
         #[subdiagnostic]
         opaque: Vec<OnlyCurrentTraitsOpaque>,
         #[subdiagnostic]

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -385,7 +385,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     span: binding.span,
                     ty: tcx.liberate_late_bound_regions(assoc_item.def_id, output),
                     fn_span: tcx.hir().span_if_local(assoc_item.def_id),
-                    note: (),
                 }));
             };
 

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -780,14 +780,13 @@ pub struct RelationshipHelp;
 
 #[derive(Diagnostic)]
 #[diag(infer_trait_impl_diff)]
+#[note(infer_expected_found)]
 pub struct TraitImplDiff {
     #[primary_span]
     #[label(infer_found)]
     pub sp: Span,
     #[label(infer_expected)]
     pub trait_sp: Span,
-    #[note(infer_expected_found)]
-    pub note: (),
     #[subdiagnostic]
     pub param_help: ConsiderBorrowingParamHelp,
     #[subdiagnostic]
@@ -1068,6 +1067,7 @@ pub enum ConsiderAddingAwait {
 #[derive(Diagnostic)]
 pub enum PlaceholderRelationLfNotSatisfied {
     #[diag(infer_lf_bound_not_satisfied)]
+    #[note(infer_prlf_known_limitation)]
     HasBoth {
         #[primary_span]
         span: Span,
@@ -1077,10 +1077,9 @@ pub enum PlaceholderRelationLfNotSatisfied {
         sup_span: Span,
         sub_symbol: Symbol,
         sup_symbol: Symbol,
-        #[note(infer_prlf_known_limitation)]
-        note: (),
     },
     #[diag(infer_lf_bound_not_satisfied)]
+    #[note(infer_prlf_known_limitation)]
     HasSub {
         #[primary_span]
         span: Span,
@@ -1089,10 +1088,9 @@ pub enum PlaceholderRelationLfNotSatisfied {
         #[note(infer_prlf_must_outlive_without_sup)]
         sup_span: Span,
         sub_symbol: Symbol,
-        #[note(infer_prlf_known_limitation)]
-        note: (),
     },
     #[diag(infer_lf_bound_not_satisfied)]
+    #[note(infer_prlf_known_limitation)]
     HasSup {
         #[primary_span]
         span: Span,
@@ -1101,10 +1099,9 @@ pub enum PlaceholderRelationLfNotSatisfied {
         #[note(infer_prlf_must_outlive_with_sup)]
         sup_span: Span,
         sup_symbol: Symbol,
-        #[note(infer_prlf_known_limitation)]
-        note: (),
     },
     #[diag(infer_lf_bound_not_satisfied)]
+    #[note(infer_prlf_known_limitation)]
     HasNone {
         #[primary_span]
         span: Span,
@@ -1112,15 +1109,12 @@ pub enum PlaceholderRelationLfNotSatisfied {
         sub_span: Span,
         #[note(infer_prlf_must_outlive_without_sup)]
         sup_span: Span,
-        #[note(infer_prlf_known_limitation)]
-        note: (),
     },
     #[diag(infer_lf_bound_not_satisfied)]
+    #[note(infer_prlf_known_limitation)]
     OnlyPrimarySpan {
         #[primary_span]
         span: Span,
-        #[note(infer_prlf_known_limitation)]
-        note: (),
     },
 }
 

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_relation.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_relation.rs
@@ -50,7 +50,6 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                             sup_span,
                             sub_symbol,
                             sup_symbol,
-                            note: (),
                         }
                     }
                     (Some(sub_span), Some(sup_span), _, Some(&sup_symbol)) => {
@@ -59,7 +58,6 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                             sub_span,
                             sup_span,
                             sup_symbol,
-                            note: (),
                         }
                     }
                     (Some(sub_span), Some(sup_span), Some(&sub_symbol), _) => {
@@ -68,18 +66,12 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                             sub_span,
                             sup_span,
                             sub_symbol,
-                            note: (),
                         }
                     }
                     (Some(sub_span), Some(sup_span), _, _) => {
-                        PlaceholderRelationLfNotSatisfied::HasNone {
-                            span,
-                            sub_span,
-                            sup_span,
-                            note: (),
-                        }
+                        PlaceholderRelationLfNotSatisfied::HasNone { span, sub_span, sup_span }
                     }
-                    _ => PlaceholderRelationLfNotSatisfied::OnlyPrimarySpan { span, note: () },
+                    _ => PlaceholderRelationLfNotSatisfied::OnlyPrimarySpan { span },
                 };
                 Some(self.tcx().dcx().create_err(diag))
             }

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
@@ -111,7 +111,6 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         let diag = TraitImplDiff {
             sp,
             trait_sp,
-            note: (),
             param_help: ConsiderBorrowingParamHelp { spans: visitor.types.to_vec() },
             rel_help: visitor.types.is_empty().then_some(RelationshipHelp),
             expected,

--- a/compiler/rustc_macros/src/diagnostics/diagnostic_builder.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic_builder.rs
@@ -353,7 +353,7 @@ impl DiagnosticDeriveVariantBuilder {
                     || type_matches_path(inner, &["rustc_span", "MultiSpan"])
                 {
                     Ok(self.add_spanned_subdiagnostic(binding, &fn_ident, slug))
-                } else if type_is_unit(inner)
+                } else if (matches!(info.ty, FieldInnerTy::Option(_)) && type_is_unit(inner))
                     || (matches!(info.ty, FieldInnerTy::Plain(_)) && type_is_bool(inner))
                 {
                     Ok(self.add_subdiagnostic(&fn_ident, slug))

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -827,6 +827,7 @@ pub struct NontrivialStructuralMatch<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_pattern_not_covered, code = E0005)]
+#[note(mir_build_pattern_ty)]
 pub(crate) struct PatternNotCovered<'s, 'tcx> {
     #[primary_span]
     pub span: Span,
@@ -841,8 +842,6 @@ pub(crate) struct PatternNotCovered<'s, 'tcx> {
     pub adt_defined_here: Option<AdtDefinedHere<'tcx>>,
     #[note(mir_build_privately_uninhabited)]
     pub witness_1_is_privately_uninhabited: Option<()>,
-    #[note(mir_build_pattern_ty)]
-    pub _p: (),
     pub pattern_ty: Ty<'tcx>,
     #[subdiagnostic]
     pub let_suggestion: Option<SuggestLet>,

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -691,7 +691,6 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             inform,
             interpreted_as_const,
             witness_1_is_privately_uninhabited: witness_1_is_privately_uninhabited.then_some(()),
-            _p: (),
             pattern_ty,
             let_suggestion,
             misc_suggestion,

--- a/compiler/rustc_query_system/src/error.rs
+++ b/compiler/rustc_query_system/src/error.rs
@@ -47,6 +47,7 @@ pub struct CycleUsage {
 
 #[derive(Diagnostic)]
 #[diag(query_system_cycle, code = E0391)]
+#[note]
 pub struct Cycle {
     #[primary_span]
     pub span: Span,
@@ -59,8 +60,6 @@ pub struct Cycle {
     pub alias: Option<Alias>,
     #[subdiagnostic]
     pub cycle_usage: Option<CycleUsage>,
-    #[note]
-    pub note_span: (),
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -591,7 +591,6 @@ pub fn report_cycle<'a>(
         alias,
         cycle_usage: cycle_usage,
         stack_count,
-        note_span: (),
     };
 
     sess.dcx().create_err(cycle_diag)


### PR DESCRIPTION
The `note` attr should be attache to the struct or variant. It only really makes sense to use `Option<()>` for optional note fields, so enforce that is the case.