### PR TITLE
Add test for getting parent HIR for synthetic HIR node

### DIFF
--- a/tests/ui/impl-trait/in-trait/synthetic-hir-has-parent.rs
+++ b/tests/ui/impl-trait/in-trait/synthetic-hir-has-parent.rs
@@ -1,0 +1,11 @@
+// Don't panic when iterating through the `hir::Map::parent_iter` of an RPITIT.
+
+pub trait Foo {
+    fn demo() -> impl Foo
+    //~^ ERROR the trait bound `String: Copy` is not satisfied
+    where
+        String: Copy;
+    //~^ ERROR the trait bound `String: Copy` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/synthetic-hir-has-parent.stderr
+++ b/tests/ui/impl-trait/in-trait/synthetic-hir-has-parent.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `String: Copy` is not satisfied
+  --> $DIR/synthetic-hir-has-parent.rs:7:9
+   |
+LL |         String: Copy;
+   |         ^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |
+   = help: see issue #48214
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+   |
+LL + #![feature(trivial_bounds)]
+   |
+
+error[E0277]: the trait bound `String: Copy` is not satisfied
+  --> $DIR/synthetic-hir-has-parent.rs:4:18
+   |
+LL |     fn demo() -> impl Foo
+   |                  ^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |
+   = help: see issue #48214
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+   |
+LL + #![feature(trivial_bounds)]
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #122991, which was actually fixed by #123415