### PR TITLE
[WIP] rustdoc (base+json): add support for variances

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -106,6 +106,7 @@ where
                     self.cx,
                     tcx.generics_of(item_def_id),
                     ty::GenericPredicates::default(),
+                    item_def_id,
                 );
                 let params = raw_generics.params;
 
@@ -456,6 +457,7 @@ where
             self.cx,
             tcx.generics_of(item_def_id),
             tcx.explicit_predicates_of(item_def_id),
+            item_def_id,
         );
         let mut generic_params = raw_generics.params;
 

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -632,19 +632,19 @@ where
         existing_predicates.extend(final_bounds);
 
         for param in generic_params.iter_mut() {
-            match param.kind {
-                GenericParamDefKind::Type { ref mut default, ref mut bounds, .. } => {
+            match &mut param.kind {
+                GenericParamDefKind::Type(ty_param) => {
                     // We never want something like `impl<T=Foo>`.
-                    default.take();
+                    ty_param.default.take();
                     let generic_ty = Type::Generic(param.name);
                     if !has_sized.contains(&generic_ty) {
-                        bounds.insert(0, GenericBound::maybe_sized(self.cx));
+                        ty_param.bounds.insert(0, GenericBound::maybe_sized(self.cx));
                     }
                 }
                 GenericParamDefKind::Lifetime { .. } => {}
-                GenericParamDefKind::Const { ref mut default, .. } => {
+                GenericParamDefKind::Const(ct_param) => {
                     // We never want something like `impl<const N: usize = 10>`
-                    default.take();
+                    ct_param.default.take();
                 }
             }
         }

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -106,6 +106,9 @@ where
                     self.cx,
                     tcx.generics_of(item_def_id),
                     ty::GenericPredicates::default(),
+                    // FIXME(fmease): This DefId isn't ideal since it stands for the implementing type, not
+                    // for the synthetic impl. The variance code has no way of knowing this and decides to
+                    // compute variances for the impl which we don't want.
                     item_def_id,
                 );
                 let params = raw_generics.params;
@@ -457,6 +460,9 @@ where
             self.cx,
             tcx.generics_of(item_def_id),
             tcx.explicit_predicates_of(item_def_id),
+            // FIXME(fmease): This DefId isn't ideal since it stands for the implementing type, not
+            // for the synthetic impl. The variance code has no way of knowing this and decides to
+            // compute variances for the impl which we don't want.
             item_def_id,
         );
         let mut generic_params = raw_generics.params;

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -101,6 +101,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                             cx,
                             cx.tcx.generics_of(impl_def_id),
                             cx.tcx.explicit_predicates_of(impl_def_id),
+                            impl_def_id,
                         ),
                         // FIXME(eddyb) compute both `trait_` and `for_` from
                         // the post-inference `trait_ref`, as it's more accurate.

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -140,20 +140,16 @@ pub(crate) fn move_bounds_to_generic_parameters(generics: &mut clean::Generics) 
     let mut where_predicates = ThinVec::new();
     for mut pred in generics.where_predicates.drain(..) {
         if let WherePredicate::BoundPredicate { ty: Generic(arg), bounds, .. } = &mut pred
-            && let Some(GenericParamDef {
-                kind: GenericParamDefKind::Type { bounds: param_bounds, .. },
-                ..
-            }) = generics.params.iter_mut().find(|param| &param.name == arg)
+            && let Some(GenericParamDef { kind: GenericParamDefKind::Type(param), .. }) =
+                generics.params.iter_mut().find(|param| &param.name == arg)
         {
-            param_bounds.extend(bounds.drain(..));
+            param.bounds.extend(bounds.drain(..));
         } else if let WherePredicate::RegionPredicate { lifetime: Lifetime(arg), bounds } =
             &mut pred
-            && let Some(GenericParamDef {
-                kind: GenericParamDefKind::Lifetime { outlives: param_bounds },
-                ..
-            }) = generics.params.iter_mut().find(|param| &param.name == arg)
+            && let Some(GenericParamDef { kind: GenericParamDefKind::Lifetime(param), .. }) =
+                generics.params.iter_mut().find(|param| &param.name == arg)
         {
-            param_bounds.extend(bounds.drain(..).map(|bound| match bound {
+            param.outlives.extend(bounds.drain(..).map(|bound| match bound {
                 GenericBound::Outlives(lifetime) => lifetime,
                 _ => unreachable!(),
             }));

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1356,11 +1356,13 @@ impl From<ConstParam> for GenericParamDefKind {
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub(crate) struct LifetimeParam {
+    pub(crate) variance: Option<ty::Variance>,
     pub(crate) outlives: ThinVec<Lifetime>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub(crate) struct TypeParam {
+    pub(crate) variance: Option<ty::Variance>,
     pub(crate) bounds: ThinVec<GenericBound>,
     pub(crate) default: Option<Type>,
     pub(crate) synthetic: bool,
@@ -1382,7 +1384,8 @@ pub(crate) struct GenericParamDef {
 
 impl GenericParamDef {
     pub(crate) fn lifetime(def_id: DefId, name: Symbol) -> Self {
-        Self { name, def_id, kind: LifetimeParam { outlives: ThinVec::new() }.into() }
+        let param = LifetimeParam { variance: None, outlives: ThinVec::new() };
+        Self { name, def_id, kind: param.into() }
     }
 
     pub(crate) fn is_synthetic_param(&self) -> bool {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -187,12 +187,12 @@ impl clean::GenericParamDef {
         cx: &'a Context<'tcx>,
     ) -> impl Display + 'a + Captures<'tcx> {
         display_fn(move |f| match &self.kind {
-            clean::GenericParamDefKind::Lifetime { outlives } => {
+            clean::GenericParamDefKind::Lifetime(param) => {
                 write!(f, "{}", self.name)?;
 
-                if !outlives.is_empty() {
+                if !param.outlives.is_empty() {
                     f.write_str(": ")?;
-                    for (i, lt) in outlives.iter().enumerate() {
+                    for (i, lt) in param.outlives.iter().enumerate() {
                         if i != 0 {
                             f.write_str(" + ")?;
                         }
@@ -202,26 +202,26 @@ impl clean::GenericParamDef {
 
                 Ok(())
             }
-            clean::GenericParamDefKind::Type { bounds, default, .. } => {
+            clean::GenericParamDefKind::Type(param) => {
                 f.write_str(self.name.as_str())?;
 
-                if !bounds.is_empty() {
+                if !param.bounds.is_empty() {
                     f.write_str(": ")?;
-                    print_generic_bounds(bounds, cx).fmt(f)?;
+                    print_generic_bounds(&param.bounds, cx).fmt(f)?;
                 }
 
-                if let Some(ref ty) = default {
+                if let Some(ref ty) = param.default {
                     f.write_str(" = ")?;
                     ty.print(cx).fmt(f)?;
                 }
 
                 Ok(())
             }
-            clean::GenericParamDefKind::Const { ty, default, .. } => {
+            clean::GenericParamDefKind::Const(param) => {
                 write!(f, "const {}: ", self.name)?;
-                ty.print(cx).fmt(f)?;
+                param.ty.print(cx).fmt(f)?;
 
-                if let Some(default) = default {
+                if let Some(default) = &param.default {
                     f.write_str(" = ")?;
                     if f.alternate() {
                         write!(f, "{default}")?;

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -453,18 +453,17 @@ impl FromWithTcx<clean::GenericParamDefKind> for GenericParamDefKind {
     fn from_tcx(kind: clean::GenericParamDefKind, tcx: TyCtxt<'_>) -> Self {
         use clean::GenericParamDefKind::*;
         match kind {
-            Lifetime { outlives } => GenericParamDefKind::Lifetime {
-                outlives: outlives.into_iter().map(convert_lifetime).collect(),
+            Lifetime(param) => GenericParamDefKind::Lifetime {
+                outlives: param.outlives.into_iter().map(convert_lifetime).collect(),
             },
-            Type { bounds, default, synthetic } => GenericParamDefKind::Type {
-                bounds: bounds.into_tcx(tcx),
-                default: default.map(|x| (*x).into_tcx(tcx)),
-                synthetic,
+            Type(param) => GenericParamDefKind::Type {
+                bounds: param.bounds.into_tcx(tcx),
+                default: param.default.map(|ty| ty.into_tcx(tcx)),
+                synthetic: param.synthetic,
             },
-            Const { ty, default, is_host_effect: _ } => GenericParamDefKind::Const {
-                type_: (*ty).into_tcx(tcx),
-                default: default.map(|x| *x),
-            },
+            Const(param) => {
+                GenericParamDefKind::Const { type_: param.ty.into_tcx(tcx), default: param.default }
+            }
         }
     }
 }
@@ -476,38 +475,7 @@ impl FromWithTcx<clean::WherePredicate> for WherePredicate {
             BoundPredicate { ty, bounds, bound_params } => WherePredicate::BoundPredicate {
                 type_: ty.into_tcx(tcx),
                 bounds: bounds.into_tcx(tcx),
-                generic_params: bound_params
-                    .into_iter()
-                    .map(|x| {
-                        let name = x.name.to_string();
-                        let kind = match x.kind {
-                            clean::GenericParamDefKind::Lifetime { outlives } => {
-                                GenericParamDefKind::Lifetime {
-                                    outlives: outlives.iter().map(|lt| lt.0.to_string()).collect(),
-                                }
-                            }
-                            clean::GenericParamDefKind::Type { bounds, default, synthetic } => {
-                                GenericParamDefKind::Type {
-                                    bounds: bounds
-                                        .into_iter()
-                                        .map(|bound| bound.into_tcx(tcx))
-                                        .collect(),
-                                    default: default.map(|ty| (*ty).into_tcx(tcx)),
-                                    synthetic,
-                                }
-                            }
-                            clean::GenericParamDefKind::Const {
-                                ty,
-                                default,
-                                is_host_effect: _,
-                            } => GenericParamDefKind::Const {
-                                type_: (*ty).into_tcx(tcx),
-                                default: default.map(|d| *d),
-                            },
-                        };
-                        GenericParamDef { name, kind }
-                    })
-                    .collect(),
+                generic_params: bound_params.into_iter().map(|param| param.into_tcx(tcx)).collect(),
             },
             RegionPredicate { lifetime, bounds } => WherePredicate::RegionPredicate {
                 lifetime: convert_lifetime(lifetime),

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -454,9 +454,11 @@ impl FromWithTcx<clean::GenericParamDefKind> for GenericParamDefKind {
         use clean::GenericParamDefKind::*;
         match kind {
             Lifetime(param) => GenericParamDefKind::Lifetime {
+                variance: param.variance.map(|var| var.into_tcx(tcx)),
                 outlives: param.outlives.into_iter().map(convert_lifetime).collect(),
             },
             Type(param) => GenericParamDefKind::Type {
+                variance: param.variance.map(|var| var.into_tcx(tcx)),
                 bounds: param.bounds.into_tcx(tcx),
                 default: param.default.map(|ty| ty.into_tcx(tcx)),
                 synthetic: param.synthetic,
@@ -464,6 +466,17 @@ impl FromWithTcx<clean::GenericParamDefKind> for GenericParamDefKind {
             Const(param) => {
                 GenericParamDefKind::Const { type_: param.ty.into_tcx(tcx), default: param.default }
             }
+        }
+    }
+}
+
+impl FromWithTcx<ty::Variance> for Variance {
+    fn from_tcx(variance: ty::Variance, _tcx: TyCtxt<'_>) -> Self {
+        match variance {
+            ty::Variance::Covariant => Self::Covariant,
+            ty::Variance::Invariant => Self::Invariant,
+            ty::Variance::Contravariant => Self::Contravariant,
+            ty::Variance::Bivariant => Self::Bivariant,
         }
     }
 }

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -443,9 +443,11 @@ pub struct GenericParamDef {
 #[serde(rename_all = "snake_case")]
 pub enum GenericParamDefKind {
     Lifetime {
+        variance: Option<Variance>,
         outlives: Vec<String>,
     },
     Type {
+        variance: Option<Variance>,
         bounds: Vec<GenericBound>,
         default: Option<Type>,
         /// This is normally `false`, which means that this generic parameter is
@@ -478,6 +480,16 @@ pub enum GenericParamDefKind {
         type_: Type,
         default: Option<String>,
     },
+}
+
+// FIXME(fmease): docs
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Variance {
+    Covariant,
+    Invariant,
+    Contravariant,
+    Bivariant,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/tools/jsondoclint/src/validator.rs
+++ b/src/tools/jsondoclint/src/validator.rs
@@ -324,8 +324,13 @@ impl<'a> Validator<'a> {
 
     fn check_generic_param_def(&mut self, gpd: &'a GenericParamDef) {
         match &gpd.kind {
-            rustdoc_json_types::GenericParamDefKind::Lifetime { outlives: _ } => {}
-            rustdoc_json_types::GenericParamDefKind::Type { bounds, default, synthetic: _ } => {
+            rustdoc_json_types::GenericParamDefKind::Lifetime { variance: _, outlives: _ } => {}
+            rustdoc_json_types::GenericParamDefKind::Type {
+                variance: _,
+                bounds,
+                default,
+                synthetic: _,
+            } => {
                 bounds.iter().for_each(|b| self.check_generic_bound(b));
                 if let Some(ty) = default {
                     self.check_type(ty);


### PR DESCRIPTION
I had this patch lying around for more than a month without much progress. Submitting this now to move things forward hopefully.

Addresses part of #22108.

---

For the sake transparency let me mention that I've stalled work on this because I haven't had the time to find ways to obtain or represent the “reason” / “provenance” of variances — a feature kindly requested by @obi1kenobi, maintainer of cargo-semver-checks. With “reason” we're referring to the set of constituent types that have had an influence on the variance of a given generic parameter.

This information could then be used in diagnostics emitted by cargo-semver-checks à la “variance of param `T` of ty `S` changed from covariant to contravariant because you changed the type of field `f` from `T` to `fn(T)`. On second thought though, this seems like a major add-on and I fear that it's infeasible to implement (smh. exposing the necessary info from rustc). On the other hand, this feature probably has a large impact on the design of the final API (i.e., how we represent variances in rustdoc JSON). I definitely don't want to hand-roll variance computation inside rustdoc. 

---

TODOs:

* clean up the implementation (see individual FIXMEs)
* write docs for `rustdoc-json-types`
* add rustdoc JSON tests


r? ghost