### PR TITLE
compiletest: print reason for failing to read tests

### DIFF
--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -571,7 +571,9 @@ pub fn make_tests(
         &modified_tests,
         &mut poisoned,
     )
-    .unwrap_or_else(|_| panic!("Could not read tests from {}", config.src_base.display()));
+    .unwrap_or_else(|reason| {
+        panic!("Could not read tests from {}: {reason}", config.src_base.display())
+    });
 
     if poisoned {
         eprintln!();


### PR DESCRIPTION
Turns this
```
Could not read tests from /path/to/rust/tests/run-make
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Build completed unsuccessfully in 0:00:05
```
into this:
```
Could not read tests from /path/to/rust/tests/run-make: run-make tests cannot have both `Makefile` and `rmake.rs`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Build completed unsuccessfully in 0:00:05
```

While first one is technically correct - it's not helpful at all, adding backtrace is not making it any better.