### PR TITLE
Suggest Explicit Lifetime for Associated Type Bindings

### DIFF
--- a/tests/ui/lifetimes/suggest-explicit-lifetime-for-associated-types-issue-122025.rs
+++ b/tests/ui/lifetimes/suggest-explicit-lifetime-for-associated-types-issue-122025.rs
@@ -1,0 +1,28 @@
+struct MyType;
+
+fn foo<F>()
+where
+    F: Iterator<Item = &MyType>, //~ `&` without an explicit lifetime name cannot be used here
+{
+}
+
+fn bar() {
+    fn baz<F>()
+    where
+        F: Iterator<Item = &MyType>, //~ `&` without an explicit lifetime name cannot be used here
+    {
+    }
+}
+
+fn function<T>()
+where
+    T: Iterator<Item = &MyType>, //~ `&` without an explicit lifetime name cannot be used here
+{
+    fn lambda<A>()
+    where
+        A: Iterator<Item = &u8>, //~ `&` without an explicit lifetime name cannot be used here
+    {
+    }
+}
+
+fn main() {}

--- a/tests/ui/lifetimes/suggest-explicit-lifetime-for-associated-types-issue-122025.stderr
+++ b/tests/ui/lifetimes/suggest-explicit-lifetime-for-associated-types-issue-122025.stderr
@@ -1,0 +1,55 @@
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/suggest-explicit-lifetime-for-associated-types-issue-122025.rs:5:24
+   |
+LL |     F: Iterator<Item = &MyType>,
+   |                        ^ explicit lifetime name needed here
+   |
+help: consider adding an explicit lifetime here
+   |
+LL ~ fn foo<'a, F>()
+LL | where
+LL ~     F: Iterator<Item = &'a MyType>,
+   |
+
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/suggest-explicit-lifetime-for-associated-types-issue-122025.rs:12:28
+   |
+LL |         F: Iterator<Item = &MyType>,
+   |                            ^ explicit lifetime name needed here
+   |
+help: consider adding an explicit lifetime here
+   |
+LL ~     fn baz<'a, F>()
+LL |     where
+LL ~         F: Iterator<Item = &'a MyType>,
+   |
+
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/suggest-explicit-lifetime-for-associated-types-issue-122025.rs:19:24
+   |
+LL |     T: Iterator<Item = &MyType>,
+   |                        ^ explicit lifetime name needed here
+   |
+help: consider adding an explicit lifetime here
+   |
+LL ~ fn function<'a, T>()
+LL | where
+LL ~     T: Iterator<Item = &'a MyType>,
+   |
+
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/suggest-explicit-lifetime-for-associated-types-issue-122025.rs:23:28
+   |
+LL |         A: Iterator<Item = &u8>,
+   |                            ^ explicit lifetime name needed here
+   |
+help: consider adding an explicit lifetime here
+   |
+LL ~     fn lambda<'a, A>()
+LL |     where
+LL ~         A: Iterator<Item = &'a u8>,
+   |
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0637`.


### PR DESCRIPTION
Fixes #122025 

This PR suggests an explicit lifetime annotation for associated type bindings. Previously, this error suggested an incorrect HRTB.

Please let me know if there's a better way to figure `is_associated_type_binding`. Also, this suggestion uses `Applicability::MaybeIncorrect` as the suggestion can be incorrect when a trait's input lifetimes are also missing.