### PR TITLE
Mention Both HRTB and Generic Lifetime Param in `E0637` documentation

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0637.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0637.md
@@ -1,5 +1,5 @@
 `'_` lifetime name or `&T` without an explicit lifetime name has been used
-on illegal place.
+in an illegal place.
 
 Erroneous code example:
 
@@ -13,7 +13,14 @@ fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
     }
 }
 
-fn and_without_explicit_lifetime<T>()
+fn without_explicit_lifetime<T>()
+where
+    T: Iterator<Item = &u32>,
+                     //^ `&` without an explicit lifetime name
+{
+}
+
+fn without_hrtb<T>()
 where
     T: Into<&u32>,
           //^ `&` without an explicit lifetime name
@@ -40,9 +47,15 @@ fn underscore_lifetime<'a>(str1: &'a str, str2: &'a str) -> &'a str {
     }
 }
 
-fn and_without_explicit_lifetime<'foo, T>()
+fn without_explicit_lifetime<'a, T>()
 where
-    T: Into<&'foo u32>,
+    T: Iterator<Item = &'a u32>,
+{
+}
+
+fn without_hrtb<T>()
+where
+    T: for<'foo> Into<&'foo u32>,
 {
 }
 ```


### PR DESCRIPTION
The compiler (rustc 1.77.0) error for `and_without_explicit_lifetime()` in the erroneous code example suggests using a HRTB. But, the corrected example uses an explicit lifetime parameter.

This PR fixes it so that the documentation and the compiler suggestion for error code `E0637` are consistent with each other. 