### PR TITLE
Re-enable `has_thread_local` for i686-msvc

### DIFF
--- a/compiler/rustc_target/src/spec/targets/i686_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_pc_windows_msvc.rs
@@ -18,8 +18,6 @@ pub fn target() -> Target {
             "/SAFESEH",
         ],
     );
-    // Workaround for #95429
-    base.has_thread_local = false;
 
     Target {
         llvm_target: "i686-pc-windows-msvc".into(),

--- a/compiler/rustc_target/src/spec/targets/i686_win7_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_win7_windows_msvc.rs
@@ -18,8 +18,6 @@ pub fn target() -> Target {
             "/SAFESEH",
         ],
     );
-    // Workaround for #95429
-    base.has_thread_local = false;
 
     Target {
         llvm_target: "i686-pc-windows-msvc".into(),


### PR DESCRIPTION
A few years back, `has_thread_local` was disabled as a workaround for a compiler issue. While the exact cause was never tracked down, it was suspected to be caused by the compiler inlining a thread local access across a dylib boundary. This should be fixed now so let's try again.