### PR TITLE
catch_panic: warn about panicking payload drop

### DIFF
--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -126,6 +126,9 @@ where
 /// Also note that unwinding into Rust code with a foreign exception (e.g.
 /// an exception thrown from C++ code) is undefined behavior.
 ///
+/// Finally, be **careful in how you drop the result of this function**.
+/// If it is `Err`, it contains the panic payload, and dropping that may in turn panic!
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
Warns about the footgun in https://github.com/rust-lang/rust/issues/86027.

Will be unnecessary if panics escaping from drop leads to abort (https://github.com/rust-lang/rfcs/pull/3288). But until that is enforced everywhere, let's warn users about this.