### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -817,6 +817,13 @@ pub trait DiscriminantKind {
 /// This can be used to declare that a constant with a generic type
 /// will not contain interior mutability, and subsequently allow
 /// placing the constant behind references.
+///
+/// # Safety
+///
+/// This trait is a core part of the language, it is just expressed as a trait in libcore for
+/// convenience. Do *not* implement it for other types.
+// FIXME: Eventually this trait should become `#[rustc_deny_explicit_impl]`.
+// That requires porting the impls below to native internal impls.
 #[lang = "freeze"]
 #[unstable(feature = "freeze", issue = "121675")]
 pub unsafe auto trait Freeze {}

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -195,6 +195,7 @@ pub unsafe trait SliceIndex<T: ?Sized>: private_slice_index::Sealed {
     fn index_mut(self, slice: &mut T) -> &mut Self::Output;
 }
 
+/// The methods `index` and `index_mut` panic if the index is out of bounds.
 #[stable(feature = "slice_get_slice_impls", since = "1.15.0")]
 #[rustc_const_unstable(feature = "const_slice_index", issue = "none")]
 unsafe impl<T> SliceIndex<[T]> for usize {
@@ -328,6 +329,9 @@ unsafe impl<T> SliceIndex<[T]> for ops::IndexRange {
     }
 }
 
+/// The methods `index` and `index_mut` panic if:
+/// - the start of the range is greater than the end of the range or
+/// - the end of the range is out of bounds.
 #[stable(feature = "slice_get_slice_impls", since = "1.15.0")]
 #[rustc_const_unstable(feature = "const_slice_index", issue = "none")]
 unsafe impl<T> SliceIndex<[T]> for ops::Range<usize> {
@@ -416,6 +420,7 @@ unsafe impl<T> SliceIndex<[T]> for ops::Range<usize> {
     }
 }
 
+/// The methods `index` and `index_mut` panic if the end of the range is out of bounds.
 #[stable(feature = "slice_get_slice_impls", since = "1.15.0")]
 #[rustc_const_unstable(feature = "const_slice_index", issue = "none")]
 unsafe impl<T> SliceIndex<[T]> for ops::RangeTo<usize> {
@@ -454,6 +459,7 @@ unsafe impl<T> SliceIndex<[T]> for ops::RangeTo<usize> {
     }
 }
 
+/// The methods `index` and `index_mut` panic if the start of the range is out of bounds.
 #[stable(feature = "slice_get_slice_impls", since = "1.15.0")]
 #[rustc_const_unstable(feature = "const_slice_index", issue = "none")]
 unsafe impl<T> SliceIndex<[T]> for ops::RangeFrom<usize> {
@@ -536,6 +542,10 @@ unsafe impl<T> SliceIndex<[T]> for ops::RangeFull {
     }
 }
 
+/// The methods `index` and `index_mut` panic if:
+/// - the end of the range is `usize::MAX` or
+/// - the start of the range is greater than the end of the range or
+/// - the end of the range is out of bounds.
 #[stable(feature = "inclusive_range", since = "1.26.0")]
 #[rustc_const_unstable(feature = "const_slice_index", issue = "none")]
 unsafe impl<T> SliceIndex<[T]> for ops::RangeInclusive<usize> {
@@ -580,6 +590,7 @@ unsafe impl<T> SliceIndex<[T]> for ops::RangeInclusive<usize> {
     }
 }
 
+/// The methods `index` and `index_mut` panic if the end of the range is out of bounds.
 #[stable(feature = "inclusive_range", since = "1.26.0")]
 #[rustc_const_unstable(feature = "const_slice_index", issue = "none")]
 unsafe impl<T> SliceIndex<[T]> for ops::RangeToInclusive<usize> {

--- a/src/tools/run-make-support/src/rustc.rs
+++ b/src/tools/run-make-support/src/rustc.rs
@@ -104,6 +104,20 @@ impl Rustc {
         self
     }
 
+    /// Specify the crate type.
+    pub fn crate_type(&mut self, crate_type: &str) -> &mut Self {
+        self.cmd.arg("--crate-type");
+        self.cmd.arg(crate_type);
+        self
+    }
+
+    /// Specify the edition year.
+    pub fn edition(&mut self, edition: &str) -> &mut Self {
+        self.cmd.arg("--edition");
+        self.cmd.arg(edition);
+        self
+    }
+
     /// Generic command arguments provider. Use `.arg("-Zname")` over `.arg("-Z").arg("arg")`.
     /// This method will panic if a plain `-Z` or `-C` is passed, or if `-Z <name>` or `-C <name>`
     /// is passed (note the space).

--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -31,7 +31,6 @@ run-make/compiler-rt-works-on-mingw/Makefile
 run-make/compressed-debuginfo/Makefile
 run-make/const-prop-lint/Makefile
 run-make/const_fn_mir/Makefile
-run-make/core-no-fp-fmt-parse/Makefile
 run-make/core-no-oom-handling/Makefile
 run-make/crate-data-smoke/Makefile
 run-make/crate-hash-rustc-version/Makefile

--- a/tests/run-make/core-no-fp-fmt-parse/Makefile
+++ b/tests/run-make/core-no-fp-fmt-parse/Makefile
@@ -1,4 +1,0 @@
-include ../tools.mk
-
-all:
-	$(RUSTC) --edition=2021 -Dwarnings --crate-type=rlib ../../../library/core/src/lib.rs --cfg no_fp_fmt_parse

--- a/tests/run-make/core-no-fp-fmt-parse/rmake.rs
+++ b/tests/run-make/core-no-fp-fmt-parse/rmake.rs
@@ -1,0 +1,17 @@
+// This test checks that the core library of Rust can be compiled without enabling
+// support for formatting and parsing floating-point numbers.
+
+extern crate run_make_support;
+
+use run_make_support::rustc;
+use std::path::PathBuf;
+
+fn main() {
+    rustc()
+        .edition("2021")
+        .arg("-Dwarnings")
+        .crate_type("rlib")
+        .input("../../../library/core/src/lib.rs")
+        .cfg("no_fp_fmt_parse")
+        .run();
+}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -788,6 +788,7 @@ compiler-team-contributors = [
     "@Nadrieril",
     "@fmease",
     "@fee1-dead",
+    "@BoxyUwU",
 ]
 compiler = [
     "compiler-team",


### PR DESCRIPTION
Successful merges:

 - #123180 (Rewrite `core-no-fp-fmt-parse` test in Rust)
 - #123267 (std::thread: adding get_name haiku implementation.)
 - #123268 (warn against implementing Freeze)
 - #123271 (doc: describe panic conditions for SliceIndex implementations)
 - #123295 (add myself to compiler review rotation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=123180,123267,123268,123271,123295)
<!-- homu-ignore:end -->