### PR TITLE
Don't inherit codegen attrs from parent static

### DIFF
--- a/tests/ui/statics/nested-allocations-dont-inherit-codegen-attrs.rs
+++ b/tests/ui/statics/nested-allocations-dont-inherit-codegen-attrs.rs
@@ -1,0 +1,11 @@
+//@ build-pass
+
+// Make sure that the nested static allocation for `FOO` doesn't inherit `no_mangle`.
+#[no_mangle]
+pub static mut FOO: &mut [i32] = &mut [42];
+
+// Make sure that the nested static allocation for `BAR` doesn't inherit `export_name`.
+#[export_name = "BAR_"]
+pub static mut BAR: &mut [i32] = &mut [42];
+
+fn main() {}


### PR DESCRIPTION
Putting this up partly for discussion and partly for review. Specifically, in #121644, @oli-obk designed a system that creates new static items for representing nested allocations in statics. However, in that PR, oli made it so that these statics inherited the codegen attrs from the parent.

This causes problems such as colliding symbols with `#[export_name]` and ICEs with `#[no_mangle]` since these synthetic statics have no `tcx.item_name(..)`.

So the question is, is there any case where we *do* want to inherit codegen attrs from the parent? The only one that seems a bit suspicious is the thread-local attribute. And there may be some interesting interactions with the coverage attributes as well...

Fixes (after backport) #123274. Fixes #123243. cc #121644. 

r? @oli-obk cc @nnethercote @RalfJung (reviewers on that pr)