### PR TITLE
Skip `unused_parens` report for `Paren(Path(..))` in macro.

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1074,10 +1074,14 @@ impl UnusedParens {
                 // Otherwise proceed with linting.
                 _ => {}
             }
-            let spans = inner
-                .span
-                .find_ancestor_inside(value.span)
-                .map(|inner| (value.span.with_hi(inner.lo()), value.span.with_lo(inner.hi())));
+            let spans = if !value.span.from_expansion() {
+                inner
+                    .span
+                    .find_ancestor_inside(value.span)
+                    .map(|inner| (value.span.with_hi(inner.lo()), value.span.with_lo(inner.hi())))
+            } else {
+                None
+            };
             self.emit_unused_delims(cx, value.span, spans, "pattern", keep_space, false);
         }
     }
@@ -1233,11 +1237,13 @@ impl EarlyLintPass for UnusedParens {
                         if self.with_self_ty_parens && b.generic_params.len() > 0 => {}
                     ast::TyKind::ImplTrait(_, bounds) if bounds.len() > 1 => {}
                     _ => {
-                        let spans = r
-                            .span
-                            .find_ancestor_inside(ty.span)
-                            .map(|r| (ty.span.with_hi(r.lo()), ty.span.with_lo(r.hi())));
-
+                        let spans = if !ty.span.from_expansion() {
+                            r.span
+                                .find_ancestor_inside(ty.span)
+                                .map(|r| (ty.span.with_hi(r.lo()), ty.span.with_lo(r.hi())))
+                        } else {
+                            None
+                        };
                         self.emit_unused_delims(cx, ty.span, spans, "type", (false, false), false);
                     }
                 }

--- a/tests/ui/lint/unused/unused_parens/unused-parens-in-macro-issue-120642.rs
+++ b/tests/ui/lint/unused/unused_parens/unused-parens-in-macro-issue-120642.rs
@@ -1,0 +1,39 @@
+//@ run-pass
+
+#![warn(unused_parens)]
+#![allow(dead_code)]
+
+trait Foo {
+    fn bar();
+    fn tar();
+}
+
+macro_rules! unused_parens {
+    ($ty:ident) => {
+        impl<$ty: Foo> Foo for ($ty,) {
+            fn bar() { <$ty>::bar() }
+            fn tar() {}
+        }
+    };
+
+    ($ty:ident $(, $rest:ident)*) => {
+        impl<$ty: Foo, $($rest: Foo),*> Foo for ($ty, $($rest),*) {
+            fn bar() {
+                <$ty>::bar();
+                <($($rest),*)>::bar() //~WARN unnecessary parentheses around type
+            }
+            fn tar() {
+              let (_t) = 1; //~WARN unnecessary parentheses around pattern
+                            //~| WARN unnecessary parentheses around pattern
+              let (_t1,) = (1,);
+              let (_t2, _t3) = (1, 2);
+            }
+        }
+
+        unused_parens!($($rest),*);
+    }
+}
+
+unused_parens!(T1, T2, T3);
+
+fn main() {}

--- a/tests/ui/lint/unused/unused_parens/unused-parens-in-macro-issue-120642.stderr
+++ b/tests/ui/lint/unused/unused_parens/unused-parens-in-macro-issue-120642.stderr
@@ -1,0 +1,40 @@
+warning: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-in-macro-issue-120642.rs:26:19
+   |
+LL |               let (_t) = 1;
+   |                   ^^^^
+...
+LL | unused_parens!(T1, T2, T3);
+   | -------------------------- in this macro invocation
+   |
+note: the lint level is defined here
+  --> $DIR/unused-parens-in-macro-issue-120642.rs:3:9
+   |
+LL | #![warn(unused_parens)]
+   |         ^^^^^^^^^^^^^
+   = note: this warning originates in the macro `unused_parens` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unnecessary parentheses around type
+  --> $DIR/unused-parens-in-macro-issue-120642.rs:23:18
+   |
+LL |                 <($($rest),*)>::bar()
+   |                  ^^^^^^^^^^^^
+...
+LL | unused_parens!(T1, T2, T3);
+   | -------------------------- in this macro invocation
+   |
+   = note: this warning originates in the macro `unused_parens` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-in-macro-issue-120642.rs:26:19
+   |
+LL |               let (_t) = 1;
+   |                   ^^^^
+...
+LL | unused_parens!(T1, T2, T3);
+   | -------------------------- in this macro invocation
+   |
+   = note: this warning originates in the macro `unused_parens` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 3 warnings emitted
+


### PR DESCRIPTION
fixes #120642

In following code, `unused_parens` suggest change `<($($rest),*)>::bar()` to `<$rest>::bar()`  which will cause another err: `error: variable 'rest' is still repeating at this depth`：

```rust
trait Foo {
    fn bar();
}

macro_rules! problem {
    ($ty:ident) => {
        impl<$ty: Foo> Foo for ($ty,) {
            fn bar() { <$ty>::bar() }
        }
    };
    ($ty:ident $(, $rest:ident)*) => {
        impl<$ty: Foo, $($rest: Foo),*> Foo for ($ty, $($rest),*) {
            fn bar() {
                <$ty>::bar();
                <($($rest),*)>::bar()
            }
        }
        problem!($($rest),*);
    }
}
```


I think maybe we can handle this by avoid warning for `Paren(Path(..))` in the macro. Is this reasonable approach?

