### PR TITLE
Test `#[unix_sigpipe = "inherit"]` with both `SIG_DFL` and `SIG_IGN`

### DIFF
--- a/tests/ui/attributes/unix_sigpipe/auxiliary/assert-inherit-sig_dfl.rs
+++ b/tests/ui/attributes/unix_sigpipe/auxiliary/assert-inherit-sig_dfl.rs
@@ -1,0 +1,8 @@
+//@ aux-crate: sigpipe_utils=sigpipe-utils.rs
+
+#![feature(unix_sigpipe)]
+
+#[unix_sigpipe = "inherit"]
+fn main() {
+    sigpipe_utils::assert_sigpipe_handler(sigpipe_utils::SignalHandler::Default);
+}

--- a/tests/ui/attributes/unix_sigpipe/auxiliary/assert-inherit-sig_ign.rs
+++ b/tests/ui/attributes/unix_sigpipe/auxiliary/assert-inherit-sig_ign.rs
@@ -1,0 +1,8 @@
+//@ aux-crate: sigpipe_utils=sigpipe-utils.rs
+
+#![feature(unix_sigpipe)]
+
+#[unix_sigpipe = "inherit"]
+fn main() {
+    sigpipe_utils::assert_sigpipe_handler(sigpipe_utils::SignalHandler::Ignore);
+}

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-inherit.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-inherit.rs
@@ -1,14 +1,29 @@
+//@ ignore-cross-compile because aux-bin does not yet support it
+//@ only-unix because SIGPIPE is a unix thing
+//@ aux-bin: assert-inherit-sig_dfl.rs
+//@ aux-bin: assert-inherit-sig_ign.rs
 //@ run-pass
-//@ aux-build:sigpipe-utils.rs
 
-#![feature(unix_sigpipe)]
+#![feature(rustc_private, unix_sigpipe)]
 
-#[unix_sigpipe = "inherit"]
+extern crate libc;
+
+// By default the Rust runtime resets SIGPIPE to SIG_DFL before exec:ing child
+// processes so opt-out of that with `#[unix_sigpipe = "sig_dfl"]`. See
+// https://github.com/rust-lang/rust/blob/bf4de3a874753bbee3323081c8b0c133444fed2d/library/std/src/sys/pal/unix/process/process_unix.rs#L359-L384
+#[unix_sigpipe = "sig_dfl"]
 fn main() {
-    extern crate sigpipe_utils;
+    // First expect SIG_DFL in a child process with #[unix_sigpipe = "inherit"].
+    assert_inherit_sigpipe_disposition("auxiliary/bin/assert-inherit-sig_dfl");
 
-    // #[unix_sigpipe = "inherit"] is active, so SIGPIPE shall NOT be ignored,
-    // instead the default handler shall be installed. (We assume that the
-    // process that runs these tests have the default handler.)
-    sigpipe_utils::assert_sigpipe_handler(sigpipe_utils::SignalHandler::Default);
+    // With SIG_IGN we expect #[unix_sigpipe = "inherit"] to also get SIG_IGN.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+    }
+    assert_inherit_sigpipe_disposition("auxiliary/bin/assert-inherit-sig_ign");
+}
+
+fn assert_inherit_sigpipe_disposition(aux_bin: &str) {
+    let mut cmd = std::process::Command::new(aux_bin);
+    assert!(cmd.status().unwrap().success());
 }


### PR DESCRIPTION
Extend our `#[unix_sigpipe = "inherit"]` test so that it detects if  `SIGPIPE` wrongly ends up being `SIG_DFL` when the parent has `SIG_IGN`. We have no current test for this particular case.

Tracking issue: https://github.com/rust-lang/rust/issues/97889