### PR TITLE
Note impact of `-Cstrip` on backtraces

### DIFF
--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -557,8 +557,10 @@ Supported values for this option are:
   using a debugger like gdb or lldb ineffectual.
 - `symbols` - same as `debuginfo`, but the rest of the symbol table section is
   stripped as well if the linker supports it. On platforms which depend on the
-  binary's symbol table for backtraces, this can affect them so negatively as to
-  make the trace completely incomprehensible.
+  binary's symbol table for backtraces, profiling, and similar, this can affect
+  them so negatively as to make the results completely incomprehensible.
+  Programs which may be combined with others, using e.g. CLI pipelines, or any
+  developer tooling whatsoever, should avoid stripping symbols for this reason.
 
 ## symbol-mangling-version
 

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -561,6 +561,10 @@ Supported values for this option are:
   Programs which may be combined with others, such as CLI pipelines and developer tooling,
   or even anything which wants crash-reporting, should usually avoid `-Cstrip=symbols`.
 
+Note that, at any level, removing debuginfo only necessarily impacts "friendly" introspection.
+`-Cstrip` cannot be relied on as a meaningful security or obfuscation measure, as disassemblers
+and decompilers can extract considerable information even in the absence of symbols.
+
 ## symbol-mangling-version
 
 This option controls the [name mangling] format for encoding Rust item names

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -553,9 +553,12 @@ Supported values for this option are:
   of MSVC).
 - `debuginfo` - debuginfo sections and debuginfo symbols from the symbol table
   section are stripped at link time and are not copied to the produced binary
-  or separate files.
+  or separate files. This should leave backtraces mostly-intact but may make
+  using a debugger like gdb or lldb ineffectual.
 - `symbols` - same as `debuginfo`, but the rest of the symbol table section is
-  stripped as well if the linker supports it.
+  stripped as well if the linker supports it. On platforms which depend on the
+  binary's symbol table for backtraces, this can affect them so negatively as to
+  make the trace completely incomprehensible.
 
 ## symbol-mangling-version
 

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -555,12 +555,11 @@ Supported values for this option are:
   section are stripped at link time and are not copied to the produced binary
   or separate files. This should leave backtraces mostly-intact but may make
   using a debugger like gdb or lldb ineffectual.
-- `symbols` - same as `debuginfo`, but the rest of the symbol table section is
-  stripped as well if the linker supports it. On platforms which depend on the
-  binary's symbol table for backtraces, profiling, and similar, this can affect
-  them so negatively as to make the results completely incomprehensible.
-  Programs which may be combined with others, using e.g. CLI pipelines, or any
-  developer tooling whatsoever, should avoid stripping symbols for this reason.
+- `symbols` - same as `debuginfo`, but the rest of the symbol table section is stripped as well,
+  depending on platform support. On platforms which depend on this symbol table for backtraces,
+  profiling, and similar, this can affect them so negatively as to make the trace incomprehensible.
+  Programs which may be combined with others, such as CLI pipelines and developer tooling,
+  or even anything which wants crash-reporting, should usually avoid `-Cstrip=symbols`.
 
 ## symbol-mangling-version
 


### PR DESCRIPTION
It is not always clear to people what the impact of `-Cstrip` options are. They are a common question on sites like StackOverflow, and sometimes people even report bugs with "no backtrace" after deliberately mangling the symbol table. We cannot exhaustively document every permutation, but we should warn people about common effects.