### PR TITLE
fix: build on haiku by adding missing import

### DIFF
--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -278,7 +278,7 @@ impl Thread {
                 return None;
             }
             let info = tinfo.assume_init();
-            let name = slice::from_raw_parts(info.name.as_ptr() as *const u8, info.name.len());
+            let name = core::slice::from_raw_parts(info.name.as_ptr() as *const u8, info.name.len());
             CStr::from_bytes_until_nul(name).map(CStr::to_owned).ok()
         }
     }

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -278,7 +278,8 @@ impl Thread {
                 return None;
             }
             let info = tinfo.assume_init();
-            let name = core::slice::from_raw_parts(info.name.as_ptr() as *const u8, info.name.len());
+            let name =
+                core::slice::from_raw_parts(info.name.as_ptr() as *const u8, info.name.len());
             CStr::from_bytes_until_nul(name).map(CStr::to_owned).ok()
         }
     }


### PR DESCRIPTION
Fix the build on Haiku by adding a missing import

```
error[E0433]: failed to resolve: use of undeclared crate or module `slice`
   --> /localhome/somers/.rustup/toolchains/nightly-x86_64-unknown-freebsd/lib/rustlib/src/rust/library/std/src/sys/pal/unix/thread.rs:272:24
    |
272 |             let name = slice::from_raw_parts(info.name.as_ptr() as *const u8, info.name.len());
    |                        ^^^^^ use of undeclared crate or module `slice`
    |
help: consider importing one of these items
    |
1   + use alloc::slice;
    |
1   + use core::slice;
    |
1   + use crate::slice;
```

Closes #123343