### PR TITLE
Support type '/' to search

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -438,6 +438,7 @@ function preLoadCss(cssUrl) {
 
             case "s":
             case "S":
+            case "/":
                 ev.preventDefault();
                 searchState.focus();
                 break;
@@ -1310,7 +1311,7 @@ function preLoadCss(cssUrl) {
 
         const shortcuts = [
             ["?", "Show this help dialog"],
-            ["S", "Focus the search field"],
+            ["S / /", "Focus the search field"],
             ["↑", "Move up in search results"],
             ["↓", "Move down in search results"],
             ["← / →", "Switch result tab (when results focused)"],

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -135,7 +135,7 @@
                         aria-label="Run search in the documentation" {#+ #}
                         autocomplete="off" {#+ #}
                         spellcheck="false" {#+ #}
-                        placeholder="Click or press ‘S’ to search, ‘?’ for more options…" {#+ #}
+                        placeholder="Type ‘S’ or ‘/’ to search, ‘?’ for more options…" {#+ #}
                         type="search"> {# #}
                     <div id="help-button" tabindex="-1"> {# #}
                         <a href="{{page.root_path|safe}}help.html" title="help">?</a> {# #}


### PR DESCRIPTION
Related topic on IRLO: https://internals.rust-lang.org/t/rustdoc-use-key-to-search-instead-of-s/20559