### PR TITLE
Reduce code size of `thread::set_current`

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -686,6 +686,8 @@ thread_local! {
 ///
 /// Aborts if the handle has been set already to reduce code size.
 pub(crate) fn set_current(thread: Thread) {
+    // Using `unwrap` here can add ~3kB to the binary size. We have complete
+    // control over where this is called, so just abort if there is a bug.
     CURRENT.with(|current| match current.set(thread) {
         Ok(()) => {}
         Err(_) => rtabort!("should only be set once"),

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -690,7 +690,7 @@ pub(crate) fn set_current(thread: Thread) {
     // control over where this is called, so just abort if there is a bug.
     CURRENT.with(|current| match current.set(thread) {
         Ok(()) => {}
-        Err(_) => rtabort!("should only be set once"),
+        Err(_) => rtabort!("thread::set_current should only be called once per thread"),
     });
 }
 

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -684,9 +684,12 @@ thread_local! {
 
 /// Sets the thread handle for the current thread.
 ///
-/// Panics if the handle has been set already or when called from a TLS destructor.
+/// Aborts if the handle has been set already to reduce code size.
 pub(crate) fn set_current(thread: Thread) {
-    CURRENT.with(|current| current.set(thread).unwrap());
+    CURRENT.with(|current| match current.set(thread) {
+        Ok(()) => {}
+        Err(_) => rtabort!("should only be set once"),
+    });
 }
 
 /// Gets a handle to the thread that invokes it.


### PR DESCRIPTION
#123265 introduced a rather large binary size regression, because it added an `unwrap()` call on a `Result<(), Thread>`, which in turn pulled its rather heavy `Debug` implementation. This PR fixes this by readding the `rtassert!` that was removed.