### PR TITLE
CI: Redirect stderr to stdout to order GHA logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         run: src/ci/scripts/verify-stable-version-number.sh
         if: success() && !env.SKIP_JOB
       - name: run the build
-        run: src/ci/scripts/run-build-from-ci.sh
+        run: src/ci/scripts/run-build-from-ci.sh 2>&1
         env:
           AWS_ACCESS_KEY_ID: "${{ env.CACHES_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.CACHES_AWS_ACCESS_KEY_ID)] }}"
@@ -566,7 +566,7 @@ jobs:
         run: src/ci/scripts/verify-stable-version-number.sh
         if: success() && !env.SKIP_JOB
       - name: run the build
-        run: src/ci/scripts/run-build-from-ci.sh
+        run: src/ci/scripts/run-build-from-ci.sh 2>&1
         env:
           AWS_ACCESS_KEY_ID: "${{ env.CACHES_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.CACHES_AWS_ACCESS_KEY_ID)] }}"
@@ -705,7 +705,7 @@ jobs:
         run: src/ci/scripts/verify-stable-version-number.sh
         if: success() && !env.SKIP_JOB
       - name: run the build
-        run: src/ci/scripts/run-build-from-ci.sh
+        run: src/ci/scripts/run-build-from-ci.sh 2>&1
         env:
           AWS_ACCESS_KEY_ID: "${{ env.CACHES_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.CACHES_AWS_ACCESS_KEY_ID)] }}"

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -249,7 +249,8 @@ x--expand-yaml-anchors--remove:
         <<: *step
 
       - name: run the build
-        run: src/ci/scripts/run-build-from-ci.sh
+        # Redirect stderr to stdout to avoid reordering the two streams in the GHA logs.
+        run: src/ci/scripts/run-build-from-ci.sh 2>&1
         env:
           AWS_ACCESS_KEY_ID: ${{ env.CACHES_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.CACHES_AWS_ACCESS_KEY_ID)] }}


### PR DESCRIPTION
This PR modifies the main CI workflow so that its stderr is redirected to stdout. This should make it so that stderr and stdout output is not interleaved in the wrong order in GHA logs (see discussion [here](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Github.20actions.20logs.20show.20lines.20in.20the.20wrong.20order)).