### PR TITLE
Link against libc++abi and libunwind as well when building LLVM wrappers on AIX

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -391,6 +391,11 @@ fn main() {
         }
     }
 
+    // libc++abi have to be specified explicitly on AIX.
+    if target.contains("aix") {
+        println!("cargo:rustc-link-lib=c++abi");
+    }
+
     // Libstdc++ depends on pthread which Rust doesn't link on MinGW
     // since nothing else requires it.
     if target.ends_with("windows-gnu") {

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -391,9 +391,10 @@ fn main() {
         }
     }
 
-    // libc++abi have to be specified explicitly on AIX.
+    // libc++abi and libunwind have to be specified explicitly on AIX.
     if target.contains("aix") {
         println!("cargo:rustc-link-lib=c++abi");
+        println!("cargo:rustc-link-lib=unwind");
     }
 
     // Libstdc++ depends on pthread which Rust doesn't link on MinGW


### PR DESCRIPTION
Unlike `libc++.so` on Linux which is a linker script
```ld
INPUT(libc++.so.1 -lc++abi -lunwind)
```
AIX linker doesn't support such script, so `c++abi` and `unwind` have to be specified explicitly.