### PR TITLE
Check that nested statics in thread locals are duplicated per thread.

### DIFF
--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -222,6 +222,7 @@ const_eval_mut_deref =
 
 const_eval_mutable_ptr_in_final = encountered mutable pointer in final value of {const_eval_intern_kind}
 
+const_eval_nested_static_in_thread_local = #[thread_local] does not support implicit nested statics, please create explicit static items and refer to them instead
 const_eval_non_const_fmt_macro_call =
     cannot call non-const formatting macro in {const_eval_const_context}s
 

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -25,6 +25,13 @@ pub(crate) struct DanglingPtrInFinal {
     pub kind: InternKind,
 }
 
+#[derive(Diagnostic)]
+#[diag(const_eval_nested_static_in_thread_local)]
+pub(crate) struct NestedStaticInThreadLocal {
+    #[primary_span]
+    pub span: Span,
+}
+
 #[derive(LintDiagnostic)]
 #[diag(const_eval_mutable_ptr_in_final)]
 pub(crate) struct MutablePtrInFinal {

--- a/tests/ui/statics/nested_thread_local.rs
+++ b/tests/ui/statics/nested_thread_local.rs
@@ -1,0 +1,24 @@
+// Check that nested statics in thread locals are
+// duplicated per thread.
+
+#![feature(const_refs_to_cell)]
+#![feature(thread_local)]
+
+//@run-pass
+
+#[thread_local]
+static mut FOO: &mut u32 = &mut 42;
+
+fn main() {
+    unsafe {
+        *FOO = 1;
+
+        let _ = std::thread::spawn(|| {
+            assert_eq!(*FOO, 42);
+            *FOO = 99;
+        })
+        .join();
+
+        assert_eq!(*FOO, 1);
+    }
+}

--- a/tests/ui/statics/nested_thread_local.rs
+++ b/tests/ui/statics/nested_thread_local.rs
@@ -1,24 +1,14 @@
-// Check that nested statics in thread locals are
-// duplicated per thread.
+// Check that we forbid nested statics in `thread_local` statics.
 
 #![feature(const_refs_to_cell)]
 #![feature(thread_local)]
 
-//@run-pass
-
 #[thread_local]
-static mut FOO: &mut u32 = &mut 42;
+static mut FOO: &u32 = {
+    //~^ ERROR: does not support implicit nested statics
+    // Prevent promotion (that would trigger on `&42` as an expression)
+    let x = 42;
+    &{ x }
+};
 
-fn main() {
-    unsafe {
-        *FOO = 1;
-
-        let _ = std::thread::spawn(|| {
-            assert_eq!(*FOO, 42);
-            *FOO = 99;
-        })
-        .join();
-
-        assert_eq!(*FOO, 1);
-    }
-}
+fn main() {}

--- a/tests/ui/statics/nested_thread_local.stderr
+++ b/tests/ui/statics/nested_thread_local.stderr
@@ -1,0 +1,8 @@
+error: #[thread_local] does not support implicit nested statics, please create explicit static items and refer to them instead
+  --> $DIR/nested_thread_local.rs:7:1
+   |
+LL | static mut FOO: &u32 = {
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
follow-up to #123310

cc @compiler-errors @RalfJung 

fwiw: I have no idea how thread local statics make that work under LLVM, and miri fails on this example, which I would have expected to be the correct behaviour.

Since the `#[thread_local]` attribute is just an internal implementation detail, I'm just going to start hard erroring on nested mutable statics in thread locals.