### PR TITLE
bootstrap: actually allow set debuginfo-level to "line-tables-only"

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -517,11 +517,8 @@
 #overflow-checks-std = rust.overflow-checks (boolean)
 
 # Debuginfo level for most of Rust code, corresponds to the `-C debuginfo=N` option of `rustc`.
-# `0` - no debug info
-# `1` - line tables only - sufficient to generate backtraces that include line
-#       information and inlined functions, set breakpoints at source code
-#       locations, and step through execution in a debugger.
-# `2` - full debug info with variable and type information
+# See https://doc.rust-lang.org/rustc/codegen-options/index.html#debuginfo for available options.
+#
 # Can be overridden for specific subsets of Rust code (rustc, std or tools).
 # Debuginfo for tests run with compiletest is not controlled by this option
 # and needs to be enabled separately with `debuginfo-level-tests`.

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -55,6 +55,7 @@ pub enum DryRun {
 pub enum DebuginfoLevel {
     #[default]
     None,
+    LineDirectivesOnly,
     LineTablesOnly,
     Limited,
     Full,
@@ -72,6 +73,9 @@ impl<'de> Deserialize<'de> for DebuginfoLevel {
         Ok(match Deserialize::deserialize(deserializer)? {
             StringOrInt::String(s) if s == "none" => DebuginfoLevel::None,
             StringOrInt::Int(0) => DebuginfoLevel::None,
+            StringOrInt::String(s) if s == "line-directives-only" => {
+                DebuginfoLevel::LineDirectivesOnly
+            }
             StringOrInt::String(s) if s == "line-tables-only" => DebuginfoLevel::LineTablesOnly,
             StringOrInt::String(s) if s == "limited" => DebuginfoLevel::Limited,
             StringOrInt::Int(1) => DebuginfoLevel::Limited,
@@ -98,6 +102,7 @@ impl Display for DebuginfoLevel {
         use DebuginfoLevel::*;
         f.write_str(match self {
             None => "0",
+            LineDirectivesOnly => "line-directives-only",
             LineTablesOnly => "line-tables-only",
             Limited => "1",
             Full => "2",

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -70,16 +70,19 @@ impl<'de> Deserialize<'de> for DebuginfoLevel {
         use serde::de::Error;
 
         Ok(match Deserialize::deserialize(deserializer)? {
-            StringOrInt::String("none") | StringOrInt::Int(0) => DebuginfoLevel::None,
-            StringOrInt::String("line-tables-only") => DebuginfoLevel::LineTablesOnly,
-            StringOrInt::String("limited") | StringOrInt::Int(1) => DebuginfoLevel::Limited,
-            StringOrInt::String("full") | StringOrInt::Int(2) => DebuginfoLevel::Full,
+            StringOrInt::String(s) if s == "none" => DebuginfoLevel::None,
+            StringOrInt::Int(0) => DebuginfoLevel::None,
+            StringOrInt::String(s) if s == "line-tables-only" => DebuginfoLevel::LineTablesOnly,
+            StringOrInt::String(s) if s == "limited" => DebuginfoLevel::Limited,
+            StringOrInt::Int(1) => DebuginfoLevel::Limited,
+            StringOrInt::String(s) if s == "full" => DebuginfoLevel::Full,
+            StringOrInt::Int(2) => DebuginfoLevel::Full,
             StringOrInt::Int(n) => {
                 let other = serde::de::Unexpected::Signed(n);
                 return Err(D::Error::invalid_value(other, &"expected 0, 1, or 2"));
             }
             StringOrInt::String(s) => {
-                let other = serde::de::Unexpected::Str(s);
+                let other = serde::de::Unexpected::Str(&s);
                 return Err(D::Error::invalid_value(
                     other,
                     &"expected none, line-tables-only, limited, or full",
@@ -1021,8 +1024,8 @@ impl RustOptimize {
 
 #[derive(Deserialize)]
 #[serde(untagged)]
-enum StringOrInt<'a> {
-    String(&'a str),
+enum StringOrInt {
+    String(String),
     Int(i64),
 }
 


### PR DESCRIPTION
I've tried to set in config.toml `rust.debuginfo-level = "line-tables-only"`, but ended with:
``` failed to parse TOML configuration 'config.toml': 
data did not match any variant of untagged enum StringOrInt for key `rust.debuginfo-level`
```
Also this PR allows to set `line-directives-only` for debuginfo in config.toml too.
1. Fixes this. Alternative is remove that Deserialize and use default one:
https://github.com/rust-lang/rust/blob/0e682e9875458ebf811206a48b688e07d762d9bb/src/bootstrap/src/core/config/config.rs#L725-L728

2. Should `line-directives-only` be added too?

3. I've tried to add test to rust/src/bootstrap/src/core/config/tests.rs:
```rust
#[test]
fn rust_debuginfo() {
    assert!(matches!(
        parse("rust.debuginfo-level-rustc = 1").rust_debuginfo_level_rustc,
        DebuginfoLevel::Limited
    ));
    assert!(matches!(
        parse("rust.debuginfo-level-rustc = \"line-tables-only\"").rust_debuginfo_level_rustc,
        DebuginfoLevel::LineTablesOnly
    ));
}
```

But test passes before that PR too; looks like config parse tests checks something wrong? I mean, that tests check something which isn't actual bootstrap behavior.