### PR TITLE
At test discovery, write to logfile in the same format as to stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5515,6 +5515,7 @@ dependencies = [
  "libc",
  "panic_abort",
  "panic_unwind",
+ "rand",
  "std",
 ]
 

--- a/library/test/Cargo.toml
+++ b/library/test/Cargo.toml
@@ -10,3 +10,6 @@ core = { path = "../core" }
 panic_unwind = { path = "../panic_unwind" }
 panic_abort = { path = "../panic_abort" }
 libc = { version = "0.2.150", default-features = false }
+
+[dev-dependencies]
+rand = { version = "0.8.5" }

--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -207,7 +207,7 @@ pub fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Res
         OutputFormat::Pretty | OutputFormat::Junit => {
             Box::new(PrettyFormatter::new(&mut output, false, 0, false, None))
         }
-        OutputFormat::Terse => Box::new(TerseFormatter::new(output, false, 0, false)),
+        OutputFormat::Terse => Box::new(TerseFormatter::new(&mut output, false, 0, false)),
         OutputFormat::Json => Box::new(JsonFormatter::new(&mut output)),
     };
     let mut st = ConsoleTestDiscoveryState::new(opts)?;
@@ -332,9 +332,12 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
             is_multithreaded,
             opts.time_options,
         )),
-        OutputFormat::Terse => {
-            Box::new(TerseFormatter::new(output, opts.use_color(), max_name_len, is_multithreaded))
-        }
+        OutputFormat::Terse => Box::new(TerseFormatter::new(
+            &mut output,
+            opts.use_color(),
+            max_name_len,
+            is_multithreaded,
+        )),
         OutputFormat::Json => Box::new(JsonFormatter::new(&mut output)),
         OutputFormat::Junit => Box::new(JunitFormatter::new(&mut output)),
     };

--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -336,7 +336,7 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
             Box::new(TerseFormatter::new(output, opts.use_color(), max_name_len, is_multithreaded))
         }
         OutputFormat::Json => Box::new(JsonFormatter::new(&mut output)),
-        OutputFormat::Junit => Box::new(JunitFormatter::new(output)),
+        OutputFormat::Junit => Box::new(JunitFormatter::new(&mut output)),
     };
     let mut st = ConsoleTestState::new(opts)?;
 

--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -57,9 +57,8 @@ impl<T: Write> OutputLocation<T> {
         self.flush()
     }
 
-    pub fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
-        let s = s.as_ref();
-        self.write_all(s.as_bytes())?;
+    pub fn write_plain(&mut self, word: &str) -> io::Result<()> {
+        self.write_all(word.as_bytes())?;
         self.flush()
     }
 }

--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -41,6 +41,29 @@ impl<T: Write> Write for OutputLocation<T> {
     }
 }
 
+impl<T: Write> OutputLocation<T> {
+    pub fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
+        match self {
+            OutputLocation::Pretty(ref mut term) => {
+                term.fg(color)?;
+                term.write_all(word.as_bytes())?;
+                term.reset()?;
+            }
+            OutputLocation::Raw(ref mut stdout) => {
+                stdout.write_all(word.as_bytes())?;
+            }
+        }
+
+        self.flush()
+    }
+
+    pub fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
+        let s = s.as_ref();
+        self.write_all(s.as_bytes())?;
+        self.flush()
+    }
+}
+
 pub struct ConsoleTestDiscoveryState {
     pub log_out: Option<File>,
     pub tests: usize,

--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -208,7 +208,7 @@ pub fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Res
             Box::new(PrettyFormatter::new(&mut output, false, 0, false, None))
         }
         OutputFormat::Terse => Box::new(TerseFormatter::new(output, false, 0, false)),
-        OutputFormat::Json => Box::new(JsonFormatter::new(output)),
+        OutputFormat::Json => Box::new(JsonFormatter::new(&mut output)),
     };
     let mut st = ConsoleTestDiscoveryState::new(opts)?;
 
@@ -335,7 +335,7 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
         OutputFormat::Terse => {
             Box::new(TerseFormatter::new(output, opts.use_color(), max_name_len, is_multithreaded))
         }
-        OutputFormat::Json => Box::new(JsonFormatter::new(output)),
+        OutputFormat::Json => Box::new(JsonFormatter::new(&mut output)),
         OutputFormat::Junit => Box::new(JunitFormatter::new(output)),
     };
     let mut st = ConsoleTestState::new(opts)?;

--- a/library/test/src/formatters/json.rs
+++ b/library/test/src/formatters/json.rs
@@ -1,19 +1,19 @@
-use std::{borrow::Cow, io, io::prelude::Write};
+use std::{borrow::Cow, io};
 
 use super::OutputFormatter;
 use crate::{
-    console::{ConsoleTestDiscoveryState, ConsoleTestState, OutputLocation},
+    console::{ConsoleTestDiscoveryState, ConsoleTestState, Output},
     test_result::TestResult,
     time,
     types::TestDesc,
 };
 
-pub(crate) struct JsonFormatter<T> {
-    out: OutputLocation<T>,
+pub(crate) struct JsonFormatter<'a> {
+    out: &'a mut dyn Output,
 }
 
-impl<T: Write> JsonFormatter<T> {
-    pub fn new(out: OutputLocation<T>) -> Self {
+impl<'a> JsonFormatter<'a> {
+    pub fn new(out: &'a mut dyn Output) -> Self {
         Self { out }
     }
 
@@ -23,7 +23,7 @@ impl<T: Write> JsonFormatter<T> {
         // by issuing `write_all` calls line-by-line.
         assert_eq!(s.chars().last(), Some('\n'));
 
-        self.out.write_all(s.as_ref())
+        self.out.write_plain(s)
     }
 
     fn write_event(
@@ -56,7 +56,7 @@ impl<T: Write> JsonFormatter<T> {
     }
 }
 
-impl<T: Write> OutputFormatter for JsonFormatter<T> {
+impl OutputFormatter for JsonFormatter<'_> {
     fn write_discovery_start(&mut self) -> io::Result<()> {
         self.writeln_message(concat!(r#"{ "type": "suite", "event": "discovery" }"#, "\n"))
     }

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -69,29 +69,12 @@ impl<T: Write> PrettyFormatter<T> {
         self.write_pretty(result, color)
     }
 
-    pub fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
-        match self.out {
-            OutputLocation::Pretty(ref mut term) => {
-                if self.use_color {
-                    term.fg(color)?;
-                }
-                term.write_all(word.as_bytes())?;
-                if self.use_color {
-                    term.reset()?;
-                }
-                term.flush()
-            }
-            OutputLocation::Raw(ref mut stdout) => {
-                stdout.write_all(word.as_bytes())?;
-                stdout.flush()
-            }
-        }
+    fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
+        if self.use_color { self.out.write_pretty(word, color) } else { self.out.write_plain(word) }
     }
 
-    pub fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
-        let s = s.as_ref();
-        self.out.write_all(s.as_bytes())?;
-        self.out.flush()
+    fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
+        self.out.write_plain(s)
     }
 
     fn write_time(

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -69,6 +69,7 @@ impl<T: Write> PrettyFormatter<T> {
     }
 
     fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
+        let s = s.as_ref();
         self.out.write_plain(s)
     }
 

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -1,17 +1,17 @@
-use std::{io, io::prelude::Write};
+use std::io;
 
 use super::OutputFormatter;
 use crate::{
     bench::fmt_bench_samples,
-    console::{ConsoleTestDiscoveryState, ConsoleTestState, OutputLocation},
+    console::{ConsoleTestDiscoveryState, ConsoleTestState, Output},
     term,
     test_result::TestResult,
     time,
     types::TestDesc,
 };
 
-pub(crate) struct PrettyFormatter<T> {
-    out: OutputLocation<T>,
+pub(crate) struct PrettyFormatter<'a> {
+    out: &'a mut dyn Output,
     use_color: bool,
     time_options: Option<time::TestTimeOptions>,
 
@@ -21,9 +21,9 @@ pub(crate) struct PrettyFormatter<T> {
     is_multithreaded: bool,
 }
 
-impl<T: Write> PrettyFormatter<T> {
+impl<'a> PrettyFormatter<'a> {
     pub fn new(
-        out: OutputLocation<T>,
+        out: &'a mut dyn Output,
         use_color: bool,
         max_name_len: usize,
         is_multithreaded: bool,
@@ -159,7 +159,7 @@ impl<T: Write> PrettyFormatter<T> {
     }
 }
 
-impl<T: Write> OutputFormatter for PrettyFormatter<T> {
+impl OutputFormatter for PrettyFormatter<'_> {
     fn write_discovery_start(&mut self) -> io::Result<()> {
         Ok(())
     }

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -32,11 +32,6 @@ impl<T: Write> PrettyFormatter<T> {
         PrettyFormatter { out, use_color, max_name_len, is_multithreaded, time_options }
     }
 
-    #[cfg(test)]
-    pub fn output_location(&self) -> &OutputLocation<T> {
-        &self.out
-    }
-
     pub fn write_ok(&mut self) -> io::Result<()> {
         self.write_short_result("ok", term::color::GREEN)
     }

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -1,3 +1,7 @@
+use rand::RngCore;
+use std::fs;
+use std::path::PathBuf;
+
 use super::*;
 
 use crate::{
@@ -37,6 +41,36 @@ impl TestOpts {
             fail_fast: false,
         }
     }
+}
+
+// These implementations of TempDir and tmpdir are forked from rust/library/std/src/sys_common/io.rs.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn join(&self, path: &str) -> PathBuf {
+        let TempDir(ref p) = *self;
+        p.join(path)
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let TempDir(ref p) = *self;
+        let result = fs::remove_dir_all(p);
+        // Avoid panicking while panicking as this causes the process to
+        // immediately abort, without displaying test results.
+        if !thread::panicking() {
+            result.unwrap();
+        }
+    }
+}
+
+fn tmpdir() -> TempDir {
+    let p = env::temp_dir();
+    let mut r = rand::thread_rng();
+    let ret = p.join(&format!("rust-{}", r.next_u32()));
+    fs::create_dir(&ret).unwrap();
+    TempDir(ret)
 }
 
 fn one_ignored_one_unignored_test() -> Vec<TestDescAndFn> {
@@ -921,4 +955,43 @@ fn test_dyn_bench_returning_err_fails_when_run_as_test() {
     run_tests(&TestOpts { run_tests: true, ..TestOpts::new() }, vec![desc], notify).unwrap();
     let result = rx.recv().unwrap().result;
     assert_eq!(result, TrFailed);
+}
+
+#[test]
+fn test_logfile_format() {
+    let desc = TestDescAndFn {
+        desc: TestDesc {
+            name: StaticTestName("whatever"),
+            ignore: false,
+            ignore_message: None,
+            source_file: "",
+            start_line: 0,
+            start_col: 0,
+            end_line: 0,
+            end_col: 0,
+            should_panic: ShouldPanic::No,
+            compile_fail: false,
+            no_run: false,
+            test_type: TestType::Unknown,
+        },
+        testfn: DynTestFn(Box::new(move || Ok(()))),
+    };
+
+    let tmpdir = tmpdir();
+    let output_path = &tmpdir.join("output.txt");
+
+    let opts = TestOpts {
+        run_tests: true,
+        logfile: Some(output_path.clone()),
+        format: OutputFormat::Pretty,
+        ..TestOpts::new()
+    };
+    run_tests_console(&opts, vec![desc]).unwrap();
+
+    let contents = fs::read_to_string(output_path).expect("`--logfile` did not create file");
+
+    // Split output at line breaks to make the comparison platform-agnostic regarding newline style.
+    let contents_lines = contents.as_str().lines().collect::<Vec<&str>>();
+
+    assert_eq!(contents_lines, vec!["ok whatever"]);
 }

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -893,7 +893,8 @@ fn should_sort_failures_before_printing_them() {
         test_type: TestType::Unknown,
     };
 
-    let mut out = PrettyFormatter::new(OutputLocation::Raw(Vec::new()), false, 10, false, None);
+    let mut output = Vec::new();
+    let mut out = PrettyFormatter::new(OutputLocation::Raw(&mut output), false, 10, false, None);
 
     let st = console::ConsoleTestState {
         log_out: None,
@@ -913,11 +914,8 @@ fn should_sort_failures_before_printing_them() {
     };
 
     out.write_failures(&st).unwrap();
-    let s = match out.output_location() {
-        &OutputLocation::Raw(ref m) => String::from_utf8_lossy(&m[..]),
-        &OutputLocation::Pretty(_) => unreachable!(),
-    };
 
+    let s = String::from_utf8_lossy(&output[..]);
     let apos = s.find("a").unwrap();
     let bpos = s.find("b").unwrap();
     assert!(apos < bpos);

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -994,7 +994,7 @@ fn test_discovery_logfile_format() {
     // Split output at line breaks to make the comparison platform-agnostic regarding newline style.
     let contents_lines = contents.as_str().lines().collect::<Vec<&str>>();
 
-    assert_eq!(contents_lines, vec!["test whatever"]);
+    assert_eq!(contents_lines, vec!["whatever: test", "", "1 test, 0 benchmarks"]);
 }
 
 #[test]

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -894,7 +894,8 @@ fn should_sort_failures_before_printing_them() {
     };
 
     let mut output = Vec::new();
-    let mut out = PrettyFormatter::new(OutputLocation::Raw(&mut output), false, 10, false, None);
+    let mut raw = OutputLocation::Raw(&mut output);
+    let mut out = PrettyFormatter::new(&mut raw, false, 10, false, None);
 
     let st = console::ConsoleTestState {
         log_out: None,


### PR DESCRIPTION
At test discovery, write to logfile in the same format as to stdout.

The top-most commit of current PR is the only commit that contains a behavior change: https://github.com/aspotashev/rust/commit/d01f463203a32285b2afb7a417f8e16a93e18e4a

Example of affected command:

```
cargo test -- --logfile=/tmp/1.log --list
```

Old format:
```
test whatever
```

New format:
```
whatever: test

1 test, 0 benchmarks
```

Rationale for the behavior change:
* The code becomes easier to maintain: we reuse the same code to generate output into stdout and into log file
* Fix user confusion, as they currently see different formats in stdout and in log file.

----

In addition to the behavior change, the following refactorings are applies:

* Added `OutputMultiplexer`. It simplifies writing to multiple outputs (e.g. stdout + logfile). In a future PR, I'm going to change `run_tests_console()` to also use `OutputMultiplexer`.
  * To demonstrate the simplification, https://github.com/rust-lang/rust/pull/96290 has repeated calls like `out.write_result` + `log_output.write_result` (one for stdout, one for log file output.) This repetition won't be needed when we use `OutputMultiplexer`.
* Eliminate tight coupling of formatters to the enum `OutputLocation<T>`. This is good for code health, and also unblocks the introduction of `OutputMultiplexer`.

Future work:
* Change `run_tests_console()` to also use `OutputMultiplexer`.
* Reimplement https://github.com/rust-lang/rust/pull/96290 (to fix https://github.com/rust-lang/rust/issues/57147.)