### PR TITLE
rustdoc: synthetic auto trait impls: accept unresolved region vars for now

### DIFF
--- a/tests/rustdoc-ui/synthetic-auto-trait-impls/lifetime-generic-user-impl-normalize.rs
+++ b/tests/rustdoc-ui/synthetic-auto-trait-impls/lifetime-generic-user-impl-normalize.rs
@@ -1,0 +1,17 @@
+// We used to ICE here while trying to synthesize auto trait impls.
+// issue: 112242
+//@ check-pass
+//@ compile-flags: -Znormalize-docs
+
+pub trait MyTrait<'a> {
+    type MyItem;
+}
+pub struct Inner<Q>(Q);
+pub struct Outer<Q>(Inner<Q>);
+
+impl<'a, Q> std::marker::Unpin for Inner<Q>
+where
+    Q: MyTrait<'a>,
+    <Q as MyTrait<'a>>::MyItem: Copy,
+{
+}

--- a/tests/rustdoc-ui/synthetic-auto-trait-impls/lifetime-generic-user-impl.rs
+++ b/tests/rustdoc-ui/synthetic-auto-trait-impls/lifetime-generic-user-impl.rs
@@ -1,0 +1,11 @@
+// We used to ICE here while trying to synthesize auto trait impls.
+// issue: 123370
+//@ check-pass
+
+pub struct Inner<'a, Q>(&'a (), Q);
+
+pub struct Outer<'a, Q>(Inner<'a, Q>);
+
+impl<'a, Q: Trait<'a>> std::marker::Unpin for Inner<'static, Q> {}
+
+pub trait Trait<'a> {}


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/123348#issuecomment-2032494255:

> Right, [in #123340] I've intentionally changed a `vid_map.get(vid).unwrap_or(r)` to a `vid_map[vid]` making rustdoc panic if `rustc::AutoTraitFinder` returns a region inference variable that cannot be resolved because that is really fishy.  I can change it back with a `FIXME: investigate` […]. [O]nce I [fully] understand [the arcane] `rustc::AutoTraitFinder` [I] can fix the underlying issue if there's one.
>
> `rustc::AutoTraitFinder` can also return placeholder regions `RePlaceholder` which doesn't seem right either and which makes rustdoc ICE, too (we have a GitHub issue for that already[, namely #120606]).

Fixes #123370.
Fixes #112242.

r? @GuillaumeGomez