### PR TITLE
Only inspect user-written predicates for privacy concerns

### DIFF
--- a/tests/ui/privacy/generic_struct_field_projection.rs
+++ b/tests/ui/privacy/generic_struct_field_projection.rs
@@ -1,0 +1,35 @@
+//! To determine all the types that need to be private when looking at `Struct`, we
+//! invoke `predicates_of` to also look at types in `where` bounds.
+//! Unfortunately this also computes the inferred outlives bounds, which means for
+//! every field we check that if it is of type `&'a T` then `T: 'a` and if it is of
+//! struct type, we check that the struct satisfies its lifetime parameters by looking
+//! at its inferred outlives bounds. This means we end up with a `<Foo as Trait>::Assoc: 'a`
+//! in the outlives bounds of `Struct`. While this is trivially provable, privacy
+//! only sees `Foo` and `Trait` and determins that `Foo` is private and then errors.
+
+mod baz {
+    struct Foo;
+
+    pub trait Trait {
+        type Assoc;
+    }
+
+    impl Trait for Foo {
+        type Assoc = ();
+    }
+
+    pub struct Bar<'a, T: Trait> {
+        source: &'a T::Assoc,
+        //~^ ERROR: type `Foo` is private
+    }
+
+    pub struct Baz<'a> {
+        mode: Bar<'a, Foo>,
+    }
+}
+
+pub struct Struct<'a> {
+    lexer: baz::Baz<'a>,
+}
+
+fn main() {}

--- a/tests/ui/privacy/generic_struct_field_projection.rs
+++ b/tests/ui/privacy/generic_struct_field_projection.rs
@@ -1,11 +1,15 @@
 //! To determine all the types that need to be private when looking at `Struct`, we
-//! invoke `predicates_of` to also look at types in `where` bounds.
+//! used to invoke `predicates_of` to also look at types in `where` bounds.
 //! Unfortunately this also computes the inferred outlives bounds, which means for
 //! every field we check that if it is of type `&'a T` then `T: 'a` and if it is of
 //! struct type, we check that the struct satisfies its lifetime parameters by looking
 //! at its inferred outlives bounds. This means we end up with a `<Foo as Trait>::Assoc: 'a`
 //! in the outlives bounds of `Struct`. While this is trivially provable, privacy
-//! only sees `Foo` and `Trait` and determins that `Foo` is private and then errors.
+//! only sees `Foo` and `Trait` and determines that `Foo` is private and then errors.
+//! So now we invoke `explicit_predicates_of` to make sure we only care about user-written
+//! predicates.
+
+//@ check-pass
 
 mod baz {
     struct Foo;
@@ -20,7 +24,6 @@ mod baz {
 
     pub struct Bar<'a, T: Trait> {
         source: &'a T::Assoc,
-        //~^ ERROR: type `Foo` is private
     }
 
     pub struct Baz<'a> {

--- a/tests/ui/privacy/generic_struct_field_projection.stderr
+++ b/tests/ui/privacy/generic_struct_field_projection.stderr
@@ -1,8 +1,0 @@
-error: type `Foo` is private
-  --> $DIR/generic_struct_field_projection.rs:22:9
-   |
-LL |         source: &'a T::Assoc,
-   |         ^^^^^^^^^^^^^^^^^^^^ private type
-
-error: aborting due to 1 previous error
-

--- a/tests/ui/privacy/generic_struct_field_projection.stderr
+++ b/tests/ui/privacy/generic_struct_field_projection.stderr
@@ -1,0 +1,8 @@
+error: type `Foo` is private
+  --> $DIR/generic_struct_field_projection.rs:22:9
+   |
+LL |         source: &'a T::Assoc,
+   |         ^^^^^^^^^^^^^^^^^^^^ private type
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
fixes #123288

Previously we looked at the elaborated predicates, which, due to adding various bounds on fields, end up requiring trivially true bounds. But these bounds can contain private types, which the privacy visitor then found and errored about.