### PR TITLE
Put basic impls for f16 and f128 behind cfg(not(bootstrap))

### DIFF
--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -227,9 +227,12 @@ mod impls {
     impl_clone! {
         usize u8 u16 u32 u64 u128
         isize i8 i16 i32 i64 i128
-        f16 f32 f64 f128
+        f32 f64
         bool char
     }
+
+    #[cfg(not(bootstrap))]
+    impl_clone! { f16 f128 }
 
     #[unstable(feature = "never_type", issue = "35121")]
     impl Clone for ! {

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1493,8 +1493,11 @@ mod impls {
     }
 
     partial_eq_impl! {
-        bool char usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128
+        bool char usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64
     }
+
+    #[cfg(not(bootstrap))]
+    partial_eq_impl! { f16 f128 }
 
     macro_rules! eq_impl {
         ($($t:ty)*) => ($(
@@ -1546,7 +1549,10 @@ mod impls {
         }
     }
 
-    partial_ord_impl! { f16 f32 f64 f128 }
+    partial_ord_impl! { f32 f64 }
+
+    #[cfg(not(bootstrap))]
+    partial_ord_impl! { f16 f128 }
 
     macro_rules! ord_impl {
         ($($t:ty)*) => ($(

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -205,6 +205,8 @@
 //
 // Language features:
 // tidy-alphabetical-start
+#![cfg_attr(not(bootstrap), feature(f128))]
+#![cfg_attr(not(bootstrap), feature(f16))]
 #![feature(abi_unadjusted)]
 #![feature(adt_const_params)]
 #![feature(allow_internal_unsafe)]
@@ -229,8 +231,6 @@
 #![feature(doc_notable_trait)]
 #![feature(effects)]
 #![feature(extern_types)]
-#![feature(f128)]
-#![feature(f16)]
 #![feature(freeze_impls)]
 #![feature(fundamental)]
 #![feature(generic_arg_infer)]

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -422,11 +422,17 @@ marker_impls! {
     Copy for
         usize, u8, u16, u32, u64, u128,
         isize, i8, i16, i32, i64, i128,
-        f16, f32, f64, f128,
+        f32, f64,
         bool, char,
         {T: ?Sized} *const T,
         {T: ?Sized} *mut T,
+}
 
+#[cfg(not(bootstrap))]
+marker_impls! {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    Copy for
+        f16, f128,
 }
 
 #[unstable(feature = "never_type", issue = "35121")]


### PR DESCRIPTION
We will lose `f16` and `f128` in the beta compiler after the revert for <https://github.com/rust-lang/rust/issues/123282> lands. Change what was added in <https://github.com/rust-lang/rust/pull/123085> to be behind `#[cfg(not(bootstrap))]` to account for this.