### PR TITLE
Relax framework linking test

### DIFF
--- a/tests/ui/linkage-attr/framework.omit.stderr
+++ b/tests/ui/linkage-attr/framework.omit.stderr
@@ -1,4 +1,4 @@
-error: linking with `cc` failed: exit status: 1
+error: linking with `LINKER` failed: exit status: 1
    |
            ld: Undefined symbols:
              _CFRunLoopGetTypeID, referenced from:

--- a/tests/ui/linkage-attr/framework.rs
+++ b/tests/ui/linkage-attr/framework.rs
@@ -6,8 +6,10 @@
 //@ [weak]run-pass
 //@ [both]run-pass
 
-// The linker's exact error output changes between Xcode versions.
+// The linker's exact error output changes between Xcode versions, depends on
+// linker invocation details, and the linker sometimes outputs more warnings.
 //@ compare-output-lines-by-subset
+//@ normalize-stderr-test: "linking with `.*` failed" -> "linking with `LINKER` failed"
 //@ normalize-stderr-test: "Undefined symbols for architecture .*" -> "ld: Undefined symbols:"
 //@ normalize-stderr-test: "._CFRunLoopGetTypeID.," -> "_CFRunLoopGetTypeID,"
 


### PR DESCRIPTION
This test was introduced by myself in https://github.com/rust-lang/rust/pull/118644, but was over-specified in that it assumed the path of the linker was always `cc`, which [causes a test failure for Chromium](https://issues.chromium.org/issues/332562251).