### PR TITLE
Add `noundef` metadata for fits-in-target-pointer-size array immediate arguments

### DIFF
--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -786,8 +786,19 @@ fn fn_abi_adjust_for_abi<'tcx>(
                 arg.cast_to(Reg { kind: RegKind::Integer, size });
 
                 // Let's see if we can add a `noundef`. This is only legal for arrays, definitely
-                // not for unions.
-                if arg.layout.ty.is_array() {
+                // not for unions. This is also legal for `#[repr(transparent)] struct` or
+                // `#[repr(transparent)] enum` containing array.
+                let is_transparent_array =
+                    if arg.layout.is_transparent::<LayoutCx<'tcx, TyCtxt<'tcx>>>()
+                        && let Some((_, layout)) = arg.layout.non_1zst_field(cx)
+                        && layout.ty.is_array()
+                    {
+                        true
+                    } else {
+                        false
+                    };
+
+                if arg.layout.ty.is_array() || is_transparent_array {
                     // Fixup arg attribute with `noundef`.
                     let PassMode::Cast { ref mut cast, .. } = &mut arg.mode else {
                         bug!("this cannot fail because of the previous cast_to `Reg`");

--- a/tests/codegen/array-immediate-param-noundef.rs
+++ b/tests/codegen/array-immediate-param-noundef.rs
@@ -3,95 +3,94 @@
 // - `!arg.layout.is_unsized() && size <= Pointer(AddressSpace::DATA).size(cx)`
 // - optimizations are turned on.
 //
-// ignore-tidy-linelength
 //@ only-64bit (presence of noundef depends on pointer width)
 //@ compile-flags: -C no-prepopulate-passes -O
 #![crate_type = "lib"]
 
-// CHECK: define noundef i64 @replace_short_array_u64x1(ptr {{.*}}, i64 noundef %{{.*}})
+// CHECK: define noundef i64 @short_array_u64x1(i64 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_short_array_u64x1(r: &mut [u64; 1], v: [u64; 1]) -> [u64; 1] {
-    std::mem::replace(r, v)
+pub fn short_array_u64x1(v: [u64; 1]) -> [u64; 1] {
+    v
 }
 
-// CHECK: define noundef i32 @replace_short_array_u32x1(ptr {{.*}}, i32 noundef %{{.*}})
+// CHECK: define noundef i32 @short_array_u32x1(i32 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_short_array_u32x1(r: &mut [u32; 1], v: [u32; 1]) -> [u32; 1] {
-    std::mem::replace(r, v)
+pub fn short_array_u32x1(v: [u32; 1]) -> [u32; 1] {
+    v
 }
 
-// CHECK: define noundef i64 @replace_short_array_u32x2(ptr {{.*}}, i64 noundef %{{.*}})
+// CHECK: define noundef i64 @short_array_u32x2(i64 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_short_array_u32x2(r: &mut [u32; 2], v: [u32; 2]) -> [u32; 2] {
-    std::mem::replace(r, v)
+pub fn short_array_u32x2(v: [u32; 2]) -> [u32; 2] {
+    v
 }
 
-// CHECK: define noundef i16 @replace_short_array_u16x1(ptr {{.*}}, i16 noundef %{{.*}})
+// CHECK: define noundef i16 @short_array_u16x1(i16 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_short_array_u16x1(r: &mut [u16; 1], v: [u16; 1]) -> [u16; 1] {
-    std::mem::replace(r, v)
+pub fn short_array_u16x1(v: [u16; 1]) -> [u16; 1] {
+    v
 }
 
-// CHECK: define noundef i32 @replace_short_array_u16x2(ptr {{.*}}, i32 noundef %{{.*}})
+// CHECK: define noundef i32 @short_array_u16x2(i32 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_short_array_u16x2(r: &mut [u16; 2], v: [u16; 2]) -> [u16; 2] {
-    std::mem::replace(r, v)
+pub fn short_array_u16x2(v: [u16; 2]) -> [u16; 2] {
+    v
 }
 
-// CHECK: define noundef i48 @replace_short_array_u16x3(ptr {{.*}}, i48 noundef %{{.*}})
+// CHECK: define noundef i48 @short_array_u16x3(i48 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_short_array_u16x3(r: &mut [u16; 3], v: [u16; 3]) -> [u16; 3] {
-    std::mem::replace(r, v)
+pub fn short_array_u16x3(v: [u16; 3]) -> [u16; 3] {
+    v
 }
 
-// CHECK: define noundef i64 @replace_short_array_u16x4(ptr {{.*}}, i64 noundef %{{.*}})
+// CHECK: define noundef i64 @short_array_u16x4(i64 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_short_array_u16x4(r: &mut [u16; 4], v: [u16; 4]) -> [u16; 4] {
-    std::mem::replace(r, v)
+pub fn short_array_u16x4(v: [u16; 4]) -> [u16; 4] {
+    v
 }
 
-// CHECK: define noundef i8 @replace_short_array_u8x1(ptr {{.*}}, i8 noundef %{{.*}})
+// CHECK: define noundef i8 @short_array_u8x1(i8 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_short_array_u8x1(r: &mut [u8; 1], v: [u8; 1]) -> [u8; 1] {
-    std::mem::replace(r, v)
+pub fn short_array_u8x1(v: [u8; 1]) -> [u8; 1] {
+    v
 }
 
-// CHECK: define noundef i16 @replace_short_array_u8x2(ptr {{.*}}, i16 noundef %{{.*}})
+// CHECK: define noundef i16 @short_array_u8x2(i16 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_short_array_u8x2(r: &mut [u8; 2], v: [u8; 2]) -> [u8; 2] {
-    std::mem::replace(r, v)
+pub fn short_array_u8x2(v: [u8; 2]) -> [u8; 2] {
+    v
 }
 
-// CHECK: define noundef i24 @replace_short_array_u8x3(ptr {{.*}}, i24 noundef %{{.*}})
+// CHECK: define noundef i24 @short_array_u8x3(i24 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_short_array_u8x3(r: &mut [u8; 3], v: [u8; 3]) -> [u8; 3] {
-    std::mem::replace(r, v)
+pub fn short_array_u8x3(v: [u8; 3]) -> [u8; 3] {
+    v
 }
 
-// CHECK: define noundef i64 @replace_short_array_u8x8(ptr {{.*}}, i64 noundef %{{.*}})
+// CHECK: define noundef i64 @short_array_u8x8(i64 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_short_array_u8x8(r: &mut [u8; 8], v: [u8; 8]) -> [u8; 8] {
-    std::mem::replace(r, v)
+pub fn short_array_u8x8(v: [u8; 8]) -> [u8; 8] {
+    v
 }
 
 #[repr(transparent)]
 pub struct Foo([u8; 4]);
 
-// CHECK: define noundef i32 @replace_repr_transparent_struct_short_array(ptr {{.*}}, i32 noundef %{{.*}})
+// CHECK: define noundef i32 @repr_transparent_struct_short_array(i32 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_repr_transparent_struct_short_array(r: &mut Foo, v: Foo) -> Foo {
-    std::mem::replace(r, v)
+pub fn repr_transparent_struct_short_array(v: Foo) -> Foo {
+    v
 }
 
 #[repr(transparent)]
 pub enum Bar {
-    Default([u8; 4])
+    Default([u8; 4]),
 }
 
-// CHECK: define noundef i32 @replace_repr_transparent_enum_short_array(ptr {{.*}}, i32 noundef %{{.*}})
+// CHECK: define noundef i32 @repr_transparent_enum_short_array(i32 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_repr_transparent_enum_short_array(r: &mut Bar, v: Bar) -> Bar {
-    std::mem::replace(r, v)
+pub fn repr_transparent_enum_short_array(v: Bar) -> Bar {
+    v
 }
 
 #[repr(transparent)]
@@ -103,8 +102,24 @@ pub struct Uwu(Owo);
 #[repr(transparent)]
 pub struct Oowoo(Uwu);
 
-// CHECK: define noundef i32 @replace_repr_transparent_nested_struct_short_array(ptr {{.*}}, i32 noundef %{{.*}})
+// CHECK: define noundef i32 @repr_transparent_nested_struct_short_array(i32 noundef %{{.*}})
 #[no_mangle]
-pub fn replace_repr_transparent_nested_struct_short_array(r: &mut Oowoo, v: Oowoo) -> Oowoo {
-    std::mem::replace(r, v)
+pub fn repr_transparent_nested_struct_short_array(v: Oowoo) -> Oowoo {
+    v
+}
+
+// # Negative examples
+
+// This inner struct is *not* `#[repr(transparent)]`, so we must not emit `noundef` for the outer
+// struct.
+pub struct NotTransparent([u8; 4]);
+
+#[repr(transparent)]
+pub struct Transparent(NotTransparent);
+
+// CHECK-LABEL: not_all_transparent_nested_struct_short_array
+// CHECK-NOT: noundef
+#[no_mangle]
+pub fn not_all_transparent_nested_struct_short_array(v: Transparent) -> Transparent {
+    v
 }

--- a/tests/codegen/array-immediate-param-noundef.rs
+++ b/tests/codegen/array-immediate-param-noundef.rs
@@ -73,3 +73,23 @@ pub fn replace_short_array_u8x3(r: &mut [u8; 3], v: [u8; 3]) -> [u8; 3] {
 pub fn replace_short_array_u8x8(r: &mut [u8; 8], v: [u8; 8]) -> [u8; 8] {
     std::mem::replace(r, v)
 }
+
+#[repr(transparent)]
+pub struct Foo([u8; 4]);
+
+// CHECK: define noundef i32 @replace_repr_transparent_struct_short_array(ptr noalias noundef align 1 dereferenceable(4) %r, i32 noundef %0)
+#[no_mangle]
+pub fn replace_repr_transparent_struct_short_array(r: &mut Foo, v: Foo) -> Foo {
+    std::mem::replace(r, v)
+}
+
+#[repr(transparent)]
+pub enum Bar {
+    Default([u8; 4])
+}
+
+// CHECK: define noundef i32 @replace_repr_transparent_enum_short_array(ptr noalias noundef align 1 dereferenceable(4) %r, i32 noundef %0)
+#[no_mangle]
+pub fn replace_repr_transparent_enum_short_array(r: &mut Bar, v: Bar) -> Bar {
+    std::mem::replace(r, v)
+}

--- a/tests/codegen/array-immediate-param-noundef.rs
+++ b/tests/codegen/array-immediate-param-noundef.rs
@@ -1,0 +1,75 @@
+// Check that small array immediates that fits in target pointer size in argument position have
+// `noundef` parameter metadata. Note that the `noundef` parameter metadata is only applied if:
+// - `!arg.layout.is_unsized() && size <= Pointer(AddressSpace::DATA).size(cx)`
+// - optimizations are turned on.
+//
+// ignore-tidy-linelength
+//@ only-64bit (presence of noundef depends on pointer width)
+//@ compile-flags: -C no-prepopulate-passes -O
+#![crate_type = "lib"]
+
+// CHECK: define noundef i64 @replace_short_array_u64x1(ptr noalias noundef align 8 dereferenceable(8) %r, i64 noundef %0)
+#[no_mangle]
+pub fn replace_short_array_u64x1(r: &mut [u64; 1], v: [u64; 1]) -> [u64; 1] {
+    std::mem::replace(r, v)
+}
+
+// CHECK: define noundef i32 @replace_short_array_u32x1(ptr noalias noundef align 4 dereferenceable(4) %r, i32 noundef %0)
+#[no_mangle]
+pub fn replace_short_array_u32x1(r: &mut [u32; 1], v: [u32; 1]) -> [u32; 1] {
+    std::mem::replace(r, v)
+}
+
+// CHECK: define noundef i64 @replace_short_array_u32x2(ptr noalias noundef align 4 dereferenceable(8) %r, i64 noundef %0)
+#[no_mangle]
+pub fn replace_short_array_u32x2(r: &mut [u32; 2], v: [u32; 2]) -> [u32; 2] {
+    std::mem::replace(r, v)
+}
+
+// CHECK: define noundef i16 @replace_short_array_u16x1(ptr noalias noundef align 2 dereferenceable(2) %r, i16 noundef %0)
+#[no_mangle]
+pub fn replace_short_array_u16x1(r: &mut [u16; 1], v: [u16; 1]) -> [u16; 1] {
+    std::mem::replace(r, v)
+}
+
+// CHECK: define noundef i32 @replace_short_array_u16x2(ptr noalias noundef align 2 dereferenceable(4) %r, i32 noundef %0)
+#[no_mangle]
+pub fn replace_short_array_u16x2(r: &mut [u16; 2], v: [u16; 2]) -> [u16; 2] {
+    std::mem::replace(r, v)
+}
+
+// CHECK: define noundef i48 @replace_short_array_u16x3(ptr noalias noundef align 2 dereferenceable(6) %r, i48 noundef %0)
+#[no_mangle]
+pub fn replace_short_array_u16x3(r: &mut [u16; 3], v: [u16; 3]) -> [u16; 3] {
+    std::mem::replace(r, v)
+}
+
+// CHECK: define noundef i64 @replace_short_array_u16x4(ptr noalias noundef align 2 dereferenceable(8) %r, i64 noundef %0)
+#[no_mangle]
+pub fn replace_short_array_u16x4(r: &mut [u16; 4], v: [u16; 4]) -> [u16; 4] {
+    std::mem::replace(r, v)
+}
+
+// CHECK: define noundef i8 @replace_short_array_u8x1(ptr noalias noundef align 1 dereferenceable(1) %r, i8 noundef %0)
+#[no_mangle]
+pub fn replace_short_array_u8x1(r: &mut [u8; 1], v: [u8; 1]) -> [u8; 1] {
+    std::mem::replace(r, v)
+}
+
+// CHECK: define noundef i16 @replace_short_array_u8x2(ptr noalias noundef align 1 dereferenceable(2) %r, i16 noundef %0)
+#[no_mangle]
+pub fn replace_short_array_u8x2(r: &mut [u8; 2], v: [u8; 2]) -> [u8; 2] {
+    std::mem::replace(r, v)
+}
+
+// CHECK: define noundef i24 @replace_short_array_u8x3(ptr noalias noundef align 1 dereferenceable(3) %r, i24 noundef %0)
+#[no_mangle]
+pub fn replace_short_array_u8x3(r: &mut [u8; 3], v: [u8; 3]) -> [u8; 3] {
+    std::mem::replace(r, v)
+}
+
+// CHECK: define noundef i64 @replace_short_array_u8x8(ptr noalias noundef align 1 dereferenceable(8) %r, i64 noundef %0)
+#[no_mangle]
+pub fn replace_short_array_u8x8(r: &mut [u8; 8], v: [u8; 8]) -> [u8; 8] {
+    std::mem::replace(r, v)
+}

--- a/tests/codegen/array-immediate-param-noundef.rs
+++ b/tests/codegen/array-immediate-param-noundef.rs
@@ -8,67 +8,67 @@
 //@ compile-flags: -C no-prepopulate-passes -O
 #![crate_type = "lib"]
 
-// CHECK: define noundef i64 @replace_short_array_u64x1(ptr noalias noundef align 8 dereferenceable(8) %r, i64 noundef %0)
+// CHECK: define noundef i64 @replace_short_array_u64x1(ptr {{.*}}, i64 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_short_array_u64x1(r: &mut [u64; 1], v: [u64; 1]) -> [u64; 1] {
     std::mem::replace(r, v)
 }
 
-// CHECK: define noundef i32 @replace_short_array_u32x1(ptr noalias noundef align 4 dereferenceable(4) %r, i32 noundef %0)
+// CHECK: define noundef i32 @replace_short_array_u32x1(ptr {{.*}}, i32 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_short_array_u32x1(r: &mut [u32; 1], v: [u32; 1]) -> [u32; 1] {
     std::mem::replace(r, v)
 }
 
-// CHECK: define noundef i64 @replace_short_array_u32x2(ptr noalias noundef align 4 dereferenceable(8) %r, i64 noundef %0)
+// CHECK: define noundef i64 @replace_short_array_u32x2(ptr {{.*}}, i64 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_short_array_u32x2(r: &mut [u32; 2], v: [u32; 2]) -> [u32; 2] {
     std::mem::replace(r, v)
 }
 
-// CHECK: define noundef i16 @replace_short_array_u16x1(ptr noalias noundef align 2 dereferenceable(2) %r, i16 noundef %0)
+// CHECK: define noundef i16 @replace_short_array_u16x1(ptr {{.*}}, i16 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_short_array_u16x1(r: &mut [u16; 1], v: [u16; 1]) -> [u16; 1] {
     std::mem::replace(r, v)
 }
 
-// CHECK: define noundef i32 @replace_short_array_u16x2(ptr noalias noundef align 2 dereferenceable(4) %r, i32 noundef %0)
+// CHECK: define noundef i32 @replace_short_array_u16x2(ptr {{.*}}, i32 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_short_array_u16x2(r: &mut [u16; 2], v: [u16; 2]) -> [u16; 2] {
     std::mem::replace(r, v)
 }
 
-// CHECK: define noundef i48 @replace_short_array_u16x3(ptr noalias noundef align 2 dereferenceable(6) %r, i48 noundef %0)
+// CHECK: define noundef i48 @replace_short_array_u16x3(ptr {{.*}}, i48 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_short_array_u16x3(r: &mut [u16; 3], v: [u16; 3]) -> [u16; 3] {
     std::mem::replace(r, v)
 }
 
-// CHECK: define noundef i64 @replace_short_array_u16x4(ptr noalias noundef align 2 dereferenceable(8) %r, i64 noundef %0)
+// CHECK: define noundef i64 @replace_short_array_u16x4(ptr {{.*}}, i64 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_short_array_u16x4(r: &mut [u16; 4], v: [u16; 4]) -> [u16; 4] {
     std::mem::replace(r, v)
 }
 
-// CHECK: define noundef i8 @replace_short_array_u8x1(ptr noalias noundef align 1 dereferenceable(1) %r, i8 noundef %0)
+// CHECK: define noundef i8 @replace_short_array_u8x1(ptr {{.*}}, i8 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_short_array_u8x1(r: &mut [u8; 1], v: [u8; 1]) -> [u8; 1] {
     std::mem::replace(r, v)
 }
 
-// CHECK: define noundef i16 @replace_short_array_u8x2(ptr noalias noundef align 1 dereferenceable(2) %r, i16 noundef %0)
+// CHECK: define noundef i16 @replace_short_array_u8x2(ptr {{.*}}, i16 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_short_array_u8x2(r: &mut [u8; 2], v: [u8; 2]) -> [u8; 2] {
     std::mem::replace(r, v)
 }
 
-// CHECK: define noundef i24 @replace_short_array_u8x3(ptr noalias noundef align 1 dereferenceable(3) %r, i24 noundef %0)
+// CHECK: define noundef i24 @replace_short_array_u8x3(ptr {{.*}}, i24 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_short_array_u8x3(r: &mut [u8; 3], v: [u8; 3]) -> [u8; 3] {
     std::mem::replace(r, v)
 }
 
-// CHECK: define noundef i64 @replace_short_array_u8x8(ptr noalias noundef align 1 dereferenceable(8) %r, i64 noundef %0)
+// CHECK: define noundef i64 @replace_short_array_u8x8(ptr {{.*}}, i64 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_short_array_u8x8(r: &mut [u8; 8], v: [u8; 8]) -> [u8; 8] {
     std::mem::replace(r, v)
@@ -77,7 +77,7 @@ pub fn replace_short_array_u8x8(r: &mut [u8; 8], v: [u8; 8]) -> [u8; 8] {
 #[repr(transparent)]
 pub struct Foo([u8; 4]);
 
-// CHECK: define noundef i32 @replace_repr_transparent_struct_short_array(ptr noalias noundef align 1 dereferenceable(4) %r, i32 noundef %0)
+// CHECK: define noundef i32 @replace_repr_transparent_struct_short_array(ptr {{.*}}, i32 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_repr_transparent_struct_short_array(r: &mut Foo, v: Foo) -> Foo {
     std::mem::replace(r, v)
@@ -88,8 +88,23 @@ pub enum Bar {
     Default([u8; 4])
 }
 
-// CHECK: define noundef i32 @replace_repr_transparent_enum_short_array(ptr noalias noundef align 1 dereferenceable(4) %r, i32 noundef %0)
+// CHECK: define noundef i32 @replace_repr_transparent_enum_short_array(ptr {{.*}}, i32 noundef %{{.*}})
 #[no_mangle]
 pub fn replace_repr_transparent_enum_short_array(r: &mut Bar, v: Bar) -> Bar {
+    std::mem::replace(r, v)
+}
+
+#[repr(transparent)]
+pub struct Owo([u8; 4]);
+
+#[repr(transparent)]
+pub struct Uwu(Owo);
+
+#[repr(transparent)]
+pub struct Oowoo(Uwu);
+
+// CHECK: define noundef i32 @replace_repr_transparent_nested_struct_short_array(ptr {{.*}}, i32 noundef %{{.*}})
+#[no_mangle]
+pub fn replace_repr_transparent_nested_struct_short_array(r: &mut Oowoo, v: Oowoo) -> Oowoo {
     std::mem::replace(r, v)
 }

--- a/tests/codegen/union-abi.rs
+++ b/tests/codegen/union-abi.rs
@@ -54,7 +54,7 @@ pub fn test_UnionF32F32(_: UnionF32F32) -> UnionF32F32 { loop {} }
 
 pub union UnionF32U32{a:f32, b:u32}
 
-// CHECK: define noundef {{(dso_local )?}}i32 @test_UnionF32U32(i32 noundef{{( %0)?}})
+// CHECK: define {{(dso_local )?}}i32 @test_UnionF32U32(i32{{( %0)?}})
 #[no_mangle]
 pub fn test_UnionF32U32(_: UnionF32U32) -> UnionF32U32 { loop {} }
 

--- a/tests/codegen/union-abi.rs
+++ b/tests/codegen/union-abi.rs
@@ -54,7 +54,7 @@ pub fn test_UnionF32F32(_: UnionF32F32) -> UnionF32F32 { loop {} }
 
 pub union UnionF32U32{a:f32, b:u32}
 
-// CHECK: define {{(dso_local )?}}i32 @test_UnionF32U32(i32{{( %0)?}})
+// CHECK: define noundef {{(dso_local )?}}i32 @test_UnionF32U32(i32 noundef{{( %0)?}})
 #[no_mangle]
 pub fn test_UnionF32U32(_: UnionF32U32) -> UnionF32U32 { loop {} }
 


### PR DESCRIPTION
`noundef` is only added if the small array immediate fits in the target pointer size and if optimizations are enabled.

Closes #123183.