### PR TITLE
Fix incorrect 'llvm_target' value used on watchOS target

### DIFF
--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -359,6 +359,11 @@ fn watchos_deployment_target() -> (u32, u32) {
     from_set_deployment_target("WATCHOS_DEPLOYMENT_TARGET").unwrap_or((5, 0))
 }
 
+pub fn watchos_llvm_target(arch: Arch) -> String {
+    let (major, minor) = watchos_deployment_target();
+    format!("{}-apple-watchos{}.{}.0", arch.target_name(), major, minor)
+}
+
 pub fn watchos_sim_llvm_target(arch: Arch) -> String {
     let (major, minor) = watchos_deployment_target();
     format!("{}-apple-watchos{}.{}.0-simulator", arch.target_name(), major, minor)

--- a/compiler/rustc_target/src/spec/targets/arm64_32_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/targets/arm64_32_apple_watchos.rs
@@ -1,10 +1,11 @@
-use crate::spec::base::apple::{opts, Arch};
+use crate::spec::base::apple::{opts, watchos_llvm_target, Arch};
 use crate::spec::{Target, TargetOptions};
 
 pub fn target() -> Target {
-    let base = opts("watchos", Arch::Arm64_32);
+    let arch = Arch::Arm64_32;
+    let base = opts("watchos", arch);
     Target {
-        llvm_target: "arm64_32-apple-watchos".into(),
+        llvm_target: watchos_llvm_target(arch).into(),
         metadata: crate::spec::TargetMetadata {
             description: None,
             tier: None,


### PR DESCRIPTION
## Issue

`xcodebuild -create-xcframework` command doesn't recognize static libraries that are built on "arm64_32-apple-watchos" target.

Here are steps to reproduce the issue on a Mac:
1. Install nightly toolchain `nightly-2024-03-27`. Needs this specific version, because newer nightly versions are broken on watchos target.
1. Create an empty library: `mkdir watchos-lib && cd watchos-lib && cargo init --lib`.
1. Add configuration `lib.crate-type=["staticlib"]` to Cargo.toml.
1. Build the library: `cargo +nightly-2024-03-27 build --release -Zbuild-std --target arm64_32-apple-watchos`
1. Run `xcodebuild -create-xcframework` to put the static library into a xcframework, which results in an error:

```
$ xcodebuild -create-xcframework -library target/arm64_32-apple-watchos/release/libwatchos_lib.a -output test.xcframework
error: unable to determine the platform for the given binary '.../watchos-lib/target/arm64_32-apple-watchos/release/libwatchos_lib.a'; check your deployment version settings
```

## Fix

The root cause of this error is `xcodebuild` couldn't read `LC_BUILD_VERSION` from the static library to determine the library's target platform. And the reason it's missing is that an incorrect `llvm_target` value is used in `arm64_32-apple-watchos` target. The expected value is `<arch>-apple-watchos<major>.<minor>.0`, i.e. "arm64_32-apple-watchos8.0.0".

The [.../apple/mod.rs](https://github.com/rust-lang/rust/blob/43f4f2a3b1a3d3fb3dbbbe4fde33fb97c780ee98/compiler/rustc_target/src/spec/base/apple/mod.rs#L321) file contains functions that construct such string. There is an existing function `watchos_sim_llvm_target` which returns llvm target value for watchOS simulator. But there is none for watchOS device. This PR adds that missing function to align watchOS with other Apple platform targets.

To verify the fix, you can simply build a toolchain on this PR branch and repeat the steps above using the built local toolchain to verify the `xcodebuild -create-xcframework` command can create a xcframework successfully.

Furthermore, you can verify `LC_BUILD_VERSION` contains correct info by using the simple shell script below to print `LC_BUILD_VERSION` of the static library that's built on watchos target:

```shell
bin=target/arm64_32-apple-watchos/release/libwatchos_lib.a
file=$(ar -t "$bin" | grep -E '\.o$' | head -n 1)
ar -x "$bin" "$file"
vtool -show-build-version "$file"
```

Here is an example output from my machine:

```
watchos_rust-495d6aaf3bccc08d.watchos_rust.35ba42bf9255ca9d-cgu.0.rcgu.o:
Load command 1
      cmd LC_BUILD_VERSION
  cmdsize 24
 platform WATCHOS
    minos 8.0
      sdk n/a
   ntools 0
```