### PR TITLE
CI: add a script for dynamically computing CI job matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,21 @@ concurrency:
   group: "${{ github.workflow }}-${{ ((github.ref == 'refs/heads/try' || github.ref == 'refs/heads/try-perf') && github.sha) || github.ref }}"
   cancel-in-progress: true
 jobs:
+  calculate_matrix:
+    name: Calculate job matrix
+    runs-on: ubuntu-latest
+    outputs:
+      jobs: "${{ steps.jobs.outputs.jobs }}"
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v4
+      - name: Calculate the CI job matrix
+        run: python3 src/ci/scripts/calculate-job-matrix.py >> $GITHUB_OUTPUT
+        id: jobs
   pr:
     name: "PR - ${{ matrix.name }}"
+    needs:
+      - calculate_matrix
     env:
       PR_CI_JOB: 1
       CI_JOB_NAME: "${{ matrix.name }}"
@@ -51,20 +64,7 @@ jobs:
     continue-on-error: "${{ matrix.name == 'mingw-check-tidy' }}"
     strategy:
       matrix:
-        include:
-          - name: mingw-check
-            os: ubuntu-20.04-4core-16gb
-            env: {}
-          - name: mingw-check-tidy
-            os: ubuntu-20.04-4core-16gb
-            env: {}
-          - name: x86_64-gnu-llvm-17
-            env:
-              ENABLE_GCC_CODEGEN: "1"
-            os: ubuntu-20.04-16core-64gb
-          - name: x86_64-gnu-tools
-            os: ubuntu-20.04-16core-64gb
-            env: {}
+        include: "${{ fromJSON(needs.calculate_matrix.outputs.jobs) }}"
     defaults:
       run:
         shell: "${{ contains(matrix.os, 'windows') && 'msys2 {0}' || 'bash' }}"

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -340,6 +340,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The job matrix for `calculate_matrix` is defined in src/ci/github-actions/jobs.yml.
   calculate_matrix:
     name: Calculate job matrix
     runs-on: ubuntu-latest
@@ -362,6 +363,7 @@ jobs:
     continue-on-error: ${{ matrix.name == 'mingw-check-tidy' }}
     strategy:
       matrix:
+        # Check the `calculate_matrix` job to see how is the matrix defined.
         include: ${{ fromJSON(needs.calculate_matrix.outputs.jobs) }}
 
   auto:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -340,9 +340,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  calculate_matrix:
+    name: Calculate job matrix
+    runs-on: ubuntu-latest
+    outputs:
+      jobs: ${{ steps.jobs.outputs.jobs }}
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v4
+      - name: Calculate the CI job matrix
+        run: python3 src/ci/scripts/calculate-job-matrix.py >> $GITHUB_OUTPUT
+        id: jobs
   pr:
     <<: *base-ci-job
     name: PR - ${{ matrix.name }}
+    needs: [ calculate_matrix ]
     env:
       <<: [*shared-ci-variables, *public-variables]
       PR_CI_JOB: 1
@@ -350,20 +362,7 @@ jobs:
     continue-on-error: ${{ matrix.name == 'mingw-check-tidy' }}
     strategy:
       matrix:
-        include:
-          - name: mingw-check
-            <<: *job-linux-4c
-
-          - name: mingw-check-tidy
-            <<: *job-linux-4c
-
-          - name: x86_64-gnu-llvm-17
-            env:
-              ENABLE_GCC_CODEGEN: "1"
-            <<: *job-linux-16c
-
-          - name: x86_64-gnu-tools
-            <<: *job-linux-16c
+        include: ${{ fromJSON(needs.calculate_matrix.outputs.jobs) }}
 
   auto:
     <<: *base-ci-job

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -1,4 +1,8 @@
-x--expand-yaml-anchors--remove:
+# This file contains definitions of CI job parameters that are loaded
+# dynamically in CI from ci.yml.
+# You *do not* need to re-run `src/tools/expand-yaml-anchors` when you
+# modify this file.
+shared_defs:
   - &base-job
     env: { }
 

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -1,0 +1,46 @@
+x--expand-yaml-anchors--remove:
+  - &base-job
+    env: { }
+
+  - &job-linux-4c
+    os: ubuntu-20.04-4core-16gb
+    <<: *base-job
+
+  - &job-linux-8c
+    os: ubuntu-20.04-8core-32gb
+    <<: *base-job
+
+  - &job-linux-16c
+    os: ubuntu-20.04-16core-64gb
+    <<: *base-job
+
+  - &job-macos-xl
+    os: macos-13 # We use the standard runner for now
+    <<: *base-job
+
+  - &job-macos-m1
+    os: macos-14
+    <<: *base-job
+
+  - &job-windows-8c
+    os: windows-2019-8core-32gb
+    <<: *base-job
+
+  - &job-windows-16c
+    os: windows-2019-16core-64gb
+    <<: *base-job
+
+  - &job-aarch64-linux
+    os: [ self-hosted, ARM64, linux ]
+
+pr:
+  - name: mingw-check
+    <<: *job-linux-4c
+  - name: mingw-check-tidy
+    <<: *job-linux-4c
+  - name: x86_64-gnu-llvm-17
+    env:
+      ENABLE_GCC_CODEGEN: "1"
+    <<: *job-linux-16c
+  - name: x86_64-gnu-tools
+    <<: *job-linux-16c

--- a/src/ci/scripts/calculate-job-matrix.py
+++ b/src/ci/scripts/calculate-job-matrix.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+"""
+This script serves for generating a matrix of jobs that should
+be executed on CI.
+
+It reads job definitions from `src/ci/github-actions/jobs.yml`
+and filters them based on the event that happened on CI.
+
+Currently, it only supports PR builds.
+"""
+
+import json
+from pathlib import Path
+
+import yaml
+
+JOBS_YAML_PATH = Path(__file__).absolute().parent.parent / "github-actions" / "jobs.yml"
+
+
+if __name__ == "__main__":
+    with open(JOBS_YAML_PATH) as f:
+        jobs = yaml.safe_load(f)
+    job_output = jobs["pr"]
+    print(f"jobs={json.dumps(job_output)}")


### PR DESCRIPTION
It would be great if was easier to run specific CI workflows locally, and also to allow us to spawn a specific CI workflow by bors, to enable running arbitrary try builds. See discussion [here](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/CI.20workflows.20refactoring).

This PR is a first step in that direction.
- Moves the definition of CI runners and (for now) PR jobs into a separate `jobs.yml` file.
- Adds a simple Python script that reads the file, decides which jobs should be active for the current CI workflow, and prints them as JSON to their output.
- The PR job then reads this output and generates its job matrix based on it.

By moving the job definitions from `ci.yml` into a separate file, we can handle it programmatically, which should make it easier to both do local execution of CI jobs and also to do arbitrary try builds.