### PR TITLE
MSVC targets should use COFF as their archive format

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -231,7 +231,11 @@ impl<'a> ArArchiveBuilder<'a> {
             "gnu" => ArchiveKind::Gnu,
             "bsd" => ArchiveKind::Bsd,
             "darwin" => ArchiveKind::Darwin,
-            "coff" => ArchiveKind::Coff,
+            "coff" => {
+                // FIXME: ar_archive_writer doesn't support COFF archives yet.
+                // https://github.com/rust-lang/ar_archive_writer/issues/9
+                ArchiveKind::Gnu
+            }
             "aix_big" => ArchiveKind::AixBig,
             kind => {
                 self.sess.dcx().emit_fatal(UnknownArchiveKind { kind });

--- a/compiler/rustc_target/src/spec/base/msvc.rs
+++ b/compiler/rustc_target/src/spec/base/msvc.rs
@@ -14,6 +14,7 @@ pub fn opts() -> TargetOptions {
         pre_link_args,
         abi_return_struct_as_int: true,
         emit_debug_gdb_scripts: false,
+        archive_format: "coff".into(),
 
         // Currently this is the only supported method of debuginfo on MSVC
         // where `*.pdb` files show up next to the final artifact.


### PR DESCRIPTION
While adding support for Arm64EC I ran into an issue where the standard library's rlib was missing the "EC Symbol Table" which is required for the MSVC linker to find import library symbols (generated by Rust's `raw-dylib` feature) when building for EC.

The root cause of the issue is that LLVM only generated symbol tables (including the EC Symbol Table) if the `ArchiveKind` is `COFF`, but the MSVC targets didn't set their archive format, so it was defaulting to GNU.