### PR TITLE
remove miri jobserver workaround

### DIFF
--- a/src/tools/miri/cargo-miri/src/phases.rs
+++ b/src/tools/miri/cargo-miri/src/phases.rs
@@ -519,13 +519,6 @@ pub fn phase_runner(mut binary_args: impl Iterator<Item = String>, phase: Runner
     // Set missing env vars. We prefer build-time env vars over run-time ones; see
     // <https://github.com/rust-lang/miri/issues/1661> for the kind of issue that fixes.
     for (name, val) in info.env {
-        // `CARGO_MAKEFLAGS` contains information about how to reach the jobserver, but by the time
-        // the program is being run, that jobserver no longer exists (cargo only runs the jobserver
-        // for the build portion of `cargo run`/`cargo test`). Hence we shouldn't forward this.
-        // Also see <https://github.com/rust-lang/rust/pull/113730>.
-        if name == "CARGO_MAKEFLAGS" {
-            continue;
-        }
         if let Some(old_val) = env::var_os(&name) {
             if old_val == val {
                 // This one did not actually change, no need to re-set it.


### PR DESCRIPTION
This PR removes workaround, added in #113730, ~~since jobserver is kept after [rust-lang/cargo#12776](https://github.com/rust-lang/cargo/pull/12776)~~