### PR TITLE
Check def id before calling `match_projection_projections`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -793,6 +793,9 @@ fn assemble_candidates_from_trait_def<'cx, 'tcx>(
             let Some(clause) = clause.as_projection_clause() else {
                 return ControlFlow::Continue(());
             };
+            if clause.projection_def_id() != obligation.predicate.def_id {
+                return ControlFlow::Continue(());
+            }
 
             let is_match =
                 selcx.infcx.probe(|_| selcx.match_projection_projections(obligation, clause, true));

--- a/tests/ui/traits/make-sure-to-filter-projections-by-def-id.rs
+++ b/tests/ui/traits/make-sure-to-filter-projections-by-def-id.rs
@@ -1,0 +1,38 @@
+//@ check-pass
+
+#![recursion_limit = "1024"]
+// Really high recursion limit ^
+
+// Test that ensures we're filtering projections by def id before matching
+// them in `match_projection_projections`.
+
+use std::ops::{Add, Sub};
+
+pub trait Scalar {}
+
+pub trait VectorCommon: Sized {
+    type T: Scalar;
+}
+
+pub trait VectorOpsByValue<Rhs = Self, Output = Self>:
+    VectorCommon + Add<Rhs, Output = Output> + Sub<Rhs, Output = Output>
+{
+}
+
+pub trait VectorView<'a>:
+    VectorOpsByValue<Self, Self::Owned> + VectorOpsByValue<Self::Owned, Self::Owned>
+{
+    type Owned;
+}
+
+pub trait Vector: VectorOpsByValue<Self> + for<'a> VectorOpsByValue<Self::View<'a>> {
+    type View<'a>: VectorView<'a, T = Self::T, Owned = Self>
+    where
+        Self: 'a;
+}
+
+pub trait MatrixCommon {
+    type V: Vector;
+}
+
+fn main() {}


### PR DESCRIPTION
When I "inlined" `assemble_candidates_from_predicates` into `for_each_item_bound` in #120584, I forgot to copy over the check that actually made sure the def id of the candidate was equal to the def id of the obligation. This means that we normalize goal a bit too often even if it's not productive to do so.

This PR adds that def id check back.
Fixes #123448