### PR TITLE
std::net: adding `unix_socket_exclbind` feature for solaris/illumos.

### DIFF
--- a/library/std/src/os/illumos/mod.rs
+++ b/library/std/src/os/illumos/mod.rs
@@ -3,4 +3,5 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod fs;
+pub mod net;
 pub mod raw;

--- a/library/std/src/os/illumos/net.rs
+++ b/library/std/src/os/illumos/net.rs
@@ -1,0 +1,50 @@
+//! illumos-specific networking functionality.
+
+#![unstable(feature = "unix_socket_exclbind", issue = "123481")]
+
+use crate::io;
+use crate::os::unix::net;
+use crate::sealed::Sealed;
+use crate::sys_common::AsInner;
+
+/// illumos-specific functionality for `AF_UNIX` sockets [`UnixDatagram`]
+/// and [`UnixStream`].
+///
+/// [`UnixDatagram`]: net::UnixDatagram
+/// [`UnixStream`]: net::UnixStream
+#[unstable(feature = "unix_socket_exclbind", issue = "123481")]
+pub trait UnixSocketExt: Sealed {
+    /// Enables exclusive binding on the socket.
+    ///
+    /// If true and if the socket had been set with `SO_REUSEADDR`,
+    /// it neutralises its effect.
+    /// See [`man 3 tcp`](https://docs.oracle.com/cd/E88353_01/html/E37843/setsockopt-3c.html)
+    #[unstable(feature = "unix_socket_exclbind", issue = "123481")]
+    fn so_exclbind(&self, excl: bool) -> io::Result<()>;
+
+    /// Get the bind exclusivity bind state of the socket.
+    #[unstable(feature = "unix_socket_exclbind", issue = "123481")]
+    fn exclbind(&self) -> io::Result<bool>;
+}
+
+#[unstable(feature = "unix_socket_exclbind", issue = "123481")]
+impl UnixSocketExt for net::UnixDatagram {
+    fn exclbind(&self) -> io::Result<bool> {
+        self.as_inner().exclbind()
+    }
+
+    fn so_exclbind(&self, excl: bool) -> io::Result<()> {
+        self.as_inner().set_exclbind(excl)
+    }
+}
+
+#[unstable(feature = "unix_socket_exclbind", issue = "123481")]
+impl UnixSocketExt for net::UnixStream {
+    fn exclbind(&self) -> io::Result<bool> {
+        self.as_inner().exclbind()
+    }
+
+    fn so_exclbind(&self, excl: bool) -> io::Result<()> {
+        self.as_inner().set_exclbind(excl)
+    }
+}

--- a/library/std/src/os/solaris/mod.rs
+++ b/library/std/src/os/solaris/mod.rs
@@ -3,4 +3,5 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod fs;
+pub mod net;
 pub mod raw;

--- a/library/std/src/os/solaris/net.rs
+++ b/library/std/src/os/solaris/net.rs
@@ -1,0 +1,50 @@
+//! solaris-specific networking functionality.
+
+#![unstable(feature = "unix_socket_exclbind", issue = "123481")]
+
+use crate::io;
+use crate::os::unix::net;
+use crate::sealed::Sealed;
+use crate::sys_common::AsInner;
+
+/// solaris-specific functionality for `AF_UNIX` sockets [`UnixDatagram`]
+/// and [`UnixStream`].
+///
+/// [`UnixDatagram`]: net::UnixDatagram
+/// [`UnixStream`]: net::UnixStream
+#[unstable(feature = "unix_socket_exclbind", issue = "123481")]
+pub trait UnixSocketExt: Sealed {
+    /// Enables exclusive binding on the socket.
+    ///
+    /// If true and if the socket had been set with `SO_REUSEADDR`,
+    /// it neutralises its effect.
+    /// See [`man 3 tcp`](https://docs.oracle.com/cd/E88353_01/html/E37843/setsockopt-3c.html)
+    #[unstable(feature = "unix_socket_exclbind", issue = "123481")]
+    fn so_exclbind(&self, excl: bool) -> io::Result<()>;
+
+    /// Get the bind exclusivity bind state of the socket.
+    #[unstable(feature = "unix_socket_exclbind", issue = "123481")]
+    fn exclbind(&self) -> io::Result<bool>;
+}
+
+#[unstable(feature = "unix_socket_exclbind", issue = "123481")]
+impl UnixSocketExt for net::UnixDatagram {
+    fn exclbind(&self) -> io::Result<bool> {
+        self.as_inner().exclbind()
+    }
+
+    fn so_exclbind(&self, excl: bool) -> io::Result<()> {
+        self.as_inner().set_exclbind(excl)
+    }
+}
+
+#[unstable(feature = "unix_socket_exclbind", issue = "123481")]
+impl UnixSocketExt for net::UnixStream {
+    fn exclbind(&self) -> io::Result<bool> {
+        self.as_inner().exclbind()
+    }
+
+    fn so_exclbind(&self, excl: bool) -> io::Result<()> {
+        self.as_inner().set_exclbind(excl)
+    }
+}

--- a/library/std/src/sys/net/connection/socket/unix.rs
+++ b/library/std/src/sys/net/connection/socket/unix.rs
@@ -514,6 +514,21 @@ impl Socket {
         Ok(name)
     }
 
+    #[cfg(any(target_os = "solaris", target_os = "illumos"))]
+    pub fn set_exclbind(&self, excl: bool) -> io::Result<()> {
+        // not yet on libc crate
+        const SO_EXCLBIND: i32 = 0x1015;
+        setsockopt(self, libc::SOL_SOCKET, SO_EXCLBIND, excl)
+    }
+
+    #[cfg(any(target_os = "solaris", target_os = "illumos"))]
+    pub fn exclbind(&self) -> io::Result<bool> {
+        // not yet on libc crate
+        const SO_EXCLBIND: i32 = 0x1015;
+        let raw: c_int = getsockopt(self, libc::SOL_SOCKET, SO_EXCLBIND)?;
+        Ok(raw != 0)
+    }
+
     #[cfg(any(target_os = "android", target_os = "linux",))]
     pub fn set_passcred(&self, passcred: bool) -> io::Result<()> {
         setsockopt(self, libc::SOL_SOCKET, libc::SO_PASSCRED, passcred as libc::c_int)


### PR DESCRIPTION
allows to have a tigher control over the binding exclusivness of the socket.

ACP: https://github.com/rust-lang/libs-team/issues/366