### PR TITLE
Revert "Use OS thread name by default"

### DIFF
--- a/library/std/src/sys/pal/hermit/thread.rs
+++ b/library/std/src/sys/pal/hermit/thread.rs
@@ -2,7 +2,7 @@
 
 use super::abi;
 use super::thread_local_dtor::run_dtors;
-use crate::ffi::{CStr, CString};
+use crate::ffi::CStr;
 use crate::io;
 use crate::mem;
 use crate::num::NonZero;
@@ -69,10 +69,6 @@ impl Thread {
     #[inline]
     pub fn set_name(_name: &CStr) {
         // nope
-    }
-
-    pub fn get_name() -> Option<CString> {
-        None
     }
 
     #[inline]

--- a/library/std/src/sys/pal/itron/thread.rs
+++ b/library/std/src/sys/pal/itron/thread.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     cell::UnsafeCell,
-    ffi::{CStr, CString},
+    ffi::CStr,
     hint, io,
     mem::ManuallyDrop,
     num::NonZero,
@@ -202,10 +202,6 @@ impl Thread {
 
     pub fn set_name(_name: &CStr) {
         // nope
-    }
-
-    pub fn get_name() -> Option<CString> {
-        None
     }
 
     pub fn sleep(dur: Duration) {

--- a/library/std/src/sys/pal/sgx/thread.rs
+++ b/library/std/src/sys/pal/sgx/thread.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(test, allow(dead_code))] // why is this necessary?
 use super::unsupported;
-use crate::ffi::{CStr, CString};
+use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZero;
 use crate::time::Duration;
@@ -131,10 +131,6 @@ impl Thread {
         // by the platform-agnostic (target-agnostic) Rust thread code.
         // This can be observed in the [`std::thread::tests::test_named_thread`] test,
         // which succeeds as-is with the SGX target.
-    }
-
-    pub fn get_name() -> Option<CString> {
-        None
     }
 
     pub fn sleep(dur: Duration) {

--- a/library/std/src/sys/pal/teeos/thread.rs
+++ b/library/std/src/sys/pal/teeos/thread.rs
@@ -1,7 +1,7 @@
 use core::convert::TryInto;
 
 use crate::cmp;
-use crate::ffi::{CStr, CString};
+use crate::ffi::CStr;
 use crate::io;
 use crate::mem;
 use crate::num::NonZero;
@@ -99,10 +99,6 @@ impl Thread {
         // Both pthread_setname_np and prctl are not available to the TA,
         // so we can't implement this currently. If the need arises please
         // contact the teeos rustzone team.
-    }
-
-    pub fn get_name() -> Option<CString> {
-        None
     }
 
     /// only main thread could wait for sometime in teeos

--- a/library/std/src/sys/pal/uefi/thread.rs
+++ b/library/std/src/sys/pal/uefi/thread.rs
@@ -1,5 +1,5 @@
 use super::unsupported;
-use crate::ffi::{CStr, CString};
+use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZero;
 use crate::ptr::NonNull;
@@ -21,10 +21,6 @@ impl Thread {
 
     pub fn set_name(_name: &CStr) {
         // nope
-    }
-
-    pub fn get_name() -> Option<CString> {
-        None
     }
 
     pub fn sleep(dur: Duration) {

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -1,5 +1,5 @@
 use crate::cmp;
-use crate::ffi::{CStr, CString};
+use crate::ffi::CStr;
 use crate::io;
 use crate::mem;
 use crate::num::NonZero;
@@ -226,78 +226,6 @@ impl Thread {
     ))]
     pub fn set_name(_name: &CStr) {
         // Newlib, Emscripten, and VxWorks have no way to set a thread name.
-    }
-
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "solaris",
-        target_os = "illumos"
-    ))]
-    pub fn get_name() -> Option<CString> {
-        #[cfg(target_os = "linux")]
-        const TASK_COMM_LEN: usize = 16;
-        #[cfg(target_os = "freebsd")]
-        const TASK_COMM_LEN: usize = libc::MAXCOMLEN + 1;
-        #[cfg(any(target_os = "netbsd", target_os = "solaris", target_os = "illumos"))]
-        const TASK_COMM_LEN: usize = 32;
-        let mut name = vec![0u8; TASK_COMM_LEN];
-        let res = unsafe {
-            libc::pthread_getname_np(libc::pthread_self(), name.as_mut_ptr().cast(), name.len())
-        };
-        if res != 0 {
-            return None;
-        }
-        name.truncate(name.iter().position(|&c| c == 0)?);
-        CString::new(name).ok()
-    }
-
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
-    pub fn get_name() -> Option<CString> {
-        let mut name = vec![0u8; libc::MAXTHREADNAMESIZE];
-        let res = unsafe {
-            libc::pthread_getname_np(libc::pthread_self(), name.as_mut_ptr().cast(), name.len())
-        };
-        if res != 0 {
-            return None;
-        }
-        name.truncate(name.iter().position(|&c| c == 0)?);
-        CString::new(name).ok()
-    }
-
-    #[cfg(target_os = "haiku")]
-    pub fn get_name() -> Option<CString> {
-        unsafe {
-            let mut tinfo = mem::MaybeUninit::<libc::thread_info>::uninit();
-            // See BeOS teams group and threads api.
-            // https://www.haiku-os.org/legacy-docs/bebook/TheKernelKit_ThreadsAndTeams_Overview.html
-            let thread_self = libc::find_thread(ptr::null_mut());
-            let res = libc::get_thread_info(thread_self, tinfo.as_mut_ptr());
-            if res != libc::B_OK {
-                return None;
-            }
-            let info = tinfo.assume_init();
-            let name =
-                core::slice::from_raw_parts(info.name.as_ptr() as *const u8, info.name.len());
-            CStr::from_bytes_until_nul(name).map(CStr::to_owned).ok()
-        }
-    }
-
-    #[cfg(not(any(
-        target_os = "linux",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos",
-        target_os = "haiku",
-        target_os = "solaris",
-        target_os = "illumos"
-    )))]
-    pub fn get_name() -> Option<CString> {
-        None
     }
 
     #[cfg(not(target_os = "espidf"))]

--- a/library/std/src/sys/pal/unsupported/thread.rs
+++ b/library/std/src/sys/pal/unsupported/thread.rs
@@ -1,5 +1,5 @@
 use super::unsupported;
-use crate::ffi::{CStr, CString};
+use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZero;
 use crate::time::Duration;
@@ -20,10 +20,6 @@ impl Thread {
 
     pub fn set_name(_name: &CStr) {
         // nope
-    }
-
-    pub fn get_name() -> Option<CString> {
-        None
     }
 
     pub fn sleep(_dur: Duration) {

--- a/library/std/src/sys/pal/wasi/thread.rs
+++ b/library/std/src/sys/pal/wasi/thread.rs
@@ -1,4 +1,4 @@
-use crate::ffi::{CStr, CString};
+use crate::ffi::CStr;
 use crate::io;
 use crate::mem;
 use crate::num::NonZero;
@@ -132,10 +132,6 @@ impl Thread {
 
     pub fn set_name(_name: &CStr) {
         // nope
-    }
-
-    pub fn get_name() -> Option<CString> {
-        None
     }
 
     pub fn sleep(dur: Duration) {

--- a/library/std/src/sys/pal/wasm/atomics/thread.rs
+++ b/library/std/src/sys/pal/wasm/atomics/thread.rs
@@ -1,5 +1,4 @@
 use crate::ffi::CStr;
-use crate::ffi::CString;
 use crate::io;
 use crate::num::NonZero;
 use crate::sys::unsupported;
@@ -18,9 +17,6 @@ impl Thread {
     pub fn yield_now() {}
 
     pub fn set_name(_name: &CStr) {}
-    pub fn get_name() -> Option<CString> {
-        None
-    }
 
     pub fn sleep(dur: Duration) {
         use crate::arch::wasm32;

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -9,7 +9,6 @@ use crate::sys::handle::Handle;
 use crate::sys::stack_overflow;
 use crate::sys_common::FromInner;
 use crate::time::Duration;
-use alloc::ffi::CString;
 use core::ffi::c_void;
 
 use super::time::WaitableTimer;
@@ -65,29 +64,6 @@ impl Thread {
                 };
             };
         };
-    }
-
-    pub fn get_name() -> Option<CString> {
-        unsafe {
-            let mut ptr = core::ptr::null_mut();
-            let result = c::GetThreadDescription(c::GetCurrentThread(), &mut ptr);
-            if result < 0 {
-                return None;
-            }
-            let name = String::from_utf16_lossy({
-                let mut len = 0;
-                while *ptr.add(len) != 0 {
-                    len += 1;
-                }
-                core::slice::from_raw_parts(ptr, len)
-            })
-            .into_bytes();
-            // Attempt to free the memory.
-            // This should never fail but if it does then there's not much we can do about it.
-            let result = c::LocalFree(ptr.cast::<c_void>());
-            debug_assert!(result.is_null());
-            if name.is_empty() { None } else { Some(CString::from_vec_unchecked(name)) }
-        }
     }
 
     pub fn join(self) {

--- a/library/std/src/sys/pal/xous/thread.rs
+++ b/library/std/src/sys/pal/xous/thread.rs
@@ -1,4 +1,4 @@
-use crate::ffi::{CStr, CString};
+use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZero;
 use crate::os::xous::ffi::{
@@ -111,10 +111,6 @@ impl Thread {
 
     pub fn set_name(_name: &CStr) {
         // nope
-    }
-
-    pub fn get_name() -> Option<CString> {
-        None
     }
 
     pub fn sleep(dur: Duration) {

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -694,9 +694,7 @@ pub(crate) fn set_current(thread: Thread) {
 /// In contrast to the public `current` function, this will not panic if called
 /// from inside a TLS destructor.
 pub(crate) fn try_current() -> Option<Thread> {
-    CURRENT
-        .try_with(|current| current.get_or_init(|| Thread::new(imp::Thread::get_name())).clone())
-        .ok()
+    CURRENT.try_with(|current| current.get_or_init(|| Thread::new(None)).clone()).ok()
 }
 
 /// Gets a handle to the thread that invokes it.

--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -69,26 +69,6 @@ fn test_named_thread_truncation() {
     result.unwrap().join().unwrap();
 }
 
-#[cfg(any(
-    all(target_os = "windows", not(target_vendor = "win7")),
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "tvos",
-    target_os = "watchos"
-))]
-#[test]
-fn test_get_os_named_thread() {
-    use crate::sys::thread::Thread;
-    // Spawn a new thread to avoid interfering with other tests running on this thread.
-    let handler = thread::spawn(|| {
-        let name = c"test me please";
-        Thread::set_name(name);
-        assert_eq!(name, Thread::get_name().unwrap().as_c_str());
-    });
-    handler.join().unwrap();
-}
-
 #[test]
 #[should_panic]
 fn test_invalid_named_thread() {


### PR DESCRIPTION
This reverts #121666 (Use the OS thread name by default if `THREAD_INFO` has not been initialized) due to #123495 (Thread names are not always valid UTF-8).

It's not a direct revert because there have been other changes since that PR.