### PR TITLE
Edition 2024: Make `!` fall back to `!`

### DIFF
--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -18,12 +18,12 @@ use rustc_span::{def_id::LocalDefId, Span};
 #[derive(Copy, Clone)]
 pub enum DivergingFallbackBehavior {
     /// Always fallback to `()` (aka "always spontaneous decay")
-    FallbackToUnit,
+    ToUnit,
     /// Sometimes fallback to `!`, but mainly fallback to `()` so that most of the crates are not broken.
-    FallbackToNiko,
+    ContextDependent,
     /// Always fallback to `!` (which should be equivalent to never falling back + not making
     /// never-to-any coercions unless necessary)
-    FallbackToNever,
+    ToNever,
     /// Don't fallback at all
     NoFallback,
 }
@@ -403,13 +403,12 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
                 diverging_fallback.insert(diverging_ty, ty);
             };
 
-            use DivergingFallbackBehavior::*;
             match behavior {
-                FallbackToUnit => {
+                DivergingFallbackBehavior::ToUnit => {
                     debug!("fallback to () - legacy: {:?}", diverging_vid);
                     fallback_to(self.tcx.types.unit);
                 }
-                FallbackToNiko => {
+                DivergingFallbackBehavior::ContextDependent => {
                     if found_infer_var_info.self_in_trait && found_infer_var_info.output {
                         // This case falls back to () to ensure that the code pattern in
                         // tests/ui/never_type/fallback-closure-ret.rs continues to
@@ -445,14 +444,14 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
                         fallback_to(self.tcx.types.never);
                     }
                 }
-                FallbackToNever => {
+                DivergingFallbackBehavior::ToNever => {
                     debug!(
                         "fallback to ! - `rustc_never_type_mode = \"fallback_to_never\")`: {:?}",
                         diverging_vid
                     );
                     fallback_to(self.tcx.types.never);
                 }
-                NoFallback => {
+                DivergingFallbackBehavior::NoFallback => {
                     debug!(
                         "no fallback - `rustc_never_type_mode = \"no_fallback\"`: {:?}",
                         diverging_vid

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -392,6 +392,11 @@ fn never_type_behavior(tcx: TyCtxt<'_>) -> (DivergingFallbackBehavior, Diverging
 fn default_fallback(tcx: TyCtxt<'_>) -> DivergingFallbackBehavior {
     use DivergingFallbackBehavior::*;
 
+    // Edition 2024: fallback to `!`
+    if tcx.sess.edition().at_least_rust_2024() {
+        return FallbackToNever;
+    }
+
     // `feature(never_type_fallback)`: fallback to `!` or `()` trying to not break stuff
     if tcx.features().never_type_fallback {
         return FallbackToNiko;

--- a/tests/ui/editions/never-type-fallback-breaking.e2024.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2024.stderr
@@ -1,0 +1,26 @@
+error[E0277]: the trait bound `!: Default` is not satisfied
+  --> $DIR/never-type-fallback-breaking.rs:17:17
+   |
+LL |         true => Default::default(),
+   |                 ^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `!`
+   |
+   = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
+   = help: did you intend to use the type `()` here instead?
+
+error[E0277]: the trait bound `!: Default` is not satisfied
+  --> $DIR/never-type-fallback-breaking.rs:30:5
+   |
+LL |     deserialize()?;
+   |     ^^^^^^^^^^^^^ the trait `Default` is not implemented for `!`
+   |
+   = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
+   = help: did you intend to use the type `()` here instead?
+note: required by a bound in `deserialize`
+  --> $DIR/never-type-fallback-breaking.rs:26:23
+   |
+LL |     fn deserialize<T: Default>() -> Option<T> {
+   |                       ^^^^^^^ required by this bound in `deserialize`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/editions/never-type-fallback-breaking.rs
+++ b/tests/ui/editions/never-type-fallback-breaking.rs
@@ -1,0 +1,34 @@
+//@ revisions: e2021 e2024
+//
+//@[e2021] edition: 2021
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//
+//@[e2021] run-pass
+//@[e2024] check-fail
+
+fn main() {
+    m();
+    q();
+}
+
+fn m() {
+    let x = match true {
+        true => Default::default(),
+        //[e2024]~^ error: the trait bound `!: Default` is not satisfied
+        false => panic!("..."),
+    };
+
+    dbg!(x);
+}
+
+fn q() -> Option<()> {
+    fn deserialize<T: Default>() -> Option<T> {
+        Some(T::default())
+    }
+
+    deserialize()?;
+    //[e2024]~^ error: the trait bound `!: Default` is not satisfied
+
+    None
+}

--- a/tests/ui/editions/never-type-fallback.e2021.run.stdout
+++ b/tests/ui/editions/never-type-fallback.e2021.run.stdout
@@ -1,0 +1,1 @@
+return type = ()

--- a/tests/ui/editions/never-type-fallback.e2024.run.stdout
+++ b/tests/ui/editions/never-type-fallback.e2024.run.stdout
@@ -1,0 +1,1 @@
+return type = !

--- a/tests/ui/editions/never-type-fallback.rs
+++ b/tests/ui/editions/never-type-fallback.rs
@@ -1,0 +1,16 @@
+//@ revisions: e2021 e2024
+//
+//@[e2021] edition: 2021
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//
+//@ run-pass
+//@ check-run-results
+
+fn main() {
+    print_return_type_of(|| panic!());
+}
+
+fn print_return_type_of<R>(_: impl FnOnce() -> R) {
+    println!("return type = {}", std::any::type_name::<R>());
+}

--- a/tests/ui/never_type/from_infer_breaking_with_unit_fallback.rs
+++ b/tests/ui/never_type/from_infer_breaking_with_unit_fallback.rs
@@ -1,0 +1,29 @@
+// issue: rust-lang/rust#66757
+//
+// This is a *minimization* of the issue.
+// Note that the original version with the `?` does not fail anymore even with fallback to unit,
+// see `tests/ui/never_type/question_mark_from_never.rs`.
+//
+//@ revisions: unit never
+//@[never] check-pass
+#![allow(internal_features)]
+#![feature(rustc_attrs, never_type)]
+#![cfg_attr(unit, rustc_never_type_options(fallback = "unit"))]
+#![cfg_attr(never, rustc_never_type_options(fallback = "never"))]
+
+struct E;
+
+impl From<!> for E {
+    fn from(_: !) -> E {
+        E
+    }
+}
+
+#[allow(unreachable_code)]
+fn foo(never: !) {
+    <E as From<!>>::from(never); // Ok
+    <E as From<_>>::from(never); // Should the inference fail?
+    //[unit]~^ error: the trait bound `E: From<()>` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/never_type/from_infer_breaking_with_unit_fallback.unit.stderr
+++ b/tests/ui/never_type/from_infer_breaking_with_unit_fallback.unit.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `E: From<()>` is not satisfied
+  --> $DIR/from_infer_breaking_with_unit_fallback.rs:25:6
+   |
+LL |     <E as From<_>>::from(never); // Should the inference fail?
+   |      ^ the trait `From<()>` is not implemented for `E`
+   |
+   = help: the trait `From<!>` is implemented for `E`
+   = help: for that trait implementation, expected `!`, found `()`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/never_type/question_mark_from_never.rs
+++ b/tests/ui/never_type/question_mark_from_never.rs
@@ -1,0 +1,46 @@
+// issue: rust-lang/rust#66757
+//
+// See also: `tests/ui/never_type/from_infer_breaking_with_unit_fallback.rs`.
+//
+//@ revisions: unit never
+//@ check-pass
+#![allow(internal_features)]
+#![feature(rustc_attrs, never_type)]
+#![cfg_attr(unit, rustc_never_type_options(fallback = "unit"))]
+#![cfg_attr(never, rustc_never_type_options(fallback = "never"))]
+
+type Infallible = !;
+
+struct E;
+
+impl From<Infallible> for E {
+    fn from(_: Infallible) -> E {
+        E
+    }
+}
+
+fn u32_try_from(x: u32) -> Result<u32, Infallible> {
+    Ok(x)
+}
+
+fn _f() -> Result<(), E> {
+    // In an old attempt to make `Infallible = !` this caused a problem.
+    //
+    // Because at the time the code desugared to
+    //
+    //   match u32::try_from(1u32) {
+    //       Ok(x) => x, Err(e) => return Err(E::from(e))
+    //   }
+    //
+    // With `Infallible = !`, `e: !` but with fallback to `()`, `e` in `E::from(e)` decayed to `()`
+    // causing an error.
+    //
+    // This does not happen with `Infallible = !`.
+    // And also does not happen with the newer `?` desugaring that does not pass `e` by value.
+    // (instead we only pass `Result<!, Error>` (where `Error = !` in this case) which does not get
+    // the implicit coercion and thus does not decay even with fallback to unit)
+    u32_try_from(1u32)?;
+    Ok(())
+}
+
+fn main() {}


### PR DESCRIPTION
This PR changes never type fallback to be `!` (the never type itself) in the next, 2024, edition.

This makes the never type's behavior more intuitive (in 2024 edition) and is the first step of the path to stabilize it.

r? @compiler-errors

Tracking:

- https://github.com/rust-lang/rust/issues/123748