### PR TITLE
Use `include` command to reduce code duplication

### DIFF
--- a/tests/rustdoc-gui/anchors.goml
+++ b/tests/rustdoc-gui/anchors.goml
@@ -1,4 +1,5 @@
 // This test is to ensure that the anchors (`§`) have the expected color and position.
+include: "utils.goml"
 
 define-function: (
     "check-colors",
@@ -8,10 +9,7 @@ define-function: (
         // This is needed to ensure that the text color is computed.
         show-text: true
 
-        // Setting the theme.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        // We reload the page so the local storage settings are being used.
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         assert-css: ("#toggle-all-docs", {"color": |main_color|})
         assert-css: (".main-heading h1 a:nth-of-type(1)", {"color": |main_heading_color|})

--- a/tests/rustdoc-gui/code-color.goml
+++ b/tests/rustdoc-gui/code-color.goml
@@ -2,6 +2,7 @@
 // check that the rule isn't applied on other "<code>" elements.
 //
 // While we're at it, we also check it for the other themes.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
 // If the text isn't displayed, the browser doesn't compute color style correctly...
 show-text: true
@@ -10,10 +11,7 @@ define-function: (
     "check-colors",
     [theme, doc_code_color, doc_inline_code_color],
     block {
-        // Set the theme.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        // We reload the page so the local storage settings are being used.
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (".docblock pre > code", {"color": |doc_code_color|}, ALL)
         assert-css: (".docblock > p > code", {"color": |doc_inline_code_color|}, ALL)
     },

--- a/tests/rustdoc-gui/codeblock-tooltip.goml
+++ b/tests/rustdoc-gui/codeblock-tooltip.goml
@@ -1,4 +1,5 @@
 // Checking the colors of the codeblocks tooltips.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
 show-text: true
 
@@ -6,9 +7,7 @@ define-function: (
     "check-colors",
     [theme, background, color, border],
     block {
-        // Setting the theme.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         // compile_fail block
         assert-css: (

--- a/tests/rustdoc-gui/docblock-code-block-line-number.goml
+++ b/tests/rustdoc-gui/docblock-code-block-line-number.goml
@@ -1,4 +1,5 @@
 // Checks that the setting "line numbers" is working as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
 
 // Otherwise, we can't check text color
@@ -13,14 +14,10 @@ define-function: (
     [theme, color],
     block {
         // We now set the setting to show the line numbers on code examples.
-        set-local-storage: {
-            "rustdoc-theme": |theme|,
-            "rustdoc-use-system-theme": "false",
-            "rustdoc-line-numbers": "true"
-        }
-        // We reload to make the line numbers appear and change theme.
-        reload:
-        // We wait for them to be added into the DOM by the JS...
+        set-local-storage: {"rustdoc-line-numbers": "true"}
+        // Page will be reloaded in "switch-theme".
+        call-function: ("switch-theme", {"theme": |theme|})
+        // We wait for the line numbers to be added into the DOM by the JS...
         wait-for: "pre.example-line-numbers"
         // If the test didn't fail, it means that it was found!
         assert-css: (

--- a/tests/rustdoc-gui/docblock-details.goml
+++ b/tests/rustdoc-gui/docblock-details.goml
@@ -1,8 +1,8 @@
 // This ensures that the `<details>`/`<summary>` elements are displayed as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/details/struct.Details.html"
 show-text: true
-set-local-storage: {"rustdoc-theme": "dark", "rustdoc-use-system-theme": "false"}
-reload:
+call-function: ("switch-theme", {"theme": "dark"})
 
 // We first check that the headers in the `.top-doc` doc block still have their
 // bottom border.

--- a/tests/rustdoc-gui/docblock-table.goml
+++ b/tests/rustdoc-gui/docblock-table.goml
@@ -1,4 +1,5 @@
 // This test checks the appearance of the tables in the doc comments.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/doc_block_table/struct.DocBlockTable.html#method.func"
 
 compare-elements-css: (".impl-items .docblock table th", ".top-doc .docblock table th", ["border"])
@@ -8,8 +9,7 @@ define-function: (
     "check-colors",
     [theme, border_color, zebra_stripe_color],
     block {
-        set-local-storage: {"rustdoc-use-system-theme": "false", "rustdoc-theme": |theme|}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (".top-doc .docblock table tbody tr:nth-child(1)", {
             "background-color": "rgba(0, 0, 0, 0)",
         })

--- a/tests/rustdoc-gui/headers-color.goml
+++ b/tests/rustdoc-gui/headers-color.goml
@@ -1,5 +1,7 @@
 // This test check for headings text and background colors for the different themes.
 
+include: "utils.goml"
+
 define-function: (
     "check-colors",
     [theme, color, code_header_color, focus_background_color, headings_color],
@@ -7,8 +9,7 @@ define-function: (
         go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
         // This is needed so that the text color is computed.
         show-text: true
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (
             ".impl",
             {"color": |color|, "background-color": "rgba(0, 0, 0, 0)"},

--- a/tests/rustdoc-gui/headings.goml
+++ b/tests/rustdoc-gui/headings.goml
@@ -11,6 +11,7 @@
 // 18px  1.125em
 // 16px  1rem
 // 14px  0.875rem
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.HeavilyDocumentedStruct.html"
 
 assert-css: (".main-heading h1", {"font-size": "24px"})
@@ -158,8 +159,8 @@ define-function: (
     "check-colors",
     [theme, heading_color, small_heading_color, heading_border_color],
     block {
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
+
         assert-css: (
             ".top-doc .docblock h2",
             {"color": |heading_color|, "border-bottom": "1px solid " + |heading_border_color|},
@@ -222,8 +223,7 @@ define-function: (
     "check-since-color",
     [theme],
     block {
-        set-local-storage: {"rustdoc-theme": |theme|}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (".since", {"color": "#808080"}, ALL)
     },
 )

--- a/tests/rustdoc-gui/help-page.goml
+++ b/tests/rustdoc-gui/help-page.goml
@@ -1,4 +1,5 @@
 // This test ensures that opening the help page in its own tab works.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/help.html"
 set-window-size: (1000, 1000) // Try desktop size first.
 wait-for: "#help"
@@ -19,10 +20,7 @@ define-function: (
     "check-colors",
     [theme, color, background, box_shadow],
     block {
-        // Setting the theme.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        // We reload the page so the local storage settings are being used.
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: ("#help kbd", {
             "color": |color|,
             "background-color": |background|,

--- a/tests/rustdoc-gui/highlight-colors.goml
+++ b/tests/rustdoc-gui/highlight-colors.goml
@@ -1,4 +1,5 @@
 // This test checks the highlight colors in the source code pages.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 show-text: true
 
@@ -22,8 +23,7 @@ define-function: (
         doc_comment,
     ],
     block {
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: ("pre.rust .kw", {"color": |kw|}, ALL)
         assert-css: ("pre.rust .kw-2", {"color": |kw2|}, ALL)
         assert-css: ("pre.rust .prelude-ty", {"color": |prelude_ty|}, ALL)

--- a/tests/rustdoc-gui/item-decl-colors.goml
+++ b/tests/rustdoc-gui/item-decl-colors.goml
@@ -1,5 +1,7 @@
 // This test ensures that the color of the items in the type decl are working as expected.
 
+include: "utils.goml"
+
 // We need to disable this check because `trait.impl/test_docs/trait.TraitWithoutGenerics.js`
 // doesn't exist.
 fail-on-request-error: false
@@ -21,8 +23,8 @@ define-function: (
         go-to: "file://" + |DOC_PATH| + "/test_docs/struct.WithGenerics.html"
         show-text: true
 
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
+
         assert-css: (".item-decl .code-attribute", {"color": |attr_color|}, ALL)
         assert-css: (".item-decl .trait", {"color": |trait_color|}, ALL)
         // We need to add `code` here because otherwise it would select the parent too.

--- a/tests/rustdoc-gui/item-decl-comment-highlighting.goml
+++ b/tests/rustdoc-gui/item-decl-comment-highlighting.goml
@@ -1,4 +1,5 @@
 // This test checks that comments in item declarations are highlighted.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/private/enum.Enum.html"
 show-text: true
 
@@ -7,8 +8,7 @@ define-function: (
     [theme, url, comment_color],
     block {
         go-to: |url|
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (".item-decl .comment", {"color": |comment_color|}, ALL)
     }
 )

--- a/tests/rustdoc-gui/jump-to-def-background.goml
+++ b/tests/rustdoc-gui/jump-to-def-background.goml
@@ -1,14 +1,12 @@
 // We check the background color on the jump to definition links in the src code page.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/src/link_to_definition/lib.rs.html"
 
 define-function: (
     "check-background-color",
     [theme, background_color],
     block {
-        // Set the theme.
-        set-local-storage: { "rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false" }
-        // We reload the page so the local storage settings are being used.
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (
             "body.src .example-wrap pre.rust a",
             {"background-color": |background_color|},

--- a/tests/rustdoc-gui/links-color.goml
+++ b/tests/rustdoc-gui/links-color.goml
@@ -1,4 +1,5 @@
 // This test checks links colors.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 
 // This is needed so that the text color is computed.
@@ -9,11 +10,7 @@ define-function: (
     [theme, mod, macro, struct, enum, trait, fn, type, union, keyword,
      sidebar, sidebar_current, sidebar_current_background],
     block {
-        set-local-storage: {
-            "rustdoc-theme": |theme|,
-            "rustdoc-use-system-theme": "false",
-        }
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         // Checking results colors.
         assert-css: (".item-table .mod", {"color": |mod|}, ALL)
         assert-css: (".item-table .macro", {"color": |macro|}, ALL)

--- a/tests/rustdoc-gui/notable-trait.goml
+++ b/tests/rustdoc-gui/notable-trait.goml
@@ -1,4 +1,5 @@
 // This test checks the position of the `i` for the notable traits.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.NotableStructWithLongName.html"
 show-text: true
 // We start with a wide screen.
@@ -128,10 +129,7 @@ define-function: (
         // This is needed to ensure that the text color is computed.
         show-text: true
 
-        // Setting the theme.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        // We reload the page so the local storage settings are being used.
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         assert-css: (
              "//*[@id='method.create_an_iterator_from_read']//*[@class='tooltip']",

--- a/tests/rustdoc-gui/pocket-menu.goml
+++ b/tests/rustdoc-gui/pocket-menu.goml
@@ -1,4 +1,5 @@
 // This test ensures that the "pocket menus" are working as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 // First we check that the help menu doesn't exist yet.
 assert-false: "#help-button .popover"
@@ -33,11 +34,7 @@ define-function: (
     "check-popover-colors",
     [theme, border_color],
     block {
-        set-local-storage: {
-            "rustdoc-theme": |theme|,
-            "rustdoc-use-system-theme": "false",
-        }
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         click: "#help-button"
         assert-css: (

--- a/tests/rustdoc-gui/run-on-hover.goml
+++ b/tests/rustdoc-gui/run-on-hover.goml
@@ -2,6 +2,7 @@
 // Playground. That button is hidden until the user hovers over the code block.
 // This test checks that it is hidden, and that it shows on hover. It also
 // checks for its color.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
 show-text: true
 
@@ -9,8 +10,7 @@ define-function: (
     "check-run-button",
     [theme, color, background, hover_color, hover_background],
     block {
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (".test-arrow", {"visibility": "hidden"})
         move-cursor-to: ".example-wrap"
         assert-css: (".test-arrow", {

--- a/tests/rustdoc-gui/rust-logo.goml
+++ b/tests/rustdoc-gui/rust-logo.goml
@@ -1,4 +1,5 @@
 // This test ensures that the correct style is applied to the rust logo in the sidebar.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/staged_api/index.html"
 
 define-function: (
@@ -8,14 +9,12 @@ define-function: (
         // Going to the doc page.
         go-to: "file://" + |DOC_PATH| + "/staged_api/index.html"
         // Changing theme.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (".rust-logo", {"filter": |filter|})
         // Now we check that the non-rust logos don't have a CSS filter set.
         go-to: "file://" + |DOC_PATH| + "/huge_logo/index.html"
         // Changing theme on the new page (again...).
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         // Check there is no rust logo
         assert-false: ".rust-logo"
         // Check there is no filter.

--- a/tests/rustdoc-gui/scrape-examples-color.goml
+++ b/tests/rustdoc-gui/scrape-examples-color.goml
@@ -1,4 +1,5 @@
 // Check that scrape example code blocks have the expected colors.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/scrape_examples/fn.test_many.html"
 show-text: true
 
@@ -7,8 +8,7 @@ define-function: (
     [theme, highlight, highlight_focus, help_border, help_color, help_hover_border,
      help_hover_color],
     block {
-        set-local-storage: { "rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false", }
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         wait-for: ".more-examples-toggle"
         assert-css: (".scraped-example .example-wrap .rust span.highlight:not(.focus)", {
             "background-color": |highlight|,
@@ -66,8 +66,7 @@ define-function: (
     "check-background",
     [theme, background_color_start, background_color_end],
     block {
-        set-local-storage: { "rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false", }
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (".scraped-example:not(.expanded) .code-wrapper::before", {
             "background-image": "linear-gradient(" + |background_color_start| + ", " +
                 |background_color_end| + ")",

--- a/tests/rustdoc-gui/scrape-examples-toggle.goml
+++ b/tests/rustdoc-gui/scrape-examples-toggle.goml
@@ -1,4 +1,5 @@
 // This tests checks that the "scraped examples" toggle is working as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/scrape_examples/fn.test_many.html"
 
 // Checking the color of the toggle line.
@@ -7,8 +8,7 @@ define-function: (
     "check-color",
     [theme, toggle_line_color, toggle_line_hover_color],
     block {
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         // Clicking "More examples..." will open additional examples
         assert-attribute-false: (".more-examples-toggle", {"open": ""})

--- a/tests/rustdoc-gui/search-error.goml
+++ b/tests/rustdoc-gui/search-error.goml
@@ -1,4 +1,5 @@
 // Checks that the crate search filtering is handled correctly and changes the results.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=sa'%3Bda'%3Bds"
 show-text: true
 
@@ -6,11 +7,7 @@ define-function: (
     "check-colors",
     [theme, error_background],
     block {
-        // Setting the theme.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        // We reload the page so the local storage settings are being used.
-        reload:
-
+        call-function: ("switch-theme", {"theme": |theme|})
         wait-for: "#search .error code"
         assert-css: ("#search .error code", {"background-color": |error_background|})
     }

--- a/tests/rustdoc-gui/search-filter.goml
+++ b/tests/rustdoc-gui/search-filter.goml
@@ -1,4 +1,5 @@
 // Checks that the crate search filtering is handled correctly and changes the results.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 show-text: true
 write-into: (".search-input", "test")
@@ -59,8 +60,7 @@ assert-text: (".search-results-title", "Results in all crates", STARTS_WITH)
 
 // Checking the display of the crate filter.
 // We start with the light theme.
-set-local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
-reload:
+call-function: ("switch-theme", {"theme": "light"})
 
 set-timeout: 2000
 wait-for: "#crate-search"

--- a/tests/rustdoc-gui/search-form-elements.goml
+++ b/tests/rustdoc-gui/search-form-elements.goml
@@ -1,4 +1,5 @@
 // This test ensures that the elements in ".search-form" have the expected display.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 show-text: true
 
@@ -9,11 +10,7 @@ define-function: (
         menu_button_border, menu_button_a_color, menu_button_a_border_hover, menu_a_color,
     ],
     block {
-        set-local-storage: {
-            "rustdoc-theme": |theme|,
-            "rustdoc-use-system-theme": "false",
-        }
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (
             ".search-input",
             {

--- a/tests/rustdoc-gui/search-no-result.goml
+++ b/tests/rustdoc-gui/search-no-result.goml
@@ -1,4 +1,5 @@
 // The goal of this test is to check the color of the "no result" links.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/lib2/index.html?search=sdkfskjfsdks"
 show-text: true
 
@@ -6,9 +7,7 @@ define-function: (
     "check-no-result",
     [theme, link, link_hover],
     block {
-        // Changing theme.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         wait-for: "#results"
         assert: ".search-failed.active"
         assert-css: ("#results a", {"color": |link|}, ALL)

--- a/tests/rustdoc-gui/search-reexport.goml
+++ b/tests/rustdoc-gui/search-reexport.goml
@@ -1,8 +1,8 @@
 // Checks that the reexports are present in the search index, can have
 // doc aliases and are highligted when their ID is the hash of the page.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-set-local-storage: {"rustdoc-theme": "dark", "rustdoc-use-system-theme": "false"}
-reload:
+call-function: ("switch-theme", {"theme": "dark"})
 // First we check that the reexport has the correct ID and no background color.
 assert-text: ("//*[@id='reexport.TheStdReexport']", "pub use ::std as TheStdReexport;")
 assert-css: ("//*[@id='reexport.TheStdReexport']", {"background-color": "rgba(0, 0, 0, 0)"})

--- a/tests/rustdoc-gui/search-result-color.goml
+++ b/tests/rustdoc-gui/search-result-color.goml
@@ -1,5 +1,6 @@
 // The goal of this test is to ensure the color of the text is the one expected.
 
+include: "utils.goml"
 define-function: (
     "check-result-color",
     [result_kind, color, hover_color],
@@ -43,11 +44,7 @@ go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=coo"
 show-text: true
 
 // Ayu theme
-set-local-storage: {
-    "rustdoc-theme": "ayu",
-    "rustdoc-use-system-theme": "false",
-}
-reload:
+call-function: ("switch-theme", {"theme": "ayu"})
 
 // Waiting for the search results to appear...
 wait-for: "#search-tabs"
@@ -155,11 +152,7 @@ assert-css: (
 )
 
 // Dark theme
-set-local-storage: {
-    "rustdoc-theme": "dark",
-    "rustdoc-use-system-theme": "false",
-}
-reload:
+call-function: ("switch-theme", {"theme": "dark"})
 
 // Waiting for the search results to appear...
 wait-for: "#search-tabs"
@@ -255,8 +248,7 @@ assert-css: (
 )
 
 // Light theme
-set-local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
-reload:
+call-function: ("switch-theme", {"theme": "light"})
 
 // Waiting for the search results to appear...
 wait-for: "#search-tabs"
@@ -360,8 +352,7 @@ define-function: (
     "check-alias",
     [theme, alias, grey],
     block {
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         write-into: (".search-input", "thisisanalias")
         // To be SURE that the search will be run.
         press-key: 'Enter'

--- a/tests/rustdoc-gui/search-result-display.goml
+++ b/tests/rustdoc-gui/search-result-display.goml
@@ -1,5 +1,6 @@
 // ignore-tidy-linelength
 // Checks that the search results have the expected width.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 set-window-size: (900, 1000)
 write-into: (".search-input", "test")
@@ -71,8 +72,7 @@ define-function: (
     "check-filter",
     [theme, border, filter, hover_border, hover_filter],
     block {
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         wait-for: "#crate-search"
         assert-css: ("#crate-search", {"border": "1px solid " + |border|})
         assert-css: ("#crate-search-div::after", {"filter": |filter|})

--- a/tests/rustdoc-gui/search-tab.goml
+++ b/tests/rustdoc-gui/search-tab.goml
@@ -1,4 +1,5 @@
 // Checking the colors of the search tab headers.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html?search=foo"
 show-text: true
 
@@ -8,9 +9,7 @@ define-function: (
      border_bottom_selected, border_bottom_hover, border_top, border_top_selected,
      border_top_hover],
     block {
-        // Setting the theme.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         // These two commands are used to be sure the search will be run.
         focus: ".search-input"

--- a/tests/rustdoc-gui/settings.goml
+++ b/tests/rustdoc-gui/settings.goml
@@ -1,5 +1,6 @@
 // This test ensures that the settings menu display is working as expected and that
 // the settings page is also rendered as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 show-text: true // needed when we check for colors below.
 // First, we check that the settings page doesn't exist.
@@ -35,8 +36,7 @@ wait-for: "#alternative-display #search"
 assert: "#main-content.hidden"
 
 // Now let's check the content of the settings menu.
-set-local-storage: {"rustdoc-theme": "dark", "rustdoc-use-system-theme": "false"}
-reload:
+call-function: ("switch-theme", {"theme": "dark"})
 click: "#settings-menu"
 wait-for: "#settings"
 

--- a/tests/rustdoc-gui/sidebar-links-color.goml
+++ b/tests/rustdoc-gui/sidebar-links-color.goml
@@ -1,4 +1,5 @@
 // This test checks links colors in sidebar before and after hover.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
 
 // This is needed so that the text color is computed.
@@ -13,8 +14,7 @@ define-function: (
         type_hover_background, keyword, keyword_hover, keyword_hover_background,
     ],
     block {
-        set-local-storage: { "rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false" }
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         // Struct
         assert-css: (
             ".sidebar .block.struct li:not(.current) a",

--- a/tests/rustdoc-gui/sidebar-mobile.goml
+++ b/tests/rustdoc-gui/sidebar-mobile.goml
@@ -1,6 +1,7 @@
 // This test ensure that the sidebar isn't "hidden" on mobile but instead moved out of the viewport.
 // This is especially important for devices for "text-first" content (like for users with
 // sight issues).
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
 // Switching to "mobile view" by reducing the width to 600px.
 set-window-size: (600, 600)
@@ -59,7 +60,7 @@ define-function: (
     "check-colors",
     [theme, color, background],
     block {
-        set-local-storage: {"rustdoc-use-system-theme": "false", "rustdoc-theme": |theme|}
+        call-function: ("switch-theme", {"theme": |theme|})
         reload:
 
         // Open the sidebar menu.

--- a/tests/rustdoc-gui/sidebar-source-code-display.goml
+++ b/tests/rustdoc-gui/sidebar-source-code-display.goml
@@ -1,4 +1,5 @@
 // This test ensures that the elements in the sidebar are displayed correctly.
+include: "utils.goml"
 javascript: false
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 // Since the javascript is disabled, there shouldn't be a toggle.
@@ -34,8 +35,7 @@ define-function: (
         theme, color, color_hover, background, background_hover, background_toggle,
     ],
     block {
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         wait-for-css: (".src .sidebar > *", {"visibility": "visible"})
         assert-css: (
             "#src-sidebar details[open] > .files a.selected",

--- a/tests/rustdoc-gui/sidebar-source-code.goml
+++ b/tests/rustdoc-gui/sidebar-source-code.goml
@@ -1,5 +1,6 @@
 // The goal of this test is to ensure that the sidebar is working as expected in the source
 // code pages.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 show-text: true
 
@@ -8,11 +9,7 @@ define-function: (
     "check-colors",
     [theme, color, background_color],
     block {
-        set-local-storage: {
-            "rustdoc-theme": |theme|,
-            "rustdoc-use-system-theme": "false",
-        }
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         // Checking results colors.
         assert-css: (".src .sidebar", {
             "color": |color|,

--- a/tests/rustdoc-gui/sidebar.goml
+++ b/tests/rustdoc-gui/sidebar.goml
@@ -1,4 +1,5 @@
 // Checks multiple things on the sidebar display (width of its elements, colors, etc).
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 assert-property: (".sidebar", {"clientWidth": "200"})
 show-text: true
@@ -8,11 +9,7 @@ define-function: (
     "check-colors",
     [theme, color, background_color],
     block {
-        set-local-storage: {
-            "rustdoc-theme": |theme|,
-            "rustdoc-use-system-theme": "false",
-        }
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         // Checking results colors.
         assert-css: (".sidebar", {
             "color": |color|,
@@ -46,9 +43,7 @@ call-function: (
     }
 )
 
-set-local-storage: {"rustdoc-theme": "light"}
-// We reload the page so the local storage settings are being used.
-reload:
+call-function: ("switch-theme", {"theme": "light"})
 
 assert-text: (".sidebar > .sidebar-crate > h2 > a", "test_docs")
 // Crate root has no "location" element

--- a/tests/rustdoc-gui/source-code-page.goml
+++ b/tests/rustdoc-gui/source-code-page.goml
@@ -1,4 +1,5 @@
 // Checks that the interactions with the source code pages are working as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 show-text: true
 // Check that we can click on the line number.
@@ -23,8 +24,7 @@ define-function: (
     "check-colors",
     [theme, color, background_color, highlight_color, highlight_background_color],
     block {
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (
             ".src-line-numbers > a:not(.line-highlighted)",
             {"color": |color|, "background-color": |background_color|},

--- a/tests/rustdoc-gui/stab-badge.goml
+++ b/tests/rustdoc-gui/stab-badge.goml
@@ -1,12 +1,13 @@
 // All stability badges should have rounded corners and colored backgrounds.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 show-text: true
 define-function: (
     "check-badge",
     [theme, background, color],
     block {
-        set-local-storage: {"rustdoc-use-system-theme": "false", "rustdoc-theme": |theme|}
         go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+        call-function: ("switch-theme", {"theme": |theme|})
         assert: ".docblock .stab"
         assert: ".item-table .stab"
         assert-css: (".stab", {

--- a/tests/rustdoc-gui/target.goml
+++ b/tests/rustdoc-gui/target.goml
@@ -1,4 +1,5 @@
 // Check that the targeted element has the expected styles.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/lib2/struct.Foo.html#method.a_method"
 show-text: true
 
@@ -9,8 +10,7 @@ define-function: (
     "check-style",
     [theme, background, border],
     block {
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: ("#method\.a_method:target", {
             "background-color": |background|,
             "border-right": "3px solid " + |border|,

--- a/tests/rustdoc-gui/theme-change.goml
+++ b/tests/rustdoc-gui/theme-change.goml
@@ -1,7 +1,7 @@
 // Ensures that the theme change is working as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-set-local-storage: {"rustdoc-use-system-theme": "false", "rustdoc-theme": "dark"}
-reload:
+call-function: ("switch-theme", {"theme": "dark"})
 
 store-value: (background_light, "white")
 store-value: (background_dark, "#353535")
@@ -68,8 +68,7 @@ assert: "#preferred-light-theme.setting-line.hidden"
 
 // Ensures that the custom theme feature is working as expected.
 go-to: "file://" + |DOC_PATH| + "/theme_css/index.html"
-set-local-storage: {"rustdoc-use-system-theme": "false", "rustdoc-theme": "dark"}
-reload:
+call-function: ("switch-theme", {"theme": "dark"})
 
 store-value: (background_light, "white")
 store-value: (background_dark, "#353535")

--- a/tests/rustdoc-gui/theme-in-history.goml
+++ b/tests/rustdoc-gui/theme-in-history.goml
@@ -1,12 +1,10 @@
 // Ensures that the theme is working when going back in history.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+
 // Set the theme to dark.
-set-local-storage: {
-    "rustdoc-theme": "dark",
-    "rustdoc-use-system-theme": "false",
-}
-// We reload the page so the local storage settings are being used.
-reload:
+call-function: ("switch-theme", {"theme": "dark"})
+
 assert-css: ("body", { "background-color": "#353535" })
 assert-local-storage: { "rustdoc-theme": "dark" }
 

--- a/tests/rustdoc-gui/toggle-docs.goml
+++ b/tests/rustdoc-gui/toggle-docs.goml
@@ -1,4 +1,5 @@
 // Checks that the documentation toggles have the correct position, style and work as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 assert-attribute: ("#main-content > details.top-doc", {"open": ""})
 assert-text: ("#toggle-all-docs", "[−]")
@@ -51,10 +52,7 @@ define-function: (
     "check-color",
     [theme, filter],
     block {
-        // Setting the theme.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        // We reload the page so the local storage settings are being used.
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         assert-css: ("details.toggle > summary::before", {
             "opacity": "0.5",

--- a/tests/rustdoc-gui/unsafe-fn.goml
+++ b/tests/rustdoc-gui/unsafe-fn.goml
@@ -1,4 +1,5 @@
 // Check position and color of the `<sup>` for unsafe elements.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 // If the text isn't displayed, the browser doesn't compute color style correctly...
 show-text: true
@@ -15,10 +16,7 @@ define-function: (
     // `color` is the expected color of the `<sup>` element.
     [theme, color],
     block {
-        // Set the theme.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        // We reload the page so the local storage settings are being used.
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (".item-name sup", {"color": |color|})
     },
 )

--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -1,0 +1,11 @@
+// This file contains code to be re-used by other tests.
+define-function: (
+    "switch-theme",
+    [theme],
+    block {
+        // Set the theme.
+        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
+        // We reload the page so the local storage settings are being used.
+        reload:
+    },
+)

--- a/tests/rustdoc-gui/warning-block.goml
+++ b/tests/rustdoc-gui/warning-block.goml
@@ -1,4 +1,5 @@
 // Test to check that the "warning blocks" are displayed as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
 show-text: true
 
@@ -7,8 +8,7 @@ define-function: (
     "check-warning",
     [theme, color, border_color],
     block {
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         // The IDs are added directly into the DOM to make writing this test easier.
         assert-css: ("#doc-warning-1", {


### PR DESCRIPTION
Since we updated `browser-ui-test` version, let's make use of the new commands. :)

r? @notriddle