### PR TITLE
Do not ICE on field access check on expr with `ty::Error`

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -153,7 +153,8 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                 self.insert_def_id(def.non_enum_variant().fields[index].did);
             }
             ty::Tuple(..) => {}
-            _ => span_bug!(lhs.span, "named field access on non-ADT"),
+            ty::Error(_) => {}
+            kind => span_bug!(lhs.span, "named field access on non-ADT: {kind:?}"),
         }
     }
 

--- a/tests/ui/consts/do-not-ice-on-field-access-of-err-type.rs
+++ b/tests/ui/consts/do-not-ice-on-field-access-of-err-type.rs
@@ -1,0 +1,9 @@
+trait Foo {}
+impl<T> Foo for T {}
+
+fn main() {
+    let array = [(); { loop {} }]; //~ ERROR constant evaluation is taking a long time
+
+    let tup = (7,);
+    let x: &dyn Foo = &tup.0;
+}

--- a/tests/ui/consts/do-not-ice-on-field-access-of-err-type.stderr
+++ b/tests/ui/consts/do-not-ice-on-field-access-of-err-type.stderr
@@ -1,0 +1,17 @@
+error: constant evaluation is taking a long time
+  --> $DIR/do-not-ice-on-field-access-of-err-type.rs:5:24
+   |
+LL |     let array = [(); { loop {} }];
+   |                        ^^^^^^^
+   |
+   = note: this lint makes sure the compiler doesn't get stuck due to infinite loops in const eval.
+           If your compilation actually takes a long time, you can safely allow the lint.
+help: the constant being evaluated
+  --> $DIR/do-not-ice-on-field-access-of-err-type.rs:5:22
+   |
+LL |     let array = [(); { loop {} }];
+   |                      ^^^^^^^^^^^
+   = note: `#[deny(long_running_const_eval)]` on by default
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fix #123428