### PR TITLE
Stabilize const Atomic*::into_inner

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -578,9 +578,9 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "atomic_access", since = "1.15.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
+    #[rustc_const_stable(feature = "const_atomic_into_inner", since = "CURRENT_RUSTC_VERSION")]
     pub const fn into_inner(self) -> bool {
-        self.v.into_inner() != 0
+        self.v.primitive_into_inner() != 0
     }
 
     /// Loads a value from the bool.
@@ -1397,9 +1397,9 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "atomic_access", since = "1.15.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
+    #[rustc_const_stable(feature = "const_atomic_into_inner", since = "CURRENT_RUSTC_VERSION")]
     pub const fn into_inner(self) -> *mut T {
-        self.p.into_inner()
+        self.p.primitive_into_inner()
     }
 
     /// Loads a value from the pointer.
@@ -2378,9 +2378,9 @@ macro_rules! atomic_int {
             /// ```
             #[inline]
             #[$stable_access]
-            #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
+            #[rustc_const_stable(feature = "const_atomic_into_inner", since = "CURRENT_RUSTC_VERSION")]
             pub const fn into_inner(self) -> $int_type {
-                self.v.into_inner()
+                self.v.primitive_into_inner()
             }
 
             /// Loads a value from the atomic integer.


### PR DESCRIPTION
Partial stabilization for https://github.com/rust-lang/rust/issues/78729, for which the FCP has already completed.

The other `into_inner` functions in that tracking issue (`UnsafeCell`, `Cell`, `RefCell`) are blocked on https://github.com/rust-lang/rust/issues/73255 for now.

```console
error[E0493]: destructor of `UnsafeCell<T>` cannot be evaluated at compile-time
    --> library/core/src/cell.rs:2076:29
     |
2076 |     pub const fn into_inner(self) -> T {
     |                             ^^^^ the destructor for this type cannot be evaluated in constant functions
2077 |         self.value
2078 |     }
     |     - value is dropped here
```