### PR TITLE
Account for trait/impl difference when suggesting changing argument from ref to mut ref

### DIFF
--- a/tests/ui/borrowck/argument_number_mismatch_ice.stderr
+++ b/tests/ui/borrowck/argument_number_mismatch_ice.stderr
@@ -12,6 +12,11 @@ error[E0594]: cannot assign to `*input`, which is behind a `&` reference
    |
 LL |         *input = self.0;
    |         ^^^^^^^^^^^^^^^ `input` is a `&` reference, so the data it refers to cannot be written
+   |
+help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
+   |
+LL |     fn example(&self, input: &mut i32) {
+   |                               +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/trait-impl-argument-difference-ice.rs
+++ b/tests/ui/borrowck/trait-impl-argument-difference-ice.rs
@@ -1,0 +1,25 @@
+// Issue https://github.com/rust-lang/rust/issues/123414
+trait MemoryUnit {
+    extern "C" fn read_word(&mut self) -> u8;
+    extern "C" fn read_dword(Self::Assoc<'_>) -> u16;
+    //~^ WARNING anonymous parameters are deprecated and will be removed in the next edition
+    //~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+    //~| ERROR associated type `Assoc` not found for `Self`
+}
+
+struct ROM {}
+
+impl MemoryUnit for ROM {
+//~^ ERROR not all trait items implemented, missing: `read_word`
+    extern "C" fn read_dword(&'_ self) -> u16 {
+        //~^ ERROR method `read_dword` has a `&self` declaration in the impl, but not in the trait
+        let a16 = self.read_word() as u16;
+        //~^ ERROR cannot borrow `*self` as mutable, as it is behind a `&` reference
+        let b16 = self.read_word() as u16;
+        //~^ ERROR cannot borrow `*self` as mutable, as it is behind a `&` reference
+
+        (b16 << 8) | a16
+    }
+}
+
+pub fn main() {}

--- a/tests/ui/borrowck/trait-impl-argument-difference-ice.stderr
+++ b/tests/ui/borrowck/trait-impl-argument-difference-ice.stderr
@@ -1,0 +1,60 @@
+warning: anonymous parameters are deprecated and will be removed in the next edition
+  --> $DIR/trait-impl-argument-difference-ice.rs:4:30
+   |
+LL |     extern "C" fn read_dword(Self::Assoc<'_>) -> u16;
+   |                              ^^^^^^^^^^^^^^^ help: try naming the parameter or explicitly ignoring it: `_: Self::Assoc<'_>`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
+   = note: `#[warn(anonymous_parameters)]` on by default
+
+error[E0220]: associated type `Assoc` not found for `Self`
+  --> $DIR/trait-impl-argument-difference-ice.rs:4:36
+   |
+LL |     extern "C" fn read_dword(Self::Assoc<'_>) -> u16;
+   |                                    ^^^^^ associated type `Assoc` not found
+
+error[E0185]: method `read_dword` has a `&self` declaration in the impl, but not in the trait
+  --> $DIR/trait-impl-argument-difference-ice.rs:14:5
+   |
+LL |     extern "C" fn read_dword(Self::Assoc<'_>) -> u16;
+   |     ------------------------------------------------- trait method declared without `&self`
+...
+LL |     extern "C" fn read_dword(&'_ self) -> u16 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&self` used in impl
+
+error[E0046]: not all trait items implemented, missing: `read_word`
+  --> $DIR/trait-impl-argument-difference-ice.rs:12:1
+   |
+LL |     extern "C" fn read_word(&mut self) -> u8;
+   |     ----------------------------------------- `read_word` from trait
+...
+LL | impl MemoryUnit for ROM {
+   | ^^^^^^^^^^^^^^^^^^^^^^^ missing `read_word` in implementation
+
+error[E0596]: cannot borrow `*self` as mutable, as it is behind a `&` reference
+  --> $DIR/trait-impl-argument-difference-ice.rs:16:19
+   |
+LL |         let a16 = self.read_word() as u16;
+   |                   ^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |
+help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
+   |
+LL |     extern "C" fn read_dword(&'_ mut self) -> u16 {
+   |                              ~~~~~~~~~~~~
+
+error[E0596]: cannot borrow `*self` as mutable, as it is behind a `&` reference
+  --> $DIR/trait-impl-argument-difference-ice.rs:18:19
+   |
+LL |         let b16 = self.read_word() as u16;
+   |                   ^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |
+help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
+   |
+LL |     extern "C" fn read_dword(&'_ mut self) -> u16 {
+   |                              ~~~~~~~~~~~~
+
+error: aborting due to 5 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0046, E0185, E0220, E0596.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/suggestions/issue-68049-1.stderr
+++ b/tests/ui/suggestions/issue-68049-1.stderr
@@ -1,6 +1,8 @@
 error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-1.rs:7:9
    |
+LL |     unsafe fn alloc(&self, _layout: Layout) -> *mut u8 {
+   |                     ----- this is an immutable reference
 LL |         self.0 += 1;
    |         ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
 

--- a/tests/ui/suggestions/issue-68049-2.rs
+++ b/tests/ui/suggestions/issue-68049-2.rs
@@ -1,11 +1,11 @@
 trait Hello {
-  fn example(&self, input: &i32); // should suggest here
+  fn example(&self, input: &i32);
 }
 
 struct Test1(i32);
 
 impl Hello for Test1 {
-  fn example(&self, input: &i32) { // should not suggest here
+  fn example(&self, input: &i32) {
       *input = self.0; //~ ERROR cannot assign
   }
 }
@@ -13,7 +13,7 @@ impl Hello for Test1 {
 struct Test2(i32);
 
 impl Hello for Test2 {
-  fn example(&self, input: &i32) { // should not suggest here
+  fn example(&self, input: &i32) {
     self.0 += *input; //~ ERROR cannot assign
   }
 }

--- a/tests/ui/suggestions/issue-68049-2.stderr
+++ b/tests/ui/suggestions/issue-68049-2.stderr
@@ -4,9 +4,9 @@ error[E0594]: cannot assign to `*input`, which is behind a `&` reference
 LL |       *input = self.0;
    |       ^^^^^^^^^^^^^^^ `input` is a `&` reference, so the data it refers to cannot be written
    |
-help: consider changing this to be a mutable reference
+help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
    |
-LL |   fn example(&self, input: &mut i32) { // should not suggest here
+LL |   fn example(&self, input: &mut i32) {
    |                             +++
 
 error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
@@ -15,10 +15,14 @@ error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
 LL |     self.0 += *input;
    |     ^^^^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
    |
-help: consider changing this to be a mutable reference
+help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
    |
-LL |   fn example(&mut self, input: &i32); // should suggest here
-   |              ~~~~~~~~~
+LL ~   fn example(&mut self, input: &i32);
+LL | }
+ ...
+LL | impl Hello for Test2 {
+LL ~   fn example(&mut self, input: &i32) {
+   |
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Do not ICE when encountering a lifetime error involving an argument with an immutable reference of a method that differs from the trait definition.

Fix #123414.