### PR TITLE
Do not ICE when calling incorrectly defined `transmute` intrinsic

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -547,13 +547,20 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if tcx.fn_sig(did).skip_binder().abi() == RustIntrinsic
                 && tcx.item_name(did) == sym::transmute
             {
-                let from = fn_sig.inputs().skip_binder()[0];
+                let Some(from) = fn_sig.inputs().skip_binder().get(0) else {
+                    let e = self.dcx().span_delayed_bug(
+                        tcx.def_span(did),
+                        "intrinsic fn `transmute` defined with no parameters",
+                    );
+                    self.set_tainted_by_errors(e);
+                    return Ty::new_error(tcx, e);
+                };
                 let to = fn_sig.output().skip_binder();
                 // We defer the transmute to the end of typeck, once all inference vars have
                 // been resolved or we errored. This is important as we can only check transmute
                 // on concrete types, but the output type may not be known yet (it would only
                 // be known if explicitly specified via turbofish).
-                self.deferred_transmute_checks.borrow_mut().push((from, to, expr.hir_id));
+                self.deferred_transmute_checks.borrow_mut().push((*from, to, expr.hir_id));
             }
             if !tcx.features().unsized_fn_params {
                 // We want to remove some Sized bounds from std functions,

--- a/tests/ui/intrinsics/incorrect-transmute.rs
+++ b/tests/ui/intrinsics/incorrect-transmute.rs
@@ -1,0 +1,8 @@
+fn main() {
+    transmute(); // does not ICE
+}
+
+extern "rust-intrinsic" fn transmute() {}
+//~^ ERROR intrinsic has wrong number of type parameters: found 0, expected 2
+//~| ERROR intrinsics are subject to change
+//~| ERROR intrinsic must be in `extern "rust-intrinsic" { ... }` block

--- a/tests/ui/intrinsics/incorrect-transmute.stderr
+++ b/tests/ui/intrinsics/incorrect-transmute.stderr
@@ -1,0 +1,25 @@
+error[E0658]: intrinsics are subject to change
+  --> $DIR/incorrect-transmute.rs:5:8
+   |
+LL | extern "rust-intrinsic" fn transmute() {}
+   |        ^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0094]: intrinsic has wrong number of type parameters: found 0, expected 2
+  --> $DIR/incorrect-transmute.rs:5:37
+   |
+LL | extern "rust-intrinsic" fn transmute() {}
+   |                                     ^ expected 2 type parameters
+
+error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
+  --> $DIR/incorrect-transmute.rs:5:40
+   |
+LL | extern "rust-intrinsic" fn transmute() {}
+   |                                        ^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0094, E0658.
+For more information about an error, try `rustc --explain E0094`.


### PR DESCRIPTION
Fix #123442