### PR TITLE
Hide async_gen_internals from standard library documentation

### DIFF
--- a/library/core/src/async_iter/async_iter.rs
+++ b/library/core/src/async_iter/async_iter.rs
@@ -116,6 +116,7 @@ where
 impl<T> Poll<Option<T>> {
     /// A helper function for internal desugaring -- produces `Ready(Some(t))`,
     /// which corresponds to the async iterator yielding a value.
+    #[doc(hidden)]
     #[unstable(feature = "async_gen_internals", issue = "none")]
     #[lang = "AsyncGenReady"]
     pub fn async_gen_ready(t: T) -> Self {
@@ -124,6 +125,7 @@ impl<T> Poll<Option<T>> {
 
     /// A helper constant for internal desugaring -- produces `Pending`,
     /// which corresponds to the async iterator pending on an `.await`.
+    #[doc(hidden)]
     #[unstable(feature = "async_gen_internals", issue = "none")]
     #[lang = "AsyncGenPending"]
     // FIXME(gen_blocks): This probably could be deduplicated.
@@ -131,6 +133,7 @@ impl<T> Poll<Option<T>> {
 
     /// A helper constant for internal desugaring -- produces `Ready(None)`,
     /// which corresponds to the async iterator finishing its iteration.
+    #[doc(hidden)]
     #[unstable(feature = "async_gen_internals", issue = "none")]
     #[lang = "AsyncGenFinished"]
     pub const FINISHED: Self = Poll::Ready(None);


### PR DESCRIPTION
These are from https://github.com/rust-lang/rust/pull/118420. It doesn't appear that there is any intention to ever make these APIs available to user code. These are just conveniences meant for the compiler's implementation of `async gen`. I don't think having them featured in documentation in <https://doc.rust-lang.org/1.77.1/core/task/enum.Poll.html> is appropriate.

![image](https://github.com/rust-lang/rust/assets/1940490/0a8ae90d-5c83-4ab1-b08a-50bad2433d69)
