### PR TITLE
libtest: also measure time in Miri

### DIFF
--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -315,10 +315,8 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
 
     // Prevent the usage of `Instant` in some cases:
     // - It's currently not supported for wasm targets.
-    // - We disable it for miri because it's not available when isolation is enabled.
-    let is_instant_unsupported = (cfg!(target_family = "wasm") && !cfg!(target_os = "wasi"))
-        || cfg!(target_os = "zkvm")
-        || cfg!(miri);
+    let is_instant_unsupported =
+        (cfg!(target_family = "wasm") && !cfg!(target_os = "wasi")) || cfg!(target_os = "zkvm");
 
     let start_time = (!is_instant_unsupported).then(Instant::now);
     run_tests(opts, tests, |x| on_test_event(&x, &mut st, &mut *out))?;

--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -377,7 +377,7 @@ struct SuiteOutcome {
     measured: usize,
     filtered_out: usize,
     /// The time it took to execute this test suite, or `None` if time measurement was not possible
-    /// (e.g. due to running inside Miri).
+    /// (e.g. due to running on wasm).
     exec_time: Option<f64>,
 }
 


### PR DESCRIPTION
A long time ago we disabled timekeeping of the default test harness in Miri, as otherwise it would fail to run without `-Zmiri-disable-isolation`. However, since then Miri gained a "fake clock" that lets it present some deterministic notion of time when isolation is enabled.

So we could now let libtest do timekeeping again when running in Miri. That's nice as it can help detect tests that run too long. However it can also be confusing as the results with isolation can be quite different than the real time.

@rust-lang/miri what do you think?