### PR TITLE
Add missing -Zquery-dep-graph to the spike-neg incr comp tests

### DIFF
--- a/tests/incremental/spike-neg1.rs
+++ b/tests/incremental/spike-neg1.rs
@@ -7,6 +7,7 @@
 
 //@ revisions:rpass1 rpass2
 //@ should-fail
+//@ compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 

--- a/tests/incremental/spike-neg2.rs
+++ b/tests/incremental/spike-neg2.rs
@@ -7,6 +7,7 @@
 
 //@ revisions:rpass1 rpass2
 //@ should-fail
+//@ compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 


### PR DESCRIPTION
This ensures that the tests actually test what they are meant to test rather than exitting immediately with an error that -Zquery-dep-graph has to be passed.