### PR TITLE
Rewrite `version` test run-make as an UI test

### DIFF
--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -321,7 +321,6 @@ run-make/use-suggestions-rust-2018/Makefile
 run-make/used-cdylib-macos/Makefile
 run-make/used/Makefile
 run-make/valid-print-requests/Makefile
-run-make/version/Makefile
 run-make/volatile-intrinsics/Makefile
 run-make/wasm-exceptions-nostd/Makefile
 run-make/wasm-override-linker/Makefile

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -18,7 +18,7 @@ const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 
 const ISSUES_ENTRY_LIMIT: usize = 1733;
-const ROOT_ENTRY_LIMIT: usize = 860;
+const ROOT_ENTRY_LIMIT: usize = 861;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/run-make/version/Makefile
+++ b/tests/run-make/version/Makefile
@@ -1,6 +1,0 @@
-include ../tools.mk
-
-all:
-	$(RUSTC) -V
-	$(RUSTC) -vV
-	$(RUSTC) --version --verbose

--- a/tests/ui/version/version-info-flags.rs
+++ b/tests/ui/version/version-info-flags.rs
@@ -1,0 +1,9 @@
+// Check that rustc accepts various version info flags.
+//@ dont-check-compiler-stdout
+//@ revisions: version verbose-version long-verbose-version
+//@ check-pass
+//@[version] compile-flags: -V
+//@[verbose-version] compile-flags: -vV
+//@[long-verbose-verison] compile-flags: --version --verbose
+
+fn main() {}


### PR DESCRIPTION
Claiming the simple `version` test from #121876.

Reasoning: As discussed in #123297, 10 years ago, some changes to CLI flags warranted the creation of the `version` test. Since it's not actually executing the compiled binary, it has no purpose being a `run-make` test and should instead be an UI test.

This is the exact same change as it was shown on my closed PR #123297. Changes were ready, but I did a major Git mishap while trying to fix a tidy error and messed up my branch. The details of this error are explained [here](https://github.com/rust-lang/rust/pull/123297#issuecomment-2041152379).