### PR TITLE
Clean up tests/ui by removing `does-nothing.rs`

### DIFF
--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -18,7 +18,7 @@ const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 
 const ISSUES_ENTRY_LIMIT: usize = 1722;
-const ROOT_ENTRY_LIMIT: usize = 861;
+const ROOT_ENTRY_LIMIT: usize = 859;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/ui/does-nothing.rs
+++ b/tests/ui/does-nothing.rs
@@ -1,2 +1,0 @@
-fn main() { println!("doing"); this_does_nothing_what_the; println!("boing"); }
-//~^ ERROR cannot find value `this_does_nothing_what_the` in this scope

--- a/tests/ui/does-nothing.stderr
+++ b/tests/ui/does-nothing.stderr
@@ -1,9 +1,0 @@
-error[E0425]: cannot find value `this_does_nothing_what_the` in this scope
-  --> $DIR/does-nothing.rs:1:32
-   |
-LL | fn main() { println!("doing"); this_does_nothing_what_the; println!("boing"); }
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
-
-error: aborting due to 1 previous error
-
-For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
In [a previous PR](https://github.com/rust-lang/rust/pull/123297#issuecomment-2039887806), it was suggested that this test be removed:

> it's testing a basic diagnostic for an unknown variable (added over a decade ago for https://github.com/rust-lang/rust/issues/154) that is already covered by probably dozens or hundreds of other tests.

It was then suggested that [opening a new PR](https://github.com/rust-lang/rust/pull/123563#discussion_r1554654102) for this would be more organized.

I'm setting this as a draft, as:

1. The tests/ui directory is rather disorganized, a large quantity of tests are not even contained inside their own directories. This PR could turn into "clean up the UI tests directory", if I were to place everything into categories (for example, everything related to CLI flags could get placed in a cli directory).
2. This will have a merge conflict with #123563 should that get merged. I trust that _this time_, I won't run into [The Incident](https://github.com/rust-lang/rust/pull/123297#issuecomment-2041137569) while rebasing. Edit: Yay, I did it properly!