### PR TITLE
Do some preparation work for compiletest check-cfg

### DIFF
--- a/tests/ui/asm/inline-syntax.rs
+++ b/tests/ui/asm/inline-syntax.rs
@@ -16,7 +16,7 @@
 #![feature(no_core, lang_items, rustc_attrs)]
 #![crate_type = "rlib"]
 #![no_core]
-#![cfg_attr(x86_64_allowed, allow(bad_asm_style))]
+
 
 #[rustc_builtin_macro]
 macro_rules! asm {

--- a/tests/ui/cfg/cfg-attr-cfg.rs
+++ b/tests/ui/cfg/cfg-attr-cfg.rs
@@ -4,5 +4,5 @@
 
 //@ pretty-expanded FIXME #23616
 
-#[cfg_attr(foo, cfg(bar))]
+#[cfg_attr(FALSE, cfg(bar))]
 fn main() { }

--- a/tests/ui/cfg/cfg-attr-crate.rs
+++ b/tests/ui/cfg/cfg-attr-crate.rs
@@ -3,6 +3,6 @@
 
 //@ pretty-expanded FIXME #23616
 
-#![cfg_attr(not_used, no_core)]
+#![cfg_attr(FALSE, no_core)]
 
 fn main() { }

--- a/tests/ui/cfg/cfg-macros-notfoo.rs
+++ b/tests/ui/cfg/cfg-macros-notfoo.rs
@@ -1,11 +1,9 @@
 //@ run-pass
-//@ compile-flags:
 
 // check that cfg correctly chooses between the macro impls (see also
 // cfg-macros-foo.rs)
 
-
-#[cfg(foo)]
+#[cfg(FALSE)]
 #[macro_use]
 mod foo {
     macro_rules! bar {
@@ -13,7 +11,7 @@ mod foo {
     }
 }
 
-#[cfg(not(foo))]
+#[cfg(not(FALSE))]
 #[macro_use]
 mod foo {
     macro_rules! bar {

--- a/tests/ui/cfg/cfg-match-arm.rs
+++ b/tests/ui/cfg/cfg-match-arm.rs
@@ -10,9 +10,9 @@ enum Foo {
 fn foo(f: Foo) {
     match f {
         Foo::Bar => {},
-        #[cfg(not(asdfa))]
+        #[cfg(not(FALSE))]
         Foo::Baz => {},
-        #[cfg(afsd)]
+        #[cfg(FALSE)]
         Basdfwe => {}
     }
 }

--- a/tests/ui/cfg/cfg-panic-abort.rs
+++ b/tests/ui/cfg/cfg-panic-abort.rs
@@ -2,14 +2,10 @@
 //@ compile-flags: -C panic=abort
 //@ no-prefer-dynamic
 
-
 #[cfg(panic = "unwind")]
 pub fn bad() -> i32 { }
 
 #[cfg(not(panic = "abort"))]
-pub fn bad() -> i32 { }
-
-#[cfg(panic = "some_imaginary_future_panic_handler")]
 pub fn bad() -> i32 { }
 
 #[cfg(panic = "abort")]

--- a/tests/ui/cfg/cfg-panic.rs
+++ b/tests/ui/cfg/cfg-panic.rs
@@ -2,14 +2,10 @@
 //@ compile-flags: -C panic=unwind
 //@ needs-unwind
 
-
 #[cfg(panic = "abort")]
 pub fn bad() -> i32 { }
 
 #[cfg(not(panic = "unwind"))]
-pub fn bad() -> i32 { }
-
-#[cfg(panic = "some_imaginary_future_panic_handler")]
 pub fn bad() -> i32 { }
 
 #[cfg(panic = "unwind")]

--- a/tests/ui/cfg/cfg_stmt_expr.rs
+++ b/tests/ui/cfg/cfg_stmt_expr.rs
@@ -7,49 +7,49 @@
 
 fn main() {
     let a = 413;
-    #[cfg(unset)]
+    #[cfg(FALSE)]
     let a = ();
     assert_eq!(a, 413);
 
     let mut b = 612;
-    #[cfg(unset)]
+    #[cfg(FALSE)]
     {
         b = 1111;
     }
     assert_eq!(b, 612);
 
-    #[cfg(unset)]
+    #[cfg(FALSE)]
     undefined_fn();
 
-    #[cfg(unset)]
+    #[cfg(FALSE)]
     undefined_macro!();
-    #[cfg(unset)]
+    #[cfg(FALSE)]
     undefined_macro![];
-    #[cfg(unset)]
+    #[cfg(FALSE)]
     undefined_macro!{};
 
     // pretty printer bug...
-    // #[cfg(unset)]
+    // #[cfg(FALSE)]
     // undefined_macro!{}
 
-    let () = (#[cfg(unset)] 341,); // Should this also work on parens?
-    let t = (1, #[cfg(unset)] 3, 4);
+    let () = (#[cfg(FALSE)] 341,); // Should this also work on parens?
+    let t = (1, #[cfg(FALSE)] 3, 4);
     assert_eq!(t, (1, 4));
 
     let f = |_: u32, _: u32| ();
-    f(2, 1, #[cfg(unset)] 6);
+    f(2, 1, #[cfg(FALSE)] 6);
 
-    let _: u32 = a.clone(#[cfg(unset)] undefined);
+    let _: u32 = a.clone(#[cfg(FALSE)] undefined);
 
-    let _: [(); 0] = [#[cfg(unset)] 126];
-    let t = [#[cfg(unset)] 1, 2, 6];
+    let _: [(); 0] = [#[cfg(FALSE)] 126];
+    let t = [#[cfg(FALSE)] 1, 2, 6];
     assert_eq!(t, [2, 6]);
 
     {
         let r;
-        #[cfg(unset)]
+        #[cfg(FALSE)]
         (r = 5);
-        #[cfg(not(unset))]
+        #[cfg(not(FALSE))]
         (r = 10);
         assert_eq!(r, 10);
     }
@@ -69,13 +69,13 @@ fn main() {
         }
     }
 
-    let n = if_cfg!(unset? {
+    let n = if_cfg!(FALSE? {
         413
     } else {
         612
     });
 
-    assert_eq!((#[cfg(unset)] 1, #[cfg(not(unset))] 2), (2,));
+    assert_eq!((#[cfg(FALSE)] 1, #[cfg(not(FALSE))] 2), (2,));
     assert_eq!(n, 612);
 
     // check that lints work

--- a/tests/ui/cfg/conditional-compile.rs
+++ b/tests/ui/cfg/conditional-compile.rs
@@ -6,31 +6,31 @@
 
 // Crate use statements
 
-#[cfg(bogus)]
+#[cfg(FALSE)]
 use flippity;
 
-#[cfg(bogus)]
+#[cfg(FALSE)]
 static b: bool = false;
 
 static b: bool = true;
 
 mod rustrt {
-    #[cfg(bogus)]
+    #[cfg(FALSE)]
     extern "C" {
         // This symbol doesn't exist and would be a link error if this
         // module was codegened
-        pub fn bogus();
+        pub fn FALSE();
     }
 
     extern "C" {}
 }
 
-#[cfg(bogus)]
+#[cfg(FALSE)]
 type t = isize;
 
 type t = bool;
 
-#[cfg(bogus)]
+#[cfg(FALSE)]
 enum tg {
     foo,
 }
@@ -39,12 +39,12 @@ enum tg {
     bar,
 }
 
-#[cfg(bogus)]
+#[cfg(FALSE)]
 struct r {
     i: isize,
 }
 
-#[cfg(bogus)]
+#[cfg(FALSE)]
 fn r(i: isize) -> r {
     r { i: i }
 }
@@ -57,11 +57,11 @@ fn r(i: isize) -> r {
     r { i: i }
 }
 
-#[cfg(bogus)]
+#[cfg(FALSE)]
 mod m {
     // This needs to parse but would fail in typeck. Since it's not in
     // the current config it should not be typechecked.
-    pub fn bogus() {
+    pub fn FALSE() {
         return 0;
     }
 }
@@ -69,22 +69,22 @@ mod m {
 mod m {
     // Submodules have slightly different code paths than the top-level
     // module, so let's make sure this jazz works here as well
-    #[cfg(bogus)]
+    #[cfg(FALSE)]
     pub fn f() {}
 
     pub fn f() {}
 }
 
-// Since the bogus configuration isn't defined main will just be
+// Since the FALSE configuration isn't defined main will just be
 // parsed, but nothing further will be done with it
-#[cfg(bogus)]
+#[cfg(FALSE)]
 pub fn main() {
     panic!()
 }
 
 pub fn main() {
     // Exercise some of the configured items in ways that wouldn't be possible
-    // if they had the bogus definition
+    // if they had the FALSE definition
     assert!((b));
     let _x: t = true;
     let _y: tg = tg::bar;
@@ -93,14 +93,14 @@ pub fn main() {
 }
 
 fn test_in_fn_ctxt() {
-    #[cfg(bogus)]
+    #[cfg(FALSE)]
     fn f() {
         panic!()
     }
     fn f() {}
     f();
 
-    #[cfg(bogus)]
+    #[cfg(FALSE)]
     static i: isize = 0;
     static i: isize = 1;
     assert_eq!(i, 1);
@@ -109,7 +109,7 @@ fn test_in_fn_ctxt() {
 mod test_foreign_items {
     pub mod rustrt {
         extern "C" {
-            #[cfg(bogus)]
+            #[cfg(FALSE)]
             pub fn write() -> String;
             pub fn write() -> String;
         }
@@ -117,7 +117,7 @@ mod test_foreign_items {
 }
 
 mod test_use_statements {
-    #[cfg(bogus)]
+    #[cfg(FALSE)]
     use flippity_foo;
 }
 
@@ -127,24 +127,24 @@ mod test_methods {
     }
 
     impl Fooable for Foo {
-        #[cfg(bogus)]
+        #[cfg(FALSE)]
         fn what(&self) {}
 
         fn what(&self) {}
 
-        #[cfg(bogus)]
+        #[cfg(FALSE)]
         fn the(&self) {}
 
         fn the(&self) {}
     }
 
     trait Fooable {
-        #[cfg(bogus)]
+        #[cfg(FALSE)]
         fn what(&self);
 
         fn what(&self);
 
-        #[cfg(bogus)]
+        #[cfg(FALSE)]
         fn the(&self);
 
         fn the(&self);

--- a/tests/ui/cfg/diagnostics-reexport.rs
+++ b/tests/ui/cfg/diagnostics-reexport.rs
@@ -14,7 +14,7 @@ pub use a::x;
 //~| NOTE no `x` in `a`
 
 mod a {
-    #[cfg(no)]
+    #[cfg(FALSE)]
     pub fn x() {}
     //~^ NOTE found an item that was configured out
 }
@@ -25,10 +25,10 @@ pub use b::{x, y};
 //~| NOTE no `y` in `b`
 
 mod b {
-    #[cfg(no)]
+    #[cfg(FALSE)]
     pub fn x() {}
     //~^ NOTE found an item that was configured out
-    #[cfg(no)]
+    #[cfg(FALSE)]
     pub fn y() {}
     //~^ NOTE found an item that was configured out
 }

--- a/tests/ui/conditional-compilation/cfg-attr-empty-is-unused.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-empty-is-unused.rs
@@ -1,13 +1,11 @@
 // Check that `#[cfg_attr($PREDICATE,)]` triggers the `unused_attribute` lint.
 
-//@ compile-flags: --cfg TRUE
-
 #![deny(unused)]
 
 #[cfg_attr(FALSE,)] //~ ERROR `#[cfg_attr]` does not expand to any attributes
 fn _f() {}
 
-#[cfg_attr(TRUE,)] //~ ERROR `#[cfg_attr]` does not expand to any attributes
+#[cfg_attr(not(FALSE),)] //~ ERROR `#[cfg_attr]` does not expand to any attributes
 fn _g() {}
 
 fn main() {}

--- a/tests/ui/conditional-compilation/cfg-attr-empty-is-unused.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-empty-is-unused.stderr
@@ -1,21 +1,21 @@
 error: `#[cfg_attr]` does not expand to any attributes
-  --> $DIR/cfg-attr-empty-is-unused.rs:7:1
+  --> $DIR/cfg-attr-empty-is-unused.rs:5:1
    |
 LL | #[cfg_attr(FALSE,)]
    | ^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/cfg-attr-empty-is-unused.rs:5:9
+  --> $DIR/cfg-attr-empty-is-unused.rs:3:9
    |
 LL | #![deny(unused)]
    |         ^^^^^^
    = note: `#[deny(unused_attributes)]` implied by `#[deny(unused)]`
 
 error: `#[cfg_attr]` does not expand to any attributes
-  --> $DIR/cfg-attr-empty-is-unused.rs:10:1
+  --> $DIR/cfg-attr-empty-is-unused.rs:8:1
    |
-LL | #[cfg_attr(TRUE,)]
-   | ^^^^^^^^^^^^^^^^^^
+LL | #[cfg_attr(not(FALSE),)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/conditional-compilation/cfg-in-crate-1.rs
+++ b/tests/ui/conditional-compilation/cfg-in-crate-1.rs
@@ -1,3 +1,3 @@
 //@ error-pattern: `main` function not found
 
-#![cfg(bar)]
+#![cfg(FALSE)]

--- a/tests/ui/conditional-compilation/cfg-in-crate-1.stderr
+++ b/tests/ui/conditional-compilation/cfg-in-crate-1.stderr
@@ -1,8 +1,8 @@
 error[E0601]: `main` function not found in crate `cfg_in_crate_1`
-  --> $DIR/cfg-in-crate-1.rs:3:13
+  --> $DIR/cfg-in-crate-1.rs:3:15
    |
-LL | #![cfg(bar)]
-   |             ^ consider adding a `main` function to `$DIR/cfg-in-crate-1.rs`
+LL | #![cfg(FALSE)]
+   |               ^ consider adding a `main` function to `$DIR/cfg-in-crate-1.rs`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/conditional-compilation/cfg-non-opt-expr.rs
+++ b/tests/ui/conditional-compilation/cfg-non-opt-expr.rs
@@ -2,10 +2,10 @@
 #![feature(custom_test_frameworks)]
 
 fn main() {
-    let _ = #[cfg(unset)] ();
+    let _ = #[cfg(FALSE)] ();
     //~^ ERROR removing an expression is not supported in this position
-    let _ = 1 + 2 + #[cfg(unset)] 3;
+    let _ = 1 + 2 + #[cfg(FALSE)] 3;
     //~^ ERROR removing an expression is not supported in this position
-    let _ = [1, 2, 3][#[cfg(unset)] 1];
+    let _ = [1, 2, 3][#[cfg(FALSE)] 1];
     //~^ ERROR removing an expression is not supported in this position
 }

--- a/tests/ui/conditional-compilation/cfg-non-opt-expr.stderr
+++ b/tests/ui/conditional-compilation/cfg-non-opt-expr.stderr
@@ -1,19 +1,19 @@
 error: removing an expression is not supported in this position
   --> $DIR/cfg-non-opt-expr.rs:5:13
    |
-LL |     let _ = #[cfg(unset)] ();
+LL |     let _ = #[cfg(FALSE)] ();
    |             ^^^^^^^^^^^^^
 
 error: removing an expression is not supported in this position
   --> $DIR/cfg-non-opt-expr.rs:7:21
    |
-LL |     let _ = 1 + 2 + #[cfg(unset)] 3;
+LL |     let _ = 1 + 2 + #[cfg(FALSE)] 3;
    |                     ^^^^^^^^^^^^^
 
 error: removing an expression is not supported in this position
   --> $DIR/cfg-non-opt-expr.rs:9:23
    |
-LL |     let _ = [1, 2, 3][#[cfg(unset)] 1];
+LL |     let _ = [1, 2, 3][#[cfg(FALSE)] 1];
    |                       ^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors

--- a/tests/ui/expr/if/attrs/cfg-false-if-attr.rs
+++ b/tests/ui/expr/if/attrs/cfg-false-if-attr.rs
@@ -25,7 +25,7 @@ fn bar() {
         let x: () = true; // Should not error due to the #[cfg(FALSE)]
     }
 
-    #[cfg_attr(not(unset_attr), cfg(FALSE))]
+    #[cfg_attr(not(FALSE), cfg(FALSE))]
     if true {
         let a: () = true; // Should not error due to the applied #[cfg(FALSE)]
     }

--- a/tests/ui/filter-block-view-items.rs
+++ b/tests/ui/filter-block-view-items.rs
@@ -4,5 +4,5 @@
 pub fn main() {
     // Make sure that this view item is filtered out because otherwise it would
     // trigger a compilation error
-    #[cfg(not_present)] use bar as foo;
+    #[cfg(FALSE)] use bar as foo;
 }

--- a/tests/ui/imports/unused-import-issue-87973.rs
+++ b/tests/ui/imports/unused-import-issue-87973.rs
@@ -4,7 +4,7 @@
 // Check that attributes get removed too. See #87973.
 #[deprecated]
 #[allow(unsafe_code)]
-#[cfg(not(foo))]
+#[cfg(not(FALSE))]
 use std::fs;
 //~^ ERROR unused import
 

--- a/tests/ui/inner-attrs-on-impl.rs
+++ b/tests/ui/inner-attrs-on-impl.rs
@@ -3,16 +3,16 @@
 struct Foo;
 
 impl Foo {
-    #![cfg(cfg_that_surely_doesnt_exist)]
+    #![cfg(FALSE)]
 
     fn method(&self) -> bool { false }
 }
 
 impl Foo {
-    #![cfg(not(cfg_that_surely_doesnt_exist))]
+    #![cfg(not(FALSE))]
 
     // check that we don't eat attributes too eagerly.
-    #[cfg(cfg_that_surely_doesnt_exist)]
+    #[cfg(FALSE)]
     fn method(&self) -> bool { false }
 
     fn method(&self) -> bool { true }

--- a/tests/ui/instrument-coverage/off-values.rs
+++ b/tests/ui/instrument-coverage/off-values.rs
@@ -1,9 +1,9 @@
 //@ check-pass
-//@ revisions: n no off false zero
+//@ revisions: n no off _false zero
 //@ [n] compile-flags: -Cinstrument-coverage=n
 //@ [no] compile-flags: -Cinstrument-coverage=no
 //@ [off] compile-flags: -Cinstrument-coverage=off
-//@ [false] compile-flags: -Cinstrument-coverage=false
+//@ [_false] compile-flags: -Cinstrument-coverage=false
 //@ [zero] compile-flags: -Cinstrument-coverage=0
 
 fn main() {}

--- a/tests/ui/issues/issue-11004.rs
+++ b/tests/ui/issues/issue-11004.rs
@@ -2,14 +2,14 @@ use std::mem;
 
 struct A { x: i32, y: f64 }
 
-#[cfg(not(works))]
+#[cfg(not(FALSE))]
 unsafe fn access(n:*mut A) -> (i32, f64) {
     let x : i32 = n.x; //~ no field `x` on type `*mut A`
     let y : f64 = n.y; //~ no field `y` on type `*mut A`
     (x, y)
 }
 
-#[cfg(works)]
+#[cfg(FALSE)]
 unsafe fn access(n:*mut A) -> (i32, f64) {
     let x : i32 = (*n).x;
     let y : f64 = (*n).y;

--- a/tests/ui/issues/issue-11085.rs
+++ b/tests/ui/issues/issue-11085.rs
@@ -5,7 +5,7 @@
 //@ pretty-expanded FIXME #23616
 
 struct Foo {
-    #[cfg(fail)]
+    #[cfg(FALSE)]
     bar: baz,
     foo: isize,
 }
@@ -17,18 +17,18 @@ struct Foo2 {
 
 enum Bar1 {
     Bar1_1,
-    #[cfg(fail)]
+    #[cfg(FALSE)]
     Bar1_2(NotAType),
 }
 
 enum Bar2 {
-    #[cfg(fail)]
+    #[cfg(FALSE)]
     Bar2_1(NotAType),
 }
 
 enum Bar3 {
     Bar3_1 {
-        #[cfg(fail)]
+        #[cfg(FALSE)]
         foo: isize,
         bar: isize,
     }

--- a/tests/ui/issues/issue-16819.rs
+++ b/tests/ui/issues/issue-16819.rs
@@ -3,7 +3,7 @@
 // `#[cfg]` on struct field permits empty unusable struct
 
 struct S {
-    #[cfg(untrue)]
+    #[cfg(FALSE)]
     a: int,
 }
 

--- a/tests/ui/lint/unused_braces_macro.rs
+++ b/tests/ui/lint/unused_braces_macro.rs
@@ -2,5 +2,5 @@
 pub fn foo<const BAR: bool> () {}
 
 fn main() {
-    foo::<{cfg!(feature = "foo")}>();
+    foo::<{cfg!(FALSE)}>();
 }

--- a/tests/ui/macros/macro-attributes.rs
+++ b/tests/ui/macros/macro-attributes.rs
@@ -9,7 +9,7 @@ macro_rules! compiles_fine {
 
         // check that the attributes are recognised by requiring this
         // to be removed to avoid a compile error
-        #[cfg(always_remove)]
+        #[cfg(FALSE)]
         static MISTYPED: () = "foo";
     }
 }

--- a/tests/ui/macros/macro-error.rs
+++ b/tests/ui/macros/macro-error.rs
@@ -5,5 +5,5 @@ macro_rules! foo {
 fn main() {
     foo!(0); // Check that we report errors at macro definition, not expansion.
 
-    let _: cfg!(foo) = (); //~ ERROR non-type macro in type position
+    let _: cfg!(FALSE) = (); //~ ERROR non-type macro in type position
 }

--- a/tests/ui/macros/macro-error.stderr
+++ b/tests/ui/macros/macro-error.stderr
@@ -7,8 +7,8 @@ LL |     ($a:expr) => a;
 error: non-type macro in type position: cfg
   --> $DIR/macro-error.rs:8:12
    |
-LL |     let _: cfg!(foo) = ();
-   |            ^^^^^^^^^
+LL |     let _: cfg!(FALSE) = ();
+   |            ^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/macros/macro-inner-attributes.rs
+++ b/tests/ui/macros/macro-inner-attributes.rs
@@ -5,11 +5,11 @@ macro_rules! test { ($nm:ident,
                      $i:item) => (mod $nm { #![$a] $i }); }
 
 test!(a,
-      #[cfg(qux)],
+      #[cfg(FALSE)],
       pub fn bar() { });
 
 test!(b,
-      #[cfg(not(qux))],
+      #[cfg(not(FALSE))],
       pub fn bar() { });
 
 #[rustc_dummy]

--- a/tests/ui/macros/macro-outer-attributes.rs
+++ b/tests/ui/macros/macro-outer-attributes.rs
@@ -5,11 +5,11 @@ macro_rules! test { ($nm:ident,
                      $i:item) => (mod $nm { #[$a] $i }); }
 
 test!(a,
-      #[cfg(qux)],
+      #[cfg(FALSE)],
       pub fn bar() { });
 
 test!(b,
-      #[cfg(not(qux))],
+      #[cfg(not(FALSE))],
       pub fn bar() { });
 
 // test1!(#[bar])

--- a/tests/ui/macros/macro-with-attrs2.rs
+++ b/tests/ui/macros/macro-with-attrs2.rs
@@ -1,9 +1,9 @@
 //@ run-pass
 
-#[cfg(foo)]
+#[cfg(FALSE)]
 macro_rules! foo { () => (1) }
 
-#[cfg(not(foo))]
+#[cfg(not(FALSE))]
 macro_rules! foo { () => (2) }
 
 pub fn main() {

--- a/tests/ui/nested-cfg-attrs.rs
+++ b/tests/ui/nested-cfg-attrs.rs
@@ -1,4 +1,4 @@
-#[cfg_attr(all(), cfg_attr(all(), cfg(foo)))]
+#[cfg_attr(all(), cfg_attr(all(), cfg(FALSE)))]
 fn f() {}
 
 fn main() { f() } //~ ERROR cannot find function `f` in this scope

--- a/tests/ui/parser/attribute/multiple-tail-expr-behind-cfg.rs
+++ b/tests/ui/parser/attribute/multiple-tail-expr-behind-cfg.rs
@@ -1,9 +1,9 @@
 #![feature(stmt_expr_attributes)]
 
 fn foo() -> String {
-    #[cfg(feature = "validation")]
+    #[cfg(FALSE)]
     [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>() //~ ERROR expected `;`, found `#`
-    #[cfg(not(feature = "validation"))]
+    #[cfg(not(FALSE))]
     String::new()
 }
 

--- a/tests/ui/parser/attribute/multiple-tail-expr-behind-cfg.stderr
+++ b/tests/ui/parser/attribute/multiple-tail-expr-behind-cfg.stderr
@@ -1,11 +1,11 @@
 error: expected `;`, found `#`
   --> $DIR/multiple-tail-expr-behind-cfg.rs:5:64
    |
-LL |     #[cfg(feature = "validation")]
-   |     ------------------------------ only `;` terminated statements or tail expressions are allowed after this attribute
+LL |     #[cfg(FALSE)]
+   |     ------------- only `;` terminated statements or tail expressions are allowed after this attribute
 LL |     [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>()
    |                                                                ^ expected `;` here
-LL |     #[cfg(not(feature = "validation"))]
+LL |     #[cfg(not(FALSE))]
    |     - unexpected token
    |
 help: add `;` here
@@ -18,9 +18,9 @@ LL |     { [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>() }
    |     +                                                             +
 help: it seems like you are trying to provide different expressions depending on `cfg`, consider using `if cfg!(..)`
    |
-LL ~     if cfg!(feature = "validation") {
+LL ~     if cfg!(FALSE) {
 LL ~         [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>()
-LL ~     } else if cfg!(not(feature = "validation")) {
+LL ~     } else if cfg!(not(FALSE)) {
 LL ~         String::new()
 LL +     }
    |

--- a/tests/ui/parser/attribute/properly-recover-from-trailing-outer-attribute-in-body-2.rs
+++ b/tests/ui/parser/attribute/properly-recover-from-trailing-outer-attribute-in-body-2.rs
@@ -5,7 +5,7 @@ macro_rules! the_macro {
         #[cfg()]
         $foo //~ ERROR expected `;`, found `#`
 
-        #[cfg(bar)]
+        #[cfg(FALSE)]
         $bar
     };
 }

--- a/tests/ui/parser/attribute/properly-recover-from-trailing-outer-attribute-in-body-2.stderr
+++ b/tests/ui/parser/attribute/properly-recover-from-trailing-outer-attribute-in-body-2.stderr
@@ -6,7 +6,7 @@ LL |         #[cfg()]
 LL |         $foo
    |             ^ expected `;` here
 LL |
-LL |         #[cfg(bar)]
+LL |         #[cfg(FALSE)]
    |         - unexpected token
 ...
 LL |     the_macro!( (); (); );

--- a/tests/ui/parser/issues/issue-103381.fixed
+++ b/tests/ui/parser/issues/issue-103381.fixed
@@ -37,21 +37,6 @@ fn should_ok_3() {
     if true && if true { true } else { false } {}
 }
 
-fn shoule_match_ok() {
-    #[cfg(feature = "full")]
-    {
-        let a = 1;
-        let b = 2;
-        if match a {
-            1 if b == 1 => true,
-            _ => false,
-        } && if a > 1 { true } else { false }
-        {
-            true
-        }
-    }
-}
-
 fn should_ok_in_nested() {
     if true && if true { true } else { false } { true } else { false };
 }

--- a/tests/ui/parser/issues/issue-103381.rs
+++ b/tests/ui/parser/issues/issue-103381.rs
@@ -37,21 +37,6 @@ fn should_ok_3() {
     if true && if true { true } else { false } {}
 }
 
-fn shoule_match_ok() {
-    #[cfg(feature = "full")]
-    {
-        let a = 1;
-        let b = 2;
-        if match a {
-            1 if b == 1 => true,
-            _ => false,
-        } && if a > 1 { true } else { false }
-        {
-            true
-        }
-    }
-}
-
 fn should_ok_in_nested() {
     if true && if true { true } else { false } { true } else { false };
 }

--- a/tests/ui/proc-macro/modify-ast.rs
+++ b/tests/ui/proc-macro/modify-ast.rs
@@ -7,7 +7,7 @@ use modify_ast::*;
 
 #[derive(Foo)]
 pub struct MyStructc {
-    #[cfg_attr(my_cfg, foo)]
+    #[cfg_attr(FALSE, foo)]
     _a: i32,
 }
 

--- a/tests/ui/sanitizer/cfg-kasan.rs
+++ b/tests/ui/sanitizer/cfg-kasan.rs
@@ -2,7 +2,7 @@
 // the `#[cfg(sanitize = "address")]` attribute is configured.
 
 //@ check-pass
-//@ compile-flags: -Zsanitizer=kernel-address --cfg kernel_address
+//@ compile-flags: -Zsanitizer=kernel-address
 //@ revisions: aarch64 riscv64imac riscv64gc x86_64
 //@[aarch64] compile-flags: --target aarch64-unknown-none
 //@[aarch64] needs-llvm-components: aarch64
@@ -22,5 +22,5 @@ trait Sized {}
 
 const _: fn() -> () = main;
 
-#[cfg(all(sanitize = "address", kernel_address))]
+#[cfg(sanitize = "address")]
 fn main() {}

--- a/tests/ui/stmt_expr_attrs_no_feature.rs
+++ b/tests/ui/stmt_expr_attrs_no_feature.rs
@@ -25,25 +25,25 @@ fn main() {
 
 // Check that cfg works right
 
-#[cfg(unset)]
+#[cfg(FALSE)]
 fn c() {
     #[rustc_dummy]
     5;
 }
 
-#[cfg(not(unset))]
+#[cfg(not(FALSE))]
 fn j() {
     #[rustc_dummy]
     5;
 }
 
-#[cfg_attr(not(unset), cfg(unset))]
+#[cfg_attr(not(FALSE), cfg(FALSE))]
 fn d() {
     #[rustc_dummy]
     8;
 }
 
-#[cfg_attr(not(unset), cfg(not(unset)))]
+#[cfg_attr(not(FALSE), cfg(not(FALSE)))]
 fn i() {
     #[rustc_dummy]
     8;
@@ -57,25 +57,25 @@ macro_rules! item_mac {
             #[rustc_dummy]
             42;
 
-            #[cfg(unset)]
+            #[cfg(FALSE)]
             fn f() {
                 #[rustc_dummy]
                 5;
             }
 
-            #[cfg(not(unset))]
+            #[cfg(not(FALSE))]
             fn k() {
                 #[rustc_dummy]
                 5;
             }
 
-            #[cfg_attr(not(unset), cfg(unset))]
+            #[cfg_attr(not(FALSE), cfg(FALSE))]
             fn g() {
                 #[rustc_dummy]
                 8;
             }
 
-            #[cfg_attr(not(unset), cfg(not(unset)))]
+            #[cfg_attr(not(FALSE), cfg(not(FALSE)))]
             fn h() {
                 #[rustc_dummy]
                 8;
@@ -90,42 +90,42 @@ item_mac!(e);
 // check that the gate visitor works right:
 
 extern "C" {
-    #[cfg(unset)]
+    #[cfg(FALSE)]
     fn x(a: [u8; #[rustc_dummy] 5]);
     fn y(a: [u8; #[rustc_dummy] 5]); //~ ERROR attributes on expressions are experimental
 }
 
 struct Foo;
 impl Foo {
-    #[cfg(unset)]
+    #[cfg(FALSE)]
     const X: u8 = #[rustc_dummy] 5;
     const Y: u8 = #[rustc_dummy] 5; //~ ERROR attributes on expressions are experimental
 }
 
 trait Bar {
-    #[cfg(unset)]
+    #[cfg(FALSE)]
     const X: [u8; #[rustc_dummy] 5];
     const Y: [u8; #[rustc_dummy] 5]; //~ ERROR attributes on expressions are experimental
 }
 
 struct Joyce {
-    #[cfg(unset)]
+    #[cfg(FALSE)]
     field: [u8; #[rustc_dummy] 5],
     field2: [u8; #[rustc_dummy] 5] //~ ERROR attributes on expressions are experimental
 }
 
 struct Walky(
-    #[cfg(unset)] [u8; #[rustc_dummy] 5],
+    #[cfg(FALSE)] [u8; #[rustc_dummy] 5],
     [u8; #[rustc_dummy] 5] //~ ERROR attributes on expressions are experimental
 );
 
 enum Mike {
     Happy(
-        #[cfg(unset)] [u8; #[rustc_dummy] 5],
+        #[cfg(FALSE)] [u8; #[rustc_dummy] 5],
         [u8; #[rustc_dummy] 5] //~ ERROR attributes on expressions are experimental
     ),
     Angry {
-        #[cfg(unset)]
+        #[cfg(FALSE)]
         field: [u8; #[rustc_dummy] 5],
         field2: [u8; #[rustc_dummy] 5] //~ ERROR attributes on expressions are experimental
     }
@@ -133,7 +133,7 @@ enum Mike {
 
 fn pat() {
     match 5 {
-        #[cfg(unset)]
+        #[cfg(FALSE)]
         5 => #[rustc_dummy] (),
         6 => #[rustc_dummy] (), //~ ERROR attributes on expressions are experimental
         _ => (),

--- a/tests/ui/suggestions/option-to-bool.rs
+++ b/tests/ui/suggestions/option-to-bool.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(let_chains, feature(let_chains))]
-
 fn foo(x: Option<i32>) {
     if true && x {}
     //~^ ERROR mismatched types

--- a/tests/ui/suggestions/option-to-bool.stderr
+++ b/tests/ui/suggestions/option-to-bool.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/option-to-bool.rs:4:16
+  --> $DIR/option-to-bool.rs:2:16
    |
 LL |     if true && x {}
    |        ----    ^ expected `bool`, found `Option<i32>`


### PR DESCRIPTION
This PR does several preparation work for having always-on check-cfg in compiletest.

In particular, this PR does two main things:
 - It unifies all the *always-false* cfgs under the `FALSE` cfg (as it seems to be the convention under `tests/ui`)
 - It also removes some useless conditions

This is done ahead of the introduction of the always-on check-cfg in compiletest to reduce the amount of changes in that follow-up work. I also think that this is useful even without that follow-up work.