### PR TITLE
Edition 2024: don't special-case diverging blocks as much

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -46,19 +46,18 @@ use rustc_trait_selection::traits::{self, ObligationCauseCode, SelectionContext}
 use std::iter;
 use std::mem;
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 pub enum DivergingBlockBehavior {
-    /// This is the current stable behavior:
+    /// This is edition <= 2021 behavior:
     ///
     /// ```rust
     /// {
     ///     return;
     /// } // block has type = !, even though we are supposedly dropping it with `;`
     /// ```
-    #[default]
     Never,
 
-    /// Alternative behavior:
+    /// This is edition >= 2024 behavior:
     ///
     /// ```ignore (very-unstable-new-attribute)
     /// #![rustc_never_type_options(diverging_block_default = "unit")]

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -441,7 +441,16 @@ fn parse_never_type_options_attr(
         if tcx.features().never_type_fallback { FallbackToNiko } else { FallbackToUnit }
     });
 
-    let block = block.unwrap_or_default();
+    let block = block.unwrap_or_else(|| default_diverging_block_behavior(tcx));
 
     (fallback, block)
+}
+
+/// Returns the edition-based default diverging block behavior
+fn default_diverging_block_behavior(tcx: TyCtxt<'_>) -> DivergingBlockBehavior {
+    if tcx.sess.edition().at_least_rust_2024() {
+        return DivergingBlockBehavior::Unit;
+    }
+
+    DivergingBlockBehavior::Never
 }

--- a/compiler/rustc_infer/src/infer/error_reporting/suggest.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/suggest.rs
@@ -714,6 +714,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         let last_expr_ty = self.typeck_results.as_ref()?.expr_ty_opt(last_expr)?;
         let needs_box = match (last_expr_ty.kind(), expected_ty.kind()) {
             _ if last_expr_ty.references_error() => return None,
+            (ty::Never, _) => StatementAsExpression::CorrectType,
             _ if self.same_type_modulo_infer(last_expr_ty, expected_ty) => {
                 StatementAsExpression::CorrectType
             }

--- a/tests/ui/editions/diverging-block.e2024.fixed
+++ b/tests/ui/editions/diverging-block.e2024.fixed
@@ -16,14 +16,14 @@ fn main() {
     // edition <= 2021: the block has type `!`, which then can be coerced.
     // edition >= 2024: the block has type `()`, as with any block with no tail.
     let _: u32 = { //[e2024]~ error: mismatched types
-        return;
+        return
     };
 }
 
 fn _f() {
     // Same as the above, but with an if
     if true {
-        return;
+        return
     } else {
         0_u32 //[e2024]~ error: `if` and `else` have incompatible types
     };

--- a/tests/ui/editions/diverging-block.e2024.stderr
+++ b/tests/ui/editions/diverging-block.e2024.stderr
@@ -1,0 +1,24 @@
+error[E0308]: mismatched types
+  --> $DIR/diverging-block.rs:15:18
+   |
+LL |       let _: u32 = {
+   |  __________________^
+LL | |         return;
+LL | |     };
+   | |_____^ expected `u32`, found `()`
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/diverging-block.rs:25:9
+   |
+LL | /     if true {
+LL | |         return;
+   | |         ------- expected because of this
+LL | |     } else {
+LL | |         0_u32
+   | |         ^^^^^ expected `()`, found `u32`
+LL | |     };
+   | |_____- `if` and `else` have incompatible types
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/editions/diverging-block.e2024.stderr
+++ b/tests/ui/editions/diverging-block.e2024.stderr
@@ -1,18 +1,22 @@
 error[E0308]: mismatched types
-  --> $DIR/diverging-block.rs:15:18
+  --> $DIR/diverging-block.rs:18:18
    |
 LL |       let _: u32 = {
    |  __________________^
 LL | |         return;
+   | |               - help: remove this semicolon to return this value
 LL | |     };
    | |_____^ expected `u32`, found `()`
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/diverging-block.rs:25:9
+  --> $DIR/diverging-block.rs:28:9
    |
 LL | /     if true {
 LL | |         return;
-   | |         ------- expected because of this
+   | |         -------
+   | |         |     |
+   | |         |     help: consider removing this semicolon
+   | |         expected because of this
 LL | |     } else {
 LL | |         0_u32
    | |         ^^^^^ expected `()`, found `u32`

--- a/tests/ui/editions/diverging-block.rs
+++ b/tests/ui/editions/diverging-block.rs
@@ -1,0 +1,27 @@
+//@ revisions: e2021 e2024
+//
+//@[e2021] edition: 2021
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//
+//@[e2021] check-pass
+//@[e2024] check-fail
+
+fn main() {
+    // a diverging block, with no tail expression.
+    //
+    // edition <= 2021: the block has type `!`, which then can be coerced.
+    // edition >= 2024: the block has type `()`, as with any block with no tail.
+    let _: u32 = { //[e2024]~ error: mismatched types
+        return;
+    };
+}
+
+fn _f() {
+    // Same as the above, but with an if
+    if true {
+        return;
+    } else {
+        0_u32 //[e2024]~ error: `if` and `else` have incompatible types
+    };
+}


### PR DESCRIPTION
Normally, when a block has no tail-expression its type is `()`:

```rust
let a /*: ()*/ = {};
let a /*: ()*/ = {
    statement(); // note the `;`!
};
```

However, this is not the case when the block is known to diverge, in which case its type becomes `!`[^1]:

```rust
let a /*: !*/ = {
    return; // note the `;`!
};

let a /*: !*/ = {
    returns_never();
    blah(); // note the `;`!
}
```

I think that this is a useless special case and unnecessary complicates the language. **I propose that we remove it in the next edition.**

Note that you can always fix the code that used this special case by removing a `;` (and removing dead-code, if there is any). We already have a machine-applicable fix (as can be seen in the test added in this PR).

```rust
// from the above example, changes you'd need to do in the next edition

let a /*: !*/ = {
    return // no `;`!
};

let a /*: !*/ = {
    returns_never() // no `;`!
                    // removed `blah();` which was dead code
}
```

Also note that while this is related to the never type, this change is independent of the work on its stabilization. I personally think that if we are going to stabilize `!`, we should make it less weird and this is one of the ways to do that; but, this is not required for `!` stabilization and is a completely separate cleanup.

The only hard part of this change is that `rustfmt` currently adds `;` to `return`s which are at the end of blocks. We'll have to change rustfmt style in this regard in order to support the next edition. Out options are

1. Make rustfmt keep `;`, but not add `;` (this won't break any existing users)
2. Make rustfmt add `;` in the edition<=2021 and remove `;` in the edition>=2024 (this will automatically fix code when porting to the new edition) (does rustfmt even support editions?...)
3. Make rustfmt remove `;` (this will break all existing formatting, I don't think that's desirable)

Tracking:
- https://github.com/rust-lang/rust/issues/123747

r? compiler-errors

[^1]: it then immediately decays to `()`  due to current never type fallback, but it does not matter -- you can still specify any type and the block will be coerced to that