### PR TITLE
Remove unnecessary cast from `LLVMRustGetInstrProfIncrementIntrinsic`

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1524,8 +1524,8 @@ extern "C" LLVMValueRef LLVMRustBuildCall(LLVMBuilderRef B, LLVMTypeRef Ty, LLVM
 }
 
 extern "C" LLVMValueRef LLVMRustGetInstrProfIncrementIntrinsic(LLVMModuleRef M) {
-  return wrap(llvm::Intrinsic::getDeclaration(unwrap(M),
-              (llvm::Intrinsic::ID)llvm::Intrinsic::instrprof_increment));
+  return wrap(llvm::Intrinsic::getDeclaration(
+      unwrap(M), llvm::Intrinsic::instrprof_increment));
 }
 
 extern "C" LLVMValueRef LLVMRustBuildMemCpy(LLVMBuilderRef B,


### PR DESCRIPTION
(Noticed while reviewing #123409.)

This particular cast appears to have been copied over from clang, but there are plenty of other call sites in clang that don't bother with a cast here, and it works fine without one.

For context, `llvm::Intrinsic::ID` is a typedef for `unsigned`, and `llvm::Intrinsic::instrprof_increment` is a member of `enum IndependentIntrinsics : unsigned`.

---

The formatting change in `unwrap(M)` is the result of manually running `clang-format` on this file, and then reverting all changes other than the ones affecting these lines.