### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/library/std/src/sys_common/thread_local_key.rs
+++ b/library/std/src/sys_common/thread_local_key.rs
@@ -1,4 +1,4 @@
-//! OS-based thread local storage
+//! OS-based thread local storage for non-Windows systems
 //!
 //! This module provides an implementation of OS-based thread local storage,
 //! using the native OS-provided facilities (think `TlsAlloc` or
@@ -10,6 +10,9 @@
 //! initialization, and does not contain a `Drop` implementation to deallocate
 //! the OS-TLS key. The other is a type which does implement `Drop` and hence
 //! has a safe interface.
+//!
+//! Windows doesn't use this module at all; `sys::pal::windows::thread_local_key`
+//! gets imported in its stead.
 //!
 //! # Usage
 //!


### PR DESCRIPTION
Successful merges:

 - #123584 (Emit an error when `rustc_doc_primitive` has an unknown value)
 - #123589 (sys_common::thread_local_key: make a note that this is not used on Windows)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=123584,123589)
<!-- homu-ignore:end -->