### PR TITLE
propagate `--target` only if target is not host

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1343,10 +1343,9 @@ impl<'a> Builder<'a> {
             Color::Auto => {} // nothing to do
         }
 
-        if cmd != "install" {
+        if target != compiler.host {
+            assert!(cmd != "install", "`x install` can only be called for the host triple.");
             cargo.arg("--target").arg(target.rustc_target_arg());
-        } else {
-            assert_eq!(target, compiler.host);
         }
 
         if self.config.rust_optimize.is_release() {

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -129,6 +129,27 @@ fn validate_path_remap() {
 }
 
 #[test]
+fn validate_cargo_output() {
+    let build = Build::new(configure("test", &["A"], &["A"]));
+
+    let out = build.cargo_out(
+        Compiler { host: TargetSelection::default(), stage: 1 },
+        Mode::Rustc,
+        TargetSelection::default(),
+    );
+
+    assert!(out.ends_with("stage1-rustc/release"));
+
+    let out = build.cargo_out(
+        Compiler { host: TargetSelection::default(), stage: 1 },
+        Mode::Rustc,
+        TargetSelection::from_user("B"),
+    );
+
+    assert!(out.ends_with("stage1-rustc/B/release"));
+}
+
+#[test]
 fn test_exclude() {
     let mut config = configure("test", &["A"], &["A"]);
     config.skip = vec!["src/tools/tidy".into()];

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -797,7 +797,13 @@ impl Build {
     /// running a particular compiler, whether or not we're building the
     /// standard library, and targeting the specified architecture.
     fn cargo_out(&self, compiler: Compiler, mode: Mode, target: TargetSelection) -> PathBuf {
-        self.stage_out(compiler, mode).join(&*target.triple).join(self.cargo_dir())
+        let stage_out = self.stage_out(compiler, mode);
+
+        if self.config.build == target {
+            stage_out.join(self.cargo_dir())
+        } else {
+            stage_out.join(&*target.triple).join(self.cargo_dir())
+        }
     }
 
     /// Root output directory of LLVM for `target`


### PR DESCRIPTION
Passing `--target` alters `RUSTFLAGS` in the build scripts. Since there is no reason to pass them when building for the host triple, exclude them if the target is the host triple.

To test this PR, apply this patch:

```diff
diff --git a/src/tools/miri/build.rs b/src/tools/miri/build.rs
index 0977c0ba016..b26d318d57c 100644
--- a/src/tools/miri/build.rs
+++ b/src/tools/miri/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    assert!(cfg!(foo));
     // Don't rebuild miri when nothing changed.
     println!("cargo:rerun-if-changed=build.rs");
     // Re-export the TARGET environment variable so it can
``` 

Then, run `RUSTFLAGS_NOT_BOOTSTRAP='--cfg=foo --check-cfg=cfg(foo) -Zunstable-options' x build miri`.

Partially resolves #94007.