### PR TITLE
Fix trait solver overflow with `non_local_definitions` lint

### DIFF
--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -265,7 +265,19 @@ fn impl_trait_ref_has_enough_non_local_candidates<'tcx>(
     binder: EarlyBinder<TraitRef<'tcx>>,
     mut did_has_local_parent: impl FnMut(DefId) -> bool,
 ) -> bool {
-    let infcx = tcx.infer_ctxt().build();
+    let infcx = tcx
+        .infer_ctxt()
+        // We use the new trait solver since the obligation we are trying to
+        // prove here may overflow and those are fatal in the old trait solver.
+        // Which is unacceptable for a lint.
+        //
+        // Thanksfully the part we use here are very similar to the
+        // new-trait-solver-as-coherence, which is in stabilization.
+        //
+        // https://github.com/rust-lang/rust/issues/123573
+        .with_next_trait_solver(true)
+        .build();
+
     let trait_ref = binder.instantiate(tcx, infcx.fresh_args_for_item(infer_span, trait_def_id));
 
     let trait_ref = trait_ref.fold_with(&mut ReplaceLocalTypesWithInfer {

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.rs
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+//@ edition:2021
+
+// https://github.com/rust-lang/rust/issues/123573#issue-2229428739
+
+pub trait Test {}
+
+impl<'a, T: 'a> Test for &[T] where &'a T: Test {}
+
+fn main() {
+    struct Local {}
+    impl Test for &Local {}
+    //~^ WARN non-local `impl` definition
+}

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
@@ -1,0 +1,14 @@
+warning: non-local `impl` definition, they should be avoided as they go against expectation
+  --> $DIR/trait-solver-overflow-123573.rs:12:5
+   |
+LL |     impl Test for &Local {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: move this `impl` block outside the of the current function `main`
+   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
+   = note: `#[warn(non_local_definitions)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
This PR fixes the trait solver overflow with the `non_local_definitions` lint reported in https://github.com/rust-lang/rust/issues/123573 using the suggestion from @lcnr: https://github.com/rust-lang/rust/issues/123573#issuecomment-2041348320 to use the next trait solver.

~~I have not (yet) tried to create a minimized repro~~ `@compiler-errors` did the minimization (thanks you) but I have manually tested on the `starlark-rust` project that it fixes the issue.

Fixes #123573
r? @lcnr