### PR TITLE
compiletest: properly handle revisioned run-rustfix tests

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -4252,7 +4252,7 @@ impl<'test> TestCx<'test> {
         if self.props.run_rustfix && self.config.compare_mode.is_none() {
             // And finally, compile the fixed code and make sure it both
             // succeeds and has no diagnostics.
-            let rustc = self.make_compile_args(
+            let mut rustc = self.make_compile_args(
                 &self.expected_output_path(UI_FIXED),
                 TargetLocation::ThisFile(self.make_exe_name()),
                 emit_metadata,
@@ -4260,6 +4260,26 @@ impl<'test> TestCx<'test> {
                 LinkToAux::Yes,
                 Vec::new(),
             );
+
+            // If a test is revisioned, it's fixed source file can be named "a.foo.fixed", which,
+            // well, "a.foo" isn't a valid crate name. So we explicitly mangle the test name
+            // (including the revision) here to avoid the test writer having to manually specify a
+            // `#![crate_name = "..."]` as a workaround. This is okay since we're only checking if
+            // the fixed code is compilable.
+            if self.revision.is_some() {
+                let crate_name =
+                    self.testpaths.file.file_stem().expect("test must have a file stem");
+                // crate name must be alphanumeric or `_`.
+                let crate_name =
+                    crate_name.to_str().expect("crate name implies file name must be valid UTF-8");
+                // replace `a.foo` -> `a__foo` for crate name purposes.
+                // replace `revision-name-with-dashes` -> `revision_name_with_underscore`
+                let crate_name = crate_name.replace(".", "__");
+                let crate_name = crate_name.replace("-", "_");
+                rustc.arg("--crate-name");
+                rustc.arg(crate_name);
+            }
+
             let res = self.compose_and_run_compiler(rustc, None);
             if !res.status.success() {
                 self.fatal_proc_rec("failed to compile fixed code", &res);

--- a/tests/ui/compiletest-self-test/run-rustfix-revisions.foo.fixed
+++ b/tests/ui/compiletest-self-test/run-rustfix-revisions.foo.fixed
@@ -1,0 +1,9 @@
+// Check that revisioned `run-rustfix` does not fail with issues related to `.` in crate name.
+//@ revisions: foo
+//@[foo] run-rustfix
+#![deny(unused_variables)]
+
+fn main() {
+    let _x = 0usize;
+    //~^ ERROR unused variable: `x`
+}

--- a/tests/ui/compiletest-self-test/run-rustfix-revisions.foo.stderr
+++ b/tests/ui/compiletest-self-test/run-rustfix-revisions.foo.stderr
@@ -1,0 +1,14 @@
+error: unused variable: `x`
+  --> $DIR/run-rustfix-revisions.rs:7:9
+   |
+LL |     let x = 0usize;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+note: the lint level is defined here
+  --> $DIR/run-rustfix-revisions.rs:4:9
+   |
+LL | #![deny(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/compiletest-self-test/run-rustfix-revisions.rs
+++ b/tests/ui/compiletest-self-test/run-rustfix-revisions.rs
@@ -1,0 +1,9 @@
+// Check that revisioned `run-rustfix` does not fail with issues related to `.` in crate name.
+//@ revisions: foo
+//@[foo] run-rustfix
+#![deny(unused_variables)]
+
+fn main() {
+    let x = 0usize;
+    //~^ ERROR unused variable: `x`
+}

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.new.fixed
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.new.fixed
@@ -2,8 +2,6 @@
 //@[old] edition:2015
 //@[new] edition:2021
 //@[new] run-rustfix
-// FIXME: the test suite tries to create a crate called `bare_trait_dont_suggest_dyn.new`
-#![crate_name="bare_trait_dont_suggest_dyn"]
 #![deny(bare_trait_objects)]
 fn ord_prefer_dot(s: String) -> impl Ord {
     //~^ ERROR the trait `Ord` cannot be made into an object

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.new.stderr
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.new.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Ord` cannot be made into an object
-  --> $DIR/bare-trait-dont-suggest-dyn.rs:8:33
+  --> $DIR/bare-trait-dont-suggest-dyn.rs:6:33
    |
 LL | fn ord_prefer_dot(s: String) -> Ord {
    |                                 ^^^ `Ord` cannot be made into an object

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.old.stderr
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.old.stderr
@@ -1,5 +1,5 @@
 error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-dont-suggest-dyn.rs:8:33
+  --> $DIR/bare-trait-dont-suggest-dyn.rs:6:33
    |
 LL | fn ord_prefer_dot(s: String) -> Ord {
    |                                 ^^^
@@ -7,7 +7,7 @@ LL | fn ord_prefer_dot(s: String) -> Ord {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
-  --> $DIR/bare-trait-dont-suggest-dyn.rs:7:9
+  --> $DIR/bare-trait-dont-suggest-dyn.rs:5:9
    |
 LL | #![deny(bare_trait_objects)]
    |         ^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | fn ord_prefer_dot(s: String) -> dyn Ord {
    |                                 +++
 
 error[E0038]: the trait `Ord` cannot be made into an object
-  --> $DIR/bare-trait-dont-suggest-dyn.rs:8:33
+  --> $DIR/bare-trait-dont-suggest-dyn.rs:6:33
    |
 LL | fn ord_prefer_dot(s: String) -> Ord {
    |                                 ^^^ `Ord` cannot be made into an object

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.rs
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.rs
@@ -2,8 +2,6 @@
 //@[old] edition:2015
 //@[new] edition:2021
 //@[new] run-rustfix
-// FIXME: the test suite tries to create a crate called `bare_trait_dont_suggest_dyn.new`
-#![crate_name="bare_trait_dont_suggest_dyn"]
 #![deny(bare_trait_objects)]
 fn ord_prefer_dot(s: String) -> Ord {
     //~^ ERROR the trait `Ord` cannot be made into an object


### PR DESCRIPTION
Before this PR, if you have a revisioned `//@ run-rustfix` test like `//@[foo] run-rustfix`, you would run into an error saying crate name cannot contain `.` characters because the fixed test file trying to be compiled is named `<test-name>.<revision>.fixed`, from which `rustc` infers the crate name to be `<test-name>.<revision>` which is not a valid crate name.

This PR fixes the problem by constructing a synthetic crate name from `<test-name>.<revision>`, by

1. replacing all `-` with `_`, and
2. replacing all `.` with `__`

and pass that constructed crate name with `--crate-name` to rustc to compile the fixed file.

Fixes https://github.com/rust-lang/rust/issues/123596.