### PR TITLE
Improve diagnostics by suggesting to remove visibility qualifier

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -273,6 +273,7 @@ ast_passes_visibility_not_permitted =
     .trait_impl = trait items always share the visibility of their trait
     .individual_impl_items = place qualifiers on individual impl items instead
     .individual_foreign_items = place qualifiers on individual foreign items instead
+    .help = remove the qualifier
 
 ast_passes_where_clause_after_type_alias = where clauses are not allowed after the type for type aliases
     .note = see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -26,6 +26,7 @@ pub struct InvalidLabel {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_visibility_not_permitted, code = E0449)]
+#[help]
 pub struct VisibilityNotPermitted {
     #[primary_span]
     pub span: Span,

--- a/tests/ui/error-codes/E0449.stderr
+++ b/tests/ui/error-codes/E0449.stderr
@@ -4,6 +4,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL | pub impl Bar {}
    | ^^^
    |
+   = help: remove the qualifier
    = note: place qualifiers on individual impl items instead
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -12,6 +13,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL | pub impl Foo for Bar {
    | ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -20,6 +22,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub fn foo() {}
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error: aborting due to 3 previous errors

--- a/tests/ui/issues/issue-123529.rs
+++ b/tests/ui/issues/issue-123529.rs
@@ -1,0 +1,8 @@
+trait Fun {
+    pub fn test() {}
+    //~^ ERROR visibility qualifiers are not permitted here
+    //~| NOTE trait items always share the visibility of their trait
+    //~| HELP remove the qualifier
+}
+
+fn main() {}

--- a/tests/ui/issues/issue-123529.stderr
+++ b/tests/ui/issues/issue-123529.stderr
@@ -1,7 +1,7 @@
 error[E0449]: visibility qualifiers are not permitted here
-  --> $DIR/trait-pub-assoc-ty.rs:2:5
+  --> $DIR/issue-123529.rs:2:5
    |
-LL |     pub type Foo;
+LL |     pub fn test() {}
    |     ^^^
    |
    = help: remove the qualifier

--- a/tests/ui/issues/issue-28433.stderr
+++ b/tests/ui/issues/issue-28433.stderr
@@ -4,6 +4,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub Duck,
    |     ^^^
    |
+   = help: remove the qualifier
    = note: enum variants and their fields always share the visibility of the enum they are in
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -12,6 +13,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub(crate) Dove
    |     ^^^^^^^^^^
    |
+   = help: remove the qualifier
    = note: enum variants and their fields always share the visibility of the enum they are in
 
 error: aborting due to 2 previous errors

--- a/tests/ui/parser/assoc/assoc-static-semantic-fail.stderr
+++ b/tests/ui/parser/assoc/assoc-static-semantic-fail.stderr
@@ -140,6 +140,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub(crate) default static TD: u8;
    |     ^^^^^^^^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error: associated constant in `impl` without body
@@ -164,6 +165,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub default static TD: u8;
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes

--- a/tests/ui/parser/default.stderr
+++ b/tests/ui/parser/default.stderr
@@ -23,6 +23,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub default fn foo<T: Default>() -> T {
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes

--- a/tests/ui/parser/trait-pub-assoc-const.stderr
+++ b/tests/ui/parser/trait-pub-assoc-const.stderr
@@ -4,6 +4,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub const Foo: u32;
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error: aborting due to 1 previous error

--- a/tests/ui/parser/trait-pub-method.stderr
+++ b/tests/ui/parser/trait-pub-method.stderr
@@ -4,6 +4,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub fn foo();
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error: aborting due to 1 previous error

--- a/tests/ui/privacy/issue-113860-1.stderr
+++ b/tests/ui/privacy/issue-113860-1.stderr
@@ -4,6 +4,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub(self) fn fun() {}
    |     ^^^^^^^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error: module has missing stability attribute

--- a/tests/ui/privacy/issue-113860-2.stderr
+++ b/tests/ui/privacy/issue-113860-2.stderr
@@ -4,6 +4,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub(self) type X = Self;
    |     ^^^^^^^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error: module has missing stability attribute

--- a/tests/ui/privacy/issue-113860.stderr
+++ b/tests/ui/privacy/issue-113860.stderr
@@ -4,6 +4,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub(self) const X: u32 = 3;
    |     ^^^^^^^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error: module has missing stability attribute

--- a/tests/ui/privacy/issue-29161.stderr
+++ b/tests/ui/privacy/issue-29161.stderr
@@ -4,6 +4,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |         pub fn default() -> A {
    |         ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0603]: struct `A` is private

--- a/tests/ui/privacy/priv-in-bad-locations.stderr
+++ b/tests/ui/privacy/priv-in-bad-locations.stderr
@@ -4,6 +4,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL | pub extern "C" {
    | ^^^
    |
+   = help: remove the qualifier
    = note: place qualifiers on individual foreign items instead
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -12,6 +13,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL | pub impl B {}
    | ^^^
    |
+   = help: remove the qualifier
    = note: place qualifiers on individual impl items instead
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -20,6 +22,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL | pub impl A for B {
    | ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -28,6 +31,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub fn foo(&self) {}
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error: aborting due to 4 previous errors

--- a/tests/ui/privacy/privacy-sanity.stderr
+++ b/tests/ui/privacy/privacy-sanity.stderr
@@ -4,6 +4,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL | pub impl Tr for S {
    | ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -12,6 +13,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub fn f() {}
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -20,6 +22,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub const C: u8 = 0;
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -28,6 +31,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub type T = u8;
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -36,6 +40,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL | pub impl S {
    | ^^^
    |
+   = help: remove the qualifier
    = note: place qualifiers on individual impl items instead
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -44,6 +49,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL | pub extern "C" {
    | ^^^
    |
+   = help: remove the qualifier
    = note: place qualifiers on individual foreign items instead
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -52,6 +58,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub impl Tr for S {
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -60,6 +67,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |         pub fn f() {}
    |         ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -68,6 +76,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |         pub const C: u8 = 0;
    |         ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -76,6 +85,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |         pub type T = u8;
    |         ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -84,6 +94,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub impl S {
    |     ^^^
    |
+   = help: remove the qualifier
    = note: place qualifiers on individual impl items instead
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -92,6 +103,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub extern "C" {
    |     ^^^
    |
+   = help: remove the qualifier
    = note: place qualifiers on individual foreign items instead
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -100,6 +112,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub impl Tr for S {
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -108,6 +121,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |         pub fn f() {}
    |         ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -116,6 +130,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |         pub const C: u8 = 0;
    |         ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -124,6 +139,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |         pub type T = u8;
    |         ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -132,6 +148,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub impl S {
    |     ^^^
    |
+   = help: remove the qualifier
    = note: place qualifiers on individual impl items instead
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -140,6 +157,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub extern "C" {
    |     ^^^
    |
+   = help: remove the qualifier
    = note: place qualifiers on individual foreign items instead
 
 error: aborting due to 18 previous errors

--- a/tests/ui/privacy/useless-pub.stderr
+++ b/tests/ui/privacy/useless-pub.stderr
@@ -4,6 +4,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     pub fn foo(&self) {}
    |     ^^^
    |
+   = help: remove the qualifier
    = note: trait items always share the visibility of their trait
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -12,6 +13,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     V1 { pub f: i32 },
    |          ^^^
    |
+   = help: remove the qualifier
    = note: enum variants and their fields always share the visibility of the enum they are in
 
 error[E0449]: visibility qualifiers are not permitted here
@@ -20,6 +22,7 @@ error[E0449]: visibility qualifiers are not permitted here
 LL |     V2(pub i32),
    |        ^^^
    |
+   = help: remove the qualifier
    = note: enum variants and their fields always share the visibility of the enum they are in
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
Resolves #123529

This adds a suggestion to remove the qualifier since trait items always share the visibility of their trait.