### PR TITLE
Default-enable share-generics, with available_externally to still allow inlining.

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1127,7 +1127,10 @@ pub(crate) fn should_codegen_locally<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance
         || instance.polymorphize(tcx).upstream_monomorphization(tcx).is_some()
     {
         // We can link to the item in question, no instance needed in this crate.
-        return false;
+        // However, we will still codegen this item locally *if* we have the MIR to do so.
+        // This codegen will happen in LLVM with available_externally linkage, which lets us benefit
+        // from inlining etc. while saving on binary size.
+        return tcx.is_mir_available(def_id);
     }
 
     if let DefKind::Static { .. } = tcx.def_kind(def_id) {

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -174,6 +174,37 @@ where
         debug_dump(tcx, "INTERNALIZE", &codegen_units);
     }
 
+    // Mark items we're importing from upstream
+    for cgu in codegen_units.iter_mut() {
+        for (item, data) in cgu.items_mut() {
+            if let MonoItem::Fn(instance) = item {
+                let Some(def_id) = instance.def.def_id_if_not_guaranteed_local_codegen() else {
+                    continue;
+                };
+
+                if tcx.is_foreign_item(def_id) {
+                    continue;
+                }
+
+                if def_id.is_local() {
+                    continue;
+                }
+
+                if tcx.is_reachable_non_generic(instance.def_id())
+                    || instance.polymorphize(tcx).upstream_monomorphization(tcx).is_some()
+                {
+                    // We can link to the item in question, no instance needed in this crate.
+                    // However, we will still codegen this item locally *if* we have the MIR to do so.
+                    // This codegen will happen in LLVM with available_externally linkage, which lets us benefit
+                    // from inlining etc. while saving on binary size.
+                    if tcx.is_mir_available(instance.def_id()) {
+                        data.linkage = Linkage::AvailableExternally;
+                    }
+                }
+            }
+        }
+    }
+
     // Mark one CGU for dead code, if necessary.
     if tcx.sess.instrument_coverage() {
         mark_code_coverage_dead_code_cgu(&mut codegen_units);

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1095,13 +1095,7 @@ impl Options {
 
     #[inline]
     pub fn share_generics(&self) -> bool {
-        match self.unstable_opts.share_generics {
-            Some(setting) => setting,
-            None => match self.optimize {
-                OptLevel::No | OptLevel::Less | OptLevel::Size | OptLevel::SizeMin => true,
-                OptLevel::Default | OptLevel::Aggressive => false,
-            },
-        }
+        true
     }
 
     pub fn get_symbol_mangling_version(&self) -> SymbolManglingVersion {

--- a/compiler/rustc_symbol_mangling/src/lib.rs
+++ b/compiler/rustc_symbol_mangling/src/lib.rs
@@ -141,7 +141,7 @@ fn symbol_name_provider<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> ty
         // to differentiate between local copies.
         if is_generic(instance, tcx) {
             // For generics we might find re-usable upstream instances. If there
-            // is one, we rely on the symbol being instantiated locally.
+            // is not one, we rely on the symbol being instantiated locally.
             instance.upstream_monomorphization(tcx).unwrap_or(LOCAL_CRATE)
         } else {
             // For non-generic things that need to avoid naming conflicts, we


### PR DESCRIPTION
WIP, just experimenting, not clear whether this works for other codegen backends, or how practical of a tradeoff it is.

cc https://github.com/rust-lang/rust/issues/14527

r? @Mark-Simulacrum for now