### PR TITLE
[Test] issue-122805.rs should limit to little endian target

### DIFF
--- a/tests/codegen/issues/issue-122805.rs
+++ b/tests/codegen/issues/issue-122805.rs
@@ -20,6 +20,7 @@
 // CHECK-NEXT: store <8 x i16>
 // CHECK-NEXT: ret void
 #[no_mangle]
+#[cfg(target_endian = "little")]
 pub fn convert(value: [u16; 8]) -> [u8; 16] {
     let addr16 = [
         value[0].to_be(),


### PR DESCRIPTION
In issue-122805.rs, codegen on big endian target is different from little endian target. 
```llvm
%0 = load <8 x i16>, ptr %value, align 2
store <8 x i16> %0, ptr %_0, align 1
ret void
```
This is expected since the conversion is unnecessary on BE target for this case.
