### PR TITLE
sanitizers: Stabilize AddressSanitizer and LeakSanitizer

### DIFF
--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -16,7 +16,7 @@ use rustc_session::{Session, config};
 use rustc_target::callconv::{
     ArgAbi, ArgAttribute, ArgAttributes, ArgExtension, CastTarget, FnAbi, PassMode,
 };
-use rustc_target::spec::{Arch, SanitizerSet};
+use rustc_target::spec::Arch;
 use smallvec::SmallVec;
 
 use crate::attributes::{self, llfn_attrs_from_instance};
@@ -94,7 +94,7 @@ fn get_attrs<'ll>(this: &ArgAttributes, cx: &CodegenCx<'ll, '_>) -> SmallVec<[&'
                 break;
             }
         }
-    } else if cx.tcx.sess.sanitizers().contains(SanitizerSet::MEMORY) {
+    } else if cx.tcx.sess.is_sanitizer_memory_enabled() {
         // If we're not optimising, *but* memory sanitizer is on, emit noundef, since it affects
         // memory sanitizer's behavior.
 

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -263,7 +263,7 @@ fn probestack_attr<'ll, 'tcx>(cx: &SimpleCx<'ll>, tcx: TyCtxt<'tcx>) -> Option<&
     // Currently stack probes seem somewhat incompatible with the address
     // sanitizer and thread sanitizer. With asan we're already protected from
     // stack overflow anyway so we don't really need stack probes regardless.
-    if tcx.sess.sanitizers().intersects(SanitizerSet::ADDRESS | SanitizerSet::THREAD) {
+    if tcx.sess.is_sanitizer_address_enabled() || tcx.sess.is_sanitizer_thread_enabled() {
         return None;
     }
 

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2718,7 +2718,7 @@ fn add_order_independent_options(
         && crate_type == CrateType::Executable
         && !matches!(flavor, LinkerFlavor::Gnu(Cc::Yes, _))
     {
-        let prefix = if sess.sanitizers().contains(SanitizerSet::ADDRESS) { "asan/" } else { "" };
+        let prefix = if sess.is_sanitizer_address_enabled() { "asan/" } else { "" };
         cmd.link_arg(format!("--dynamic-linker={prefix}ld.so.1"));
     }
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -634,6 +634,7 @@ fn test_codegen_options_tracking_hash() {
     tracked!(profile_use, Some(PathBuf::from("abc")));
     tracked!(relocation_model, Some(RelocModel::Pic));
     tracked!(relro_level, Some(RelroLevel::Full));
+    tracked!(sanitize, SanitizerSet::ADDRESS);
     tracked!(split_debuginfo, Some(SplitDebuginfo::Packed));
     tracked!(symbol_mangling_version, Some(SymbolManglingVersion::V0));
     tracked!(target_cpu, Some(String::from("abc")));
@@ -851,7 +852,6 @@ fn test_unstable_options_tracking_hash() {
     tracked!(regparm, Some(3));
     tracked!(relax_elf_relocations, Some(true));
     tracked!(remap_cwd_prefix, Some(PathBuf::from("abc")));
-    tracked!(sanitizer, SanitizerSet::ADDRESS);
     tracked!(sanitizer_cfi_canonical_jump_tables, None);
     tracked!(sanitizer_cfi_generalize_pointers, Some(true));
     tracked!(sanitizer_cfi_normalize_integers, Some(true));

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -295,7 +295,7 @@ pub(crate) struct SanitizersNotSupported {
 }
 
 #[derive(Diagnostic)]
-#[diag("`-Zsanitizer={$first}` is incompatible with `-Zsanitizer={$second}`")]
+#[diag("`-Csanitize={$first}` is incompatible with `-Csanitize={$second}`")]
 pub(crate) struct CannotMixAndMatchSanitizers {
     pub(crate) first: String,
     pub(crate) second: String,
@@ -308,31 +308,31 @@ pub(crate) struct CannotMixAndMatchSanitizers {
 pub(crate) struct CannotEnableCrtStaticLinux;
 
 #[derive(Diagnostic)]
-#[diag("`-Zsanitizer=cfi` requires `-Clto` or `-Clinker-plugin-lto`")]
+#[diag("`-Csanitize=cfi` requires `-Clto` or `-Clinker-plugin-lto`")]
 pub(crate) struct SanitizerCfiRequiresLto;
 
 #[derive(Diagnostic)]
-#[diag("`-Zsanitizer=cfi` with `-Clto` requires `-Ccodegen-units=1`")]
+#[diag("`-Csanitize=cfi` with `-Clto` requires `-Ccodegen-units=1`")]
 pub(crate) struct SanitizerCfiRequiresSingleCodegenUnit;
 
 #[derive(Diagnostic)]
-#[diag("`-Zsanitizer-cfi-canonical-jump-tables` requires `-Zsanitizer=cfi`")]
+#[diag("`-Zsanitizer-cfi-canonical-jump-tables` requires `-Csanitize=cfi`")]
 pub(crate) struct SanitizerCfiCanonicalJumpTablesRequiresCfi;
 
 #[derive(Diagnostic)]
-#[diag("`-Zsanitizer-cfi-generalize-pointers` requires `-Zsanitizer=cfi` or `-Zsanitizer=kcfi`")]
+#[diag("`-Zsanitizer-cfi-generalize-pointers` requires `-Csanitize=cfi` or `-Csanitize=kcfi`")]
 pub(crate) struct SanitizerCfiGeneralizePointersRequiresCfi;
 
 #[derive(Diagnostic)]
-#[diag("`-Zsanitizer-cfi-normalize-integers` requires `-Zsanitizer=cfi` or `-Zsanitizer=kcfi`")]
+#[diag("`-Zsanitizer-cfi-normalize-integers` requires `-Csanitize=cfi` or `-Csanitize=kcfi`")]
 pub(crate) struct SanitizerCfiNormalizeIntegersRequiresCfi;
 
 #[derive(Diagnostic)]
-#[diag("`-Zsanitizer-kcfi-arity` requires `-Zsanitizer=kcfi`")]
+#[diag("`-Zsanitizer-kcfi-arity` requires `-Csanitize=kcfi`")]
 pub(crate) struct SanitizerKcfiArityRequiresKcfi;
 
 #[derive(Diagnostic)]
-#[diag("`-Z sanitizer=kcfi` requires `-C panic=abort`")]
+#[diag("`-Csanitize=kcfi` requires `-C panic=abort`")]
 pub(crate) struct SanitizerKcfiRequiresPanicAbort;
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -140,10 +140,12 @@ impl TargetModifier {
     pub fn consistent(&self, sess: &Session, other: Option<&TargetModifier>) -> bool {
         assert!(other.is_none() || self.opt == other.unwrap().opt);
         match self.opt {
-            OptionsTargetModifiers::UnstableOptions(unstable) => match unstable {
-                UnstableOptionsTargetModifiers::Sanitizer => {
+            OptionsTargetModifiers::CodegenOptions(stable) => match stable {
+                CodegenOptionsTargetModifiers::Sanitizer => {
                     return target_modifier_consistency_check::sanitizer(self, other);
                 }
+            },
+            OptionsTargetModifiers::UnstableOptions(unstable) => match unstable {
                 UnstableOptionsTargetModifiers::SanitizerCfiNormalizeIntegers => {
                     return target_modifier_consistency_check::sanitizer_cfi_normalize_integers(
                         sess, self, other,
@@ -151,7 +153,6 @@ impl TargetModifier {
                 }
                 _ => {}
             },
-            _ => {}
         };
         match other {
             Some(other) => self.extend().tech_value == other.extend().tech_value,
@@ -1214,27 +1215,14 @@ pub mod parse {
     }
 
     pub(crate) fn parse_sanitizers(slot: &mut SanitizerSet, v: Option<&str>) -> bool {
-        if let Some(v) = v {
-            for s in v.split(',') {
-                *slot |= match s {
-                    "address" => SanitizerSet::ADDRESS,
-                    "cfi" => SanitizerSet::CFI,
-                    "dataflow" => SanitizerSet::DATAFLOW,
-                    "kcfi" => SanitizerSet::KCFI,
-                    "kernel-address" => SanitizerSet::KERNELADDRESS,
-                    "kernel-hwaddress" => SanitizerSet::KERNELHWADDRESS,
-                    "leak" => SanitizerSet::LEAK,
-                    "memory" => SanitizerSet::MEMORY,
-                    "memtag" => SanitizerSet::MEMTAG,
-                    "shadow-call-stack" => SanitizerSet::SHADOWCALLSTACK,
-                    "thread" => SanitizerSet::THREAD,
-                    "hwaddress" => SanitizerSet::HWADDRESS,
-                    "safestack" => SanitizerSet::SAFESTACK,
-                    "realtime" => SanitizerSet::REALTIME,
-                    _ => return false,
-                }
+        if let Some(s) = v {
+            let sanitizer_set = SanitizerSet::from_comma_list(s);
+            if sanitizer_set.is_ok() {
+                *slot |= sanitizer_set.unwrap();
+                true
+            } else {
+                false
             }
-            true
         } else {
             false
         }
@@ -2151,6 +2139,9 @@ options! {
         "output remarks for these optimization passes (space separated, or \"all\")"),
     rpath: bool = (false, parse_bool, [UNTRACKED],
         "set rpath values in libs/exes (default: no)"),
+    #[rustc_lint_opt_deny_field_access("use `Session::sanitizers()` instead of this field")]
+    sanitize: SanitizerSet = (SanitizerSet::empty(), parse_sanitizers, [TRACKED] { TARGET_MODIFIER: Sanitizer },
+        "use one or multiple sanitizers"),
     save_temps: bool = (false, parse_bool, [UNTRACKED],
         "save all temporary output files during compilation (default: no)"),
     soft_float: () = ((), parse_ignore, [UNTRACKED],
@@ -2585,9 +2576,6 @@ written to standard error output)"),
     retpoline_external_thunk: bool = (false, parse_bool, [TRACKED] { TARGET_MODIFIER: RetpolineExternalThunk },
         "enables retpoline-external-thunk, retpoline-indirect-branches and retpoline-indirect-calls \
         target features (default: no)"),
-    #[rustc_lint_opt_deny_field_access("use `Session::sanitizers()` instead of this field")]
-    sanitizer: SanitizerSet = (SanitizerSet::empty(), parse_sanitizers, [TRACKED] { TARGET_MODIFIER: Sanitizer },
-        "use a sanitizer"),
     sanitizer_cfi_canonical_jump_tables: Option<bool> = (Some(true), parse_opt_bool, [TRACKED],
         "enable canonical jump tables (default: yes)"),
     sanitizer_cfi_generalize_pointers: Option<bool> = (None, parse_opt_bool, [TRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -341,6 +341,10 @@ impl Session {
         &self.opts.unstable_opts.coverage_options
     }
 
+    pub fn is_sanitizer_address_enabled(&self) -> bool {
+        self.sanitizers().contains(SanitizerSet::ADDRESS)
+    }
+
     pub fn is_sanitizer_cfi_enabled(&self) -> bool {
         self.sanitizers().contains(SanitizerSet::CFI)
     }
@@ -361,12 +365,40 @@ impl Session {
         self.opts.unstable_opts.sanitizer_cfi_normalize_integers == Some(true)
     }
 
+    pub fn is_sanitizer_hwaddress_enabled(&self) -> bool {
+        self.sanitizers().contains(SanitizerSet::HWADDRESS)
+    }
+
     pub fn is_sanitizer_kcfi_arity_enabled(&self) -> bool {
         self.opts.unstable_opts.sanitizer_kcfi_arity == Some(true)
     }
 
     pub fn is_sanitizer_kcfi_enabled(&self) -> bool {
         self.sanitizers().contains(SanitizerSet::KCFI)
+    }
+
+    pub fn is_sanitizer_kernel_address_enabled(&self) -> bool {
+        self.sanitizers().contains(SanitizerSet::KERNELADDRESS)
+    }
+
+    pub fn is_sanitizer_kernel_hwaddress_enabled(&self) -> bool {
+        self.sanitizers().contains(SanitizerSet::KERNELHWADDRESS)
+    }
+
+    pub fn is_sanitizer_memory_enabled(&self) -> bool {
+        self.sanitizers().contains(SanitizerSet::MEMORY)
+    }
+
+    pub fn is_sanitizer_memory_recover_enabled(&self) -> bool {
+        self.opts.unstable_opts.sanitizer_recover.contains(SanitizerSet::MEMORY)
+    }
+
+    pub fn is_sanitizer_memory_track_origins_enabled(&self) -> bool {
+        self.opts.unstable_opts.sanitizer_memory_track_origins != 0
+    }
+
+    pub fn is_sanitizer_thread_enabled(&self) -> bool {
+        self.sanitizers().contains(SanitizerSet::THREAD)
     }
 
     pub fn is_split_lto_unit_enabled(&self) -> bool {
@@ -543,13 +575,15 @@ impl Session {
     /// Checks if LLVM lifetime markers should be emitted.
     pub fn emit_lifetime_markers(&self) -> bool {
         self.opts.optimize != config::OptLevel::No
-        // AddressSanitizer and KernelAddressSanitizer uses lifetimes to detect use after scope bugs.
-        //
+        // AddressSanitizer and KernelAddressSanitizer use lifetimes to detect use after scope bugs.
         // MemorySanitizer uses lifetimes to detect use of uninitialized stack variables.
-        //
         // HWAddressSanitizer and KernelHWAddressSanitizer will use lifetimes to detect use after
         // scope bugs in the future.
-        || self.sanitizers().intersects(SanitizerSet::ADDRESS | SanitizerSet::KERNELADDRESS | SanitizerSet::MEMORY | SanitizerSet::HWADDRESS | SanitizerSet::KERNELHWADDRESS)
+        || self.is_sanitizer_address_enabled()
+        || self.is_sanitizer_kernel_address_enabled()
+        || self.is_sanitizer_kernel_hwaddress_enabled()
+        || self.is_sanitizer_memory_enabled()
+        || self.is_sanitizer_hwaddress_enabled()
     }
 
     pub fn diagnostic_width(&self) -> usize {
@@ -701,7 +735,7 @@ impl Session {
             let more_names = self.opts.output_types.contains_key(&OutputType::LlvmAssembly)
                 || self.opts.output_types.contains_key(&OutputType::Bitcode)
                 // AddressSanitizer and MemorySanitizer use alloca name when reporting an issue.
-                || self.opts.unstable_opts.sanitizer.intersects(SanitizerSet::ADDRESS | SanitizerSet::MEMORY);
+                || self.is_sanitizer_address_enabled() || self.is_sanitizer_memory_enabled();
             !more_names
         }
     }
@@ -934,7 +968,28 @@ impl Session {
     }
 
     pub fn sanitizers(&self) -> SanitizerSet {
-        return self.opts.unstable_opts.sanitizer | self.target.options.default_sanitizers;
+        self.opts.cg.sanitize
+            | (self.target.options.default_sanitizers & self.supported_sanitizers())
+    }
+
+    pub fn supported_sanitizers(&self) -> SanitizerSet {
+        if self.unstable_options() {
+            self.target.options.supported_sanitizers | self.target.options.stable_sanitizers
+        } else {
+            self.target.options.stable_sanitizers
+        }
+    }
+
+    pub fn unsupported_sanitizers(&self) -> SanitizerSet {
+        let mut unsupported_sanitizers = self.sanitizers() - self.supported_sanitizers();
+
+        // Niche: if `fixed-x18`, or effectively switching on `reserved-x18` flag, is enabled
+        // we should allow Shadow Call Stack sanitizer.
+        if self.opts.unstable_opts.fixed_x18 && self.target.arch == Arch::AArch64 {
+            unsupported_sanitizers -= SanitizerSet::SHADOWCALLSTACK;
+        }
+
+        unsupported_sanitizers
     }
 }
 
@@ -1173,14 +1228,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
         }
     }
 
-    // Sanitizers can only be used on platforms that we know have working sanitizer codegen.
-    let supported_sanitizers = sess.target.options.supported_sanitizers;
-    let mut unsupported_sanitizers = sess.opts.unstable_opts.sanitizer - supported_sanitizers;
-    // Niche: if `fixed-x18`, or effectively switching on `reserved-x18` flag, is enabled
-    // we should allow Shadow Call Stack sanitizer.
-    if sess.opts.unstable_opts.fixed_x18 && sess.target.arch == Arch::AArch64 {
-        unsupported_sanitizers -= SanitizerSet::SHADOWCALLSTACK;
-    }
+    let unsupported_sanitizers = sess.unsupported_sanitizers();
     match unsupported_sanitizers.into_iter().count() {
         0 => {}
         1 => {
@@ -1195,7 +1243,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     }
 
     // Cannot mix and match mutually-exclusive sanitizers.
-    if let Some((first, second)) = sess.opts.unstable_opts.sanitizer.mutually_exclusive() {
+    if let Some((first, second)) = sess.opts.cg.sanitize.mutually_exclusive() {
         sess.dcx().emit_err(errors::CannotMixAndMatchSanitizers {
             first: first.to_string(),
             second: second.to_string(),
@@ -1203,10 +1251,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     }
 
     // Cannot enable crt-static with sanitizers on Linux
-    if sess.crt_static(None)
-        && !sess.opts.unstable_opts.sanitizer.is_empty()
-        && !sess.target.is_like_msvc
-    {
+    if sess.crt_static(None) && !sess.sanitizers().is_empty() && !sess.target.is_like_msvc {
         sess.dcx().emit_err(errors::CannotEnableCrtStaticLinux);
     }
 

--- a/compiler/rustc_target/src/spec/json.rs
+++ b/compiler/rustc_target/src/spec/json.rs
@@ -219,6 +219,11 @@ impl Target {
                 default_sanitizers.into_iter().fold(SanitizerSet::empty(), |a, b| a | b);
         }
 
+        if let Some(stable_sanitizers) = json.stable_sanitizers {
+            base.stable_sanitizers =
+                stable_sanitizers.into_iter().fold(SanitizerSet::empty(), |a, b| a | b);
+        }
+
         forward!(generate_arange_section);
         forward!(supports_stack_protector);
         forward!(small_data_threshold_support);
@@ -401,6 +406,7 @@ impl ToJson for Target {
         target_option_val!(supported_split_debuginfo);
         target_option_val!(supported_sanitizers);
         target_option_val!(default_sanitizers);
+        target_option_val!(stable_sanitizers);
         target_option_val!(c_enum_min_bits);
         target_option_val!(generate_arange_section);
         target_option_val!(supports_stack_protector);
@@ -624,6 +630,8 @@ struct TargetSpecJson {
     supported_split_debuginfo: Option<StaticCow<[SplitDebuginfo]>>,
     supported_sanitizers: Option<Vec<SanitizerSet>>,
     default_sanitizers: Option<Vec<SanitizerSet>>,
+    #[serde(rename = "stable-sanitizers")]
+    stable_sanitizers: Option<Vec<SanitizerSet>>,
     generate_arange_section: Option<bool>,
     supports_stack_protector: Option<bool>,
     small_data_threshold_support: Option<SmallDataThresholdSupport>,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -37,6 +37,7 @@
 //!
 //! [JSON]: https://json.org
 
+// ignore-tidy-filelength
 use core::result::Result;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -1244,6 +1245,39 @@ impl SanitizerSet {
         })
     }
 
+    pub fn from_comma_list(s: &str) -> Result<Self, String> {
+        let mut sanitizer_set = SanitizerSet::empty();
+        for name in s.split(',') {
+            sanitizer_set |= match name {
+                "address" => SanitizerSet::ADDRESS,
+                "cfi" => SanitizerSet::CFI,
+                "dataflow" => SanitizerSet::DATAFLOW,
+                "kcfi" => SanitizerSet::KCFI,
+                "kernel-address" => SanitizerSet::KERNELADDRESS,
+                "kernel-hwaddress" => SanitizerSet::KERNELHWADDRESS,
+                "leak" => SanitizerSet::LEAK,
+                "memory" => SanitizerSet::MEMORY,
+                "memtag" => SanitizerSet::MEMTAG,
+                "realtime" => SanitizerSet::REALTIME,
+                "safestack" => SanitizerSet::SAFESTACK,
+                "shadow-call-stack" => SanitizerSet::SHADOWCALLSTACK,
+                "thread" => SanitizerSet::THREAD,
+                "hwaddress" => SanitizerSet::HWADDRESS,
+                _ => return Err(format!("Unknown sanitizer {}", name)),
+            };
+        }
+        return Ok(sanitizer_set);
+    }
+
+    pub fn from_json(json: &Json) -> Result<Self, String> {
+        if let Some(array) = json.as_array() {
+            let s: String = array.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(",");
+            return Self::from_comma_list(&s);
+        } else {
+            return Err("Expected a list of sanitizers".to_string());
+        }
+    }
+
     pub fn mutually_exclusive(self) -> Option<(SanitizerSet, SanitizerSet)> {
         Self::MUTUALLY_EXCLUSIVE
             .into_iter()
@@ -1281,11 +1315,11 @@ impl FromStr for SanitizerSet {
             "leak" => SanitizerSet::LEAK,
             "memory" => SanitizerSet::MEMORY,
             "memtag" => SanitizerSet::MEMTAG,
+            "realtime" => SanitizerSet::REALTIME,
             "safestack" => SanitizerSet::SAFESTACK,
             "shadow-call-stack" => SanitizerSet::SHADOWCALLSTACK,
             "thread" => SanitizerSet::THREAD,
             "hwaddress" => SanitizerSet::HWADDRESS,
-            "realtime" => SanitizerSet::REALTIME,
             s => return Err(format!("unknown sanitizer {s}")),
         })
     }
@@ -2684,6 +2718,13 @@ pub struct TargetOptions {
     /// distributed with the target, the sanitizer should still appear in this list for the target.
     pub default_sanitizers: SanitizerSet,
 
+    /// The stable sanitizers supported by this target
+    ///
+    /// Note that the support here is at a codegen level. If the machine code with sanitizer
+    /// enabled can generated on this target, but the necessary supporting libraries are not
+    /// distributed with the target, the sanitizer should still appear in this list for the target.
+    pub stable_sanitizers: SanitizerSet,
+
     /// Minimum number of bits in #[repr(C)] enum. Defaults to the size of c_int
     pub c_enum_min_bits: Option<u64>,
 
@@ -2939,6 +2980,7 @@ impl Default for TargetOptions {
             supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             supported_sanitizers: SanitizerSet::empty(),
             default_sanitizers: SanitizerSet::empty(),
+            stable_sanitizers: SanitizerSet::empty(),
             c_enum_min_bits: None,
             generate_arange_section: true,
             supports_stack_protector: true,

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_darwin.rs
@@ -22,8 +22,9 @@ pub(crate) fn target() -> Target {
             // FIXME: The leak sanitizer currently fails the tests, see #88132.
             supported_sanitizers: SanitizerSet::ADDRESS
                 | SanitizerSet::CFI
-                | SanitizerSet::THREAD
-                | SanitizerSet::REALTIME,
+                | SanitizerSet::REALTIME
+                | SanitizerSet::THREAD,
+            stable_sanitizers: SanitizerSet::ADDRESS,
             supports_xray: true,
             ..opts
         },

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
@@ -25,13 +25,14 @@ pub(crate) fn target() -> Target {
             stack_probes: StackProbeType::Inline,
             supported_sanitizers: SanitizerSet::ADDRESS
                 | SanitizerSet::CFI
+                | SanitizerSet::HWADDRESS
                 | SanitizerSet::KCFI
                 | SanitizerSet::LEAK
                 | SanitizerSet::MEMORY
                 | SanitizerSet::MEMTAG
-                | SanitizerSet::THREAD
-                | SanitizerSet::HWADDRESS
-                | SanitizerSet::REALTIME,
+                | SanitizerSet::REALTIME
+                | SanitizerSet::THREAD,
+            stable_sanitizers: SanitizerSet::ADDRESS | SanitizerSet::LEAK,
             supports_xray: true,
             ..base::linux_gnu::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/i686_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_pc_windows_msvc.rs
@@ -6,6 +6,7 @@ pub(crate) fn target() -> Target {
     base.cpu = "pentium4".into();
     base.max_atomic_width = Some(64);
     base.supported_sanitizers = SanitizerSet::ADDRESS;
+    base.stable_sanitizers = SanitizerSet::ADDRESS;
 
     base.add_pre_link_args(
         LinkerFlavor::Msvc(Lld::No),

--- a/compiler/rustc_target/src/spec/targets/i686_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_unknown_linux_gnu.rs
@@ -20,6 +20,7 @@ pub(crate) fn target() -> Target {
     base.cpu = "pentium4".into();
     base.max_atomic_width = Some(64);
     base.supported_sanitizers = SanitizerSet::ADDRESS;
+    base.stable_sanitizers = SanitizerSet::ADDRESS;
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32"]);
     base.stack_probes = StackProbeType::Inline;
 

--- a/compiler/rustc_target/src/spec/targets/x86_64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_apple_darwin.rs
@@ -21,8 +21,9 @@ pub(crate) fn target() -> Target {
             supported_sanitizers: SanitizerSet::ADDRESS
                 | SanitizerSet::CFI
                 | SanitizerSet::LEAK
-                | SanitizerSet::THREAD
-                | SanitizerSet::REALTIME,
+                | SanitizerSet::REALTIME
+                | SanitizerSet::THREAD,
+            stable_sanitizers: SanitizerSet::ADDRESS | SanitizerSet::LEAK,
             supports_xray: true,
             ..opts
         },

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_windows_msvc.rs
@@ -7,6 +7,7 @@ pub(crate) fn target() -> Target {
     base.plt_by_default = false;
     base.max_atomic_width = Some(128);
     base.supported_sanitizers = SanitizerSet::ADDRESS;
+    base.stable_sanitizers = SanitizerSet::ADDRESS;
 
     Target {
         llvm_target: "x86_64-pc-windows-msvc".into(),

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
@@ -12,13 +12,14 @@ pub(crate) fn target() -> Target {
     base.static_position_independent_executables = true;
     base.supported_sanitizers = SanitizerSet::ADDRESS
         | SanitizerSet::CFI
-        | SanitizerSet::KCFI
         | SanitizerSet::DATAFLOW
+        | SanitizerSet::KCFI
         | SanitizerSet::LEAK
         | SanitizerSet::MEMORY
         | SanitizerSet::SAFESTACK
-        | SanitizerSet::THREAD
-        | SanitizerSet::REALTIME;
+        | SanitizerSet::REALTIME
+        | SanitizerSet::THREAD;
+    base.stable_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::LEAK;
     base.supports_xray = true;
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnuasan.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnuasan.rs
@@ -11,6 +11,7 @@ pub(crate) fn target() -> Target {
         std: Some(true),
     };
     base.supported_sanitizers = SanitizerSet::ADDRESS;
+    base.stable_sanitizers = SanitizerSet::ADDRESS;
     base.default_sanitizers = SanitizerSet::ADDRESS;
     base
 }

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnumsan.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnumsan.rs
@@ -11,6 +11,7 @@ pub(crate) fn target() -> Target {
         std: Some(true),
     };
     base.supported_sanitizers = SanitizerSet::MEMORY;
+    base.stable_sanitizers = SanitizerSet::empty();
     base.default_sanitizers = SanitizerSet::MEMORY;
     base
 }

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnutsan.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnutsan.rs
@@ -11,6 +11,7 @@ pub(crate) fn target() -> Target {
         std: Some(true),
     };
     base.supported_sanitizers = SanitizerSet::THREAD;
+    base.stable_sanitizers = SanitizerSet::empty();
     base.default_sanitizers = SanitizerSet::THREAD;
     base
 }

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -25,6 +25,7 @@
     - [Cargo Specifics](check-cfg/cargo-specifics.md)
 - [Remap source paths](remap-source-paths.md)
 - [Exploit Mitigations](exploit-mitigations.md)
+- [Sanitizers](sanitizers.md)
 - [Symbol Mangling](symbol-mangling/index.md)
     - [v0 Symbol Format](symbol-mangling/v0.md)
 - [Contributing to `rustc`](contributing.md)

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -654,15 +654,16 @@ This option allows for use of one or more of these sanitizers:
 These are the valid values for this option for targets that support one or more
 of these sanitizers:
 
-| Target                      | Sanitizers      |
-|-----------------------------|-----------------|
-| aarch64-apple-darwin        | address         |
-| aarch64-unknown-linux-gnu   | address, leak   |
-| i686-pc-windows-msvc        | address         |
-| i686-unknown-linux-gnu      | address         |
-| x86_64-apple-darwin         | address, leak   |
-| x86_64-pc-windows-msvc      | address         |
-| x86_64-unknown-linux-gnu    | address, leak   |
+| Target                       | Sanitizers      |
+|------------------------------|-----------------|
+| aarch64-apple-darwin         | address         |
+| aarch64-unknown-linux-gnu    | address, leak   |
+| i686-pc-windows-msvc         | address         |
+| i686-unknown-linux-gnu       | address         |
+| x86_64-apple-darwin          | address, leak   |
+| x86_64-pc-windows-msvc       | address         |
+| x86_64-unknown-linux-gnu     | address, leak   |
+| x86_64-unknown-linux-gnuasan | address         |
 
 The quality of the Sanitizers implementation and support varies across operating
 systems and architectures, and relies heavily on LLVM implementation--they are

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -633,6 +633,49 @@ This is primarily useful for local development, to ensure that all the `dylib` d
 
 To set the rpath to a different value (which can be useful for distribution), `-Clink-arg` with a platform-specific linker argument can be used to set the rpath directly.
 
+## sanitize
+
+Sanitizers are a set of compiler-based runtime error detection tools that
+instrument programs to detect bugs during execution. They work by instrumenting
+code at compile time and runtime to monitor program behavior and detect specific
+classes of errors at runtime. Sanitizers enable precise, low-overhead runtime
+bug detection, improving software reliability and security.
+
+This option allows for use of one or more of these sanitizers:
+
+  * [AddressSanitizer
+    (ASan)](../sanitizers.md#addresssanitizer):
+    Detects memory errors (e.g., buffer overflows, use after free).
+  * [LeakSanitizer
+    (LSan)](../sanitizers.md#leaksanitizer):
+    Detects memory leaks either as part of AddressSanitizer or as a standalone
+    tool.
+
+These are the valid values for this option for targets that support one or more
+of these sanitizers:
+
+| Target                      | Sanitizers      |
+|-----------------------------|-----------------|
+| aarch64-apple-darwin        | address         |
+| aarch64-unknown-linux-gnu   | address, leak   |
+| i686-pc-windows-msvc        | address         |
+| i686-unknown-linux-gnu      | address         |
+| x86_64-apple-darwin         | address, leak   |
+| x86_64-pc-windows-msvc      | address         |
+| x86_64-unknown-linux-gnu    | address, leak   |
+
+The quality of the Sanitizers implementation and support varies across operating
+systems and architectures, and relies heavily on LLVM implementation--they are
+mostly implemented in and supported by LLVM.
+
+Using a different LLVM or runtime version than the one used by the Rust compiler
+is not supported. Using Sanitizers in mixed-language binaries (also known as
+“mixed binaries”) is supported when the same LLVM and runtime version is used by
+all languages.
+
+For more information about the available sanitizers, see the [Sanitizers
+chapter](../sanitizers.md).
+
 ## save-temps
 
 This flag controls whether temporary files generated during compilation are

--- a/src/doc/rustc/src/sanitizers.md
+++ b/src/doc/rustc/src/sanitizers.md
@@ -1,0 +1,98 @@
+# Sanitizers
+
+## Introduction
+
+Sanitizers are a set of compiler-based runtime error detection tools that
+instrument programs to detect bugs during execution. They work by instrumenting
+code at compile time and runtime to monitor program behavior and detect specific
+classes of errors at runtime. Sanitizers enable precise, low-overhead runtime
+bug detection, improving software reliability and security.
+
+This option allows for use of one or more of these sanitizers:
+
+  * [AddressSanitizer (ASan)](#addresssanitizer): Detects memory errors (e.g.,
+    buffer overflows, use after free).
+  * [LeakSanitizer (LSan)](#leaksanitizer): Detects memory leaks either as part
+    of AddressSanitizer or as a standalone tool.
+
+These are the valid values for this option for targets that support one or more
+of these sanitizers:
+
+| Target                      | Sanitizers      |
+|-----------------------------|-----------------|
+| aarch64-apple-darwin        | address         |
+| aarch64-unknown-linux-gnu   | address, leak   |
+| i686-pc-windows-msvc        | address         |
+| i686-unknown-linux-gnu      | address         |
+| x86_64-apple-darwin         | address, leak   |
+| x86_64-pc-windows-msvc      | address         |
+| x86_64-unknown-linux-gnu    | address, leak   |
+
+## AddressSanitizer
+
+AddressSanitizer (ASan) detects memory errors by instrumenting code at compile
+time and runtime to mark regions around allocated memory (i.e., red zones) as
+unaddressable (i.e., poisoned), quarantine and mark deallocated memory as
+unaddressable, and add checks before memory accesses. It uses a shadow memory
+mapping to store metadata information about whether a memory region is
+addressable. It can detect:
+
+* Heap-based buffer overflows, Stack-based buffer overflows, and other variants
+  of out-of-bounds reads and writes.
+* Use after free, double free, and other variants of expired pointer dereference
+  (also known as “dangling pointer”).
+* Initialization order bugs (such as [“Static Initialization Order
+  Fiasco”](https://en.cppreference.com/w/cpp/language/siof)).
+* Memory leaks.
+
+AddressSanitizer uses both instrumentation at compile time and runtime. It is
+recommended to recompile all code using AddressSanitizer for best results. If
+parts of the compiled code are not instrumented, AddressSanitizer may not detect
+certain memory errors or detect false positives.
+
+AddressSanitizer increases memory usage and also impacts performance due to the
+red zones and shadow memory mapping, and the added checks before memory
+accesses. AddressSanitizer and its runtime are not suitable for production use.
+
+For more information, see the [AddressSanitizer
+documentation](https://clang.llvm.org/docs/AddressSanitizer.html).
+
+## LeakSanitizer
+
+LeakSanitizer (LSan) detects memory leaks either as part of AddressSanitizer or
+as a standalone tool by instrumenting code at runtime to track all memory and
+thread management functions (i.e., interceptors), and searching for memory that
+remain allocated but are no longer reachable by any references in the program,
+at program termination or during specific checkpoints.
+
+LeakSanitizer can detect:
+
+* Memory allocated dynamically (e.g., via `malloc`, `new`) that are not freed or
+  deleted and is no longer referenced in the program (i.e., directly leaked
+  memory).
+* Memory allocated dynamically that is referenced by another memory that are not
+  freed or deleted and is no longer referenced in the program (i.e., indirectly
+  leaked memory).
+
+LeakSanitizer does not use instrumentation at compile time and works without
+recompiling all code using LeakSanitizer.
+
+LeakSanitizer impacts performance due to the interceptors and the checks for
+memory leaks at program termination. LeakSanitizer and its runtime are not
+suitable for production use.
+
+For more information, see the [LeakSanitizer
+documentation](https://clang.llvm.org/docs/LeakSanitizer.html).
+
+## Disclaimer
+
+The quality of the Sanitizers implementation and support varies across operating
+systems and architectures, and relies heavily on LLVM implementation--they are
+mostly implemented in and supported by LLVM. The sanitizers may also be
+discontinued at any time by LLVM, and as such, their availability in the Rust
+compiler is not guaranteed.
+
+Using a different LLVM or runtime version than the one used by the Rust compiler
+is not supported. Using Sanitizers in mixed-language binaries (also known as
+“mixed binaries”) is supported when the same LLVM and runtime version is used by
+all languages.

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -1081,7 +1081,9 @@ pub(crate) struct TargetCfg {
     #[serde(default)]
     pub(crate) dynamic_linking: bool,
     #[serde(rename = "supported-sanitizers", default)]
-    pub(crate) sanitizers: Vec<Sanitizer>,
+    pub(crate) supported_sanitizers: Vec<Sanitizer>,
+    #[serde(rename = "stable-sanitizers", default)]
+    pub(crate) stable_sanitizers: Vec<Sanitizer>,
     #[serde(rename = "supports-xray", default)]
     pub(crate) xray: bool,
     #[serde(default = "default_reloc_model")]

--- a/src/tools/compiletest/src/directives/needs.rs
+++ b/src/tools/compiletest/src/directives/needs.rs
@@ -42,13 +42,13 @@ pub(super) fn handle_needs(
             ignore_reason: "ignored on targets without kernel CFI sanitizer",
         },
         Need {
-            name: "needs-sanitizer-kasan",
-            condition: cache.sanitizer_kasan,
+            name: "needs-sanitizer-kernel-address",
+            condition: cache.sanitizer_kernel_address,
             ignore_reason: "ignored on targets without kernel address sanitizer",
         },
         Need {
-            name: "needs-sanitizer-khwasan",
-            condition: cache.sanitizer_khwasan,
+            name: "needs-sanitizer-kernel-hwaddress",
+            condition: cache.sanitizer_kernel_hwaddress,
             ignore_reason: "ignored on targets without kernel hardware-assisted address sanitizer",
         },
         Need {
@@ -367,8 +367,8 @@ pub(super) struct CachedNeedsConditions {
     sanitizer_cfi: bool,
     sanitizer_dataflow: bool,
     sanitizer_kcfi: bool,
-    sanitizer_kasan: bool,
-    sanitizer_khwasan: bool,
+    sanitizer_kernel_address: bool,
+    sanitizer_kernel_hwaddress: bool,
     sanitizer_leak: bool,
     sanitizer_memory: bool,
     sanitizer_thread: bool,
@@ -392,15 +392,19 @@ pub(super) struct CachedNeedsConditions {
 impl CachedNeedsConditions {
     pub(super) fn load(config: &Config) -> Self {
         let target = &&*config.target;
-        let sanitizers = &config.target_cfg().sanitizers;
+        let sanitizers = [
+            config.target_cfg().supported_sanitizers.clone(),
+            config.target_cfg().stable_sanitizers.clone(),
+        ]
+        .concat();
         Self {
             sanitizer_support: std::env::var_os("RUSTC_SANITIZER_SUPPORT").is_some(),
             sanitizer_address: sanitizers.contains(&Sanitizer::Address),
             sanitizer_cfi: sanitizers.contains(&Sanitizer::Cfi),
             sanitizer_dataflow: sanitizers.contains(&Sanitizer::Dataflow),
             sanitizer_kcfi: sanitizers.contains(&Sanitizer::Kcfi),
-            sanitizer_kasan: sanitizers.contains(&Sanitizer::KernelAddress),
-            sanitizer_khwasan: sanitizers.contains(&Sanitizer::KernelHwaddress),
+            sanitizer_kernel_address: sanitizers.contains(&Sanitizer::KernelAddress),
+            sanitizer_kernel_hwaddress: sanitizers.contains(&Sanitizer::KernelHwaddress),
             sanitizer_leak: sanitizers.contains(&Sanitizer::Leak),
             sanitizer_memory: sanitizers.contains(&Sanitizer::Memory),
             sanitizer_thread: sanitizers.contains(&Sanitizer::Thread),

--- a/tests/assembly-llvm/sanitizer/hwasan-vs-khwasan.rs
+++ b/tests/assembly-llvm/sanitizer/hwasan-vs-khwasan.rs
@@ -3,11 +3,10 @@
 //@ add-minicore
 //@ assembly-output: emit-asm
 //@ revisions: hwasan khwasan
-//@[hwasan] compile-flags: --target aarch64-unknown-linux-gnu -Zsanitizer=hwaddress
+//@[hwasan] compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=hwaddress -Copt-level=1 --target aarch64-unknown-linux-gnu
 //@[hwasan] needs-llvm-components: aarch64
-//@[khwasan] compile-flags: --target aarch64-unknown-none -Zsanitizer=kernel-hwaddress
+//@[khwasan] compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-hwaddress -Copt-level=1 --target aarch64-unknown-none
 //@[khwasan] needs-llvm-components: aarch64
-//@ compile-flags: -Copt-level=1
 
 #![crate_type = "lib"]
 #![feature(no_core, lang_items)]

--- a/tests/assembly-llvm/sanitizer/kcfi/emit-arity-indicator.rs
+++ b/tests/assembly-llvm/sanitizer/kcfi/emit-arity-indicator.rs
@@ -3,7 +3,7 @@
 //@ add-minicore
 //@ revisions: x86_64
 //@ assembly-output: emit-asm
-//@[x86_64] compile-flags: --target x86_64-unknown-linux-gnu -Cllvm-args=-x86-asm-syntax=intel -Ctarget-feature=-crt-static -Cpanic=abort -Zsanitizer=kcfi -Zsanitizer-kcfi-arity -Copt-level=0
+//@[x86_64] compile-flags: -Cpanic=abort -Cprefer-dynamic=off -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi -Zsanitizer-kcfi-arity --target x86_64-unknown-linux-gnu -Cllvm-args=-x86-asm-syntax=intel -Copt-level=0
 //@ [x86_64] needs-llvm-components: x86
 
 #![crate_type = "lib"]

--- a/tests/assembly-llvm/stack-protector/stack-protector-safe-stack.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-safe-stack.rs
@@ -2,13 +2,19 @@
 //@ revisions: all strong none safestack safestack_strong safestack_all
 //@ assembly-output: emit-asm
 //@ only-x86_64-unknown-linux-gnu
-//@ [all] compile-flags: -Z stack-protector=all
-//@ [strong] compile-flags: -Z stack-protector=strong
-//@ [none] compile-flags: -Z stack-protector=none
-//@ [safestack] compile-flags: -Z stack-protector=none -Z sanitizer=safestack
-//@ [safestack_strong] compile-flags: -Z stack-protector=strong -Z sanitizer=safestack
-//@ [safestack_all] compile-flags: -Z stack-protector=all -Z sanitizer=safestack
-//@ compile-flags: -C opt-level=2 -Z merge-functions=disabled --target x86_64-unknown-linux-gnu
+//@ [all] compile-flags: -Zstack-protector=all
+//@ [strong] compile-flags: -Zstack-protector=strong
+//@ [none] compile-flags: -Zstack-protector=none
+//@ [safestack] compile-flags: -Zstack-protector=none
+//@ [safestack] compile-flags: -Cunsafe-allow-abi-mismatch=sanitize
+//@ [safestack] compile-flags: -Zunstable-options -Csanitize=safestack
+//@ [safestack_strong] compile-flags: -Zstack-protector=strong
+//@ [safestack_strong] compile-flags: -Cunsafe-allow-abi-mismatch=sanitize
+//@ [safestack_strong] compile-flags: -Zunstable-options -Csanitize=safestack
+//@ [safestack_all] compile-flags: -Zstack-protector=all
+//@ [safestack_all] compile-flags: -Cunsafe-allow-abi-mismatch=sanitize
+//@ [safestack_all] compile-flags -Zunstable-options -Csanitize=safestack
+//@ compile-flags: -Copt-level=2 -Zmerge-functions=disabled --target x86_64-unknown-linux-gnu
 //@ needs-llvm-components: x86
 
 #![feature(unsized_fn_params)]
@@ -49,6 +55,5 @@ pub unsafe fn test1(x: *mut u8) -> u8 {
     // safestack_strong: __safestack_unsafe_stack_ptr
     // safestack_strong: __stack_chk_fail
 
-    // safestack_all: __safestack_unsafe_stack_ptr
     // safestack_all: __stack_chk_fail
 }

--- a/tests/assembly-llvm/stack-protector/stack-protector-target-support.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-target-support.rs
@@ -173,8 +173,7 @@
 //@ [r84] needs-llvm-components: x86
 //@ [r85] compile-flags: --target x86_64-unknown-redox
 //@ [r85] needs-llvm-components: x86
-//@ compile-flags: -Z stack-protector=all -Cpanic=abort
-//@ compile-flags: -C opt-level=2
+//@ compile-flags: -Cpanic=abort -Zunstable-options -Zstack-protector=all -Copt-level=2
 
 #![crate_type = "lib"]
 #![feature(no_core, lang_items)]

--- a/tests/assembly-llvm/targets/targets-elf.rs
+++ b/tests/assembly-llvm/targets/targets-elf.rs
@@ -1,5 +1,6 @@
 //@ add-minicore
 //@ assembly-output: emit-asm
+//@ compile-flags: -Zunstable-options
 // ignore-tidy-linelength
 //@ revisions: aarch64_be_unknown_hermit
 //@ [aarch64_be_unknown_hermit] compile-flags: --target aarch64_be-unknown-hermit

--- a/tests/assembly-llvm/targets/targets-macho.rs
+++ b/tests/assembly-llvm/targets/targets-macho.rs
@@ -1,5 +1,6 @@
 //@ add-minicore
 //@ assembly-output: emit-asm
+//@ compile-flags: -Zunstable-options
 // ignore-tidy-linelength
 //@ revisions: aarch64_apple_darwin
 //@ [aarch64_apple_darwin] compile-flags: --target aarch64-apple-darwin

--- a/tests/assembly-llvm/targets/targets-pe.rs
+++ b/tests/assembly-llvm/targets/targets-pe.rs
@@ -1,5 +1,6 @@
 //@ add-minicore
 //@ assembly-output: emit-asm
+//@ compile-flags: -Zunstable-options
 // ignore-tidy-linelength
 //@ revisions: aarch64_pc_windows_msvc
 //@ [aarch64_pc_windows_msvc] compile-flags: --target aarch64-pc-windows-msvc

--- a/tests/codegen-llvm/naked-asan.rs
+++ b/tests/codegen-llvm/naked-asan.rs
@@ -1,8 +1,9 @@
-//@ add-minicore
-//@ needs-llvm-components: x86
-//@ compile-flags: --target x86_64-unknown-linux-gnu -Zsanitizer=address -Ctarget-feature=-crt-static
-
 // Make sure we do not request sanitizers for naked functions.
+//@ add-minicore
+//@ only-x86_64
+//@ needs-llvm-components: x86
+//@ needs-sanitizer-address
+//@ compile-flags: --target x86_64-unknown-linux-gnu -Zunstable-options -Csanitize=address -Ctarget-feature=-crt-static
 
 #![crate_type = "lib"]
 #![feature(no_core)]

--- a/tests/codegen-llvm/sanitizer/aarch64-shadow-call-stack-with-fixed-x18.rs
+++ b/tests/codegen-llvm/sanitizer/aarch64-shadow-call-stack-with-fixed-x18.rs
@@ -1,9 +1,10 @@
 //@ add-minicore
 //@ revisions: aarch64 android
-//@[aarch64] compile-flags: --target aarch64-unknown-none -Zfixed-x18 -Zsanitizer=shadow-call-stack
+//@[aarch64] compile-flags: --target aarch64-unknown-none -Zfixed-x18
 //@[aarch64] needs-llvm-components: aarch64
-//@[android] compile-flags: --target aarch64-linux-android -Zsanitizer=shadow-call-stack
+//@[android] compile-flags: --target aarch64-linux-android
 //@[android] needs-llvm-components: aarch64
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=shadow-call-stack
 
 #![allow(internal_features)]
 #![crate_type = "rlib"]

--- a/tests/codegen-llvm/sanitizer/address-sanitizer-globals-tracking.rs
+++ b/tests/codegen-llvm/sanitizer/address-sanitizer-globals-tracking.rs
@@ -19,9 +19,11 @@
 //@ only-linux
 //
 //@ revisions:ASAN ASAN-FAT-LTO
-//@ compile-flags: -Zsanitizer=address -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
-// [ASAN] no extra compile-flags
-//@[ASAN-FAT-LTO] compile-flags: -Cprefer-dynamic=false -Clto=fat
+//@                compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static
+//@                compile-flags: -Cunsafe-allow-abi-mismatch=sanitize
+//@[ASAN]          compile-flags: -Zunstable-options -Csanitize=address
+//@[ASAN-FAT-LTO]  compile-flags: -Clto=fat -Cprefer-dynamic=false
+//@[ASAN-FAT-LTO]  compile-flags: -Zunstable-options -Csanitize=address
 
 #![crate_type = "staticlib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/add-canonical-jump-tables-flag.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/add-canonical-jump-tables-flag.rs
@@ -1,7 +1,7 @@
 // Verifies that "CFI Canonical Jump Tables" module flag is added.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/add-cfi-normalize-integers-flag.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/add-cfi-normalize-integers-flag.rs
@@ -1,7 +1,7 @@
 // Verifies that "cfi-normalize-integers" module flag is added.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi -Zsanitizer-cfi-normalize-integers -C unsafe-allow-abi-mismatch=sanitizer,sanitizer-cfi-normalize-integers
+//@ compile-flags: -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Zsanitizer-cfi-normalize-integers
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/add-enable-split-lto-unit-flag.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/add-enable-split-lto-unit-flag.rs
@@ -1,7 +1,7 @@
 // Verifies that "EnableSplitLTOUnit" module flag is added.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/dbg-location-on-cfi-blocks.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/dbg-location-on-cfi-blocks.rs
@@ -1,7 +1,7 @@
 // Verifies that the parent block's debug information are assigned to the inserted cfi block.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -Cdebuginfo=1 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Cdebuginfo=1
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-checks-attr-sanitize-off.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-checks-attr-sanitize-off.rs
@@ -1,7 +1,7 @@
 // Verifies that pointer type membership tests for indirect calls are omitted.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Copt-level=0 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 #![feature(sanitize)]

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-checks.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-checks.rs
@@ -1,7 +1,7 @@
 // Verifies that pointer type membership tests for indirect calls are emitted.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Copt-level=0 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-attr-cfi-encoding.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-attr-cfi-encoding.rs
@@ -1,7 +1,7 @@
 // Verifies that user-defined CFI encoding for types are emitted.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Copt-level=0 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 #![feature(cfi_encoding, extern_types)]

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-const-generics.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-const-generics.rs
@@ -2,7 +2,7 @@
 // for const generics.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Copt-level=0 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 #![feature(type_alias_impl_trait)]

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-drop-in-place.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-drop-in-place.rs
@@ -5,7 +5,7 @@
 // future.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-function-types.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-function-types.rs
@@ -2,7 +2,7 @@
 // for function types.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-lifetimes.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-lifetimes.rs
@@ -2,7 +2,7 @@
 // for lifetimes/regions.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Copt-level=0 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 #![feature(type_alias_impl_trait)]

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-method-secondary-typeid.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-method-secondary-typeid.rs
@@ -2,7 +2,7 @@
 // self so they can be used as function pointers.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-paths.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-paths.rs
@@ -2,7 +2,7 @@
 // for paths.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 #![feature(type_alias_impl_trait)]

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-pointer-types.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-pointer-types.rs
@@ -2,7 +2,7 @@
 // for pointer types.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-primitive-types.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-primitive-types.rs
@@ -2,7 +2,7 @@
 // for primitive types.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-repr-transparent-types.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-repr-transparent-types.rs
@@ -2,7 +2,7 @@
 // for repr transparent types.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-sequence-types.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-sequence-types.rs
@@ -2,7 +2,7 @@
 // for sequence types.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-trait-types.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-trait-types.rs
@@ -2,7 +2,7 @@
 // for trait types.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-user-defined-types.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-user-defined-types.rs
@@ -2,7 +2,7 @@
 // for user-defined types.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 #![feature(extern_types)]

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-itanium-cxx-abi-generalized.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-itanium-cxx-abi-generalized.rs
@@ -1,7 +1,7 @@
 // Verifies that generalized type metadata for functions are emitted.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Zsanitizer-cfi-generalize-pointers -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Zsanitizer-cfi-generalize-pointers
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-itanium-cxx-abi-normalized-generalized.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-itanium-cxx-abi-normalized-generalized.rs
@@ -1,7 +1,7 @@
 // Verifies that normalized and generalized type metadata for functions are emitted.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Zsanitizer-cfi-normalize-integers -Zsanitizer-cfi-generalize-pointers -C unsafe-allow-abi-mismatch=sanitizer,sanitizer-cfi-normalize-integers
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Zsanitizer-cfi-normalize-integers -Zsanitizer-cfi-generalize-pointers
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-itanium-cxx-abi-normalized.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-itanium-cxx-abi-normalized.rs
@@ -1,7 +1,7 @@
 // Verifies that normalized type metadata for functions are emitted.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Zsanitizer-cfi-normalize-integers -C unsafe-allow-abi-mismatch=sanitizer,sanitizer-cfi-normalize-integers
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Zsanitizer-cfi-normalize-integers
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-itanium-cxx-abi.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-itanium-cxx-abi.rs
@@ -1,7 +1,7 @@
 // Verifies that type metadata for functions are emitted.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-trait-objects.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-trait-objects.rs
@@ -1,7 +1,7 @@
 // Verifies that type metadata identifiers for trait objects are emitted correctly.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Ctarget-feature=-crt-static -Zsanitizer=cfi -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/external_weak_symbols.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/external_weak_symbols.rs
@@ -2,7 +2,8 @@
 // emitted correctly.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clinker-plugin-lto -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clinker-plugin-lto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
+
 #![crate_type = "bin"]
 #![feature(linkage)]
 

--- a/tests/codegen-llvm/sanitizer/cfi/generalize-pointers.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/generalize-pointers.rs
@@ -1,7 +1,7 @@
 // Verifies that pointer types are generalized.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Zsanitizer-cfi-generalize-pointers -Copt-level=0 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Zsanitizer-cfi-generalize-pointers
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/cfi/normalize-integers.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/normalize-integers.rs
@@ -1,7 +1,7 @@
 // Verifies that integer types are normalized.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Zsanitizer-cfi-normalize-integers -Copt-level=0 -C unsafe-allow-abi-mismatch=sanitizer,sanitizer-cfi-normalize-integers
+//@ compile-flags: -Clto -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Zsanitizer-cfi-normalize-integers
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/dataflow-instrument-functions.rs
+++ b/tests/codegen-llvm/sanitizer/dataflow-instrument-functions.rs
@@ -1,7 +1,7 @@
 // Verifies that functions are instrumented.
 //
 //@ needs-sanitizer-dataflow
-//@ compile-flags: -Copt-level=0 -Zsanitizer=dataflow -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Copt-level=0 -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=dataflow
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/hwasan-vs-khwasan.rs
+++ b/tests/codegen-llvm/sanitizer/hwasan-vs-khwasan.rs
@@ -2,11 +2,10 @@
 //
 //@ add-minicore
 //@ revisions: hwasan khwasan
-//@[hwasan] compile-flags: --target aarch64-unknown-linux-gnu -Zsanitizer=hwaddress
+//@[hwasan] compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=hwaddress -Copt-level=0 --target aarch64-unknown-linux-gnu
 //@[hwasan] needs-llvm-components: aarch64
-//@[khwasan] compile-flags: --target aarch64-unknown-none -Zsanitizer=kernel-hwaddress
+//@[khwasan] compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-hwaddress -Copt-level=0 --target aarch64-unknown-none
 //@[khwasan] needs-llvm-components: aarch64
-//@ compile-flags: -Copt-level=0
 
 #![crate_type = "lib"]
 #![feature(no_core, lang_items, sanitize)]

--- a/tests/codegen-llvm/sanitizer/kasan-emits-instrumentation.rs
+++ b/tests/codegen-llvm/sanitizer/kasan-emits-instrumentation.rs
@@ -1,7 +1,6 @@
-// Verifies that `-Zsanitizer=kernel-address` emits sanitizer instrumentation.
+// Verifies that `-Csanitize=kernel-address` emits sanitizer instrumentation.
 
 //@ add-minicore
-//@ compile-flags: -Zsanitizer=kernel-address -Copt-level=0
 //@ revisions: aarch64 aarch64v8r riscv64imac riscv64gc x86_64
 //@[aarch64] compile-flags: --target aarch64-unknown-none
 //@[aarch64] needs-llvm-components: aarch64
@@ -13,6 +12,7 @@
 //@[riscv64gc] needs-llvm-components: riscv
 //@[x86_64] compile-flags: --target x86_64-unknown-none
 //@[x86_64] needs-llvm-components: x86
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-address
 
 #![crate_type = "rlib"]
 #![feature(no_core, sanitize, lang_items)]

--- a/tests/codegen-llvm/sanitizer/kasan-recover.rs
+++ b/tests/codegen-llvm/sanitizer/kasan-recover.rs
@@ -3,9 +3,9 @@
 //
 //@ add-minicore
 //@ revisions: KASAN KASAN-RECOVER
-//@ compile-flags: -Copt-level=0
+//@ compile-flags: -Copt-level=0  -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options
 //@ needs-llvm-components: x86
-//@ compile-flags: -Zsanitizer=kernel-address --target x86_64-unknown-none
+//@ compile-flags: -Csanitize=kernel-address --target x86_64-unknown-none
 //@[KASAN-RECOVER] compile-flags: -Zsanitizer-recover=kernel-address
 
 #![feature(no_core, sanitize, lang_items)]

--- a/tests/codegen-llvm/sanitizer/kcfi/add-cfi-normalize-integers-flag.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/add-cfi-normalize-integers-flag.rs
@@ -8,7 +8,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Ctarget-feature=-crt-static -Zsanitizer=kcfi -Zsanitizer-cfi-normalize-integers
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi -Zsanitizer-cfi-normalize-integers
 
 #![feature(no_core, lang_items)]
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/sanitizer/kcfi/add-kcfi-arity-flag.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/add-kcfi-arity-flag.rs
@@ -4,7 +4,7 @@
 //@ revisions: x86_64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Ctarget-feature=-crt-static -Cpanic=abort -Zsanitizer=kcfi -Zsanitizer-kcfi-arity
+//@ compile-flags: -Cpanic=abort -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi -Zsanitizer-kcfi-arity -Copt-level=0 -Ctarget-feature=-crt-static
 
 #![feature(no_core, lang_items)]
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/sanitizer/kcfi/add-kcfi-flag.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/add-kcfi-flag.rs
@@ -8,7 +8,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Ctarget-feature=-crt-static -Zsanitizer=kcfi
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi
 
 #![feature(no_core, lang_items)]
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/sanitizer/kcfi/add-kcfi-offset-flag.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/add-kcfi-offset-flag.rs
@@ -8,7 +8,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Ctarget-feature=-crt-static -Zsanitizer=kcfi -Z patchable-function-entry=4,3
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi -Zpatchable-function-entry=4,3
 
 #![feature(no_core, lang_items, patchable_function_entry)]
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle-attr-sanitize-off.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle-attr-sanitize-off.rs
@@ -8,7 +8,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Cno-prepopulate-passes -Zsanitizer=kcfi -Copt-level=0
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi
 
 #![crate_type = "lib"]
 #![feature(no_core, sanitize, lang_items)]

--- a/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-generalized.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-generalized.rs
@@ -8,7 +8,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Cno-prepopulate-passes -Zsanitizer=kcfi -Zsanitizer-cfi-generalize-pointers
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi -Zsanitizer-cfi-generalize-pointers
 
 #![crate_type = "lib"]
 #![feature(no_core, lang_items)]

--- a/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-normalized-generalized.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-normalized-generalized.rs
@@ -8,7 +8,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Cno-prepopulate-passes -Zsanitizer=kcfi -Zsanitizer-cfi-normalize-integers -Zsanitizer-cfi-generalize-pointers
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi -Zsanitizer-cfi-normalize-integers -Zsanitizer-cfi-generalize-pointers
 
 #![crate_type = "lib"]
 #![feature(no_core, lang_items)]

--- a/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-normalized.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-normalized.rs
@@ -8,7 +8,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Cno-prepopulate-passes -Zsanitizer=kcfi -Zsanitizer-cfi-normalize-integers
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi -Zsanitizer-cfi-normalize-integers
 
 #![crate_type = "lib"]
 #![feature(no_core, lang_items)]

--- a/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi.rs
@@ -8,7 +8,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Cno-prepopulate-passes -Zsanitizer=kcfi -Copt-level=0
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi
 
 #![crate_type = "lib"]
 #![feature(no_core, lang_items)]

--- a/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/emit-kcfi-operand-bundle.rs
@@ -8,7 +8,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Cno-prepopulate-passes -Zsanitizer=kcfi -Copt-level=0
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi
 
 #![crate_type = "lib"]
 #![feature(no_core, lang_items)]

--- a/tests/codegen-llvm/sanitizer/kcfi/emit-type-metadata-trait-objects.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/emit-type-metadata-trait-objects.rs
@@ -8,7 +8,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Cno-prepopulate-passes -Zsanitizer=kcfi -Copt-level=0
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi
 
 #![crate_type = "lib"]
 #![feature(arbitrary_self_types, no_core, lang_items)]

--- a/tests/codegen-llvm/sanitizer/kcfi/fn-ptr-reify-shim.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/fn-ptr-reify-shim.rs
@@ -6,7 +6,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Ctarget-feature=-crt-static -Zsanitizer=kcfi -Cno-prepopulate-passes -Copt-level=0
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi
 
 #![feature(no_core, lang_items)]
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/sanitizer/kcfi/naked-function.rs
+++ b/tests/codegen-llvm/sanitizer/kcfi/naked-function.rs
@@ -6,7 +6,7 @@
 //@ [aarch64v8r] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Ctarget-feature=-crt-static -Zsanitizer=kcfi -Cno-prepopulate-passes -Copt-level=0
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi
 
 #![feature(no_core, lang_items)]
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/sanitizer/khwasan-lifetime-markers.rs
+++ b/tests/codegen-llvm/sanitizer/khwasan-lifetime-markers.rs
@@ -1,7 +1,7 @@
 // Verifies that `-Zsanitizer=kernel-hwaddress` enables lifetime markers.
 
 //@ add-minicore
-//@ compile-flags: -Zsanitizer=kernel-hwaddress -Copt-level=0
+//@ compile-flags: -Copt-level=0 -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-hwaddress
 //@ compile-flags: --target aarch64-unknown-none
 //@ needs-llvm-components: aarch64
 

--- a/tests/codegen-llvm/sanitizer/khwasan-recover.rs
+++ b/tests/codegen-llvm/sanitizer/khwasan-recover.rs
@@ -5,8 +5,7 @@
 //@ needs-llvm-components: aarch64
 //@ revisions: KHWASAN KHWASAN-RECOVER
 //@ no-prefer-dynamic
-//@ compile-flags: -Copt-level=0
-//@ compile-flags: -Zsanitizer=kernel-hwaddress --target aarch64-unknown-none
+//@ compile-flags: -Copt-level=0 -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-hwaddress --target aarch64-unknown-none
 //@[KHWASAN-RECOVER] compile-flags: -Zsanitizer-recover=kernel-hwaddress
 
 #![feature(no_core, sanitize, lang_items)]

--- a/tests/codegen-llvm/sanitizer/memory-track-origins.rs
+++ b/tests/codegen-llvm/sanitizer/memory-track-origins.rs
@@ -3,13 +3,12 @@
 //
 //@ needs-sanitizer-memory
 //@ revisions:MSAN-0 MSAN-1 MSAN-2 MSAN-1-LTO MSAN-2-LTO
-//
-//@ compile-flags: -Zsanitizer=memory -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
-// [MSAN-0] no extra compile-flags
-//@[MSAN-1] compile-flags: -Zsanitizer-memory-track-origins=1
-//@[MSAN-2] compile-flags: -Zsanitizer-memory-track-origins
-//@[MSAN-1-LTO] compile-flags: -Zsanitizer-memory-track-origins=1 -C lto=fat
-//@[MSAN-2-LTO] compile-flags: -Zsanitizer-memory-track-origins -C lto=fat
+//@[MSAN-0] compile-flags: -Zunstable-options -Csanitize=memory
+//@[MSAN-1] compile-flags: -Zunstable-options -Csanitize=memory -Zsanitizer-memory-track-origins=1
+//@[MSAN-2] compile-flags: -Zunstable-options -Csanitize=memory -Zsanitizer-memory-track-origins
+//@[MSAN-1-LTO] compile-flags: -Clto=fat -Zunstable-options -Csanitize=memory -Zsanitizer-memory-track-origins=1
+//@[MSAN-2-LTO] compile-flags: -Clto=fat -Zunstable-options -Csanitize=memory -Zsanitizer-memory-track-origins
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/memtag-attr-check.rs
+++ b/tests/codegen-llvm/sanitizer/memtag-attr-check.rs
@@ -2,7 +2,7 @@
 // applied when enabling the memtag sanitizer.
 //
 //@ needs-sanitizer-memtag
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer -Zsanitizer=memtag -Ctarget-feature=+mte -Copt-level=0
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=memtag -Ctarget-feature=+mte -Copt-level=0
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/riscv64-shadow-call-stack.rs
+++ b/tests/codegen-llvm/sanitizer/riscv64-shadow-call-stack.rs
@@ -1,5 +1,5 @@
 //@ add-minicore
-//@ compile-flags: --target riscv64imac-unknown-none-elf -Zsanitizer=shadow-call-stack
+//@ compile-flags: --target riscv64imac-unknown-none-elf -Copt-level=0 -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=shadow-call-stack
 //@ needs-llvm-components: riscv
 
 #![allow(internal_features)]

--- a/tests/codegen-llvm/sanitizer/safestack-attr-check.rs
+++ b/tests/codegen-llvm/sanitizer/safestack-attr-check.rs
@@ -1,7 +1,7 @@
 // This tests that the safestack attribute is applied when enabling the safe-stack sanitizer.
 //
 //@ needs-sanitizer-safestack
-//@ compile-flags: -Zsanitizer=safestack -Copt-level=0 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Copt-level=0 -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=safestack
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/sanitize-off-asan-kasan.rs
+++ b/tests/codegen-llvm/sanitizer/sanitize-off-asan-kasan.rs
@@ -2,7 +2,6 @@
 // the kernel address sanitizer.
 //
 //@ add-minicore
-//@ compile-flags: -Zsanitizer=kernel-address -Ctarget-feature=-crt-static -Copt-level=0
 //@ revisions: aarch64 aarch64v8r riscv64imac riscv64gc x86_64
 //@[aarch64] compile-flags: --target aarch64-unknown-none
 //@[aarch64] needs-llvm-components: aarch64
@@ -14,6 +13,7 @@
 //@[riscv64gc] needs-llvm-components: riscv
 //@[x86_64] compile-flags: --target x86_64-unknown-none
 //@[x86_64] needs-llvm-components: x86
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-address
 
 #![crate_type = "rlib"]
 #![feature(no_core, sanitize, lang_items)]

--- a/tests/codegen-llvm/sanitizer/sanitize-off-hwasan-khwasan.rs
+++ b/tests/codegen-llvm/sanitizer/sanitize-off-hwasan-khwasan.rs
@@ -2,8 +2,7 @@
 // the kernel hardware-assisted address sanitizer.
 //
 //@ add-minicore
-//@ compile-flags: -Zsanitizer=kernel-hwaddress --target aarch64-unknown-none
-//@ compile-flags: -Ctarget-feature=-crt-static -Copt-level=0
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-hwaddress -Copt-level=0 --target aarch64-unknown-none -Ctarget-feature=-crt-static
 //@ needs-llvm-components: aarch64
 
 #![crate_type = "rlib"]

--- a/tests/codegen-llvm/sanitizer/sanitize-off-inlining.rs
+++ b/tests/codegen-llvm/sanitizer/sanitize-off-inlining.rs
@@ -3,10 +3,10 @@
 //@ needs-sanitizer-address
 //@ needs-sanitizer-leak
 //@ revisions: ASAN LSAN
-//@       compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
-//@       compile-flags: -Copt-level=3 -Zmir-opt-level=4 -Ctarget-feature=-crt-static
-//@[ASAN] compile-flags: -Zsanitizer=address
-//@[LSAN] compile-flags: -Zsanitizer=leak
+//@       compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
+//@       compile-flags: -Copt-level=3 -Zmir-opt-level=4
+//@[ASAN] compile-flags: -Zunstable-options -Csanitize=address
+//@[LSAN] compile-flags: -Zunstable-options -Csanitize=leak
 
 #![crate_type = "lib"]
 #![feature(sanitize)]

--- a/tests/codegen-llvm/sanitizer/sanitize-off-kasan-asan.rs
+++ b/tests/codegen-llvm/sanitizer/sanitize-off-kasan-asan.rs
@@ -2,7 +2,7 @@
 // the address sanitizer.
 //
 //@ needs-sanitizer-address
-//@ compile-flags: -Zsanitizer=address -Ctarget-feature=-crt-static -Copt-level=0 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=address
 
 #![crate_type = "lib"]
 #![feature(sanitize)]

--- a/tests/codegen-llvm/sanitizer/sanitize-off-khwasan-hwasan.rs
+++ b/tests/codegen-llvm/sanitizer/sanitize-off-khwasan-hwasan.rs
@@ -2,9 +2,8 @@
 // the hardware-assisted address sanitizer.
 //
 //@ needs-sanitizer-hwaddress
-//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitizer
-//@ compile-flags: -Ctarget-feature=-crt-static
-//@ compile-flags: -Zsanitizer=hwaddress -Copt-level=0
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Ctarget-feature=-crt-static
+//@ compile-flags: -Zunstable-options -Csanitize=hwaddress -Copt-level=0
 
 #![crate_type = "lib"]
 #![feature(sanitize)]

--- a/tests/codegen-llvm/sanitizer/sanitize-off.rs
+++ b/tests/codegen-llvm/sanitizer/sanitize-off.rs
@@ -2,7 +2,7 @@
 // selectively disable sanitizer instrumentation.
 //
 //@ needs-sanitizer-address
-//@ compile-flags: -Zsanitizer=address -Ctarget-feature=-crt-static -Copt-level=0
+//@ compile-flags: -Copt-level=0 -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=address
 
 #![crate_type = "lib"]
 #![feature(sanitize)]

--- a/tests/codegen-llvm/sanitizer/sanitizer-recover.rs
+++ b/tests/codegen-llvm/sanitizer/sanitizer-recover.rs
@@ -5,13 +5,17 @@
 //@ needs-sanitizer-memory
 //@ revisions:ASAN ASAN-RECOVER MSAN MSAN-RECOVER MSAN-RECOVER-LTO
 //@ no-prefer-dynamic
-//@                   compile-flags: -Cunsafe-allow-abi-mismatch=sanitizer
+//@                   compile-flags: -Cunsafe-allow-abi-mismatch=sanitize
 //@                   compile-flags: -Ctarget-feature=-crt-static
-//@[ASAN]             compile-flags: -Zsanitizer=address -Copt-level=0
-//@[ASAN-RECOVER]     compile-flags: -Zsanitizer=address -Zsanitizer-recover=address -Copt-level=0
-//@[MSAN]             compile-flags: -Zsanitizer=memory
-//@[MSAN-RECOVER]     compile-flags: -Zsanitizer=memory  -Zsanitizer-recover=memory
-//@[MSAN-RECOVER-LTO] compile-flags: -Zsanitizer=memory  -Zsanitizer-recover=memory -C lto=fat
+//@[ASAN]             compile-flags: -Zunstable-options -Csanitize=address
+//@[ASAN]             compile-flags: -Copt-level=0
+//@[ASAN-RECOVER]     compile-flags: -Zunstable-options -Csanitize=address
+//@[ASAN-RECOVER]     compile-flags: -Zsanitizer-recover=address -Copt-level=0
+//@[MSAN]             compile-flags: -Zunstable-options -Csanitize=memory
+//@[MSAN-RECOVER]     compile-flags: -Zunstable-options -Csanitize=memory
+//@[MSAN-RECOVER]     compile-flags: -Zsanitizer-recover=memory
+//@[MSAN-RECOVER-LTO] compile-flags: -Zunstable-options -Csanitize=memory
+//@[MSAN-RECOVER-LTO] compile-flags: -Zsanitizer-recover=memory -Clto=fat
 //
 // MSAN-NOT:         @__msan_keep_going
 // MSAN-RECOVER:     @__msan_keep_going = weak_odr {{.*}}constant i32 1

--- a/tests/codegen-llvm/sanitizer/scs-attr-check.rs
+++ b/tests/codegen-llvm/sanitizer/scs-attr-check.rs
@@ -2,7 +2,7 @@
 // applied when enabling the shadow-call-stack sanitizer.
 //
 //@ needs-sanitizer-shadow-call-stack
-//@ compile-flags: -Zsanitizer=shadow-call-stack
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=shadow-call-stack
 
 #![crate_type = "lib"]
 #![feature(sanitize)]

--- a/tests/run-make/sanitizer-cdylib-link/rmake.rs
+++ b/tests/run-make/sanitizer-cdylib-link/rmake.rs
@@ -8,12 +8,12 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-address
 
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitize
 
 use run_make_support::{run_fail, rustc};
 
 fn main() {
-    rustc().arg("-g").arg("-Zsanitizer=address").crate_type("cdylib").input("library.rs").run();
-    rustc().arg("-g").arg("-Zsanitizer=address").crate_type("bin").input("program.rs").run();
+    rustc().arg("-g").arg("-Csanitize=address").crate_type("cdylib").input("library.rs").run();
+    rustc().arg("-g").arg("-Csanitize=address").crate_type("bin").input("program.rs").run();
     run_fail("program").assert_stderr_contains("stack-buffer-overflow");
 }

--- a/tests/run-make/sanitizer-dylib-link/rmake.rs
+++ b/tests/run-make/sanitizer-dylib-link/rmake.rs
@@ -7,12 +7,12 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-address
 
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitize
 
 use run_make_support::{run_fail, rustc};
 
 fn main() {
-    rustc().arg("-g").arg("-Zsanitizer=address").crate_type("dylib").input("library.rs").run();
-    rustc().arg("-g").arg("-Zsanitizer=address").crate_type("bin").input("program.rs").run();
+    rustc().arg("-g").arg("-Csanitize=address").crate_type("dylib").input("library.rs").run();
+    rustc().arg("-g").arg("-Csanitize=address").crate_type("bin").input("program.rs").run();
     run_fail("program").assert_stderr_contains("stack-buffer-overflow");
 }

--- a/tests/run-make/sanitizer-staticlib-link/rmake.rs
+++ b/tests/run-make/sanitizer-staticlib-link/rmake.rs
@@ -11,18 +11,18 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-address
 
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitize
 
 use run_make_support::{cc, extra_c_flags, extra_cxx_flags, run_fail, rustc, static_lib_name};
 
 fn main() {
-    rustc().arg("-g").arg("-Zsanitizer=address").crate_type("staticlib").input("library.rs").run();
+    rustc().arg("-g").arg("-Csanitize=address").crate_type("staticlib").input("library.rs").run();
     cc().input("program.c")
         .arg(static_lib_name("library"))
         .out_exe("program")
         .args(extra_c_flags())
         .args(extra_cxx_flags())
         .run_fail();
-    rustc().arg("-g").arg("-Zsanitizer=address").crate_type("bin").input("program.rs").run();
+    rustc().arg("-g").arg("-Csanitize=address").crate_type("bin").input("program.rs").run();
     run_fail("program").assert_stderr_contains("stack-buffer-overflow");
 }

--- a/tests/ui/abi/shadow-call-stack-without-fixed-x18.rs
+++ b/tests/ui/abi/shadow-call-stack-without-fixed-x18.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --target aarch64-unknown-none -Zsanitizer=shadow-call-stack
+//@ compile-flags: --target aarch64-unknown-none -Zunstable-options -Csanitize=shadow-call-stack
 //@ dont-check-compiler-stderr
 //@ needs-llvm-components: aarch64
 //@ ignore-backends: gcc

--- a/tests/ui/asm/global-asm-isnt-really-a-mir-body.rs
+++ b/tests/ui/asm/global-asm-isnt-really-a-mir-body.rs
@@ -1,7 +1,5 @@
 //@ revisions: emit_mir instrument cfi
 
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
-
 // Make sure we don't try to emit MIR for it.
 //@[emit_mir] compile-flags: --emit=mir
 
@@ -10,7 +8,7 @@
 //@[instrument] only-linux
 
 // Make sure we don't try to CFI encode it.
-//@[cfi] compile-flags: -Zsanitizer=cfi -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Clink-dead-code=true
+//@[cfi] compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Clink-dead-code=true
 //@[cfi] needs-sanitizer-cfi
 //@[cfi] no-prefer-dynamic
 // FIXME(#122848) Remove only-linux once OSX CFI binaries work

--- a/tests/ui/lto/issue-100772.rs
+++ b/tests/ui/lto/issue-100772.rs
@@ -1,6 +1,6 @@
 //@ build-pass
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 //@ no-prefer-dynamic
 //@ only-x86_64-unknown-linux-gnu
 //@ ignore-backends: gcc

--- a/tests/ui/sanitizer/address.rs
+++ b/tests/ui/sanitizer/address.rs
@@ -2,7 +2,7 @@
 //@ needs-sanitizer-address
 //@ ignore-cross-compile
 //
-//@ compile-flags: -Z sanitizer=address -O -g -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=address -O -g
 //
 //@ run-fail-or-crash
 //@ error-pattern: AddressSanitizer: stack-buffer-overflow

--- a/tests/ui/sanitizer/asan_odr_windows.rs
+++ b/tests/ui/sanitizer/asan_odr_windows.rs
@@ -2,7 +2,7 @@
 //! See <https://github.com/rust-lang/rust/issues/124390>.
 
 //@ run-pass
-//@ compile-flags:-Zsanitizer=address -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=address
 //@ aux-build: asan_odr_win-2.rs
 //@ only-windows-msvc
 //@ needs-sanitizer-support

--- a/tests/ui/sanitizer/auxiliary/asan_odr_win-2.rs
+++ b/tests/ui/sanitizer/auxiliary/asan_odr_win-2.rs
@@ -1,5 +1,5 @@
 //@ no-prefer-dynamic
-//@ compile-flags: -Z sanitizer=address
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=address
 #![crate_name = "othercrate"]
 #![crate_type = "rlib"]
 

--- a/tests/ui/sanitizer/badfree.rs
+++ b/tests/ui/sanitizer/badfree.rs
@@ -2,7 +2,7 @@
 //@ needs-sanitizer-address
 //@ ignore-cross-compile
 //
-//@ compile-flags: -Z sanitizer=address -O -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags:  -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=address -O
 //
 //@ run-fail-or-crash
 //@ regex-error-pattern: AddressSanitizer: (SEGV|attempting free on address which was not malloc)

--- a/tests/ui/sanitizer/cfg-kasan.rs
+++ b/tests/ui/sanitizer/cfg-kasan.rs
@@ -1,9 +1,8 @@
-// Verifies that when compiling with -Zsanitizer=kernel-address,
+// Verifies that when compiling with -Csanitize=kernel-address,
 // the `#[cfg(sanitize = "address")]` attribute is configured.
 
 //@ add-minicore
 //@ check-pass
-//@ compile-flags: -Zsanitizer=kernel-address
 //@ revisions: aarch64 riscv64imac riscv64gc x86_64
 //@[aarch64] compile-flags: --target aarch64-unknown-none
 //@[aarch64] needs-llvm-components: aarch64
@@ -13,6 +12,7 @@
 //@[riscv64gc] needs-llvm-components: riscv
 //@[x86_64] compile-flags: --target x86_64-unknown-none
 //@[x86_64] needs-llvm-components: x86
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-address
 //@ ignore-backends: gcc
 
 #![crate_type = "rlib"]

--- a/tests/ui/sanitizer/cfg-khwasan.rs
+++ b/tests/ui/sanitizer/cfg-khwasan.rs
@@ -1,9 +1,9 @@
-// Verifies that when compiling with -Zsanitizer=kernel-hwaddress,
+// Verifies that when compiling with -Csanitize=kernel-hwaddress,
 // the `#[cfg(sanitize = "hwaddress")]` attribute is configured.
 
 //@ add-minicore
 //@ check-pass
-//@ compile-flags: -Zsanitizer=kernel-hwaddress --target aarch64-unknown-none
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-hwaddress --target aarch64-unknown-none
 //@ needs-llvm-components: aarch64
 //@ ignore-backends: gcc
 

--- a/tests/ui/sanitizer/cfg.rs
+++ b/tests/ui/sanitizer/cfg.rs
@@ -1,24 +1,24 @@
-// Verifies that when compiling with -Zsanitizer=option,
+// Verifies that when compiling with -Csanitize=option,
 // the `#[cfg(sanitize = "option")]` attribute is configured.
 
 //@ add-minicore
 //@ check-pass
 //@ revisions: address cfi kcfi leak memory thread
-//@compile-flags: -Ctarget-feature=-crt-static
 //@[address]needs-sanitizer-address
-//@[address]compile-flags: -Zsanitizer=address
+//@[address]compile-flags: -Zunstable-options -Csanitize=address
 //@[cfi]needs-sanitizer-cfi
-//@[cfi]compile-flags:     -Zsanitizer=cfi
+//@[cfi]compile-flags:     -Zunstable-options -Csanitize=cfi
 //@[cfi]compile-flags:     -Clto -Ccodegen-units=1
 //@[kcfi]needs-llvm-components: x86
-//@[kcfi]compile-flags:    -Zsanitizer=kcfi --target x86_64-unknown-none
-//@[kcfi]compile-flags:    -C panic=abort
+//@[kcfi]compile-flags:    -Zunstable-options -Csanitize=kcfi
+//@[kcfi]compile-flags:    --target x86_64-unknown-none -C panic=abort
 //@[leak]needs-sanitizer-leak
-//@[leak]compile-flags:    -Zsanitizer=leak
+//@[leak]compile-flags:    -Zunstable-options -Csanitize=leak
 //@[memory]needs-sanitizer-memory
-//@[memory]compile-flags:  -Zsanitizer=memory
+//@[memory]compile-flags:  -Zunstable-options -Csanitize=memory
 //@[thread]needs-sanitizer-thread
-//@[thread]compile-flags:  -Zsanitizer=thread
+//@[thread]compile-flags:  -Zunstable-options -Csanitize=thread
+//@compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
 //@ ignore-backends: gcc
 
 #![feature(cfg_sanitize, no_core)]

--- a/tests/ui/sanitizer/cfi/assoc-const-projection-issue-151878.rs
+++ b/tests/ui/sanitizer/cfi/assoc-const-projection-issue-151878.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zsanitizer=cfi -Cunsafe-allow-abi-mismatch=sanitizer -Ccodegen-units=1 -Clto
+//@ compile-flags: -Ccodegen-units=1 -Clto -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 //@ needs-rustc-debug-assertions
 //@ needs-sanitizer-cfi
 //@ build-pass

--- a/tests/ui/sanitizer/cfi/assoc-ty-lifetime-issue-123053.rs
+++ b/tests/ui/sanitizer/cfi/assoc-ty-lifetime-issue-123053.rs
@@ -2,7 +2,7 @@
 // trait object type to fail, causing an ICE.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 //@ edition: 2021
 //@ no-prefer-dynamic
 //@ only-x86_64-unknown-linux-gnu

--- a/tests/ui/sanitizer/cfi/async-closures.rs
+++ b/tests/ui/sanitizer/cfi/async-closures.rs
@@ -7,11 +7,11 @@
 //@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
-//@ compile-flags: -C target-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
-//@ [cfi] compile-flags: -C codegen-units=1 -C lto -C prefer-dynamic=off -C opt-level=0
-//@ [cfi] compile-flags: -Z sanitizer=cfi
-//@ [kcfi] compile-flags: -Z sanitizer=kcfi
-//@ [kcfi] compile-flags: -C panic=abort -Z panic-abort-tests -C prefer-dynamic=off
+//@ [cfi] compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off
+//@ [cfi] compile-flags: -Zunstable-options -Csanitize=cfi
+//@ [kcfi] compile-flags: -Cpanic=abort -Zpanic-abort-tests -Cprefer-dynamic=off
+//@ [kcfi] compile-flags: -Zunstable-options -Csanitize=kcfi
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
 //@ run-pass
 
 #![feature(async_fn_traits)]

--- a/tests/ui/sanitizer/cfi/can-reveal-opaques.rs
+++ b/tests/ui/sanitizer/cfi/can-reveal-opaques.rs
@@ -1,5 +1,5 @@
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize  -Zunstable-options -Csanitize=cfi
 //@ no-prefer-dynamic
 //@ only-x86_64-unknown-linux-gnu
 //@ ignore-backends: gcc

--- a/tests/ui/sanitizer/cfi/canonical-jump-tables-requires-cfi.rs
+++ b/tests/ui/sanitizer/cfi/canonical-jump-tables-requires-cfi.rs
@@ -1,10 +1,10 @@
-// Verifies that `-Zsanitizer-cfi-canonical-jump-tables` requires `-Zsanitizer=cfi`.
+// Verifies that `-Zsanitizer-cfi-canonical-jump-tables` requires `-Csanitize=cfi`.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer-cfi-canonical-jump-tables=false
+//@ compile-flags: -Ctarget-feature=-crt-static -Zsanitizer-cfi-canonical-jump-tables=false
 
 #![feature(no_core)]
 #![no_core]
 #![no_main]
 
-//~? ERROR `-Zsanitizer-cfi-canonical-jump-tables` requires `-Zsanitizer=cfi`
+//~? ERROR `-Zsanitizer-cfi-canonical-jump-tables` requires `-Csanitize=cfi`

--- a/tests/ui/sanitizer/cfi/canonical-jump-tables-requires-cfi.stderr
+++ b/tests/ui/sanitizer/cfi/canonical-jump-tables-requires-cfi.stderr
@@ -1,4 +1,4 @@
-error: `-Zsanitizer-cfi-canonical-jump-tables` requires `-Zsanitizer=cfi`
+error: `-Zsanitizer-cfi-canonical-jump-tables` requires `-Csanitize=cfi`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sanitizer/cfi/closures.rs
+++ b/tests/ui/sanitizer/cfi/closures.rs
@@ -6,11 +6,11 @@
 //@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
-//@ compile-flags: -C target-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
-//@ [cfi] compile-flags: -C codegen-units=1 -C lto -C prefer-dynamic=off -C opt-level=0
-//@ [cfi] compile-flags: -Z sanitizer=cfi
-//@ [kcfi] compile-flags: -Z sanitizer=kcfi
-//@ [kcfi] compile-flags: -C panic=abort -Z panic-abort-tests -C prefer-dynamic=off
+//@ [cfi] compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off
+//@ [cfi] compile-flags: -Zunstable-options -Csanitize=cfi
+//@ [kcfi] compile-flags: -Cpanic=abort -Zpanic-abort-tests -Cprefer-dynamic=off
+//@ [kcfi] compile-flags: -Zunstable-options -Csanitize=kcfi
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
 //@ compile-flags: --test
 //@ run-pass
 

--- a/tests/ui/sanitizer/cfi/complex-receiver.rs
+++ b/tests/ui/sanitizer/cfi/complex-receiver.rs
@@ -8,11 +8,11 @@
 //@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
-//@ compile-flags: -C target-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
-//@ [cfi] compile-flags: -C codegen-units=1 -C lto -C prefer-dynamic=off -C opt-level=0
-//@ [cfi] compile-flags: -Z sanitizer=cfi
-//@ [kcfi] compile-flags: -Z sanitizer=kcfi
-//@ [kcfi] compile-flags: -C panic=abort -C prefer-dynamic=off
+//@ [cfi] compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off
+//@ [cfi] compile-flags: -Zunstable-options -Csanitize=cfi
+//@ [kcfi] compile-flags: -Cpanic=abort -Cprefer-dynamic=off
+//@ [kcfi] compile-flags: -Zunstable-options -Csanitize=kcfi
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
 //@ run-pass
 
 use std::sync::Arc;

--- a/tests/ui/sanitizer/cfi/coroutine.rs
+++ b/tests/ui/sanitizer/cfi/coroutine.rs
@@ -7,12 +7,11 @@
 //@ edition: 2024
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
-//@ compile-flags: -C target-feature=-crt-static
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
-//@ [cfi] compile-flags: -C codegen-units=1 -C lto -C prefer-dynamic=off -C opt-level=0
-//@ [cfi] compile-flags: -Z sanitizer=cfi
-//@ [kcfi] compile-flags: -Z sanitizer=kcfi
-//@ [kcfi] compile-flags: -C panic=abort -Z panic-abort-tests -C prefer-dynamic=off
+//@ [cfi] compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off
+//@ [cfi] compile-flags: -Zunstable-options -Csanitize=cfi
+//@ [kcfi] compile-flags: -Cpanic=abort -Zpanic-abort-tests -Cprefer-dynamic=off
+//@ [kcfi] compile-flags: -Zunstable-options -Csanitize=kcfi
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
 //@ compile-flags: --test
 //@ run-pass
 

--- a/tests/ui/sanitizer/cfi/drop-in-place.rs
+++ b/tests/ui/sanitizer/cfi/drop-in-place.rs
@@ -4,8 +4,7 @@
 //@ only-linux
 //@ ignore-backends: gcc
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Copt-level=0 -Cprefer-dynamic=off -Ctarget-feature=-crt-static -Zsanitizer=cfi
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 //@ run-pass
 
 struct EmptyDrop;

--- a/tests/ui/sanitizer/cfi/drop-no-principal.rs
+++ b/tests/ui/sanitizer/cfi/drop-no-principal.rs
@@ -2,14 +2,11 @@
 
 //@ needs-sanitizer-cfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries works
-//@ only-linux
+//@ needs-sanitizer-support
 //@ ignore-backends: gcc
-//@ compile-flags: --crate-type=bin -Cprefer-dynamic=off -Clto -Zsanitizer=cfi -C unsafe-allow-abi-mismatch=sanitizer
-//@ compile-flags: -C target-feature=-crt-static -C codegen-units=1 -C opt-level=0
-// FIXME(#118761) Should be run-pass once the labels on drop are compatible.
-// This test is being landed ahead of that to test that the compiler doesn't ICE while labeling the
-// callsite for a drop, but the vtable doesn't have the correct label yet.
-//@ build-pass
+//@ only-linux
+//@ compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
+//@ run-pass
 
 struct CustomDrop;
 

--- a/tests/ui/sanitizer/cfi/fn-ptr.rs
+++ b/tests/ui/sanitizer/cfi/fn-ptr.rs
@@ -6,13 +6,11 @@
 //@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
-//@ compile-flags: -C target-feature=-crt-static
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
-//@ [cfi] compile-flags: -C opt-level=0 -C codegen-units=1 -C lto
-//@ [cfi] compile-flags: -C prefer-dynamic=off
-//@ [cfi] compile-flags: -Z sanitizer=cfi
-//@ [kcfi] compile-flags: -Z sanitizer=kcfi
-//@ [kcfi] compile-flags: -C panic=abort -C prefer-dynamic=off
+//@ [cfi] compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off
+//@ [cfi] compile-flags: -Zunstable-options -Csanitize=cfi
+//@ [kcfi] compile-flags: -Cpanic=abort -Cprefer-dynamic=off
+//@ [kcfi] compile-flags: -Zunstable-options -Csanitize=kcfi
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
 //@ run-pass
 
 trait Foo {

--- a/tests/ui/sanitizer/cfi/fn-trait-objects.rs
+++ b/tests/ui/sanitizer/cfi/fn-trait-objects.rs
@@ -4,7 +4,7 @@
 //@ needs-sanitizer-cfi
 //@ only-linux
 //@ ignore-backends: gcc
-//@ compile-flags: -Ctarget-feature=-crt-static -Ccodegen-units=1 -Clto -Cprefer-dynamic=off -Copt-level=0 -Zsanitizer=cfi -Cunsafe-allow-abi-mismatch=sanitizer --test
+//@ compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi --test
 //@ run-pass
 
 #![feature(fn_traits)]

--- a/tests/ui/sanitizer/cfi/generalize-pointers-attr-cfg.rs
+++ b/tests/ui/sanitizer/cfi/generalize-pointers-attr-cfg.rs
@@ -3,8 +3,7 @@
 //
 //@ needs-sanitizer-cfi
 //@ check-pass
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Zsanitizer-cfi-generalize-pointers
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Zsanitizer-cfi-generalize-pointers
 
 #![feature(cfg_sanitizer_cfi)]
 

--- a/tests/ui/sanitizer/cfi/generalize-pointers-requires-cfi.rs
+++ b/tests/ui/sanitizer/cfi/generalize-pointers-requires-cfi.rs
@@ -1,11 +1,11 @@
-// Verifies that `-Zsanitizer-cfi-generalize-pointers` requires `-Zsanitizer=cfi` or
-// `-Zsanitizer=kcfi`.
+// Verifies that `-Zsanitizer-cfi-generalize-pointers` requires `-Csanitize=cfi` or
+// `-Csanitize=kcfi`.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer-cfi-generalize-pointers
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer-cfi-generalize-pointers
 
 #![feature(no_core)]
 #![no_core]
 #![no_main]
 
-//~? ERROR `-Zsanitizer-cfi-generalize-pointers` requires `-Zsanitizer=cfi` or `-Zsanitizer=kcfi`
+//~? ERROR `-Zsanitizer-cfi-generalize-pointers` requires `-Csanitize=cfi` or `-Csanitize=kcfi`

--- a/tests/ui/sanitizer/cfi/generalize-pointers-requires-cfi.stderr
+++ b/tests/ui/sanitizer/cfi/generalize-pointers-requires-cfi.stderr
@@ -1,4 +1,4 @@
-error: `-Zsanitizer-cfi-generalize-pointers` requires `-Zsanitizer=cfi` or `-Zsanitizer=kcfi`
+error: `-Zsanitizer-cfi-generalize-pointers` requires `-Csanitize=cfi` or `-Csanitize=kcfi`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sanitizer/cfi/invalid-attr-encoding.rs
+++ b/tests/ui/sanitizer/cfi/invalid-attr-encoding.rs
@@ -1,7 +1,7 @@
 // Verifies that invalid user-defined CFI encodings can't be used.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Zsanitizer-cfi-generalize-pointers
 
 #![feature(cfi_encoding, no_core)]
 #![no_core]

--- a/tests/ui/sanitizer/cfi/is-incompatible-with-kcfi.aarch64.stderr
+++ b/tests/ui/sanitizer/cfi/is-incompatible-with-kcfi.aarch64.stderr
@@ -1,6 +1,6 @@
 error: cfi sanitizer is not supported for this target
 
-error: `-Zsanitizer=cfi` is incompatible with `-Zsanitizer=kcfi`
+error: `-Csanitize=cfi` is incompatible with `-Csanitize=kcfi`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/sanitizer/cfi/is-incompatible-with-kcfi.rs
+++ b/tests/ui/sanitizer/cfi/is-incompatible-with-kcfi.rs
@@ -1,11 +1,11 @@
-// Verifies that `-Zsanitizer=cfi` is incompatible with `-Zsanitizer=kcfi`.
+// Verifies that `-Csanitize=cfi` is incompatible with `-Csanitize=kcfi`.
 //
 //@ revisions: aarch64 x86_64
 //@ [aarch64] compile-flags: --target aarch64-unknown-none
 //@ [aarch64] needs-llvm-components: aarch64
 //@ [x86_64] compile-flags: --target x86_64-unknown-none
 //@ [x86_64] needs-llvm-components: x86
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Zsanitizer=kcfi
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Csanitize=kcfi
 //@ ignore-backends: gcc
 
 #![feature(no_core)]
@@ -13,4 +13,4 @@
 #![no_main]
 
 //~? ERROR cfi sanitizer is not supported for this target
-//~? ERROR `-Zsanitizer=cfi` is incompatible with `-Zsanitizer=kcfi`
+//~? ERROR `-Csanitize=cfi` is incompatible with `-Csanitize=kcfi`

--- a/tests/ui/sanitizer/cfi/is-incompatible-with-kcfi.x86_64.stderr
+++ b/tests/ui/sanitizer/cfi/is-incompatible-with-kcfi.x86_64.stderr
@@ -1,6 +1,6 @@
 error: cfi sanitizer is not supported for this target
 
-error: `-Zsanitizer=cfi` is incompatible with `-Zsanitizer=kcfi`
+error: `-Csanitize=cfi` is incompatible with `-Csanitize=kcfi`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/sanitizer/cfi/normalize-integers-attr-cfg.rs
+++ b/tests/ui/sanitizer/cfi/normalize-integers-attr-cfg.rs
@@ -3,7 +3,7 @@
 //
 //@ needs-sanitizer-cfi
 //@ check-pass
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi -Zsanitizer-cfi-normalize-integers -C unsafe-allow-abi-mismatch=sanitizer,sanitizer-cfi-normalize-integers
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi -Zsanitizer-cfi-normalize-integers
 
 #![feature(cfg_sanitizer_cfi)]
 

--- a/tests/ui/sanitizer/cfi/normalize-integers-requires-cfi.rs
+++ b/tests/ui/sanitizer/cfi/normalize-integers-requires-cfi.rs
@@ -1,11 +1,11 @@
-// Verifies that `-Zsanitizer-cfi-normalize-integers` requires `-Zsanitizer=cfi` or
-// `-Zsanitizer=kcfi`
+// Verifies that `-Zsanitizer-cfi-normalize-integers` requires `-Csanitize=cfi` or
+// `-Csanitize=kcfi`
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer-cfi-normalize-integers
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer-cfi-normalize-integers
 
 #![feature(no_core)]
 #![no_core]
 #![no_main]
 
-//~? ERROR `-Zsanitizer-cfi-normalize-integers` requires `-Zsanitizer=cfi` or `-Zsanitizer=kcfi`
+//~? ERROR `-Zsanitizer-cfi-normalize-integers` requires `-Csanitize=cfi` or `-Csanitize=kcfi`

--- a/tests/ui/sanitizer/cfi/normalize-integers-requires-cfi.stderr
+++ b/tests/ui/sanitizer/cfi/normalize-integers-requires-cfi.stderr
@@ -1,4 +1,4 @@
-error: `-Zsanitizer-cfi-normalize-integers` requires `-Zsanitizer=cfi` or `-Zsanitizer=kcfi`
+error: `-Zsanitizer-cfi-normalize-integers` requires `-Csanitize=cfi` or `-Csanitize=kcfi`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sanitizer/cfi/requires-lto.rs
+++ b/tests/ui/sanitizer/cfi/requires-lto.rs
@@ -1,10 +1,10 @@
-// Verifies that `-Zsanitizer=cfi` requires `-Clto` or `-Clinker-plugin-lto`.
+// Verifies that `-Csanitize=cfi` requires `-Clto` or `-Clinker-plugin-lto`.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer=cfi
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![feature(no_core)]
 #![no_core]
 #![no_main]
 
-//~? ERROR `-Zsanitizer=cfi` requires `-Clto` or `-Clinker-plugin-lto`
+//~? ERROR `-Csanitize=cfi` requires `-Clto` or `-Clinker-plugin-lto`

--- a/tests/ui/sanitizer/cfi/requires-lto.stderr
+++ b/tests/ui/sanitizer/cfi/requires-lto.stderr
@@ -1,4 +1,4 @@
-error: `-Zsanitizer=cfi` requires `-Clto` or `-Clinker-plugin-lto`
+error: `-Csanitize=cfi` requires `-Clto` or `-Clinker-plugin-lto`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sanitizer/cfi/self-ref.rs
+++ b/tests/ui/sanitizer/cfi/self-ref.rs
@@ -6,11 +6,11 @@
 //@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
-//@ compile-flags: -C target-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
-//@ [cfi] compile-flags: -C codegen-units=1 -C lto -C prefer-dynamic=off -C opt-level=0
-//@ [cfi] compile-flags: -Z sanitizer=cfi
-//@ [kcfi] compile-flags: -Z sanitizer=kcfi
-//@ [kcfi] compile-flags: -C panic=abort -C prefer-dynamic=off
+//@ [cfi] compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off
+//@ [cfi] compile-flags: -Zunstable-options -Csanitize=cfi
+//@ [kcfi] compile-flags: -Cpanic=abort -Cprefer-dynamic=off
+//@ [kcfi] compile-flags: -Zunstable-options -Csanitize=kcfi
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
 //@ run-pass
 
 use std::marker::PhantomData;

--- a/tests/ui/sanitizer/cfi/sized-associated-ty.rs
+++ b/tests/ui/sanitizer/cfi/sized-associated-ty.rs
@@ -7,11 +7,11 @@
 //@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
-//@ compile-flags: -C target-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
-//@ [cfi] compile-flags: -C codegen-units=1 -C lto -C prefer-dynamic=off -C opt-level=0
-//@ [cfi] compile-flags: -Z sanitizer=cfi
-//@ [kcfi] compile-flags: -Z sanitizer=kcfi
-//@ [kcfi] compile-flags: -C panic=abort -C prefer-dynamic=off
+//@ [cfi] compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off
+//@ [cfi] compile-flags: -Zunstable-options -Csanitize=cfi
+//@ [kcfi] compile-flags: -Cpanic=abort -Cprefer-dynamic=off
+//@ [kcfi] compile-flags: -Zunstable-options -Csanitize=kcfi
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
 //@ run-pass
 
 trait Foo {

--- a/tests/ui/sanitizer/cfi/supertraits.rs
+++ b/tests/ui/sanitizer/cfi/supertraits.rs
@@ -6,11 +6,11 @@
 //@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
-//@ compile-flags: -C target-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
-//@ [cfi] compile-flags: -C codegen-units=1 -C lto -C prefer-dynamic=off -C opt-level=0
-//@ [cfi] compile-flags: -Z sanitizer=cfi
-//@ [kcfi] compile-flags: -Z sanitizer=kcfi
-//@ [kcfi] compile-flags: -C panic=abort -C prefer-dynamic=off
+//@ [cfi] compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off
+//@ [cfi] compile-flags: -Zunstable-options -Csanitize=cfi
+//@ [kcfi] compile-flags: -Cpanic=abort -Cprefer-dynamic=off
+//@ [kcfi] compile-flags: -Zunstable-options -Csanitize=kcfi
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
 //@ run-pass
 
 trait Parent1 {

--- a/tests/ui/sanitizer/cfi/transparent-has-regions.rs
+++ b/tests/ui/sanitizer/cfi/transparent-has-regions.rs
@@ -1,5 +1,5 @@
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 //@ no-prefer-dynamic
 //@ only-x86_64-unknown-linux-gnu
 //@ build-pass

--- a/tests/ui/sanitizer/cfi/virtual-auto.rs
+++ b/tests/ui/sanitizer/cfi/virtual-auto.rs
@@ -6,11 +6,11 @@
 //@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
-//@ compile-flags: -C target-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
-//@ [cfi] compile-flags: -C codegen-units=1 -C lto -C prefer-dynamic=off -C opt-level=0
-//@ [cfi] compile-flags: -Z sanitizer=cfi
-//@ [kcfi] compile-flags: -Z sanitizer=kcfi
-//@ [kcfi] compile-flags: -C panic=abort -C prefer-dynamic=off
+//@ [cfi] compile-flags: -Ccodegen-units=1 -Clto -Cprefer-dynamic=off
+//@ [cfi] compile-flags: -Zunstable-options -Csanitize=cfi
+//@ [kcfi] compile-flags: -Cpanic=abort -Cprefer-dynamic=off
+//@ [kcfi] compile-flags: -Zunstable-options -Csanitize=kcfi
+//@ compile-flags: -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize
 //@ run-pass
 
 trait Foo {

--- a/tests/ui/sanitizer/cfi/with-rustc-lto-requires-single-codegen-unit.rs
+++ b/tests/ui/sanitizer/cfi/with-rustc-lto-requires-single-codegen-unit.rs
@@ -1,10 +1,10 @@
-// Verifies that `-Zsanitizer=cfi` with `-Clto` or `-Clto=thin` requires `-Ccodegen-units=1`.
+// Verifies that `-Csanitize=cfi` with `-Clto` or `-Clto=thin` requires `-Ccodegen-units=1`.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Ccodegen-units=2 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi
+//@ compile-flags: -Ccodegen-units=2 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 
 #![feature(no_core)]
 #![no_core]
 #![no_main]
 
-//~? ERROR `-Zsanitizer=cfi` with `-Clto` requires `-Ccodegen-units=1`
+//~? ERROR `-Csanitize=cfi` with `-Clto` requires `-Ccodegen-units=1`

--- a/tests/ui/sanitizer/cfi/with-rustc-lto-requires-single-codegen-unit.stderr
+++ b/tests/ui/sanitizer/cfi/with-rustc-lto-requires-single-codegen-unit.stderr
@@ -1,4 +1,4 @@
-error: `-Zsanitizer=cfi` with `-Clto` requires `-Ccodegen-units=1`
+error: `-Csanitize=cfi` with `-Clto` requires `-Ccodegen-units=1`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sanitizer/crt-static.rs
+++ b/tests/ui/sanitizer/crt-static.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z sanitizer=address -C target-feature=+crt-static --target x86_64-unknown-linux-gnu
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=address -Ctarget-feature=+crt-static --target x86_64-unknown-linux-gnu
 //@ needs-llvm-components: x86
 
 #![feature(no_core)]

--- a/tests/ui/sanitizer/dataflow.rs
+++ b/tests/ui/sanitizer/dataflow.rs
@@ -4,7 +4,7 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-dataflow
 //@ run-pass
-//@ compile-flags: -Zsanitizer=dataflow -Zsanitizer-dataflow-abilist={{src-base}}/sanitizer/dataflow-abilist.txt -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=dataflow -Zsanitizer-dataflow-abilist={{src-base}}/sanitizer/dataflow-abilist.txt
 //@ ignore-backends: gcc
 
 use std::mem::size_of;

--- a/tests/ui/sanitizer/hwaddress.rs
+++ b/tests/ui/sanitizer/hwaddress.rs
@@ -1,7 +1,7 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-hwaddress
 //
-//@ compile-flags: -Z sanitizer=hwaddress -O -g -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Z sanitizer=hwaddress -O -g -C target-feature=+tagged-globals
 //
 //@ run-fail
 //@ error-pattern: HWAddressSanitizer: tag-mismatch

--- a/tests/ui/sanitizer/incompatible-khwasan.rs
+++ b/tests/ui/sanitizer/incompatible-khwasan.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z sanitizer=kernel-hwaddress -Z sanitizer=kernel-address --target aarch64-unknown-none
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-address -Csanitize=kernel-hwaddress --target aarch64-unknown-none
 //@ needs-llvm-components: aarch64
 //@ ignore-backends: gcc
 
@@ -6,4 +6,4 @@
 #![no_core]
 #![no_main]
 
-//~? ERROR `-Zsanitizer=kernel-address` is incompatible with `-Zsanitizer=kernel-hwaddress`
+//~? ERROR `-Csanitize=kernel-address` is incompatible with `-Csanitize=kernel-hwaddress`

--- a/tests/ui/sanitizer/incompatible-khwasan.stderr
+++ b/tests/ui/sanitizer/incompatible-khwasan.stderr
@@ -1,4 +1,4 @@
-error: `-Zsanitizer=kernel-address` is incompatible with `-Zsanitizer=kernel-hwaddress`
+error: `-Csanitize=kernel-address` is incompatible with `-Csanitize=kernel-hwaddress`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sanitizer/incompatible.rs
+++ b/tests/ui/sanitizer/incompatible.rs
@@ -1,8 +1,8 @@
-//@ compile-flags: -Z sanitizer=address -Z sanitizer=memory --target x86_64-unknown-linux-gnu
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=address -Csanitize=memory --target x86_64-unknown-linux-gnu
 //@ needs-llvm-components: x86
 
 #![feature(no_core)]
 #![no_core]
 #![no_main]
 
-//~? ERROR `-Zsanitizer=address` is incompatible with `-Zsanitizer=memory`
+//~? ERROR `-Csanitize=address` is incompatible with `-Csanitize=memory`

--- a/tests/ui/sanitizer/incompatible.stderr
+++ b/tests/ui/sanitizer/incompatible.stderr
@@ -1,4 +1,4 @@
-error: `-Zsanitizer=address` is incompatible with `-Zsanitizer=memory`
+error: `-Csanitize=address` is incompatible with `-Csanitize=memory`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sanitizer/issue-111184-cfi-coroutine-witness.rs
+++ b/tests/ui/sanitizer/issue-111184-cfi-coroutine-witness.rs
@@ -2,7 +2,7 @@
 // encode_ty and caused the compiler to ICE.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 //@ edition: 2021
 //@ no-prefer-dynamic
 //@ only-x86_64-unknown-linux-gnu

--- a/tests/ui/sanitizer/issue-114275-cfi-const-expr-in-arry-len.rs
+++ b/tests/ui/sanitizer/issue-114275-cfi-const-expr-in-arry-len.rs
@@ -2,7 +2,7 @@
 // was expecting array type lengths to be evaluated, this was causing an ICE.
 //
 //@ build-pass
-//@ compile-flags: -Ccodegen-units=1 -Clto -Zsanitizer=cfi -Ctarget-feature=-crt-static -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=cfi
 //@ needs-sanitizer-cfi
 
 #![crate_type = "lib"]

--- a/tests/ui/sanitizer/issue-72154-address-lifetime-markers.rs
+++ b/tests/ui/sanitizer/issue-72154-address-lifetime-markers.rs
@@ -7,7 +7,7 @@
 //@ needs-sanitizer-address
 //@ ignore-cross-compile
 //
-//@ compile-flags: -Copt-level=0 -Zsanitizer=address -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Copt-level=0 -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=address
 //@ run-pass
 
 pub struct Wrap {

--- a/tests/ui/sanitizer/kcfi-arity-requires-kcfi.rs
+++ b/tests/ui/sanitizer/kcfi-arity-requires-kcfi.rs
@@ -1,9 +1,10 @@
-// Verifies that `-Zsanitizer-kcfi-arity` requires `-Zsanitizer=kcfi`.
+// Verifies that `-Zsanitizer-kcfi-arity` requires `-Csanitize=kcfi`.
 //
 //@ needs-sanitizer-kcfi
-//@ compile-flags: -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsanitizer-kcfi-arity
+//@ compile-flags: -Ctarget-feature=-crt-static -Zsanitizer-kcfi-arity
 
-//~? ERROR `-Zsanitizer-kcfi-arity` requires `-Zsanitizer=kcfi`
 #![feature(no_core)]
 #![no_core]
 #![no_main]
+
+//~? ERROR `-Zsanitizer-kcfi-arity` requires `-Csanitize=kcfi`

--- a/tests/ui/sanitizer/kcfi-arity-requires-kcfi.stderr
+++ b/tests/ui/sanitizer/kcfi-arity-requires-kcfi.stderr
@@ -1,4 +1,4 @@
-error: `-Zsanitizer-kcfi-arity` requires `-Zsanitizer=kcfi`
+error: `-Zsanitizer-kcfi-arity` requires `-Csanitize=kcfi`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sanitizer/kcfi-c-variadic.rs
+++ b/tests/ui/sanitizer/kcfi-c-variadic.rs
@@ -1,6 +1,6 @@
 //@ needs-sanitizer-kcfi
 //@ no-prefer-dynamic
-//@ compile-flags: -Zsanitizer=kcfi -Cpanic=abort -Cunsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cpanic=abort -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi
 //@ ignore-backends: gcc
 //@ run-pass
 

--- a/tests/ui/sanitizer/kcfi-mangling.rs
+++ b/tests/ui/sanitizer/kcfi-mangling.rs
@@ -2,7 +2,7 @@
 
 //@ needs-sanitizer-kcfi
 //@ no-prefer-dynamic
-//@ compile-flags: -C panic=abort -Zsanitizer=kcfi -C symbol-mangling-version=v0 -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cpanic=abort -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi -Csymbol-mangling-version=v0
 //@ build-pass
 //@ ignore-backends: gcc
 

--- a/tests/ui/sanitizer/kcfi/fn-trait-objects.rs
+++ b/tests/ui/sanitizer/kcfi/fn-trait-objects.rs
@@ -4,7 +4,7 @@
 //@ needs-sanitizer-kcfi
 //@ only-linux
 //@ ignore-backends: gcc
-//@ compile-flags: -Ctarget-feature=-crt-static -Zpanic_abort_tests -Cpanic=abort -Cprefer-dynamic=off -Copt-level=0 -Zsanitizer=kcfi -Cunsafe-allow-abi-mismatch=sanitizer --test
+//@ compile-flags: -Cpanic=abort -Cprefer-dynamic=off -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kcfi -Zpanic_abort_tests --test
 //@ run-pass
 
 #![feature(fn_traits)]

--- a/tests/ui/sanitizer/leak.rs
+++ b/tests/ui/sanitizer/leak.rs
@@ -1,7 +1,7 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-leak
 //
-//@ compile-flags: -Z sanitizer=leak -O -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=leak -O
 //
 //@ run-fail
 //@ error-pattern: LeakSanitizer: detected memory leaks

--- a/tests/ui/sanitizer/memory-eager.rs
+++ b/tests/ui/sanitizer/memory-eager.rs
@@ -1,12 +1,14 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-memory
 //
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize
 //
 //@ revisions: unoptimized optimized
 //
-//@ [optimized]compile-flags: -Z sanitizer=memory -Zsanitizer-memory-track-origins -O
-//@ [unoptimized]compile-flags: -Z sanitizer=memory -Zsanitizer-memory-track-origins
+//@ [optimized]compile-flags: -Zunstable-options -Csanitize=memory
+//@ [optimized]compile-flags: -Zsanitizer-memory-track-origins -O
+//@ [unoptimized]compile-flags: -Zunstable-options -Csanitize=memory
+//@ [unoptimized]compile-flags: -Zsanitizer-memory-track-origins
 //
 //@ run-fail
 //@ error-pattern: MemorySanitizer: use-of-uninitialized-value

--- a/tests/ui/sanitizer/memory-passing.rs
+++ b/tests/ui/sanitizer/memory-passing.rs
@@ -1,12 +1,14 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-memory
 //
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize
 //
 //@ revisions: unoptimized optimized
 //
-//@ [optimized]compile-flags: -Z sanitizer=memory -Zsanitizer-memory-track-origins -O
-//@ [unoptimized]compile-flags: -Z sanitizer=memory -Zsanitizer-memory-track-origins
+//@ [optimized]compile-flags: -Zunstable-options -Csanitize=memory
+//@ [optimized]compile-flags: -Zsanitizer-memory-track-origins -O
+//@ [unoptimized]compile-flags: -Zunstable-options -Csanitize=memory
+//@ [unoptimized]compile-flags: -Zsanitizer-memory-track-origins
 //
 //@ run-pass
 //

--- a/tests/ui/sanitizer/memory.rs
+++ b/tests/ui/sanitizer/memory.rs
@@ -1,12 +1,14 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-memory
 //
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize
 //
 //@ revisions: unoptimized optimized
 //
-//@ [optimized]compile-flags: -Z sanitizer=memory -Zsanitizer-memory-track-origins -O
-//@ [unoptimized]compile-flags: -Z sanitizer=memory -Zsanitizer-memory-track-origins
+//@ [optimized]compile-flags: -Zunstable-options -Csanitize=memory
+//@ [optimized]compile-flags: -Zsanitizer-memory-track-origins -O
+//@ [unoptimized]compile-flags: -Zunstable-options -Csanitize=memory
+//@ [unoptimized]compile-flags: -Zsanitizer-memory-track-origins
 //
 //@ run-fail
 //@ error-pattern: MemorySanitizer: use-of-uninitialized-value

--- a/tests/ui/sanitizer/new-llvm-pass-manager-thin-lto.rs
+++ b/tests/ui/sanitizer/new-llvm-pass-manager-thin-lto.rs
@@ -6,11 +6,11 @@
 //@ needs-sanitizer-address
 //@ ignore-cross-compile
 //
-//@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize
 //
 //@ no-prefer-dynamic
 //@ revisions: opt0 opt1
-//@ compile-flags: -Zsanitizer=address -Clto=thin
+//@ compile-flags: -Zunstable-options -Csanitize=address -Clto=thin
 //@[opt0]compile-flags: -Copt-level=0
 //@[opt1]compile-flags: -Copt-level=1
 //@ run-fail-or-crash

--- a/tests/ui/sanitizer/realtime-alloc.rs
+++ b/tests/ui/sanitizer/realtime-alloc.rs
@@ -1,7 +1,7 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-realtime
 //
-//@ compile-flags: -Z sanitizer=realtime
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=realtime
 //@ exec-env: RTSAN_OPTIONS=abort_on_error=0
 //
 //@ run-fail

--- a/tests/ui/sanitizer/realtime-blocking.rs
+++ b/tests/ui/sanitizer/realtime-blocking.rs
@@ -1,7 +1,7 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-realtime
 //
-//@ compile-flags: -Z sanitizer=realtime
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=realtime
 //@ exec-env: RTSAN_OPTIONS=abort_on_error=0
 //
 //@ run-fail

--- a/tests/ui/sanitizer/split-lto-unit-requires-lto.rs
+++ b/tests/ui/sanitizer/split-lto-unit-requires-lto.rs
@@ -1,7 +1,7 @@
 // Verifies that `-Zsplit-lto-unit` requires `-Clto`, `-Clto=thin`, or `-Clinker-plugin-lto`.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Cno-prepopulate-passes -Ctarget-feature=-crt-static -Zsplit-lto-unit
+//@ compile-flags: -Ctarget-feature=-crt-static -Zsplit-lto-unit
 
 #![feature(no_core)]
 #![no_core]

--- a/tests/ui/sanitizer/stable-and-unstable-supported-can-be-used-with-unstable-options.rs
+++ b/tests/ui/sanitizer/stable-and-unstable-supported-can-be-used-with-unstable-options.rs
@@ -1,0 +1,12 @@
+// Verifies that stable and unstable supported sanitizers can be used with `-Zunstable-options`.
+//
+//@ needs-llvm-components: x86
+//@ needs-sanitizer-support
+//@ ignore-backends: gcc
+//@ build-pass
+//@ compile-flags: -Zunstable-options -Clto -Csanitize=address,cfi --target x86_64-unknown-linux-gnu
+
+#![crate_type = "rlib"]
+#![feature(no_core)]
+#![no_core]
+#![no_main]

--- a/tests/ui/sanitizer/stable-and-unstable-supported-cannot-be-used-without-unstable-options.rs
+++ b/tests/ui/sanitizer/stable-and-unstable-supported-cannot-be-used-without-unstable-options.rs
@@ -1,0 +1,10 @@
+// Verifies that stable and unstable supported sanitizers cannot be used without
+// `-Zunstable-options`.
+//
+//@ needs-llvm-components: x86
+//@ needs-sanitizer-support
+//@ ignore-backends: gcc
+//@ compile-flags: -Clto -Csanitize=address,cfi --target x86_64-unknown-linux-gnu
+//@ error-pattern: error: cfi sanitizer is not supported for this target
+
+fn main() { }

--- a/tests/ui/sanitizer/stable-and-unstable-supported-cannot-be-used-without-unstable-options.stderr
+++ b/tests/ui/sanitizer/stable-and-unstable-supported-cannot-be-used-without-unstable-options.stderr
@@ -1,0 +1,4 @@
+error: cfi sanitizer is not supported for this target
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/sanitizer/stable-supported-can-be-used-with-unstable-options.rs
+++ b/tests/ui/sanitizer/stable-supported-can-be-used-with-unstable-options.rs
@@ -1,0 +1,9 @@
+// Verifies that stable supported sanitizers can be used with `-Zunstable-options`.
+//
+//@ needs-llvm-components: x86
+//@ needs-sanitizer-support
+//@ ignore-backends: gcc
+//@ build-pass
+//@ compile-flags: -Zunstable-options -Csanitize=address --target x86_64-unknown-linux-gnu
+
+fn main() { }

--- a/tests/ui/sanitizer/stable-supported-can-be-used-without-unstable-options.rs
+++ b/tests/ui/sanitizer/stable-supported-can-be-used-without-unstable-options.rs
@@ -1,0 +1,9 @@
+// Verifies that stable supported sanitizers can be used without `-Zunstable-options`.
+//
+//@ needs-llvm-components: x86
+//@ needs-sanitizer-support
+//@ ignore-backends: gcc
+//@ build-pass
+//@ compile-flags: -Csanitize=address --target x86_64-unknown-linux-gnu
+
+fn main() { }

--- a/tests/ui/sanitizer/thread.rs
+++ b/tests/ui/sanitizer/thread.rs
@@ -13,7 +13,7 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-thread
 //
-//@ compile-flags: -Z sanitizer=thread -O -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=thread -O
 //
 //@ run-fail-or-crash
 //@ error-pattern: WARNING: ThreadSanitizer: data race

--- a/tests/ui/sanitizer/unstable-supported-can-be-used-with-unstable-options.rs
+++ b/tests/ui/sanitizer/unstable-supported-can-be-used-with-unstable-options.rs
@@ -1,0 +1,12 @@
+// Verifies that unstable supported sanitizers can be used with `-Zunstable-options`.
+//
+//@ needs-llvm-components: x86
+//@ needs-sanitizer-support
+//@ ignore-backends: gcc
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-address --target x86_64-unknown-none
+//@ build-pass
+
+#![crate_type = "rlib"]
+#![feature(no_core)]
+#![no_core]
+#![no_main]

--- a/tests/ui/sanitizer/unstable-supported-cannot-be-used-without-unstable-options.rs
+++ b/tests/ui/sanitizer/unstable-supported-cannot-be-used-without-unstable-options.rs
@@ -1,0 +1,12 @@
+// Verifies that unstable supported sanitizers cannot be used without `-Zunstable-options`.
+//
+//@ needs-llvm-components: x86
+//@ needs-sanitizer-support
+//@ ignore-backends: gcc
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Csanitize=kernel-address --target x86_64-unknown-none
+
+#![feature(no_core)]
+#![no_core]
+#![no_main]
+
+//~? ERROR kernel-address sanitizer is not supported for this target

--- a/tests/ui/sanitizer/unstable-supported-cannot-be-used-without-unstable-options.stderr
+++ b/tests/ui/sanitizer/unstable-supported-cannot-be-used-without-unstable-options.stderr
@@ -1,0 +1,4 @@
+error: kernel-address sanitizer is not supported for this target
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/sanitizer/unsupported-cannot-be-used-with-unstable-options.rs
+++ b/tests/ui/sanitizer/unsupported-cannot-be-used-with-unstable-options.rs
@@ -1,0 +1,12 @@
+// Verifies that unsupported sanitizers cannot be used with `-Zunstable-options`.
+//
+//@ needs-llvm-components: x86
+//@ needs-sanitizer-support
+//@ ignore-backends: gcc
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-address --target x86_64-unknown-linux-gnu
+
+#![feature(no_core)]
+#![no_core]
+#![no_main]
+
+//~? ERROR kernel-address sanitizer is not supported for this target

--- a/tests/ui/sanitizer/unsupported-cannot-be-used-with-unstable-options.stderr
+++ b/tests/ui/sanitizer/unsupported-cannot-be-used-with-unstable-options.stderr
@@ -1,0 +1,4 @@
+error: kernel-address sanitizer is not supported for this target
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/sanitizer/unsupported-cannot-be-used-without-unstable-options.rs
+++ b/tests/ui/sanitizer/unsupported-cannot-be-used-without-unstable-options.rs
@@ -1,0 +1,12 @@
+// Verifies that unsupported sanitizers cannot be used without `-Zunstable-options`.
+//
+//@ needs-llvm-components: x86
+//@ needs-sanitizer-support
+//@ ignore-backends: gcc
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Csanitize=kernel-address --target x86_64-unknown-linux-gnu
+
+#![feature(no_core)]
+#![no_core]
+#![no_main]
+
+//~? ERROR kernel-address sanitizer is not supported for this target

--- a/tests/ui/sanitizer/unsupported-cannot-be-used-without-unstable-options.stderr
+++ b/tests/ui/sanitizer/unsupported-cannot-be-used-without-unstable-options.stderr
@@ -1,0 +1,4 @@
+error: kernel-address sanitizer is not supported for this target
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/sanitizer/unsupported-target-khwasan.rs
+++ b/tests/ui/sanitizer/unsupported-target-khwasan.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z sanitizer=kernel-hwaddress --target x86_64-unknown-none
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=kernel-hwaddress --target x86_64-unknown-none
 //@ needs-llvm-components: x86
 //@ ignore-backends: gcc
 

--- a/tests/ui/sanitizer/unsupported-target.rs
+++ b/tests/ui/sanitizer/unsupported-target.rs
@@ -1,9 +1,0 @@
-//@ compile-flags: -Z sanitizer=leak --target i686-unknown-linux-gnu
-//@ needs-llvm-components: x86
-//@ ignore-backends: gcc
-
-#![feature(no_core)]
-#![no_core]
-#![no_main]
-
-//~? ERROR leak sanitizer is not supported for this target

--- a/tests/ui/sanitizer/unsupported-target.stderr
+++ b/tests/ui/sanitizer/unsupported-target.stderr
@@ -1,4 +1,0 @@
-error: leak sanitizer is not supported for this target
-
-error: aborting due to 1 previous error
-

--- a/tests/ui/sanitizer/use-after-scope.rs
+++ b/tests/ui/sanitizer/use-after-scope.rs
@@ -2,7 +2,7 @@
 //@ needs-sanitizer-address
 //@ ignore-cross-compile
 //
-//@ compile-flags: -Zsanitizer=address -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Cunsafe-allow-abi-mismatch=sanitize -Zunstable-options -Csanitize=address
 //@ run-fail-or-crash
 //@ error-pattern: ERROR: AddressSanitizer: stack-use-after-scope
 //@ ignore-backends: gcc

--- a/tests/ui/target_modifiers/auxiliary/kcfi-normalize-ints.rs
+++ b/tests/ui/target_modifiers/auxiliary/kcfi-normalize-ints.rs
@@ -1,6 +1,6 @@
 //@ no-prefer-dynamic
 //@ needs-sanitizer-kcfi
-//@ compile-flags: -C panic=abort -Zsanitizer=kcfi -Zsanitizer-cfi-normalize-integers
+//@ compile-flags: -Cpanic=abort -Zunstable-options -Csanitize=kcfi -Zsanitizer-cfi-normalize-integers
 
 #![feature(no_core)]
 #![crate_type = "rlib"]

--- a/tests/ui/target_modifiers/auxiliary/safestack-and-kcfi.rs
+++ b/tests/ui/target_modifiers/auxiliary/safestack-and-kcfi.rs
@@ -3,7 +3,7 @@
 //@ needs-sanitizer-kcfi
 //@ needs-sanitizer-safestack
 
-//@ compile-flags: -C panic=abort -Zsanitizer=safestack,kcfi
+//@ compile-flags: -Cpanic=abort -Zunstable-options -Csanitize=safestack,kcfi
 
 #![feature(no_core)]
 #![crate_type = "rlib"]

--- a/tests/ui/target_modifiers/sanitizer-kcfi-normalize-ints.rs
+++ b/tests/ui/target_modifiers/sanitizer-kcfi-normalize-ints.rs
@@ -5,13 +5,13 @@
 //@ compile-flags: -Cpanic=abort
 
 //@ revisions: ok wrong_flag wrong_sanitizer
-//@[ok] compile-flags: -Zsanitizer=kcfi -Zsanitizer-cfi-normalize-integers
-//@[wrong_flag] compile-flags: -Zsanitizer=kcfi
+//@[ok] compile-flags: -Zunstable-options -Csanitize=kcfi -Zsanitizer-cfi-normalize-integers
+//@[wrong_flag] compile-flags: -Zunstable-options -Csanitize=kcfi
 //@[ok] check-pass
 
 #![feature(no_core)]
 //[wrong_flag]~^ ERROR mixing `-Zsanitizer-cfi-normalize-integers` will cause an ABI mismatch in crate `sanitizer_kcfi_normalize_ints`
-//[wrong_sanitizer]~^^ ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizer_kcfi_normalize_ints`
+//[wrong_sanitizer]~^^ ERROR mixing `-Csanitize` will cause an ABI mismatch in crate `sanitizer_kcfi_normalize_ints`
 #![crate_type = "rlib"]
 #![no_core]
 

--- a/tests/ui/target_modifiers/sanitizer-kcfi-normalize-ints.wrong_sanitizer.stderr
+++ b/tests/ui/target_modifiers/sanitizer-kcfi-normalize-ints.wrong_sanitizer.stderr
@@ -1,13 +1,13 @@
-error: mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizer_kcfi_normalize_ints`
+error: mixing `-Csanitize` will cause an ABI mismatch in crate `sanitizer_kcfi_normalize_ints`
   --> $DIR/sanitizer-kcfi-normalize-ints.rs:12:1
    |
 LL | #![feature(no_core)]
    | ^
    |
-   = help: the `-Zsanitizer` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
-   = note: unset `-Zsanitizer` in this crate is incompatible with `-Zsanitizer=kcfi` in dependency `kcfi_normalize_ints`
-   = help: set `-Zsanitizer=kcfi` in this crate or unset `-Zsanitizer` in `kcfi_normalize_ints`
-   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=sanitizer` to silence this error
+   = help: the `-Csanitize` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+   = note: unset `-Csanitize` in this crate is incompatible with `-Csanitize=kcfi` in dependency `kcfi_normalize_ints`
+   = help: set `-Csanitize=kcfi` in this crate or unset `-Csanitize` in `kcfi_normalize_ints`
+   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=sanitize` to silence this error
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/target_modifiers/sanitizers-good-for-inconsistency.rs
+++ b/tests/ui/target_modifiers/sanitizers-good-for-inconsistency.rs
@@ -6,10 +6,10 @@
 //@[wrong_leak_san] needs-sanitizer-leak
 
 //@ aux-build:no-sanitizers.rs
-//@ compile-flags: -Cpanic=abort -C target-feature=-crt-static
+//@ compile-flags: -Cpanic=abort -Ctarget-feature=-crt-static
 
-//@[wrong_address_san] compile-flags: -Zsanitizer=address
-//@[wrong_leak_san] compile-flags: -Zsanitizer=leak
+//@[wrong_address_san] compile-flags: -Zunstable-options -Csanitize=address
+//@[wrong_leak_san] compile-flags: -Zunstable-options -Csanitize=leak
 //@ check-pass
 
 #![feature(no_core)]

--- a/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_both.stderr
+++ b/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_both.stderr
@@ -1,13 +1,13 @@
-error: mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
+error: mixing `-Csanitize` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
   --> $DIR/sanitizers-safestack-and-kcfi.rs:16:1
    |
 LL | #![feature(no_core)]
    | ^
    |
-   = help: the `-Zsanitizer` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
-   = note: unset `-Zsanitizer` in this crate is incompatible with `-Zsanitizer=safestack,kcfi` in dependency `safestack_and_kcfi`
-   = help: set `-Zsanitizer=safestack,kcfi` in this crate or unset `-Zsanitizer` in `safestack_and_kcfi`
-   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=sanitizer` to silence this error
+   = help: the `-Csanitize` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+   = note: unset `-Csanitize` in this crate is incompatible with `-Csanitize=safestack,kcfi` in dependency `safestack_and_kcfi`
+   = help: set `-Csanitize=safestack,kcfi` in this crate or unset `-Csanitize` in `safestack_and_kcfi`
+   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=sanitize` to silence this error
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_kcfi.stderr
+++ b/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_kcfi.stderr
@@ -1,13 +1,13 @@
-error: mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
+error: mixing `-Csanitize` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
   --> $DIR/sanitizers-safestack-and-kcfi.rs:16:1
    |
 LL | #![feature(no_core)]
    | ^
    |
-   = help: the `-Zsanitizer` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
-   = note: `-Zsanitizer=safestack` in this crate is incompatible with `-Zsanitizer=safestack,kcfi` in dependency `safestack_and_kcfi`
-   = help: set `-Zsanitizer=safestack,kcfi` in this crate or `-Zsanitizer=safestack` in `safestack_and_kcfi`
-   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=sanitizer` to silence this error
+   = help: the `-Csanitize` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+   = note: `-Csanitize=safestack` in this crate is incompatible with `-Csanitize=safestack,kcfi` in dependency `safestack_and_kcfi`
+   = help: set `-Csanitize=safestack,kcfi` in this crate or `-Csanitize=safestack` in `safestack_and_kcfi`
+   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=sanitize` to silence this error
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_safestack.stderr
+++ b/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_safestack.stderr
@@ -1,13 +1,13 @@
-error: mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
+error: mixing `-Csanitize` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
   --> $DIR/sanitizers-safestack-and-kcfi.rs:16:1
    |
 LL | #![feature(no_core)]
    | ^
    |
-   = help: the `-Zsanitizer` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
-   = note: `-Zsanitizer=kcfi` in this crate is incompatible with `-Zsanitizer=safestack,kcfi` in dependency `safestack_and_kcfi`
-   = help: set `-Zsanitizer=safestack,kcfi` in this crate or `-Zsanitizer=kcfi` in `safestack_and_kcfi`
-   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=sanitizer` to silence this error
+   = help: the `-Csanitize` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+   = note: `-Csanitize=kcfi` in this crate is incompatible with `-Csanitize=safestack,kcfi` in dependency `safestack_and_kcfi`
+   = help: set `-Csanitize=safestack,kcfi` in this crate or `-Csanitize=kcfi` in `safestack_and_kcfi`
+   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=sanitize` to silence this error
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.rs
+++ b/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.rs
@@ -5,18 +5,18 @@
 //@ compile-flags: -Cpanic=abort
 
 //@ revisions: good good_reverted missed_safestack missed_kcfi missed_both
-//@[good] compile-flags: -Zsanitizer=safestack,kcfi
-//@[good_reverted] compile-flags: -Zsanitizer=kcfi,safestack
-//@[missed_safestack] compile-flags: -Zsanitizer=kcfi
-//@[missed_kcfi] compile-flags: -Zsanitizer=safestack
+//@[good] compile-flags: -Zunstable-options -Csanitize=safestack,kcfi
+//@[good_reverted] compile-flags: -Zunstable-options -Csanitize=kcfi,safestack
+//@[missed_safestack] compile-flags: -Zunstable-options -Csanitize=kcfi
+//@[missed_kcfi] compile-flags: -Zunstable-options -Csanitize=safestack
 // [missed_both] no additional compile-flags:
 //@[good] check-pass
 //@[good_reverted] check-pass
 
 #![feature(no_core)]
-//[missed_safestack]~^ ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
-//[missed_kcfi]~^^ ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
-//[missed_both]~^^^ ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
+//[missed_safestack]~^ ERROR mixing `-Csanitize` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
+//[missed_kcfi]~^^ ERROR mixing `-Csanitize` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
+//[missed_both]~^^^ ERROR mixing `-Csanitize` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
 #![crate_type = "rlib"]
 #![no_core]
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/123617)*
<!-- homu-ignore:end -->

Add support for specifying stable sanitizers in addition to the existing supported sanitizers, remove the `-Zsanitizer` unstable option and have only the `-Csanitize` codegen option, requiring the `-Zunstable-options` to be passed for using unstable sanitizers, add AddressSanitizer and LeakSanitizer for the Tier 1 targets that support them, and also stabilize the `no_sanitize` attribute so stable sanitizers can also be selectively disabled for annotated functions.. The tracking issue for stabilizing the sanitizers is rust-lang/rust#123615. This is part of our work to stabilize support for sanitizers in the Rust compiler. (See our roadmap at https://hackmd.io/@rcvalle/S1Ou9K6H6.)

# Stabilization Report

## Summary

We would like to propose stabilizing AddressSanitizer and LeakSanitizer for the Tier 1 targets that support them, and stabilize the `no_sanitize` attribute so stable sanitizers can also be selectively disabled for annotated functions.. This will be done by

* Add support for specifying stable sanitizers in addition to the existing supported sanitizers.
* Removing the `-Zsanitizer` unstable option and having only the `-Csanitize` codegen option, and requiring the `-Zunstable-options` to be passed for using unstable sanitizers.
* Adding these sanitizers to the stable sanitizers.
* Stabilize the `no_sanitize` attribute.

After stabilizing these sanitizers, the supported sanitizers will look like this:

| Target | Supported Sanitizers (Stable) | Supported Sanitizers (Unstable) |
|--------|-------------------------------|---------------------------------|
| aarch64-apple-darwin | address | cfi, thread |
| aarch64-apple-ios |  | address, thread |
| aarch64-apple-ios-macabi |  | address, leak, thread |
| aarch64-apple-ios-sim |  | address, thread |
| aarch64-apple-visionos |  | address, thread |
| aarch64-apple-visionos-sim |  | address, thread |
| aarch64-linux-android |  | address, cfi, hwaddress, memtag, shadow-call-stack |
| aarch64-unknown-freebsd |  | address, cfi, memory, thread |
| aarch64-unknown-fuchsia |  | address, cfi, shadow-call-stack |
| aarch64-unknown-illumos |  | address, cfi |
| aarch64-unknown-linux-gnu | address, leak | cfi, hwaddress, kcfi, memory, memtag, thread |
| aarch64-unknown-linux-musl |  | address, cfi, leak, memory, thread |
| aarch64-unknown-linux-ohos |  | address, cfi, hwaddress, leak, memory, memtag, thread |
| aarch64-unknown-none |  | kcfi, kernel-address |
| arm-linux-androideabi |  | address |
| arm64e-apple-darwin |  | address, cfi, thread |
| arm64e-apple-ios |  | address, thread |
| armv7-linux-androideabi |  | address |
| i586-pc-windows-msvc | address |  |
| i586-unknown-linux-gnu | address |  |
| i686-linux-android |  | address |
| i686-pc-windows-msvc | address |  |
| i686-unknown-linux-gnu | address |  |
| loongarch64-unknown-linux-gnu |  | address, cfi, leak, memory, thread |
| loongarch64-unknown-linux-musl |  | address, cfi, leak, memory, thread |
| loongarch64-unknown-linux-ohos |  | address, cfi, leak, memory, thread |
| riscv64-linux-android |  | address |
| riscv64gc-unknown-fuchsia |  | shadow-call-stack |
| riscv64gc-unknown-none-elf |  | kernel-address, shadow-call-stack |
| riscv64gc-unknown-nuttx-elf |  | kernel-address |
| riscv64imac-unknown-none-elf |  | kernel-address, shadow-call-stack |
| riscv64imac-unknown-nuttx-elf |  | kernel-address |
| s390x-unknown-linux-gnu |  | address, leak, memory, thread |
| s390x-unknown-linux-musl |  | address, leak, memory, thread |
| thumbv7neon-linux-androideabi |  | address |
| x86_64-apple-darwin | address, leak | cfi, thread |
| x86_64-apple-ios |  | address, thread |
| x86_64-apple-ios-macabi |  | address, leak, thread |
| x86_64-linux-android |  | address |
| x86_64-pc-solaris |  | address, cfi, thread |
| x86_64-pc-windows-msvc | address |  |
| x86_64-unknown-freebsd |  | address, cfi, memory, thread |
| x86_64-unknown-fuchsia |  | address, cfi, leak |
| x86_64-unknown-illumos |  | address, cfi, thread |
| x86_64-unknown-linux-gnu | address, leak | cfi, dataflow, kcfi, memory, safestack, thread |
| x86_64-unknown-linux-musl |  | address, cfi, leak, memory, thread |
| x86_64-unknown-linux-ohos |  | address, cfi, leak, memory, thread |
| x86_64-unknown-netbsd |  | address, cfi, leak, memory, thread |
| x86_64-unknown-none |  | kcfi, kernel-address |
| x86_64h-apple-darwin |  | address, cfi, leak, thread |


The tracking issue for stabilizing the sanitizers is https://github.com/rust-lang/rust/issues/123615. This is part of our work to stabilize support for sanitizers in the Rust compiler. (See our roadmap at https://hackmd.io/@rcvalle/S1Ou9K6H6.)

## Documentation

Documentation will be updated by adding documentation for the `-Csanitizer` codegen option to the [Codegen Options](https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-options) in the [The rustc book](https://doc.rust-lang.org/rustc/).

## Tests

You may find current and will find additional test cases for the sanitizers in:

* [tests/ui/sanitizer](https://github.com/rust-lang/rust/tree/master/tests/ui/sanitizer)
* [tests/codegen/sanitizer](https://github.com/rust-lang/rust/tree/master/tests/codegen/sanitizer)

## Unresolved questions

* Doesn't the sanitizers require rebuilding the Rust Standard Library (i.e., Cargo build-std feature)?
   We will prioritize stabilizing sanitizers that provide incremental value without requiring rebuilding the Rust Standard Library (i.e., Cargo build-std feature). We're also working on https://github.com/rust-lang/compiler-team/issues/738, which should help with `-Zbuild-std`.
