### PR TITLE
Discard overflow obligations in `impl_may_apply`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2398,12 +2398,12 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 if ambiguities.len() > 5 {
                     let infcx = self.infcx;
                     if !ambiguities.iter().all(|option| match option {
-                        DefId(did) => infcx.fresh_args_for_item(DUMMY_SP, *did).is_empty(),
+                        DefId(did) => infcx.tcx.generics_of(*did).count() == 0,
                         ParamEnv(_) => true,
                     }) {
                         // If not all are blanket impls, we filter blanked impls out.
                         ambiguities.retain(|option| match option {
-                            DefId(did) => infcx.fresh_args_for_item(DUMMY_SP, *did).is_empty(),
+                            DefId(did) => infcx.tcx.generics_of(*did).count() == 0,
                             ParamEnv(_) => true,
                         });
                     }

--- a/tests/ui/traits/overflow-computing-ambiguity.rs
+++ b/tests/ui/traits/overflow-computing-ambiguity.rs
@@ -1,0 +1,14 @@
+trait Hello {}
+
+struct Foo<'a, T: ?Sized>(&'a T);
+
+impl<'a, T: ?Sized> Hello for Foo<'a, &'a T> where Foo<'a, T>: Hello {}
+
+impl Hello for Foo<'static, i32> {}
+
+fn hello<T: ?Sized + Hello>() {}
+
+fn main() {
+    hello();
+    //~^ ERROR type annotations needed
+}

--- a/tests/ui/traits/overflow-computing-ambiguity.stderr
+++ b/tests/ui/traits/overflow-computing-ambiguity.stderr
@@ -1,0 +1,23 @@
+error[E0283]: type annotations needed
+  --> $DIR/overflow-computing-ambiguity.rs:12:5
+   |
+LL |     hello();
+   |     ^^^^^ cannot infer type of the type parameter `T` declared on the function `hello`
+   |
+   = note: cannot satisfy `_: Hello`
+   = help: the following types implement trait `Hello`:
+             Foo<'a, &'a T>
+             Foo<'static, i32>
+note: required by a bound in `hello`
+  --> $DIR/overflow-computing-ambiguity.rs:9:22
+   |
+LL | fn hello<T: ?Sized + Hello>() {}
+   |                      ^^^^^ required by this bound in `hello`
+help: consider specifying the generic argument
+   |
+LL |     hello::<T>();
+   |          +++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
Hacky fix for #123493. Throws away obligations that are overflowing in `impl_may_apply` when we recompute if an impl applies, since those will lead to fatal overflow if processed during fulfillment.

Something about #114811 (I think it's the predicate reordering) caused us to evaluate predicates differently in error reporting leading to fatal overflow, though I believe the underlying overflow is possible to hit since this code was rewritten to use fulfillment.

Fixes #123493