### PR TITLE
CFI: Fix ICE in KCFI non-associated function pointers

### DIFF
--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -520,7 +520,10 @@ impl<'tcx> Instance<'tcx> {
                 // Reify `Trait::method` implementations if KCFI is enabled
                 // FIXME(maurer) only reify it if it is a vtable-safe function
                 _ if tcx.sess.is_sanitizer_kcfi_enabled()
-                    && tcx.associated_item(def_id).trait_item_def_id.is_some() =>
+                    && tcx
+                        .opt_associated_item(def_id)
+                        .and_then(|assoc| assoc.trait_item_def_id)
+                        .is_some() =>
                 {
                     // If this function could also go in a vtable, we need to `ReifyShim` it with
                     // KCFI because it can only attach one type per function.

--- a/tests/ui/sanitizer/cfi-fn-ptr.rs
+++ b/tests/ui/sanitizer/cfi-fn-ptr.rs
@@ -1,4 +1,4 @@
-// Verifies that casting a method to a function pointer works.
+// Verifies that casting to a function pointer works.
 
 //@ revisions: cfi kcfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries work
@@ -46,6 +46,8 @@ impl Trait1 for Type1 {
     fn foo(&self) {}
 }
 
+fn foo<T>(_: &T) {}
+
 fn main() {
     let type1 = Type1 {};
     let f = <Type1 as Trait1>::foo;
@@ -53,5 +55,7 @@ fn main() {
     // Check again with different optimization barriers
     S2 { f: <S as Foo>::foo }.foo(&S);
     // Check mismatched #[track_caller]
-    S2 { f: <S as Foo>::bar }.foo(&S)
+    S2 { f: <S as Foo>::bar }.foo(&S);
+    // Check non-method functions
+    S2 { f: foo }.foo(&S)
 }


### PR DESCRIPTION
We oddly weren't testing the more usual case of casting non-methods to function pointers. The KCFI shim insertion logic would ICE on these due to asking for an irrefutable associated item if we cast a function to a function pointer without needing a traditional shim.

r? @compiler-errors 