### PR TITLE
rustdoc: synthetic auto: filter out clauses from the implementor's ParamEnv

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -168,7 +168,7 @@ fn clean_param_env<'tcx>(
 
     // FIXME(#111101): Incorporate the explicit predicates of the item here...
     let item_predicates: FxIndexSet<_> =
-        tcx.predicates_of(item_def_id).predicates.iter().map(|(pred, _)| pred).collect();
+        tcx.param_env(item_def_id).caller_bounds().iter().collect();
     let where_predicates = param_env
         .caller_bounds()
         .iter()

--- a/tests/rustdoc/synthetic_auto/supertrait-bounds.rs
+++ b/tests/rustdoc/synthetic_auto/supertrait-bounds.rs
@@ -1,0 +1,14 @@
+// Check that we don't add bounds to synthetic auto trait impls that are
+// already implied by the item (like supertrait bounds).
+
+// In this case we don't want to add the bounds `T: Copy` and `T: 'static`
+// to the auto trait impl because they're implied by the bound `T: Bound`
+// on the implementor `Type`.
+
+pub struct Type<T: Bound>(T);
+
+// @has supertrait_bounds/struct.Type.html
+// @has - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]//h3[@class="code-header"]' \
+// "impl<T> Send for Type<T>where T: Send,"
+
+pub trait Bound: Copy + 'static {}


### PR DESCRIPTION
... not just the elaborated clauses.

Fixes another regression introduced by me in #123340, oops!
Fixes https://github.com/rust-lang/rust/pull/123340#issuecomment-2034195786, cc @tamird.

An earlier local iteration of branch `rustdoc-simplify-auto-trait-impl-synth` (PR #123340) included a fix for issue #111101 before I decided to limit the scope of the patch. I must've introduced this bug when manually reverting that part of the code.

r? @GuillaumeGomez or rustdoc