### PR TITLE
do not allow using local llvm while using rustc from ci

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -50,7 +50,7 @@
 #
 # Note that many of the LLVM options are not currently supported for
 # downloading. Currently only the "assertions" option can be toggled.
-#download-ci-llvm = if rust.channel == "dev" { "if-unchanged" } else { false }
+#download-ci-llvm = if rust.channel == "dev" || rust.download-rustc != false { "if-unchanged" } else { false }
 
 # Indicates whether the LLVM build is a Release or Debug build
 #optimize = true

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2483,9 +2483,20 @@ impl Config {
                 llvm::is_ci_llvm_available(self, asserts)
             }
         };
+
         match download_ci_llvm {
-            None => self.channel == "dev" && if_unchanged(),
-            Some(StringOrBool::Bool(b)) => b,
+            None => {
+                (self.channel == "dev" || self.download_rustc_commit.is_some()) && if_unchanged()
+            }
+            Some(StringOrBool::Bool(b)) => {
+                if !b && self.download_rustc_commit.is_some() {
+                    panic!(
+                        "`llvm.download-ci-llvm` cannot be set to `false` if `rust.download-rustc` is set to `true` or `if-unchanged`."
+                    );
+                }
+
+                b
+            }
             // FIXME: "if-available" is deprecated. Remove this block later (around mid 2024)
             // to not break builds between the recent-to-old checkouts.
             Some(StringOrBool::String(s)) if s == "if-available" => {


### PR DESCRIPTION
From: https://github.com/rust-lang/rust/issues/123586#issuecomment-2043296578

> Even if `llvm.download-ci-llvm` is set to true, `stage > 0` rustc will always use the prebuilt LLVM library which comes with ci-rustc. So I tried to use locally-built LLVM libraries in the ci-rustc by replacing the existing LLVM libraries with the locally built ones, and it appears that this is indeed a limitation of using `rust.download-rustc=true` as it fails with the following error:
> 
> ```
> $ ./build/host/ci-rustc/bin/rustc --version
> ./build/host/ci-rustc/bin/rustc: symbol lookup error: /home/nimda/devspace/.other/rustc-builds/build/x86_64-unknown-linux-gnu/ci-rustc/bin/../lib/librustc_driver-a03ea465d8e03db1.so: undefined symbol: LLVMInitializeARMTargetInfo, version LLVM_18.1
> ```
> 
> So, if `rust.download-rustc` is set to true and `llvm.download-ci-llvm` is false, I believe bootstrap should terminate the process (as it always uses prebuilt LLVM libraries from ci-rustc, there is no point to build LLVM locally) while parsing the configuration.

Resolves #123586

r? Mark-Simulacrum 