### PR TITLE
rustdoc: slightly clean up the synthesis of blanket impls

### DIFF
--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -1,141 +1,130 @@
-use crate::rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt;
 use rustc_hir as hir;
 use rustc_infer::infer::{DefineOpaqueTypes, InferOk, TyCtxtInferExt};
 use rustc_infer::traits;
-use rustc_middle::ty::ToPredicate;
+use rustc_middle::ty::{self, ToPredicate};
+use rustc_span::def_id::DefId;
 use rustc_span::DUMMY_SP;
+use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt;
 
-use super::*;
+use thin_vec::ThinVec;
 
-pub(crate) struct BlanketImplFinder<'a, 'tcx> {
-    pub(crate) cx: &'a mut core::DocContext<'tcx>,
-}
+use crate::clean;
+use crate::clean::{
+    clean_middle_assoc_item, clean_middle_ty, clean_trait_ref_with_bindings, clean_ty_generics,
+};
+use crate::core::DocContext;
 
-impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
-    pub(crate) fn get_blanket_impls(&mut self, item_def_id: DefId) -> Vec<Item> {
-        let cx = &mut self.cx;
-        let ty = cx.tcx.type_of(item_def_id);
+#[instrument(level = "debug", skip(cx))]
+pub(crate) fn synthesize_blanket_impls(
+    cx: &mut DocContext<'_>,
+    item_def_id: DefId,
+) -> Vec<clean::Item> {
+    let tcx = cx.tcx;
+    let ty = tcx.type_of(item_def_id);
 
-        trace!("get_blanket_impls({ty:?})");
-        let mut impls = Vec::new();
-        for trait_def_id in cx.tcx.all_traits() {
-            if !cx.cache.effective_visibilities.is_reachable(cx.tcx, trait_def_id)
-                || cx.generated_synthetics.get(&(ty.skip_binder(), trait_def_id)).is_some()
-            {
+    let mut blanket_impls = Vec::new();
+    for trait_def_id in tcx.all_traits() {
+        if !cx.cache.effective_visibilities.is_reachable(tcx, trait_def_id)
+            || cx.generated_synthetics.get(&(ty.skip_binder(), trait_def_id)).is_some()
+        {
+            continue;
+        }
+        // NOTE: doesn't use `for_each_relevant_impl` to avoid looking at anything besides blanket impls
+        let trait_impls = tcx.trait_impls_of(trait_def_id);
+        'blanket_impls: for &impl_def_id in trait_impls.blanket_impls() {
+            trace!("considering impl `{impl_def_id:?}` for trait `{trait_def_id:?}`");
+
+            let trait_ref = tcx.impl_trait_ref(impl_def_id).unwrap();
+            if !matches!(trait_ref.skip_binder().self_ty().kind(), ty::Param(_)) {
                 continue;
             }
-            // NOTE: doesn't use `for_each_relevant_impl` to avoid looking at anything besides blanket impls
-            let trait_impls = cx.tcx.trait_impls_of(trait_def_id);
-            'blanket_impls: for &impl_def_id in trait_impls.blanket_impls() {
-                trace!(
-                    "get_blanket_impls: Considering impl for trait '{:?}' {:?}",
-                    trait_def_id,
-                    impl_def_id
-                );
-                let trait_ref = cx.tcx.impl_trait_ref(impl_def_id).unwrap();
-                if !matches!(trait_ref.skip_binder().self_ty().kind(), ty::Param(_)) {
-                    continue;
-                }
-                let infcx = cx.tcx.infer_ctxt().build();
-                let args = infcx.fresh_args_for_item(DUMMY_SP, item_def_id);
-                let impl_ty = ty.instantiate(infcx.tcx, args);
-                let param_env = ty::ParamEnv::empty();
+            let infcx = tcx.infer_ctxt().build();
+            let args = infcx.fresh_args_for_item(DUMMY_SP, item_def_id);
+            let impl_ty = ty.instantiate(tcx, args);
+            let param_env = ty::ParamEnv::empty();
 
-                let impl_args = infcx.fresh_args_for_item(DUMMY_SP, impl_def_id);
-                let impl_trait_ref = trait_ref.instantiate(infcx.tcx, impl_args);
+            let impl_args = infcx.fresh_args_for_item(DUMMY_SP, impl_def_id);
+            let impl_trait_ref = trait_ref.instantiate(tcx, impl_args);
 
-                // Require the type the impl is implemented on to match
-                // our type, and ignore the impl if there was a mismatch.
-                let Ok(eq_result) = infcx.at(&traits::ObligationCause::dummy(), param_env).eq(
-                    DefineOpaqueTypes::Yes,
-                    impl_trait_ref.self_ty(),
-                    impl_ty,
-                ) else {
-                    continue;
-                };
-                let InferOk { value: (), obligations } = eq_result;
-                // FIXME(eddyb) ignoring `obligations` might cause false positives.
-                drop(obligations);
+            // Require the type the impl is implemented on to match
+            // our type, and ignore the impl if there was a mismatch.
+            let Ok(eq_result) = infcx.at(&traits::ObligationCause::dummy(), param_env).eq(
+                DefineOpaqueTypes::Yes,
+                impl_trait_ref.self_ty(),
+                impl_ty,
+            ) else {
+                continue;
+            };
+            let InferOk { value: (), obligations } = eq_result;
+            // FIXME(eddyb) ignoring `obligations` might cause false positives.
+            drop(obligations);
 
-                trace!(
-                    "invoking predicate_may_hold: param_env={:?}, impl_trait_ref={:?}, impl_ty={:?}",
+            let predicates = tcx
+                .predicates_of(impl_def_id)
+                .instantiate(tcx, impl_args)
+                .predicates
+                .into_iter()
+                .chain(Some(ty::Binder::dummy(impl_trait_ref).to_predicate(tcx)));
+            for predicate in predicates {
+                let obligation = traits::Obligation::new(
+                    tcx,
+                    traits::ObligationCause::dummy(),
                     param_env,
-                    impl_trait_ref,
-                    impl_ty
+                    predicate,
                 );
-                let predicates = cx
-                    .tcx
-                    .predicates_of(impl_def_id)
-                    .instantiate(cx.tcx, impl_args)
-                    .predicates
-                    .into_iter()
-                    .chain(Some(ty::Binder::dummy(impl_trait_ref).to_predicate(infcx.tcx)));
-                for predicate in predicates {
-                    debug!("testing predicate {predicate:?}");
-                    let obligation = traits::Obligation::new(
-                        infcx.tcx,
-                        traits::ObligationCause::dummy(),
-                        param_env,
-                        predicate,
-                    );
-                    match infcx.evaluate_obligation(&obligation) {
-                        Ok(eval_result) if eval_result.may_apply() => {}
-                        Err(traits::OverflowError::Canonical) => {}
-                        _ => continue 'blanket_impls,
-                    }
+                match infcx.evaluate_obligation(&obligation) {
+                    Ok(eval_result) if eval_result.may_apply() => {}
+                    Err(traits::OverflowError::Canonical) => {}
+                    _ => continue 'blanket_impls,
                 }
-                debug!(
-                    "get_blanket_impls: found applicable impl for trait_ref={:?}, ty={:?}",
-                    trait_ref, ty
-                );
-
-                cx.generated_synthetics.insert((ty.skip_binder(), trait_def_id));
-
-                impls.push(Item {
-                    name: None,
-                    attrs: Default::default(),
-                    item_id: ItemId::Blanket { impl_id: impl_def_id, for_: item_def_id },
-                    kind: Box::new(ImplItem(Box::new(Impl {
-                        unsafety: hir::Unsafety::Normal,
-                        generics: clean_ty_generics(
-                            cx,
-                            cx.tcx.generics_of(impl_def_id),
-                            cx.tcx.explicit_predicates_of(impl_def_id),
-                        ),
-                        // FIXME(eddyb) compute both `trait_` and `for_` from
-                        // the post-inference `trait_ref`, as it's more accurate.
-                        trait_: Some(clean_trait_ref_with_bindings(
-                            cx,
-                            ty::Binder::dummy(trait_ref.instantiate_identity()),
-                            ThinVec::new(),
-                        )),
-                        for_: clean_middle_ty(
-                            ty::Binder::dummy(ty.instantiate_identity()),
-                            cx,
-                            None,
-                            None,
-                        ),
-                        items: cx
-                            .tcx
-                            .associated_items(impl_def_id)
-                            .in_definition_order()
-                            .filter(|item| !item.is_impl_trait_in_trait())
-                            .map(|item| clean_middle_assoc_item(item, cx))
-                            .collect::<Vec<_>>(),
-                        polarity: ty::ImplPolarity::Positive,
-                        kind: ImplKind::Blanket(Box::new(clean_middle_ty(
-                            ty::Binder::dummy(trait_ref.instantiate_identity().self_ty()),
-                            cx,
-                            None,
-                            None,
-                        ))),
-                    }))),
-                    cfg: None,
-                    inline_stmt_id: None,
-                });
             }
-        }
+            debug!("found applicable impl for trait ref {trait_ref:?}");
 
-        impls
+            cx.generated_synthetics.insert((ty.skip_binder(), trait_def_id));
+
+            blanket_impls.push(clean::Item {
+                name: None,
+                attrs: Default::default(),
+                item_id: clean::ItemId::Blanket { impl_id: impl_def_id, for_: item_def_id },
+                kind: Box::new(clean::ImplItem(Box::new(clean::Impl {
+                    unsafety: hir::Unsafety::Normal,
+                    generics: clean_ty_generics(
+                        cx,
+                        tcx.generics_of(impl_def_id),
+                        tcx.explicit_predicates_of(impl_def_id),
+                    ),
+                    // FIXME(eddyb) compute both `trait_` and `for_` from
+                    // the post-inference `trait_ref`, as it's more accurate.
+                    trait_: Some(clean_trait_ref_with_bindings(
+                        cx,
+                        ty::Binder::dummy(trait_ref.instantiate_identity()),
+                        ThinVec::new(),
+                    )),
+                    for_: clean_middle_ty(
+                        ty::Binder::dummy(ty.instantiate_identity()),
+                        cx,
+                        None,
+                        None,
+                    ),
+                    items: tcx
+                        .associated_items(impl_def_id)
+                        .in_definition_order()
+                        .filter(|item| !item.is_impl_trait_in_trait())
+                        .map(|item| clean_middle_assoc_item(item, cx))
+                        .collect(),
+                    polarity: ty::ImplPolarity::Positive,
+                    kind: clean::ImplKind::Blanket(Box::new(clean_middle_ty(
+                        ty::Binder::dummy(trait_ref.instantiate_identity().self_ty()),
+                        cx,
+                        None,
+                        None,
+                    ))),
+                }))),
+                cfg: None,
+                inline_stmt_id: None,
+            });
+        }
     }
+
+    blanket_impls
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -29,7 +29,7 @@ use rustc_middle::ty::{self, AdtKind, Ty, TyCtxt};
 use rustc_middle::{bug, span_bug};
 use rustc_span::hygiene::{AstPass, MacroKind};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
-use rustc_span::{self, ExpnKind};
+use rustc_span::ExpnKind;
 use rustc_trait_selection::traits::wf::object_region_bounds;
 
 use std::borrow::Cow;
@@ -37,14 +37,14 @@ use std::collections::BTreeMap;
 use std::mem;
 use thin_vec::ThinVec;
 
-use crate::core::{self, DocContext};
+use crate::core::DocContext;
 use crate::formats::item_type::ItemType;
 use crate::visit_ast::Module as DocModule;
 
 use utils::*;
 
 pub(crate) use self::types::*;
-pub(crate) use self::utils::{get_auto_trait_and_blanket_impls, krate, register_res};
+pub(crate) use self::utils::{krate, register_res, synthesize_auto_trait_and_blanket_impls};
 
 pub(crate) fn clean_doc_module<'tcx>(doc: &DocModule<'tcx>, cx: &mut DocContext<'tcx>) -> Item {
     let mut items: Vec<Item> = vec![];

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -1,5 +1,5 @@
 use crate::clean::auto_trait::synthesize_auto_trait_impls;
-use crate::clean::blanket_impl::BlanketImplFinder;
+use crate::clean::blanket_impl::synthesize_blanket_impls;
 use crate::clean::render_macro_matchers::render_macro_matcher;
 use crate::clean::{
     clean_doc_module, clean_middle_const, clean_middle_region, clean_middle_ty, inline, Crate,
@@ -477,8 +477,7 @@ pub(crate) fn resolve_type(cx: &mut DocContext<'_>, path: Path) -> Type {
     }
 }
 
-// FIXME(fmease): Update the `get_*` terminology to the `synthesize_` one.
-pub(crate) fn get_auto_trait_and_blanket_impls(
+pub(crate) fn synthesize_auto_trait_and_blanket_impls(
     cx: &mut DocContext<'_>,
     item_def_id: DefId,
 ) -> impl Iterator<Item = Item> {
@@ -490,8 +489,8 @@ pub(crate) fn get_auto_trait_and_blanket_impls(
     let blanket_impls = cx
         .sess()
         .prof
-        .generic_activity("get_blanket_impls")
-        .run(|| BlanketImplFinder { cx }.get_blanket_impls(item_def_id));
+        .generic_activity("synthesize_blanket_impls")
+        .run(|| synthesize_blanket_impls(cx, item_def_id));
     auto_impls.into_iter().chain(blanket_impls)
 }
 

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -122,7 +122,7 @@ pub(crate) fn collect_trait_impls(mut krate: Crate, cx: &mut DocContext<'_>) -> 
                         _ => true,
                     }
                 }) {
-                    let impls = get_auto_trait_and_blanket_impls(cx, def_id);
+                    let impls = synthesize_auto_trait_and_blanket_impls(cx, def_id);
                     new_items_external.extend(impls.filter(|i| cx.inlined.insert(i.item_id)));
                 }
             }
@@ -230,8 +230,10 @@ impl<'a, 'tcx> DocVisitor for SyntheticImplCollector<'a, 'tcx> {
         if i.is_struct() || i.is_enum() || i.is_union() {
             // FIXME(eddyb) is this `doc(hidden)` check needed?
             if !self.cx.tcx.is_doc_hidden(i.item_id.expect_def_id()) {
-                self.impls
-                    .extend(get_auto_trait_and_blanket_impls(self.cx, i.item_id.expect_def_id()));
+                self.impls.extend(synthesize_auto_trait_and_blanket_impls(
+                    self.cx,
+                    i.item_id.expect_def_id(),
+                ));
             }
         }
 


### PR DESCRIPTION
Small follow-up to #123340 as promised in https://github.com/rust-lang/rust/pull/123340#discussion_r1546918604. No functional changes whatsoever.

* inline the over-engineered “type namespace” (struct) `BlanketImplFinder` just like I did with `AutoTraitFinder` in #123340
* use the new `synthesize_*` terminology over the old nondescript / misleading `get_*` one 
* inline a `use super::*;` (not super modular, lead to `clean/mod.rs` (!) accumulating cruft)
* use `tracing` properly

r? GuillaumeGomez or rustdoc