### PR TITLE
Remove `HashSet::get_or_insert_with`

### DIFF
--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -756,39 +756,6 @@ where
         self.base.get_or_insert_owned(value)
     }
 
-    /// Inserts a value computed from `f` into the set if the given `value` is
-    /// not present, then returns a reference to the value in the set.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(hash_set_entry)]
-    ///
-    /// use std::collections::HashSet;
-    ///
-    /// let mut set: HashSet<String> = ["cat", "dog", "horse"]
-    ///     .iter().map(|&pet| pet.to_owned()).collect();
-    ///
-    /// assert_eq!(set.len(), 3);
-    /// for &pet in &["cat", "dog", "fish"] {
-    ///     let value = set.get_or_insert_with(pet, str::to_owned);
-    ///     assert_eq!(value, pet);
-    /// }
-    /// assert_eq!(set.len(), 4); // a new "fish" was inserted
-    /// ```
-    #[inline]
-    #[unstable(feature = "hash_set_entry", issue = "60896")]
-    pub fn get_or_insert_with<Q: ?Sized, F>(&mut self, value: &Q, f: F) -> &T
-    where
-        T: Borrow<Q>,
-        Q: Hash + Eq,
-        F: FnOnce(&Q) -> T,
-    {
-        // Although the raw entry gives us `&mut T`, we only return `&T` to be consistent with
-        // `get`. Key mutation is "raw" because you're not supposed to affect `Eq` or `Hash`.
-        self.base.get_or_insert_with(value, f)
-    }
-
     /// Returns `true` if `self` has no elements in common with `other`.
     /// This is equivalent to checking for an empty intersection.
     ///

--- a/tests/rustdoc-js-std/path-ordering.js
+++ b/tests/rustdoc-js-std/path-ordering.js
@@ -5,7 +5,6 @@ const EXPECTED = [
             // ensure hashset::insert comes first
             { 'path': 'std::collections::hash_set::HashSet', 'name': 'insert' },
             { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert' },
-            { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_with' },
             { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_owned' },
         ],
     },


### PR DESCRIPTION
This method is unsound because it allows inserting a key at the "wrong" position in a `HashSet`, which could result in it not appearing it future lookups or being inserted multiple times in the set.

Instead, `HashSet::get_or_insert` and `HashSet::get_or_insert_owned` should be preferred.