### PR TITLE
Stop making any assumption about the projections applied to the upvars in the `ByMoveBody` pass

### DIFF
--- a/tests/ui/async-await/async-closures/truncated-fields-when-imm.rs
+++ b/tests/ui/async-await/async-closures/truncated-fields-when-imm.rs
@@ -1,0 +1,17 @@
+//@ edition: 2021
+//@ check-pass
+
+#![feature(async_closure)]
+
+pub struct Struct {
+    pub path: String,
+}
+
+// In `upvar.rs`, `truncate_capture_for_optimization` means that we don't actually
+// capture `&(*s.path)` here, but instead just `&(*s)`, but ONLY when the upvar is
+// immutable. This means that the assumption we have in `ByMoveBody` pass is wrong.
+pub fn test(s: &Struct) {
+    let c = async move || { let path = &s.path; };
+}
+
+fn main() {}


### PR DESCRIPTION
So it turns out that because of subtle optimizations like [`truncate_capture_for_optimization`](https://github.com/rust-lang/rust/blob/ab5bda1aa70f707014e2e691e43bc37a8819252a/compiler/rustc_hir_typeck/src/upvar.rs#L2351), we simply cannot make any assumptions about the shape of the projections applied to the upvar locals in a coroutine body.

So stop doing that -- the code is resilient to such projections, so the assertion really existed only to "protect against the unknown".

r? oli-obk
Fixes #123650