### PR TITLE
Fix typo in `Future::poll()` docs

### DIFF
--- a/library/core/src/future/future.rs
+++ b/library/core/src/future/future.rs
@@ -81,7 +81,7 @@ pub trait Future {
     /// An implementation of `poll` should strive to return quickly, and should
     /// not block. Returning quickly prevents unnecessarily clogging up
     /// threads or event loops. If it is known ahead of time that a call to
-    /// `poll` may end up taking awhile, the work should be offloaded to a
+    /// `poll` may end up taking a while, the work should be offloaded to a
     /// thread pool (or something similar) to ensure that `poll` can return
     /// quickly.
     ///


### PR DESCRIPTION
@rustbot label A-docs