### PR TITLE
compiletest: unset `RUSTC_LOG_COLOR`

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -266,7 +266,7 @@ impl TestProps {
             aux_crates: vec![],
             revisions: vec![],
             rustc_env: vec![("RUSTC_ICE".to_string(), "0".to_string())],
-            unset_rustc_env: vec![],
+            unset_rustc_env: vec![("RUSTC_LOG_COLOR".to_string())],
             exec_env: vec![],
             unset_exec_env: vec![],
             build_aux_docs: false,


### PR DESCRIPTION
If this leaks in from the environment then it can make tests fail when they deliberately trigger `WARN` or `ERROR` logging, currently this makes these tests fail if you set `RUSTC_LOG_COLOR=always` in the parent environment:

- `tests/ui/coherence/occurs-check/associated-type.rs#next`
- `tests/ui/coherence/occurs-check/associated-type.rs#old`
- `tests/ui/higher-ranked/structually-relate-aliases.rs`
- `tests/ui/self/arbitrary-self-from-method-substs.rs#default`
- `tests/ui/traits/next-solver/issue-118950-root-region.rs`
