### PR TITLE
Silence some follow-up errors on trait impls in case the trait has conflicting or otherwise incoherent impls

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -534,8 +534,14 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) {
         }
         DefKind::Impl { of_trait } => {
             if of_trait && let Some(impl_trait_header) = tcx.impl_trait_header(def_id) {
-                check_impl_items_against_trait(tcx, def_id, impl_trait_header);
-                check_on_unimplemented(tcx, def_id);
+                if tcx
+                    .ensure()
+                    .coherent_trait(impl_trait_header.trait_ref.instantiate_identity().def_id)
+                    .is_ok()
+                {
+                    check_impl_items_against_trait(tcx, def_id, impl_trait_header);
+                    check_on_unimplemented(tcx, def_id);
+                }
             }
         }
         DefKind::Trait => {

--- a/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.rs
+++ b/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.rs
@@ -22,8 +22,7 @@ struct MyType {
 impl MyTrait<MyType> for MyType {
 //~^ ERROR E0119
     fn get(&self) -> usize { (*self).clone() }
-    //~^ ERROR incompatible type
-    //~| ERROR mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn main() { }

--- a/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.stderr
+++ b/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.stderr
@@ -7,23 +7,6 @@ LL | impl<T> MyTrait<T> for T {
 LL | impl MyTrait<MyType> for MyType {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyType`
 
-error[E0053]: method `get` has an incompatible type for trait
-  --> $DIR/coherence-blanket-conflicts-with-specific-multidispatch.rs:24:22
-   |
-LL |     fn get(&self) -> usize { (*self).clone() }
-   |                      ^^^^^
-   |                      |
-   |                      expected `MyType`, found `usize`
-   |                      help: change the output type to match the trait: `MyType`
-   |
-note: type in trait
-  --> $DIR/coherence-blanket-conflicts-with-specific-multidispatch.rs:8:22
-   |
-LL |     fn get(&self) -> T;
-   |                      ^
-   = note: expected signature `fn(&MyType) -> MyType`
-              found signature `fn(&MyType) -> usize`
-
 error[E0308]: mismatched types
   --> $DIR/coherence-blanket-conflicts-with-specific-multidispatch.rs:24:30
    |
@@ -32,7 +15,7 @@ LL |     fn get(&self) -> usize { (*self).clone() }
    |                      |
    |                      expected `usize` because of return type
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0053, E0119, E0308.
-For more information about an error, try `rustc --explain E0053`.
+Some errors have detailed explanations: E0119, E0308.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/coherence/coherence-orphan.rs
+++ b/tests/ui/coherence/coherence-orphan.rs
@@ -9,13 +9,10 @@ struct TheType;
 
 impl TheTrait<usize> for isize {}
 //~^ ERROR E0117
-//~| ERROR not all trait items implemented
 
 impl TheTrait<TheType> for isize {}
-//~^ ERROR not all trait items implemented
 
 impl TheTrait<isize> for TheType {}
-//~^ ERROR not all trait items implemented
 
 impl !Send for Vec<isize> {} //~ ERROR E0117
 

--- a/tests/ui/coherence/coherence-orphan.stderr
+++ b/tests/ui/coherence/coherence-orphan.stderr
@@ -10,32 +10,8 @@ LL | impl TheTrait<usize> for isize {}
    |
    = note: define and implement a trait or new type instead
 
-error[E0046]: not all trait items implemented, missing: `the_fn`
-  --> $DIR/coherence-orphan.rs:10:1
-   |
-LL | impl TheTrait<usize> for isize {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `the_fn` in implementation
-   |
-   = help: implement the missing item: `fn the_fn(&self) { todo!() }`
-
-error[E0046]: not all trait items implemented, missing: `the_fn`
-  --> $DIR/coherence-orphan.rs:14:1
-   |
-LL | impl TheTrait<TheType> for isize {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `the_fn` in implementation
-   |
-   = help: implement the missing item: `fn the_fn(&self) { todo!() }`
-
-error[E0046]: not all trait items implemented, missing: `the_fn`
-  --> $DIR/coherence-orphan.rs:17:1
-   |
-LL | impl TheTrait<isize> for TheType {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `the_fn` in implementation
-   |
-   = help: implement the missing item: `fn the_fn(&self) { todo!() }`
-
 error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
-  --> $DIR/coherence-orphan.rs:20:1
+  --> $DIR/coherence-orphan.rs:17:1
    |
 LL | impl !Send for Vec<isize> {}
    | ^^^^^^^^^^^^^^^----------
@@ -45,7 +21,6 @@ LL | impl !Send for Vec<isize> {}
    |
    = note: define and implement a trait or new type instead
 
-error: aborting due to 5 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0046, E0117.
-For more information about an error, try `rustc --explain E0046`.
+For more information about this error, try `rustc --explain E0117`.

--- a/tests/ui/error-codes/E0117.rs
+++ b/tests/ui/error-codes/E0117.rs
@@ -1,5 +1,4 @@
 impl Drop for u32 {} //~ ERROR E0117
 //~| ERROR the `Drop` trait may only be implemented for local structs, enums, and unions
-//~| ERROR not all trait items implemented
 
 fn main() {}

--- a/tests/ui/error-codes/E0117.stderr
+++ b/tests/ui/error-codes/E0117.stderr
@@ -15,15 +15,7 @@ error[E0120]: the `Drop` trait may only be implemented for local structs, enums,
 LL | impl Drop for u32 {}
    |               ^^^ must be a struct, enum, or union in the current crate
 
-error[E0046]: not all trait items implemented, missing: `drop`
-  --> $DIR/E0117.rs:1:1
-   |
-LL | impl Drop for u32 {}
-   | ^^^^^^^^^^^^^^^^^ missing `drop` in implementation
-   |
-   = help: implement the missing item: `fn drop(&mut self) { todo!() }`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0046, E0117, E0120.
-For more information about an error, try `rustc --explain E0046`.
+Some errors have detailed explanations: E0117, E0120.
+For more information about an error, try `rustc --explain E0117`.

--- a/tests/ui/issues/issue-67535.rs
+++ b/tests/ui/issues/issue-67535.rs
@@ -2,21 +2,21 @@ fn main() {}
 
 impl std::ops::AddAssign for () {
     //~^ ERROR only traits defined in the current crate can be implemented for arbitrary types
-    fn add_assign(&self, other: ()) -> () { //~ ERROR incompatible type
+    fn add_assign(&self, other: ()) -> () {
         ()
     }
 }
 
 impl std::ops::AddAssign for [(); 1] {
     //~^ ERROR only traits defined in the current crate can be implemented for arbitrary types
-    fn add_assign(&self, other: [(); 1]) -> [(); 1] { //~ ERROR incompatible type
+    fn add_assign(&self, other: [(); 1]) -> [(); 1] {
         [()]
     }
 }
 
 impl std::ops::AddAssign for &[u8] {
     //~^ ERROR only traits defined in the current crate can be implemented for arbitrary types
-    fn add_assign(&self, other: &[u8]) -> &[u8] { //~ ERROR incompatible type
+    fn add_assign(&self, other: &[u8]) -> &[u8] {
         self
     }
 }

--- a/tests/ui/issues/issue-67535.stderr
+++ b/tests/ui/issues/issue-67535.stderr
@@ -34,43 +34,6 @@ LL | impl std::ops::AddAssign for &[u8] {
    |
    = note: define and implement a trait or new type instead
 
-error[E0053]: method `add_assign` has an incompatible type for trait
-  --> $DIR/issue-67535.rs:5:19
-   |
-LL |     fn add_assign(&self, other: ()) -> () {
-   |                   ^^^^^
-   |                   |
-   |                   types differ in mutability
-   |                   help: change the self-receiver type to match the trait: `&mut self`
-   |
-   = note: expected signature `fn(&mut (), ())`
-              found signature `fn(&(), ())`
+error: aborting due to 3 previous errors
 
-error[E0053]: method `add_assign` has an incompatible type for trait
-  --> $DIR/issue-67535.rs:12:19
-   |
-LL |     fn add_assign(&self, other: [(); 1]) -> [(); 1] {
-   |                   ^^^^^
-   |                   |
-   |                   types differ in mutability
-   |                   help: change the self-receiver type to match the trait: `&mut self`
-   |
-   = note: expected signature `fn(&mut _, _)`
-              found signature `fn(&_, _) -> [(); 1]`
-
-error[E0053]: method `add_assign` has an incompatible type for trait
-  --> $DIR/issue-67535.rs:19:19
-   |
-LL |     fn add_assign(&self, other: &[u8]) -> &[u8] {
-   |                   ^^^^^
-   |                   |
-   |                   types differ in mutability
-   |                   help: change the self-receiver type to match the trait: `&mut self`
-   |
-   = note: expected signature `fn(&mut &_, &_)`
-              found signature `fn(&&_, &_) -> &[u8]`
-
-error: aborting due to 6 previous errors
-
-Some errors have detailed explanations: E0053, E0117.
-For more information about an error, try `rustc --explain E0053`.
+For more information about this error, try `rustc --explain E0117`.

--- a/tests/ui/wf/conflicting-impls.rs
+++ b/tests/ui/wf/conflicting-impls.rs
@@ -5,7 +5,6 @@ struct Ty;
 impl TryFrom<Ty> for u8 {
     type Error = Ty;
     fn try_from(_: Ty) -> Result<Self, Self::Error> {
-        //~^ ERROR type annotations needed
         loop {}
     }
 }
@@ -14,7 +13,6 @@ impl TryFrom<Ty> for u8 {
     //~^ ERROR conflicting implementations of trait
     type Error = Ty;
     fn try_from(_: Ty) -> Result<Self, Self::Error> {
-        //~^ ERROR type annotations needed
         loop {}
     }
 }

--- a/tests/ui/wf/conflicting-impls.rs
+++ b/tests/ui/wf/conflicting-impls.rs
@@ -1,0 +1,22 @@
+//@ edition: 2021
+
+struct Ty;
+
+impl TryFrom<Ty> for u8 {
+    type Error = Ty;
+    fn try_from(_: Ty) -> Result<Self, Self::Error> {
+        //~^ ERROR type annotations needed
+        loop {}
+    }
+}
+
+impl TryFrom<Ty> for u8 {
+    //~^ ERROR conflicting implementations of trait
+    type Error = Ty;
+    fn try_from(_: Ty) -> Result<Self, Self::Error> {
+        //~^ ERROR type annotations needed
+        loop {}
+    }
+}
+
+fn main() {}

--- a/tests/ui/wf/conflicting-impls.stderr
+++ b/tests/ui/wf/conflicting-impls.stderr
@@ -7,35 +7,6 @@ LL | impl TryFrom<Ty> for u8 {
 LL | impl TryFrom<Ty> for u8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `u8`
 
-error[E0282]: type annotations needed
-  --> $DIR/conflicting-impls.rs:7:5
-   |
-LL |     fn try_from(_: Ty) -> Result<Self, Self::Error> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
-   |
-note: the requirement `_ <: _` appears on the `impl`'s method `try_from` but not on the corresponding trait's method
-  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
-   |
-   = note: in this trait
-  ::: $SRC_DIR/core/src/convert/mod.rs:LL:COL
-   |
-   = note: this trait's method doesn't have the requirement `_ <: _`
+error: aborting due to 1 previous error
 
-error[E0282]: type annotations needed
-  --> $DIR/conflicting-impls.rs:14:5
-   |
-LL |     fn try_from(_: Ty) -> Result<Self, Self::Error> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
-   |
-note: the requirement `_ <: _` appears on the `impl`'s method `try_from` but not on the corresponding trait's method
-  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
-   |
-   = note: in this trait
-  ::: $SRC_DIR/core/src/convert/mod.rs:LL:COL
-   |
-   = note: this trait's method doesn't have the requirement `_ <: _`
-
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0119, E0282.
-For more information about an error, try `rustc --explain E0119`.
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/wf/conflicting-impls.stderr
+++ b/tests/ui/wf/conflicting-impls.stderr
@@ -1,0 +1,41 @@
+error[E0119]: conflicting implementations of trait `TryFrom<Ty>` for type `u8`
+  --> $DIR/conflicting-impls.rs:12:1
+   |
+LL | impl TryFrom<Ty> for u8 {
+   | ----------------------- first implementation here
+...
+LL | impl TryFrom<Ty> for u8 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `u8`
+
+error[E0282]: type annotations needed
+  --> $DIR/conflicting-impls.rs:7:5
+   |
+LL |     fn try_from(_: Ty) -> Result<Self, Self::Error> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+note: the requirement `_ <: _` appears on the `impl`'s method `try_from` but not on the corresponding trait's method
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+   = note: in this trait
+  ::: $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+   = note: this trait's method doesn't have the requirement `_ <: _`
+
+error[E0282]: type annotations needed
+  --> $DIR/conflicting-impls.rs:14:5
+   |
+LL |     fn try_from(_: Ty) -> Result<Self, Self::Error> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+note: the requirement `_ <: _` appears on the `impl`'s method `try_from` but not on the corresponding trait's method
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+   = note: in this trait
+  ::: $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+   = note: this trait's method doesn't have the requirement `_ <: _`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0119, E0282.
+For more information about an error, try `rustc --explain E0119`.


### PR DESCRIPTION
fixes #123292

Also removes a bunch of extra diagnostics that were introduced in https://github.com/rust-lang/rust/pull/121154 and https://github.com/rust-lang/rust/pull/120558