### PR TITLE
Improve the experience of running Docker locally

### DIFF
--- a/src/ci/docker/README.md
+++ b/src/ci/docker/README.md
@@ -14,7 +14,7 @@ for example:
 ./src/ci/docker/run.sh x86_64-gnu
 ```
 
-Images will output artifacts in an `obj` dir at the root of a repository. Note
+Images will output artifacts in an `obj/$image_name` dir at the root of a repository. Note
 that the script will overwrite the contents of this directory.
 
 To match conditions in rusts CI, also set the environment variable `DEPLOY=1`, e.g.:
@@ -22,12 +22,9 @@ To match conditions in rusts CI, also set the environment variable `DEPLOY=1`, e
 DEPLOY=1 ./src/ci/docker/run.sh x86_64-gnu
 ```
 
-**NOTE**: Re-using the same `obj` dir with different docker images with
-the same target triple (e.g. `dist-x86_64-linux` and `dist-various-1`)
-may result in strange linker errors, due shared library versions differing between platforms.
-
-If you encounter any issues when using multiple Docker images, try deleting your `obj` directory
-before running your command.
+**NOTE**: In CI, the script outputs the artifacts to the `obj` directory,
+while locally, to the `obj/$image_name` directory. This is primarily to prevent
+strange linker errors when using multiple Docker images.
 
 ## Filesystem layout
 

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -46,7 +46,7 @@ source "$ci_dir/shared.sh"
 CACHE_DOMAIN="${CACHE_DOMAIN:-ci-caches.rust-lang.org}"
 
 if [ -f "$docker_dir/$image/Dockerfile" ]; then
-    if [ "$CI" != "" ]; then
+    if isCI; then
       hash_key=/tmp/.docker-hash-key.txt
       rm -f "${hash_key}"
       echo $image >> $hash_key
@@ -102,7 +102,7 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
     CACHE_IMAGE_TAG=${REGISTRY}/${REGISTRY_USERNAME}/rust-ci-cache:${cksum}
 
     # On non-CI jobs, we don't do any caching.
-    if [[ "$CI" == "" ]];
+    if ! isCI;
     then
         retry docker build --rm -t rust-ci -f "$dockerfile" "$context"
     # On PR CI jobs, we don't have permissions to write to the registry cache,
@@ -289,7 +289,7 @@ else
   command=(/checkout/src/ci/run.sh)
 fi
 
-if [ "$CI" != "" ]; then
+if isCI; then
   # Get some needed information for $BASE_COMMIT
   #
   # This command gets the last merge commit which we'll use as base to list

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -339,7 +339,9 @@ docker \
   rust-ci \
   "${command[@]}"
 
-cat $objdir/${SUMMARY_FILE} >> "${GITHUB_STEP_SUMMARY}"
+if isCI; then
+    cat $objdir/${SUMMARY_FILE} >> "${GITHUB_STEP_SUMMARY}"
+fi
 
 if [ -f /.dockerenv ]; then
   rm -rf $objdir

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -33,15 +33,19 @@ ci_dir="`dirname $script_dir`"
 src_dir="`dirname $ci_dir`"
 root_dir="`dirname $src_dir`"
 
-objdir=$root_dir/obj
+source "$ci_dir/shared.sh"
+
+if isCI; then
+    objdir=$root_dir/obj
+else
+    objdir=$root_dir/obj/$image
+fi
 dist=$objdir/build/dist
 
 
 if [ -d "$root_dir/.git" ]; then
     IS_GIT_SOURCE=1
 fi
-
-source "$ci_dir/shared.sh"
 
 CACHE_DOMAIN="${CACHE_DOMAIN:-ci-caches.rust-lang.org}"
 


### PR DESCRIPTION
When running locally, the absence of the `GITHUB_STEP_SUMMARY` environment variable will lead to the following error:

```
::endgroup::
./src/ci/docker/run.sh: line 349: : No such file or directory
```

I've also changed the output artifacts directory to `obj/$image_name`, allowing me to easily run all images locally. We always encounter various strange issues when modifying the test cases in the `codegen` directory.

r? Kobzol cc @saethlin