### PR TITLE
Disable assert_unsafe_precondition to measure compile-time cost

### DIFF
--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -69,8 +69,10 @@ macro_rules! assert_unsafe_precondition {
                 }
             }
 
+            if cfg!(debug_assertions) {
             if ::core::ub_checks::$kind() {
                 precondition_check($($arg,)*);
+            }
             }
         }
     };


### PR DESCRIPTION
r? ghost