### PR TITLE
Clarify guarantees about calling `Iterator:next()` after it returns `None`

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -58,7 +58,7 @@ pub trait Iterator {
     /// again may eventually start returning [`Some(Item)`] again at some
     /// point. Alternately, implementations may choose to continue returning [`None`]
     /// forever, in which case they should implement [`FusedIterator`] as well.
-    /// 
+    ///
     /// Implementations should document their behavior, or their lack of a guarantee
     /// about their behavior, after `None` is returned. If they must panic,
     /// block forever, or otherwise cause problems, then this should be prominently

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -48,17 +48,24 @@ pub trait Iterator {
     type Item;
 
     /// Advances the iterator and returns the next value.
+    /// Returns [`None`] when iteration is finished.
     ///
-    /// Returns [`None`] when iteration is finished. Individual iterator
-    /// implementations may choose to resume iteration, and so calling `next()`
-    /// again may or may not eventually start returning [`Some(Item)`] again at some
-    /// point. (Calling `next()` on an iterator after it has returned `None`
-    /// is in general a perfectly valid use of the interface;
-    /// implementations must *not* panic, block forever, or otherwise misbehave
-    /// when this happens, though they *may* choose not to guarantee their exact
-    /// behavior.)
+    /// # Behavior after [`None`] is returned
+    ///
+    /// Calling `next()` on an iterator after it has returned `None`
+    /// is in general a perfectly valid use of the interface.
+    /// Implementations may choose to resume iteration, and so calling `next()`
+    /// again may eventually start returning [`Some(Item)`] again at some
+    /// point. Alternately, implementations may choose to continue returning [`None`]
+    /// forever, in which case they should implement [`FusedIterator`] as well.
+    /// 
+    /// Implementations should document their behavior, or their lack of a guarantee
+    /// about their behavior, after `None` is returned. If they must panic,
+    /// block forever, or otherwise cause problems, then this should be prominently
+    /// indicated in their docs (no different from any other potentially-misbehaving API).
     ///
     /// [`Some(Item)`]: Some
+    /// [`FusedIterator`]: crate::iter::FusedIterator
     ///
     /// # Examples
     ///

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -54,7 +54,7 @@ pub trait Iterator {
     /// again may or may not eventually start returning [`Some(Item)`] again at some
     /// point. (Calling `next()` on an iterator after it has returned `None`
     /// is in general a perfectly valid use of the interface;
-    /// implementations should *not* panic, block forever, or otherwise misbehave
+    /// implementations must *not* panic, block forever, or otherwise misbehave
     /// when this happens, though they *may* choose not to guarantee their exact
     /// behavior.)
     ///

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -52,7 +52,11 @@ pub trait Iterator {
     /// Returns [`None`] when iteration is finished. Individual iterator
     /// implementations may choose to resume iteration, and so calling `next()`
     /// again may or may not eventually start returning [`Some(Item)`] again at some
-    /// point.
+    /// point. (Calling `next()` on an iterator after it has returned `None`
+    /// is in general a perfectly valid use of the interface;
+    /// implementations should *not* panic, block forever, or otherwise misbehave
+    /// when this happens, though they *may* choose not to guarantee their exact
+    /// behavior.)
     ///
     /// [`Some(Item)`]: Some
     ///


### PR DESCRIPTION
From [discussion on the Users forum](https://users.rust-lang.org/t/am-i-the-only-one-who-uses-non-fused-iterators/109573), it appears there is no wide agreement on how an iterator should behave when `next()` is called again after it returns `None`. In the spirit of [Cunningham's Law](https://en.wikipedia.org/wiki/Ward_Cunningham#%22Cunningham's_Law%22), here is my interpretation.

r? libs-api

@rustbot label A-docs -T-libs T-libs-api