### PR TITLE
expand: fix minor diagnostics bug

### DIFF
--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -10,6 +10,11 @@ expand_attribute_meta_item =
 expand_attribute_single_word =
     attribute must only be a single word
 
+expand_attributes_on_expressions_experimental =
+    attributes on expressions are experimental
+    .help_outer_doc = `///` is used for outer documentation comments; for a plain comment, use `//`
+    .help_inner_doc = `//!` is used for inner documentation comments; for a plain comment, use `//` by removing the `!` or inserting a space in between them: `// !`
+
 expand_attributes_wrong_form =
     attribute must be of form: `attributes(foo, bar)`
 

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -387,7 +387,11 @@ impl<'a> StripUnconfigured<'a> {
             );
 
             if attr.is_doc_comment() {
-                err.help("`///` is for documentation comments. For a plain comment, use `//`.");
+                err.help(if attr.style == AttrStyle::Outer {
+                    "`///` is used for outer documentation comments; for a plain comment, use `//`"
+                } else {
+                    "`//!` is used for inner documentation comments; for a plain comment, use `//` by removing the `!` or inserting a space in between them: `// !`"
+                });
             }
 
             err.emit();

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -373,7 +373,6 @@ impl<'a> StripUnconfigured<'a> {
     }
 
     /// If attributes are not allowed on expressions, emit an error for `attr`
-    #[allow(rustc::untranslatable_diagnostic)] // FIXME: make this translatable
     #[instrument(level = "trace", skip(self))]
     pub(crate) fn maybe_emit_expr_attr_err(&self, attr: &Attribute) {
         if self.features.is_some_and(|features| !features.stmt_expr_attributes)
@@ -383,14 +382,14 @@ impl<'a> StripUnconfigured<'a> {
                 &self.sess,
                 sym::stmt_expr_attributes,
                 attr.span,
-                "attributes on expressions are experimental",
+                crate::fluent_generated::expand_attributes_on_expressions_experimental,
             );
 
             if attr.is_doc_comment() {
                 err.help(if attr.style == AttrStyle::Outer {
-                    "`///` is used for outer documentation comments; for a plain comment, use `//`"
+                    crate::fluent_generated::expand_help_outer_doc
                 } else {
-                    "`//!` is used for inner documentation comments; for a plain comment, use `//` by removing the `!` or inserting a space in between them: `// !`"
+                    crate::fluent_generated::expand_help_inner_doc
                 });
             }
 

--- a/tests/ui/feature-gates/feature-gate-stmt_expr_attributes.rs
+++ b/tests/ui/feature-gates/feature-gate-stmt_expr_attributes.rs
@@ -1,4 +1,15 @@
 const X: i32 = #[allow(dead_code)] 8;
 //~^ ERROR attributes on expressions are experimental
 
+const Y: i32 =
+    /// foo
+//~^ ERROR attributes on expressions are experimental
+    8;
+
+const Z: i32 = {
+    //! foo
+//~^ ERROR attributes on expressions are experimental
+    8
+};
+
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-stmt_expr_attributes.stderr
+++ b/tests/ui/feature-gates/feature-gate-stmt_expr_attributes.stderr
@@ -8,6 +8,28 @@ LL | const X: i32 = #[allow(dead_code)] 8;
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/feature-gate-stmt_expr_attributes.rs:5:5
+   |
+LL |     /// foo
+   |     ^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: `///` is for documentation comments. For a plain comment, use `//`.
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/feature-gate-stmt_expr_attributes.rs:10:5
+   |
+LL |     //! foo
+   |     ^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: `///` is for documentation comments. For a plain comment, use `//`.
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-stmt_expr_attributes.stderr
+++ b/tests/ui/feature-gates/feature-gate-stmt_expr_attributes.stderr
@@ -17,7 +17,7 @@ LL |     /// foo
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: `///` is for documentation comments. For a plain comment, use `//`.
+   = help: `///` is used for outer documentation comments; for a plain comment, use `//`
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/feature-gate-stmt_expr_attributes.rs:10:5
@@ -28,7 +28,7 @@ LL |     //! foo
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: `///` is for documentation comments. For a plain comment, use `//`.
+   = help: `//!` is used for inner documentation comments; for a plain comment, use `//` by removing the `!` or inserting a space in between them: `// !`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
+++ b/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
@@ -13,7 +13,7 @@ LL |     /// useless doc comment
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: `///` is for documentation comments. For a plain comment, use `//`.
+   = help: `///` is used for outer documentation comments; for a plain comment, use `//`
 
 error: unused doc comment
   --> $DIR/unused-doc-comments-edge-cases.rs:6:9


### PR DESCRIPTION
The error mentions `///`, when it's actually `//!`:

```
error[E0658]: attributes on expressions are experimental
 --> test.rs:4:9
  |
4 |         //! wah
  |         ^^^^^^^
  |
  = note: see issue https://github.com/rust-lang/rust/issues/15701 <https://github.com/rust-lang/rust/issues/15701> for more information
  = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
  = help: `///` is for documentation comments. For a plain comment, use `//`.
```