### PR TITLE
Only assert for child/parent projection compatibility AFTER checking that theyre coming from the same place

### DIFF
--- a/tests/ui/async-await/async-closures/different-projection-lengths-for-different-upvars.rs
+++ b/tests/ui/async-await/async-closures/different-projection-lengths-for-different-upvars.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+//@ edition: 2021
+// issue: rust-lang/rust#123697
+
+#![feature(async_closure)]
+
+struct S { t: i32 }
+
+fn test(s: &S, t: &i32) {
+    async || {
+        println!("{}", s.t);
+        println!("{}", t);
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
This assertion doesn't make sense until we check that these captures are actually equivalent.

Fixes #123697

<sub>Some days I wonder how I even write code that works...</sub>