### PR TITLE
Further cleanup cfgs in the UI test suite

### DIFF
--- a/tests/ui/conditional-compilation/cfg-generic-params.rs
+++ b/tests/ui/conditional-compilation/cfg-generic-params.rs
@@ -1,36 +1,36 @@
 //@ compile-flags:--cfg yes
 
-fn f_lt<#[cfg(yes)] 'a: 'a, #[cfg(no)] T>() {}
-fn f_ty<#[cfg(no)] 'a: 'a, #[cfg(yes)] T>() {}
+fn f_lt<#[cfg(yes)] 'a: 'a, #[cfg(FALSE)] T>() {}
+fn f_ty<#[cfg(FALSE)] 'a: 'a, #[cfg(yes)] T>() {}
 
-type FnGood = for<#[cfg(yes)] 'a, #[cfg(no)] T> fn(); // OK
-type FnBad = for<#[cfg(no)] 'a, #[cfg(yes)] T> fn();
+type FnGood = for<#[cfg(yes)] 'a, #[cfg(FALSE)] T> fn(); // OK
+type FnBad = for<#[cfg(FALSE)] 'a, #[cfg(yes)] T> fn();
 //~^ ERROR only lifetime parameters can be used in this context
 
-type PolyGood = dyn for<#[cfg(yes)] 'a, #[cfg(no)] T> Copy; // OK
-type PolyBad = dyn for<#[cfg(no)] 'a, #[cfg(yes)] T> Copy;
+type PolyGood = dyn for<#[cfg(yes)] 'a, #[cfg(FALSE)] T> Copy; // OK
+type PolyBad = dyn for<#[cfg(FALSE)] 'a, #[cfg(yes)] T> Copy;
 //~^ ERROR only lifetime parameters can be used in this context
 
-struct WhereGood where for<#[cfg(yes)] 'a, #[cfg(no)] T> u8: Copy; // OK
-struct WhereBad where for<#[cfg(no)] 'a, #[cfg(yes)] T> u8: Copy;
+struct WhereGood where for<#[cfg(yes)] 'a, #[cfg(FALSE)] T> u8: Copy; // OK
+struct WhereBad where for<#[cfg(FALSE)] 'a, #[cfg(yes)] T> u8: Copy;
 //~^ ERROR only lifetime parameters can be used in this context
 
-fn f_lt_no<#[cfg_attr(no, unknown)] 'a>() {} // OK
+fn f_lt_no<#[cfg_attr(FALSE, unknown)] 'a>() {} // OK
 fn f_lt_yes<#[cfg_attr(yes, unknown)] 'a>() {}
 //~^ ERROR cannot find attribute `unknown` in this scope
-fn f_ty_no<#[cfg_attr(no, unknown)] T>() {} // OK
+fn f_ty_no<#[cfg_attr(FALSE, unknown)] T>() {} // OK
 fn f_ty_yes<#[cfg_attr(yes, unknown)] T>() {}
 //~^ ERROR cannot find attribute `unknown` in this scope
 
-type FnNo = for<#[cfg_attr(no, unknown)] 'a> fn(); // OK
+type FnNo = for<#[cfg_attr(FALSE, unknown)] 'a> fn(); // OK
 type FnYes = for<#[cfg_attr(yes, unknown)] 'a> fn();
 //~^ ERROR cannot find attribute `unknown` in this scope
 
-type PolyNo = dyn for<#[cfg_attr(no, unknown)] 'a> Copy; // OK
+type PolyNo = dyn for<#[cfg_attr(FALSE, unknown)] 'a> Copy; // OK
 type PolyYes = dyn for<#[cfg_attr(yes, unknown)] 'a> Copy;
 //~^ ERROR cannot find attribute `unknown` in this scope
 
-struct WhereNo where for<#[cfg_attr(no, unknown)] 'a> u8: Copy; // OK
+struct WhereNo where for<#[cfg_attr(FALSE, unknown)] 'a> u8: Copy; // OK
 struct WhereYes where for<#[cfg_attr(yes, unknown)] 'a> u8: Copy;
 //~^ ERROR cannot find attribute `unknown` in this scope
 

--- a/tests/ui/conditional-compilation/cfg-generic-params.stderr
+++ b/tests/ui/conditional-compilation/cfg-generic-params.stderr
@@ -29,30 +29,30 @@ LL | struct WhereYes where for<#[cfg_attr(yes, unknown)] 'a> u8: Copy;
    |                                           ^^^^^^^
 
 error[E0658]: only lifetime parameters can be used in this context
-  --> $DIR/cfg-generic-params.rs:7:45
+  --> $DIR/cfg-generic-params.rs:7:48
    |
-LL | type FnBad = for<#[cfg(no)] 'a, #[cfg(yes)] T> fn();
-   |                                             ^
-   |
-   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
-   = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: only lifetime parameters can be used in this context
-  --> $DIR/cfg-generic-params.rs:11:51
-   |
-LL | type PolyBad = dyn for<#[cfg(no)] 'a, #[cfg(yes)] T> Copy;
-   |                                                   ^
+LL | type FnBad = for<#[cfg(FALSE)] 'a, #[cfg(yes)] T> fn();
+   |                                                ^
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: only lifetime parameters can be used in this context
-  --> $DIR/cfg-generic-params.rs:15:54
+  --> $DIR/cfg-generic-params.rs:11:54
    |
-LL | struct WhereBad where for<#[cfg(no)] 'a, #[cfg(yes)] T> u8: Copy;
+LL | type PolyBad = dyn for<#[cfg(FALSE)] 'a, #[cfg(yes)] T> Copy;
    |                                                      ^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: only lifetime parameters can be used in this context
+  --> $DIR/cfg-generic-params.rs:15:57
+   |
+LL | struct WhereBad where for<#[cfg(FALSE)] 'a, #[cfg(yes)] T> u8: Copy;
+   |                                                         ^
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable

--- a/tests/ui/const-generics/const-arg-in-const-arg.rs
+++ b/tests/ui/const-generics/const-arg-in-const-arg.rs
@@ -2,8 +2,8 @@
 // we use a single revision because this should have a `full` revision
 // but right now that ICEs and I(@BoxyUwU) could not get stderr normalization to work
 
-#![cfg_attr(full, feature(generic_const_exprs))]
-#![cfg_attr(full, allow(incomplete_features))]
+// #![cfg_attr(full, feature(generic_const_exprs))]
+// #![cfg_attr(full, allow(incomplete_features))]
 
 const fn foo<T>() -> usize { std::mem::size_of::<T>() }
 const fn bar<const N: usize>() -> usize { N }

--- a/tests/ui/feature-gates/feature-gate-yeet_expr-in-cfg.rs
+++ b/tests/ui/feature-gates/feature-gate-yeet_expr-in-cfg.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: --edition 2021
 
 pub fn demo() -> Option<i32> {
-    #[cfg(nope)]
+    #[cfg(FALSE)]
     {
         do yeet //~ ERROR `do yeet` expression is experimental
     }
@@ -9,7 +9,7 @@ pub fn demo() -> Option<i32> {
     Some(1)
 }
 
-#[cfg(nope)]
+#[cfg(FALSE)]
 pub fn alternative() -> Result<(), String> {
     do yeet "hello"; //~ ERROR `do yeet` expression is experimental
 }

--- a/tests/ui/proc-macro/derive-helper-configured.rs
+++ b/tests/ui/proc-macro/derive-helper-configured.rs
@@ -1,17 +1,15 @@
 // Derive helpers are resolved successfully inside `cfg_attr`.
 
 //@ check-pass
-// compile-flats:--cfg TRUE
 //@ aux-build:test-macros.rs
 
 #[macro_use]
 extern crate test_macros;
 
-#[cfg_attr(TRUE, empty_helper)]
 #[derive(Empty)]
-#[cfg_attr(TRUE, empty_helper)]
+#[cfg_attr(all(), empty_helper)]
 struct S {
-    #[cfg_attr(TRUE, empty_helper)]
+    #[cfg_attr(all(), empty_helper)]
     field: u8,
 }
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop-fail-2.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop-fail-2.rs
@@ -1,7 +1,7 @@
 //@ known-bug: #110395
 #![feature(const_trait_impl)]
 #![feature(const_mut_refs)]
-#![cfg_attr(precise, feature(const_precise_live_drops))]
+// #![cfg_attr(precise, feature(const_precise_live_drops))]
 
 use std::marker::{Destruct, PhantomData};
 

--- a/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.fixed
+++ b/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.fixed
@@ -1,6 +1,6 @@
 //@ aux-build:edition-lint-paths.rs
 //@ run-rustfix
-//@ compile-flags:--extern edition_lint_paths --cfg blandiloquence
+//@ compile-flags:--extern edition_lint_paths
 //@ edition:2018
 
 #![deny(rust_2018_idioms)]

--- a/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.rs
+++ b/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.rs
@@ -1,6 +1,6 @@
 //@ aux-build:edition-lint-paths.rs
 //@ run-rustfix
-//@ compile-flags:--extern edition_lint_paths --cfg blandiloquence
+//@ compile-flags:--extern edition_lint_paths
 //@ edition:2018
 
 #![deny(rust_2018_idioms)]
@@ -8,7 +8,7 @@
 
 // The suggestion span should include the attribute.
 
-#[cfg(blandiloquence)] //~ HELP remove it
+#[cfg(not(FALSE))] //~ HELP remove it
 extern crate edition_lint_paths;
 //~^ ERROR unused extern crate
 

--- a/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
+++ b/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
@@ -1,7 +1,7 @@
 error: unused extern crate
   --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:12:1
    |
-LL | / #[cfg(blandiloquence)]
+LL | / #[cfg(not(FALSE))]
 LL | | extern crate edition_lint_paths;
    | | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    | |________________________________|


### PR DESCRIPTION
This PR does more cleanup of cfgs in our UI test suite, in preparation for adding automatic always on check-cfg (but is IMO worth landing even without that follow up).

To be more specific this PR:
 - replaces (the last remaining) never true cfgs by the `FALSE` cfg
 - fix `proc-macro/derive-helper-configured.rs` *(typo in directive)*
 - and comment some current unused `#[cfg_attr]` *(missing revisions)*

Follow-up to https://github.com/rust-lang/rust/pull/123577.