### PR TITLE
Add test for fn pointer duplication.

### DIFF
--- a/tests/ui/mir/auxiliary/static_fnptr.rs
+++ b/tests/ui/mir/auxiliary/static_fnptr.rs
@@ -1,0 +1,10 @@
+//@ compile-flags:-O
+
+fn foo() {}
+
+pub static ADDR: fn() = foo;
+
+#[inline(always)]
+pub fn bar(x: fn()) -> bool {
+    x == ADDR
+}

--- a/tests/ui/mir/auxiliary/static_fnptr.rs
+++ b/tests/ui/mir/auxiliary/static_fnptr.rs
@@ -1,5 +1,6 @@
 //@ compile-flags:-O
 
+#[inline]
 fn foo() {}
 
 pub static ADDR: fn() = foo;

--- a/tests/ui/mir/static_fnptr.rs
+++ b/tests/ui/mir/static_fnptr.rs
@@ -1,3 +1,10 @@
+//! Verify that we correctly handle fn pointer provenance in MIR optimizations.
+//! By asking to inline `static_fnptr::bar`, we have two copies of `static_fnptr::foo`, one in the
+//! auxiliary crate and one in the local crate CGU.
+//! `baz` must only consider the versions from upstream crate, and not try to compare with the
+//! address of the CGU-local copy.
+//! Related issue: #123670
+
 //@ run-pass
 //@ compile-flags:-Cno-prepopulate-passes -Copt-level=0
 //@ aux-build:static_fnptr.rs

--- a/tests/ui/mir/static_fnptr.rs
+++ b/tests/ui/mir/static_fnptr.rs
@@ -1,0 +1,14 @@
+//@ run-pass
+//@ compile-flags:-Cno-prepopulate-passes -Copt-level=0
+//@ aux-build:static_fnptr.rs
+
+extern crate static_fnptr;
+use static_fnptr::{ADDR, bar};
+
+fn baz() -> bool {
+    bar(ADDR)
+}
+
+fn main() {
+    assert!(baz())
+}


### PR DESCRIPTION
I managed to make it fail when removing provenance checks in GVN.

cc https://github.com/rust-lang/rust/issues/123670

r? @oli-obk 