### PR TITLE
Update documentation of Path::to_path_buf and Path::ancestors

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2278,10 +2278,9 @@ impl Path {
     /// Produces an iterator over `Path` and its ancestors.
     ///
     /// The iterator will yield the `Path` that is returned if the [`parent`] method is used zero
-    /// or more times. That means, the iterator will yield `&self`, `&self.parent().unwrap()`,
-    /// `&self.parent().unwrap().parent().unwrap()` and so on. If the [`parent`] method returns
-    /// [`None`], the iterator will do likewise. The iterator will always yield at least one value,
-    /// namely `&self`.
+    /// or more times. If the [`parent`] method returns [`None`], the iterator will do likewise.
+    /// The iterator will always yield at least one value, namely `Some(&self)`. Next it will yield
+    /// `&self.parent()`, `&self.parent().and_then(Path::parent)` and so on.
     ///
     /// # Examples
     ///

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2143,10 +2143,10 @@ impl Path {
     /// # Examples
     ///
     /// ```
-    /// use std::path::Path;
+    /// use std::path::{Path, PathBuf};
     ///
     /// let path_buf = Path::new("foo.txt").to_path_buf();
-    /// assert_eq!(path_buf, std::path::PathBuf::from("foo.txt"));
+    /// assert_eq!(path_buf, PathBuf::from("foo.txt"));
     /// ```
     #[rustc_conversion_suggestion]
     #[must_use = "this returns the result of the operation, \


### PR DESCRIPTION
`Path::to_path_buf`
> Changes the example from using the qualified path of PathBuf with an import. This is what's done in all other Path/PathBuf examples and makes the code look a bit cleaner.

`Path::ancestors`
> If you take a quick glance at the documentation for Path::ancestors, the unwraps take the natural focus. Potentially indicating that ancestors might panic.
In the reworked version I've also moved the link with parent returning None and that the iterator will always yield &self to before the yield examples.

Feel free to cherry-pick the changes you like.