### PR TITLE
update compiler_builtins to 0.1.109

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,9 +739,9 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.108"
+version = "0.1.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68bc55329711cd719c2687bb147bc06211b0521f97ef398280108ccb23227e9"
+checksum = "f11973008a8cf741fe6d22f339eba21fd0ca81e2760a769ba8243ed6c21edd7e"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",


### PR DESCRIPTION
This pulls in https://github.com/rust-lang/compiler-builtins/pull/583 so we should make sure that does not come with any perf surprises.

Cc @Amanieu 