### PR TITLE
Various visionOS fixes

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -3029,9 +3029,10 @@ fn get_apple_sdk_root(sdk_name: &str) -> Result<String, errors::AppleSdkRootErro
                     || sdkroot.contains("MacOSX.platform") => {}
             "watchsimulator"
                 if sdkroot.contains("WatchOS.platform") || sdkroot.contains("MacOSX.platform") => {}
-            "visionos"
-                if sdkroot.contains("XROS.platform") || sdkroot.contains("MacOSX.platform") => {}
-            "visionossimulator"
+            "xros"
+                if sdkroot.contains("XRSimulator.platform")
+                    || sdkroot.contains("MacOSX.platform") => {}
+            "xrsimulator"
                 if sdkroot.contains("XROS.platform") || sdkroot.contains("MacOSX.platform") => {}
             // Ignore `SDKROOT` if it's not a valid path.
             _ if !p.is_absolute() || p == Path::new("/") || !p.exists() => {}

--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -298,6 +298,7 @@ fn link_env_remove(os: &'static str) -> StaticCow<[StaticCow<str>]> {
                 || sdkroot.contains("WatchOS.platform")
                 || sdkroot.contains("WatchSimulator.platform")
                 || sdkroot.contains("XROS.platform")
+                || sdkroot.contains("XRSimulator.platform")
             {
                 env_remove.push("SDKROOT".into())
             }

--- a/library/std/src/sys/pal/unix/process/process_unix.rs
+++ b/library/std/src/sys/pal/unix/process/process_unix.rs
@@ -11,18 +11,6 @@ use crate::os::linux::process::PidFd;
 #[cfg(target_os = "linux")]
 use crate::os::unix::io::AsRawFd;
 
-#[cfg(any(
-    target_os = "macos",
-    target_os = "watchos",
-    target_os = "visionos",
-    target_os = "tvos",
-    target_os = "freebsd",
-    all(target_os = "linux", target_env = "gnu"),
-    all(target_os = "linux", target_env = "musl"),
-    target_os = "nto",
-))]
-use crate::sys::weak::weak;
-
 #[cfg(target_os = "vxworks")]
 use libc::RTP_ID as pid_t;
 
@@ -466,6 +454,7 @@ impl Command {
         envp: Option<&CStringArray>,
     ) -> io::Result<Option<Process>> {
         use crate::mem::MaybeUninit;
+        use crate::sys::weak::weak;
         use crate::sys::{self, cvt_nz, unix_sigpipe_attr_specified};
 
         if self.get_gid().is_some()


### PR DESCRIPTION
A few small mistakes was introduced in https://github.com/rust-lang/rust/pull/121419, probably after the rename from `xros` to `visionos`. See the commits for details.

CC @agg23

Since you reviewed https://github.com/rust-lang/rust/pull/121419
r? davidtwco
