### PR TITLE
Make `std::os::darwin` public

### DIFF
--- a/library/std/src/os/darwin/fs.rs
+++ b/library/std/src/os/darwin/fs.rs
@@ -1,7 +1,8 @@
-#![allow(dead_code)]
+//! Darwin-specific extension traits to [`fs`].
+//!
+//! [`fs`]: crate::fs
+#![stable(feature = "metadata_ext", since = "1.1.0")]
 
-#[allow(deprecated)]
-use super::raw;
 use crate::fs::{self, Metadata};
 use crate::sealed::Sealed;
 use crate::sys_common::{AsInner, AsInnerMut, IntoInner};
@@ -25,7 +26,10 @@ pub trait MetadataExt {
                 methods of this trait"
     )]
     #[allow(deprecated)]
-    fn as_raw_stat(&self) -> &raw::stat;
+    // Only available on macOS and iOS, since they were stably exposed there.
+    #[cfg(any(doc, target_os = "macos", target_os = "ios"))]
+    #[doc(cfg(any(target_os = "macos", target_os = "ios")))]
+    fn as_raw_stat(&self) -> &super::raw::stat;
 
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_dev(&self) -> u64;
@@ -77,8 +81,9 @@ pub trait MetadataExt {
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 impl MetadataExt for Metadata {
     #[allow(deprecated)]
-    fn as_raw_stat(&self) -> &raw::stat {
-        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
+    #[cfg(any(doc, target_os = "macos", target_os = "ios"))]
+    fn as_raw_stat(&self) -> &super::raw::stat {
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const super::raw::stat) }
     }
     fn st_dev(&self) -> u64 {
         self.as_inner().as_inner().st_dev as u64

--- a/library/std/src/os/darwin/mod.rs
+++ b/library/std/src/os/darwin/mod.rs
@@ -13,7 +13,10 @@
 //! `aarch64-apple-darwin` target names, which are mostly named that way for
 //! legacy reasons.
 
-pub(crate) mod fs;
+#![stable(feature = "os_darwin", since = "CURRENT_RUSTC_VERSION")]
+#![doc(cfg(target_vendor = "apple"))]
+
+pub mod fs;
 // deprecated, but used for public reexport under `std::os::unix::raw`, as
 // well as `std::os::macos`/`std::os::ios`, because those modules precede the
 // decision to remove these.

--- a/library/std/src/os/ios/mod.rs
+++ b/library/std/src/os/ios/mod.rs
@@ -4,10 +4,8 @@
 
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 pub mod fs {
-    #[doc(inline)]
     #[stable(feature = "file_set_times", since = "1.75.0")]
     pub use crate::os::darwin::fs::FileTimesExt;
-    #[doc(inline)]
     #[stable(feature = "metadata_ext", since = "1.1.0")]
     pub use crate::os::darwin::fs::MetadataExt;
 }

--- a/library/std/src/os/macos/mod.rs
+++ b/library/std/src/os/macos/mod.rs
@@ -4,10 +4,8 @@
 
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 pub mod fs {
-    #[doc(inline)]
     #[stable(feature = "file_set_times", since = "1.75.0")]
     pub use crate::os::darwin::fs::FileTimesExt;
-    #[doc(inline)]
     #[stable(feature = "metadata_ext", since = "1.1.0")]
     pub use crate::os::darwin::fs::MetadataExt;
 }

--- a/library/std/src/os/mod.rs
+++ b/library/std/src/os/mod.rs
@@ -15,7 +15,16 @@ pub mod raw;
 // documented don't compile (missing things in `libc` which is empty),
 // so just omit them with an empty module and add the "unstable" attribute.
 
-// unix, linux, wasi and windows are handled a bit differently.
+// darwin, unix, linux, wasi and windows are handled a bit differently.
+#[cfg(all(
+    doc,
+    any(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        all(target_vendor = "fortanix", target_env = "sgx")
+    )
+))]
+#[unstable(issue = "none", feature = "std_internals")]
+pub mod darwin {}
 #[cfg(all(
     doc,
     any(
@@ -52,6 +61,17 @@ pub mod wasi {}
 ))]
 #[unstable(issue = "none", feature = "std_internals")]
 pub mod windows {}
+
+// darwin
+#[cfg(not(all(
+    doc,
+    any(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        all(target_vendor = "fortanix", target_env = "sgx")
+    )
+)))]
+#[cfg(any(target_vendor = "apple", doc))]
+pub mod darwin;
 
 // unix
 #[cfg(not(all(
@@ -105,8 +125,6 @@ pub mod windows;
 pub mod aix;
 #[cfg(target_os = "android")]
 pub mod android;
-#[cfg(target_vendor = "apple")]
-pub(crate) mod darwin;
 #[cfg(target_os = "dragonfly")]
 pub mod dragonfly;
 #[cfg(target_os = "emscripten")]

--- a/library/std/src/os/unix/mod.rs
+++ b/library/std/src/os/unix/mod.rs
@@ -42,7 +42,7 @@ mod platform {
     #[cfg(target_os = "android")]
     pub use crate::os::android::*;
     #[cfg(target_vendor = "apple")]
-    pub(super) use crate::os::darwin::*;
+    pub use crate::os::darwin::*;
     #[cfg(target_os = "dragonfly")]
     pub use crate::os::dragonfly::*;
     #[cfg(target_os = "emscripten")]


### PR DESCRIPTION
I'm not sure of the reasoning behind them not being public before, but I think they should be, just like `std::os::ios` and `std::os::macos` are public.

Additionally, I've merged their source code, as it was otherwise just a bunch of unnecessary duplication.

Ultimately, I've done this PR to fix `./x build library --target=aarch64-apple-tvos,aarch64-apple-watchos,aarch64-apple-visionos`, as that currently fails because of dead code warnings.

Since you reviewed https://github.com/rust-lang/rust/pull/121419
r? davidtwco

Fixes https://github.com/rust-lang/rust/issues/121640.

@rustbot label O-tvos O-watchos O-visionos

EDIT: Link to FCP summary: https://github.com/rust-lang/rust/pull/123723#issuecomment-2287276599