### PR TITLE
Fix read_link is followed by an extra \0 on wasi target

### DIFF
--- a/library/std/src/sys/pal/wasi/fs.rs
+++ b/library/std/src/sys/pal/wasi/fs.rs
@@ -616,6 +616,7 @@ fn read_link(fd: &WasiFd, file: &Path) -> io::Result<PathBuf> {
     loop {
         let len = fd.readlink(file, &mut destination)?;
         if len < destination.len() {
+            let len = CStr::from_ptr(destination.as_ptr() as *const libc::c_char).to_bytes().len();
             destination.truncate(len);
             destination.shrink_to_fit();
             return Ok(PathBuf::from(OsString::from_vec(destination)));


### PR DESCRIPTION
The result of `fs::read_link` on wasi target is followed by an extra `\0` on wasi target, this pull request is trying to fix it by aligning the implementation with the [`getcwd`](https://github.com/rust-lang/rust/blob/1.77.2/library/std/src/sys/pal/wasi/os.rs#L77)