### PR TITLE
Don't delay a bug if we suggest adding a semicolon to the RHS of an assign operator

### DIFF
--- a/tests/ui/binop/multiply-is-deref-on-rhs.rs
+++ b/tests/ui/binop/multiply-is-deref-on-rhs.rs
@@ -1,0 +1,8 @@
+pub fn test(y: &i32) {
+    let x;
+    x = ()
+    *y
+    //~^ ERROR cannot multiply `()` by `&i32`
+}
+
+fn main() {}

--- a/tests/ui/binop/multiply-is-deref-on-rhs.stderr
+++ b/tests/ui/binop/multiply-is-deref-on-rhs.stderr
@@ -1,0 +1,16 @@
+error[E0369]: cannot multiply `()` by `&i32`
+  --> $DIR/multiply-is-deref-on-rhs.rs:4:5
+   |
+LL |     x = ()
+   |         -- ()
+LL |     *y
+   |     ^- &i32
+   |
+help: you might have meant to write a semicolon here
+   |
+LL |     x = ();
+   |           +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0369`.


### PR DESCRIPTION
It only makes sense to delay a bug based on the assumption that "[we] defer to the later error produced by `check_lhs_assignable`" *if* the expression we're erroring actually is an LHS; otherwise, we should still report the error since it's both useful and required.

Fixes #123722