### PR TITLE
Check alias args for WF even if they have escaping bound vars

### DIFF
--- a/tests/ui/higher-ranked/well-formed-aliases.rs
+++ b/tests/ui/higher-ranked/well-formed-aliases.rs
@@ -1,0 +1,8 @@
+trait Trait {
+    type Gat<U: ?Sized>;
+}
+
+fn test<T>(f: for<'a> fn(<&'a T as Trait>::Gat<&'a [str]>)) where for<'a> &'a T: Trait {}
+//~^ ERROR the size for values of type `str` cannot be known at compilation time
+
+fn main() {}

--- a/tests/ui/higher-ranked/well-formed-aliases.stderr
+++ b/tests/ui/higher-ranked/well-formed-aliases.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/well-formed-aliases.rs:5:52
+   |
+LL | fn test<T>(f: for<'a> fn(<&'a T as Trait>::Gat<&'a [str]>)) where for<'a> &'a T: Trait {}
+   |                                                    ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: slice and array elements must have `Sized` type
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
#### What

This PR stops skipping arguments of aliases if they have escaping bound vars, instead recursing into them and only discarding the resulting obligations referencing bounds vars.

#### An example:

From the test:
```
trait Trait {
    type Gat<U: ?Sized>;
}

fn test<T>(f: for<'a> fn(<&'a T as Trait>::Gat<&'a [str]>)) where for<'a> &'a T: Trait {}
//~^ ERROR the size for values of type `[()]` cannot be known at compilation time

fn main() {}
```

We now prove that `str: Sized` in order for `&'a [str]` to be well-formed. We were previously unconditionally skipping over `&'a [str]` as it referenced a buond variable. We now recurse into it and instead only discard the `[str]: 'a` obligation because of the escaping bound vars.

#### Why?

This is a change that improves consistency about proving well-formedness earlier in the pipeline, which is necessary for future work on where-bounds in binders and correctly handling higher-ranked implied bounds. I don't expect this to fix any unsoundness.

#### What doesn't it fix?

Specifically, this doesn't check projection predicates' components are well-formed, because there are too many regressions: https://github.com/rust-lang/rust/pull/123737#issuecomment-2052198478