### PR TITLE
Reduce Size of `ModifierInfo`

### DIFF
--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -9,11 +9,11 @@ use std::str::FromStr;
 pub struct ModifierInfo {
     pub modifier: char,
     pub result: &'static str,
-    pub size: u64,
+    pub size: u16,
 }
 
-impl From<(char, &'static str, u64)> for ModifierInfo {
-    fn from((modifier, result, size): (char, &'static str, u64)) -> Self {
+impl From<(char, &'static str, u16)> for ModifierInfo {
+    fn from((modifier, result, size): (char, &'static str, u16)) -> Self {
         Self { modifier, result, size }
     }
 }


### PR DESCRIPTION
I added `ModifierInfo` in #121940 and had used a `u64` for  the `size` field even though the largest value it holds is `512`. 

This PR changes the type of the `size` field to `u16`.