### PR TITLE
Set the host library path in run-make v2

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3785,6 +3785,11 @@ impl<'test> TestCx<'test> {
         debug!(?support_lib_deps);
         debug!(?support_lib_deps_deps);
 
+        let mut host_dylib_env_paths = String::new();
+        host_dylib_env_paths.push_str(&cwd.join(&self.config.compile_lib_path).to_string_lossy());
+        host_dylib_env_paths.push(':');
+        host_dylib_env_paths.push_str(&env::var(dylib_env_var()).unwrap());
+
         let mut cmd = Command::new(&self.config.rustc_path);
         cmd.arg("-o")
             .arg(&recipe_bin)
@@ -3801,6 +3806,7 @@ impl<'test> TestCx<'test> {
             .env("RUSTC", cwd.join(&self.config.rustc_path))
             .env("TMPDIR", &tmpdir)
             .env("LD_LIB_PATH_ENVVAR", dylib_env_var())
+            .env(dylib_env_var(), &host_dylib_env_paths)
             .env("HOST_RPATH_DIR", cwd.join(&self.config.compile_lib_path))
             .env("TARGET_RPATH_DIR", cwd.join(&self.config.run_lib_path))
             .env("LLVM_COMPONENTS", &self.config.llvm_components)

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3785,10 +3785,13 @@ impl<'test> TestCx<'test> {
         debug!(?support_lib_deps);
         debug!(?support_lib_deps_deps);
 
-        let mut host_dylib_env_paths = String::new();
-        host_dylib_env_paths.push_str(&cwd.join(&self.config.compile_lib_path).to_string_lossy());
-        host_dylib_env_paths.push(':');
-        host_dylib_env_paths.push_str(&env::var(dylib_env_var()).unwrap());
+        let orig_dylib_env_paths =
+            Vec::from_iter(env::split_paths(&env::var(dylib_env_var()).unwrap()));
+
+        let mut host_dylib_env_paths = Vec::new();
+        host_dylib_env_paths.push(cwd.join(&self.config.compile_lib_path));
+        host_dylib_env_paths.extend(orig_dylib_env_paths.iter().cloned());
+        let host_dylib_env_paths = env::join_paths(host_dylib_env_paths).unwrap();
 
         let mut cmd = Command::new(&self.config.rustc_path);
         cmd.arg("-o")
@@ -3834,19 +3837,15 @@ impl<'test> TestCx<'test> {
         // Finally, we need to run the recipe binary to build and run the actual tests.
         debug!(?recipe_bin);
 
-        let mut dylib_env_paths = String::new();
-        dylib_env_paths.push_str(&env::var(dylib_env_var()).unwrap());
-        dylib_env_paths.push(':');
-        dylib_env_paths.push_str(&support_lib_path.parent().unwrap().to_string_lossy());
-        dylib_env_paths.push(':');
-        dylib_env_paths.push_str(
-            &stage_std_path.join("rustlib").join(&self.config.host).join("lib").to_string_lossy(),
-        );
+        let mut dylib_env_paths = orig_dylib_env_paths.clone();
+        dylib_env_paths.push(support_lib_path.parent().unwrap().to_path_buf());
+        dylib_env_paths.push(stage_std_path.join("rustlib").join(&self.config.host).join("lib"));
+        let dylib_env_paths = env::join_paths(dylib_env_paths).unwrap();
 
-        let mut target_rpath_env_path = String::new();
-        target_rpath_env_path.push_str(&tmpdir.to_string_lossy());
-        target_rpath_env_path.push(':');
-        target_rpath_env_path.push_str(&dylib_env_paths);
+        let mut target_rpath_env_path = Vec::new();
+        target_rpath_env_path.push(&tmpdir);
+        target_rpath_env_path.extend(&orig_dylib_env_paths);
+        let target_rpath_env_path = env::join_paths(target_rpath_env_path).unwrap();
 
         let mut cmd = Command::new(&recipe_bin);
         cmd.current_dir(&self.testpaths.file)

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -115,3 +115,17 @@ fn handle_failed_output(cmd: &str, output: Output, caller_line_number: u32) -> !
     eprintln!("=== STDERR ===\n{}\n\n", String::from_utf8(output.stderr).unwrap());
     std::process::exit(1)
 }
+
+/// Set the runtime library path as needed for running the host rustc/rustdoc/etc.
+pub fn set_host_rpath(cmd: &mut Command) {
+    let ld_lib_path_envvar = env::var("LD_LIB_PATH_ENVVAR").unwrap();
+    cmd.env(&ld_lib_path_envvar, {
+        let mut paths = vec![];
+        paths.push(PathBuf::from(env::var("TMPDIR").unwrap()));
+        paths.push(PathBuf::from(env::var("HOST_RPATH_DIR").unwrap()));
+        for p in env::split_paths(&env::var(&ld_lib_path_envvar).unwrap()) {
+            paths.push(p.to_path_buf());
+        }
+        env::join_paths(paths.iter()).unwrap()
+    });
+}

--- a/src/tools/run-make-support/src/rustc.rs
+++ b/src/tools/run-make-support/src/rustc.rs
@@ -3,7 +3,7 @@ use std::ffi::{OsStr, OsString};
 use std::path::Path;
 use std::process::{Command, Output};
 
-use crate::{handle_failed_output, tmp_dir};
+use crate::{handle_failed_output, set_host_rpath, tmp_dir};
 
 /// Construct a new `rustc` invocation.
 pub fn rustc() -> Rustc {
@@ -24,6 +24,7 @@ pub struct Rustc {
 fn setup_common() -> Command {
     let rustc = env::var("RUSTC").unwrap();
     let mut cmd = Command::new(rustc);
+    set_host_rpath(&mut cmd);
     cmd.arg("--out-dir").arg(tmp_dir()).arg("-L").arg(tmp_dir());
     cmd
 }

--- a/src/tools/run-make-support/src/rustdoc.rs
+++ b/src/tools/run-make-support/src/rustdoc.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::Path;
 use std::process::{Command, Output};
 
-use crate::handle_failed_output;
+use crate::{handle_failed_output, set_host_rpath};
 
 /// Construct a plain `rustdoc` invocation with no flags set.
 pub fn bare_rustdoc() -> Rustdoc {
@@ -21,7 +21,9 @@ pub struct Rustdoc {
 
 fn setup_common() -> Command {
     let rustdoc = env::var("RUSTDOC").unwrap();
-    Command::new(rustdoc)
+    let mut cmd = Command::new(rustdoc);
+    set_host_rpath(&mut cmd);
+    cmd
 }
 
 impl Rustdoc {

--- a/tests/run-make/compiler-builtins/rmake.rs
+++ b/tests/run-make/compiler-builtins/rmake.rs
@@ -22,6 +22,7 @@ use run_make_support::object::read::Object;
 use run_make_support::object::ObjectSection;
 use run_make_support::object::ObjectSymbol;
 use run_make_support::object::RelocationTarget;
+use run_make_support::set_host_rpath;
 use run_make_support::tmp_dir;
 use std::collections::HashSet;
 
@@ -48,8 +49,8 @@ fn main() {
     let path = std::env::var("PATH").unwrap();
     let rustc = std::env::var("RUSTC").unwrap();
     let bootstrap_cargo = std::env::var("BOOTSTRAP_CARGO").unwrap();
-    let status = std::process::Command::new(bootstrap_cargo)
-        .args([
+    let mut cmd = std::process::Command::new(bootstrap_cargo);
+    cmd.args([
             "build",
             "--manifest-path",
             manifest_path.to_str().unwrap(),
@@ -62,10 +63,10 @@ fn main() {
         .env("RUSTC", rustc)
         .env("RUSTFLAGS", "-Copt-level=0 -Cdebug-assertions=yes")
         .env("CARGO_TARGET_DIR", &target_dir)
-        .env("RUSTC_BOOTSTRAP", "1")
-        .status()
-        .unwrap();
+        .env("RUSTC_BOOTSTRAP", "1");
+    set_host_rpath(&mut cmd);
 
+    let status = cmd.status().unwrap();
     assert!(status.success());
 
     let rlibs_path = target_dir.join(target).join("debug").join("deps");


### PR DESCRIPTION
When the build is configured with `[rust] rpath = false`, we need to set
`LD_LIBRARY_PATH` (or equivalent) to what would have been the `RPATH`,
so the compiler can find its own libraries. The old `tools.mk` code has
this environment prefixed in the `$(BARE_RUSTC)` variable, so we just
need to wire up something similar for run-make v2.

This is now set while building each `rmake.rs` itself, as well as in the
`rust-make-support` helpers for `rustc` and `rustdoc` commands. This is
also available in a `set_host_rpath` function for manual commands, like
in the `compiler-builtins` test.
