### PR TITLE
Correct broken link in core::pin doc

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -379,11 +379,11 @@
 //!
 //! Exposing access to the inner field which you want to remain pinned must then be carefully
 //! considered as well! Remember, exposing a method that gives access to a
-//! <code>[Pin]<[&mut] InnerT>></code> where `InnerT: [Unpin]` would allow safe code to trivially
-//! move the inner value out of that pinning pointer, which is precisely what you're seeking to
-//! prevent! Exposing a field of a pinned value through a pinning pointer is called "projecting"
-//! a pin, and the more general case of deciding in which cases a pin should be able to be
-//! projected or not is called "structural pinning." We will go into more detail about this
+//! <code>[Pin]<[&mut] InnerT>></code> where <code>InnerT: [Unpin]</code> would allow safe code to
+//! trivially move the inner value out of that pinning pointer, which is precisely what you're
+//! seeking to prevent! Exposing a field of a pinned value through a pinning pointer is called
+//! "projecting" a pin, and the more general case of deciding in which cases a pin should be able
+//! to be projected or not is called "structural pinning." We will go into more detail about this
 //! [below][structural-pinning].
 //!
 //! # Examples of address-sensitive types


### PR DESCRIPTION
This is a minor correction to the doc, which fails to link `Unpin` trait.

Before (rendered):
![before](https://github.com/rust-lang/rust/assets/49511064/c4f2f94d-91ea-4cee-be69-b0053453194a)

After (rendered):
![before](https://github.com/rust-lang/rust/assets/49511064/847068f8-73b2-4acb-ab78-3351ffe5b0a0)
