### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -655,8 +655,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
     fn ty_kind_suggestion(&self, ty: Ty<'tcx>) -> Option<String> {
         // Keep in sync with `rustc_hir_analysis/src/check/mod.rs:ty_kind_suggestion`.
         // FIXME: deduplicate the above.
+        let tcx = self.infcx.tcx;
         let implements_default = |ty| {
-            let Some(default_trait) = self.infcx.tcx.get_diagnostic_item(sym::Default) else {
+            let Some(default_trait) = tcx.get_diagnostic_item(sym::Default) else {
                 return false;
             };
             self.infcx
@@ -671,8 +672,20 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             ty::Int(_) | ty::Uint(_) => "42".into(),
             ty::Float(_) => "3.14159".into(),
             ty::Slice(_) => "[]".to_string(),
-            ty::Adt(def, _) if Some(def.did()) == self.infcx.tcx.get_diagnostic_item(sym::Vec) => {
+            ty::Adt(def, _) if Some(def.did()) == tcx.get_diagnostic_item(sym::Vec) => {
                 "vec![]".to_string()
+            }
+            ty::Adt(def, _) if Some(def.did()) == tcx.get_diagnostic_item(sym::String) => {
+                "String::new()".to_string()
+            }
+            ty::Adt(def, args) if def.is_box() => {
+                format!("Box::new({})", self.ty_kind_suggestion(args[0].expect_ty())?)
+            }
+            ty::Adt(def, _) if Some(def.did()) == tcx.get_diagnostic_item(sym::Option) => {
+                "None".to_string()
+            }
+            ty::Adt(def, args) if Some(def.did()) == tcx.get_diagnostic_item(sym::Result) => {
+                format!("Ok({})", self.ty_kind_suggestion(args[0].expect_ty())?)
             }
             ty::Adt(_, _) if implements_default(ty) => "Default::default()".to_string(),
             ty::Ref(_, ty, mutability) => {
@@ -688,7 +701,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             ty::Array(ty, len) => format!(
                 "[{}; {}]",
                 self.ty_kind_suggestion(*ty)?,
-                len.eval_target_usize(self.infcx.tcx, ty::ParamEnv::reveal_all()),
+                len.eval_target_usize(tcx, ty::ParamEnv::reveal_all()),
             ),
             ty::Tuple(tys) => format!(
                 "({})",

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -672,23 +672,21 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         };
 
         let assign_value = match ty.kind() {
+            ty::Never | ty::Error(_) => return,
             ty::Bool => "false",
             ty::Float(_) => "0.0",
             ty::Int(_) | ty::Uint(_) => "0",
-            ty::Never | ty::Error(_) => "",
             ty::Adt(def, _) if Some(def.did()) == tcx.get_diagnostic_item(sym::Vec) => "vec![]",
             ty::Adt(_, _) if implements_default(ty, self.param_env) => "Default::default()",
-            _ => "todo!()",
+            _ => "value",
         };
 
-        if !assign_value.is_empty() {
-            err.span_suggestion_verbose(
-                sugg_span.shrink_to_hi(),
-                "consider assigning a value",
-                format!(" = {assign_value}"),
-                Applicability::MaybeIncorrect,
-            );
-        }
+        err.span_suggestion_verbose(
+            sugg_span.shrink_to_hi(),
+            "consider assigning a value",
+            format!(" = {assign_value}"),
+            Applicability::MaybeIncorrect,
+        );
     }
 
     fn suggest_borrow_fn_like(

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -652,6 +652,55 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
+    fn ty_kind_suggestion(&self, ty: Ty<'tcx>) -> Option<String> {
+        // Keep in sync with `rustc_hir_analysis/src/check/mod.rs:ty_kind_suggestion`.
+        // FIXME: deduplicate the above.
+        let implements_default = |ty| {
+            let Some(default_trait) = self.infcx.tcx.get_diagnostic_item(sym::Default) else {
+                return false;
+            };
+            self.infcx
+                .type_implements_trait(default_trait, [ty], self.param_env)
+                .must_apply_modulo_regions()
+        };
+
+        Some(match ty.kind() {
+            ty::Never | ty::Error(_) => return None,
+            ty::Bool => "false".to_string(),
+            ty::Char => "\'x\'".to_string(),
+            ty::Int(_) | ty::Uint(_) => "42".into(),
+            ty::Float(_) => "3.14159".into(),
+            ty::Slice(_) => "[]".to_string(),
+            ty::Adt(def, _) if Some(def.did()) == self.infcx.tcx.get_diagnostic_item(sym::Vec) => {
+                "vec![]".to_string()
+            }
+            ty::Adt(_, _) if implements_default(ty) => "Default::default()".to_string(),
+            ty::Ref(_, ty, mutability) => {
+                if let (ty::Str, hir::Mutability::Not) = (ty.kind(), mutability) {
+                    "\"\"".to_string()
+                } else {
+                    let Some(ty) = self.ty_kind_suggestion(*ty) else {
+                        return None;
+                    };
+                    format!("&{}{ty}", mutability.prefix_str())
+                }
+            }
+            ty::Array(ty, len) => format!(
+                "[{}; {}]",
+                self.ty_kind_suggestion(*ty)?,
+                len.eval_target_usize(self.infcx.tcx, ty::ParamEnv::reveal_all()),
+            ),
+            ty::Tuple(tys) => format!(
+                "({})",
+                tys.iter()
+                    .map(|ty| self.ty_kind_suggestion(ty))
+                    .collect::<Option<Vec<String>>>()?
+                    .join(", ")
+            ),
+            _ => "value".to_string(),
+        })
+    }
+
     fn suggest_assign_value(
         &self,
         err: &mut Diag<'_>,
@@ -661,24 +710,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let ty = moved_place.ty(self.body, self.infcx.tcx).ty;
         debug!("ty: {:?}, kind: {:?}", ty, ty.kind());
 
-        let tcx = self.infcx.tcx;
-        let implements_default = |ty, param_env| {
-            let Some(default_trait) = tcx.get_diagnostic_item(sym::Default) else {
-                return false;
-            };
-            self.infcx
-                .type_implements_trait(default_trait, [ty], param_env)
-                .must_apply_modulo_regions()
-        };
-
-        let assign_value = match ty.kind() {
-            ty::Never | ty::Error(_) => return,
-            ty::Bool => "false",
-            ty::Float(_) => "0.0",
-            ty::Int(_) | ty::Uint(_) => "0",
-            ty::Adt(def, _) if Some(def.did()) == tcx.get_diagnostic_item(sym::Vec) => "vec![]",
-            ty::Adt(_, _) if implements_default(ty, self.param_env) => "Default::default()",
-            _ => "value",
+        let Some(assign_value) = self.ty_kind_suggestion(ty) else {
+            return;
         };
 
         err.span_suggestion_verbose(

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -22,7 +22,6 @@ use rustc_middle::ty::{
     AdtDef, ParamEnv, RegionKind, TypeSuperVisitable, TypeVisitable, TypeVisitableExt,
 };
 use rustc_session::lint::builtin::{UNINHABITED_STATIC, UNSUPPORTED_CALLING_CONVENTIONS};
-use rustc_span::symbol::sym;
 use rustc_target::abi::FieldIdx;
 use rustc_trait_selection::traits::error_reporting::on_unimplemented::OnUnimplementedDirective;
 use rustc_trait_selection::traits::error_reporting::TypeErrCtxtExt as _;

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -490,6 +490,18 @@ pub fn ty_kind_suggestion<'tcx>(ty: Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Option<Strin
         ty::Adt(def, _) if Some(def.did()) == tcx.get_diagnostic_item(sym::Vec) => {
             "vec![]".to_string()
         }
+        ty::Adt(def, _) if Some(def.did()) == tcx.get_diagnostic_item(sym::String) => {
+            "String::new()".to_string()
+        }
+        ty::Adt(def, args) if def.is_box() => {
+            format!("Box::new({})", ty_kind_suggestion(args[0].expect_ty(), tcx)?)
+        }
+        ty::Adt(def, _) if Some(def.did()) == tcx.get_diagnostic_item(sym::Option) => {
+            "None".to_string()
+        }
+        ty::Adt(def, args) if Some(def.did()) == tcx.get_diagnostic_item(sym::Result) => {
+            format!("Ok({})", ty_kind_suggestion(args[0].expect_ty(), tcx)?)
+        }
         ty::Adt(_, _) if implements_default(ty) => "Default::default()".to_string(),
         ty::Ref(_, ty, mutability) => {
             if let (ty::Str, Mutability::Not) = (ty.kind(), mutability) {

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -81,6 +81,7 @@ use rustc_errors::ErrorGuaranteed;
 use rustc_errors::{pluralize, struct_span_code_err, Diag};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::Visitor;
+use rustc_hir::Mutability;
 use rustc_index::bit_set::BitSet;
 use rustc_infer::infer::error_reporting::ObligationCauseExt as _;
 use rustc_infer::infer::outlives::env::OutlivesEnvironment;
@@ -467,7 +468,9 @@ fn fn_sig_suggestion<'tcx>(
     )
 }
 
-pub fn ty_kind_suggestion<'tcx>(ty: Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Option<&'static str> {
+pub fn ty_kind_suggestion<'tcx>(ty: Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Option<String> {
+    // Keep in sync with `rustc_borrowck/src/diagnostics/conflict_errors.rs:ty_kind_suggestion`.
+    // FIXME: deduplicate the above.
     let implements_default = |ty| {
         let Some(default_trait) = tcx.get_diagnostic_item(sym::Default) else {
             return false;
@@ -478,14 +481,39 @@ pub fn ty_kind_suggestion<'tcx>(ty: Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Option<&'sta
             .must_apply_modulo_regions()
     };
     Some(match ty.kind() {
-        ty::Bool => "true",
-        ty::Char => "'a'",
-        ty::Int(_) | ty::Uint(_) => "42",
-        ty::Float(_) => "3.14159",
-        ty::Error(_) | ty::Never => return None,
-        ty::Adt(def, _) if Some(def.did()) == tcx.get_diagnostic_item(sym::Vec) => "vec![]",
-        ty::Adt(_, _) if implements_default(ty) => "Default::default()",
-        _ => "value",
+        ty::Never | ty::Error(_) => return None,
+        ty::Bool => "false".to_string(),
+        ty::Char => "\'x\'".to_string(),
+        ty::Int(_) | ty::Uint(_) => "42".into(),
+        ty::Float(_) => "3.14159".into(),
+        ty::Slice(_) => "[]".to_string(),
+        ty::Adt(def, _) if Some(def.did()) == tcx.get_diagnostic_item(sym::Vec) => {
+            "vec![]".to_string()
+        }
+        ty::Adt(_, _) if implements_default(ty) => "Default::default()".to_string(),
+        ty::Ref(_, ty, mutability) => {
+            if let (ty::Str, Mutability::Not) = (ty.kind(), mutability) {
+                "\"\"".to_string()
+            } else {
+                let Some(ty) = ty_kind_suggestion(*ty, tcx) else {
+                    return None;
+                };
+                format!("&{}{ty}", mutability.prefix_str())
+            }
+        }
+        ty::Array(ty, len) => format!(
+            "[{}; {}]",
+            ty_kind_suggestion(*ty, tcx)?,
+            len.eval_target_usize(tcx, ty::ParamEnv::reveal_all()),
+        ),
+        ty::Tuple(tys) => format!(
+            "({})",
+            tys.iter()
+                .map(|ty| ty_kind_suggestion(ty, tcx))
+                .collect::<Option<Vec<String>>>()?
+                .join(", ")
+        ),
+        _ => "value".to_string(),
     })
 }
 
@@ -523,7 +551,7 @@ fn suggestion_signature<'tcx>(
         }
         ty::AssocKind::Const => {
             let ty = tcx.type_of(assoc.def_id).instantiate_identity();
-            let val = ty_kind_suggestion(ty, tcx).unwrap_or("todo!()");
+            let val = ty_kind_suggestion(ty, tcx).unwrap_or_else(|| "value".to_string());
             format!("const {}: {} = {};", assoc.name, ty, val)
         }
     }

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -694,10 +694,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             );
                             let error = Some(Sorts(ExpectedFound { expected: ty, found: e_ty }));
                             self.annotate_loop_expected_due_to_inference(err, expr, error);
-                            if let Some(val) = ty_kind_suggestion(ty) {
+                            if let Some(val) = ty_kind_suggestion(ty, tcx) {
                                 err.span_suggestion_verbose(
                                     expr.span.shrink_to_hi(),
-                                    "give it a value of the expected type",
+                                    "give the `break` a value of the expected type",
                                     format!(" {val}"),
                                     Applicability::HasPlaceholders,
                                 );

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -19,6 +19,8 @@
 #![feature(panic_unwind)]
 #![feature(staged_api)]
 #![feature(std_internals)]
+#![feature(strict_provenance)]
+#![feature(exposed_provenance)]
 #![feature(rustc_attrs)]
 #![panic_runtime]
 #![feature(panic_runtime)]

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -109,58 +109,80 @@ struct Exception {
 // [1]: https://www.geoffchappell.com/studies/msvc/language/predefined/
 
 #[cfg(target_arch = "x86")]
-#[macro_use]
 mod imp {
-    pub type ptr_t = *mut u8;
+    #[repr(transparent)]
+    #[derive(Copy, Clone)]
+    pub struct ptr_t(*mut u8);
 
-    macro_rules! ptr {
-        (0) => {
-            core::ptr::null_mut()
-        };
-        ($e:expr) => {
-            $e as *mut u8
-        };
+    impl ptr_t {
+        pub const fn null() -> Self {
+            Self(core::ptr::null_mut())
+        }
+
+        pub const fn new(ptr: *mut u8) -> Self {
+            Self(ptr)
+        }
     }
 }
 
 #[cfg(not(target_arch = "x86"))]
-#[macro_use]
 mod imp {
-    pub type ptr_t = u32;
+    use core::ptr::addr_of;
+
+    // On 64-bit systems, SEH represents pointers as 32-bit offsets from `__ImageBase`.
+    #[repr(transparent)]
+    #[derive(Copy, Clone)]
+    pub struct ptr_t(u32);
 
     extern "C" {
         pub static __ImageBase: u8;
     }
 
-    macro_rules! ptr {
-        (0) => (0);
-        ($e:expr) => {
-            (($e as usize) - (addr_of!(imp::__ImageBase) as usize)) as u32
+    impl ptr_t {
+        pub const fn null() -> Self {
+            Self(0)
+        }
+
+        pub fn new(ptr: *mut u8) -> Self {
+            // We need to expose the provenance of the pointer because it is not carried by
+            // the `u32`, while the FFI needs to have this provenance to excess our statics.
+            //
+            // NOTE(niluxv): we could use `MaybeUninit<u32>` instead to leak the provenance
+            // into the FFI. In theory then the other side would need to do some processing
+            // to get a pointer with correct provenance, but these system functions aren't
+            // going to be cross-lang LTOed anyway. However, using expose is shorter and
+            // requires less unsafe.
+            let addr: usize = ptr.expose_provenance();
+            let image_base = unsafe { addr_of!(__ImageBase) }.addr();
+            let offset: usize = addr - image_base;
+            Self(offset as u32)
         }
     }
 }
 
+use imp::ptr_t;
+
 #[repr(C)]
 pub struct _ThrowInfo {
     pub attributes: c_uint,
-    pub pmfnUnwind: imp::ptr_t,
-    pub pForwardCompat: imp::ptr_t,
-    pub pCatchableTypeArray: imp::ptr_t,
+    pub pmfnUnwind: ptr_t,
+    pub pForwardCompat: ptr_t,
+    pub pCatchableTypeArray: ptr_t,
 }
 
 #[repr(C)]
 pub struct _CatchableTypeArray {
     pub nCatchableTypes: c_int,
-    pub arrayOfCatchableTypes: [imp::ptr_t; 1],
+    pub arrayOfCatchableTypes: [ptr_t; 1],
 }
 
 #[repr(C)]
 pub struct _CatchableType {
     pub properties: c_uint,
-    pub pType: imp::ptr_t,
+    pub pType: ptr_t,
     pub thisDisplacement: _PMD,
     pub sizeOrOffset: c_int,
-    pub copyFunction: imp::ptr_t,
+    pub copyFunction: ptr_t,
 }
 
 #[repr(C)]
@@ -186,20 +208,20 @@ const TYPE_NAME: [u8; 11] = *b"rust_panic\0";
 
 static mut THROW_INFO: _ThrowInfo = _ThrowInfo {
     attributes: 0,
-    pmfnUnwind: ptr!(0),
-    pForwardCompat: ptr!(0),
-    pCatchableTypeArray: ptr!(0),
+    pmfnUnwind: ptr_t::null(),
+    pForwardCompat: ptr_t::null(),
+    pCatchableTypeArray: ptr_t::null(),
 };
 
 static mut CATCHABLE_TYPE_ARRAY: _CatchableTypeArray =
-    _CatchableTypeArray { nCatchableTypes: 1, arrayOfCatchableTypes: [ptr!(0)] };
+    _CatchableTypeArray { nCatchableTypes: 1, arrayOfCatchableTypes: [ptr_t::null()] };
 
 static mut CATCHABLE_TYPE: _CatchableType = _CatchableType {
     properties: 0,
-    pType: ptr!(0),
+    pType: ptr_t::null(),
     thisDisplacement: _PMD { mdisp: 0, pdisp: -1, vdisp: 0 },
     sizeOrOffset: mem::size_of::<Exception>() as c_int,
-    copyFunction: ptr!(0),
+    copyFunction: ptr_t::null(),
 };
 
 extern "C" {
@@ -246,9 +268,9 @@ macro_rules! define_cleanup {
                 super::__rust_drop_panic();
             }
         }
-        unsafe extern $abi2 fn exception_copy(_dest: *mut Exception,
-                                             _src: *mut Exception)
-                                             -> *mut Exception {
+        unsafe extern $abi2 fn exception_copy(
+            _dest: *mut Exception, _src: *mut Exception
+        ) -> *mut Exception {
             panic!("Rust panics cannot be copied");
         }
     }
@@ -296,24 +318,24 @@ pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
     // In any case, we basically need to do something like this until we can
     // express more operations in statics (and we may never be able to).
     atomic_store_seqcst(
-        addr_of_mut!(THROW_INFO.pmfnUnwind) as *mut u32,
-        ptr!(exception_cleanup) as u32,
+        addr_of_mut!(THROW_INFO.pmfnUnwind).cast(),
+        ptr_t::new(exception_cleanup as *mut u8),
     );
     atomic_store_seqcst(
-        addr_of_mut!(THROW_INFO.pCatchableTypeArray) as *mut u32,
-        ptr!(addr_of!(CATCHABLE_TYPE_ARRAY)) as u32,
+        addr_of_mut!(THROW_INFO.pCatchableTypeArray).cast(),
+        ptr_t::new(addr_of_mut!(CATCHABLE_TYPE_ARRAY).cast()),
     );
     atomic_store_seqcst(
-        addr_of_mut!(CATCHABLE_TYPE_ARRAY.arrayOfCatchableTypes[0]) as *mut u32,
-        ptr!(addr_of!(CATCHABLE_TYPE)) as u32,
+        addr_of_mut!(CATCHABLE_TYPE_ARRAY.arrayOfCatchableTypes[0]).cast(),
+        ptr_t::new(addr_of_mut!(CATCHABLE_TYPE).cast()),
     );
     atomic_store_seqcst(
-        addr_of_mut!(CATCHABLE_TYPE.pType) as *mut u32,
-        ptr!(addr_of!(TYPE_DESCRIPTOR)) as u32,
+        addr_of_mut!(CATCHABLE_TYPE.pType).cast(),
+        ptr_t::new(addr_of_mut!(TYPE_DESCRIPTOR).cast()),
     );
     atomic_store_seqcst(
-        addr_of_mut!(CATCHABLE_TYPE.copyFunction) as *mut u32,
-        ptr!(exception_copy) as u32,
+        addr_of_mut!(CATCHABLE_TYPE.copyFunction).cast(),
+        ptr_t::new(exception_copy as *mut u8),
     );
 
     extern "system-unwind" {

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -667,3 +667,24 @@ fn test_non_rs_unknown_directive_not_checked() {
     );
     assert!(!poisoned);
 }
+
+#[test]
+fn test_trailing_directive() {
+    let mut poisoned = false;
+    run_path(&mut poisoned, Path::new("a.rs"), b"//@ only-x86 only-arm");
+    assert!(poisoned);
+}
+
+#[test]
+fn test_trailing_directive_with_comment() {
+    let mut poisoned = false;
+    run_path(&mut poisoned, Path::new("a.rs"), b"//@ only-x86   only-arm with comment");
+    assert!(poisoned);
+}
+
+#[test]
+fn test_not_trailing_directive() {
+    let mut poisoned = false;
+    run_path(&mut poisoned, Path::new("a.rs"), b"//@ revisions: incremental");
+    assert!(!poisoned);
+}

--- a/tests/ui/asm/aarch64/type-check-2-2.stderr
+++ b/tests/ui/asm/aarch64/type-check-2-2.stderr
@@ -8,8 +8,8 @@ LL |         asm!("{}", in(reg) x);
    |
 help: consider assigning a value
    |
-LL |         let x: u64 = 0;
-   |                    +++
+LL |         let x: u64 = 42;
+   |                    ++++
 
 error[E0381]: used binding `y` isn't initialized
   --> $DIR/type-check-2-2.rs:22:9
@@ -21,8 +21,8 @@ LL |         asm!("{}", inout(reg) y);
    |
 help: consider assigning a value
    |
-LL |         let mut y: u64 = 0;
-   |                        +++
+LL |         let mut y: u64 = 42;
+   |                        ++++
 
 error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
   --> $DIR/type-check-2-2.rs:28:13

--- a/tests/ui/asm/x86_64/type-check-5.stderr
+++ b/tests/ui/asm/x86_64/type-check-5.stderr
@@ -8,8 +8,8 @@ LL |         asm!("{}", in(reg) x);
    |
 help: consider assigning a value
    |
-LL |         let x: u64 = 0;
-   |                    +++
+LL |         let x: u64 = 42;
+   |                    ++++
 
 error[E0381]: used binding `y` isn't initialized
   --> $DIR/type-check-5.rs:18:9
@@ -21,8 +21,8 @@ LL |         asm!("{}", inout(reg) y);
    |
 help: consider assigning a value
    |
-LL |         let mut y: u64 = 0;
-   |                        +++
+LL |         let mut y: u64 = 42;
+   |                        ++++
 
 error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
   --> $DIR/type-check-5.rs:24:13

--- a/tests/ui/binop/issue-77910-1.stderr
+++ b/tests/ui/binop/issue-77910-1.stderr
@@ -32,8 +32,8 @@ LL |     xs
    |
 help: consider assigning a value
    |
-LL |     let xs = todo!();
-   |            +++++++++
+LL |     let xs = value;
+   |            +++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/binop/issue-77910-1.stderr
+++ b/tests/ui/binop/issue-77910-1.stderr
@@ -32,8 +32,8 @@ LL |     xs
    |
 help: consider assigning a value
    |
-LL |     let xs = value;
-   |            +++++++
+LL |     let xs = &42;
+   |            +++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/binop/issue-77910-2.stderr
+++ b/tests/ui/binop/issue-77910-2.stderr
@@ -21,8 +21,8 @@ LL |     xs
    |
 help: consider assigning a value
    |
-LL |     let xs = todo!();
-   |            +++++++++
+LL |     let xs = value;
+   |            +++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/binop/issue-77910-2.stderr
+++ b/tests/ui/binop/issue-77910-2.stderr
@@ -21,8 +21,8 @@ LL |     xs
    |
 help: consider assigning a value
    |
-LL |     let xs = value;
-   |            +++++++
+LL |     let xs = &42;
+   |            +++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrowck-block-uninit.stderr
+++ b/tests/ui/borrowck/borrowck-block-uninit.stderr
@@ -10,8 +10,8 @@ LL |         println!("{}", x);
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-break-uninit-2.stderr
+++ b/tests/ui/borrowck/borrowck-break-uninit-2.stderr
@@ -10,8 +10,8 @@ LL |     println!("{}", x);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-break-uninit.stderr
+++ b/tests/ui/borrowck/borrowck-break-uninit.stderr
@@ -10,8 +10,8 @@ LL |     println!("{}", x);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-init-in-called-fn-expr.stderr
+++ b/tests/ui/borrowck/borrowck-init-in-called-fn-expr.stderr
@@ -8,8 +8,8 @@ LL |         i
    |
 help: consider assigning a value
    |
-LL |         let i: isize = 0;
-   |                      +++
+LL |         let i: isize = 42;
+   |                      ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-init-in-fn-expr.stderr
+++ b/tests/ui/borrowck/borrowck-init-in-fn-expr.stderr
@@ -8,8 +8,8 @@ LL |         i
    |
 help: consider assigning a value
    |
-LL |         let i: isize = 0;
-   |                      +++
+LL |         let i: isize = 42;
+   |                      ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-init-in-fru.stderr
+++ b/tests/ui/borrowck/borrowck-init-in-fru.stderr
@@ -8,8 +8,8 @@ LL |     origin = Point { x: 10, ..origin };
    |
 help: consider assigning a value
    |
-LL |     let mut origin: Point = todo!();
-   |                           +++++++++
+LL |     let mut origin: Point = value;
+   |                           +++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-init-op-equal.stderr
+++ b/tests/ui/borrowck/borrowck-init-op-equal.stderr
@@ -8,8 +8,8 @@ LL |     v += 1;
    |
 help: consider assigning a value
    |
-LL |     let v: isize = 0;
-   |                  +++
+LL |     let v: isize = 42;
+   |                  ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-init-plus-equal.stderr
+++ b/tests/ui/borrowck/borrowck-init-plus-equal.stderr
@@ -8,8 +8,8 @@ LL |     v = v + 1;
    |
 help: consider assigning a value
    |
-LL |     let mut v: isize = 0;
-   |                      +++
+LL |     let mut v: isize = 42;
+   |                      ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-return.stderr
+++ b/tests/ui/borrowck/borrowck-return.stderr
@@ -8,8 +8,8 @@ LL |     return x;
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-storage-dead.stderr
+++ b/tests/ui/borrowck/borrowck-storage-dead.stderr
@@ -8,8 +8,8 @@ LL |         let _ = x + 1;
    |
 help: consider assigning a value
    |
-LL |         let x: i32 = 0;
-   |                    +++
+LL |         let x: i32 = 42;
+   |                    ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-uninit-after-item.stderr
+++ b/tests/ui/borrowck/borrowck-uninit-after-item.stderr
@@ -9,8 +9,8 @@ LL |     baz(bar);
    |
 help: consider assigning a value
    |
-LL |     let bar = 0;
-   |             +++
+LL |     let bar = 42;
+   |             ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-uninit-in-assignop.stderr
+++ b/tests/ui/borrowck/borrowck-uninit-in-assignop.stderr
@@ -8,8 +8,8 @@ LL |     x += 1;
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-in-assignop.rs:9:5
@@ -21,8 +21,8 @@ LL |     x -= 1;
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-in-assignop.rs:12:5
@@ -34,8 +34,8 @@ LL |     x *= 1;
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-in-assignop.rs:15:5
@@ -47,8 +47,8 @@ LL |     x /= 1;
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-in-assignop.rs:18:5
@@ -60,8 +60,8 @@ LL |     x %= 1;
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-in-assignop.rs:21:5
@@ -73,8 +73,8 @@ LL |     x ^= 1;
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-in-assignop.rs:24:5
@@ -86,8 +86,8 @@ LL |     x &= 1;
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-in-assignop.rs:27:5
@@ -99,8 +99,8 @@ LL |     x |= 1;
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-in-assignop.rs:30:5
@@ -112,8 +112,8 @@ LL |     x <<= 1;
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-in-assignop.rs:33:5
@@ -125,8 +125,8 @@ LL |     x >>= 1;
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/borrowck/borrowck-uninit-ref-chain.stderr
+++ b/tests/ui/borrowck/borrowck-uninit-ref-chain.stderr
@@ -8,8 +8,8 @@ LL |     let _y = &**x;
    |
 help: consider assigning a value
    |
-LL |     let x: &&Box<i32> = todo!();
-   |                       +++++++++
+LL |     let x: &&Box<i32> = value;
+   |                       +++++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-ref-chain.rs:11:14
@@ -21,8 +21,8 @@ LL |     let _y = &**x;
    |
 help: consider assigning a value
    |
-LL |     let x: &&S<i32, i32> = todo!();
-   |                          +++++++++
+LL |     let x: &&S<i32, i32> = value;
+   |                          +++++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-ref-chain.rs:14:14
@@ -34,8 +34,8 @@ LL |     let _y = &**x;
    |
 help: consider assigning a value
    |
-LL |     let x: &&i32 = todo!();
-   |                  +++++++++
+LL |     let x: &&i32 = value;
+   |                  +++++++
 
 error[E0381]: partially assigned binding `a` isn't fully initialized
   --> $DIR/borrowck-uninit-ref-chain.rs:18:5

--- a/tests/ui/borrowck/borrowck-uninit-ref-chain.stderr
+++ b/tests/ui/borrowck/borrowck-uninit-ref-chain.stderr
@@ -8,8 +8,8 @@ LL |     let _y = &**x;
    |
 help: consider assigning a value
    |
-LL |     let x: &&Box<i32> = &&Default::default();
-   |                       ++++++++++++++++++++++
+LL |     let x: &&Box<i32> = &&Box::new(42);
+   |                       ++++++++++++++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-ref-chain.rs:11:14

--- a/tests/ui/borrowck/borrowck-uninit-ref-chain.stderr
+++ b/tests/ui/borrowck/borrowck-uninit-ref-chain.stderr
@@ -8,8 +8,8 @@ LL |     let _y = &**x;
    |
 help: consider assigning a value
    |
-LL |     let x: &&Box<i32> = value;
-   |                       +++++++
+LL |     let x: &&Box<i32> = &&Default::default();
+   |                       ++++++++++++++++++++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-ref-chain.rs:11:14
@@ -21,8 +21,8 @@ LL |     let _y = &**x;
    |
 help: consider assigning a value
    |
-LL |     let x: &&S<i32, i32> = value;
-   |                          +++++++
+LL |     let x: &&S<i32, i32> = &&value;
+   |                          +++++++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-ref-chain.rs:14:14
@@ -34,8 +34,8 @@ LL |     let _y = &**x;
    |
 help: consider assigning a value
    |
-LL |     let x: &&i32 = value;
-   |                  +++++++
+LL |     let x: &&i32 = &&42;
+   |                  ++++++
 
 error[E0381]: partially assigned binding `a` isn't fully initialized
   --> $DIR/borrowck-uninit-ref-chain.rs:18:5

--- a/tests/ui/borrowck/borrowck-uninit.stderr
+++ b/tests/ui/borrowck/borrowck-uninit.stderr
@@ -8,8 +8,8 @@ LL |     foo(x);
    |
 help: consider assigning a value
    |
-LL |     let x: isize = 0;
-   |                  +++
+LL |     let x: isize = 42;
+   |                  ++++
 
 error[E0381]: used binding `a` isn't initialized
   --> $DIR/borrowck-uninit.rs:14:32

--- a/tests/ui/borrowck/borrowck-use-in-index-lvalue.fixed
+++ b/tests/ui/borrowck/borrowck-use-in-index-lvalue.fixed
@@ -1,10 +1,10 @@
 //@ run-rustfix
 #[allow(unused_mut)]
 fn test() {
-    let w: &mut [isize];
+    let w: &mut [isize] = &mut [];
     w[5] = 0; //~ ERROR [E0381]
 
-    let mut w: &mut [isize];
+    let mut w: &mut [isize] = &mut [];
     w[5] = 0; //~ ERROR [E0381]
 }
 

--- a/tests/ui/borrowck/borrowck-use-in-index-lvalue.stderr
+++ b/tests/ui/borrowck/borrowck-use-in-index-lvalue.stderr
@@ -8,8 +8,8 @@ LL |     w[5] = 0;
    |
 help: consider assigning a value
    |
-LL |     let w: &mut [isize] = todo!();
-   |                         +++++++++
+LL |     let w: &mut [isize] = value;
+   |                         +++++++
 
 error[E0381]: used binding `w` isn't initialized
   --> $DIR/borrowck-use-in-index-lvalue.rs:6:5
@@ -21,8 +21,8 @@ LL |     w[5] = 0;
    |
 help: consider assigning a value
    |
-LL |     let mut w: &mut [isize] = todo!();
-   |                             +++++++++
+LL |     let mut w: &mut [isize] = value;
+   |                             +++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrowck-use-in-index-lvalue.stderr
+++ b/tests/ui/borrowck/borrowck-use-in-index-lvalue.stderr
@@ -1,5 +1,5 @@
 error[E0381]: used binding `w` isn't initialized
-  --> $DIR/borrowck-use-in-index-lvalue.rs:3:5
+  --> $DIR/borrowck-use-in-index-lvalue.rs:5:5
    |
 LL |     let w: &mut [isize];
    |         - binding declared here but left uninitialized
@@ -8,11 +8,11 @@ LL |     w[5] = 0;
    |
 help: consider assigning a value
    |
-LL |     let w: &mut [isize] = value;
-   |                         +++++++
+LL |     let w: &mut [isize] = &mut [];
+   |                         +++++++++
 
 error[E0381]: used binding `w` isn't initialized
-  --> $DIR/borrowck-use-in-index-lvalue.rs:6:5
+  --> $DIR/borrowck-use-in-index-lvalue.rs:8:5
    |
 LL |     let mut w: &mut [isize];
    |         ----- binding declared here but left uninitialized
@@ -21,8 +21,8 @@ LL |     w[5] = 0;
    |
 help: consider assigning a value
    |
-LL |     let mut w: &mut [isize] = value;
-   |                             +++++++
+LL |     let mut w: &mut [isize] = &mut [];
+   |                             +++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrowck-use-uninitialized-in-cast-trait.fixed
+++ b/tests/ui/borrowck/borrowck-use-uninitialized-in-cast-trait.fixed
@@ -7,6 +7,6 @@ trait Foo { fn dummy(&self) { } }
 impl Foo for i32 { }
 
 fn main() {
-    let x: &i32;
+    let x: &i32 = &42;
     let y = x as *const dyn Foo; //~ ERROR [E0381]
 }

--- a/tests/ui/borrowck/borrowck-use-uninitialized-in-cast-trait.stderr
+++ b/tests/ui/borrowck/borrowck-use-uninitialized-in-cast-trait.stderr
@@ -8,8 +8,8 @@ LL |     let y = x as *const dyn Foo;
    |
 help: consider assigning a value
    |
-LL |     let x: &i32 = todo!();
-   |                 +++++++++
+LL |     let x: &i32 = value;
+   |                 +++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-use-uninitialized-in-cast-trait.stderr
+++ b/tests/ui/borrowck/borrowck-use-uninitialized-in-cast-trait.stderr
@@ -1,5 +1,5 @@
 error[E0381]: used binding `x` isn't initialized
-  --> $DIR/borrowck-use-uninitialized-in-cast-trait.rs:9:13
+  --> $DIR/borrowck-use-uninitialized-in-cast-trait.rs:11:13
    |
 LL |     let x: &i32;
    |         - binding declared here but left uninitialized
@@ -8,8 +8,8 @@ LL |     let y = x as *const dyn Foo;
    |
 help: consider assigning a value
    |
-LL |     let x: &i32 = value;
-   |                 +++++++
+LL |     let x: &i32 = &42;
+   |                 +++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-use-uninitialized-in-cast.fixed
+++ b/tests/ui/borrowck/borrowck-use-uninitialized-in-cast.fixed
@@ -5,6 +5,6 @@
 #![allow(unused_variables)]
 
 fn main() {
-    let x: &i32;
+    let x: &i32 = &42;
     let y = x as *const i32; //~ ERROR [E0381]
 }

--- a/tests/ui/borrowck/borrowck-use-uninitialized-in-cast.stderr
+++ b/tests/ui/borrowck/borrowck-use-uninitialized-in-cast.stderr
@@ -8,8 +8,8 @@ LL |     let y = x as *const i32;
    |
 help: consider assigning a value
    |
-LL |     let x: &i32 = todo!();
-   |                 +++++++++
+LL |     let x: &i32 = value;
+   |                 +++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-use-uninitialized-in-cast.stderr
+++ b/tests/ui/borrowck/borrowck-use-uninitialized-in-cast.stderr
@@ -1,5 +1,5 @@
 error[E0381]: used binding `x` isn't initialized
-  --> $DIR/borrowck-use-uninitialized-in-cast.rs:7:13
+  --> $DIR/borrowck-use-uninitialized-in-cast.rs:9:13
    |
 LL |     let x: &i32;
    |         - binding declared here but left uninitialized
@@ -8,8 +8,8 @@ LL |     let y = x as *const i32;
    |
 help: consider assigning a value
    |
-LL |     let x: &i32 = value;
-   |                 +++++++
+LL |     let x: &i32 = &42;
+   |                 +++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-103250.stderr
+++ b/tests/ui/borrowck/issue-103250.stderr
@@ -9,8 +9,8 @@ LL |         Err(last_error)
    |
 help: consider assigning a value
    |
-LL |         let mut last_error: Box<dyn std::error::Error> = todo!();
-   |                                                        +++++++++
+LL |         let mut last_error: Box<dyn std::error::Error> = value;
+   |                                                        +++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-103250.stderr
+++ b/tests/ui/borrowck/issue-103250.stderr
@@ -9,8 +9,8 @@ LL |         Err(last_error)
    |
 help: consider assigning a value
    |
-LL |         let mut last_error: Box<dyn std::error::Error> = value;
-   |                                                        +++++++
+LL |         let mut last_error: Box<dyn std::error::Error> = Box::new(value);
+   |                                                        +++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-24267-flow-exit.stderr
+++ b/tests/ui/borrowck/issue-24267-flow-exit.stderr
@@ -10,8 +10,8 @@ LL |     println!("{}", x);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let x: i32 = 0;
-   |                +++
+LL |     let x: i32 = 42;
+   |                ++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/issue-24267-flow-exit.rs:18:20
@@ -25,8 +25,8 @@ LL |     println!("{}", x);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let x: i32 = 0;
-   |                +++
+LL |     let x: i32 = 42;
+   |                ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/issue-62107-match-arm-scopes.stderr
+++ b/tests/ui/borrowck/issue-62107-match-arm-scopes.stderr
@@ -9,8 +9,8 @@ LL |         ref u if true => {}
    |
 help: consider assigning a value
    |
-LL |     let e: i32 = 0;
-   |                +++
+LL |     let e: i32 = 42;
+   |                ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/suggest-assign-rvalue.stderr
+++ b/tests/ui/borrowck/suggest-assign-rvalue.stderr
@@ -50,8 +50,8 @@ LL |     println!("demo_no: {:?}", demo_no);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let demo_no: DemoNoDef = todo!();
-   |                            +++++++++
+LL |     let demo_no: DemoNoDef = value;
+   |                            +++++++
 
 error[E0381]: used binding `arr` isn't initialized
   --> $DIR/suggest-assign-rvalue.rs:34:27
@@ -64,8 +64,8 @@ LL |     println!("arr: {:?}", arr);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let arr: [i32; 5] = todo!();
-   |                       +++++++++
+LL |     let arr: [i32; 5] = value;
+   |                       +++++++
 
 error[E0381]: used binding `foo` isn't initialized
   --> $DIR/suggest-assign-rvalue.rs:37:27
@@ -106,8 +106,8 @@ LL |     println!("my_int: {}", *my_int);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let my_int: &i32 = todo!();
-   |                      +++++++++
+LL |     let my_int: &i32 = value;
+   |                      +++++++
 
 error[E0381]: used binding `hello` isn't initialized
   --> $DIR/suggest-assign-rvalue.rs:49:27
@@ -120,8 +120,8 @@ LL |     println!("hello: {}", hello);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let hello: &str = todo!();
-   |                     +++++++++
+LL |     let hello: &str = value;
+   |                     +++++++
 
 error[E0381]: used binding `never` isn't initialized
   --> $DIR/suggest-assign-rvalue.rs:53:27

--- a/tests/ui/borrowck/suggest-assign-rvalue.stderr
+++ b/tests/ui/borrowck/suggest-assign-rvalue.stderr
@@ -8,8 +8,8 @@ LL |     apple(chaenomeles);
    |
 help: consider assigning a value
    |
-LL |     let chaenomeles = 0;
-   |                     +++
+LL |     let chaenomeles = 42;
+   |                     ++++
 
 error[E0381]: used binding `my_float` isn't initialized
   --> $DIR/suggest-assign-rvalue.rs:23:30
@@ -22,8 +22,8 @@ LL |     println!("my_float: {}", my_float);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let my_float: f32 = 0.0;
-   |                       +++++
+LL |     let my_float: f32 = 3.14159;
+   |                       +++++++++
 
 error[E0381]: used binding `demo` isn't initialized
   --> $DIR/suggest-assign-rvalue.rs:26:28
@@ -64,8 +64,8 @@ LL |     println!("arr: {:?}", arr);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let arr: [i32; 5] = value;
-   |                       +++++++
+LL |     let arr: [i32; 5] = [42; 5];
+   |                       +++++++++
 
 error[E0381]: used binding `foo` isn't initialized
   --> $DIR/suggest-assign-rvalue.rs:37:27
@@ -106,8 +106,8 @@ LL |     println!("my_int: {}", *my_int);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let my_int: &i32 = value;
-   |                      +++++++
+LL |     let my_int: &i32 = &42;
+   |                      +++++
 
 error[E0381]: used binding `hello` isn't initialized
   --> $DIR/suggest-assign-rvalue.rs:49:27
@@ -120,8 +120,8 @@ LL |     println!("hello: {}", hello);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let hello: &str = value;
-   |                     +++++++
+LL |     let hello: &str = "";
+   |                     ++++
 
 error[E0381]: used binding `never` isn't initialized
   --> $DIR/suggest-assign-rvalue.rs:53:27

--- a/tests/ui/closures/2229_closure_analysis/match/pattern-matching-should-fail.stderr
+++ b/tests/ui/closures/2229_closure_analysis/match/pattern-matching-should-fail.stderr
@@ -79,8 +79,8 @@ LL |     let c1 = || match x { };
    |
 help: consider assigning a value
    |
-LL |     let x: u8 = 0;
-   |               +++
+LL |     let x: u8 = 42;
+   |               ++++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/const-generics/const-generic-default-wont-borrowck.fixed
+++ b/tests/ui/const-generics/const-generic-default-wont-borrowck.fixed
@@ -1,6 +1,6 @@
 //@ run-rustfix
 pub struct X<const N: usize = {
-    let s: &'static str; s.len() //~ ERROR E0381
+    let s: &'static str = ""; s.len() //~ ERROR E0381
 }>;
 
 fn main() {}

--- a/tests/ui/const-generics/const-generic-default-wont-borrowck.stderr
+++ b/tests/ui/const-generics/const-generic-default-wont-borrowck.stderr
@@ -8,8 +8,8 @@ LL |     let s: &'static str; s.len()
    |
 help: consider assigning a value
    |
-LL |     let s: &'static str = todo!(); s.len()
-   |                         +++++++++
+LL |     let s: &'static str = value; s.len()
+   |                         +++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/const-generic-default-wont-borrowck.stderr
+++ b/tests/ui/const-generics/const-generic-default-wont-borrowck.stderr
@@ -1,5 +1,5 @@
 error[E0381]: used binding `s` isn't initialized
-  --> $DIR/const-generic-default-wont-borrowck.rs:2:26
+  --> $DIR/const-generic-default-wont-borrowck.rs:3:26
    |
 LL |     let s: &'static str; s.len()
    |         -                ^ `*s` used here but it isn't initialized
@@ -8,8 +8,8 @@ LL |     let s: &'static str; s.len()
    |
 help: consider assigning a value
    |
-LL |     let s: &'static str = value; s.len()
-   |                         +++++++
+LL |     let s: &'static str = ""; s.len()
+   |                         ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-78655.stderr
+++ b/tests/ui/consts/issue-78655.stderr
@@ -8,8 +8,8 @@ LL |     &x
    |
 help: consider assigning a value
    |
-LL |     let x = 0;
-   |           +++
+LL |     let x = 42;
+   |           ++++
 
 error: could not evaluate constant pattern
   --> $DIR/issue-78655.rs:7:9

--- a/tests/ui/drop/repeat-drop-2.stderr
+++ b/tests/ui/drop/repeat-drop-2.stderr
@@ -32,8 +32,8 @@ LL |     let _ = [x; 0];
    |
 help: consider assigning a value
    |
-LL |     let x: u8 = 0;
-   |               +++
+LL |     let x: u8 = 42;
+   |               ++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/issues/issue-27042.stderr
+++ b/tests/ui/issues/issue-27042.stderr
@@ -19,7 +19,7 @@ LL |         loop { break };
    |         |
    |         this loop is expected to be of type `i32`
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |         loop { break 42 };
    |                      ++

--- a/tests/ui/loops/loop-break-value.rs
+++ b/tests/ui/loops/loop-break-value.rs
@@ -23,6 +23,10 @@ fn main() {
         };
     };
 
+    let _: Option<String> = loop {
+        break; //~ ERROR mismatched types
+    };
+
     'while_loop: while true { //~ WARN denote infinite loops with
         break;
         break (); //~ ERROR `break` with value from a `while` loop

--- a/tests/ui/loops/loop-break-value.stderr
+++ b/tests/ui/loops/loop-break-value.stderr
@@ -1,5 +1,5 @@
 warning: label name `'a` shadows a label name that is already in scope
-  --> $DIR/loop-break-value.rs:136:17
+  --> $DIR/loop-break-value.rs:140:17
    |
 LL |     'a: loop {
    |     -- first declared here
@@ -8,7 +8,7 @@ LL |         let _ = 'a: loop {
    |                 ^^ label `'a` already in scope
 
 warning: label name `'a` shadows a label name that is already in scope
-  --> $DIR/loop-break-value.rs:148:17
+  --> $DIR/loop-break-value.rs:152:17
    |
 LL |     'a: loop {
    |     -- first declared here
@@ -17,7 +17,7 @@ LL |         let _ = 'a: loop {
    |                 ^^ label `'a` already in scope
 
 error[E0425]: cannot find value `LOOP` in this scope
-  --> $DIR/loop-break-value.rs:95:15
+  --> $DIR/loop-break-value.rs:99:15
    |
 LL |     'LOOP: for _ in 0 .. 9 {
    |     ----- a label with a similar name exists
@@ -28,7 +28,7 @@ LL |         break LOOP;
    |               help: use the similarly named label: `'LOOP`
 
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/loop-break-value.rs:26:5
+  --> $DIR/loop-break-value.rs:30:5
    |
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
@@ -36,7 +36,7 @@ LL |     'while_loop: while true {
    = note: `#[warn(while_true)]` on by default
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/loop-break-value.rs:28:9
+  --> $DIR/loop-break-value.rs:32:9
    |
 LL |     'while_loop: while true {
    |     ----------------------- you can't `break` with a value in a `while` loop
@@ -54,7 +54,7 @@ LL |         break 'while_loop;
    |               ~~~~~~~~~~~
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/loop-break-value.rs:30:13
+  --> $DIR/loop-break-value.rs:34:13
    |
 LL |     'while_loop: while true {
    |     ----------------------- you can't `break` with a value in a `while` loop
@@ -68,7 +68,7 @@ LL |             break 'while_loop;
    |             ~~~~~~~~~~~~~~~~~
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/loop-break-value.rs:38:12
+  --> $DIR/loop-break-value.rs:42:12
    |
 LL |     while let Some(_) = Some(()) {
    |     ---------------------------- you can't `break` with a value in a `while` loop
@@ -81,7 +81,7 @@ LL |         if break {
    |            ~~~~~
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/loop-break-value.rs:43:9
+  --> $DIR/loop-break-value.rs:47:9
    |
 LL |     while let Some(_) = Some(()) {
    |     ---------------------------- you can't `break` with a value in a `while` loop
@@ -94,7 +94,7 @@ LL |         break;
    |         ~~~~~
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/loop-break-value.rs:49:13
+  --> $DIR/loop-break-value.rs:53:13
    |
 LL |     'while_let_loop: while let Some(_) = Some(()) {
    |     --------------------------------------------- you can't `break` with a value in a `while` loop
@@ -108,7 +108,7 @@ LL |             break 'while_let_loop;
    |             ~~~~~~~~~~~~~~~~~~~~~
 
 error[E0571]: `break` with value from a `for` loop
-  --> $DIR/loop-break-value.rs:56:9
+  --> $DIR/loop-break-value.rs:60:9
    |
 LL |     for _ in &[1,2,3] {
    |     ----------------- you can't `break` with a value in a `for` loop
@@ -121,7 +121,7 @@ LL |         break;
    |         ~~~~~
 
 error[E0571]: `break` with value from a `for` loop
-  --> $DIR/loop-break-value.rs:57:9
+  --> $DIR/loop-break-value.rs:61:9
    |
 LL |     for _ in &[1,2,3] {
    |     ----------------- you can't `break` with a value in a `for` loop
@@ -135,7 +135,7 @@ LL |         break;
    |         ~~~~~
 
 error[E0571]: `break` with value from a `for` loop
-  --> $DIR/loop-break-value.rs:64:13
+  --> $DIR/loop-break-value.rs:68:13
    |
 LL |     'for_loop: for _ in &[1,2,3] {
    |     ---------------------------- you can't `break` with a value in a `for` loop
@@ -191,7 +191,24 @@ LL |             break 'outer_loop "nope";
    |                               ^^^^^^ expected `i32`, found `&str`
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:73:26
+  --> $DIR/loop-break-value.rs:27:9
+   |
+LL |     let _: Option<String> = loop {
+   |         -                   ---- this loop is expected to be of type `Option<String>`
+   |         |
+   |         expected because of this assignment
+LL |         break;
+   |         ^^^^^ expected `Option<String>`, found `()`
+   |
+   = note:   expected enum `Option<String>`
+           found unit type `()`
+help: give the `break` a value of the expected type
+   |
+LL |         break Default::default();
+   |               ++++++++++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/loop-break-value.rs:77:26
    |
 LL |                 break;
    |                 ----- expected because of this `break`
@@ -199,7 +216,7 @@ LL |                 break 'c 123;
    |                          ^^^ expected `()`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:80:15
+  --> $DIR/loop-break-value.rs:84:15
    |
 LL |         break (break, break);
    |               ^-----^^-----^
@@ -212,7 +229,7 @@ LL |         break (break, break);
                   found tuple `(!, !)`
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:85:15
+  --> $DIR/loop-break-value.rs:89:15
    |
 LL |         break;
    |         ----- expected because of this `break`
@@ -220,20 +237,20 @@ LL |         break 2;
    |               ^ expected `()`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:90:9
+  --> $DIR/loop-break-value.rs:94:9
    |
 LL |         break 2;
    |         ------- expected because of this `break`
 LL |         break;
    |         ^^^^^ expected integer, found `()`
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |         break value;
    |               +++++
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:108:9
+  --> $DIR/loop-break-value.rs:112:9
    |
 LL |                     break 'a 1;
    |                     ---------- expected because of this `break`
@@ -241,13 +258,13 @@ LL |                     break 'a 1;
 LL |         break;
    |         ^^^^^ expected integer, found `()`
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |         break value;
    |               +++++
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:120:9
+  --> $DIR/loop-break-value.rs:124:9
    |
 LL |                     break 'a 1;
    |                     ---------- expected because of this `break`
@@ -255,13 +272,13 @@ LL |                     break 'a 1;
 LL |         break 'a;
    |         ^^^^^^^^ expected integer, found `()`
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |         break 'a value;
    |                  +++++
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:131:15
+  --> $DIR/loop-break-value.rs:135:15
    |
 LL |         break;
    |         ----- expected because of this `break`
@@ -270,7 +287,7 @@ LL |         break 2;
    |               ^ expected `()`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:140:17
+  --> $DIR/loop-break-value.rs:144:17
    |
 LL |             break 2;
    |             ------- expected because of this `break`
@@ -278,13 +295,13 @@ LL |             loop {
 LL |                 break 'a;
    |                 ^^^^^^^^ expected integer, found `()`
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |                 break 'a value;
    |                          +++++
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:143:15
+  --> $DIR/loop-break-value.rs:147:15
    |
 LL |         break;
    |         ----- expected because of this `break`
@@ -293,7 +310,7 @@ LL |         break 2;
    |               ^ expected `()`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:152:17
+  --> $DIR/loop-break-value.rs:156:17
    |
 LL |             break 'a 2;
    |             ---------- expected because of this `break`
@@ -301,13 +318,13 @@ LL |             loop {
 LL |                 break 'a;
    |                 ^^^^^^^^ expected integer, found `()`
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |                 break 'a value;
    |                          +++++
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:155:15
+  --> $DIR/loop-break-value.rs:159:15
    |
 LL |         break;
    |         ----- expected because of this `break`
@@ -316,7 +333,7 @@ LL |         break 2;
    |               ^ expected `()`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/loop-break-value.rs:159:15
+  --> $DIR/loop-break-value.rs:163:15
    |
 LL | fn main() {
    |          - expected `()` because of this return type
@@ -326,7 +343,7 @@ LL |     loop { // point at the return type
 LL |         break 2;
    |               ^ expected `()`, found integer
 
-error: aborting due to 25 previous errors; 3 warnings emitted
+error: aborting due to 26 previous errors; 3 warnings emitted
 
 Some errors have detailed explanations: E0308, E0425, E0571.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/loops/loop-break-value.stderr
+++ b/tests/ui/loops/loop-break-value.stderr
@@ -204,8 +204,8 @@ LL |         break;
            found unit type `()`
 help: give the `break` a value of the expected type
    |
-LL |         break Default::default();
-   |               ++++++++++++++++++
+LL |         break None;
+   |               ++++
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:77:26

--- a/tests/ui/loops/loop-labeled-break-value.stderr
+++ b/tests/ui/loops/loop-labeled-break-value.stderr
@@ -7,7 +7,7 @@ LL |         let _: i32 = loop { break };
    |             |        this loop is expected to be of type `i32`
    |             expected because of this assignment
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |         let _: i32 = loop { break 42 };
    |                                   ++
@@ -21,7 +21,7 @@ LL |         let _: i32 = 'inner: loop { break 'inner };
    |             |                this loop is expected to be of type `i32`
    |             expected because of this assignment
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |         let _: i32 = 'inner: loop { break 'inner 42 };
    |                                                  ++
@@ -35,7 +35,7 @@ LL |         let _: i32 = 'inner2: loop { loop { break 'inner2 } };
    |             |                 this loop is expected to be of type `i32`
    |             expected because of this assignment
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |         let _: i32 = 'inner2: loop { loop { break 'inner2 42 } };
    |                                                           ++

--- a/tests/ui/loops/loop-proper-liveness.stderr
+++ b/tests/ui/loops/loop-proper-liveness.stderr
@@ -10,8 +10,8 @@ LL |     println!("{:?}", x);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let x: i32 = 0;
-   |                +++
+LL |     let x: i32 = 42;
+   |                ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/loops/loop-properly-diverging-2.stderr
+++ b/tests/ui/loops/loop-properly-diverging-2.stderr
@@ -7,7 +7,7 @@ LL |   let x: i32 = loop { break };
    |       |        this loop is expected to be of type `i32`
    |       expected because of this assignment
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |   let x: i32 = loop { break 42 };
    |                             ++

--- a/tests/ui/moves/issue-72649-uninit-in-loop.stderr
+++ b/tests/ui/moves/issue-72649-uninit-in-loop.stderr
@@ -56,8 +56,8 @@ LL |         let _used = value;
    |
 help: consider assigning a value
    |
-LL |         let value: NonCopy = todo!();
-   |                            +++++++++
+LL |         let value: NonCopy = value;
+   |                            +++++++
 
 error[E0381]: used binding `value` isn't initialized
   --> $DIR/issue-72649-uninit-in-loop.rs:69:21
@@ -70,8 +70,8 @@ LL |         let _used = value;
    |
 help: consider assigning a value
    |
-LL |     let mut value: NonCopy = todo!();
-   |                            +++++++++
+LL |     let mut value: NonCopy = value;
+   |                            +++++++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/moves/move-into-dead-array-1.stderr
+++ b/tests/ui/moves/move-into-dead-array-1.stderr
@@ -8,8 +8,8 @@ LL |     a[i] = d();
    |
 help: consider assigning a value
    |
-LL |     let mut a: [D; 4] = value;
-   |                       +++++++
+LL |     let mut a: [D; 4] = [value; 4];
+   |                       ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/moves/move-into-dead-array-1.stderr
+++ b/tests/ui/moves/move-into-dead-array-1.stderr
@@ -8,8 +8,8 @@ LL |     a[i] = d();
    |
 help: consider assigning a value
    |
-LL |     let mut a: [D; 4] = todo!();
-   |                       +++++++++
+LL |     let mut a: [D; 4] = value;
+   |                       +++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/moves/move-of-addr-of-mut.stderr
+++ b/tests/ui/moves/move-of-addr-of-mut.stderr
@@ -9,8 +9,8 @@ LL |     std::ptr::addr_of_mut!(x);
    = note: this error originates in the macro `std::ptr::addr_of_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let mut x: S = todo!();
-   |                  +++++++++
+LL |     let mut x: S = value;
+   |                  +++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/never_type/issue-52443.stderr
+++ b/tests/ui/never_type/issue-52443.stderr
@@ -36,7 +36,7 @@ error[E0308]: mismatched types
 LL |     [(); loop { break }];
    |                 ^^^^^ expected `usize`, found `()`
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |     [(); loop { break 42 }];
    |                       ++

--- a/tests/ui/nll/match-cfg-fake-edges.stderr
+++ b/tests/ui/nll/match-cfg-fake-edges.stderr
@@ -126,8 +126,8 @@ LL |         _ if { x; false } => 2,
    |
 help: consider assigning a value
    |
-LL |     let x = 0;
-   |           +++
+LL |     let x = 42;
+   |           ++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/match-cfg-fake-edges.rs:86:31
@@ -142,8 +142,8 @@ LL |         _ if let Some(()) = { x; None } => 2,
    |
 help: consider assigning a value
    |
-LL |     let x = 0;
-   |           +++
+LL |     let x = 42;
+   |           ++++
 
 error[E0382]: use of moved value: `x`
   --> $DIR/match-cfg-fake-edges.rs:99:22

--- a/tests/ui/nll/match-on-borrowed.stderr
+++ b/tests/ui/nll/match-on-borrowed.stderr
@@ -43,8 +43,8 @@ LL |     match n {}
    |
 help: consider assigning a value
    |
-LL |     let n: Never = todo!();
-   |                  +++++++++
+LL |     let n: Never = value;
+   |                  +++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/type/type-error-break-tail.stderr
+++ b/tests/ui/type/type-error-break-tail.stderr
@@ -8,7 +8,7 @@ LL |     loop {
 LL |         if false { break; }
    |                    ^^^^^ expected `i32`, found `()`
    |
-help: give it a value of the expected type
+help: give the `break` a value of the expected type
    |
 LL |         if false { break 42; }
    |                          ++

--- a/tests/ui/uninhabited/privately-uninhabited-mir-call.fixed
+++ b/tests/ui/uninhabited/privately-uninhabited-mir-call.fixed
@@ -23,7 +23,7 @@ pub mod widget {
 }
 
 fn main() {
-    let y: &mut u32;
+    let y: &mut u32 = &mut 42;
     widget::Widget::new();
     // Error. Widget type is not known to be uninhabited here,
     // so the following code is considered reachable.

--- a/tests/ui/uninhabited/privately-uninhabited-mir-call.stderr
+++ b/tests/ui/uninhabited/privately-uninhabited-mir-call.stderr
@@ -1,5 +1,5 @@
 error[E0381]: used binding `y` isn't initialized
-  --> $DIR/privately-uninhabited-mir-call.rs:28:5
+  --> $DIR/privately-uninhabited-mir-call.rs:30:5
    |
 LL |     let y: &mut u32;
    |         - binding declared here but left uninitialized
@@ -9,8 +9,8 @@ LL |     *y = 2;
    |
 help: consider assigning a value
    |
-LL |     let y: &mut u32 = value;
-   |                     +++++++
+LL |     let y: &mut u32 = &mut 42;
+   |                     +++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/uninhabited/privately-uninhabited-mir-call.stderr
+++ b/tests/ui/uninhabited/privately-uninhabited-mir-call.stderr
@@ -9,8 +9,8 @@ LL |     *y = 2;
    |
 help: consider assigning a value
    |
-LL |     let y: &mut u32 = todo!();
-   |                     +++++++++
+LL |     let y: &mut u32 = value;
+   |                     +++++++
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Successful merges:

 - #123490 (Refactor `panic_unwind/seh.rs` pointer use)
 - #123704 (Tweak value suggestions in `borrowck` and `hir_analysis`)
 - #123753 (compiletest: error when finding a trailing directive)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=123490,123704,123753)
<!-- homu-ignore:end -->