### PR TITLE
Require explicitly marking closures as coroutines

### DIFF
--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -163,3 +163,6 @@ ast_lowering_underscore_expr_lhs_assign =
     .label = `_` not allowed here
 
 ast_lowering_use_angle_brackets = use angle brackets instead
+ast_lowering_yield_in_closure =
+    `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+    .suggestion = use `#[coroutine]` to make this closure a coroutine

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -421,3 +421,12 @@ pub(crate) struct NoPreciseCapturesOnApit {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(ast_lowering_yield_in_closure)]
+pub(crate) struct YieldInClosure {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(code = "#[coroutine] ", applicability = "maybe-incorrect", style = "verbose")]
+    pub suggestion: Option<Span>,
+}

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -203,7 +203,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 body,
                 ..
             }) => {
-                self.with_new_scopes(ident.span, |this| {
+                self.with_new_scopes(*fn_sig_span, |this| {
                     // Note: we don't need to change the return type from `T` to
                     // `impl Future<Output = T>` here because lower_body
                     // only cares about the input argument patterns in the function

--- a/compiler/rustc_codegen_cranelift/example/polymorphize_coroutine.rs
+++ b/compiler/rustc_codegen_cranelift/example/polymorphize_coroutine.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;
@@ -8,7 +8,8 @@ fn main() {
 }
 
 fn run_coroutine<T>() {
-    let mut coroutine = || {
+    let mut coroutine = #[coroutine]
+    || {
         yield;
         return;
     };

--- a/compiler/rustc_codegen_cranelift/example/std_example.rs
+++ b/compiler/rustc_codegen_cranelift/example/std_example.rs
@@ -1,6 +1,7 @@
 #![feature(
     core_intrinsics,
     coroutines,
+    stmt_expr_attributes,
     coroutine_trait,
     is_sorted,
     repr_simd,
@@ -123,9 +124,12 @@ fn main() {
         test_simd();
     }
 
-    Box::pin(move |mut _task_context| {
-        yield ();
-    })
+    Box::pin(
+        #[coroutine]
+        move |mut _task_context| {
+            yield ();
+        },
+    )
     .as_mut()
     .resume(0);
 

--- a/compiler/rustc_codegen_gcc/example/std_example.rs
+++ b/compiler/rustc_codegen_gcc/example/std_example.rs
@@ -1,5 +1,5 @@
 #![allow(internal_features)]
-#![feature(core_intrinsics, coroutines, coroutine_trait, is_sorted)]
+#![feature(core_intrinsics, coroutines, coroutine_trait, is_sorted, stmt_expr_attributes)]
 
 #[cfg(feature="master")]
 #[cfg(target_arch="x86_64")]
@@ -103,7 +103,7 @@ fn main() {
         test_simd();
     }
 
-    Box::pin(move |mut _task_context| {
+    Box::pin(#[coroutine] move |mut _task_context| {
         yield ();
     }).as_mut().resume(0);
 

--- a/compiler/rustc_error_codes/src/error_codes/E0626.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0626.md
@@ -4,10 +4,10 @@ yield point.
 Erroneous code example:
 
 ```compile_fail,E0626
-# #![feature(coroutines, coroutine_trait, pin)]
+# #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 # use std::ops::Coroutine;
 # use std::pin::Pin;
-let mut b = || {
+let mut b = #[coroutine] || {
     let a = &String::new(); // <-- This borrow...
     yield (); // ...is still in scope here, when the yield occurs.
     println!("{}", a);
@@ -23,10 +23,10 @@ resolve the previous example by removing the borrow and just storing
 the integer by value:
 
 ```
-# #![feature(coroutines, coroutine_trait, pin)]
+# #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 # use std::ops::Coroutine;
 # use std::pin::Pin;
-let mut b = || {
+let mut b = #[coroutine] || {
     let a = 3;
     yield ();
     println!("{}", a);
@@ -41,10 +41,10 @@ in those cases, something like the `Rc` or `Arc` types may be useful.
 This error also frequently arises with iteration:
 
 ```compile_fail,E0626
-# #![feature(coroutines, coroutine_trait, pin)]
+# #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 # use std::ops::Coroutine;
 # use std::pin::Pin;
-let mut b = || {
+let mut b = #[coroutine] || {
   let v = vec![1,2,3];
   for &x in &v { // <-- borrow of `v` is still in scope...
     yield x; // ...when this yield occurs.
@@ -57,10 +57,10 @@ Such cases can sometimes be resolved by iterating "by value" (or using
 `into_iter()`) to avoid borrowing:
 
 ```
-# #![feature(coroutines, coroutine_trait, pin)]
+# #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 # use std::ops::Coroutine;
 # use std::pin::Pin;
-let mut b = || {
+let mut b = #[coroutine] || {
   let v = vec![1,2,3];
   for x in v { // <-- Take ownership of the values instead!
     yield x; // <-- Now yield is OK.
@@ -72,10 +72,10 @@ Pin::new(&mut b).resume(());
 If taking ownership is not an option, using indices can work too:
 
 ```
-# #![feature(coroutines, coroutine_trait, pin)]
+# #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 # use std::ops::Coroutine;
 # use std::pin::Pin;
-let mut b = || {
+let mut b = #[coroutine] || {
   let v = vec![1,2,3];
   let len = v.len(); // (*)
   for i in 0..len {

--- a/compiler/rustc_error_codes/src/error_codes/E0627.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0627.md
@@ -3,7 +3,7 @@ A yield expression was used outside of the coroutine literal.
 Erroneous code example:
 
 ```compile_fail,E0627
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 fn fake_coroutine() -> &'static str {
     yield 1;
@@ -19,10 +19,10 @@ The error occurs because keyword `yield` can only be used inside the coroutine
 literal. This can be fixed by constructing the coroutine correctly.
 
 ```
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 fn main() {
-    let mut coroutine = || {
+    let mut coroutine = #[coroutine] || {
         yield 1;
         return "foo"
     };

--- a/compiler/rustc_error_codes/src/error_codes/E0628.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0628.md
@@ -3,10 +3,10 @@ More than one parameter was used for a coroutine.
 Erroneous code example:
 
 ```compile_fail,E0628
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 fn main() {
-    let coroutine = |a: i32, b: i32| {
+    let coroutine = #[coroutine] |a: i32, b: i32| {
         // error: too many parameters for a coroutine
         // Allowed only 0 or 1 parameter
         yield a;
@@ -20,10 +20,10 @@ at most 1 parameter for the coroutine. For example, we might resolve
 the previous example by passing only one parameter.
 
 ```
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 fn main() {
-    let coroutine = |a: i32| {
+    let coroutine = #[coroutine] |a: i32| {
         yield a;
     };
 }

--- a/compiler/rustc_error_codes/src/error_codes/E0727.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0727.md
@@ -3,10 +3,10 @@ A `yield` clause was used in an `async` context.
 Erroneous code example:
 
 ```compile_fail,E0727,edition2018
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn main() {
-    let coroutine = || {
+    let coroutine = #[coroutine] || {
         async {
             yield;
         }
@@ -20,10 +20,10 @@ which is not yet supported.
 To fix this error, you have to move `yield` out of the `async` block:
 
 ```edition2018
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn main() {
-    let coroutine = || {
+    let coroutine = #[coroutine] || {
         yield;
     };
 }

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -534,6 +534,12 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::Yes, experimental!(cfi_encoding)
     ),
 
+    // `#[coroutine]` attribute to be applied to closures to make them coroutines instead
+    gated!(
+        coroutine, Normal, template!(Word), ErrorFollowing,
+        EncodeCrossCrate::No, coroutines, experimental!(coroutines)
+    ),
+
     // ==========================================================================
     // Internal attributes: Stability, deprecation, and unsafe:
     // ==========================================================================

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1260,30 +1260,34 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         id: DefIndex,
         sess: &'a Session,
     ) -> impl Iterator<Item = ModChild> + 'a {
-        iter::from_coroutine(move || {
-            if let Some(data) = &self.root.proc_macro_data {
-                // If we are loading as a proc macro, we want to return
-                // the view of this crate as a proc macro crate.
-                if id == CRATE_DEF_INDEX {
-                    for child_index in data.macros.decode(self) {
+        iter::from_coroutine(
+            #[cfg_attr(not(bootstrap), coroutine)]
+            move || {
+                if let Some(data) = &self.root.proc_macro_data {
+                    // If we are loading as a proc macro, we want to return
+                    // the view of this crate as a proc macro crate.
+                    if id == CRATE_DEF_INDEX {
+                        for child_index in data.macros.decode(self) {
+                            yield self.get_mod_child(child_index, sess);
+                        }
+                    }
+                } else {
+                    // Iterate over all children.
+                    let non_reexports =
+                        self.root.tables.module_children_non_reexports.get(self, id);
+                    for child_index in non_reexports.unwrap().decode(self) {
                         yield self.get_mod_child(child_index, sess);
                     }
-                }
-            } else {
-                // Iterate over all children.
-                let non_reexports = self.root.tables.module_children_non_reexports.get(self, id);
-                for child_index in non_reexports.unwrap().decode(self) {
-                    yield self.get_mod_child(child_index, sess);
-                }
 
-                let reexports = self.root.tables.module_children_reexports.get(self, id);
-                if !reexports.is_default() {
-                    for reexport in reexports.decode((self, sess)) {
-                        yield reexport;
+                    let reexports = self.root.tables.module_children_reexports.get(self, id);
+                    if !reexports.is_default() {
+                        for reexport in reexports.decode((self, sess)) {
+                            yield reexport;
+                        }
                     }
                 }
-            }
-        })
+            },
+        )
     }
 
     fn is_ctfe_mir_available(self, id: DefIndex) -> bool {

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -35,6 +35,7 @@
 #![feature(const_type_name)]
 #![feature(discriminant_kind)]
 #![feature(coroutines)]
+#![feature(stmt_expr_attributes)]
 #![feature(if_let_guard)]
 #![feature(inline_const)]
 #![feature(iter_from_coroutine)]

--- a/compiler/rustc_middle/src/ty/closure.rs
+++ b/compiler/rustc_middle/src/ty/closure.rs
@@ -422,49 +422,53 @@ pub fn analyze_coroutine_closure_captures<'a, 'tcx: 'a, T>(
     child_captures: impl IntoIterator<Item = &'a CapturedPlace<'tcx>>,
     mut for_each: impl FnMut((usize, &'a CapturedPlace<'tcx>), (usize, &'a CapturedPlace<'tcx>)) -> T,
 ) -> impl Iterator<Item = T> + Captures<'a> + Captures<'tcx> {
-    std::iter::from_coroutine(move || {
-        let mut child_captures = child_captures.into_iter().enumerate().peekable();
+    std::iter::from_coroutine(
+        #[cfg_attr(not(bootstrap), coroutine)]
+        move || {
+            let mut child_captures = child_captures.into_iter().enumerate().peekable();
 
-        // One parent capture may correspond to several child captures if we end up
-        // refining the set of captures via edition-2021 precise captures. We want to
-        // match up any number of child captures with one parent capture, so we keep
-        // peeking off this `Peekable` until the child doesn't match anymore.
-        for (parent_field_idx, parent_capture) in parent_captures.into_iter().enumerate() {
-            // Make sure we use every field at least once, b/c why are we capturing something
-            // if it's not used in the inner coroutine.
-            let mut field_used_at_least_once = false;
+            // One parent capture may correspond to several child captures if we end up
+            // refining the set of captures via edition-2021 precise captures. We want to
+            // match up any number of child captures with one parent capture, so we keep
+            // peeking off this `Peekable` until the child doesn't match anymore.
+            for (parent_field_idx, parent_capture) in parent_captures.into_iter().enumerate() {
+                // Make sure we use every field at least once, b/c why are we capturing something
+                // if it's not used in the inner coroutine.
+                let mut field_used_at_least_once = false;
 
-            // A parent matches a child if they share the same prefix of projections.
-            // The child may have more, if it is capturing sub-fields out of
-            // something that is captured by-move in the parent closure.
-            while child_captures.peek().map_or(false, |(_, child_capture)| {
-                child_prefix_matches_parent_projections(parent_capture, child_capture)
-            }) {
-                let (child_field_idx, child_capture) = child_captures.next().unwrap();
-                // This analysis only makes sense if the parent capture is a
-                // prefix of the child capture.
-                assert!(
-                    child_capture.place.projections.len() >= parent_capture.place.projections.len(),
-                    "parent capture ({parent_capture:#?}) expected to be prefix of \
+                // A parent matches a child if they share the same prefix of projections.
+                // The child may have more, if it is capturing sub-fields out of
+                // something that is captured by-move in the parent closure.
+                while child_captures.peek().map_or(false, |(_, child_capture)| {
+                    child_prefix_matches_parent_projections(parent_capture, child_capture)
+                }) {
+                    let (child_field_idx, child_capture) = child_captures.next().unwrap();
+                    // This analysis only makes sense if the parent capture is a
+                    // prefix of the child capture.
+                    assert!(
+                        child_capture.place.projections.len()
+                            >= parent_capture.place.projections.len(),
+                        "parent capture ({parent_capture:#?}) expected to be prefix of \
                     child capture ({child_capture:#?})"
-                );
+                    );
 
-                yield for_each(
-                    (parent_field_idx, parent_capture),
-                    (child_field_idx, child_capture),
-                );
+                    yield for_each(
+                        (parent_field_idx, parent_capture),
+                        (child_field_idx, child_capture),
+                    );
 
-                field_used_at_least_once = true;
+                    field_used_at_least_once = true;
+                }
+
+                // Make sure the field was used at least once.
+                assert!(
+                    field_used_at_least_once,
+                    "we captured {parent_capture:#?} but it was not used in the child coroutine?"
+                );
             }
-
-            // Make sure the field was used at least once.
-            assert!(
-                field_used_at_least_once,
-                "we captured {parent_capture:#?} but it was not used in the child coroutine?"
-            );
-        }
-        assert_eq!(child_captures.next(), None, "leftover child captures?");
-    })
+            assert_eq!(child_captures.next(), None, "leftover child captures?");
+        },
+    )
 }
 
 fn child_prefix_matches_parent_projections(

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1284,20 +1284,23 @@ impl<'tcx> TyCtxt<'tcx> {
         self.dep_graph.read_index(DepNodeIndex::FOREVER_RED_NODE);
 
         let definitions = &self.untracked.definitions;
-        std::iter::from_coroutine(|| {
-            let mut i = 0;
+        std::iter::from_coroutine(
+            #[cfg_attr(not(bootstrap), coroutine)]
+            || {
+                let mut i = 0;
 
-            // Recompute the number of definitions each time, because our caller may be creating
-            // new ones.
-            while i < { definitions.read().num_definitions() } {
-                let local_def_index = rustc_span::def_id::DefIndex::from_usize(i);
-                yield LocalDefId { local_def_index };
-                i += 1;
-            }
+                // Recompute the number of definitions each time, because our caller may be creating
+                // new ones.
+                while i < { definitions.read().num_definitions() } {
+                    let local_def_index = rustc_span::def_id::DefIndex::from_usize(i);
+                    yield LocalDefId { local_def_index };
+                    i += 1;
+                }
 
-            // Freeze definitions once we finish iterating on them, to prevent adding new ones.
-            definitions.freeze();
-        })
+                // Freeze definitions once we finish iterating on them, to prevent adding new ones.
+                definitions.freeze();
+            },
+        )
     }
 
     pub fn def_path_table(self) -> &'tcx rustc_hir::definitions::DefPathTable {

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -183,7 +183,7 @@ pub enum TyKind<I: Interner> {
     ///
     /// ```
     /// #![feature(coroutines)]
-    /// static |a| {
+    /// #[coroutine] static |a| {
     ///     let x = &vec![3];
     ///     yield a;
     ///     yield x[0];

--- a/library/core/src/iter/sources/from_coroutine.rs
+++ b/library/core/src/iter/sources/from_coroutine.rs
@@ -14,7 +14,7 @@ use crate::pin::Pin;
 /// #![feature(coroutines)]
 /// #![feature(iter_from_coroutine)]
 ///
-/// let it = std::iter::from_coroutine(|| {
+/// let it = std::iter::from_coroutine(#[cfg_attr(not(bootstrap), coroutine)] || {
 ///     yield 1;
 ///     yield 2;
 ///     yield 3;

--- a/library/core/src/ops/coroutine.rs
+++ b/library/core/src/ops/coroutine.rs
@@ -40,12 +40,13 @@ pub enum CoroutineState<Y, R> {
 /// ```rust
 /// #![feature(coroutines)]
 /// #![feature(coroutine_trait)]
+/// #![feature(stmt_expr_attributes)]
 ///
 /// use std::ops::{Coroutine, CoroutineState};
 /// use std::pin::Pin;
 ///
 /// fn main() {
-///     let mut coroutine = || {
+///     let mut coroutine = #[cfg_attr(not(bootstrap), coroutine)] || {
 ///         yield 1;
 ///         "foo"
 ///     };

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1809,7 +1809,7 @@ impl<Ptr, U> DispatchFromDyn<Pin<U>> for Pin<Ptr> where Ptr: DispatchFromDyn<U> 
 /// fn coroutine_fn() -> impl Coroutine<Yield = usize, Return = ()> /* not Unpin */ {
 ///  // Allow coroutine to be self-referential (not `Unpin`)
 ///  // vvvvvv        so that locals can cross yield points.
-///     static || {
+///     #[cfg_attr(not(bootstrap), coroutine)] static || {
 ///         let foo = String::from("foo");
 ///         let foo_ref = &foo; // ------+
 ///         yield 0;                  // | <- crosses yield point!

--- a/src/doc/unstable-book/src/language-features/coroutines.md
+++ b/src/doc/unstable-book/src/language-features/coroutines.md
@@ -26,13 +26,13 @@ tweaks to the overall design.
 A syntactical example of a coroutine is:
 
 ```rust
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
 
 fn main() {
-    let mut coroutine = || {
+    let mut coroutine = #[coroutine] || {
         yield 1;
         return "foo"
     };
@@ -48,7 +48,8 @@ fn main() {
 }
 ```
 
-Coroutines are closure-like literals which can contain a `yield` statement. The
+Coroutines are closure-like literals which are annotated with `#[coroutine]`
+and can contain a `yield` statement. The
 `yield` statement takes an optional expression of a value to yield out of the
 coroutine. All coroutine literals implement the `Coroutine` trait in the
 `std::ops` module. The `Coroutine` trait has one main method, `resume`, which
@@ -58,13 +59,13 @@ An example of the control flow of coroutines is that the following example
 prints all numbers in order:
 
 ```rust
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;
 
 fn main() {
-    let mut coroutine = || {
+    let mut coroutine = #[coroutine] || {
         println!("2");
         yield;
         println!("4");
@@ -78,9 +79,9 @@ fn main() {
 }
 ```
 
-At this time the main intended use case of coroutines is an implementation
-primitive for async/await syntax, but coroutines will likely be extended to
-ergonomic implementations of iterators and other primitives in the future.
+At this time the main use case of coroutines is an implementation
+primitive for `async`/`await` and `gen` syntax, but coroutines
+will likely be extended to other primitives in the future.
 Feedback on the design and usage is always appreciated!
 
 ### The `Coroutine` trait
@@ -163,14 +164,14 @@ which point all state is saved off in the coroutine and a value is returned.
 Let's take a look at an example to see what's going on here:
 
 ```rust
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;
 
 fn main() {
     let ret = "foo";
-    let mut coroutine = move || {
+    let mut coroutine = #[coroutine] move || {
         yield 1;
         return ret
     };
@@ -183,7 +184,7 @@ fn main() {
 This coroutine literal will compile down to something similar to:
 
 ```rust
-#![feature(arbitrary_self_types, coroutines, coroutine_trait)]
+#![feature(arbitrary_self_types, coroutine_trait)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;

--- a/src/doc/unstable-book/src/the-unstable-book.md
+++ b/src/doc/unstable-book/src/the-unstable-book.md
@@ -5,13 +5,13 @@ each one organized by a "feature flag." That is, when using an unstable
 feature of Rust, you must use a flag, like this:
 
 ```rust
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
 
 fn main() {
-    let mut coroutine = || {
+    let mut coroutine = #[coroutine] || {
         yield 1;
         return "foo"
     };

--- a/src/tools/clippy/tests/ui/crashes/ice-5238.rs
+++ b/src/tools/clippy/tests/ui/crashes/ice-5238.rs
@@ -1,9 +1,9 @@
 // Regression test for #5238 / https://github.com/rust-lang/rust/pull/69562
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 fn main() {
-    let _ = || {
+    let _ = #[coroutine] || {
         yield;
     };
 }

--- a/src/tools/clippy/tests/ui/large_futures.fixed
+++ b/src/tools/clippy/tests/ui/large_futures.fixed
@@ -1,4 +1,3 @@
-#![feature(coroutines)]
 #![warn(clippy::large_futures)]
 #![allow(clippy::never_loop)]
 #![allow(clippy::future_not_send)]

--- a/src/tools/clippy/tests/ui/large_futures.rs
+++ b/src/tools/clippy/tests/ui/large_futures.rs
@@ -1,4 +1,3 @@
-#![feature(coroutines)]
 #![warn(clippy::large_futures)]
 #![allow(clippy::never_loop)]
 #![allow(clippy::future_not_send)]

--- a/src/tools/clippy/tests/ui/large_futures.stderr
+++ b/src/tools/clippy/tests/ui/large_futures.stderr
@@ -1,5 +1,5 @@
 error: large future with a size of 16385 bytes
-  --> tests/ui/large_futures.rs:11:9
+  --> tests/ui/large_futures.rs:10:9
    |
 LL |         big_fut([0u8; 1024 * 16]).await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(big_fut([0u8; 1024 * 16]))`
@@ -8,37 +8,37 @@ LL |         big_fut([0u8; 1024 * 16]).await;
    = help: to override `-D warnings` add `#[allow(clippy::large_futures)]`
 
 error: large future with a size of 16386 bytes
-  --> tests/ui/large_futures.rs:15:5
+  --> tests/ui/large_futures.rs:14:5
    |
 LL |     f.await
    |     ^ help: consider `Box::pin` on it: `Box::pin(f)`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:20:9
+  --> tests/ui/large_futures.rs:19:9
    |
 LL |         wait().await;
    |         ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:25:13
+  --> tests/ui/large_futures.rs:24:13
    |
 LL |             wait().await;
    |             ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:33:5
+  --> tests/ui/large_futures.rs:32:5
    |
 LL |     foo().await;
    |     ^^^^^ help: consider `Box::pin` on it: `Box::pin(foo())`
 
 error: large future with a size of 49159 bytes
-  --> tests/ui/large_futures.rs:35:5
+  --> tests/ui/large_futures.rs:34:5
    |
 LL |     calls_fut(fut).await;
    |     ^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(calls_fut(fut))`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:48:5
+  --> tests/ui/large_futures.rs:47:5
    |
 LL | /     async {
 LL | |
@@ -59,7 +59,7 @@ LL +     })
    |
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:60:13
+  --> tests/ui/large_futures.rs:59:13
    |
 LL | /             async {
 LL | |                 let x = [0i32; 1024 * 16];

--- a/src/tools/clippy/tests/ui/redundant_locals.rs
+++ b/src/tools/clippy/tests/ui/redundant_locals.rs
@@ -1,7 +1,7 @@
 //@aux-build:proc_macros.rs
 #![allow(unused, clippy::no_effect, clippy::needless_pass_by_ref_mut)]
 #![warn(clippy::redundant_locals)]
-#![feature(async_closure, coroutines)]
+#![feature(async_closure, coroutines, stmt_expr_attributes)]
 
 extern crate proc_macros;
 use proc_macros::{external, with_span};
@@ -191,11 +191,11 @@ fn issue12225() {
         let v4 = v4;
         dbg!(&v4);
     });
-    assert_static(static || {
+    assert_static(#[coroutine] static || {
         let v5 = v5;
         yield;
     });
-    assert_static(|| {
+    assert_static(#[coroutine] || {
         let v6 = v6;
         yield;
     });

--- a/src/tools/miri/tests/fail/coroutine-pinned-moved.rs
+++ b/src/tools/miri/tests/fail/coroutine-pinned-moved.rs
@@ -1,5 +1,5 @@
 //@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::{
     ops::{Coroutine, CoroutineState},
@@ -7,7 +7,7 @@ use std::{
 };
 
 fn firstn() -> impl Coroutine<Yield = u64, Return = ()> {
-    static move || {
+    #[coroutine] static move || {
         let mut num = 0;
         let num = &mut num;
         *num += 0;

--- a/src/tools/miri/tests/pass/stacked-borrows/coroutine-self-referential.rs
+++ b/src/tools/miri/tests/pass/stacked-borrows/coroutine-self-referential.rs
@@ -1,6 +1,6 @@
 // See https://github.com/rust-lang/unsafe-code-guidelines/issues/148:
 // this fails when Stacked Borrows is strictly applied even to `!Unpin` types.
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::{
     ops::{Coroutine, CoroutineState},
@@ -8,7 +8,7 @@ use std::{
 };
 
 fn firstn() -> impl Coroutine<Yield = u64, Return = ()> {
-    static move || {
+    #[coroutine] static move || {
         let mut num = 0;
         let num = &mut num;
 

--- a/src/tools/miri/tests/pass/track-caller-attribute.rs
+++ b/src/tools/miri/tests/pass/track-caller-attribute.rs
@@ -232,7 +232,7 @@ fn test_coroutine() {
     }
 
     #[rustfmt::skip]
-    let coroutine = #[track_caller] |arg: String| {
+    let coroutine = #[track_caller] #[coroutine] |arg: String| {
         yield ("first", arg.clone(), Location::caller());
         yield ("second", arg.clone(), Location::caller());
     };
@@ -255,7 +255,7 @@ fn test_coroutine() {
     assert_eq!(mono_loc.column(), 42);
 
     #[rustfmt::skip]
-    let non_tracked_coroutine = || { yield Location::caller(); };
+    let non_tracked_coroutine = #[coroutine] || { yield Location::caller(); };
     let non_tracked_line = line!() - 1; // This is the line of the coroutine, not its caller
     let non_tracked_loc = match Box::pin(non_tracked_coroutine).as_mut().resume(()) {
         CoroutineState::Yielded(val) => val,
@@ -263,7 +263,7 @@ fn test_coroutine() {
     };
     assert_eq!(non_tracked_loc.file(), file!());
     assert_eq!(non_tracked_loc.line(), non_tracked_line);
-    assert_eq!(non_tracked_loc.column(), 44);
+    assert_eq!(non_tracked_loc.column(), 57);
 }
 
 fn main() {

--- a/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
+++ b/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
@@ -3869,7 +3869,7 @@ use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
 
 fn main() {
-    let mut coroutine = || {
+    let mut coroutine = #[coroutine] || {
         yield 1;
         return "foo"
     };
@@ -3901,7 +3901,7 @@ use std::ops::Coroutine;
 use std::pin::Pin;
 
 fn main() {
-    let mut coroutine = || {
+    let mut coroutine = #[coroutine] || {
         println!("2");
         yield;
         println!("4");
@@ -4007,7 +4007,7 @@ use std::pin::Pin;
 
 fn main() {
     let ret = "foo";
-    let mut coroutine = move || {
+    let mut coroutine = #[coroutine] move || {
         yield 1;
         return ret
     };

--- a/src/tools/rustfmt/tests/source/immovable_coroutines.rs
+++ b/src/tools/rustfmt/tests/source/immovable_coroutines.rs
@@ -1,7 +1,8 @@
 #![feature(coroutines)]
 
 unsafe fn foo() {
-    let mut ga = static || { 
+    let mut ga = #[coroutine]
+    static || {
         yield 1;
     };
 }

--- a/src/tools/rustfmt/tests/target/immovable_coroutines.rs
+++ b/src/tools/rustfmt/tests/target/immovable_coroutines.rs
@@ -1,7 +1,8 @@
 #![feature(coroutines)]
 
 unsafe fn foo() {
-    let mut ga = static || {
+    let mut ga = #[coroutine]
+    static || {
         yield 1;
     };
 }

--- a/tests/codegen/coroutine-debug-msvc.rs
+++ b/tests/codegen/coroutine-debug-msvc.rs
@@ -11,7 +11,7 @@
 use std::ops::Coroutine;
 
 fn coroutine_test() -> impl Coroutine<Yield = i32, Return = ()> {
-    || {
+    #[coroutine] || {
         yield 0;
         let s = String::from("foo");
         yield 1;

--- a/tests/codegen/coroutine-debug.rs
+++ b/tests/codegen/coroutine-debug.rs
@@ -11,7 +11,7 @@
 use std::ops::Coroutine;
 
 fn coroutine_test() -> impl Coroutine<Yield = i32, Return = ()> {
-    || {
+    #[coroutine] || {
         yield 0;
         let s = String::from("foo");
         yield 1;

--- a/tests/coverage/coroutine.cov-map
+++ b/tests/coverage/coroutine.cov-map
@@ -43,11 +43,11 @@ Number of file 0 mappings: 9
     = ((c4 - c5) - c6)
 
 Function name: coroutine::main::{closure#0}
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 15, 1c, 01, 1f, 05, 02, 10, 01, 06]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 15, 29, 01, 1f, 05, 02, 10, 01, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 21, 28) to (start + 1, 31)
+- Code(Counter(0)) at (prev + 21, 41) to (start + 1, 31)
 - Code(Counter(1)) at (prev + 2, 16) to (start + 1, 6)
 

--- a/tests/coverage/coroutine.coverage
+++ b/tests/coverage/coroutine.coverage
@@ -1,4 +1,4 @@
-   LL|       |#![feature(coroutines, coroutine_trait)]
+   LL|       |#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
    LL|       |
    LL|       |use std::ops::{Coroutine, CoroutineState};
    LL|       |use std::pin::Pin;
@@ -18,7 +18,7 @@
    LL|       |
    LL|      1|fn main() {
    LL|      1|    let is_true = std::env::args().len() == 1;
-   LL|      1|    let mut coroutine = || {
+   LL|      1|    let mut coroutine = #[coroutine] || {
    LL|      1|        yield get_u32(is_true);
    LL|      1|        return "foo";
    LL|      1|    };

--- a/tests/coverage/coroutine.rs
+++ b/tests/coverage/coroutine.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
@@ -18,7 +18,7 @@ fn get_u32(val: bool) -> Result<u32, String> {
 
 fn main() {
     let is_true = std::env::args().len() == 1;
-    let mut coroutine = || {
+    let mut coroutine = #[coroutine] || {
         yield get_u32(is_true);
         return "foo";
     };

--- a/tests/coverage/yield.cov-map
+++ b/tests/coverage/yield.cov-map
@@ -41,21 +41,21 @@ Number of file 0 mappings: 16
 - Code(Counter(11)) at (prev + 2, 1) to (start + 0, 2)
 
 Function name: yield::main::{closure#0}
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 08, 1c, 01, 10, 05, 02, 10, 01, 06]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 08, 29, 01, 10, 05, 02, 10, 01, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 8, 28) to (start + 1, 16)
+- Code(Counter(0)) at (prev + 8, 41) to (start + 1, 16)
 - Code(Counter(1)) at (prev + 2, 16) to (start + 1, 6)
 
 Function name: yield::main::{closure#1}
-Raw bytes (24): 0x[01, 01, 00, 04, 01, 16, 1c, 01, 10, 05, 02, 09, 00, 10, 09, 01, 09, 00, 10, 0d, 01, 10, 01, 06]
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 16, 29, 01, 10, 05, 02, 09, 00, 10, 09, 01, 09, 00, 10, 0d, 01, 10, 01, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 22, 28) to (start + 1, 16)
+- Code(Counter(0)) at (prev + 22, 41) to (start + 1, 16)
 - Code(Counter(1)) at (prev + 2, 9) to (start + 0, 16)
 - Code(Counter(2)) at (prev + 1, 9) to (start + 0, 16)
 - Code(Counter(3)) at (prev + 1, 16) to (start + 1, 6)

--- a/tests/coverage/yield.coverage
+++ b/tests/coverage/yield.coverage
@@ -1,11 +1,11 @@
-   LL|       |#![feature(coroutines, coroutine_trait)]
+   LL|       |#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
    LL|       |#![allow(unused_assignments)]
    LL|       |
    LL|       |use std::ops::{Coroutine, CoroutineState};
    LL|       |use std::pin::Pin;
    LL|       |
    LL|      1|fn main() {
-   LL|      1|    let mut coroutine = || {
+   LL|      1|    let mut coroutine = #[coroutine] || {
    LL|      1|        yield 1;
    LL|      1|        return "foo";
    LL|      1|    };
@@ -19,7 +19,7 @@
    LL|      0|        _ => panic!("unexpected value from resume"),
    LL|       |    }
    LL|       |
-   LL|      1|    let mut coroutine = || {
+   LL|      1|    let mut coroutine = #[coroutine] || {
    LL|      1|        yield 1;
    LL|      1|        yield 2;
    LL|      0|        yield 3;

--- a/tests/coverage/yield.rs
+++ b/tests/coverage/yield.rs
@@ -1,11 +1,11 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 #![allow(unused_assignments)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
 
 fn main() {
-    let mut coroutine = || {
+    let mut coroutine = #[coroutine] || {
         yield 1;
         return "foo";
     };
@@ -19,7 +19,7 @@ fn main() {
         _ => panic!("unexpected value from resume"),
     }
 
-    let mut coroutine = || {
+    let mut coroutine = #[coroutine] || {
         yield 1;
         yield 2;
         yield 3;

--- a/tests/debuginfo/coroutine-locals.rs
+++ b/tests/debuginfo/coroutine-locals.rs
@@ -46,7 +46,7 @@
 // lldb-command:v c
 // lldb-check:(int) c = 6
 
-#![feature(omit_gdb_pretty_printer_section, coroutines, coroutine_trait)]
+#![feature(omit_gdb_pretty_printer_section, coroutines, coroutine_trait, stmt_expr_attributes)]
 #![omit_gdb_pretty_printer_section]
 
 use std::ops::Coroutine;
@@ -54,7 +54,8 @@ use std::pin::Pin;
 
 fn main() {
     let mut a = 5;
-    let mut b = || {
+    let mut b = #[coroutine]
+    || {
         let c = 6; // Live across multiple yield points
 
         let d = 7; // Live across only one yield point
@@ -76,4 +77,6 @@ fn main() {
     _zzz(); // #break
 }
 
-fn _zzz() {()}
+fn _zzz() {
+    ()
+}

--- a/tests/debuginfo/coroutine-objects.rs
+++ b/tests/debuginfo/coroutine-objects.rs
@@ -63,7 +63,7 @@
 // cdb-check: b                : Returned [Type: enum2$<coroutine_objects::main::coroutine_env$0>]
 // cdb-check:    [+0x[...]] _ref__a          : 0x[...] : 6 [Type: int *]
 
-#![feature(omit_gdb_pretty_printer_section, coroutines, coroutine_trait)]
+#![feature(omit_gdb_pretty_printer_section, coroutines, coroutine_trait, stmt_expr_attributes)]
 #![omit_gdb_pretty_printer_section]
 
 use std::ops::Coroutine;
@@ -71,7 +71,8 @@ use std::pin::Pin;
 
 fn main() {
     let mut a = 5;
-    let mut b = || {
+    let mut b = #[coroutine]
+    || {
         let mut c = 6;
         let mut d = 7;
 

--- a/tests/debuginfo/function-names.rs
+++ b/tests/debuginfo/function-names.rs
@@ -83,7 +83,7 @@
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![feature(adt_const_params, coroutines, coroutine_trait)]
+#![feature(adt_const_params, coroutines, coroutine_trait, stmt_expr_attributes)]
 #![allow(incomplete_features)]
 
 use std::ops::Coroutine;
@@ -111,7 +111,8 @@ fn main() {
     closure();
 
     // Coroutine
-    let mut coroutine = || {
+    let mut coroutine = #[coroutine]
+    || {
         yield;
         return;
     };

--- a/tests/debuginfo/issue-57822.rs
+++ b/tests/debuginfo/issue-57822.rs
@@ -26,7 +26,7 @@
 // lldb-command:v b
 // lldbg-check:(issue_57822::main::{coroutine_env#3}) b =
 
-#![feature(omit_gdb_pretty_printer_section, coroutines, coroutine_trait)]
+#![feature(omit_gdb_pretty_printer_section, coroutines, coroutine_trait, stmt_expr_attributes)]
 #![omit_gdb_pretty_printer_section]
 
 use std::ops::Coroutine;
@@ -38,11 +38,13 @@ fn main() {
     let g = move || f();
 
     let mut y = 2;
-    let mut a = move || {
+    let mut a = #[coroutine]
+    move || {
         y += 1;
         yield;
     };
-    let mut b = move || {
+    let mut b = #[coroutine]
+    move || {
         Pin::new(&mut a).resume(());
         yield;
     };

--- a/tests/mir-opt/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-abort.mir
+++ b/tests/mir-opt/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-abort.mir
@@ -1,6 +1,6 @@
 // MIR for `main::{closure#0}` 0 coroutine_drop
 
-fn main::{closure#0}(_1: *mut {coroutine@$DIR/coroutine_drop_cleanup.rs:11:15: 11:17}) -> () {
+fn main::{closure#0}(_1: *mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12:7}) -> () {
     let mut _0: ();
     let mut _2: ();
     let _3: std::string::String;

--- a/tests/mir-opt/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-unwind.mir
+++ b/tests/mir-opt/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-unwind.mir
@@ -1,6 +1,6 @@
 // MIR for `main::{closure#0}` 0 coroutine_drop
 
-fn main::{closure#0}(_1: *mut {coroutine@$DIR/coroutine_drop_cleanup.rs:11:15: 11:17}) -> () {
+fn main::{closure#0}(_1: *mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12:7}) -> () {
     let mut _0: ();
     let mut _2: ();
     let _3: std::string::String;

--- a/tests/mir-opt/coroutine_drop_cleanup.rs
+++ b/tests/mir-opt/coroutine_drop_cleanup.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
@@ -8,7 +8,8 @@
 
 // EMIT_MIR coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.mir
 fn main() {
-    let gen = || {
+    let gen = #[coroutine]
+    || {
         let _s = String::new();
         yield;
     };

--- a/tests/mir-opt/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-abort.mir
+++ b/tests/mir-opt/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-abort.mir
@@ -1,6 +1,6 @@
 // MIR for `main::{closure#0}` before StateTransform
 
-fn main::{closure#0}(_1: {coroutine@$DIR/coroutine_storage_dead_unwind.rs:23:16: 23:18}, _2: ()) -> ()
+fn main::{closure#0}(_1: {coroutine@$DIR/coroutine_storage_dead_unwind.rs:24:5: 24:7}, _2: ()) -> ()
 yields ()
  {
     let mut _0: ();

--- a/tests/mir-opt/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-unwind.mir
+++ b/tests/mir-opt/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-unwind.mir
@@ -1,6 +1,6 @@
 // MIR for `main::{closure#0}` before StateTransform
 
-fn main::{closure#0}(_1: {coroutine@$DIR/coroutine_storage_dead_unwind.rs:23:16: 23:18}, _2: ()) -> ()
+fn main::{closure#0}(_1: {coroutine@$DIR/coroutine_storage_dead_unwind.rs:24:5: 24:7}, _2: ()) -> ()
 yields ()
  {
     let mut _0: ();

--- a/tests/mir-opt/coroutine_storage_dead_unwind.rs
+++ b/tests/mir-opt/coroutine_storage_dead_unwind.rs
@@ -6,7 +6,7 @@
 // Basic block and local names can safely change, but the StorageDead statements
 // should not go away.
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 struct Foo(i32);
 
@@ -20,7 +20,8 @@ fn take<T>(_x: T) {}
 
 // EMIT_MIR coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
 fn main() {
-    let _gen = || {
+    let _gen = #[coroutine]
+    || {
         let a = Foo(5);
         let b = Bar(6);
         yield;

--- a/tests/mir-opt/coroutine_tiny.main-{closure#0}.coroutine_resume.0.mir
+++ b/tests/mir-opt/coroutine_tiny.main-{closure#0}.coroutine_resume.0.mir
@@ -4,7 +4,7 @@
         _0: CoroutineSavedTy {
             ty: HasDrop,
             source_info: SourceInfo {
-                span: $DIR/coroutine_tiny.rs:21:13: 21:15 (#0),
+                span: $DIR/coroutine_tiny.rs:22:13: 22:15 (#0),
                 scope: scope[0],
             },
             ignore_for_traits: false,
@@ -21,7 +21,7 @@
     },
 } */
 
-fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine_tiny.rs:20:16: 20:24}>, _2: u8) -> CoroutineState<(), ()> {
+fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine_tiny.rs:21:5: 21:13}>, _2: u8) -> CoroutineState<(), ()> {
     debug _x => _10;
     let mut _0: std::ops::CoroutineState<(), ()>;
     let _3: HasDrop;
@@ -34,18 +34,18 @@ fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine_tiny.rs:20:16: 20:24
     let _10: u8;
     let mut _11: u32;
     scope 1 {
-        debug _d => (((*(_1.0: &mut {coroutine@$DIR/coroutine_tiny.rs:20:16: 20:24})) as variant#3).0: HasDrop);
+        debug _d => (((*(_1.0: &mut {coroutine@$DIR/coroutine_tiny.rs:21:5: 21:13})) as variant#3).0: HasDrop);
     }
 
     bb0: {
-        _11 = discriminant((*(_1.0: &mut {coroutine@$DIR/coroutine_tiny.rs:20:16: 20:24})));
+        _11 = discriminant((*(_1.0: &mut {coroutine@$DIR/coroutine_tiny.rs:21:5: 21:13})));
         switchInt(move _11) -> [0: bb1, 3: bb5, otherwise: bb6];
     }
 
     bb1: {
         _10 = move _2;
         nop;
-        (((*(_1.0: &mut {coroutine@$DIR/coroutine_tiny.rs:20:16: 20:24})) as variant#3).0: HasDrop) = HasDrop;
+        (((*(_1.0: &mut {coroutine@$DIR/coroutine_tiny.rs:21:5: 21:13})) as variant#3).0: HasDrop) = HasDrop;
         StorageLive(_4);
         goto -> bb2;
     }
@@ -58,7 +58,7 @@ fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine_tiny.rs:20:16: 20:24
         StorageDead(_4);
         StorageDead(_6);
         StorageDead(_7);
-        discriminant((*(_1.0: &mut {coroutine@$DIR/coroutine_tiny.rs:20:16: 20:24}))) = 3;
+        discriminant((*(_1.0: &mut {coroutine@$DIR/coroutine_tiny.rs:21:5: 21:13}))) = 3;
         return;
     }
 

--- a/tests/mir-opt/coroutine_tiny.rs
+++ b/tests/mir-opt/coroutine_tiny.rs
@@ -5,7 +5,7 @@
 //@ compile-flags: -C panic=abort
 //@ no-prefer-dynamic
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 struct HasDrop;
 
@@ -17,7 +17,8 @@ fn callee() {}
 
 // EMIT_MIR coroutine_tiny.main-{closure#0}.coroutine_resume.0.mir
 fn main() {
-    let _gen = |_x: u8| {
+    let _gen = #[coroutine]
+    |_x: u8| {
         let _d = HasDrop;
         loop {
             yield;

--- a/tests/mir-opt/inline/inline_coroutine.main.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_coroutine.main.Inline.panic-abort.diff
@@ -4,24 +4,24 @@
   fn main() -> () {
       let mut _0: ();
       let _1: std::ops::CoroutineState<i32, bool>;
-      let mut _2: std::pin::Pin<&mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8}>;
-      let mut _3: &mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8};
-      let mut _4: {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8};
+      let mut _2: std::pin::Pin<&mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8}>;
+      let mut _3: &mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8};
+      let mut _4: {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8};
 +     let mut _5: bool;
       scope 1 {
           debug _r => _1;
       }
 +     scope 2 (inlined g) {
 +     }
-+     scope 3 (inlined Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8}>::new) {
++     scope 3 (inlined Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8}>::new) {
 +         debug pointer => _3;
-+         scope 4 (inlined Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8}>::new_unchecked) {
++         scope 4 (inlined Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8}>::new_unchecked) {
 +             debug pointer => _3;
 +         }
 +     }
 +     scope 5 (inlined g::{closure#0}) {
 +         debug a => _5;
-+         let mut _6: &mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8};
++         let mut _6: &mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8};
 +         let mut _7: u32;
 +         let mut _8: i32;
 +     }
@@ -32,22 +32,22 @@
           StorageLive(_3);
           StorageLive(_4);
 -         _4 = g() -> [return: bb1, unwind unreachable];
-+         _4 = {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8 (#0)};
++         _4 = {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8 (#0)};
 +         _3 = &mut _4;
-+         _2 = Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8}> { __pointer: _3 };
++         _2 = Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8}> { __pointer: _3 };
 +         StorageDead(_3);
 +         StorageLive(_5);
 +         _5 = const false;
 +         StorageLive(_6);
 +         StorageLive(_7);
-+         _6 = (_2.0: &mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8});
++         _6 = (_2.0: &mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8});
 +         _7 = discriminant((*_6));
 +         switchInt(move _7) -> [0: bb3, 1: bb7, 3: bb8, otherwise: bb9];
       }
   
       bb1: {
 -         _3 = &mut _4;
--         _2 = Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8}>::new(move _3) -> [return: bb2, unwind unreachable];
+-         _2 = Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8}>::new(move _3) -> [return: bb2, unwind unreachable];
 +         StorageDead(_4);
 +         _0 = const ();
 +         StorageDead(_1);
@@ -56,7 +56,7 @@
   
       bb2: {
 -         StorageDead(_3);
--         _1 = <{coroutine@$DIR/inline_coroutine.rs:19:5: 19:8} as Coroutine<bool>>::resume(move _2, const false) -> [return: bb3, unwind unreachable];
+-         _1 = <{coroutine@$DIR/inline_coroutine.rs:20:5: 20:8} as Coroutine<bool>>::resume(move _2, const false) -> [return: bb3, unwind unreachable];
 +         StorageDead(_7);
 +         StorageDead(_6);
 +         StorageDead(_5);

--- a/tests/mir-opt/inline/inline_coroutine.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_coroutine.main.Inline.panic-unwind.diff
@@ -4,24 +4,24 @@
   fn main() -> () {
       let mut _0: ();
       let _1: std::ops::CoroutineState<i32, bool>;
-      let mut _2: std::pin::Pin<&mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8}>;
-      let mut _3: &mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8};
-      let mut _4: {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8};
+      let mut _2: std::pin::Pin<&mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8}>;
+      let mut _3: &mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8};
+      let mut _4: {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8};
 +     let mut _5: bool;
       scope 1 {
           debug _r => _1;
       }
 +     scope 2 (inlined g) {
 +     }
-+     scope 3 (inlined Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8}>::new) {
++     scope 3 (inlined Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8}>::new) {
 +         debug pointer => _3;
-+         scope 4 (inlined Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8}>::new_unchecked) {
++         scope 4 (inlined Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8}>::new_unchecked) {
 +             debug pointer => _3;
 +         }
 +     }
 +     scope 5 (inlined g::{closure#0}) {
 +         debug a => _5;
-+         let mut _6: &mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8};
++         let mut _6: &mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8};
 +         let mut _7: u32;
 +         let mut _8: i32;
 +     }
@@ -32,22 +32,22 @@
           StorageLive(_3);
           StorageLive(_4);
 -         _4 = g() -> [return: bb1, unwind continue];
-+         _4 = {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8 (#0)};
++         _4 = {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8 (#0)};
 +         _3 = &mut _4;
-+         _2 = Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8}> { __pointer: _3 };
++         _2 = Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8}> { __pointer: _3 };
 +         StorageDead(_3);
 +         StorageLive(_5);
 +         _5 = const false;
 +         StorageLive(_6);
 +         StorageLive(_7);
-+         _6 = (_2.0: &mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8});
++         _6 = (_2.0: &mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8});
 +         _7 = discriminant((*_6));
 +         switchInt(move _7) -> [0: bb5, 1: bb9, 3: bb10, otherwise: bb11];
       }
   
       bb1: {
 -         _3 = &mut _4;
--         _2 = Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:19:5: 19:8}>::new(move _3) -> [return: bb2, unwind: bb5];
+-         _2 = Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8}>::new(move _3) -> [return: bb2, unwind: bb5];
 +         StorageDead(_4);
 +         _0 = const ();
 +         StorageDead(_1);
@@ -56,7 +56,7 @@
   
 -     bb2: {
 -         StorageDead(_3);
--         _1 = <{coroutine@$DIR/inline_coroutine.rs:19:5: 19:8} as Coroutine<bool>>::resume(move _2, const false) -> [return: bb3, unwind: bb5];
+-         _1 = <{coroutine@$DIR/inline_coroutine.rs:20:5: 20:8} as Coroutine<bool>>::resume(move _2, const false) -> [return: bb3, unwind: bb5];
 +     bb2 (cleanup): {
 +         drop(_4) -> [return: bb3, unwind terminate(cleanup)];
       }

--- a/tests/mir-opt/inline/inline_coroutine.rs
+++ b/tests/mir-opt/inline/inline_coroutine.rs
@@ -16,5 +16,6 @@ fn main() {
 #[inline]
 pub fn g() -> impl Coroutine<bool> {
     #[inline]
-    |a| { yield if a { 7 } else { 13 } }
+    #[coroutine]
+    |a| yield if a { 7 } else { 13 }
 }

--- a/tests/ui/async-await/async-outside-of-await-issue-121096.stderr
+++ b/tests/ui/async-await/async-outside-of-await-issue-121096.stderr
@@ -2,7 +2,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/async-outside-of-await-issue-121096.rs:7:7
    |
 LL | fn main() {
-   |    ---- this is not `async`
+   | --------- this is not `async`
 ...
 LL |     }.await
    |       ^^^^^ only allowed inside `async` functions and blocks

--- a/tests/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
+++ b/tests/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
@@ -141,7 +141,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/incorrect-syntax-suggestions.rs:68:19
    |
 LL | fn foo13() -> Result<(), ()> {
-   |    ----- this is not `async`
+   | ---------------------------- this is not `async`
 LL |     let _ = bar().await();
    |                   ^^^^^ only allowed inside `async` functions and blocks
 
@@ -149,7 +149,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/incorrect-syntax-suggestions.rs:73:19
    |
 LL | fn foo14() -> Result<(), ()> {
-   |    ----- this is not `async`
+   | ---------------------------- this is not `async`
 LL |     let _ = bar().await()?;
    |                   ^^^^^ only allowed inside `async` functions and blocks
 
@@ -157,7 +157,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/incorrect-syntax-suggestions.rs:78:19
    |
 LL | fn foo15() -> Result<(), ()> {
-   |    ----- this is not `async`
+   | ---------------------------- this is not `async`
 LL |     let _ = bar().await;
    |                   ^^^^^ only allowed inside `async` functions and blocks
 
@@ -165,7 +165,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/incorrect-syntax-suggestions.rs:82:19
    |
 LL | fn foo16() -> Result<(), ()> {
-   |    ----- this is not `async`
+   | ---------------------------- this is not `async`
 LL |     let _ = bar().await?;
    |                   ^^^^^ only allowed inside `async` functions and blocks
 
@@ -173,7 +173,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/incorrect-syntax-suggestions.rs:87:23
    |
 LL |     fn foo() -> Result<(), ()> {
-   |        --- this is not `async`
+   |     -------------------------- this is not `async`
 LL |         let _ = bar().await?;
    |                       ^^^^^ only allowed inside `async` functions and blocks
 

--- a/tests/ui/async-await/coroutine-not-future.stderr
+++ b/tests/ui/async-await/coroutine-not-future.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `impl Future<Output = ()>: Coroutine<_>` is not satisfied
-  --> $DIR/coroutine-not-future.rs:31:21
+  --> $DIR/coroutine-not-future.rs:35:21
    |
 LL |     takes_coroutine(async_fn());
    |     --------------- ^^^^^^^^^^ the trait `Coroutine<_>` is not implemented for `impl Future<Output = ()>`
@@ -7,13 +7,13 @@ LL |     takes_coroutine(async_fn());
    |     required by a bound introduced by this call
    |
 note: required by a bound in `takes_coroutine`
-  --> $DIR/coroutine-not-future.rs:18:39
+  --> $DIR/coroutine-not-future.rs:19:39
    |
 LL | fn takes_coroutine<ResumeTy>(_g: impl Coroutine<ResumeTy, Yield = (), Return = ()>) {}
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_coroutine`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Coroutine<_>` is not satisfied
-  --> $DIR/coroutine-not-future.rs:33:21
+  --> $DIR/coroutine-not-future.rs:37:21
    |
 LL |     takes_coroutine(returns_async_block());
    |     --------------- ^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine<_>` is not implemented for `impl Future<Output = ()>`
@@ -21,27 +21,27 @@ LL |     takes_coroutine(returns_async_block());
    |     required by a bound introduced by this call
    |
 note: required by a bound in `takes_coroutine`
-  --> $DIR/coroutine-not-future.rs:18:39
+  --> $DIR/coroutine-not-future.rs:19:39
    |
 LL | fn takes_coroutine<ResumeTy>(_g: impl Coroutine<ResumeTy, Yield = (), Return = ()>) {}
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_coroutine`
 
-error[E0277]: the trait bound `{async block@$DIR/coroutine-not-future.rs:35:21: 35:29}: Coroutine<_>` is not satisfied
-  --> $DIR/coroutine-not-future.rs:35:21
+error[E0277]: the trait bound `{async block@$DIR/coroutine-not-future.rs:39:21: 39:29}: Coroutine<_>` is not satisfied
+  --> $DIR/coroutine-not-future.rs:39:21
    |
 LL |     takes_coroutine(async {});
-   |     --------------- ^^^^^^^^ the trait `Coroutine<_>` is not implemented for `{async block@$DIR/coroutine-not-future.rs:35:21: 35:29}`
+   |     --------------- ^^^^^^^^ the trait `Coroutine<_>` is not implemented for `{async block@$DIR/coroutine-not-future.rs:39:21: 39:29}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `takes_coroutine`
-  --> $DIR/coroutine-not-future.rs:18:39
+  --> $DIR/coroutine-not-future.rs:19:39
    |
 LL | fn takes_coroutine<ResumeTy>(_g: impl Coroutine<ResumeTy, Yield = (), Return = ()>) {}
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_coroutine`
 
 error[E0277]: `impl Coroutine<Yield = (), Return = ()>` is not a future
-  --> $DIR/coroutine-not-future.rs:39:18
+  --> $DIR/coroutine-not-future.rs:43:18
    |
 LL |     takes_future(returns_coroutine());
    |     ------------ ^^^^^^^^^^^^^^^^^^^ `impl Coroutine<Yield = (), Return = ()>` is not a future
@@ -50,26 +50,26 @@ LL |     takes_future(returns_coroutine());
    |
    = help: the trait `Future` is not implemented for `impl Coroutine<Yield = (), Return = ()>`
 note: required by a bound in `takes_future`
-  --> $DIR/coroutine-not-future.rs:17:26
+  --> $DIR/coroutine-not-future.rs:18:26
    |
 LL | fn takes_future(_f: impl Future<Output = ()>) {}
    |                          ^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_future`
 
-error[E0277]: `{coroutine@$DIR/coroutine-not-future.rs:41:18: 41:23}` is not a future
-  --> $DIR/coroutine-not-future.rs:41:18
+error[E0277]: `{coroutine@$DIR/coroutine-not-future.rs:47:9: 47:14}` is not a future
+  --> $DIR/coroutine-not-future.rs:47:9
    |
-LL |       takes_future(|ctx| {
-   |  _____------------_^
-   | |     |
-   | |     required by a bound introduced by this call
+LL |       takes_future(
+   |       ------------ required by a bound introduced by this call
+LL |           #[coroutine]
+LL | /         |ctx| {
 LL | |
-LL | |         ctx = yield ();
-LL | |     });
-   | |_____^ `{coroutine@$DIR/coroutine-not-future.rs:41:18: 41:23}` is not a future
+LL | |             ctx = yield ();
+LL | |         },
+   | |_________^ `{coroutine@$DIR/coroutine-not-future.rs:47:9: 47:14}` is not a future
    |
-   = help: the trait `Future` is not implemented for `{coroutine@$DIR/coroutine-not-future.rs:41:18: 41:23}`
+   = help: the trait `Future` is not implemented for `{coroutine@$DIR/coroutine-not-future.rs:47:9: 47:14}`
 note: required by a bound in `takes_future`
-  --> $DIR/coroutine-not-future.rs:17:26
+  --> $DIR/coroutine-not-future.rs:18:26
    |
 LL | fn takes_future(_f: impl Future<Output = ()>) {}
    |                          ^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_future`

--- a/tests/ui/async-await/issues/issue-51751.stderr
+++ b/tests/ui/async-await/issues/issue-51751.stderr
@@ -2,7 +2,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/issue-51751.rs:9:27
    |
 LL | fn main() {
-   |    ---- this is not `async`
+   | --------- this is not `async`
 LL |     let result = inc(10000);
 LL |     let finished = result.await;
    |                           ^^^^^ only allowed inside `async` functions and blocks

--- a/tests/ui/async-await/issues/issue-62009-1.stderr
+++ b/tests/ui/async-await/issues/issue-62009-1.stderr
@@ -2,7 +2,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/issue-62009-1.rs:6:23
    |
 LL | fn main() {
-   |    ---- this is not `async`
+   | --------- this is not `async`
 LL |     async { let (); }.await;
    |                       ^^^^^ only allowed inside `async` functions and blocks
 
@@ -10,7 +10,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/issue-62009-1.rs:10:7
    |
 LL | fn main() {
-   |    ---- this is not `async`
+   | --------- this is not `async`
 ...
 LL |     }.await;
    |       ^^^^^ only allowed inside `async` functions and blocks
@@ -19,7 +19,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/issue-62009-1.rs:12:16
    |
 LL | fn main() {
-   |    ---- this is not `async`
+   | --------- this is not `async`
 ...
 LL |     (|_| 2333).await;
    |                ^^^^^ only allowed inside `async` functions and blocks

--- a/tests/ui/async-await/issues/issue-62009-2.stderr
+++ b/tests/ui/async-await/issues/issue-62009-2.stderr
@@ -2,7 +2,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/issue-62009-2.rs:8:23
    |
 LL | fn main() {
-   |    ---- this is not `async`
+   | --------- this is not `async`
 LL |     (async || 2333)().await;
    |                       ^^^^^ only allowed inside `async` functions and blocks
 

--- a/tests/ui/async-await/issues/issue-65419/issue-65419-coroutine-resume-after-completion.rs
+++ b/tests/ui/async-await/issues/issue-65419/issue-65419-coroutine-resume-after-completion.rs
@@ -6,15 +6,13 @@
 //@ error-pattern:coroutine resumed after completion
 //@ edition:2018
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
-use std::{
-    ops::Coroutine,
-    pin::Pin,
-};
+use std::{ops::Coroutine, pin::Pin};
 
 fn main() {
-    let mut g = || {
+    let mut g = #[coroutine]
+    || {
         yield;
     };
     Pin::new(&mut g).resume(()); // Yields once.

--- a/tests/ui/async-await/issues/non-async-enclosing-span.stderr
+++ b/tests/ui/async-await/issues/non-async-enclosing-span.stderr
@@ -2,7 +2,7 @@ error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/non-async-enclosing-span.rs:9:28
    |
 LL | fn main() {
-   |    ---- this is not `async`
+   | --------- this is not `async`
 LL |     let x = move || {};
 LL |     let y = do_the_thing().await;
    |                            ^^^^^ only allowed inside `async` functions and blocks

--- a/tests/ui/async-await/non-trivial-drop.rs
+++ b/tests/ui/async-await/non-trivial-drop.rs
@@ -8,7 +8,7 @@ fn main() {
 }
 
 fn foo() {
-    || {
+    #[coroutine] || {
         yield drop(Config {
             nickname: NonCopy,
             b: NonCopy2,

--- a/tests/ui/coherence/coherence-with-coroutine.rs
+++ b/tests/ui/coherence/coherence-with-coroutine.rs
@@ -8,6 +8,7 @@
 
 type OpaqueCoroutine = impl Sized;
 fn defining_use() -> OpaqueCoroutine {
+    #[coroutine]
     || {
         for i in 0..10 {
             yield i;

--- a/tests/ui/coherence/coherence-with-coroutine.stock.stderr
+++ b/tests/ui/coherence/coherence-with-coroutine.stock.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `Trait` for type `Wrapper<OpaqueCoroutine>`
-  --> $DIR/coherence-with-coroutine.rs:21:1
+  --> $DIR/coherence-with-coroutine.rs:22:1
    |
 LL | impl Trait for Wrapper<OpaqueCoroutine> {}
    | --------------------------------------- first implementation here

--- a/tests/ui/coroutine/addassign-yield.rs
+++ b/tests/ui/coroutine/addassign-yield.rs
@@ -5,21 +5,21 @@
 // is being used), we were failing to account for all types that might
 // possibly be live across a yield point.
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn foo() {
-    let _x = static || {
+    let _x = #[coroutine] static || {
         let mut s = String::new();
         s += { yield; "" };
     };
 
-    let _y = static || {
+    let _y = #[coroutine] static || {
         let x = &mut 0;
         *{ yield; x } += match String::new() { _ => 0 };
     };
 
     // Please don't ever actually write something like this
-    let _z = static || {
+    let _z = #[coroutine] static || {
         let x = &mut 0;
         *{
             let inner = &mut 1;

--- a/tests/ui/coroutine/auto-trait-regions.rs
+++ b/tests/ui/coroutine/auto-trait-regions.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![feature(auto_traits)]
 #![feature(negative_impls)]
 
@@ -23,7 +23,7 @@ fn assert_foo<T: Foo>(f: T) {}
 fn main() {
     // Make sure 'static is erased for coroutine interiors so we can't match it in trait selection
     let x: &'static _ = &OnlyFooIfStaticRef(No);
-    let gen = move || {
+    let gen = #[coroutine] move || {
         let x = x;
         yield;
         assert_foo(x);
@@ -33,7 +33,7 @@ fn main() {
 
     // Allow impls which matches any lifetime
     let x = &OnlyFooIfRef(No);
-    let gen = move || {
+    let gen = #[coroutine] move || {
         let x = x;
         yield;
         assert_foo(x);
@@ -41,7 +41,7 @@ fn main() {
     assert_foo(gen); // ok
 
     // Disallow impls which relates lifetimes in the coroutine interior
-    let gen = move || {
+    let gen = #[coroutine] move || {
         let a = A(&mut true, &mut true, No);
         //~^ temporary value dropped while borrowed
         //~| temporary value dropped while borrowed

--- a/tests/ui/coroutine/auxiliary/metadata-sufficient-for-layout.rs
+++ b/tests/ui/coroutine/auxiliary/metadata-sufficient-for-layout.rs
@@ -5,6 +5,7 @@ use std::marker::Unpin;
 use std::ops::Coroutine;
 
 pub fn g() -> impl Coroutine<(), Yield = (), Return = ()> {
+    #[coroutine]
     || {
         yield;
     }

--- a/tests/ui/coroutine/auxiliary/unwind-aux.rs
+++ b/tests/ui/coroutine/auxiliary/unwind-aux.rs
@@ -2,9 +2,10 @@
 //@ no-prefer-dynamic
 //@ edition:2021
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 pub fn run<T>(a: T) {
-    let _ = move || {
+    let _ = #[coroutine]
+    move || {
         drop(a);
         yield;
     };

--- a/tests/ui/coroutine/auxiliary/xcrate-reachable.rs
+++ b/tests/ui/coroutine/auxiliary/xcrate-reachable.rs
@@ -7,6 +7,7 @@ fn msg() -> u32 {
 }
 
 pub fn foo() -> impl Coroutine<(), Yield = (), Return = u32> {
+    #[coroutine]
     || {
         yield;
         return msg();

--- a/tests/ui/coroutine/auxiliary/xcrate.rs
+++ b/tests/ui/coroutine/auxiliary/xcrate.rs
@@ -1,9 +1,10 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::marker::Unpin;
 use std::ops::Coroutine;
 
 pub fn foo() -> impl Coroutine<(), Yield = (), Return = ()> {
+    #[coroutine]
     || {
         if false {
             yield;
@@ -12,7 +13,10 @@ pub fn foo() -> impl Coroutine<(), Yield = (), Return = ()> {
 }
 
 pub fn bar<T: 'static>(t: T) -> Box<Coroutine<(), Yield = T, Return = ()> + Unpin> {
-    Box::new(|| {
-        yield t;
-    })
+    Box::new(
+        #[coroutine]
+        || {
+            yield t;
+        },
+    )
 }

--- a/tests/ui/coroutine/borrow-in-tail-expr.rs
+++ b/tests/ui/coroutine/borrow-in-tail-expr.rs
@@ -1,9 +1,9 @@
 //@ run-pass
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn main() {
-    let _a = || {
+    let _a = #[coroutine] || {
         yield;
         let a = String::new();
         a.len()

--- a/tests/ui/coroutine/borrowing.rs
+++ b/tests/ui/coroutine/borrowing.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;
@@ -6,13 +6,13 @@ use std::pin::Pin;
 fn main() {
     let _b = {
         let a = 3;
-        Pin::new(&mut || yield &a).resume(())
+        Pin::new(&mut #[coroutine] || yield &a).resume(())
         //~^ ERROR: `a` does not live long enough
     };
 
     let _b = {
         let a = 3;
-        || {
+        #[coroutine] || {
             yield &a
             //~^ ERROR: `a` does not live long enough
         }

--- a/tests/ui/coroutine/borrowing.stderr
+++ b/tests/ui/coroutine/borrowing.stderr
@@ -1,13 +1,13 @@
 error[E0597]: `a` does not live long enough
-  --> $DIR/borrowing.rs:9:33
+  --> $DIR/borrowing.rs:9:46
    |
 LL |     let _b = {
    |         -- borrow later stored here
 LL |         let a = 3;
-LL |         Pin::new(&mut || yield &a).resume(())
-   |                       --        ^ borrowed value does not live long enough
-   |                       |
-   |                       value captured here by coroutine
+LL |         Pin::new(&mut #[coroutine] || yield &a).resume(())
+   |                                    --        ^ borrowed value does not live long enough
+   |                                    |
+   |                                    value captured here by coroutine
 LL |
 LL |     };
    |     - `a` dropped here while still borrowed
@@ -18,8 +18,8 @@ error[E0597]: `a` does not live long enough
 LL |     let _b = {
    |         -- borrow later stored here
 LL |         let a = 3;
-LL |         || {
-   |         -- value captured here by coroutine
+LL |         #[coroutine] || {
+   |                      -- value captured here by coroutine
 LL |             yield &a
    |                    ^ borrowed value does not live long enough
 ...

--- a/tests/ui/coroutine/check-resume-ty-lifetimes-2.rs
+++ b/tests/ui/coroutine/check-resume-ty-lifetimes-2.rs
@@ -7,27 +7,27 @@ struct Contravariant<'a>(fn(&'a ()));
 struct Covariant<'a>(fn() -> &'a ());
 
 fn bad1<'short, 'long: 'short>() -> impl Coroutine<Covariant<'short>> {
-    |_: Covariant<'short>| {
+    #[coroutine] |_: Covariant<'short>| {
         let a: Covariant<'long> = yield ();
         //~^ ERROR lifetime may not live long enough
     }
 }
 
 fn bad2<'short, 'long: 'short>() -> impl Coroutine<Contravariant<'long>> {
-    |_: Contravariant<'long>| {
+    #[coroutine] |_: Contravariant<'long>| {
         let a: Contravariant<'short> = yield ();
         //~^ ERROR lifetime may not live long enough
     }
 }
 
 fn good1<'short, 'long: 'short>() -> impl Coroutine<Covariant<'long>> {
-    |_: Covariant<'long>| {
+    #[coroutine] |_: Covariant<'long>| {
         let a: Covariant<'short> = yield ();
     }
 }
 
 fn good2<'short, 'long: 'short>() -> impl Coroutine<Contravariant<'short>> {
-    |_: Contravariant<'short>| {
+    #[coroutine] |_: Contravariant<'short>| {
         let a: Contravariant<'long> = yield ();
     }
 }

--- a/tests/ui/coroutine/check-resume-ty-lifetimes-2.stderr
+++ b/tests/ui/coroutine/check-resume-ty-lifetimes-2.stderr
@@ -5,15 +5,15 @@ LL | fn bad1<'short, 'long: 'short>() -> impl Coroutine<Covariant<'short>> {
    |         ------  ----- lifetime `'long` defined here
    |         |
    |         lifetime `'short` defined here
-LL |     |_: Covariant<'short>| {
+LL |     #[coroutine] |_: Covariant<'short>| {
 LL |         let a: Covariant<'long> = yield ();
    |                ^^^^^^^^^^^^^^^^ type annotation requires that `'short` must outlive `'long`
    |
    = help: consider adding the following bound: `'short: 'long`
 help: consider adding 'move' keyword before the nested closure
    |
-LL |     move |_: Covariant<'short>| {
-   |     ++++
+LL |     #[coroutine] move |_: Covariant<'short>| {
+   |                  ++++
 
 error: lifetime may not live long enough
   --> $DIR/check-resume-ty-lifetimes-2.rs:18:40
@@ -22,15 +22,15 @@ LL | fn bad2<'short, 'long: 'short>() -> impl Coroutine<Contravariant<'long>> {
    |         ------  ----- lifetime `'long` defined here
    |         |
    |         lifetime `'short` defined here
-LL |     |_: Contravariant<'long>| {
+LL |     #[coroutine] |_: Contravariant<'long>| {
 LL |         let a: Contravariant<'short> = yield ();
    |                                        ^^^^^^^^ yielding this value requires that `'short` must outlive `'long`
    |
    = help: consider adding the following bound: `'short: 'long`
 help: consider adding 'move' keyword before the nested closure
    |
-LL |     move |_: Contravariant<'long>| {
-   |     ++++
+LL |     #[coroutine] move |_: Contravariant<'long>| {
+   |                  ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/coroutine/check-resume-ty-lifetimes.rs
+++ b/tests/ui/coroutine/check-resume-ty-lifetimes.rs
@@ -1,5 +1,5 @@
 #![feature(coroutine_trait)]
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![allow(unused)]
 
 use std::ops::Coroutine;
@@ -9,11 +9,14 @@ use std::pin::pin;
 fn mk_static(s: &str) -> &'static str {
     let mut storage: Option<&'static str> = None;
 
-    let mut coroutine = pin!(|_: &str| {
-        let x: &'static str = yield ();
-        //~^ ERROR lifetime may not live long enough
-        storage = Some(x);
-    });
+    let mut coroutine = pin!(
+        #[coroutine]
+        |_: &str| {
+            let x: &'static str = yield ();
+            //~^ ERROR lifetime may not live long enough
+            storage = Some(x);
+        }
+    );
 
     coroutine.as_mut().resume(s);
     coroutine.as_mut().resume(s);

--- a/tests/ui/coroutine/check-resume-ty-lifetimes.stderr
+++ b/tests/ui/coroutine/check-resume-ty-lifetimes.stderr
@@ -1,11 +1,11 @@
 error: lifetime may not live long enough
-  --> $DIR/check-resume-ty-lifetimes.rs:13:16
+  --> $DIR/check-resume-ty-lifetimes.rs:15:20
    |
 LL | fn mk_static(s: &str) -> &'static str {
    |                 - let's call the lifetime of this reference `'1`
 ...
-LL |         let x: &'static str = yield ();
-   |                ^^^^^^^^^^^^ type annotation requires that `'1` must outlive `'static`
+LL |             let x: &'static str = yield ();
+   |                    ^^^^^^^^^^^^ type annotation requires that `'1` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coroutine/clone-impl-static.rs
+++ b/tests/ui/coroutine/clone-impl-static.rs
@@ -1,10 +1,11 @@
 // gate-test-coroutine_clone
 // Verifies that static coroutines cannot be cloned/copied.
 
-#![feature(coroutines, coroutine_clone)]
+#![feature(coroutines, coroutine_clone, stmt_expr_attributes)]
 
 fn main() {
-    let gen = static move || {
+    let gen = #[coroutine]
+    static move || {
         yield;
     };
     check_copy(&gen);

--- a/tests/ui/coroutine/clone-impl-static.stderr
+++ b/tests/ui/coroutine/clone-impl-static.stderr
@@ -1,27 +1,27 @@
-error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:7:15: 7:29}: Copy` is not satisfied
-  --> $DIR/clone-impl-static.rs:10:16
+error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:8:5: 8:19}: Copy` is not satisfied
+  --> $DIR/clone-impl-static.rs:11:16
    |
 LL |     check_copy(&gen);
-   |     ---------- ^^^^ the trait `Copy` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:7:15: 7:29}`
+   |     ---------- ^^^^ the trait `Copy` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:8:5: 8:19}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-static.rs:16:18
+  --> $DIR/clone-impl-static.rs:17:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:7:15: 7:29}: Clone` is not satisfied
-  --> $DIR/clone-impl-static.rs:12:17
+error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:8:5: 8:19}: Clone` is not satisfied
+  --> $DIR/clone-impl-static.rs:13:17
    |
 LL |     check_clone(&gen);
-   |     ----------- ^^^^ the trait `Clone` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:7:15: 7:29}`
+   |     ----------- ^^^^ the trait `Clone` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:8:5: 8:19}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-static.rs:17:19
+  --> $DIR/clone-impl-static.rs:18:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`

--- a/tests/ui/coroutine/clone-impl.rs
+++ b/tests/ui/coroutine/clone-impl.rs
@@ -2,13 +2,14 @@
 // Verifies that non-static coroutines can be cloned/copied if all their upvars and locals held
 // across awaits can be cloned/copied.
 
-#![feature(coroutines, coroutine_clone)]
+#![feature(coroutines, coroutine_clone, stmt_expr_attributes)]
 
 struct NonClone;
 
 fn test1() {
     let copyable: u32 = 123;
-    let gen_copy_0 = move || {
+    let gen_copy_0 = #[coroutine]
+    move || {
         yield;
         drop(copyable);
     };
@@ -18,7 +19,8 @@ fn test1() {
 
 fn test2() {
     let copyable: u32 = 123;
-    let gen_copy_1 = move || {
+    let gen_copy_1 = #[coroutine]
+    move || {
         /*
         let v = vec!['a'];
         let n = NonClone;
@@ -37,7 +39,8 @@ fn test2() {
 
 fn test3() {
     let clonable_0: Vec<u32> = Vec::new();
-    let gen_clone_0 = move || {
+    let gen_clone_0 = #[coroutine]
+    move || {
         let v = vec!['a'];
         yield;
         drop(v);
@@ -51,7 +54,8 @@ fn test3() {
 
 fn test4() {
     let clonable_1: Vec<u32> = Vec::new();
-    let gen_clone_1 = move || {
+    let gen_clone_1 = #[coroutine]
+    move || {
         let v = vec!['a'];
         /*
         let n = NonClone;
@@ -71,7 +75,8 @@ fn test4() {
 
 fn test5() {
     let non_clonable: NonClone = NonClone;
-    let gen_non_clone = move || {
+    let gen_non_clone = #[coroutine]
+    move || {
         yield;
         drop(non_clonable);
     };

--- a/tests/ui/coroutine/clone-impl.stderr
+++ b/tests/ui/coroutine/clone-impl.stderr
@@ -1,76 +1,76 @@
-error[E0277]: the trait bound `Vec<u32>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:40:23: 40:30}`
-  --> $DIR/clone-impl.rs:46:5
+error[E0277]: the trait bound `Vec<u32>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`
+  --> $DIR/clone-impl.rs:49:5
    |
-LL |     let gen_clone_0 = move || {
-   |                       ------- within this `{coroutine@$DIR/clone-impl.rs:40:23: 40:30}`
+LL |     move || {
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`
 ...
 LL |     check_copy(&gen_clone_0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:40:23: 40:30}`, the trait `Copy` is not implemented for `Vec<u32>`, which is required by `{coroutine@$DIR/clone-impl.rs:40:23: 40:30}: Copy`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`, the trait `Copy` is not implemented for `Vec<u32>`, which is required by `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}: Copy`
    |
 note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:44:14
+  --> $DIR/clone-impl.rs:47:14
    |
 LL |         drop(clonable_0);
    |              ^^^^^^^^^^ has type `Vec<u32>` which does not implement `Copy`
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:84:18
+  --> $DIR/clone-impl.rs:89:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `Vec<char>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:40:23: 40:30}`
-  --> $DIR/clone-impl.rs:46:5
+error[E0277]: the trait bound `Vec<char>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`
+  --> $DIR/clone-impl.rs:49:5
    |
-LL |     let gen_clone_0 = move || {
-   |                       ------- within this `{coroutine@$DIR/clone-impl.rs:40:23: 40:30}`
+LL |     move || {
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`
 ...
 LL |     check_copy(&gen_clone_0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:40:23: 40:30}`, the trait `Copy` is not implemented for `Vec<char>`, which is required by `{coroutine@$DIR/clone-impl.rs:40:23: 40:30}: Copy`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`, the trait `Copy` is not implemented for `Vec<char>`, which is required by `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}: Copy`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
-  --> $DIR/clone-impl.rs:42:9
+  --> $DIR/clone-impl.rs:45:9
    |
 LL |         let v = vec!['a'];
    |             - has type `Vec<char>` which does not implement `Copy`
 LL |         yield;
    |         ^^^^^ yield occurs here, with `v` maybe used later
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:84:18
+  --> $DIR/clone-impl.rs:89:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `Vec<u32>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:54:23: 54:30}`
-  --> $DIR/clone-impl.rs:66:5
+error[E0277]: the trait bound `Vec<u32>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`
+  --> $DIR/clone-impl.rs:70:5
    |
-LL |     let gen_clone_1 = move || {
-   |                       ------- within this `{coroutine@$DIR/clone-impl.rs:54:23: 54:30}`
+LL |     move || {
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`
 ...
 LL |     check_copy(&gen_clone_1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:54:23: 54:30}`, the trait `Copy` is not implemented for `Vec<u32>`, which is required by `{coroutine@$DIR/clone-impl.rs:54:23: 54:30}: Copy`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`, the trait `Copy` is not implemented for `Vec<u32>`, which is required by `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}: Copy`
    |
 note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:64:14
+  --> $DIR/clone-impl.rs:68:14
    |
 LL |         drop(clonable_1);
    |              ^^^^^^^^^^ has type `Vec<u32>` which does not implement `Copy`
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:84:18
+  --> $DIR/clone-impl.rs:89:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `Vec<char>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:54:23: 54:30}`
-  --> $DIR/clone-impl.rs:66:5
+error[E0277]: the trait bound `Vec<char>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`
+  --> $DIR/clone-impl.rs:70:5
    |
-LL |     let gen_clone_1 = move || {
-   |                       ------- within this `{coroutine@$DIR/clone-impl.rs:54:23: 54:30}`
+LL |     move || {
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`
 ...
 LL |     check_copy(&gen_clone_1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:54:23: 54:30}`, the trait `Copy` is not implemented for `Vec<char>`, which is required by `{coroutine@$DIR/clone-impl.rs:54:23: 54:30}: Copy`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`, the trait `Copy` is not implemented for `Vec<char>`, which is required by `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}: Copy`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
-  --> $DIR/clone-impl.rs:60:9
+  --> $DIR/clone-impl.rs:64:9
    |
 LL |         let v = vec!['a'];
    |             - has type `Vec<char>` which does not implement `Copy`
@@ -78,27 +78,27 @@ LL |         let v = vec!['a'];
 LL |         yield;
    |         ^^^^^ yield occurs here, with `v` maybe used later
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:84:18
+  --> $DIR/clone-impl.rs:89:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `NonClone: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:74:25: 74:32}`
-  --> $DIR/clone-impl.rs:78:5
+error[E0277]: the trait bound `NonClone: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`
+  --> $DIR/clone-impl.rs:83:5
    |
-LL |     let gen_non_clone = move || {
-   |                         ------- within this `{coroutine@$DIR/clone-impl.rs:74:25: 74:32}`
+LL |     move || {
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`
 ...
 LL |     check_copy(&gen_non_clone);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:74:25: 74:32}`, the trait `Copy` is not implemented for `NonClone`, which is required by `{coroutine@$DIR/clone-impl.rs:74:25: 74:32}: Copy`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`, the trait `Copy` is not implemented for `NonClone`, which is required by `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}: Copy`
    |
 note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:76:14
+  --> $DIR/clone-impl.rs:81:14
    |
 LL |         drop(non_clonable);
    |              ^^^^^^^^^^^^ has type `NonClone` which does not implement `Copy`
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:84:18
+  --> $DIR/clone-impl.rs:89:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
@@ -108,22 +108,22 @@ LL + #[derive(Copy)]
 LL | struct NonClone;
    |
 
-error[E0277]: the trait bound `NonClone: Clone` is not satisfied in `{coroutine@$DIR/clone-impl.rs:74:25: 74:32}`
-  --> $DIR/clone-impl.rs:80:5
+error[E0277]: the trait bound `NonClone: Clone` is not satisfied in `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`
+  --> $DIR/clone-impl.rs:85:5
    |
-LL |     let gen_non_clone = move || {
-   |                         ------- within this `{coroutine@$DIR/clone-impl.rs:74:25: 74:32}`
+LL |     move || {
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`
 ...
 LL |     check_clone(&gen_non_clone);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:74:25: 74:32}`, the trait `Clone` is not implemented for `NonClone`, which is required by `{coroutine@$DIR/clone-impl.rs:74:25: 74:32}: Clone`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`, the trait `Clone` is not implemented for `NonClone`, which is required by `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}: Clone`
    |
 note: captured value does not implement `Clone`
-  --> $DIR/clone-impl.rs:76:14
+  --> $DIR/clone-impl.rs:81:14
    |
 LL |         drop(non_clonable);
    |              ^^^^^^^^^^^^ has type `NonClone` which does not implement `Clone`
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl.rs:85:19
+  --> $DIR/clone-impl.rs:90:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`

--- a/tests/ui/coroutine/clone-rpit.next.stderr
+++ b/tests/ui/coroutine/clone-rpit.next.stderr
@@ -5,32 +5,32 @@ LL | pub fn foo<'a, 'b>() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: ...which requires coroutine witness types for `foo::{closure#0}`...
-  --> $DIR/clone-rpit.rs:14:5
+  --> $DIR/clone-rpit.rs:15:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
 note: ...which requires promoting constants in MIR for `foo::{closure#0}`...
-  --> $DIR/clone-rpit.rs:14:5
+  --> $DIR/clone-rpit.rs:15:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
 note: ...which requires checking if `foo::{closure#0}` contains FFI-unwind calls...
-  --> $DIR/clone-rpit.rs:14:5
+  --> $DIR/clone-rpit.rs:15:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
 note: ...which requires building MIR for `foo::{closure#0}`...
-  --> $DIR/clone-rpit.rs:14:5
+  --> $DIR/clone-rpit.rs:15:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
 note: ...which requires match-checking `foo::{closure#0}`...
-  --> $DIR/clone-rpit.rs:14:5
+  --> $DIR/clone-rpit.rs:15:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^
 note: ...which requires type-checking `foo::{closure#0}`...
-  --> $DIR/clone-rpit.rs:14:5
+  --> $DIR/clone-rpit.rs:15:5
    |
 LL |     move |_: ()| {
    |     ^^^^^^^^^^^^

--- a/tests/ui/coroutine/clone-rpit.rs
+++ b/tests/ui/coroutine/clone-rpit.rs
@@ -11,6 +11,7 @@
 // witness types, which we don't know until after borrowck. When we later check
 // the goal for correctness, we want to be able to bind the `impl Clone` opaque.
 pub fn foo<'a, 'b>() -> impl Clone {
+    #[coroutine]
     move |_: ()| {
         let () = yield ();
     }

--- a/tests/ui/coroutine/conditional-drop.rs
+++ b/tests/ui/coroutine/conditional-drop.rs
@@ -3,7 +3,7 @@
 //@ revisions: default nomiropt
 //@[nomiropt]compile-flags: -Z mir-opt-level=0
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;
@@ -29,7 +29,7 @@ fn main() {
 }
 
 fn t1() {
-    let mut a = || {
+    let mut a = #[coroutine] || {
         let b = B;
         if test() {
             drop(b);
@@ -45,7 +45,7 @@ fn t1() {
 }
 
 fn t2() {
-    let mut a = || {
+    let mut a = #[coroutine] || {
         let b = B;
         if test2() {
             drop(b);

--- a/tests/ui/coroutine/control-flow.rs
+++ b/tests/ui/coroutine/control-flow.rs
@@ -3,7 +3,7 @@
 //@ revisions: default nomiropt
 //@[nomiropt]compile-flags: -Z mir-opt-level=0
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::{CoroutineState, Coroutine};
 use std::pin::Pin;
@@ -24,25 +24,25 @@ fn finish<T>(mut amt: usize, mut t: T) -> T::Return
 }
 
 fn main() {
-    finish(1, || yield);
-    finish(8, || {
+    finish(1, #[coroutine] || yield);
+    finish(8, #[coroutine] || {
         for _ in 0..8 {
             yield;
         }
     });
-    finish(1, || {
+    finish(1, #[coroutine] || {
         if true {
             yield;
         } else {
         }
     });
-    finish(1, || {
+    finish(1, #[coroutine] || {
         if false {
         } else {
             yield;
         }
     });
-    finish(2, || {
+    finish(2, #[coroutine] || {
         if { yield; false } {
             yield;
             panic!()

--- a/tests/ui/coroutine/coroutine-region-requirements.rs
+++ b/tests/ui/coroutine/coroutine-region-requirements.rs
@@ -1,9 +1,9 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
 
 fn dangle(x: &mut i32) -> &'static mut i32 {
-    let mut g = || {
+    let mut g = #[coroutine] || {
         yield;
         x
     };

--- a/tests/ui/coroutine/coroutine-resume-after-panic.rs
+++ b/tests/ui/coroutine/coroutine-resume-after-panic.rs
@@ -5,7 +5,7 @@
 
 // Test that we get the correct message for resuming a panicked coroutine.
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::{
     ops::Coroutine,
@@ -14,7 +14,7 @@ use std::{
 };
 
 fn main() {
-    let mut g = || {
+    let mut g = #[coroutine] || {
         panic!();
         yield;
     };

--- a/tests/ui/coroutine/coroutine-with-nll.rs
+++ b/tests/ui/coroutine/coroutine-with-nll.rs
@@ -1,6 +1,7 @@
 #![feature(coroutines)]
 
 fn main() {
+    #[coroutine]
     || {
         // The reference in `_a` is a Legal with NLL since it ends before the yield
         let _a = &mut true;

--- a/tests/ui/coroutine/coroutine-with-nll.stderr
+++ b/tests/ui/coroutine/coroutine-with-nll.stderr
@@ -1,5 +1,5 @@
 error[E0626]: borrow may still be in use when coroutine yields
-  --> $DIR/coroutine-with-nll.rs:7:17
+  --> $DIR/coroutine-with-nll.rs:8:17
    |
 LL |         let b = &mut true;
    |                 ^^^^^^^^^

--- a/tests/ui/coroutine/coroutine-yielding-or-returning-itself.rs
+++ b/tests/ui/coroutine/coroutine-yielding-or-returning-itself.rs
@@ -1,5 +1,5 @@
 #![feature(coroutine_trait)]
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 // Test that we cannot create a coroutine that returns a value of its
 // own type.
@@ -12,7 +12,7 @@ pub fn want_cyclic_coroutine_return<T>(_: T)
 }
 
 fn supply_cyclic_coroutine_return() {
-    want_cyclic_coroutine_return(|| {
+    want_cyclic_coroutine_return(#[coroutine] || {
         //~^ ERROR type mismatch
         if false { yield None.unwrap(); }
         None.unwrap()
@@ -25,7 +25,7 @@ pub fn want_cyclic_coroutine_yield<T>(_: T)
 }
 
 fn supply_cyclic_coroutine_yield() {
-    want_cyclic_coroutine_yield(|| {
+    want_cyclic_coroutine_yield(#[coroutine] || {
         //~^ ERROR type mismatch
         if false { yield None.unwrap(); }
         None.unwrap()

--- a/tests/ui/coroutine/coroutine-yielding-or-returning-itself.stderr
+++ b/tests/ui/coroutine/coroutine-yielding-or-returning-itself.stderr
@@ -1,8 +1,8 @@
-error[E0271]: type mismatch resolving `<{coroutine@$DIR/coroutine-yielding-or-returning-itself.rs:15:34: 15:36} as Coroutine>::Return == {coroutine@$DIR/coroutine-yielding-or-returning-itself.rs:15:34: 15:36}`
-  --> $DIR/coroutine-yielding-or-returning-itself.rs:15:34
+error[E0271]: type mismatch resolving `<{coroutine@$DIR/coroutine-yielding-or-returning-itself.rs:15:47: 15:49} as Coroutine>::Return == {coroutine@$DIR/coroutine-yielding-or-returning-itself.rs:15:47: 15:49}`
+  --> $DIR/coroutine-yielding-or-returning-itself.rs:15:47
    |
-LL |       want_cyclic_coroutine_return(|| {
-   |  _____----------------------------_^
+LL |       want_cyclic_coroutine_return(#[coroutine] || {
+   |  _____----------------------------______________^
    | |     |
    | |     required by a bound introduced by this call
 LL | |
@@ -23,11 +23,11 @@ LL | pub fn want_cyclic_coroutine_return<T>(_: T)
 LL |     where T: Coroutine<Yield = (), Return = T>
    |                                    ^^^^^^^^^^ required by this bound in `want_cyclic_coroutine_return`
 
-error[E0271]: type mismatch resolving `<{coroutine@$DIR/coroutine-yielding-or-returning-itself.rs:28:33: 28:35} as Coroutine>::Yield == {coroutine@$DIR/coroutine-yielding-or-returning-itself.rs:28:33: 28:35}`
-  --> $DIR/coroutine-yielding-or-returning-itself.rs:28:33
+error[E0271]: type mismatch resolving `<{coroutine@$DIR/coroutine-yielding-or-returning-itself.rs:28:46: 28:48} as Coroutine>::Yield == {coroutine@$DIR/coroutine-yielding-or-returning-itself.rs:28:46: 28:48}`
+  --> $DIR/coroutine-yielding-or-returning-itself.rs:28:46
    |
-LL |       want_cyclic_coroutine_yield(|| {
-   |  _____---------------------------_^
+LL |       want_cyclic_coroutine_yield(#[coroutine] || {
+   |  _____---------------------------______________^
    | |     |
    | |     required by a bound introduced by this call
 LL | |

--- a/tests/ui/coroutine/derived-drop-parent-expr.rs
+++ b/tests/ui/coroutine/derived-drop-parent-expr.rs
@@ -10,7 +10,7 @@ pub struct Client { pub nickname: String }
 
 fn main() {
     let g = move || match drop(Client { ..Client::default() }) {
-        _status => yield,
-    };
+            _status => yield,
+        };
     assert_send(g);
 }

--- a/tests/ui/coroutine/derived-drop-parent-expr.rs
+++ b/tests/ui/coroutine/derived-drop-parent-expr.rs
@@ -1,7 +1,7 @@
 //@ build-pass
 
 //! Like drop-tracking-parent-expression, but also tests that this doesn't ICE when building MIR
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn assert_send<T: Send>(_thing: T) {}
 
@@ -9,7 +9,7 @@ fn assert_send<T: Send>(_thing: T) {}
 pub struct Client { pub nickname: String }
 
 fn main() {
-    let g = move || match drop(Client { ..Client::default() }) {
+    let g = #[coroutine] move || match drop(Client { ..Client::default() }) {
             _status => yield,
         };
     assert_send(g);

--- a/tests/ui/coroutine/discriminant.rs
+++ b/tests/ui/coroutine/discriminant.rs
@@ -86,7 +86,7 @@ fn cycle(
 fn main() {
     // Has only one invalid discr. value.
     let gen_u8_tiny_niche = || {
-        || {
+        #[coroutine] || {
             // 3 reserved variants
 
             yield250!(); // 253 variants
@@ -98,7 +98,7 @@ fn main() {
 
     // Uses all values in the u8 discriminant.
     let gen_u8_full = || {
-        || {
+        #[coroutine] || {
             // 3 reserved variants
 
             yield250!(); // 253 variants
@@ -111,7 +111,7 @@ fn main() {
 
     // Barely needs a u16 discriminant.
     let gen_u16 = || {
-        || {
+        #[coroutine] || {
             // 3 reserved variants
 
             yield250!(); // 253 variants

--- a/tests/ui/coroutine/drop-and-replace.rs
+++ b/tests/ui/coroutine/drop-and-replace.rs
@@ -4,7 +4,7 @@
 // #60187, this produced incorrect code for coroutines when a saved local was
 // re-assigned.
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
@@ -17,7 +17,8 @@ impl Drop for Foo {
 }
 
 fn main() {
-    let mut a = || {
+    let mut a = #[coroutine]
+    || {
         let mut x = Foo(4);
         yield;
         assert_eq!(x.0, 4);

--- a/tests/ui/coroutine/drop-control-flow.rs
+++ b/tests/ui/coroutine/drop-control-flow.rs
@@ -4,7 +4,7 @@
 // and also that values that are dropped along all paths to a yield do not get
 // included in the coroutine type.
 
-#![feature(coroutines, negative_impls)]
+#![feature(coroutines, negative_impls, stmt_expr_attributes)]
 #![allow(unused_assignments, dead_code)]
 
 struct Ptr;
@@ -19,7 +19,7 @@ fn assert_send<T: Send>(_: T) {}
 
 // This test case is reduced from tests/ui/drop/dynamic-drop-async.rs
 fn one_armed_if(arg: bool) {
-    let _ = || {
+    let _ = #[coroutine] || {
         let arr = [Ptr];
         if arg {
             drop(arr);
@@ -29,7 +29,7 @@ fn one_armed_if(arg: bool) {
 }
 
 fn two_armed_if(arg: bool) {
-    assert_send(|| {
+    assert_send(#[coroutine] || {
         let arr = [Ptr];
         if arg {
             drop(arr);
@@ -41,7 +41,7 @@ fn two_armed_if(arg: bool) {
 }
 
 fn if_let(arg: Option<i32>) {
-    let _ = || {
+    let _ = #[coroutine] || {
         let arr = [Ptr];
         if let Some(_) = arg {
             drop(arr);
@@ -51,7 +51,7 @@ fn if_let(arg: Option<i32>) {
 }
 
 fn init_in_if(arg: bool) {
-    assert_send(|| {
+    assert_send(#[coroutine] || {
         let mut x = NonSend;
         drop(x);
         if arg {
@@ -63,7 +63,7 @@ fn init_in_if(arg: bool) {
 }
 
 fn init_in_match_arm(arg: Option<i32>) {
-    assert_send(|| {
+    assert_send(#[coroutine] || {
         let mut x = NonSend;
         drop(x);
         match arg {
@@ -74,7 +74,7 @@ fn init_in_match_arm(arg: Option<i32>) {
 }
 
 fn reinit() {
-    let _ = || {
+    let _ = #[coroutine] || {
         let mut arr = [Ptr];
         drop(arr);
         arr = [Ptr];
@@ -83,7 +83,7 @@ fn reinit() {
 }
 
 fn loop_uninit() {
-    let _ = || {
+    let _ = #[coroutine] || {
         let mut arr = [Ptr];
         let mut count = 0;
         drop(arr);
@@ -96,7 +96,7 @@ fn loop_uninit() {
 }
 
 fn nested_loop() {
-    let _ = || {
+    let _ = #[coroutine] || {
         let mut arr = [Ptr];
         let mut count = 0;
         drop(arr);
@@ -111,7 +111,7 @@ fn nested_loop() {
 }
 
 fn loop_continue(b: bool) {
-    let _ = || {
+    let _ = #[coroutine] || {
         let mut arr = [Ptr];
         let mut count = 0;
         drop(arr);

--- a/tests/ui/coroutine/drop-env.rs
+++ b/tests/ui/coroutine/drop-env.rs
@@ -3,7 +3,7 @@
 //@ revisions: default nomiropt
 //@[nomiropt]compile-flags: -Z mir-opt-level=0
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 #![allow(dropping_copy_types)]
 
 use std::ops::Coroutine;
@@ -28,7 +28,7 @@ fn main() {
 
 fn t1() {
     let b = B;
-    let mut foo = || {
+    let mut foo = #[coroutine] || {
         yield;
         drop(b);
     };
@@ -42,7 +42,7 @@ fn t1() {
 
 fn t2() {
     let b = B;
-    let mut foo = || {
+    let mut foo = #[coroutine] || {
         yield b;
     };
 
@@ -55,7 +55,7 @@ fn t2() {
 
 fn t3() {
     let b = B;
-    let foo = || {
+    let foo = #[coroutine] || {
         yield;
         drop(b);
     };

--- a/tests/ui/coroutine/drop-track-addassign-yield.rs
+++ b/tests/ui/coroutine/drop-track-addassign-yield.rs
@@ -3,10 +3,10 @@
 // Based on addassign-yield.rs, but with drop tracking enabled. Originally we did not implement
 // the fake_read callback on ExprUseVisitor which caused this case to break.
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn foo() {
-    let _y = static || {
+    let _y = #[coroutine] static || {
         let x = &mut 0;
         *{
             yield;
@@ -17,7 +17,7 @@ fn foo() {
     };
 
     // Please don't ever actually write something like this
-    let _z = static || {
+    let _z = #[coroutine] static || {
         let x = &mut 0;
         *{
             let inner = &mut 1;

--- a/tests/ui/coroutine/drop-tracking-parent-expression.rs
+++ b/tests/ui/coroutine/drop-tracking-parent-expression.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines, negative_impls, rustc_attrs)]
+#![feature(coroutines, negative_impls, rustc_attrs, stmt_expr_attributes)]
 
 macro_rules! type_combinations {
     (
@@ -14,7 +14,7 @@ macro_rules! type_combinations {
         // Struct update syntax. This fails because the Client used in the update is considered
         // dropped *after* the yield.
         {
-            let g = move || match drop($name::Client { ..$name::Client::default() }) {
+            let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
             //~^ `significant_drop::Client` which is not `Send`
             //~| `insignificant_dtor::Client` which is not `Send`
             //~| `derived_drop::Client` which is not `Send`
@@ -29,7 +29,7 @@ macro_rules! type_combinations {
         // Simple owned value. This works because the Client is considered moved into `drop`,
         // even though the temporary expression doesn't end until after the yield.
         {
-            let g = move || match drop($name::Client::default()) {
+            let g = #[coroutine] move || match drop($name::Client::default()) {
                 _ => yield,
             };
             assert_send(g);

--- a/tests/ui/coroutine/drop-tracking-parent-expression.stderr
+++ b/tests/ui/coroutine/drop-tracking-parent-expression.stderr
@@ -13,12 +13,12 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `derived_drop::Client`, which is required by `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}: Send`
+   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `derived_drop::Client`, which is required by `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:34: 17:41}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:21:22
    |
-LL |               let g = move || match drop($name::Client { ..$name::Client::default() }) {
-   |                                                            ------------------------ has type `derived_drop::Client` which is not `Send`
+LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
+   |                                                                         ------------------------ has type `derived_drop::Client` which is not `Send`
 ...
 LL |                   _ => yield,
    |                        ^^^^^ yield occurs here, with `$name::Client::default()` maybe used later
@@ -53,12 +53,12 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `significant_drop::Client`, which is required by `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}: Send`
+   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `significant_drop::Client`, which is required by `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:34: 17:41}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:21:22
    |
-LL |               let g = move || match drop($name::Client { ..$name::Client::default() }) {
-   |                                                            ------------------------ has type `significant_drop::Client` which is not `Send`
+LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
+   |                                                                         ------------------------ has type `significant_drop::Client` which is not `Send`
 ...
 LL |                   _ => yield,
    |                        ^^^^^ yield occurs here, with `$name::Client::default()` maybe used later
@@ -93,12 +93,12 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `insignificant_dtor::Client`, which is required by `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}: Send`
+   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `insignificant_dtor::Client`, which is required by `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:34: 17:41}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:21:22
    |
-LL |               let g = move || match drop($name::Client { ..$name::Client::default() }) {
-   |                                                            ------------------------ has type `insignificant_dtor::Client` which is not `Send`
+LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
+   |                                                                         ------------------------ has type `insignificant_dtor::Client` which is not `Send`
 ...
 LL |                   _ => yield,
    |                        ^^^^^ yield occurs here, with `$name::Client::default()` maybe used later

--- a/tests/ui/coroutine/drop-tracking-yielding-in-match-guards.rs
+++ b/tests/ui/coroutine/drop-tracking-yielding-in-match-guards.rs
@@ -1,10 +1,10 @@
 //@ build-pass
 //@ edition:2018
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn main() {
-    let _ = static |x: u8| match x {
+    let _ = #[coroutine] static |x: u8| match x {
         y if { yield } == y + 1 => (),
         _ => (),
     };

--- a/tests/ui/coroutine/drop-yield-twice.rs
+++ b/tests/ui/coroutine/drop-yield-twice.rs
@@ -1,10 +1,10 @@
-#![feature(negative_impls, coroutines)]
+#![feature(negative_impls, coroutines, stmt_expr_attributes)]
 
 struct Foo(i32);
 impl !Send for Foo {}
 
 fn main() {
-    assert_send(|| { //~ ERROR coroutine cannot be sent between threads safely
+    assert_send(#[coroutine] || { //~ ERROR coroutine cannot be sent between threads safely
         let guard = Foo(42);
         yield;
         drop(guard);

--- a/tests/ui/coroutine/drop-yield-twice.stderr
+++ b/tests/ui/coroutine/drop-yield-twice.stderr
@@ -1,7 +1,7 @@
 error: coroutine cannot be sent between threads safely
   --> $DIR/drop-yield-twice.rs:7:5
    |
-LL | /     assert_send(|| {
+LL | /     assert_send(#[coroutine] || {
 LL | |         let guard = Foo(42);
 LL | |         yield;
 LL | |         drop(guard);
@@ -9,7 +9,7 @@ LL | |         yield;
 LL | |     })
    | |______^ coroutine is not `Send`
    |
-   = help: within `{coroutine@$DIR/drop-yield-twice.rs:7:17: 7:19}`, the trait `Send` is not implemented for `Foo`, which is required by `{coroutine@$DIR/drop-yield-twice.rs:7:17: 7:19}: Send`
+   = help: within `{coroutine@$DIR/drop-yield-twice.rs:7:30: 7:32}`, the trait `Send` is not implemented for `Foo`, which is required by `{coroutine@$DIR/drop-yield-twice.rs:7:30: 7:32}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-yield-twice.rs:9:9
    |

--- a/tests/ui/coroutine/dropck-resume.rs
+++ b/tests/ui/coroutine/dropck-resume.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
@@ -16,7 +16,8 @@ fn drop_using_coroutine() -> i32 {
     let z = &mut y;
     let r;
     {
-        let mut g = move |r| {
+        let mut g = #[coroutine]
+        move |r| {
             let _s = SetToNone(r);
             yield;
         };

--- a/tests/ui/coroutine/dropck-resume.stderr
+++ b/tests/ui/coroutine/dropck-resume.stderr
@@ -1,5 +1,5 @@
 error[E0502]: cannot borrow `y` as immutable because it is also borrowed as mutable
-  --> $DIR/dropck-resume.rs:25:13
+  --> $DIR/dropck-resume.rs:26:13
    |
 LL |     let z = &mut y;
    |             ------ mutable borrow occurs here

--- a/tests/ui/coroutine/dropck.rs
+++ b/tests/ui/coroutine/dropck.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::cell::RefCell;
 use std::ops::Coroutine;
@@ -10,7 +10,8 @@ fn main() {
     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
     //~^ ERROR `*cell` does not live long enough [E0597]
     // the upvar is the non-dropck `&mut Option<Ref<'a, i32>>`.
-    gen = || {
+    gen = #[coroutine]
+    || {
         // but the coroutine can use it to drop a `Ref<'a, i32>`.
         let _d = ref_.take(); //~ ERROR `ref_` does not live long enough
         yield;

--- a/tests/ui/coroutine/dropck.stderr
+++ b/tests/ui/coroutine/dropck.stderr
@@ -16,10 +16,10 @@ LL | }
    = note: values in a scope are dropped in the opposite order they are defined
 
 error[E0597]: `ref_` does not live long enough
-  --> $DIR/dropck.rs:15:18
+  --> $DIR/dropck.rs:16:18
    |
-LL |     gen = || {
-   |           -- value captured here by coroutine
+LL |     || {
+   |     -- value captured here by coroutine
 LL |         // but the coroutine can use it to drop a `Ref<'a, i32>`.
 LL |         let _d = ref_.take();
    |                  ^^^^ borrowed value does not live long enough

--- a/tests/ui/coroutine/gen_block.e2024.stderr
+++ b/tests/ui/coroutine/gen_block.e2024.stderr
@@ -1,5 +1,25 @@
+error[E0658]: the `#[coroutines]` attribute is an experimental feature
+  --> $DIR/gen_block.rs:20:13
+   |
+LL |     let _ = #[coroutine] || yield true;
+   |             ^^^^^^^^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the `#[coroutines]` attribute is an experimental feature
+  --> $DIR/gen_block.rs:24:13
+   |
+LL |     let _ = #[coroutine] || {};
+   |             ^^^^^^^^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: yield syntax is experimental
-  --> $DIR/gen_block.rs:15:16
+  --> $DIR/gen_block.rs:16:16
    |
 LL |     let _ = || yield true;
    |                ^^^^^^^^^^
@@ -8,13 +28,34 @@ LL |     let _ = || yield true;
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/gen_block.rs:16:16
+   |
+LL |     let _ = || yield true;
+   |                ^^^^^^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL |     let _ = #[coroutine] || yield true;
+   |             ++++++++++++
+
+error[E0658]: yield syntax is experimental
+  --> $DIR/gen_block.rs:20:29
+   |
+LL |     let _ = #[coroutine] || yield true;
+   |                             ^^^^^^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0282]: type annotations needed
-  --> $DIR/gen_block.rs:6:13
+  --> $DIR/gen_block.rs:7:13
    |
 LL |     let x = gen {};
    |             ^^^^^^ cannot infer type
 
-error: aborting due to 2 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0282, E0658.
 For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/coroutine/gen_block.none.stderr
+++ b/tests/ui/coroutine/gen_block.none.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found reserved keyword `yield`
-  --> $DIR/gen_block.rs:9:19
+  --> $DIR/gen_block.rs:10:19
    |
 LL |     let y = gen { yield 42 };
    |             ---   ^^^^^ expected identifier, found reserved keyword
@@ -7,25 +7,25 @@ LL |     let y = gen { yield 42 };
    |             while parsing this struct
 
 error[E0422]: cannot find struct, variant or union type `gen` in this scope
-  --> $DIR/gen_block.rs:6:13
+  --> $DIR/gen_block.rs:7:13
    |
 LL |     let x = gen {};
    |             ^^^ not found in this scope
 
 error[E0422]: cannot find struct, variant or union type `gen` in this scope
-  --> $DIR/gen_block.rs:9:13
+  --> $DIR/gen_block.rs:10:13
    |
 LL |     let y = gen { yield 42 };
    |             ^^^ not found in this scope
 
 error[E0422]: cannot find struct, variant or union type `gen` in this scope
-  --> $DIR/gen_block.rs:12:5
+  --> $DIR/gen_block.rs:13:5
    |
 LL |     gen {};
    |     ^^^ not found in this scope
 
 error[E0658]: yield syntax is experimental
-  --> $DIR/gen_block.rs:15:16
+  --> $DIR/gen_block.rs:16:16
    |
 LL |     let _ = || yield true;
    |                ^^^^^^^^^^
@@ -35,7 +35,37 @@ LL |     let _ = || yield true;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: yield syntax is experimental
-  --> $DIR/gen_block.rs:15:16
+  --> $DIR/gen_block.rs:20:29
+   |
+LL |     let _ = #[coroutine] || yield true;
+   |                             ^^^^^^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the `#[coroutines]` attribute is an experimental feature
+  --> $DIR/gen_block.rs:20:13
+   |
+LL |     let _ = #[coroutine] || yield true;
+   |             ^^^^^^^^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the `#[coroutines]` attribute is an experimental feature
+  --> $DIR/gen_block.rs:24:13
+   |
+LL |     let _ = #[coroutine] || {};
+   |             ^^^^^^^^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: yield syntax is experimental
+  --> $DIR/gen_block.rs:16:16
    |
 LL |     let _ = || yield true;
    |                ^^^^^^^^^^
@@ -45,7 +75,29 @@ LL |     let _ = || yield true;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 6 previous errors
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/gen_block.rs:16:16
+   |
+LL |     let _ = || yield true;
+   |                ^^^^^^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL |     let _ = #[coroutine] || yield true;
+   |             ++++++++++++
+
+error[E0658]: yield syntax is experimental
+  --> $DIR/gen_block.rs:20:29
+   |
+LL |     let _ = #[coroutine] || yield true;
+   |                             ^^^^^^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 11 previous errors
 
 Some errors have detailed explanations: E0422, E0658.
 For more information about an error, try `rustc --explain E0422`.

--- a/tests/ui/coroutine/gen_block.rs
+++ b/tests/ui/coroutine/gen_block.rs
@@ -1,6 +1,7 @@
 //@ revisions: e2024 none
 //@[e2024] compile-flags: --edition 2024 -Zunstable-options
 #![cfg_attr(e2024, feature(gen_blocks))]
+#![feature(stmt_expr_attributes)]
 
 fn main() {
     let x = gen {};
@@ -14,4 +15,12 @@ fn main() {
 
     let _ = || yield true; //[none]~ ERROR yield syntax is experimental
     //~^ ERROR yield syntax is experimental
+    //~^^ ERROR `yield` can only be used in
+
+    let _ = #[coroutine] || yield true; //[none]~ ERROR yield syntax is experimental
+    //~^ ERROR `#[coroutines]` attribute is an experimental feature
+    //~^^ ERROR yield syntax is experimental
+
+    let _ = #[coroutine] || {};
+    //~^ ERROR `#[coroutines]` attribute is an experimental feature
 }

--- a/tests/ui/coroutine/issue-102645.rs
+++ b/tests/ui/coroutine/issue-102645.rs
@@ -1,11 +1,12 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;
 
 fn main() {
     let mut a = 5;
-    let mut b = || {
+    let mut b = #[coroutine]
+    || {
         let d = 6;
         yield;
         _zzz(); // #break

--- a/tests/ui/coroutine/issue-102645.stderr
+++ b/tests/ui/coroutine/issue-102645.stderr
@@ -1,5 +1,5 @@
 error[E0061]: this method takes 1 argument but 0 arguments were supplied
-  --> $DIR/issue-102645.rs:14:22
+  --> $DIR/issue-102645.rs:15:22
    |
 LL |     Pin::new(&mut b).resume();
    |                      ^^^^^^-- an argument of type `()` is missing

--- a/tests/ui/coroutine/issue-105084.rs
+++ b/tests/ui/coroutine/issue-105084.rs
@@ -11,7 +11,8 @@ fn copy<T: Copy>(x: T) -> T {
 }
 
 fn main() {
-    let mut g = || {
+    let mut g = #[coroutine]
+    || {
         // This is desuraged as 4 stages:
         // - allocate a `*mut u8` with `exchange_malloc`;
         // - create a Box that is ignored for trait computations;

--- a/tests/ui/coroutine/issue-105084.stderr
+++ b/tests/ui/coroutine/issue-105084.stderr
@@ -1,8 +1,8 @@
 error[E0382]: borrow of moved value: `g`
-  --> $DIR/issue-105084.rs:37:14
+  --> $DIR/issue-105084.rs:38:14
    |
-LL |     let mut g = || {
-   |         ----- move occurs because `g` has type `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}`, which does not implement the `Copy` trait
+LL |     let mut g = #[coroutine]
+   |         ----- move occurs because `g` has type `{coroutine@$DIR/issue-105084.rs:15:5: 15:7}`, which does not implement the `Copy` trait
 ...
 LL |     let mut h = copy(g);
    |                      - value moved here
@@ -22,17 +22,17 @@ help: consider cloning the value if the performance cost is acceptable
 LL |     let mut h = copy(g.clone());
    |                       ++++++++
 
-error[E0277]: the trait bound `Box<(i32, ())>: Copy` is not satisfied in `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}`
-  --> $DIR/issue-105084.rs:31:17
+error[E0277]: the trait bound `Box<(i32, ())>: Copy` is not satisfied in `{coroutine@$DIR/issue-105084.rs:15:5: 15:7}`
+  --> $DIR/issue-105084.rs:32:17
    |
-LL |     let mut g = || {
-   |                 -- within this `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}`
+LL |     || {
+   |     -- within this `{coroutine@$DIR/issue-105084.rs:15:5: 15:7}`
 ...
 LL |     let mut h = copy(g);
-   |                 ^^^^^^^ within `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}`, the trait `Copy` is not implemented for `Box<(i32, ())>`, which is required by `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}: Copy`
+   |                 ^^^^^^^ within `{coroutine@$DIR/issue-105084.rs:15:5: 15:7}`, the trait `Copy` is not implemented for `Box<(i32, ())>`, which is required by `{coroutine@$DIR/issue-105084.rs:15:5: 15:7}: Copy`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
-  --> $DIR/issue-105084.rs:21:22
+  --> $DIR/issue-105084.rs:22:22
    |
 LL |         Box::new((5, yield));
    |         -------------^^^^^--

--- a/tests/ui/coroutine/issue-110929-coroutine-conflict-error-ice.rs
+++ b/tests/ui/coroutine/issue-110929-coroutine-conflict-error-ice.rs
@@ -1,11 +1,12 @@
 //@ edition:2021
 //@ check-pass
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn main() {
     let x = &mut ();
     || {
-        let _c = || yield *&mut *x;
+        let _c = #[coroutine]
+        || yield *&mut *x;
         || _ = &mut *x;
     };
 }

--- a/tests/ui/coroutine/issue-113279.rs
+++ b/tests/ui/coroutine/issue-113279.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 // `foo` attempts to dereference `""`, which results in an error being reported. Later, the
 // coroutine transform for `foo` then produces a union which contains a `str` type - unions should
@@ -9,7 +9,8 @@
 // makes sure that doesn't happen again.
 
 fn foo() {
-    let _y = static || {
+    let _y = #[coroutine]
+    static || {
         let x = &mut 0;
         *{
             yield;

--- a/tests/ui/coroutine/issue-113279.stderr
+++ b/tests/ui/coroutine/issue-113279.stderr
@@ -1,11 +1,11 @@
 error[E0161]: cannot move a value of type `str`
-  --> $DIR/issue-113279.rs:17:20
+  --> $DIR/issue-113279.rs:18:20
    |
 LL |         } += match { *"" }.len() {
    |                    ^^^^^^^ the size of `str` cannot be statically determined
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/issue-113279.rs:17:22
+  --> $DIR/issue-113279.rs:18:22
    |
 LL |         } += match { *"" }.len() {
    |                      ^^^ move occurs because value has type `str`, which does not implement the `Copy` trait

--- a/tests/ui/coroutine/issue-44197.rs
+++ b/tests/ui/coroutine/issue-44197.rs
@@ -10,7 +10,7 @@ fn foo(_: &str) -> String {
 }
 
 fn bar(baz: String) -> impl Coroutine<(), Yield = String, Return = ()> {
-    move || {
+    #[coroutine] move || {
         yield foo(&baz);
     }
 }
@@ -20,7 +20,7 @@ fn foo2(_: &str) -> Result<String, ()> {
 }
 
 fn bar2(baz: String) -> impl Coroutine<(), Yield = String, Return = ()> {
-    move || {
+    #[coroutine] move || {
         if let Ok(quux) = foo2(&baz) {
             yield quux;
         }

--- a/tests/ui/coroutine/issue-45729-unsafe-in-coroutine.rs
+++ b/tests/ui/coroutine/issue-45729-unsafe-in-coroutine.rs
@@ -1,7 +1,8 @@
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn main() {
-    let _ = || {
+    let _ = #[coroutine]
+    || {
         *(1 as *mut u32) = 42;
         //~^ ERROR dereference of raw pointer is unsafe
         yield;

--- a/tests/ui/coroutine/issue-45729-unsafe-in-coroutine.stderr
+++ b/tests/ui/coroutine/issue-45729-unsafe-in-coroutine.stderr
@@ -1,5 +1,5 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/issue-45729-unsafe-in-coroutine.rs:5:9
+  --> $DIR/issue-45729-unsafe-in-coroutine.rs:6:9
    |
 LL |         *(1 as *mut u32) = 42;
    |         ^^^^^^^^^^^^^^^^ dereference of raw pointer

--- a/tests/ui/coroutine/issue-48048.rs
+++ b/tests/ui/coroutine/issue-48048.rs
@@ -3,7 +3,7 @@
 fn main() {
     let x = (|_| {},);
 
-    || {
+    #[coroutine] || {
         let x = x;
 
         x.0({ //~ ERROR borrow may still be in use when coroutine yields

--- a/tests/ui/coroutine/issue-52304.rs
+++ b/tests/ui/coroutine/issue-52304.rs
@@ -5,6 +5,7 @@
 use std::ops::Coroutine;
 
 pub fn example() -> impl Coroutine {
+    #[coroutine]
     || yield &1
 }
 

--- a/tests/ui/coroutine/issue-52398.rs
+++ b/tests/ui/coroutine/issue-52398.rs
@@ -14,14 +14,14 @@ impl A {
 fn main() {
     // Test that the MIR local with type &A created for the auto-borrow adjustment
     // is caught by typeck
-    move || { //~ WARN unused coroutine that must be used
+    #[coroutine] move || { //~ WARN unused coroutine that must be used
         A.test(yield);
     };
 
     // Test that the std::cell::Ref temporary returned from the `borrow` call
     // is caught by typeck
     let y = RefCell::new(true);
-    static move || { //~ WARN unused coroutine that must be used
+    #[coroutine] static move || { //~ WARN unused coroutine that must be used
         yield *y.borrow();
         return "Done";
     };

--- a/tests/ui/coroutine/issue-52398.stderr
+++ b/tests/ui/coroutine/issue-52398.stderr
@@ -1,7 +1,8 @@
 warning: unused coroutine that must be used
-  --> $DIR/issue-52398.rs:17:5
+  --> $DIR/issue-52398.rs:17:18
    |
-LL | /     move || {
+LL |       #[coroutine] move || {
+   |  __________________^
 LL | |         A.test(yield);
 LL | |     };
    | |_____^
@@ -10,9 +11,10 @@ LL | |     };
    = note: `#[warn(unused_must_use)]` on by default
 
 warning: unused coroutine that must be used
-  --> $DIR/issue-52398.rs:24:5
+  --> $DIR/issue-52398.rs:24:18
    |
-LL | /     static move || {
+LL |       #[coroutine] static move || {
+   |  __________________^
 LL | |         yield *y.borrow();
 LL | |         return "Done";
 LL | |     };

--- a/tests/ui/coroutine/issue-53548.rs
+++ b/tests/ui/coroutine/issue-53548.rs
@@ -17,7 +17,7 @@
 //
 //@ check-pass
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -29,7 +29,7 @@ struct Store<C> {
 }
 
 fn main() {
-    Box::new(static move || {
+    Box::new(#[coroutine] static move || {
         let store = Store::<Box<dyn Trait>> {
             inner: Default::default(),
         };

--- a/tests/ui/coroutine/issue-57017.rs
+++ b/tests/ui/coroutine/issue-57017.rs
@@ -1,5 +1,5 @@
 //@ build-pass
-#![feature(coroutines, negative_impls)]
+#![feature(coroutines, negative_impls, stmt_expr_attributes)]
 #![allow(dropping_references, dropping_copy_types)]
 
 macro_rules! type_combinations {
@@ -21,7 +21,7 @@ macro_rules! type_combinations {
 
         // This is the same bug as issue 57017, but using yield instead of await
         {
-            let g = move || match drop(&$name::unsync::Client::default()) {
+            let g = #[coroutine] move || match drop(&$name::unsync::Client::default()) {
                 _status => yield,
             };
             assert_send(g);
@@ -30,7 +30,7 @@ macro_rules! type_combinations {
         // This tests that `Client` is properly considered to be dropped after moving it into the
         // function.
         {
-            let g = move || match drop($name::unsend::Client::default()) {
+            let g = #[coroutine] move || match drop($name::unsend::Client::default()) {
                 _status => yield,
             };
             assert_send(g);

--- a/tests/ui/coroutine/issue-57084.rs
+++ b/tests/ui/coroutine/issue-57084.rs
@@ -8,7 +8,7 @@ use std::ops::Coroutine;
 fn with<F>(f: F) -> impl Coroutine<Yield=(), Return=()>
 where F: Fn() -> ()
 {
-    move || {
+    #[coroutine] move || {
         loop {
             match f() {
                 _ => yield,
@@ -19,7 +19,7 @@ where F: Fn() -> ()
 
 fn main() {
     let data = &vec![1];
-    || { //~ WARN unused coroutine that must be used
+    #[coroutine] || { //~ WARN unused coroutine that must be used
         let _to_pin = with(move || println!("{:p}", data));
         loop {
             yield

--- a/tests/ui/coroutine/issue-57084.stderr
+++ b/tests/ui/coroutine/issue-57084.stderr
@@ -1,7 +1,8 @@
 warning: unused coroutine that must be used
-  --> $DIR/issue-57084.rs:22:5
+  --> $DIR/issue-57084.rs:22:18
    |
-LL | /     || {
+LL |       #[coroutine] || {
+   |  __________________^
 LL | |         let _to_pin = with(move || println!("{:p}", data));
 LL | |         loop {
 LL | |             yield

--- a/tests/ui/coroutine/issue-57478.rs
+++ b/tests/ui/coroutine/issue-57478.rs
@@ -1,16 +1,19 @@
 //@ check-pass
 
-#![feature(negative_impls, coroutines)]
+#![feature(negative_impls, coroutines, stmt_expr_attributes)]
 
 struct Foo;
 impl !Send for Foo {}
 
 fn main() {
-    assert_send(|| {
-        let guard = Foo;
-        drop(guard);
-        yield;
-    })
+    assert_send(
+        #[coroutine]
+        || {
+            let guard = Foo;
+            drop(guard);
+            yield;
+        },
+    )
 }
 
 fn assert_send<T: Send>(_: T) {}

--- a/tests/ui/coroutine/issue-58888.rs
+++ b/tests/ui/coroutine/issue-58888.rs
@@ -13,7 +13,7 @@ impl Database {
     }
 
     fn check_connection(&self) -> impl Coroutine<Yield = (), Return = ()> + '_ {
-        move || {
+        #[coroutine] move || {
             let iter = self.get_connection();
             for i in iter {
                 yield i

--- a/tests/ui/coroutine/issue-61442-stmt-expr-with-drop.rs
+++ b/tests/ui/coroutine/issue-61442-stmt-expr-with-drop.rs
@@ -4,7 +4,7 @@
 //@ check-pass
 //@ edition:2018
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 
@@ -14,12 +14,14 @@ async fn drop_and_await() {
 }
 
 fn drop_and_yield() {
-    let x = || {
+    let x = #[coroutine]
+    || {
         String::new();
         yield;
     };
     Box::pin(x).as_mut().resume(());
-    let y = static || {
+    let y = #[coroutine]
+    static || {
         String::new();
         yield;
     };

--- a/tests/ui/coroutine/issue-64620-yield-array-element.rs
+++ b/tests/ui/coroutine/issue-64620-yield-array-element.rs
@@ -4,6 +4,7 @@
 
 pub fn crash(arr: [usize; 1]) {
     yield arr[0]; //~ ERROR: yield expression outside of coroutine literal
+    //~^ ERROR: `yield` can only be used in
 }
 
 fn main() {}

--- a/tests/ui/coroutine/issue-64620-yield-array-element.stderr
+++ b/tests/ui/coroutine/issue-64620-yield-array-element.stderr
@@ -1,9 +1,20 @@
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/issue-64620-yield-array-element.rs:6:5
+   |
+LL |     yield arr[0];
+   |     ^^^^^^^^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL | #[coroutine] pub fn crash(arr: [usize; 1]) {
+   | ++++++++++++
+
 error[E0627]: yield expression outside of coroutine literal
   --> $DIR/issue-64620-yield-array-element.rs:6:5
    |
 LL |     yield arr[0];
    |     ^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0627`.

--- a/tests/ui/coroutine/issue-68112.rs
+++ b/tests/ui/coroutine/issue-68112.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::{
     cell::RefCell,
@@ -30,7 +30,7 @@ fn make_non_send_coroutine() -> impl Coroutine<Return = Arc<RefCell<i32>>> {
 }
 
 fn test1() {
-    let send_gen = || {
+    let send_gen = #[coroutine] || {
         let _non_send_gen = make_non_send_coroutine();
         //~^ NOTE not `Send`
         yield;
@@ -46,7 +46,7 @@ fn test1() {
 pub fn make_gen2<T>(t: T) -> impl Coroutine<Return = T> {
 //~^ NOTE appears within the type
 //~| NOTE expansion of desugaring
-    || { //~ NOTE used within this coroutine
+    #[coroutine] || { //~ NOTE used within this coroutine
         yield;
         t
     }
@@ -57,7 +57,7 @@ fn make_non_send_coroutine2() -> impl Coroutine<Return = Arc<RefCell<i32>>> { //
 }
 
 fn test2() {
-    let send_gen = || { //~ NOTE used within this coroutine
+    let send_gen = #[coroutine] || { //~ NOTE used within this coroutine
         let _non_send_gen = make_non_send_coroutine2();
         yield;
     };

--- a/tests/ui/coroutine/issue-68112.stderr
+++ b/tests/ui/coroutine/issue-68112.stderr
@@ -4,7 +4,7 @@ error: coroutine cannot be sent between threads safely
 LL |     require_send(send_gen);
    |     ^^^^^^^^^^^^^^^^^^^^^^ coroutine is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{coroutine@$DIR/issue-68112.rs:33:20: 33:22}: Send`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{coroutine@$DIR/issue-68112.rs:33:33: 33:35}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/issue-68112.rs:36:9
@@ -26,14 +26,14 @@ error[E0277]: `RefCell<i32>` cannot be shared between threads safely
 LL |     require_send(send_gen);
    |     ^^^^^^^^^^^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{coroutine@$DIR/issue-68112.rs:60:20: 60:22}: Send`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{coroutine@$DIR/issue-68112.rs:60:33: 60:35}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
    = note: required for `Arc<RefCell<i32>>` to implement `Send`
 note: required because it's used within this coroutine
-  --> $DIR/issue-68112.rs:49:5
+  --> $DIR/issue-68112.rs:49:18
    |
-LL |     || {
-   |     ^^
+LL |     #[coroutine] || {
+   |                  ^^
 note: required because it appears within the type `impl Coroutine<Return = Arc<RefCell<i32>>>`
   --> $DIR/issue-68112.rs:46:30
    |
@@ -45,10 +45,10 @@ note: required because it appears within the type `impl Coroutine<Return = Arc<R
 LL | fn make_non_send_coroutine2() -> impl Coroutine<Return = Arc<RefCell<i32>>> {
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required because it's used within this coroutine
-  --> $DIR/issue-68112.rs:60:20
+  --> $DIR/issue-68112.rs:60:33
    |
-LL |     let send_gen = || {
-   |                    ^^
+LL |     let send_gen = #[coroutine] || {
+   |                                 ^^
 note: required by a bound in `require_send`
   --> $DIR/issue-68112.rs:22:25
    |

--- a/tests/ui/coroutine/issue-69017.rs
+++ b/tests/ui/coroutine/issue-69017.rs
@@ -10,6 +10,7 @@
 use std::ops::Coroutine;
 
 fn gen() -> impl Coroutine<usize> {
+    #[coroutine]
     |_: usize| {
         println!("-> {}", yield);
     }

--- a/tests/ui/coroutine/issue-69039.rs
+++ b/tests/ui/coroutine/issue-69039.rs
@@ -9,6 +9,7 @@ fn mkstr(my_name: String, my_mood: String) -> String {
 }
 
 fn my_scenario() -> impl Coroutine<String, Yield = &'static str, Return = String> {
+    #[coroutine]
     |_arg: String| {
         let my_name = yield "What is your name?";
         let my_mood = yield "How are you feeling?";

--- a/tests/ui/coroutine/issue-87142.rs
+++ b/tests/ui/coroutine/issue-87142.rs
@@ -22,6 +22,7 @@ pub struct Context<G: 'static + CoroutineProviderAlt> {
 impl CoroutineProviderAlt for () {
     type Coro = impl Coroutine<(), Return = (), Yield = ()>;
     fn start(ctx: Context<Self>) -> Self::Coro {
+        #[coroutine]
         move || {
             match ctx {
                 _ => (),

--- a/tests/ui/coroutine/issue-88653.rs
+++ b/tests/ui/coroutine/issue-88653.rs
@@ -11,6 +11,7 @@ fn foo(bar: bool) -> impl Coroutine<(bool,)> {
     //~| NOTE: expected coroutine signature `fn((bool,)) -> _`
     //~| NOTE: in this expansion of desugaring of `impl Trait`
     //~| NOTE: in this expansion of desugaring of `impl Trait`
+    #[coroutine]
     |bar| {
         //~^ NOTE: found signature defined here
         if bar {

--- a/tests/ui/coroutine/issue-91477.rs
+++ b/tests/ui/coroutine/issue-91477.rs
@@ -2,6 +2,7 @@
 
 fn foo() -> impl Sized {
     yield 1; //~ ERROR E0627
+    //~^ ERROR: `yield` can only be used in
 }
 
 fn main() {}

--- a/tests/ui/coroutine/issue-91477.stderr
+++ b/tests/ui/coroutine/issue-91477.stderr
@@ -1,9 +1,20 @@
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/issue-91477.rs:4:5
+   |
+LL |     yield 1;
+   |     ^^^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL | #[coroutine] fn foo() -> impl Sized {
+   | ++++++++++++
+
 error[E0627]: yield expression outside of coroutine literal
   --> $DIR/issue-91477.rs:4:5
    |
 LL |     yield 1;
    |     ^^^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0627`.

--- a/tests/ui/coroutine/iterator-count.rs
+++ b/tests/ui/coroutine/iterator-count.rs
@@ -21,6 +21,7 @@ impl<T: Coroutine<(), Return = ()> + Unpin> Iterator for W<T> {
 }
 
 fn test() -> impl Coroutine<(), Return = (), Yield = u8> + Unpin {
+    #[coroutine]
     || {
         for i in 1..6 {
             yield i
@@ -32,6 +33,7 @@ fn main() {
     let end = 11;
 
     let closure_test = |start| {
+        #[coroutine]
         move || {
             for i in start..end {
                 yield i

--- a/tests/ui/coroutine/live-upvar-across-yield.rs
+++ b/tests/ui/coroutine/live-upvar-across-yield.rs
@@ -1,13 +1,13 @@
 //@ run-pass
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;
 
 fn main() {
     let b = |_| 3;
-    let mut a = || {
+    let mut a = #[coroutine] || {
         b(yield);
     };
     Pin::new(&mut a).resume(());

--- a/tests/ui/coroutine/match-bindings.rs
+++ b/tests/ui/coroutine/match-bindings.rs
@@ -9,7 +9,7 @@ enum Enum {
 }
 
 fn main() {
-    || { //~ WARN unused coroutine that must be used
+    #[coroutine] || { //~ WARN unused coroutine that must be used
         loop {
             if let true = true {
                 match Enum::A(String::new()) {

--- a/tests/ui/coroutine/match-bindings.stderr
+++ b/tests/ui/coroutine/match-bindings.stderr
@@ -1,7 +1,8 @@
 warning: unused coroutine that must be used
-  --> $DIR/match-bindings.rs:12:5
+  --> $DIR/match-bindings.rs:12:18
    |
-LL | /     || {
+LL |       #[coroutine] || {
+   |  __________________^
 LL | |         loop {
 LL | |             if let true = true {
 LL | |                 match Enum::A(String::new()) {

--- a/tests/ui/coroutine/missing_coroutine_attr_suggestion.fixed
+++ b/tests/ui/coroutine/missing_coroutine_attr_suggestion.fixed
@@ -1,0 +1,8 @@
+//@ run-rustfix
+
+#![feature(coroutines, gen_blocks, stmt_expr_attributes)]
+
+fn main() {
+    let _ = #[coroutine] || yield;
+    //~^ ERROR `yield` can only be used
+}

--- a/tests/ui/coroutine/missing_coroutine_attr_suggestion.rs
+++ b/tests/ui/coroutine/missing_coroutine_attr_suggestion.rs
@@ -1,0 +1,8 @@
+//@ run-rustfix
+
+#![feature(coroutines, gen_blocks, stmt_expr_attributes)]
+
+fn main() {
+    let _ = || yield;
+    //~^ ERROR `yield` can only be used
+}

--- a/tests/ui/coroutine/missing_coroutine_attr_suggestion.stderr
+++ b/tests/ui/coroutine/missing_coroutine_attr_suggestion.stderr
@@ -1,0 +1,13 @@
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/missing_coroutine_attr_suggestion.rs:6:16
+   |
+LL |     let _ = || yield;
+   |                ^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL |     let _ = #[coroutine] || yield;
+   |             ++++++++++++
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/coroutine/nested_coroutine.rs
+++ b/tests/ui/coroutine/nested_coroutine.rs
@@ -1,13 +1,15 @@
 //@ run-pass
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
 
 fn main() {
-    let _coroutine = || {
-        let mut sub_coroutine = || {
+    let _coroutine = #[coroutine]
+    || {
+        let mut sub_coroutine = #[coroutine]
+        || {
             yield 2;
         };
 

--- a/tests/ui/coroutine/niche-in-coroutine.rs
+++ b/tests/ui/coroutine/niche-in-coroutine.rs
@@ -2,7 +2,7 @@
 
 //@ run-pass
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 use std::mem::size_of_val;
 
@@ -10,7 +10,7 @@ fn take<T>(_: T) {}
 
 fn main() {
     let x = false;
-    let gen1 = || {
+    let gen1 = #[coroutine] || {
         yield;
         take(x);
     };

--- a/tests/ui/coroutine/non-static-is-unpin.rs
+++ b/tests/ui/coroutine/non-static-is-unpin.rs
@@ -3,7 +3,7 @@
 //@[next] compile-flags: -Znext-solver
 //@ run-pass
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 #![allow(dropping_copy_types)]
 
 use std::marker::PhantomPinned;
@@ -14,7 +14,7 @@ fn assert_unpin<G: Unpin>(_: G) {
 fn main() {
     // Even though this coroutine holds a `PhantomPinned` in its environment, it
     // remains `Unpin`.
-    assert_unpin(|| {
+    assert_unpin(#[coroutine] || {
         let pinned = PhantomPinned;
         yield;
         drop(pinned);

--- a/tests/ui/coroutine/not-send-sync.rs
+++ b/tests/ui/coroutine/not-send-sync.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![feature(negative_impls)]
 
 struct NotSend;
@@ -11,14 +11,14 @@ fn main() {
     fn assert_sync<T: Sync>(_: T) {}
     fn assert_send<T: Send>(_: T) {}
 
-    assert_sync(|| {
+    assert_sync(#[coroutine] || {
         //~^ ERROR: coroutine cannot be shared between threads safely
         let a = NotSync;
         yield;
         drop(a);
     });
 
-    assert_send(|| {
+    assert_send(#[coroutine] || {
         //~^ ERROR: coroutine cannot be sent between threads safely
         let a = NotSend;
         yield;

--- a/tests/ui/coroutine/not-send-sync.stderr
+++ b/tests/ui/coroutine/not-send-sync.stderr
@@ -1,7 +1,7 @@
 error: coroutine cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:14:5
    |
-LL | /     assert_sync(|| {
+LL | /     assert_sync(#[coroutine] || {
 LL | |
 LL | |         let a = NotSync;
 LL | |         yield;
@@ -9,7 +9,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Sync`
    |
-   = help: within `{coroutine@$DIR/not-send-sync.rs:14:17: 14:19}`, the trait `Sync` is not implemented for `NotSync`, which is required by `{coroutine@$DIR/not-send-sync.rs:14:17: 14:19}: Sync`
+   = help: within `{coroutine@$DIR/not-send-sync.rs:14:30: 14:32}`, the trait `Sync` is not implemented for `NotSync`, which is required by `{coroutine@$DIR/not-send-sync.rs:14:30: 14:32}: Sync`
 note: coroutine is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:17:9
    |
@@ -26,7 +26,7 @@ LL |     fn assert_sync<T: Sync>(_: T) {}
 error: coroutine cannot be sent between threads safely
   --> $DIR/not-send-sync.rs:21:5
    |
-LL | /     assert_send(|| {
+LL | /     assert_send(#[coroutine] || {
 LL | |
 LL | |         let a = NotSend;
 LL | |         yield;
@@ -34,7 +34,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Send`
    |
-   = help: within `{coroutine@$DIR/not-send-sync.rs:21:17: 21:19}`, the trait `Send` is not implemented for `NotSend`, which is required by `{coroutine@$DIR/not-send-sync.rs:21:17: 21:19}: Send`
+   = help: within `{coroutine@$DIR/not-send-sync.rs:21:30: 21:32}`, the trait `Send` is not implemented for `NotSend`, which is required by `{coroutine@$DIR/not-send-sync.rs:21:30: 21:32}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:24:9
    |

--- a/tests/ui/coroutine/overlap-locals.rs
+++ b/tests/ui/coroutine/overlap-locals.rs
@@ -1,9 +1,10 @@
 //@ run-pass
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn main() {
-    let a = || {
+    let a = #[coroutine]
+    || {
         {
             let w: i32 = 4;
             yield;

--- a/tests/ui/coroutine/panic-drops-resume.rs
+++ b/tests/ui/coroutine/panic-drops-resume.rs
@@ -3,7 +3,7 @@
 //@ run-pass
 //@ needs-unwind
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -21,7 +21,7 @@ impl Drop for Dropper {
 }
 
 fn main() {
-    let mut gen = |_arg| {
+    let mut gen = #[coroutine] |_arg| {
         if true {
             panic!();
         }

--- a/tests/ui/coroutine/panic-drops.rs
+++ b/tests/ui/coroutine/panic-drops.rs
@@ -1,8 +1,7 @@
 //@ run-pass
 //@ needs-unwind
 
-
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::panic;
@@ -25,7 +24,8 @@ fn bool_true() -> bool {
 
 fn main() {
     let b = B;
-    let mut foo = || {
+    let mut foo = #[coroutine]
+    || {
         if bool_true() {
             panic!();
         }
@@ -34,13 +34,12 @@ fn main() {
     };
 
     assert_eq!(A.load(Ordering::SeqCst), 0);
-    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        Pin::new(&mut foo).resume(())
-    }));
+    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| Pin::new(&mut foo).resume(())));
     assert!(res.is_err());
     assert_eq!(A.load(Ordering::SeqCst), 1);
 
-    let mut foo = || {
+    let mut foo = #[coroutine]
+    || {
         if bool_true() {
             panic!();
         }
@@ -49,9 +48,7 @@ fn main() {
     };
 
     assert_eq!(A.load(Ordering::SeqCst), 1);
-    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        Pin::new(&mut foo).resume(())
-    }));
+    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| Pin::new(&mut foo).resume(())));
     assert!(res.is_err());
     assert_eq!(A.load(Ordering::SeqCst), 1);
 }

--- a/tests/ui/coroutine/panic-safe.rs
+++ b/tests/ui/coroutine/panic-safe.rs
@@ -2,14 +2,14 @@
 //@ needs-unwind
 
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;
 use std::panic;
 
 fn main() {
-    let mut foo = || {
+    let mut foo = #[coroutine] || {
         if true {
             panic!();
         }

--- a/tests/ui/coroutine/parent-expression.rs
+++ b/tests/ui/coroutine/parent-expression.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines, negative_impls, rustc_attrs)]
+#![feature(coroutines, negative_impls, rustc_attrs, stmt_expr_attributes)]
 
 macro_rules! type_combinations {
     (
@@ -14,7 +14,7 @@ macro_rules! type_combinations {
         // Struct update syntax. This fails because the Client used in the update is considered
         // dropped *after* the yield.
         {
-            let g = move || match drop($name::Client { ..$name::Client::default() }) {
+            let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
             //~^ `significant_drop::Client` which is not `Send`
             //~| `insignificant_dtor::Client` which is not `Send`
             //~| `derived_drop::Client` which is not `Send`
@@ -29,7 +29,7 @@ macro_rules! type_combinations {
         // Simple owned value. This works because the Client is considered moved into `drop`,
         // even though the temporary expression doesn't end until after the yield.
         {
-            let g = move || match drop($name::Client::default()) {
+            let g = #[coroutine] move || match drop($name::Client::default()) {
                 _ => yield,
             };
             assert_send(g);

--- a/tests/ui/coroutine/parent-expression.stderr
+++ b/tests/ui/coroutine/parent-expression.stderr
@@ -13,12 +13,12 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `derived_drop::Client`, which is required by `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}: Send`
+   = help: within `{coroutine@$DIR/parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `derived_drop::Client`, which is required by `{coroutine@$DIR/parent-expression.rs:17:34: 17:41}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:21:22
    |
-LL |               let g = move || match drop($name::Client { ..$name::Client::default() }) {
-   |                                                            ------------------------ has type `derived_drop::Client` which is not `Send`
+LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
+   |                                                                         ------------------------ has type `derived_drop::Client` which is not `Send`
 ...
 LL |                   _ => yield,
    |                        ^^^^^ yield occurs here, with `$name::Client::default()` maybe used later
@@ -53,12 +53,12 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `significant_drop::Client`, which is required by `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}: Send`
+   = help: within `{coroutine@$DIR/parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `significant_drop::Client`, which is required by `{coroutine@$DIR/parent-expression.rs:17:34: 17:41}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:21:22
    |
-LL |               let g = move || match drop($name::Client { ..$name::Client::default() }) {
-   |                                                            ------------------------ has type `significant_drop::Client` which is not `Send`
+LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
+   |                                                                         ------------------------ has type `significant_drop::Client` which is not `Send`
 ...
 LL |                   _ => yield,
    |                        ^^^^^ yield occurs here, with `$name::Client::default()` maybe used later
@@ -93,12 +93,12 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `insignificant_dtor::Client`, which is required by `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}: Send`
+   = help: within `{coroutine@$DIR/parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `insignificant_dtor::Client`, which is required by `{coroutine@$DIR/parent-expression.rs:17:34: 17:41}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:21:22
    |
-LL |               let g = move || match drop($name::Client { ..$name::Client::default() }) {
-   |                                                            ------------------------ has type `insignificant_dtor::Client` which is not `Send`
+LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
+   |                                                                         ------------------------ has type `insignificant_dtor::Client` which is not `Send`
 ...
 LL |                   _ => yield,
    |                        ^^^^^ yield occurs here, with `$name::Client::default()` maybe used later

--- a/tests/ui/coroutine/partial-drop.rs
+++ b/tests/ui/coroutine/partial-drop.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-#![feature(negative_impls, coroutines)]
+#![feature(negative_impls, coroutines, stmt_expr_attributes)]
 
 struct Foo;
 impl !Send for Foo {}
@@ -10,25 +10,34 @@ struct Bar {
 }
 
 fn main() {
-    assert_send(|| {
-        let guard = Bar { foo: Foo, x: 42 };
-        drop(guard.foo);
-        yield;
-    });
+    assert_send(
+        #[coroutine]
+        || {
+            let guard = Bar { foo: Foo, x: 42 };
+            drop(guard.foo);
+            yield;
+        },
+    );
 
-    assert_send(|| {
-        let mut guard = Bar { foo: Foo, x: 42 };
-        drop(guard);
-        guard = Bar { foo: Foo, x: 23 };
-        yield;
-    });
+    assert_send(
+        #[coroutine]
+        || {
+            let mut guard = Bar { foo: Foo, x: 42 };
+            drop(guard);
+            guard = Bar { foo: Foo, x: 23 };
+            yield;
+        },
+    );
 
-    assert_send(|| {
-        let guard = Bar { foo: Foo, x: 42 };
-        let Bar { foo, x } = guard;
-        drop(foo);
-        yield;
-    });
+    assert_send(
+        #[coroutine]
+        || {
+            let guard = Bar { foo: Foo, x: 42 };
+            let Bar { foo, x } = guard;
+            drop(foo);
+            yield;
+        },
+    );
 }
 
 fn assert_send<T: Send>(_: T) {}

--- a/tests/ui/coroutine/partial-initialization-across-yield.rs
+++ b/tests/ui/coroutine/partial-initialization-across-yield.rs
@@ -1,13 +1,13 @@
 // Test that we don't allow yielding from a coroutine while a local is partially
 // initialized.
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 struct S { x: i32, y: i32 }
 struct T(i32, i32);
 
 fn test_tuple() {
-    let _ = || {
+    let _ = #[coroutine] || {
         let mut t: (i32, i32);
         t.0 = 42; //~ ERROR E0381
         yield;
@@ -17,7 +17,7 @@ fn test_tuple() {
 }
 
 fn test_tuple_struct() {
-    let _ = || {
+    let _ = #[coroutine] || {
         let mut t: T;
         t.0 = 42; //~ ERROR E0381
         yield;
@@ -27,7 +27,7 @@ fn test_tuple_struct() {
 }
 
 fn test_struct() {
-    let _ = || {
+    let _ = #[coroutine] || {
         let mut t: S;
         t.x = 42; //~ ERROR E0381
         yield;

--- a/tests/ui/coroutine/pattern-borrow.rs
+++ b/tests/ui/coroutine/pattern-borrow.rs
@@ -5,7 +5,7 @@ enum Test { A(i32), B, }
 fn main() { }
 
 fn fun(test: Test) {
-    move || {
+    #[coroutine] move || {
         if let Test::A(ref _a) = test { //~ ERROR borrow may still be in use when coroutine yields
             yield ();
             _a.use_ref();

--- a/tests/ui/coroutine/pin-box-coroutine.rs
+++ b/tests/ui/coroutine/pin-box-coroutine.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 
@@ -8,6 +8,6 @@ fn assert_coroutine<G: Coroutine>(_: G) {
 }
 
 fn main() {
-    assert_coroutine(static || yield);
-    assert_coroutine(Box::pin(static || yield));
+    assert_coroutine(#[coroutine] static || yield);
+    assert_coroutine(Box::pin(#[coroutine] static || yield));
 }

--- a/tests/ui/coroutine/polymorphize-args.rs
+++ b/tests/ui/coroutine/polymorphize-args.rs
@@ -1,14 +1,15 @@
 //@ compile-flags: -Zpolymorphize=on
 //@ build-pass
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;
 use std::thread;
 
 fn main() {
-    let mut foo = || yield;
+    let mut foo = #[coroutine]
+    || yield;
     thread::spawn(move || match Pin::new(&mut foo).resume(()) {
         s => panic!("bad state: {:?}", s),
     })

--- a/tests/ui/coroutine/print/coroutine-print-verbose-1.rs
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-1.rs
@@ -2,7 +2,7 @@
 
 // Same as: tests/ui/coroutine/issue-68112.stderr
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::{
     cell::RefCell,
@@ -30,7 +30,7 @@ fn make_non_send_coroutine() -> impl Coroutine<Return = Arc<RefCell<i32>>> {
 }
 
 fn test1() {
-    let send_gen = || {
+    let send_gen = #[coroutine] || {
         let _non_send_gen = make_non_send_coroutine();
         yield;
     };
@@ -39,7 +39,7 @@ fn test1() {
 }
 
 pub fn make_gen2<T>(t: T) -> impl Coroutine<Return = T> {
-    || {
+    #[coroutine] || {
         yield;
         t
     }
@@ -49,7 +49,7 @@ fn make_non_send_coroutine2() -> impl Coroutine<Return = Arc<RefCell<i32>>> {
 }
 
 fn test2() {
-    let send_gen = || {
+    let send_gen = #[coroutine] || {
         let _non_send_gen = make_non_send_coroutine2();
         yield;
     };

--- a/tests/ui/coroutine/print/coroutine-print-verbose-1.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-1.stderr
@@ -29,10 +29,10 @@ LL |     require_send(send_gen);
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
    = note: required for `Arc<RefCell<i32>>` to implement `Send`
 note: required because it's used within this coroutine
-  --> $DIR/coroutine-print-verbose-1.rs:42:5
+  --> $DIR/coroutine-print-verbose-1.rs:42:18
    |
-LL |     || {
-   |     ^^
+LL |     #[coroutine] || {
+   |                  ^^
 note: required because it appears within the type `Opaque(DefId(0:35 ~ coroutine_print_verbose_1[75fb]::make_gen2::{opaque#0}), [Arc<RefCell<i32>>])`
   --> $DIR/coroutine-print-verbose-1.rs:41:30
    |
@@ -44,10 +44,10 @@ note: required because it appears within the type `Opaque(DefId(0:36 ~ coroutine
 LL | fn make_non_send_coroutine2() -> impl Coroutine<Return = Arc<RefCell<i32>>> {
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required because it's used within this coroutine
-  --> $DIR/coroutine-print-verbose-1.rs:52:20
+  --> $DIR/coroutine-print-verbose-1.rs:52:33
    |
-LL |     let send_gen = || {
-   |                    ^^
+LL |     let send_gen = #[coroutine] || {
+   |                                 ^^
 note: required by a bound in `require_send`
   --> $DIR/coroutine-print-verbose-1.rs:26:25
    |

--- a/tests/ui/coroutine/print/coroutine-print-verbose-2.rs
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-2.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: -Zverbose-internals
 
 // Same as test/ui/coroutine/not-send-sync.rs
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![feature(negative_impls)]
 
 struct NotSend;
@@ -14,14 +14,14 @@ fn main() {
     fn assert_sync<T: Sync>(_: T) {}
     fn assert_send<T: Send>(_: T) {}
 
-    assert_sync(|| {
+    assert_sync(#[coroutine] || {
         //~^ ERROR: coroutine cannot be shared between threads safely
         let a = NotSync;
         yield;
         drop(a);
     });
 
-    assert_send(|| {
+    assert_send(#[coroutine] || {
         //~^ ERROR: coroutine cannot be sent between threads safely
         let a = NotSend;
         yield;

--- a/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
@@ -1,7 +1,7 @@
 error: coroutine cannot be shared between threads safely
   --> $DIR/coroutine-print-verbose-2.rs:17:5
    |
-LL | /     assert_sync(|| {
+LL | /     assert_sync(#[coroutine] || {
 LL | |
 LL | |         let a = NotSync;
 LL | |         yield;
@@ -26,7 +26,7 @@ LL |     fn assert_sync<T: Sync>(_: T) {}
 error: coroutine cannot be sent between threads safely
   --> $DIR/coroutine-print-verbose-2.rs:24:5
    |
-LL | /     assert_send(|| {
+LL | /     assert_send(#[coroutine] || {
 LL | |
 LL | |         let a = NotSend;
 LL | |         yield;

--- a/tests/ui/coroutine/print/coroutine-print-verbose-3.rs
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-3.rs
@@ -1,12 +1,13 @@
 //@ compile-flags: -Zverbose-internals
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 fn main() {
     let x = "Type mismatch test";
-    let coroutine :() = || {
-    //~^ ERROR mismatched types
+    let coroutine: () = #[coroutine]
+    || {
+        //~^ ERROR mismatched types
         yield 1i32;
-        return x
+        return x;
     };
 }

--- a/tests/ui/coroutine/print/coroutine-print-verbose-3.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-3.stderr
@@ -1,13 +1,12 @@
 error[E0308]: mismatched types
-  --> $DIR/coroutine-print-verbose-3.rs:7:25
+  --> $DIR/coroutine-print-verbose-3.rs:8:5
    |
-LL |       let coroutine :() = || {
-   |  ____________________--___^
-   | |                    |
-   | |                    expected due to this
+LL |       let coroutine: () = #[coroutine]
+   |                      -- expected due to this
+LL | /     || {
 LL | |
 LL | |         yield 1i32;
-LL | |         return x
+LL | |         return x;
 LL | |     };
    | |_____^ expected `()`, found coroutine
    |

--- a/tests/ui/coroutine/reborrow-mut-upvar.rs
+++ b/tests/ui/coroutine/reborrow-mut-upvar.rs
@@ -3,7 +3,7 @@
 #![feature(coroutines)]
 
 fn _run(bar: &mut i32) {
-    || { //~ WARN unused coroutine that must be used
+    #[coroutine] || { //~ WARN unused coroutine that must be used
         {
             let _baz = &*bar;
             yield;

--- a/tests/ui/coroutine/reborrow-mut-upvar.stderr
+++ b/tests/ui/coroutine/reborrow-mut-upvar.stderr
@@ -1,7 +1,8 @@
 warning: unused coroutine that must be used
-  --> $DIR/reborrow-mut-upvar.rs:6:5
+  --> $DIR/reborrow-mut-upvar.rs:6:18
    |
-LL | /     || {
+LL |       #[coroutine] || {
+   |  __________________^
 LL | |         {
 LL | |             let _baz = &*bar;
 LL | |             yield;

--- a/tests/ui/coroutine/ref-escapes-but-not-over-yield.rs
+++ b/tests/ui/coroutine/ref-escapes-but-not-over-yield.rs
@@ -1,16 +1,17 @@
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn foo(x: &i32) {
     // In this case, a reference to `b` escapes the coroutine, but not
     // because of a yield. We see that there is no yield in the scope of
     // `b` and give the more generic error message.
     let mut a = &3;
-    let mut b = move || {
-        yield();
+    let mut b = #[coroutine]
+    move || {
+        yield ();
         let b = 5;
         a = &b;
         //~^ ERROR borrowed data escapes outside of coroutine
     };
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/coroutine/ref-escapes-but-not-over-yield.stderr
+++ b/tests/ui/coroutine/ref-escapes-but-not-over-yield.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of coroutine
-  --> $DIR/ref-escapes-but-not-over-yield.rs:11:9
+  --> $DIR/ref-escapes-but-not-over-yield.rs:12:9
    |
 LL |     let mut a = &3;
    |         ----- `a` declared here, outside of the coroutine body

--- a/tests/ui/coroutine/ref-upvar-not-send.rs
+++ b/tests/ui/coroutine/ref-upvar-not-send.rs
@@ -1,7 +1,7 @@
 // For `Send` coroutines, suggest a `T: Sync` requirement for `&T` upvars,
 // and suggest a `T: Send` requirement for `&mut T` upvars.
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn assert_send<T: Send>(_: T) {}
 //~^ NOTE required by a bound in `assert_send`
@@ -12,7 +12,7 @@ fn assert_send<T: Send>(_: T) {}
 fn main() {
     let x: &*mut () = &std::ptr::null_mut();
     let y: &mut *mut () = &mut std::ptr::null_mut();
-    assert_send(move || {
+    assert_send(#[coroutine] move || {
         //~^ ERROR coroutine cannot be sent between threads safely
         //~| NOTE coroutine is not `Send`
         yield;
@@ -20,7 +20,7 @@ fn main() {
     });
     //~^^ NOTE captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
     //~| NOTE has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
-    assert_send(move || {
+    assert_send(#[coroutine] move || {
         //~^ ERROR coroutine cannot be sent between threads safely
         //~| NOTE coroutine is not `Send`
         yield;

--- a/tests/ui/coroutine/ref-upvar-not-send.stderr
+++ b/tests/ui/coroutine/ref-upvar-not-send.stderr
@@ -1,8 +1,8 @@
 error: coroutine cannot be sent between threads safely
-  --> $DIR/ref-upvar-not-send.rs:15:17
+  --> $DIR/ref-upvar-not-send.rs:15:30
    |
-LL |       assert_send(move || {
-   |  _________________^
+LL |       assert_send(#[coroutine] move || {
+   |  ______________________________^
 LL | |
 LL | |
 LL | |         yield;
@@ -10,7 +10,7 @@ LL | |         let _x = x;
 LL | |     });
    | |_____^ coroutine is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:15:17: 15:24}: Send`
+   = help: the trait `Sync` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:15:30: 15:37}: Send`
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/ref-upvar-not-send.rs:19:18
    |
@@ -23,10 +23,10 @@ LL | fn assert_send<T: Send>(_: T) {}
    |                   ^^^^ required by this bound in `assert_send`
 
 error: coroutine cannot be sent between threads safely
-  --> $DIR/ref-upvar-not-send.rs:23:17
+  --> $DIR/ref-upvar-not-send.rs:23:30
    |
-LL |       assert_send(move || {
-   |  _________________^
+LL |       assert_send(#[coroutine] move || {
+   |  ______________________________^
 LL | |
 LL | |
 LL | |         yield;
@@ -34,7 +34,7 @@ LL | |         let _y = y;
 LL | |     });
    | |_____^ coroutine is not `Send`
    |
-   = help: within `{coroutine@$DIR/ref-upvar-not-send.rs:23:17: 23:24}`, the trait `Send` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:23:17: 23:24}: Send`
+   = help: within `{coroutine@$DIR/ref-upvar-not-send.rs:23:30: 23:37}`, the trait `Send` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:23:30: 23:37}: Send`
 note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
   --> $DIR/ref-upvar-not-send.rs:27:18
    |

--- a/tests/ui/coroutine/reinit-in-match-guard.rs
+++ b/tests/ui/coroutine/reinit-in-match-guard.rs
@@ -1,11 +1,11 @@
 //@ build-pass
 
-#![feature(coroutines)]
-
+#![feature(coroutines, stmt_expr_attributes)]
 #![allow(unused_assignments, dead_code)]
 
 fn main() {
-    let _ = || {
+    let _ = #[coroutine]
+    || {
         let mut x = vec![22_usize];
         std::mem::drop(x);
         match y() {

--- a/tests/ui/coroutine/resume-after-return.rs
+++ b/tests/ui/coroutine/resume-after-return.rs
@@ -1,17 +1,17 @@
 //@ run-pass
 //@ needs-unwind
 
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
-#![feature(coroutines, coroutine_trait)]
-
-use std::ops::{CoroutineState, Coroutine};
-use std::pin::Pin;
+use std::ops::{Coroutine, CoroutineState};
 use std::panic;
+use std::pin::Pin;
 
 fn main() {
-    let mut foo = || {
+    let mut foo = #[coroutine]
+    || {
         if true {
-            return
+            return;
         }
         yield;
     };

--- a/tests/ui/coroutine/resume-arg-late-bound.rs
+++ b/tests/ui/coroutine/resume-arg-late-bound.rs
@@ -1,14 +1,14 @@
 //! Tests that we cannot produce a coroutine that accepts a resume argument
 //! with any lifetime and then stores it across a `yield`.
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 
 fn test(a: impl for<'a> Coroutine<&'a mut bool>) {}
 
 fn main() {
-    let gen = |arg: &mut bool| {
+    let gen = #[coroutine] |arg: &mut bool| {
         yield ();
         *arg = true;
     };

--- a/tests/ui/coroutine/resume-arg-late-bound.stderr
+++ b/tests/ui/coroutine/resume-arg-late-bound.stderr
@@ -4,7 +4,7 @@ error: implementation of `Coroutine` is not general enough
 LL |     test(gen);
    |     ^^^^^^^^^ implementation of `Coroutine` is not general enough
    |
-   = note: `{coroutine@$DIR/resume-arg-late-bound.rs:11:15: 11:31}` must implement `Coroutine<&'1 mut bool>`, for any lifetime `'1`...
+   = note: `{coroutine@$DIR/resume-arg-late-bound.rs:11:28: 11:44}` must implement `Coroutine<&'1 mut bool>`, for any lifetime `'1`...
    = note: ...but it actually implements `Coroutine<&'2 mut bool>`, for some specific lifetime `'2`
 
 error: aborting due to 1 previous error

--- a/tests/ui/coroutine/resume-arg-size.rs
+++ b/tests/ui/coroutine/resume-arg-size.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![allow(dropping_copy_types)]
 
 //@ run-pass
@@ -7,7 +7,8 @@ use std::mem::size_of_val;
 
 fn main() {
     // Coroutine taking a `Copy`able resume arg.
-    let gen_copy = |mut x: usize| {
+    let gen_copy = #[coroutine]
+    |mut x: usize| {
         loop {
             drop(x);
             x = yield;
@@ -15,7 +16,8 @@ fn main() {
     };
 
     // Coroutine taking a non-`Copy` resume arg.
-    let gen_move = |mut x: Box<usize>| {
+    let gen_move = #[coroutine]
+    |mut x: Box<usize>| {
         loop {
             drop(x);
             x = yield;

--- a/tests/ui/coroutine/resume-live-across-yield.rs
+++ b/tests/ui/coroutine/resume-live-across-yield.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
@@ -18,7 +18,8 @@ impl Drop for Dropper {
 }
 
 fn main() {
-    let mut g = |mut _d| {
+    let mut g = #[coroutine]
+    |mut _d| {
         _d = yield;
         _d
     };

--- a/tests/ui/coroutine/retain-resume-ref.rs
+++ b/tests/ui/coroutine/retain-resume-ref.rs
@@ -1,6 +1,6 @@
 //! This test ensures that a mutable reference cannot be passed as a resume argument twice.
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::marker::Unpin;
 use std::ops::{
@@ -12,7 +12,8 @@ use std::pin::Pin;
 fn main() {
     let mut thing = String::from("hello");
 
-    let mut gen = |r| {
+    let mut gen = #[coroutine]
+    |r| {
         if false {
             yield r;
         }

--- a/tests/ui/coroutine/retain-resume-ref.stderr
+++ b/tests/ui/coroutine/retain-resume-ref.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `thing` as mutable more than once at a time
-  --> $DIR/retain-resume-ref.rs:23:25
+  --> $DIR/retain-resume-ref.rs:24:25
    |
 LL |     gen.as_mut().resume(&mut thing);
    |                         ---------- first mutable borrow occurs here

--- a/tests/ui/coroutine/size-moved-locals.rs
+++ b/tests/ui/coroutine/size-moved-locals.rs
@@ -24,6 +24,7 @@ impl Drop for Foo {
 }
 
 fn move_before_yield() -> impl Coroutine<Yield = (), Return = ()> {
+    #[coroutine]
     static || {
         let first = Foo([0; FOO_SIZE]);
         let _second = first;
@@ -35,6 +36,7 @@ fn move_before_yield() -> impl Coroutine<Yield = (), Return = ()> {
 fn noop() {}
 
 fn move_before_yield_with_noop() -> impl Coroutine<Yield = (), Return = ()> {
+    #[coroutine]
     static || {
         let first = Foo([0; FOO_SIZE]);
         noop();
@@ -47,6 +49,7 @@ fn move_before_yield_with_noop() -> impl Coroutine<Yield = (), Return = ()> {
 // Today we don't have NRVO (we allocate space for both `first` and `second`,)
 // but we can overlap `first` with `_third`.
 fn overlap_move_points() -> impl Coroutine<Yield = (), Return = ()> {
+    #[coroutine]
     static || {
         let first = Foo([0; FOO_SIZE]);
         yield;
@@ -58,6 +61,7 @@ fn overlap_move_points() -> impl Coroutine<Yield = (), Return = ()> {
 }
 
 fn overlap_x_and_y() -> impl Coroutine<Yield = (), Return = ()> {
+    #[coroutine]
     static || {
         let x = Foo([0; FOO_SIZE]);
         yield;

--- a/tests/ui/coroutine/sized-yield.rs
+++ b/tests/ui/coroutine/sized-yield.rs
@@ -1,11 +1,12 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;
 
 fn main() {
     let s = String::from("foo");
-    let mut gen = move || {
+    let mut gen = #[coroutine]
+    move || {
         //~^ ERROR the size for values of type
         yield s[..];
     };

--- a/tests/ui/coroutine/sized-yield.stderr
+++ b/tests/ui/coroutine/sized-yield.stderr
@@ -1,8 +1,7 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/sized-yield.rs:8:19
+  --> $DIR/sized-yield.rs:9:5
    |
-LL |       let mut gen = move || {
-   |  ___________________^
+LL | /     move || {
 LL | |
 LL | |         yield s[..];
 LL | |     };
@@ -12,7 +11,7 @@ LL | |     };
    = note: the yield type of a coroutine must have a statically known size
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/sized-yield.rs:12:24
+  --> $DIR/sized-yield.rs:13:24
    |
 LL |     Pin::new(&mut gen).resume(());
    |                        ^^^^^^ doesn't have a size known at compile-time

--- a/tests/ui/coroutine/static-coroutine.rs
+++ b/tests/ui/coroutine/static-coroutine.rs
@@ -1,12 +1,13 @@
 //@ run-pass
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
-use std::pin::Pin;
 use std::ops::{Coroutine, CoroutineState};
+use std::pin::Pin;
 
 fn main() {
-    let mut coroutine = static || {
+    let mut coroutine = #[coroutine]
+    static || {
         let a = true;
         let b = &a;
         yield;

--- a/tests/ui/coroutine/static-mut-reference-across-yield.rs
+++ b/tests/ui/coroutine/static-mut-reference-across-yield.rs
@@ -1,6 +1,6 @@
 //@ build-pass
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 static mut A: [i32; 5] = [1, 2, 3, 4, 5];
 
@@ -8,13 +8,15 @@ fn is_send_sync<T: Send + Sync>(_: T) {}
 
 fn main() {
     unsafe {
-        let gen_index = static || {
+        let gen_index = #[coroutine]
+        static || {
             let u = A[{
                 yield;
                 1
             }];
         };
-        let gen_match = static || match A {
+        let gen_match = #[coroutine]
+        static || match A {
             i if {
                 yield;
                 true

--- a/tests/ui/coroutine/static-not-unpin.current.stderr
+++ b/tests/ui/coroutine/static-not-unpin.current.stderr
@@ -1,8 +1,8 @@
-error[E0277]: `{static coroutine@$DIR/static-not-unpin.rs:15:25: 15:34}` cannot be unpinned
+error[E0277]: `{static coroutine@$DIR/static-not-unpin.rs:15:5: 15:14}` cannot be unpinned
   --> $DIR/static-not-unpin.rs:18:18
    |
 LL |     assert_unpin(coroutine);
-   |     ------------ ^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/static-not-unpin.rs:15:25: 15:34}`
+   |     ------------ ^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/static-not-unpin.rs:15:5: 15:14}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -11,7 +11,7 @@ LL |     assert_unpin(coroutine);
 note: required by a bound in `assert_unpin`
   --> $DIR/static-not-unpin.rs:11:20
    |
-LL | fn assert_unpin<T: Unpin>(_: T) {
+LL | fn assert_unpin<T: Unpin>(_: T) {}
    |                    ^^^^^ required by this bound in `assert_unpin`
 
 error: aborting due to 1 previous error

--- a/tests/ui/coroutine/static-not-unpin.next.stderr
+++ b/tests/ui/coroutine/static-not-unpin.next.stderr
@@ -1,8 +1,8 @@
-error[E0277]: `{static coroutine@$DIR/static-not-unpin.rs:15:25: 15:34}` cannot be unpinned
+error[E0277]: `{static coroutine@$DIR/static-not-unpin.rs:15:5: 15:14}` cannot be unpinned
   --> $DIR/static-not-unpin.rs:18:18
    |
 LL |     assert_unpin(coroutine);
-   |     ------------ ^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/static-not-unpin.rs:15:25: 15:34}`
+   |     ------------ ^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/static-not-unpin.rs:15:5: 15:14}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -11,7 +11,7 @@ LL |     assert_unpin(coroutine);
 note: required by a bound in `assert_unpin`
   --> $DIR/static-not-unpin.rs:11:20
    |
-LL | fn assert_unpin<T: Unpin>(_: T) {
+LL | fn assert_unpin<T: Unpin>(_: T) {}
    |                    ^^^^^ required by this bound in `assert_unpin`
 
 error: aborting due to 1 previous error

--- a/tests/ui/coroutine/static-not-unpin.rs
+++ b/tests/ui/coroutine/static-not-unpin.rs
@@ -2,17 +2,17 @@
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 //@ normalize-stderr-test "std::pin::Unpin" -> "std::marker::Unpin"
 
 use std::marker::Unpin;
 
-fn assert_unpin<T: Unpin>(_: T) {
-}
+fn assert_unpin<T: Unpin>(_: T) {}
 
 fn main() {
-    let mut coroutine = static || {
+    let mut coroutine = #[coroutine]
+    static || {
         yield;
     };
     assert_unpin(coroutine); //~ ERROR E0277

--- a/tests/ui/coroutine/static-reference-across-yield.rs
+++ b/tests/ui/coroutine/static-reference-across-yield.rs
@@ -4,10 +4,10 @@
 static A: [i32; 5] = [1, 2, 3, 4, 5];
 
 fn main() {
-    static || {
+    #[coroutine] static || {
         let u = A[{yield; 1}];
     };
-    static || {
+    #[coroutine] static || {
         match A {
             i if { yield; true } => (),
             _ => (),

--- a/tests/ui/coroutine/too-live-local-in-immovable-gen.rs
+++ b/tests/ui/coroutine/too-live-local-in-immovable-gen.rs
@@ -5,7 +5,7 @@
 
 fn main() {
     unsafe {
-        static move || { //~ WARN unused coroutine that must be used
+        #[coroutine] static move || { //~ WARN unused coroutine that must be used
             // Tests that the coroutine transformation finds out that `a` is not live
             // during the yield expression. Type checking will also compute liveness
             // and it should also find out that `a` is not live.

--- a/tests/ui/coroutine/too-live-local-in-immovable-gen.stderr
+++ b/tests/ui/coroutine/too-live-local-in-immovable-gen.stderr
@@ -1,7 +1,8 @@
 warning: unused coroutine that must be used
-  --> $DIR/too-live-local-in-immovable-gen.rs:8:9
+  --> $DIR/too-live-local-in-immovable-gen.rs:8:22
    |
-LL | /         static move || {
+LL |           #[coroutine] static move || {
+   |  ______________________^
 LL | |             // Tests that the coroutine transformation finds out that `a` is not live
 LL | |             // during the yield expression. Type checking will also compute liveness
 LL | |             // and it should also find out that `a` is not live.

--- a/tests/ui/coroutine/too-many-parameters.rs
+++ b/tests/ui/coroutine/too-many-parameters.rs
@@ -1,6 +1,7 @@
 #![feature(coroutines)]
 
 fn main() {
+    #[coroutine]
     |(), ()| {
         //~^ error: too many parameters for a coroutine
         yield;

--- a/tests/ui/coroutine/too-many-parameters.stderr
+++ b/tests/ui/coroutine/too-many-parameters.stderr
@@ -1,5 +1,5 @@
 error[E0628]: too many parameters for a coroutine (expected 0 or 1 parameters)
-  --> $DIR/too-many-parameters.rs:4:5
+  --> $DIR/too-many-parameters.rs:5:5
    |
 LL |     |(), ()| {
    |     ^^^^^^^^

--- a/tests/ui/coroutine/type-mismatch-error.rs
+++ b/tests/ui/coroutine/type-mismatch-error.rs
@@ -1,7 +1,7 @@
 //! Test that we get the expected type mismatch error instead of "closure is expected to take 0
 //! arguments" (which got introduced after implementing resume arguments).
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::Coroutine;
 
@@ -9,6 +9,7 @@ fn f<G: Coroutine>(_: G, _: G::Return) {}
 
 fn main() {
     f(
+        #[coroutine]
         |a: u8| {
             if false {
                 yield ();

--- a/tests/ui/coroutine/type-mismatch-error.stderr
+++ b/tests/ui/coroutine/type-mismatch-error.stderr
@@ -1,5 +1,5 @@
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/type-mismatch-error.rs:16:17
+  --> $DIR/type-mismatch-error.rs:17:17
    |
 LL | /             if false {
 LL | |                 yield ();

--- a/tests/ui/coroutine/type-mismatch-signature-deduction.rs
+++ b/tests/ui/coroutine/type-mismatch-signature-deduction.rs
@@ -4,6 +4,7 @@ use std::ops::Coroutine;
 
 fn foo() -> impl Coroutine<Return = i32> {
     //~^ ERROR type mismatch
+    #[coroutine]
     || {
         if false {
             return Ok(6);

--- a/tests/ui/coroutine/type-mismatch-signature-deduction.stderr
+++ b/tests/ui/coroutine/type-mismatch-signature-deduction.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch-signature-deduction.rs:14:9
+  --> $DIR/type-mismatch-signature-deduction.rs:15:9
    |
 LL |         5
    |         ^ expected `Result<{integer}, _>`, found integer
@@ -7,7 +7,7 @@ LL |         5
    = note: expected enum `Result<{integer}, _>`
               found type `{integer}`
 note: return type inferred to be `Result<{integer}, _>` here
-  --> $DIR/type-mismatch-signature-deduction.rs:9:20
+  --> $DIR/type-mismatch-signature-deduction.rs:10:20
    |
 LL |             return Ok(6);
    |                    ^^^^^
@@ -18,7 +18,7 @@ LL |         Ok(5)
 LL |         Err(5)
    |         ++++ +
 
-error[E0271]: type mismatch resolving `<{coroutine@$DIR/type-mismatch-signature-deduction.rs:7:5: 7:7} as Coroutine>::Return == i32`
+error[E0271]: type mismatch resolving `<{coroutine@$DIR/type-mismatch-signature-deduction.rs:8:5: 8:7} as Coroutine>::Return == i32`
   --> $DIR/type-mismatch-signature-deduction.rs:5:13
    |
 LL | fn foo() -> impl Coroutine<Return = i32> {

--- a/tests/ui/coroutine/uninhabited-field.rs
+++ b/tests/ui/coroutine/uninhabited-field.rs
@@ -3,7 +3,7 @@
 #![allow(unused)]
 #![feature(assert_matches)]
 #![feature(coroutine_trait)]
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![feature(never_type)]
 use std::assert_matches::assert_matches;
 use std::ops::Coroutine;
@@ -13,7 +13,7 @@ use std::pin::Pin;
 fn conjure<T>() -> T { loop {} }
 
 fn run<T>(x: bool, y: bool) {
-    let mut c = || {
+    let mut c = #[coroutine] || {
         if x {
             let a : T;
             if y {

--- a/tests/ui/coroutine/unsized-capture-across-yield.rs
+++ b/tests/ui/coroutine/unsized-capture-across-yield.rs
@@ -7,6 +7,7 @@ use std::ops::Coroutine;
 
 fn capture() -> impl Coroutine {
     let b: [u8] = *(Box::new([]) as Box<[u8]>);
+    #[coroutine]
     move || {
         println!("{:?}", &b);
         //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui/coroutine/unsized-capture-across-yield.stderr
+++ b/tests/ui/coroutine/unsized-capture-across-yield.stderr
@@ -8,7 +8,7 @@ LL | #![feature(unsized_locals)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/unsized-capture-across-yield.rs:11:27
+  --> $DIR/unsized-capture-across-yield.rs:12:27
    |
 LL |     move || {
    |          -- this closure captures all values by move

--- a/tests/ui/coroutine/unsized-local-across-yield.rs
+++ b/tests/ui/coroutine/unsized-local-across-yield.rs
@@ -6,6 +6,7 @@
 use std::ops::Coroutine;
 
 fn across() -> impl Coroutine {
+    #[coroutine]
     move || {
         let b: [u8] = *(Box::new([]) as Box<[u8]>);
         //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui/coroutine/unsized-local-across-yield.stderr
+++ b/tests/ui/coroutine/unsized-local-across-yield.stderr
@@ -8,7 +8,7 @@ LL | #![feature(unsized_locals)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/unsized-local-across-yield.rs:10:13
+  --> $DIR/unsized-local-across-yield.rs:11:13
    |
 LL |         let b: [u8] = *(Box::new([]) as Box<[u8]>);
    |             ^ doesn't have a size known at compile-time

--- a/tests/ui/coroutine/yield-in-args-rev.rs
+++ b/tests/ui/coroutine/yield-in-args-rev.rs
@@ -10,7 +10,7 @@
 fn foo(_a: (), _b: &bool) {}
 
 fn bar() {
-    || { //~ WARN unused coroutine that must be used
+    #[coroutine] || { //~ WARN unused coroutine that must be used
         let b = true;
         foo(yield, &b);
     };

--- a/tests/ui/coroutine/yield-in-args-rev.stderr
+++ b/tests/ui/coroutine/yield-in-args-rev.stderr
@@ -1,7 +1,8 @@
 warning: unused coroutine that must be used
-  --> $DIR/yield-in-args-rev.rs:13:5
+  --> $DIR/yield-in-args-rev.rs:13:18
    |
-LL | /     || {
+LL |       #[coroutine] || {
+   |  __________________^
 LL | |         let b = true;
 LL | |         foo(yield, &b);
 LL | |     };

--- a/tests/ui/coroutine/yield-in-args.rs
+++ b/tests/ui/coroutine/yield-in-args.rs
@@ -3,6 +3,7 @@
 fn foo(_b: &bool, _a: ()) {}
 
 fn main() {
+    #[coroutine]
     || {
         let b = true;
         foo(&b, yield); //~ ERROR

--- a/tests/ui/coroutine/yield-in-args.stderr
+++ b/tests/ui/coroutine/yield-in-args.stderr
@@ -1,5 +1,5 @@
 error[E0626]: borrow may still be in use when coroutine yields
-  --> $DIR/yield-in-args.rs:8:13
+  --> $DIR/yield-in-args.rs:9:13
    |
 LL |         foo(&b, yield);
    |             ^^  ----- possible yield occurs here

--- a/tests/ui/coroutine/yield-in-const.rs
+++ b/tests/ui/coroutine/yield-in-const.rs
@@ -2,5 +2,6 @@
 
 const A: u8 = { yield 3u8; 3u8};
 //~^ ERROR yield expression outside
+//~| ERROR `yield` can only be used in
 
 fn main() {}

--- a/tests/ui/coroutine/yield-in-const.stderr
+++ b/tests/ui/coroutine/yield-in-const.stderr
@@ -1,9 +1,15 @@
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/yield-in-const.rs:3:17
+   |
+LL | const A: u8 = { yield 3u8; 3u8};
+   |                 ^^^^^^^^^
+
 error[E0627]: yield expression outside of coroutine literal
   --> $DIR/yield-in-const.rs:3:17
    |
 LL | const A: u8 = { yield 3u8; 3u8};
    |                 ^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0627`.

--- a/tests/ui/coroutine/yield-in-function.rs
+++ b/tests/ui/coroutine/yield-in-function.rs
@@ -2,3 +2,4 @@
 
 fn main() { yield; }
 //~^ ERROR yield expression outside
+//~| ERROR `yield` can only be used in

--- a/tests/ui/coroutine/yield-in-function.stderr
+++ b/tests/ui/coroutine/yield-in-function.stderr
@@ -1,9 +1,20 @@
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/yield-in-function.rs:3:13
+   |
+LL | fn main() { yield; }
+   |             ^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL | #[coroutine] fn main() { yield; }
+   | ++++++++++++
+
 error[E0627]: yield expression outside of coroutine literal
   --> $DIR/yield-in-function.rs:3:13
    |
 LL | fn main() { yield; }
    |             ^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0627`.

--- a/tests/ui/coroutine/yield-in-initializer.rs
+++ b/tests/ui/coroutine/yield-in-initializer.rs
@@ -3,7 +3,7 @@
 #![feature(coroutines)]
 
 fn main() {
-    static || { //~ WARN unused coroutine that must be used
+    #[coroutine] static || { //~ WARN unused coroutine that must be used
         loop {
             // Test that `opt` is not live across the yield, even when borrowed in a loop
             // See https://github.com/rust-lang/rust/issues/52792

--- a/tests/ui/coroutine/yield-in-initializer.stderr
+++ b/tests/ui/coroutine/yield-in-initializer.stderr
@@ -1,7 +1,8 @@
 warning: unused coroutine that must be used
-  --> $DIR/yield-in-initializer.rs:6:5
+  --> $DIR/yield-in-initializer.rs:6:18
    |
-LL | /     static || {
+LL |       #[coroutine] static || {
+   |  __________________^
 LL | |         loop {
 LL | |             // Test that `opt` is not live across the yield, even when borrowed in a loop
 LL | |             // See https://github.com/rust-lang/rust/issues/52792

--- a/tests/ui/coroutine/yield-in-static.rs
+++ b/tests/ui/coroutine/yield-in-static.rs
@@ -2,5 +2,6 @@
 
 static B: u8 = { yield 3u8; 3u8};
 //~^ ERROR yield expression outside
+//~| ERROR `yield` can only be used in
 
 fn main() {}

--- a/tests/ui/coroutine/yield-in-static.stderr
+++ b/tests/ui/coroutine/yield-in-static.stderr
@@ -1,9 +1,15 @@
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/yield-in-static.rs:3:18
+   |
+LL | static B: u8 = { yield 3u8; 3u8};
+   |                  ^^^^^^^^^
+
 error[E0627]: yield expression outside of coroutine literal
   --> $DIR/yield-in-static.rs:3:18
    |
 LL | static B: u8 = { yield 3u8; 3u8};
    |                  ^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0627`.

--- a/tests/ui/coroutine/yield-outside-coroutine-issue-78653.rs
+++ b/tests/ui/coroutine/yield-outside-coroutine-issue-78653.rs
@@ -4,4 +4,5 @@ fn main() {
     yield || for i in 0 { }
     //~^ ERROR yield expression outside of coroutine literal
     //~| ERROR `{integer}` is not an iterator
+    //~| ERROR `yield` can only be used in
 }

--- a/tests/ui/coroutine/yield-outside-coroutine-issue-78653.stderr
+++ b/tests/ui/coroutine/yield-outside-coroutine-issue-78653.stderr
@@ -1,3 +1,14 @@
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/yield-outside-coroutine-issue-78653.rs:4:5
+   |
+LL |     yield || for i in 0 { }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL | #[coroutine] fn main() {
+   | ++++++++++++
+
 error[E0627]: yield expression outside of coroutine literal
   --> $DIR/yield-outside-coroutine-issue-78653.rs:4:5
    |
@@ -14,7 +25,7 @@ LL |     yield || for i in 0 { }
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `{integer}` to implement `IntoIterator`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0277, E0627.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/coroutine/yield-subtype.rs
+++ b/tests/ui/coroutine/yield-subtype.rs
@@ -8,7 +8,7 @@ fn bar<'a>() {
     let a: &'static str = "hi";
     let b: &'a str = a;
 
-    || { //~ WARN unused coroutine that must be used
+    #[coroutine] || { //~ WARN unused coroutine that must be used
         yield a;
         yield b;
     };

--- a/tests/ui/coroutine/yield-subtype.stderr
+++ b/tests/ui/coroutine/yield-subtype.stderr
@@ -1,7 +1,8 @@
 warning: unused coroutine that must be used
-  --> $DIR/yield-subtype.rs:11:5
+  --> $DIR/yield-subtype.rs:11:18
    |
-LL | /     || {
+LL |       #[coroutine] || {
+   |  __________________^
 LL | |         yield a;
 LL | |         yield b;
 LL | |     };

--- a/tests/ui/coroutine/yield-while-iterating.rs
+++ b/tests/ui/coroutine/yield-while-iterating.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::ops::{CoroutineState, Coroutine};
 use std::cell::Cell;
@@ -9,7 +9,7 @@ fn yield_during_iter_owned_data(x: Vec<i32>) {
     // reference to it.  This winds up becoming a rather confusing
     // regionck error -- in particular, we would freeze with the
     // reference in scope, and it doesn't live long enough.
-    let _b = move || {
+    let _b =#[coroutine]  move || {
         for p in &x { //~ ERROR
             yield();
         }
@@ -17,7 +17,7 @@ fn yield_during_iter_owned_data(x: Vec<i32>) {
 }
 
 fn yield_during_iter_borrowed_slice(x: &[i32]) {
-    let _b = move || {
+    let _b = #[coroutine] move || {
         for p in x {
             yield();
         }
@@ -26,7 +26,7 @@ fn yield_during_iter_borrowed_slice(x: &[i32]) {
 
 fn yield_during_iter_borrowed_slice_2() {
     let mut x = vec![22_i32];
-    let _b = || {
+    let _b = #[coroutine] || {
         for p in &x {
             yield();
         }
@@ -38,7 +38,7 @@ fn yield_during_iter_borrowed_slice_3() {
     // OK to take a mutable ref to `x` and yield
     // up pointers from it:
     let mut x = vec![22_i32];
-    let mut b = || {
+    let mut b = #[coroutine] || {
         for p in &mut x {
             yield p;
         }
@@ -50,7 +50,7 @@ fn yield_during_iter_borrowed_slice_4() {
     // ...but not OK to do that while reading
     // from `x` too
     let mut x = vec![22_i32];
-    let mut b = || {
+    let mut b = #[coroutine] || {
         for p in &mut x {
             yield p;
         }
@@ -61,7 +61,7 @@ fn yield_during_iter_borrowed_slice_4() {
 
 fn yield_during_range_iter() {
     // Should be OK.
-    let mut b = || {
+    let mut b = #[coroutine] || {
         let v = vec![1,2,3];
         let len = v.len();
         for i in 0..len {

--- a/tests/ui/coroutine/yield-while-iterating.stderr
+++ b/tests/ui/coroutine/yield-while-iterating.stderr
@@ -9,8 +9,8 @@ LL |             yield();
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
   --> $DIR/yield-while-iterating.rs:58:20
    |
-LL |     let mut b = || {
-   |                 -- mutable borrow occurs here
+LL |     let mut b = #[coroutine] || {
+   |                              -- mutable borrow occurs here
 LL |         for p in &mut x {
    |                       - first borrow occurs due to use of `x` in coroutine
 ...

--- a/tests/ui/coroutine/yield-while-local-borrowed.rs
+++ b/tests/ui/coroutine/yield-while-local-borrowed.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::cell::Cell;
 use std::ops::{Coroutine, CoroutineState};
@@ -9,7 +9,7 @@ fn borrow_local_inline() {
     //
     // (This error occurs because the region shows up in the type of
     // `b` and gets extended by region inference.)
-    let mut b = move || {
+    let mut b = #[coroutine] move || {
         let a = &mut 3;
         //~^ ERROR borrow may still be in use when coroutine yields
         yield ();
@@ -20,7 +20,7 @@ fn borrow_local_inline() {
 
 fn borrow_local_inline_done() {
     // No error here -- `a` is not in scope at the point of `yield`.
-    let mut b = move || {
+    let mut b = #[coroutine] move || {
         {
             let a = &mut 3;
         }
@@ -34,7 +34,7 @@ fn borrow_local() {
     //
     // (This error occurs because the region shows up in the type of
     // `b` and gets extended by region inference.)
-    let mut b = move || {
+    let mut b = #[coroutine] move || {
         let a = 3;
         {
             let b = &a;

--- a/tests/ui/coroutine/yield-while-ref-reborrowed.rs
+++ b/tests/ui/coroutine/yield-while-ref-reborrowed.rs
@@ -1,15 +1,16 @@
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
-use std::ops::{CoroutineState, Coroutine};
 use std::cell::Cell;
+use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;
 
 fn reborrow_shared_ref(x: &i32) {
     // This is OK -- we have a borrow live over the yield, but it's of
     // data that outlives the coroutine.
-    let mut b = move || {
+    let mut b = #[coroutine]
+    move || {
         let a = &*x;
-        yield();
+        yield ();
         println!("{}", a);
     };
     Pin::new(&mut b).resume(());
@@ -18,9 +19,10 @@ fn reborrow_shared_ref(x: &i32) {
 fn reborrow_mutable_ref(x: &mut i32) {
     // This is OK -- we have a borrow live over the yield, but it's of
     // data that outlives the coroutine.
-    let mut b = move || {
+    let mut b = #[coroutine]
+    move || {
         let a = &mut *x;
-        yield();
+        yield ();
         println!("{}", a);
     };
     Pin::new(&mut b).resume(());
@@ -28,13 +30,14 @@ fn reborrow_mutable_ref(x: &mut i32) {
 
 fn reborrow_mutable_ref_2(x: &mut i32) {
     // ...but not OK to go on using `x`.
-    let mut b = || {
+    let mut b = #[coroutine]
+    || {
         let a = &mut *x;
-        yield();
+        yield ();
         println!("{}", a);
     };
     println!("{}", x); //~ ERROR
     Pin::new(&mut b).resume(());
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/coroutine/yield-while-ref-reborrowed.stderr
+++ b/tests/ui/coroutine/yield-while-ref-reborrowed.stderr
@@ -1,8 +1,8 @@
 error[E0501]: cannot borrow `x` as immutable because previous closure requires unique access
-  --> $DIR/yield-while-ref-reborrowed.rs:36:20
+  --> $DIR/yield-while-ref-reborrowed.rs:39:20
    |
-LL |     let mut b = || {
-   |                 -- coroutine construction occurs here
+LL |     || {
+   |     -- coroutine construction occurs here
 LL |         let a = &mut *x;
    |                      -- first borrow occurs due to use of `x` in coroutine
 ...

--- a/tests/ui/drop/dynamic-drop.rs
+++ b/tests/ui/drop/dynamic-drop.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ needs-unwind
 
-#![feature(coroutines, coroutine_trait)]
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 #![feature(if_let_guard)]
 
 #![allow(unused_assignments)]
@@ -176,7 +176,7 @@ fn vec_simple(a: &Allocator) {
 fn coroutine(a: &Allocator, run_count: usize) {
     assert!(run_count < 4);
 
-    let mut gen = || {
+    let mut gen = #[coroutine] || {
         (a.alloc(),
          yield a.alloc(),
          a.alloc(),

--- a/tests/ui/feature-gates/feature-gate-closure_track_caller.rs
+++ b/tests/ui/feature-gates/feature-gate-closure_track_caller.rs
@@ -4,6 +4,6 @@
 
 fn main() {
     let _closure = #[track_caller] || {}; //~ `#[track_caller]` on closures
-    let _coroutine = #[track_caller] || { yield; }; //~ `#[track_caller]` on closures
+    let _coroutine = #[coroutine] #[track_caller] || { yield; }; //~ `#[track_caller]` on closures
     let _future = #[track_caller] async {}; //~ `#[track_caller]` on closures
 }

--- a/tests/ui/feature-gates/feature-gate-closure_track_caller.stderr
+++ b/tests/ui/feature-gates/feature-gate-closure_track_caller.stderr
@@ -9,10 +9,10 @@ LL |     let _closure = #[track_caller] || {};
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/feature-gate-closure_track_caller.rs:7:22
+  --> $DIR/feature-gate-closure_track_caller.rs:7:35
    |
-LL |     let _coroutine = #[track_caller] || { yield; };
-   |                      ^^^^^^^^^^^^^^^
+LL |     let _coroutine = #[coroutine] #[track_caller] || { yield; };
+   |                                   ^^^^^^^^^^^^^^^
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-coroutines.e2024.stderr
+++ b/tests/ui/feature-gates/feature-gate-coroutines.e2024.stderr
@@ -8,8 +8,19 @@ LL |     yield true;
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/feature-gate-coroutines.rs:5:5
+   |
+LL |     yield true;
+   |     ^^^^^^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL | #[coroutine] fn main() {
+   | ++++++++++++
+
 error[E0658]: yield syntax is experimental
-  --> $DIR/feature-gate-coroutines.rs:9:16
+  --> $DIR/feature-gate-coroutines.rs:10:16
    |
 LL |     let _ = || yield true;
    |                ^^^^^^^^^^
@@ -18,13 +29,24 @@ LL |     let _ = || yield true;
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/feature-gate-coroutines.rs:10:16
+   |
+LL |     let _ = || yield true;
+   |                ^^^^^^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL |     let _ = #[coroutine] || yield true;
+   |             ++++++++++++
+
 error[E0627]: yield expression outside of coroutine literal
   --> $DIR/feature-gate-coroutines.rs:5:5
    |
 LL |     yield true;
    |     ^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0627, E0658.
 For more information about an error, try `rustc --explain E0627`.

--- a/tests/ui/feature-gates/feature-gate-coroutines.none.stderr
+++ b/tests/ui/feature-gates/feature-gate-coroutines.none.stderr
@@ -9,7 +9,7 @@ LL |     yield true;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: yield syntax is experimental
-  --> $DIR/feature-gate-coroutines.rs:9:16
+  --> $DIR/feature-gate-coroutines.rs:10:16
    |
 LL |     let _ = || yield true;
    |                ^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     let _ = || yield true;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: yield syntax is experimental
-  --> $DIR/feature-gate-coroutines.rs:16:5
+  --> $DIR/feature-gate-coroutines.rs:18:5
    |
 LL |     yield;
    |     ^^^^^
@@ -29,7 +29,7 @@ LL |     yield;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: yield syntax is experimental
-  --> $DIR/feature-gate-coroutines.rs:17:5
+  --> $DIR/feature-gate-coroutines.rs:19:5
    |
 LL |     yield 0;
    |     ^^^^^^^
@@ -49,8 +49,19 @@ LL |     yield true;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/feature-gate-coroutines.rs:5:5
+   |
+LL |     yield true;
+   |     ^^^^^^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL | #[coroutine] fn main() {
+   | ++++++++++++
+
 error[E0658]: yield syntax is experimental
-  --> $DIR/feature-gate-coroutines.rs:9:16
+  --> $DIR/feature-gate-coroutines.rs:10:16
    |
 LL |     let _ = || yield true;
    |                ^^^^^^^^^^
@@ -60,13 +71,24 @@ LL |     let _ = || yield true;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/feature-gate-coroutines.rs:10:16
+   |
+LL |     let _ = || yield true;
+   |                ^^^^^^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL |     let _ = #[coroutine] || yield true;
+   |             ++++++++++++
+
 error[E0627]: yield expression outside of coroutine literal
   --> $DIR/feature-gate-coroutines.rs:5:5
    |
 LL |     yield true;
    |     ^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0627, E0658.
 For more information about an error, try `rustc --explain E0627`.

--- a/tests/ui/feature-gates/feature-gate-coroutines.rs
+++ b/tests/ui/feature-gates/feature-gate-coroutines.rs
@@ -5,9 +5,11 @@ fn main() {
     yield true; //~ ERROR yield syntax is experimental
                 //~^ ERROR yield expression outside of coroutine literal
                 //[none]~^^ ERROR yield syntax is experimental
+                //~^^^ ERROR `yield` can only be used
 
     let _ = || yield true; //~ ERROR yield syntax is experimental
     //[none]~^ ERROR yield syntax is experimental
+    //~^^ ERROR `yield` can only be used
 }
 
 #[cfg(FALSE)]

--- a/tests/ui/impl-trait/issues/issue-58504.rs
+++ b/tests/ui/impl-trait/issues/issue-58504.rs
@@ -3,7 +3,7 @@
 use std::ops::Coroutine;
 
 fn mk_gen() -> impl Coroutine<Return=!, Yield=()> {
-    || { loop { yield; } }
+    #[coroutine] || { loop { yield; } }
 }
 
 fn main() {

--- a/tests/ui/impl-trait/lifetimes.rs
+++ b/tests/ui/impl-trait/lifetimes.rs
@@ -115,7 +115,7 @@ impl<'unnecessary_lifetime> MyVec {
     }
 
     fn coroutine_doesnt_capture_unnecessary_lifetime<'s: 's>() -> impl Sized {
-        || yield
+        #[coroutine] || yield
     }
 }
 

--- a/tests/ui/impl-trait/recursive-coroutine-boxed.next.stderr
+++ b/tests/ui/impl-trait/recursive-coroutine-boxed.next.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
-  --> $DIR/recursive-coroutine-boxed.rs:14:23
+  --> $DIR/recursive-coroutine-boxed.rs:15:23
    |
 LL |         let mut gen = Box::pin(foo());
    |                       ^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `Box`
@@ -13,7 +13,7 @@ LL |         let mut gen = Box::<T>::pin(foo());
    |                          +++++
 
 error[E0308]: mismatched types
-  --> $DIR/recursive-coroutine-boxed.rs:13:5
+  --> $DIR/recursive-coroutine-boxed.rs:14:18
    |
 LL |   fn foo() -> impl Coroutine<Yield = (), Return = ()> {
    |               ---------------------------------------
@@ -21,7 +21,8 @@ LL |   fn foo() -> impl Coroutine<Yield = (), Return = ()> {
    |               the expected opaque type
    |               expected `impl Coroutine<Yield = (), Return = ()>` because of return type
 ...
-LL | /     || {
+LL |       #[coroutine] || {
+   |  __________________^
 LL | |         let mut gen = Box::pin(foo());
 LL | |
 LL | |         let mut r = gen.as_mut().resume(());
@@ -31,7 +32,7 @@ LL | |     }
    | |_____^ types differ
    |
    = note: expected opaque type `impl Coroutine<Yield = (), Return = ()>`
-                found coroutine `{coroutine@$DIR/recursive-coroutine-boxed.rs:13:5: 13:7}`
+                found coroutine `{coroutine@$DIR/recursive-coroutine-boxed.rs:14:18: 14:20}`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/recursive-coroutine-boxed.rs
+++ b/tests/ui/impl-trait/recursive-coroutine-boxed.rs
@@ -10,7 +10,8 @@ fn foo() -> impl Coroutine<Yield = (), Return = ()> {
     // FIXME(-Znext-solver): this fails with a mismatched types as the
     // hidden type of the opaque ends up as {type error}. We should not
     // emit errors for such goals.
-    || { //[next]~ ERROR mismatched types
+
+    #[coroutine] || { //[next]~ ERROR mismatched types
         let mut gen = Box::pin(foo());
         //[next]~^ ERROR type annotations needed
         let mut r = gen.as_mut().resume(());

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.current.stderr
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.current.stderr
@@ -1,8 +1,8 @@
 error[E0733]: recursion in a coroutine requires boxing
-  --> $DIR/recursive-coroutine-indirect.rs:11:5
+  --> $DIR/recursive-coroutine-indirect.rs:11:18
    |
-LL |     move || {
-   |     ^^^^^^^
+LL |     #[coroutine] move || {
+   |                  ^^^^^^^
 LL |         let x = coroutine_hold();
    |             - recursive call here
 

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.next.stderr
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.next.stderr
@@ -1,8 +1,8 @@
 error[E0733]: recursion in a coroutine requires boxing
-  --> $DIR/recursive-coroutine-indirect.rs:11:5
+  --> $DIR/recursive-coroutine-indirect.rs:11:18
    |
-LL |     move || {
-   |     ^^^^^^^
+LL |     #[coroutine] move || {
+   |                  ^^^^^^^
 LL |         let x = coroutine_hold();
    |             - recursive call here
 

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.rs
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.rs
@@ -8,7 +8,7 @@
 #![feature(coroutines)]
 #![allow(unconditional_recursion)]
 fn coroutine_hold() -> impl Sized {
-    move || { //~ ERROR recursion in a coroutine requires boxing
+    #[coroutine] move || { //~ ERROR recursion in a coroutine requires boxing
         let x = coroutine_hold();
         yield;
         x;

--- a/tests/ui/impl-trait/recursive-impl-trait-type-indirect.rs
+++ b/tests/ui/impl-trait/recursive-impl-trait-type-indirect.rs
@@ -57,6 +57,8 @@ fn coroutine_sig() -> impl Sized {
 fn coroutine_capture() -> impl Sized {
     //~^ ERROR
     let x = coroutine_capture();
+
+    #[coroutine]
     move || {
         yield;
         x;

--- a/tests/ui/impl-trait/recursive-impl-trait-type-indirect.stderr
+++ b/tests/ui/impl-trait/recursive-impl-trait-type-indirect.stderr
@@ -98,10 +98,10 @@ LL | |         yield;
 LL | |         x;
    | |         - coroutine captures itself here
 LL | |     }
-   | |_____- returning here with type `{coroutine@$DIR/recursive-impl-trait-type-indirect.rs:60:5: 60:12}`
+   | |_____- returning here with type `{coroutine@$DIR/recursive-impl-trait-type-indirect.rs:62:5: 62:12}`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:66:35
+  --> $DIR/recursive-impl-trait-type-indirect.rs:68:35
    |
 LL | fn substs_change<T: 'static>() -> impl Sized {
    |                                   ^^^^^^^^^^ recursive opaque type
@@ -110,7 +110,7 @@ LL |     (substs_change::<&T>(),)
    |     ------------------------ returning here with type `(impl Sized,)`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:76:26
+  --> $DIR/recursive-impl-trait-type-indirect.rs:78:26
    |
 LL | fn mutual_recursion() -> impl Sync {
    |                          ^^^^^^^^^ recursive opaque type
@@ -122,7 +122,7 @@ LL | fn mutual_recursion_b() -> impl Sized {
    |                            ---------- returning this opaque type `impl Sized`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:81:28
+  --> $DIR/recursive-impl-trait-type-indirect.rs:83:28
    |
 LL | fn mutual_recursion() -> impl Sync {
    |                          --------- returning this opaque type `impl Sync`

--- a/tests/ui/lint/must_not_suspend/tuple-mismatch.rs
+++ b/tests/ui/lint/must_not_suspend/tuple-mismatch.rs
@@ -1,7 +1,8 @@
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 fn main() {
-    let _coroutine = || {
+    let _coroutine = #[coroutine]
+    || {
         yield ((), ((), ()));
         yield ((), ());
         //~^ ERROR mismatched types

--- a/tests/ui/lint/must_not_suspend/tuple-mismatch.stderr
+++ b/tests/ui/lint/must_not_suspend/tuple-mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/tuple-mismatch.rs:6:20
+  --> $DIR/tuple-mismatch.rs:7:20
    |
 LL |         yield ((), ());
    |                    ^^ expected `((), ())`, found `()`

--- a/tests/ui/lint/unused/issue-74883-unused-paren-baren-yield.rs
+++ b/tests/ui/lint/unused/issue-74883-unused-paren-baren-yield.rs
@@ -1,12 +1,12 @@
 #![feature(coroutine_trait)]
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![deny(unused_braces, unused_parens)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;
 
 fn main() {
-    let mut x = |_| {
+    let mut x = #[coroutine] |_| {
         while let Some(_) = (yield) {}
         while let Some(_) = {yield} {}
 

--- a/tests/ui/lint/unused/unused-closure.rs
+++ b/tests/ui/lint/unused/unused-closure.rs
@@ -2,7 +2,7 @@
 //@ edition:2018
 
 #![feature(async_closure)]
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![deny(unused_must_use)]
 
 fn unused() {
@@ -26,7 +26,7 @@ fn unused() {
 
 fn ignored() {
     let _ = || {};
-    let _ = || yield 42;
+    let _ = #[coroutine] || yield 42;
 }
 
 fn main() {

--- a/tests/ui/liveness/liveness-upvars.rs
+++ b/tests/ui/liveness/liveness-upvars.rs
@@ -1,6 +1,6 @@
 //@ edition:2018
 //@ check-pass
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![warn(unused)]
 #![allow(unreachable_code)]
 
@@ -131,7 +131,7 @@ pub fn async_coroutine() {
 
 pub fn coroutine() {
     let mut s: u32 = 0;
-    let _ = |_| {
+    let _ = #[coroutine] |_| {
         s = 0;
         yield ();
         s = 1; //~ WARN value assigned to `s` is never read

--- a/tests/ui/nll/coroutine-distinct-lifetime.rs
+++ b/tests/ui/nll/coroutine-distinct-lifetime.rs
@@ -9,6 +9,7 @@
 //@ check-pass
 
 fn foo(x: &mut u32) {
+    #[coroutine]
     move || {
         let s = &mut *x;
         yield;

--- a/tests/ui/nll/coroutine-upvar-mutability.rs
+++ b/tests/ui/nll/coroutine-upvar-mutability.rs
@@ -4,6 +4,8 @@
 
 fn mutate_upvar() {
     let x = 0;
+
+    #[coroutine]
     move || {
         x = 1;
         //~^ ERROR

--- a/tests/ui/nll/coroutine-upvar-mutability.stderr
+++ b/tests/ui/nll/coroutine-upvar-mutability.stderr
@@ -1,9 +1,9 @@
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/coroutine-upvar-mutability.rs:8:9
+  --> $DIR/coroutine-upvar-mutability.rs:10:9
    |
 LL |     let x = 0;
    |         - help: consider changing this to be mutable: `mut x`
-LL |     move || {
+...
 LL |         x = 1;
    |         ^^^^^ cannot assign
 

--- a/tests/ui/nll/extra-unused-mut.rs
+++ b/tests/ui/nll/extra-unused-mut.rs
@@ -18,6 +18,8 @@ fn mutable_upvar() {
 // #50897
 fn coroutine_mutable_upvar() {
     let mut x = 0;
+
+    #[coroutine]
     move || {
         x = 1;
         yield;
@@ -36,13 +38,13 @@ struct Expr {
 // #51904
 fn parse_dot_or_call_expr_with(mut attrs: Vec<u32>) {
     let x = Expr { attrs: vec![] };
-    Some(Some(x)).map(|expr|
+    Some(Some(x)).map(|expr| {
         expr.map(|mut expr| {
             attrs.push(666);
             expr.attrs = attrs;
             expr
         })
-    );
+    });
 }
 
 // Found when trying to bootstrap rustc

--- a/tests/ui/nll/issue-48623-coroutine.rs
+++ b/tests/ui/nll/issue-48623-coroutine.rs
@@ -12,7 +12,7 @@ impl Drop for WithDrop {
 
 fn reborrow_from_coroutine(r: &mut ()) {
     let d = WithDrop;
-    move || { d; yield; &mut *r }; //~ WARN unused coroutine that must be used
+    #[coroutine] move || { d; yield; &mut *r }; //~ WARN unused coroutine that must be used
 }
 
 fn main() {}

--- a/tests/ui/nll/issue-48623-coroutine.stderr
+++ b/tests/ui/nll/issue-48623-coroutine.stderr
@@ -1,8 +1,8 @@
 warning: unused coroutine that must be used
-  --> $DIR/issue-48623-coroutine.rs:15:5
+  --> $DIR/issue-48623-coroutine.rs:15:18
    |
-LL |     move || { d; yield; &mut *r };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[coroutine] move || { d; yield; &mut *r };
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: coroutines are lazy and do nothing unless resumed
    = note: `#[warn(unused_must_use)]` on by default

--- a/tests/ui/nll/issue-55850.rs
+++ b/tests/ui/nll/issue-55850.rs
@@ -23,7 +23,7 @@ where
 }
 
 fn bug<'a>() -> impl Iterator<Item = &'a str> {
-    GenIter(move || {
+    GenIter(#[coroutine] move || {
         let mut s = String::new();
         yield &s[..] //~ ERROR cannot yield value referencing local variable `s` [E0515]
         //~| ERROR borrow may still be in use when coroutine yields

--- a/tests/ui/packed/packed-struct-drop-aligned.rs
+++ b/tests/ui/packed/packed-struct-drop-aligned.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![feature(coroutine_trait)]
 use std::cell::Cell;
 use std::mem;
@@ -7,13 +7,12 @@ use std::ops::Coroutine;
 use std::pin::Pin;
 
 struct Aligned<'a> {
-    drop_count: &'a Cell<usize>
+    drop_count: &'a Cell<usize>,
 }
 
 #[inline(never)]
 fn check_align(ptr: *const Aligned) {
-    assert_eq!(ptr as usize % mem::align_of::<Aligned>(),
-               0);
+    assert_eq!(ptr as usize % mem::align_of::<Aligned>(), 0);
 }
 
 impl<'a> Drop for Aligned<'a> {
@@ -39,7 +38,8 @@ fn main() {
     assert_eq!(drop_count.get(), 2);
 
     let drop_count = &Cell::new(0);
-    let mut g = || {
+    let mut g = #[coroutine]
+    || {
         let mut p = Packed(NotCopy(0), Aligned { drop_count });
         let _ = &p;
         p.1 = Aligned { drop_count };

--- a/tests/ui/polymorphization/coroutine.rs
+++ b/tests/ui/polymorphization/coroutine.rs
@@ -32,6 +32,7 @@ where
 
 #[rustc_polymorphize_error]
 pub fn unused_type<T>() -> impl Coroutine<(), Yield = u32, Return = u32> + Unpin {
+    #[coroutine]
     || {
         //~^ ERROR item has unused generic parameters
         yield 1;
@@ -41,6 +42,7 @@ pub fn unused_type<T>() -> impl Coroutine<(), Yield = u32, Return = u32> + Unpin
 
 #[rustc_polymorphize_error]
 pub fn used_type_in_yield<Y: Default>() -> impl Coroutine<(), Yield = Y, Return = u32> + Unpin {
+    #[coroutine]
     || {
         yield Y::default();
         2
@@ -49,6 +51,7 @@ pub fn used_type_in_yield<Y: Default>() -> impl Coroutine<(), Yield = Y, Return 
 
 #[rustc_polymorphize_error]
 pub fn used_type_in_return<R: Default>() -> impl Coroutine<(), Yield = u32, Return = R> + Unpin {
+    #[coroutine]
     || {
         yield 3;
         R::default()
@@ -57,6 +60,7 @@ pub fn used_type_in_return<R: Default>() -> impl Coroutine<(), Yield = u32, Retu
 
 #[rustc_polymorphize_error]
 pub fn unused_const<const T: u32>() -> impl Coroutine<(), Yield = u32, Return = u32> + Unpin {
+    #[coroutine]
     || {
         //~^ ERROR item has unused generic parameters
         yield 1;
@@ -67,6 +71,7 @@ pub fn unused_const<const T: u32>() -> impl Coroutine<(), Yield = u32, Return = 
 #[rustc_polymorphize_error]
 pub fn used_const_in_yield<const Y: u32>() -> impl Coroutine<(), Yield = u32, Return = u32> + Unpin
 {
+    #[coroutine]
     || {
         yield Y;
         2
@@ -76,6 +81,7 @@ pub fn used_const_in_yield<const Y: u32>() -> impl Coroutine<(), Yield = u32, Re
 #[rustc_polymorphize_error]
 pub fn used_const_in_return<const R: u32>() -> impl Coroutine<(), Yield = u32, Return = u32> + Unpin
 {
+    #[coroutine]
     || {
         yield 4;
         R

--- a/tests/ui/polymorphization/coroutine.stderr
+++ b/tests/ui/polymorphization/coroutine.stderr
@@ -8,18 +8,20 @@ LL | #![feature(generic_const_exprs, coroutines, coroutine_trait, rustc_attrs)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: item has unused generic parameters
-  --> $DIR/coroutine.rs:35:5
+  --> $DIR/coroutine.rs:36:5
    |
 LL | pub fn unused_type<T>() -> impl Coroutine<(), Yield = u32, Return = u32> + Unpin {
    |                    - generic parameter `T` is unused
+LL |     #[coroutine]
 LL |     || {
    |     ^^
 
 error: item has unused generic parameters
-  --> $DIR/coroutine.rs:60:5
+  --> $DIR/coroutine.rs:64:5
    |
 LL | pub fn unused_const<const T: u32>() -> impl Coroutine<(), Yield = u32, Return = u32> + Unpin {
    |                     ------------ generic parameter `T` is unused
+LL |     #[coroutine]
 LL |     || {
    |     ^^
 

--- a/tests/ui/print_type_sizes/coroutine.rs
+++ b/tests/ui/print_type_sizes/coroutine.rs
@@ -7,6 +7,7 @@
 use std::ops::Coroutine;
 
 fn coroutine<const C: usize>(array: [u8; C]) -> impl Coroutine<Yield = (), Return = ()> {
+    #[coroutine]
     move |()| {
         yield ();
         let _ = array;

--- a/tests/ui/print_type_sizes/coroutine.stdout
+++ b/tests/ui/print_type_sizes/coroutine.stdout
@@ -1,4 +1,4 @@
-print-type-size type: `{coroutine@$DIR/coroutine.rs:10:5: 10:14}`: 8193 bytes, alignment: 1 bytes
+print-type-size type: `{coroutine@$DIR/coroutine.rs:11:5: 11:14}`: 8193 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 8192 bytes
 print-type-size         upvar `.array`: 8192 bytes

--- a/tests/ui/print_type_sizes/coroutine_discr_placement.rs
+++ b/tests/ui/print_type_sizes/coroutine_discr_placement.rs
@@ -5,11 +5,12 @@
 // Tests a coroutine that has its discriminant as the *final* field.
 
 // Avoid emitting panic handlers, like the rest of these tests...
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![allow(dropping_copy_types)]
 
 pub fn foo() {
-    let a = || {
+    let a = #[coroutine]
+    || {
         {
             let w: i32 = 4;
             yield;

--- a/tests/ui/print_type_sizes/coroutine_discr_placement.stdout
+++ b/tests/ui/print_type_sizes/coroutine_discr_placement.stdout
@@ -1,4 +1,4 @@
-print-type-size type: `{coroutine@$DIR/coroutine_discr_placement.rs:12:13: 12:15}`: 8 bytes, alignment: 4 bytes
+print-type-size type: `{coroutine@$DIR/coroutine_discr_placement.rs:13:5: 13:7}`: 8 bytes, alignment: 4 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 0 bytes
 print-type-size     variant `Suspend0`: 7 bytes

--- a/tests/ui/rfcs/rfc-2091-track-caller/tracked-closure.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/tracked-closure.rs
@@ -113,7 +113,7 @@ fn dyn_coroutine(
 }
 
 fn test_coroutine() {
-    let coroutine = #[track_caller] |arg: String| {
+    let coroutine = #[track_caller] #[coroutine] |arg: String| {
         yield ("first", arg.clone(), Location::caller());
         yield ("second", arg.clone(), Location::caller());
     };
@@ -136,7 +136,7 @@ fn test_coroutine() {
     assert_eq!(mono_loc.line(), mono_line);
     assert_eq!(mono_loc.column(), 42);
 
-    let non_tracked_coroutine = || { yield Location::caller(); };
+    let non_tracked_coroutine = #[coroutine] || { yield Location::caller(); };
     let non_tracked_line = line!() - 1; // This is the line of the coroutine, not its caller
     let non_tracked_loc = match Box::pin(non_tracked_coroutine).as_mut().resume(()) {
         CoroutineState::Yielded(val) => val,
@@ -144,7 +144,7 @@ fn test_coroutine() {
     };
     assert_eq!(non_tracked_loc.file(), file!());
     assert_eq!(non_tracked_loc.line(), non_tracked_line);
-    assert_eq!(non_tracked_loc.column(), 44);
+    assert_eq!(non_tracked_loc.column(), 57);
 
 }
 

--- a/tests/ui/sanitizer/cfi-coroutine.rs
+++ b/tests/ui/sanitizer/cfi-coroutine.rs
@@ -14,7 +14,7 @@
 //@ compile-flags: --test -Z unstable-options
 //@ run-pass
 
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 #![feature(coroutine_trait)]
 #![feature(noop_waker)]
 #![feature(gen_blocks)]
@@ -27,7 +27,7 @@ use std::async_iter::AsyncIterator;
 
 #[test]
 fn general_coroutine() {
-    let mut coro = |x: i32| {
+    let mut coro = #[coroutine] |x: i32| {
         yield x;
         "done"
     };

--- a/tests/ui/suggestions/issue-84973-blacklist.rs
+++ b/tests/ui/suggestions/issue-84973-blacklist.rs
@@ -14,7 +14,7 @@ struct S;
 fn main() {
     f_copy("".to_string()); //~ ERROR: the trait bound `String: Copy` is not satisfied [E0277]
     f_clone(S); //~ ERROR: the trait bound `S: Clone` is not satisfied [E0277]
-    f_unpin(static || { yield; });
+    f_unpin(#[coroutine] static || { yield; });
     //~^ ERROR: cannot be unpinned [E0277]
 
     let cl = || ();

--- a/tests/ui/suggestions/issue-84973-blacklist.stderr
+++ b/tests/ui/suggestions/issue-84973-blacklist.stderr
@@ -36,11 +36,11 @@ LL + #[derive(Clone)]
 LL | struct S;
    |
 
-error[E0277]: `{static coroutine@$DIR/issue-84973-blacklist.rs:17:13: 17:22}` cannot be unpinned
-  --> $DIR/issue-84973-blacklist.rs:17:13
+error[E0277]: `{static coroutine@$DIR/issue-84973-blacklist.rs:17:26: 17:35}` cannot be unpinned
+  --> $DIR/issue-84973-blacklist.rs:17:26
    |
-LL |     f_unpin(static || { yield; });
-   |     ------- ^^^^^^^^^^^^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/issue-84973-blacklist.rs:17:13: 17:22}`
+LL |     f_unpin(#[coroutine] static || { yield; });
+   |     -------              ^^^^^^^^^^^^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/issue-84973-blacklist.rs:17:26: 17:35}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/suggestions/unnamable-types.rs
+++ b/tests/ui/suggestions/unnamable-types.rs
@@ -1,7 +1,7 @@
 // Test that we do not suggest to add type annotations for unnamable types.
 
 #![crate_type="lib"]
-#![feature(coroutines)]
+#![feature(coroutines, stmt_expr_attributes)]
 
 const A = 5;
 //~^ ERROR: missing type for `const` item
@@ -34,6 +34,6 @@ const F = S { t: foo };
 //~| HELP: provide a type for the constant
 
 
-const G = || -> i32 { yield 0; return 1; };
+const G = #[coroutine] || -> i32 { yield 0; return 1; };
 //~^ ERROR: missing type for `const` item
 //~| NOTE: however, the inferred type

--- a/tests/ui/suggestions/unnamable-types.stderr
+++ b/tests/ui/suggestions/unnamable-types.stderr
@@ -52,14 +52,14 @@ LL | const F = S { t: foo };
 error: missing type for `const` item
   --> $DIR/unnamable-types.rs:37:8
    |
-LL | const G = || -> i32 { yield 0; return 1; };
+LL | const G = #[coroutine] || -> i32 { yield 0; return 1; };
    |        ^
    |
-note: however, the inferred type `{coroutine@$DIR/unnamable-types.rs:37:11: 37:20}` cannot be named
-  --> $DIR/unnamable-types.rs:37:11
+note: however, the inferred type `{coroutine@$DIR/unnamable-types.rs:37:24: 37:33}` cannot be named
+  --> $DIR/unnamable-types.rs:37:24
    |
-LL | const G = || -> i32 { yield 0; return 1; };
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | const G = #[coroutine] || -> i32 { yield 0; return 1; };
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/traits/next-solver/coroutine.fail.stderr
+++ b/tests/ui/traits/next-solver/coroutine.fail.stderr
@@ -1,16 +1,16 @@
-error[E0277]: the trait bound `{coroutine@$DIR/coroutine.rs:18:21: 18:23}: Coroutine<A>` is not satisfied
-  --> $DIR/coroutine.rs:18:21
+error[E0277]: the trait bound `{coroutine@$DIR/coroutine.rs:20:9: 20:11}: Coroutine<A>` is not satisfied
+  --> $DIR/coroutine.rs:20:9
    |
-LL |       needs_coroutine(|| {
-   |  _____---------------_^
-   | |     |
-   | |     required by a bound introduced by this call
+LL |       needs_coroutine(
+   |       --------------- required by a bound introduced by this call
+LL |           #[coroutine]
+LL | /         || {
 LL | |
 LL | |
 LL | |
-LL | |         yield ();
-LL | |     });
-   | |_____^ the trait `Coroutine<A>` is not implemented for `{coroutine@$DIR/coroutine.rs:18:21: 18:23}`
+LL | |             yield ();
+LL | |         },
+   | |_________^ the trait `Coroutine<A>` is not implemented for `{coroutine@$DIR/coroutine.rs:20:9: 20:11}`
    |
 note: required by a bound in `needs_coroutine`
   --> $DIR/coroutine.rs:14:28
@@ -18,19 +18,19 @@ note: required by a bound in `needs_coroutine`
 LL | fn needs_coroutine(_: impl Coroutine<A, Yield = B, Return = C>) {}
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `needs_coroutine`
 
-error[E0271]: type mismatch resolving `<{coroutine@$DIR/coroutine.rs:18:21: 18:23} as Coroutine<A>>::Yield == B`
-  --> $DIR/coroutine.rs:18:21
+error[E0271]: type mismatch resolving `<{coroutine@$DIR/coroutine.rs:20:9: 20:11} as Coroutine<A>>::Yield == B`
+  --> $DIR/coroutine.rs:20:9
    |
-LL |       needs_coroutine(|| {
-   |  _____---------------_^
-   | |     |
-   | |     required by a bound introduced by this call
+LL |       needs_coroutine(
+   |       --------------- required by a bound introduced by this call
+LL |           #[coroutine]
+LL | /         || {
 LL | |
 LL | |
 LL | |
-LL | |         yield ();
-LL | |     });
-   | |_____^ types differ
+LL | |             yield ();
+LL | |         },
+   | |_________^ types differ
    |
 note: required by a bound in `needs_coroutine`
   --> $DIR/coroutine.rs:14:41
@@ -38,19 +38,19 @@ note: required by a bound in `needs_coroutine`
 LL | fn needs_coroutine(_: impl Coroutine<A, Yield = B, Return = C>) {}
    |                                         ^^^^^^^^^ required by this bound in `needs_coroutine`
 
-error[E0271]: type mismatch resolving `<{coroutine@$DIR/coroutine.rs:18:21: 18:23} as Coroutine<A>>::Return == C`
-  --> $DIR/coroutine.rs:18:21
+error[E0271]: type mismatch resolving `<{coroutine@$DIR/coroutine.rs:20:9: 20:11} as Coroutine<A>>::Return == C`
+  --> $DIR/coroutine.rs:20:9
    |
-LL |       needs_coroutine(|| {
-   |  _____---------------_^
-   | |     |
-   | |     required by a bound introduced by this call
+LL |       needs_coroutine(
+   |       --------------- required by a bound introduced by this call
+LL |           #[coroutine]
+LL | /         || {
 LL | |
 LL | |
 LL | |
-LL | |         yield ();
-LL | |     });
-   | |_____^ types differ
+LL | |             yield ();
+LL | |         },
+   | |_________^ types differ
    |
 note: required by a bound in `needs_coroutine`
   --> $DIR/coroutine.rs:14:52

--- a/tests/ui/traits/next-solver/coroutine.rs
+++ b/tests/ui/traits/next-solver/coroutine.rs
@@ -15,18 +15,24 @@ fn needs_coroutine(_: impl Coroutine<A, Yield = B, Return = C>) {}
 
 #[cfg(fail)]
 fn main() {
-    needs_coroutine(|| {
-        //[fail]~^ ERROR Coroutine<A>` is not satisfied
-        //[fail]~| ERROR as Coroutine<A>>::Yield == B`
-        //[fail]~| ERROR as Coroutine<A>>::Return == C`
-        yield ();
-    });
+    needs_coroutine(
+        #[coroutine]
+        || {
+            //[fail]~^ ERROR Coroutine<A>` is not satisfied
+            //[fail]~| ERROR as Coroutine<A>>::Yield == B`
+            //[fail]~| ERROR as Coroutine<A>>::Return == C`
+            yield ();
+        },
+    );
 }
 
 #[cfg(pass)]
 fn main() {
-    needs_coroutine(|_: A| {
-        let _: A = yield B;
-        C
-    })
+    needs_coroutine(
+        #[coroutine]
+        |_: A| {
+            let _: A = yield B;
+            C
+        },
+    )
 }

--- a/tests/ui/type-alias-impl-trait/issue-53678-coroutine-and-const-fn.rs
+++ b/tests/ui/type-alias-impl-trait/issue-53678-coroutine-and-const-fn.rs
@@ -9,6 +9,7 @@ mod gen {
     pub type CoroOnce<Y, R> = impl Coroutine<Yield = Y, Return = R>;
 
     pub const fn const_coroutine<Y, R>(yielding: Y, returning: R) -> CoroOnce<Y, R> {
+        #[coroutine]
         move || {
             yield yielding;
 

--- a/tests/ui/type-alias-impl-trait/issue-58662-coroutine-with-lifetime.rs
+++ b/tests/ui/type-alias-impl-trait/issue-58662-coroutine-with-lifetime.rs
@@ -8,6 +8,7 @@ use std::pin::Pin;
 
 type RandCoroutine<'a> = impl Coroutine<Return = (), Yield = u64> + 'a;
 fn rand_coroutine<'a>(rng: &'a ()) -> RandCoroutine<'a> {
+    #[coroutine]
     move || {
         let _rng = rng;
         loop {
@@ -19,6 +20,7 @@ fn rand_coroutine<'a>(rng: &'a ()) -> RandCoroutine<'a> {
 pub type RandCoroutineWithIndirection<'c> = impl Coroutine<Return = (), Yield = u64> + 'c;
 pub fn rand_coroutine_with_indirection<'a>(rng: &'a ()) -> RandCoroutineWithIndirection<'a> {
     fn helper<'b>(rng: &'b ()) -> impl 'b + Coroutine<Return = (), Yield = u64> {
+        #[coroutine]
         move || {
             let _rng = rng;
             loop {

--- a/tests/ui/type-alias-impl-trait/issue-94429.rs
+++ b/tests/ui/type-alias-impl-trait/issue-94429.rs
@@ -14,6 +14,7 @@ impl Runnable for Implementor {
 
     fn run(&mut self) -> Self::Coro {
         //~^ ERROR: type mismatch resolving
+        #[coroutine]
         move || {
             yield 1;
         }

--- a/tests/ui/type-alias-impl-trait/issue-94429.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-94429.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<{coroutine@$DIR/issue-94429.rs:17:9: 17:16} as Coroutine>::Yield == ()`
+error[E0271]: type mismatch resolving `<{coroutine@$DIR/issue-94429.rs:18:9: 18:16} as Coroutine>::Yield == ()`
   --> $DIR/issue-94429.rs:15:26
    |
 LL |     fn run(&mut self) -> Self::Coro {

--- a/tests/ui/weird-exprs.rs
+++ b/tests/ui/weird-exprs.rs
@@ -152,6 +152,7 @@ fn r#match() {
 }
 
 fn i_yield() {
+    #[coroutine]
     static || {
         yield yield yield yield yield yield yield yield yield;
     };


### PR DESCRIPTION
instead of relying on patching up the closure to be a coroutine if it happens to contain a `yield` expression.

I only do this in the 2024 edition, as the `gen` keyword is only available there.