### PR TITLE
Remove unused cargo-platform dependency from tidy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5580,7 +5580,6 @@ dependencies = [
 name = "tidy"
 version = "0.1.0"
 dependencies = [
- "cargo-platform",
  "cargo_metadata 0.15.4",
  "ignore",
  "lazy_static",

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -6,7 +6,6 @@ autobins = false
 
 [dependencies]
 cargo_metadata = "0.15"
-cargo-platform = "0.1.2"
 regex = "1"
 miropt-test-tools = { path = "../miropt-test-tools" }
 lazy_static = "1"


### PR DESCRIPTION
Noticed in https://github.com/rust-lang/rust/pull/123788#issuecomment-2049806519