### PR TITLE
Avoid invalid socket address in length calculation

### DIFF
--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -591,7 +591,7 @@ impl fmt::Display for SocketAddrV4 {
         if f.precision().is_none() && f.width().is_none() {
             write!(f, "{}:{}", self.ip(), self.port())
         } else {
-            const LONGEST_IPV4_SOCKET_ADDR: &str = "255.255.255.255:65536";
+            const LONGEST_IPV4_SOCKET_ADDR: &str = "255.255.255.255:65535";
 
             let mut buf = DisplayBuffer::<{ LONGEST_IPV4_SOCKET_ADDR.len() }>::new();
             // Buffer is long enough for the longest possible IPv4 socket address, so this should never fail.
@@ -621,7 +621,7 @@ impl fmt::Display for SocketAddrV6 {
             }
         } else {
             const LONGEST_IPV6_SOCKET_ADDR: &str =
-                "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff%4294967296]:65536";
+                "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff%4294967295]:65535";
 
             let mut buf = DisplayBuffer::<{ LONGEST_IPV6_SOCKET_ADDR.len() }>::new();
             match self.scope_id() {


### PR DESCRIPTION
This has no effect on the lengths of these constants, but since the IP address portion of the socket addresses was intentionally chosen to be the largest valid value, it seems appropriate to also use the largest valid value for the other components (as opposed to invalid values exceeding the possible ranges).