### PR TITLE
Stop using `HirId` for fn-like parents since closures are not `OwnerNode`s

### DIFF
--- a/tests/ui/async-await/dont-ice-for-type-mismatch-in-closure-in-async.rs
+++ b/tests/ui/async-await/dont-ice-for-type-mismatch-in-closure-in-async.rs
@@ -1,0 +1,17 @@
+//@ edition: 2021
+
+fn call(_: impl Fn() -> bool) {}
+
+async fn test() {
+    call(|| -> Option<()> {
+        //~^ ERROR expected
+        if true {
+            false
+            //~^ ERROR mismatched types
+        }
+        true
+        //~^ ERROR mismatched types
+    })
+}
+
+fn main() {}

--- a/tests/ui/async-await/dont-ice-for-type-mismatch-in-closure-in-async.stderr
+++ b/tests/ui/async-await/dont-ice-for-type-mismatch-in-closure-in-async.stderr
@@ -1,0 +1,46 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-ice-for-type-mismatch-in-closure-in-async.rs:9:13
+   |
+LL | /         if true {
+LL | |             false
+   | |             ^^^^^ expected `()`, found `bool`
+LL | |
+LL | |         }
+   | |_________- expected this to be `()`
+
+error[E0308]: mismatched types
+  --> $DIR/dont-ice-for-type-mismatch-in-closure-in-async.rs:12:9
+   |
+LL |         true
+   |         ^^^^ expected `Option<()>`, found `bool`
+   |
+   = note: expected enum `Option<()>`
+              found type `bool`
+
+error[E0271]: expected `{closure@dont-ice-for-type-mismatch-in-closure-in-async.rs:6:10}` to be a closure that returns `bool`, but it returns `Option<()>`
+  --> $DIR/dont-ice-for-type-mismatch-in-closure-in-async.rs:6:10
+   |
+LL |       call(|| -> Option<()> {
+   |  _____----_^
+   | |     |
+   | |     required by a bound introduced by this call
+LL | |
+LL | |         if true {
+LL | |             false
+...  |
+LL | |
+LL | |     })
+   | |_____^ expected `bool`, found `Option<()>`
+   |
+   = note: expected type `bool`
+              found enum `Option<()>`
+note: required by a bound in `call`
+  --> $DIR/dont-ice-for-type-mismatch-in-closure-in-async.rs:3:25
+   |
+LL | fn call(_: impl Fn() -> bool) {}
+   |                         ^^^^ required by this bound in `call`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0271, E0308.
+For more information about an error, try `rustc --explain E0271`.


### PR DESCRIPTION
This is a minimal fix for #123273.

I'm overall pretty disappointed w/ the state of this code; although it's "just diagnostics", it still should be maintainable and understandable and neither of those are true. I believe this code really needs some major overhauling before anything more should be added to it, because there are subtle invariants that are being exercised and subsequently broken all over the place, and I don't think we should just paper over them (e.g.) by delaying bugs or things like that. I wouldn't be surprised if fixing up this code would also yield better diagnostics.