### PR TITLE
Panic on overflow in `BorrowedCursor::advance`

### DIFF
--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -249,9 +249,10 @@ impl<'a> BorrowedCursor<'a> {
     /// Panics if there are less than `n` bytes initialized.
     #[inline]
     pub fn advance(&mut self, n: usize) -> &mut Self {
-        assert!(self.buf.init >= self.buf.filled + n);
+        let filled = self.buf.filled.strict_add(n);
+        assert!(filled <= self.buf.init);
 
-        self.buf.filled += n;
+        self.buf.filled = filled;
         self
     }
 

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -210,6 +210,15 @@ fn read_buf_exact() {
 }
 
 #[test]
+#[should_panic]
+fn borrowed_cursor_advance_overflow() {
+    let mut buf = [0; 512];
+    let mut buf = BorrowedBuf::from(&mut buf[..]);
+    buf.unfilled().advance(1);
+    buf.unfilled().advance(usize::MAX);
+}
+
+#[test]
 fn take_eof() {
     struct R;
 


### PR DESCRIPTION
Passing `usize::MAX` to `advance` clearly isn't correct, but the current assertion fails to detect this when overflow checks are disabled. This isn't unsound, but should probably be fixed regardless.