### PR TITLE
Add v0 symbol mangling for `f16` and `f128`

### DIFF
--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -319,11 +319,10 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
             ty::Uint(UintTy::U64) => "y",
             ty::Uint(UintTy::U128) => "o",
             ty::Uint(UintTy::Usize) => "j",
-            // FIXME(f16_f128): update these once `rustc-demangle` supports the new types
-            ty::Float(FloatTy::F16) => unimplemented!("f16_f128"),
+            ty::Float(FloatTy::F16) => "C3f16",
             ty::Float(FloatTy::F32) => "f",
             ty::Float(FloatTy::F64) => "d",
-            ty::Float(FloatTy::F128) => unimplemented!("f16_f128"),
+            ty::Float(FloatTy::F128) => "C4f128",
             ty::Never => "z",
 
             // Placeholders (should be demangled as `_`).

--- a/src/doc/rustc/src/symbol-mangling/v0.md
+++ b/src/doc/rustc/src/symbol-mangling/v0.md
@@ -739,6 +739,8 @@ The type encodings based on the initial tag character are:
   * `z` — `!`
   * `p` — [placeholder] `_`
 
+Remaining primitives are encoded as a crate production, e.g. `C4f128`.
+
 * `A` — An [array][reference-array] `[T; N]`.
 
   > <span id="array-type">array-type</span> → `A` *[type]* *[const]*

--- a/tests/ui/symbol-names/types.rs
+++ b/tests/ui/symbol-names/types.rs
@@ -1,169 +1,270 @@
 //@ build-fail
-//@ revisions: legacy verbose-legacy
-//@ compile-flags: --crate-name=a -C symbol-mangling-version=legacy -Z unstable-options
-//@[verbose-legacy]compile-flags: -Zverbose-internals
+//@ revisions: legacy verbose-legacy v0
+//@ compile-flags: --crate-name=a -Z unstable-options
+//@ [legacy] compile-flags: -Csymbol-mangling-version=legacy
+//@ [verbose-legacy] compile-flags: -Csymbol-mangling-version=legacy -Zverbose-internals
+//@ [v0] compile-flags: -Csymbol-mangling-version=v0
 //@ normalize-stderr-test: "h[[:xdigit:]]{16}" -> "h[HASH]"
+//@ [v0] normalize-stderr-test: "\[[[:xdigit:]]{16}\]" -> "[HASH]"
 
 #![feature(never_type)]
 #![feature(rustc_attrs)]
+#![feature(f128)]
+#![feature(f16)]
 
 pub fn b() {
     struct Type<T: ?Sized>(T);
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b16Type$LT$bool$GT$
-    //~| ERROR demangling(a::b::Type<bool>::
-    //~| ERROR demangling-alt(a::b::Type<bool>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b16Type$LT$bool$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<bool>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<bool>)
+    //[v0]~^^^^ ERROR symbol-name(_RMNvCsCRATE_HASH_1a1bINtB<REF>_4TypebE)
+    //[v0]~| ERROR ::b::Type<bool>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<bool>>)
     impl Type<bool> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b16Type$LT$char$GT$
-    //~| ERROR demangling(a::b::Type<char>::
-    //~| ERROR demangling-alt(a::b::Type<char>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b16Type$LT$char$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<char>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<char>)
+    //[v0]~^^^^ ERROR symbol-name(_RMs_NvCsCRATE_HASH_1a1bINtB<REF>_4TypecE)
+    //[v0]~| ERROR ::b::Type<char>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<char>>)
     impl Type<char> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b14Type$LT$i8$GT$
-    //~| ERROR demangling(a::b::Type<i8>::
-    //~| ERROR demangling-alt(a::b::Type<i8>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b14Type$LT$i8$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<i8>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<i8>)
+    //[v0]~^^^^ ERROR symbol-name(_RMs0_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeaE)
+    //[v0]~| ERROR ::b::Type<i8>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<i8>>)
     impl Type<i8> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b15Type$LT$i16$GT$
-    //~| ERROR demangling(a::b::Type<i16>::
-    //~| ERROR demangling-alt(a::b::Type<i16>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b15Type$LT$i16$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<i16>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<i16>)
+    //[v0]~^^^^ ERROR symbol-name(_RMs1_NvCsCRATE_HASH_1a1bINtB<REF>_4TypesE)
+    //[v0]~| ERROR ::b::Type<i16>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<i16>>)
     impl Type<i16> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b15Type$LT$i32$GT$
-    //~| ERROR demangling(a::b::Type<i32>::
-    //~| ERROR demangling-alt(a::b::Type<i32>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b15Type$LT$i32$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<i32>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<i32>)
+    //[v0]~^^^^ ERROR symbol-name(_RMs2_NvCsCRATE_HASH_1a1bINtB<REF>_4TypelE)
+    //[v0]~| ERROR ::b::Type<i32>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<i32>>)
     impl Type<i32> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b15Type$LT$i64$GT$
-    //~| ERROR demangling(a::b::Type<i64>::
-    //~| ERROR demangling-alt(a::b::Type<i64>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b15Type$LT$i64$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<i64>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<i64>)
+    //[v0]~^^^^ ERROR symbol-name(_RMs3_NvCsCRATE_HASH_1a1bINtB<REF>_4TypexE)
+    //[v0]~| ERROR ::b::Type<i64>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<i64>>)
     impl Type<i64> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b14Type$LT$u8$GT$
-    //~| ERROR demangling(a::b::Type<u8>::
-    //~| ERROR demangling-alt(a::b::Type<u8>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b14Type$LT$u8$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<u8>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<u8>)
+    //[v0]~^^^^ ERROR symbol-name(_RMs4_NvCsCRATE_HASH_1a1bINtB<REF>_4TypehE)
+    //[v0]~| ERROR ::b::Type<u8>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<u8>>)
     impl Type<u8> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b15Type$LT$u16$GT$
-    //~| ERROR demangling(a::b::Type<u16>::
-    //~| ERROR demangling-alt(a::b::Type<u16>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b15Type$LT$u16$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<u16>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<u16>)
+    //[v0]~^^^^ ERROR symbol-name(_RMs5_NvCsCRATE_HASH_1a1bINtB<REF>_4TypetE)
+    //[v0]~| ERROR ::b::Type<u16>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<u16>>)
     impl Type<u16> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b15Type$LT$u32$GT$
-    //~| ERROR demangling(a::b::Type<u32>::
-    //~| ERROR demangling-alt(a::b::Type<u32>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b15Type$LT$u32$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<u32>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<u32>)
+    //[v0]~^^^^ ERROR symbol-name(_RMs6_NvCsCRATE_HASH_1a1bINtB<REF>_4TypemE)
+    //[v0]~| ERROR ::b::Type<u32>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<u32>>)
     impl Type<u32> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b15Type$LT$u64$GT$
-    //~| ERROR demangling(a::b::Type<u64>::
-    //~| ERROR demangling-alt(a::b::Type<u64>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b15Type$LT$u64$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<u64>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<u64>)
+    //[v0]~^^^^ ERROR symbol-name(_RMs7_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeyE)
+    //[v0]~| ERROR ::b::Type<u64>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<u64>>)
     impl Type<u64> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b15Type$LT$f32$GT$
-    //~| ERROR demangling(a::b::Type<f32>::
-    //~| ERROR demangling-alt(a::b::Type<f32>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b15Type$LT$f16$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<f16>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<f16>)
+    //[v0]~^^^^ ERROR symbol-name(_RMs8_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeC3f16E)
+    //[v0]~| ERROR ::b::Type<f16>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<f16>>)
+    impl Type<f16> {}
+
+    #[rustc_symbol_name]
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b15Type$LT$f32$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<f32>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<f32>)
+    //[v0]~^^^^ ERROR symbol-name(_RMs9_NvCsCRATE_HASH_1a1bINtB<REF>_4TypefE)
+    //[v0]~| ERROR ::b::Type<f32>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<f32>>)
     impl Type<f32> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b15Type$LT$f64$GT$
-    //~| ERROR demangling(a::b::Type<f64>::
-    //~| ERROR demangling-alt(a::b::Type<f64>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b15Type$LT$f64$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<f64>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<f64>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsa_NvCsCRATE_HASH_1a1bINtB<REF>_4TypedE)
+    //[v0]~| ERROR ::b::Type<f64>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<f64>>)
     impl Type<f64> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b15Type$LT$str$GT$
-    //~| ERROR demangling(a::b::Type<str>::
-    //~| ERROR demangling-alt(a::b::Type<str>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b16Type$LT$f128$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<f128>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<f128>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsb_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeC4f128E)
+    //[v0]~| ERROR ::b::Type<f128>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<f128>>)
+    impl Type<f128> {}
+
+    #[rustc_symbol_name]
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b15Type$LT$str$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<str>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<str>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsc_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeeE)
+    //[v0]~| ERROR ::b::Type<str>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<str>>)
     impl Type<str> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b17Type$LT$$u21$$GT$
-    //~| ERROR demangling(a::b::Type<!>::
-    //~| ERROR demangling-alt(a::b::Type<!>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b17Type$LT$$u21$$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<!>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<!>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsd_NvCsCRATE_HASH_1a1bINtB<REF>_4TypezE)
+    //[v0]~| ERROR ::b::Type<!>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<!>>)
     impl Type<!> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b20Type$LT$$LP$$RP$$GT
-    //~| ERROR demangling(a::b::Type<()>::
-    //~| ERROR demangling-alt(a::b::Type<()>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b20Type$LT$$LP$$RP$$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<()>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<()>)
+    //[v0]~^^^^ ERROR symbol-name(_RMse_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeuE)
+    //[v0]~| ERROR ::b::Type<()>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<()>>)
     impl Type<()> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b25Type$LT$$LP$u8$C$$RP$$GT$
-    //~| ERROR demangling(a::b::Type<(u8,)>::
-    //~| ERROR demangling-alt(a::b::Type<(u8,)>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b25Type$LT$$LP$u8$C$$RP$$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<(u8,)>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<(u8,)>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsf_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeThEE)
+    //[v0]~| ERROR ::b::Type<(u8,)>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<(u8,)>>)
     impl Type<(u8,)> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b28Type$LT$$LP$u8$C$u16$RP$$GT$
-    //~| ERROR demangling(a::b::Type<(u8,u16)>::
-    //~| ERROR demangling-alt(a::b::Type<(u8,u16)>)
-    impl Type<(u8,u16)> {}
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b28Type$LT$$LP$u8$C$u16$RP$$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<(u8,u16)>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<(u8,u16)>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsg_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeThtEE)
+    //[v0]~| ERROR ::b::Type<(u8, u16)>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<(u8, u16)>>)
+    impl Type<(u8, u16)> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b34Type$LT$$LP$u8$C$u16$C$u32$RP$$GT$
-    //~| ERROR demangling(a::b::Type<(u8,u16,u32)>::
-    //~| ERROR demangling-alt(a::b::Type<(u8,u16,u32)>)
-    impl Type<(u8,u16,u32)> {}
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b34Type$LT$$LP$u8$C$u16$C$u32$RP$$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<(u8,u16,u32)>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<(u8,u16,u32)>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsh_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeThtmEE)
+    //[v0]~| ERROR ::b::Type<(u8, u16, u32)>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<(u8, u16, u32)>>)
+    impl Type<(u8, u16, u32)> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b28Type$LT$$BP$const$u20$u8$GT$
-    //~| ERROR demangling(a::b::Type<*const u8>::
-    //~| ERROR demangling-alt(a::b::Type<*const u8>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b28Type$LT$$BP$const$u20$u8$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<*const u8>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<*const u8>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsi_NvCsCRATE_HASH_1a1bINtB<REF>_4TypePhE)
+    //[v0]~| ERROR ::b::Type<*const u8>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<*const u8>>)
     impl Type<*const u8> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b26Type$LT$$BP$mut$u20$u8$GT$
-    //~| ERROR demangling(a::b::Type<*mut u8>::
-    //~| ERROR demangling-alt(a::b::Type<*mut u8>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b26Type$LT$$BP$mut$u20$u8$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<*mut u8>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<*mut u8>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsj_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeOhE)
+    //[v0]~| ERROR ::b::Type<*mut u8>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<*mut u8>>)
     impl Type<*mut u8> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b19Type$LT$$RF$str$GT$
-    //~| ERROR demangling(a::b::Type<&str>::
-    //~| ERROR demangling-alt(a::b::Type<&str>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b19Type$LT$$RF$str$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<&str>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<&str>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsk_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeReE)
+    //[v0]~| ERROR ::b::Type<&str>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<&str>>)
     impl Type<&str> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b27Type$LT$$RF$mut$u20$str$GT$
-    //~| ERROR demangling(a::b::Type<&mut str>::
-    //~| ERROR demangling-alt(a::b::Type<&mut str>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b27Type$LT$$RF$mut$u20$str$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<&mut str>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<&mut str>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsl_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeQeE)
+    //[v0]~| ERROR ::b::Type<&mut str>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<&mut str>>)
     impl Type<&mut str> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b35Type$LT$$u5b$u8$u3b$$u20$0$u5d$$GT$
-    //~| ERROR demangling(a::b::Type<[u8; 0]>::
-    //~| ERROR demangling-alt(a::b::Type<[u8; 0]>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b35Type$LT$$u5b$u8$u3b$$u20$0$u5d$$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<[u8; 0]>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<[u8; 0]>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsm_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeAhj0_E)
+    //[v0]~| ERROR ::b::Type<[u8; 0usize]>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<[u8; 0]>>)
     impl Type<[u8; 0]> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b22Type$LT$fn$LP$$RP$$GT$
-    //~| ERROR demangling(a::b::Type<fn()>::
-    //~| ERROR demangling-alt(a::b::Type<fn()>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b22Type$LT$fn$LP$$RP$$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<fn()>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<fn()>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsn_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeFEuE)
+    //[v0]~| ERROR ::b::Type<fn()>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<fn()>>)
     impl Type<fn()> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b60Type$LT$unsafe$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RP$$GT$
-    //~| ERROR demangling(a::b::Type<unsafe extern "C" fn()>::
-    //~| ERROR demangling-alt(a::b::Type<unsafe extern "C" fn()>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b60Type$LT$unsafe$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RP$$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<unsafe extern "C" fn()>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<unsafe extern "C" fn()>)
+    //[v0]~^^^^ ERROR symbol-name(_RMso_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeFUKCEuE)
+    //[v0]~| ERROR ::b::Type<unsafe extern "C" fn()>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<unsafe extern "C" fn()>>)
     impl Type<unsafe extern "C" fn()> {}
 
     #[rustc_symbol_name]
-    //~^ ERROR symbol-name(_ZN1a1b34Type$LT$$u5b$T$u3b$$u20$N$u5d$$GT$
-    //~| ERROR demangling(a::b::Type<[T; N]>::
-    //~| ERROR demangling-alt(a::b::Type<[T; N]>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b34Type$LT$$u5b$T$u3b$$u20$N$u5d$$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<[T; N]>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<[T; N]>)
+    //[v0]~^^^^ ERROR symbol-name(_RMsp_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeAppEB<REF>_)
+    //[v0]~| ERROR ::b::Type<[_; _]>>)
+    //[v0]~| ERROR demangling-alt(<a::b::Type<[_; _]>>)
     impl<const N: usize, T> Type<[T; N]> {}
 }
 

--- a/tests/ui/symbol-names/types.v0.stderr
+++ b/tests/ui/symbol-names/types.v0.stderr
@@ -1,502 +1,502 @@
-error: symbol-name(_ZN1a1b16Type$LT$bool$GT$17h[HASH]E)
+error: symbol-name(_RMNvCsCRATE_HASH_1a1bINtB<REF>_4TypebE)
   --> $DIR/types.rs:18:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<bool>::h[HASH])
+error: demangling(<a[HASH]::b::Type<bool>>)
   --> $DIR/types.rs:18:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<bool>)
+error: demangling-alt(<a::b::Type<bool>>)
   --> $DIR/types.rs:18:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b16Type$LT$char$GT$17h[HASH]E)
+error: symbol-name(_RMs_NvCsCRATE_HASH_1a1bINtB<REF>_4TypecE)
   --> $DIR/types.rs:27:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<char>::h[HASH])
+error: demangling(<a[HASH]::b::Type<char>>)
   --> $DIR/types.rs:27:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<char>)
+error: demangling-alt(<a::b::Type<char>>)
   --> $DIR/types.rs:27:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b14Type$LT$i8$GT$17h[HASH]E)
+error: symbol-name(_RMs0_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeaE)
   --> $DIR/types.rs:36:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<i8>::h[HASH])
+error: demangling(<a[HASH]::b::Type<i8>>)
   --> $DIR/types.rs:36:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<i8>)
+error: demangling-alt(<a::b::Type<i8>>)
   --> $DIR/types.rs:36:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b15Type$LT$i16$GT$17h[HASH]E)
+error: symbol-name(_RMs1_NvCsCRATE_HASH_1a1bINtB<REF>_4TypesE)
   --> $DIR/types.rs:45:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<i16>::h[HASH])
+error: demangling(<a[HASH]::b::Type<i16>>)
   --> $DIR/types.rs:45:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<i16>)
+error: demangling-alt(<a::b::Type<i16>>)
   --> $DIR/types.rs:45:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b15Type$LT$i32$GT$17h[HASH]E)
+error: symbol-name(_RMs2_NvCsCRATE_HASH_1a1bINtB<REF>_4TypelE)
   --> $DIR/types.rs:54:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<i32>::h[HASH])
+error: demangling(<a[HASH]::b::Type<i32>>)
   --> $DIR/types.rs:54:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<i32>)
+error: demangling-alt(<a::b::Type<i32>>)
   --> $DIR/types.rs:54:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b15Type$LT$i64$GT$17h[HASH]E)
+error: symbol-name(_RMs3_NvCsCRATE_HASH_1a1bINtB<REF>_4TypexE)
   --> $DIR/types.rs:63:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<i64>::h[HASH])
+error: demangling(<a[HASH]::b::Type<i64>>)
   --> $DIR/types.rs:63:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<i64>)
+error: demangling-alt(<a::b::Type<i64>>)
   --> $DIR/types.rs:63:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b14Type$LT$u8$GT$17h[HASH]E)
+error: symbol-name(_RMs4_NvCsCRATE_HASH_1a1bINtB<REF>_4TypehE)
   --> $DIR/types.rs:72:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<u8>::h[HASH])
+error: demangling(<a[HASH]::b::Type<u8>>)
   --> $DIR/types.rs:72:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<u8>)
+error: demangling-alt(<a::b::Type<u8>>)
   --> $DIR/types.rs:72:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b15Type$LT$u16$GT$17h[HASH]E)
+error: symbol-name(_RMs5_NvCsCRATE_HASH_1a1bINtB<REF>_4TypetE)
   --> $DIR/types.rs:81:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<u16>::h[HASH])
+error: demangling(<a[HASH]::b::Type<u16>>)
   --> $DIR/types.rs:81:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<u16>)
+error: demangling-alt(<a::b::Type<u16>>)
   --> $DIR/types.rs:81:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b15Type$LT$u32$GT$17h[HASH]E)
+error: symbol-name(_RMs6_NvCsCRATE_HASH_1a1bINtB<REF>_4TypemE)
   --> $DIR/types.rs:90:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<u32>::h[HASH])
+error: demangling(<a[HASH]::b::Type<u32>>)
   --> $DIR/types.rs:90:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<u32>)
+error: demangling-alt(<a::b::Type<u32>>)
   --> $DIR/types.rs:90:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b15Type$LT$u64$GT$17h[HASH]E)
+error: symbol-name(_RMs7_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeyE)
   --> $DIR/types.rs:99:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<u64>::h[HASH])
+error: demangling(<a[HASH]::b::Type<u64>>)
   --> $DIR/types.rs:99:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<u64>)
+error: demangling-alt(<a::b::Type<u64>>)
   --> $DIR/types.rs:99:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b15Type$LT$f16$GT$17h[HASH]E)
+error: symbol-name(_RMs8_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeC3f16E)
   --> $DIR/types.rs:108:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<f16>::h[HASH])
+error: demangling(<a[HASH]::b::Type<f16>>)
   --> $DIR/types.rs:108:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<f16>)
+error: demangling-alt(<a::b::Type<f16>>)
   --> $DIR/types.rs:108:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b15Type$LT$f32$GT$17h[HASH]E)
+error: symbol-name(_RMs9_NvCsCRATE_HASH_1a1bINtB<REF>_4TypefE)
   --> $DIR/types.rs:117:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<f32>::h[HASH])
+error: demangling(<a[HASH]::b::Type<f32>>)
   --> $DIR/types.rs:117:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<f32>)
+error: demangling-alt(<a::b::Type<f32>>)
   --> $DIR/types.rs:117:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b15Type$LT$f64$GT$17h[HASH]E)
+error: symbol-name(_RMsa_NvCsCRATE_HASH_1a1bINtB<REF>_4TypedE)
   --> $DIR/types.rs:126:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<f64>::h[HASH])
+error: demangling(<a[HASH]::b::Type<f64>>)
   --> $DIR/types.rs:126:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<f64>)
+error: demangling-alt(<a::b::Type<f64>>)
   --> $DIR/types.rs:126:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b16Type$LT$f128$GT$17h[HASH]E)
+error: symbol-name(_RMsb_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeC4f128E)
   --> $DIR/types.rs:135:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<f128>::h[HASH])
+error: demangling(<a[HASH]::b::Type<f128>>)
   --> $DIR/types.rs:135:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<f128>)
+error: demangling-alt(<a::b::Type<f128>>)
   --> $DIR/types.rs:135:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b15Type$LT$str$GT$17h[HASH]E)
+error: symbol-name(_RMsc_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeeE)
   --> $DIR/types.rs:144:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<str>::h[HASH])
+error: demangling(<a[HASH]::b::Type<str>>)
   --> $DIR/types.rs:144:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<str>)
+error: demangling-alt(<a::b::Type<str>>)
   --> $DIR/types.rs:144:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b17Type$LT$$u21$$GT$17h[HASH]E)
+error: symbol-name(_RMsd_NvCsCRATE_HASH_1a1bINtB<REF>_4TypezE)
   --> $DIR/types.rs:153:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<!>::h[HASH])
+error: demangling(<a[HASH]::b::Type<!>>)
   --> $DIR/types.rs:153:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<!>)
+error: demangling-alt(<a::b::Type<!>>)
   --> $DIR/types.rs:153:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b20Type$LT$$LP$$RP$$GT$17h[HASH]E)
+error: symbol-name(_RMse_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeuE)
   --> $DIR/types.rs:162:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<()>::h[HASH])
+error: demangling(<a[HASH]::b::Type<()>>)
   --> $DIR/types.rs:162:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<()>)
+error: demangling-alt(<a::b::Type<()>>)
   --> $DIR/types.rs:162:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b25Type$LT$$LP$u8$C$$RP$$GT$17h[HASH]E)
+error: symbol-name(_RMsf_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeThEE)
   --> $DIR/types.rs:171:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<(u8,)>::h[HASH])
+error: demangling(<a[HASH]::b::Type<(u8,)>>)
   --> $DIR/types.rs:171:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<(u8,)>)
+error: demangling-alt(<a::b::Type<(u8,)>>)
   --> $DIR/types.rs:171:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b28Type$LT$$LP$u8$C$u16$RP$$GT$17h[HASH]E)
+error: symbol-name(_RMsg_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeThtEE)
   --> $DIR/types.rs:180:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<(u8,u16)>::h[HASH])
+error: demangling(<a[HASH]::b::Type<(u8, u16)>>)
   --> $DIR/types.rs:180:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<(u8,u16)>)
+error: demangling-alt(<a::b::Type<(u8, u16)>>)
   --> $DIR/types.rs:180:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b34Type$LT$$LP$u8$C$u16$C$u32$RP$$GT$17h[HASH]E)
+error: symbol-name(_RMsh_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeThtmEE)
   --> $DIR/types.rs:189:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<(u8,u16,u32)>::h[HASH])
+error: demangling(<a[HASH]::b::Type<(u8, u16, u32)>>)
   --> $DIR/types.rs:189:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<(u8,u16,u32)>)
+error: demangling-alt(<a::b::Type<(u8, u16, u32)>>)
   --> $DIR/types.rs:189:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b28Type$LT$$BP$const$u20$u8$GT$17h[HASH]E)
+error: symbol-name(_RMsi_NvCsCRATE_HASH_1a1bINtB<REF>_4TypePhE)
   --> $DIR/types.rs:198:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<*const u8>::h[HASH])
+error: demangling(<a[HASH]::b::Type<*const u8>>)
   --> $DIR/types.rs:198:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<*const u8>)
+error: demangling-alt(<a::b::Type<*const u8>>)
   --> $DIR/types.rs:198:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b26Type$LT$$BP$mut$u20$u8$GT$17h[HASH]E)
+error: symbol-name(_RMsj_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeOhE)
   --> $DIR/types.rs:207:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<*mut u8>::h[HASH])
+error: demangling(<a[HASH]::b::Type<*mut u8>>)
   --> $DIR/types.rs:207:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<*mut u8>)
+error: demangling-alt(<a::b::Type<*mut u8>>)
   --> $DIR/types.rs:207:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b19Type$LT$$RF$str$GT$17h[HASH]E)
+error: symbol-name(_RMsk_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeReE)
   --> $DIR/types.rs:216:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<&str>::h[HASH])
+error: demangling(<a[HASH]::b::Type<&str>>)
   --> $DIR/types.rs:216:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<&str>)
+error: demangling-alt(<a::b::Type<&str>>)
   --> $DIR/types.rs:216:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b27Type$LT$$RF$mut$u20$str$GT$17h[HASH]E)
+error: symbol-name(_RMsl_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeQeE)
   --> $DIR/types.rs:225:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<&mut str>::h[HASH])
+error: demangling(<a[HASH]::b::Type<&mut str>>)
   --> $DIR/types.rs:225:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<&mut str>)
+error: demangling-alt(<a::b::Type<&mut str>>)
   --> $DIR/types.rs:225:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b35Type$LT$$u5b$u8$u3b$$u20$0$u5d$$GT$17h[HASH]E)
+error: symbol-name(_RMsm_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeAhj0_E)
   --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<[u8; 0]>::h[HASH])
+error: demangling(<a[HASH]::b::Type<[u8; 0usize]>>)
   --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<[u8; 0]>)
+error: demangling-alt(<a::b::Type<[u8; 0]>>)
   --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b22Type$LT$fn$LP$$RP$$GT$17h[HASH]E)
+error: symbol-name(_RMsn_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeFEuE)
   --> $DIR/types.rs:243:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<fn()>::h[HASH])
+error: demangling(<a[HASH]::b::Type<fn()>>)
   --> $DIR/types.rs:243:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<fn()>)
+error: demangling-alt(<a::b::Type<fn()>>)
   --> $DIR/types.rs:243:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b60Type$LT$unsafe$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RP$$GT$17h[HASH]E)
+error: symbol-name(_RMso_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeFUKCEuE)
   --> $DIR/types.rs:252:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<unsafe extern "C" fn()>::h[HASH])
+error: demangling(<a[HASH]::b::Type<unsafe extern "C" fn()>>)
   --> $DIR/types.rs:252:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<unsafe extern "C" fn()>)
+error: demangling-alt(<a::b::Type<unsafe extern "C" fn()>>)
   --> $DIR/types.rs:252:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b34Type$LT$$u5b$T$u3b$$u20$N$u5d$$GT$17h[HASH]E)
+error: symbol-name(_RMsp_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeAppEB<REF>_)
   --> $DIR/types.rs:261:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<[T; N]>::h[HASH])
+error: demangling(<a[HASH]::b::Type<[_; _]>>)
   --> $DIR/types.rs:261:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<[T; N]>)
+error: demangling-alt(<a::b::Type<[_; _]>>)
   --> $DIR/types.rs:261:5
    |
 LL |     #[rustc_symbol_name]

--- a/tests/ui/symbol-names/types.verbose-legacy.stderr
+++ b/tests/ui/symbol-names/types.verbose-legacy.stderr
@@ -1,470 +1,506 @@
 error: symbol-name(_ZN1a1b16Type$LT$bool$GT$17h[HASH]E)
-  --> $DIR/types.rs:13:5
+  --> $DIR/types.rs:18:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<bool>::h[HASH])
-  --> $DIR/types.rs:13:5
+  --> $DIR/types.rs:18:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<bool>)
-  --> $DIR/types.rs:13:5
+  --> $DIR/types.rs:18:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b16Type$LT$char$GT$17h[HASH]E)
-  --> $DIR/types.rs:19:5
+  --> $DIR/types.rs:27:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<char>::h[HASH])
-  --> $DIR/types.rs:19:5
+  --> $DIR/types.rs:27:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<char>)
-  --> $DIR/types.rs:19:5
+  --> $DIR/types.rs:27:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b14Type$LT$i8$GT$17h[HASH]E)
-  --> $DIR/types.rs:25:5
+  --> $DIR/types.rs:36:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<i8>::h[HASH])
-  --> $DIR/types.rs:25:5
+  --> $DIR/types.rs:36:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<i8>)
-  --> $DIR/types.rs:25:5
+  --> $DIR/types.rs:36:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b15Type$LT$i16$GT$17h[HASH]E)
-  --> $DIR/types.rs:31:5
+  --> $DIR/types.rs:45:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<i16>::h[HASH])
-  --> $DIR/types.rs:31:5
+  --> $DIR/types.rs:45:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<i16>)
-  --> $DIR/types.rs:31:5
+  --> $DIR/types.rs:45:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b15Type$LT$i32$GT$17h[HASH]E)
-  --> $DIR/types.rs:37:5
+  --> $DIR/types.rs:54:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<i32>::h[HASH])
-  --> $DIR/types.rs:37:5
+  --> $DIR/types.rs:54:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<i32>)
-  --> $DIR/types.rs:37:5
+  --> $DIR/types.rs:54:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b15Type$LT$i64$GT$17h[HASH]E)
-  --> $DIR/types.rs:43:5
+  --> $DIR/types.rs:63:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<i64>::h[HASH])
-  --> $DIR/types.rs:43:5
+  --> $DIR/types.rs:63:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<i64>)
-  --> $DIR/types.rs:43:5
+  --> $DIR/types.rs:63:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b14Type$LT$u8$GT$17h[HASH]E)
-  --> $DIR/types.rs:49:5
+  --> $DIR/types.rs:72:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<u8>::h[HASH])
-  --> $DIR/types.rs:49:5
+  --> $DIR/types.rs:72:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<u8>)
-  --> $DIR/types.rs:49:5
+  --> $DIR/types.rs:72:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b15Type$LT$u16$GT$17h[HASH]E)
-  --> $DIR/types.rs:55:5
+  --> $DIR/types.rs:81:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<u16>::h[HASH])
-  --> $DIR/types.rs:55:5
+  --> $DIR/types.rs:81:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<u16>)
-  --> $DIR/types.rs:55:5
+  --> $DIR/types.rs:81:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b15Type$LT$u32$GT$17h[HASH]E)
-  --> $DIR/types.rs:61:5
+  --> $DIR/types.rs:90:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<u32>::h[HASH])
-  --> $DIR/types.rs:61:5
+  --> $DIR/types.rs:90:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<u32>)
-  --> $DIR/types.rs:61:5
+  --> $DIR/types.rs:90:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b15Type$LT$u64$GT$17h[HASH]E)
-  --> $DIR/types.rs:67:5
+  --> $DIR/types.rs:99:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<u64>::h[HASH])
-  --> $DIR/types.rs:67:5
+  --> $DIR/types.rs:99:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<u64>)
-  --> $DIR/types.rs:67:5
+  --> $DIR/types.rs:99:5
+   |
+LL |     #[rustc_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_ZN1a1b15Type$LT$f16$GT$17h[HASH]E)
+  --> $DIR/types.rs:108:5
+   |
+LL |     #[rustc_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(a::b::Type<f16>::h[HASH])
+  --> $DIR/types.rs:108:5
+   |
+LL |     #[rustc_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(a::b::Type<f16>)
+  --> $DIR/types.rs:108:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b15Type$LT$f32$GT$17h[HASH]E)
-  --> $DIR/types.rs:73:5
+  --> $DIR/types.rs:117:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<f32>::h[HASH])
-  --> $DIR/types.rs:73:5
+  --> $DIR/types.rs:117:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<f32>)
-  --> $DIR/types.rs:73:5
+  --> $DIR/types.rs:117:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b15Type$LT$f64$GT$17h[HASH]E)
-  --> $DIR/types.rs:79:5
+  --> $DIR/types.rs:126:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<f64>::h[HASH])
-  --> $DIR/types.rs:79:5
+  --> $DIR/types.rs:126:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<f64>)
-  --> $DIR/types.rs:79:5
+  --> $DIR/types.rs:126:5
+   |
+LL |     #[rustc_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_ZN1a1b16Type$LT$f128$GT$17h[HASH]E)
+  --> $DIR/types.rs:135:5
+   |
+LL |     #[rustc_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(a::b::Type<f128>::h[HASH])
+  --> $DIR/types.rs:135:5
+   |
+LL |     #[rustc_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(a::b::Type<f128>)
+  --> $DIR/types.rs:135:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b15Type$LT$str$GT$17h[HASH]E)
-  --> $DIR/types.rs:85:5
+  --> $DIR/types.rs:144:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<str>::h[HASH])
-  --> $DIR/types.rs:85:5
+  --> $DIR/types.rs:144:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<str>)
-  --> $DIR/types.rs:85:5
+  --> $DIR/types.rs:144:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b17Type$LT$$u21$$GT$17h[HASH]E)
-  --> $DIR/types.rs:91:5
+  --> $DIR/types.rs:153:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<!>::h[HASH])
-  --> $DIR/types.rs:91:5
+  --> $DIR/types.rs:153:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<!>)
-  --> $DIR/types.rs:91:5
+  --> $DIR/types.rs:153:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b20Type$LT$$LP$$RP$$GT$17h[HASH]E)
-  --> $DIR/types.rs:97:5
+  --> $DIR/types.rs:162:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<()>::h[HASH])
-  --> $DIR/types.rs:97:5
+  --> $DIR/types.rs:162:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<()>)
-  --> $DIR/types.rs:97:5
+  --> $DIR/types.rs:162:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b25Type$LT$$LP$u8$C$$RP$$GT$17h[HASH]E)
-  --> $DIR/types.rs:103:5
+  --> $DIR/types.rs:171:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<(u8,)>::h[HASH])
-  --> $DIR/types.rs:103:5
+  --> $DIR/types.rs:171:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<(u8,)>)
-  --> $DIR/types.rs:103:5
+  --> $DIR/types.rs:171:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b28Type$LT$$LP$u8$C$u16$RP$$GT$17h[HASH]E)
-  --> $DIR/types.rs:109:5
+  --> $DIR/types.rs:180:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<(u8,u16)>::h[HASH])
-  --> $DIR/types.rs:109:5
+  --> $DIR/types.rs:180:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<(u8,u16)>)
-  --> $DIR/types.rs:109:5
+  --> $DIR/types.rs:180:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b34Type$LT$$LP$u8$C$u16$C$u32$RP$$GT$17h[HASH]E)
-  --> $DIR/types.rs:115:5
+  --> $DIR/types.rs:189:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<(u8,u16,u32)>::h[HASH])
-  --> $DIR/types.rs:115:5
+  --> $DIR/types.rs:189:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<(u8,u16,u32)>)
-  --> $DIR/types.rs:115:5
+  --> $DIR/types.rs:189:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b28Type$LT$$BP$const$u20$u8$GT$17h[HASH]E)
-  --> $DIR/types.rs:121:5
+  --> $DIR/types.rs:198:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<*const u8>::h[HASH])
-  --> $DIR/types.rs:121:5
+  --> $DIR/types.rs:198:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<*const u8>)
-  --> $DIR/types.rs:121:5
+  --> $DIR/types.rs:198:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b26Type$LT$$BP$mut$u20$u8$GT$17h[HASH]E)
-  --> $DIR/types.rs:127:5
+  --> $DIR/types.rs:207:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<*mut u8>::h[HASH])
-  --> $DIR/types.rs:127:5
+  --> $DIR/types.rs:207:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<*mut u8>)
-  --> $DIR/types.rs:127:5
+  --> $DIR/types.rs:207:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b19Type$LT$$RF$str$GT$17h[HASH]E)
-  --> $DIR/types.rs:133:5
+  --> $DIR/types.rs:216:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<&str>::h[HASH])
-  --> $DIR/types.rs:133:5
+  --> $DIR/types.rs:216:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<&str>)
-  --> $DIR/types.rs:133:5
+  --> $DIR/types.rs:216:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b27Type$LT$$RF$mut$u20$str$GT$17h[HASH]E)
-  --> $DIR/types.rs:139:5
+  --> $DIR/types.rs:225:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<&mut str>::h[HASH])
-  --> $DIR/types.rs:139:5
+  --> $DIR/types.rs:225:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<&mut str>)
-  --> $DIR/types.rs:139:5
+  --> $DIR/types.rs:225:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b35Type$LT$$u5b$u8$u3b$$u20$0$u5d$$GT$17h[HASH]E)
-  --> $DIR/types.rs:145:5
+  --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<[u8; 0]>::h[HASH])
-  --> $DIR/types.rs:145:5
+  --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<[u8; 0]>)
-  --> $DIR/types.rs:145:5
+  --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b22Type$LT$fn$LP$$RP$$GT$17h[HASH]E)
-  --> $DIR/types.rs:151:5
+  --> $DIR/types.rs:243:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<fn()>::h[HASH])
-  --> $DIR/types.rs:151:5
+  --> $DIR/types.rs:243:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<fn()>)
-  --> $DIR/types.rs:151:5
+  --> $DIR/types.rs:243:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b60Type$LT$unsafe$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RP$$GT$17h[HASH]E)
-  --> $DIR/types.rs:157:5
+  --> $DIR/types.rs:252:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<unsafe extern "C" fn()>::h[HASH])
-  --> $DIR/types.rs:157:5
+  --> $DIR/types.rs:252:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<unsafe extern "C" fn()>)
-  --> $DIR/types.rs:157:5
+  --> $DIR/types.rs:252:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN1a1b34Type$LT$$u5b$T$u3b$$u20$N$u5d$$GT$17h[HASH]E)
-  --> $DIR/types.rs:163:5
+  --> $DIR/types.rs:261:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(a::b::Type<[T; N]>::h[HASH])
-  --> $DIR/types.rs:163:5
+  --> $DIR/types.rs:261:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(a::b::Type<[T; N]>)
-  --> $DIR/types.rs:163:5
+  --> $DIR/types.rs:261:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 78 previous errors
+error: aborting due to 84 previous errors
 


### PR DESCRIPTION
As discussed at <https://github.com/rust-lang/rust/pull/122106>, use the crate encoding to represent new primitives.