### PR TITLE
Stabilize `seek_seek_relative`

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2055,7 +2055,6 @@ pub trait Seek {
     /// # Example
     ///
     /// ```no_run
-    /// #![feature(seek_seek_relative)]
     /// use std::{
     ///     io::{self, Seek},
     ///     fs::File,
@@ -2070,7 +2069,7 @@ pub trait Seek {
     /// ```
     ///
     /// [`BufReader`]: crate::io::BufReader
-    #[unstable(feature = "seek_seek_relative", issue = "117374")]
+    #[stable(feature = "seek_seek_relative", since = "CURRENT_RUSTC_VERSION")]
     fn seek_relative(&mut self, offset: i64) -> Result<()> {
         self.seek(SeekFrom::Current(offset))?;
         Ok(())


### PR DESCRIPTION
This PR stabilizes `seek_seek_relative`:

```rust
// std::io::Seek

trait Seek {
    fn seek_relative(&mut self, offset: i64) -> Result<()>;
}
```

<br>

Tracking issue: https://github.com/rust-lang/rust/issues/117374.
Implementation PR: https://github.com/rust-lang/rust/pull/116750.

FCPs already completed in the tracking issue.

Closes https://github.com/rust-lang/rust/issues/117374.

r? libs-api