### PR TITLE
Call the panic hook for non-unwind panics in proc-macros

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -30,6 +30,7 @@
 #![feature(maybe_uninit_write_slice)]
 #![feature(negative_impls)]
 #![feature(new_uninit)]
+#![feature(panic_can_unwind)]
 #![feature(restricted_std)]
 #![feature(rustc_attrs)]
 #![feature(min_specialization)]


### PR DESCRIPTION
As I suggested in https://github.com/rust-lang/rust/issues/123286#issuecomment-2030344815.

If a proc macro causes a non-unwinding panic, `proc_macro` isn't able to catch the unwind and report the panic as a compile error by passing control back to the compiler. Our only chance to produce any diagnostic is the panic hook, so we should call it.

This scenario has already existed, but has become a lot more interesting now that we're adding more UB-detecting panics to the standard library, and such panics do not unwind.