### PR TITLE
linker: Avoid some allocations in search directory iteration

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -170,7 +170,9 @@ fn configure_and_expand(
         let mut old_path = OsString::new();
         if cfg!(windows) {
             old_path = env::var_os("PATH").unwrap_or(old_path);
-            let mut new_path = sess.host_filesearch(PathKind::All).search_path_dirs();
+            let mut new_path = Vec::from_iter(
+                sess.host_filesearch(PathKind::All).search_path_dirs().map(|p| p.to_owned()),
+            );
             for path in env::split_paths(&old_path) {
                 if !new_path.contains(&path) {
                     new_path.push(path);

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -17,12 +17,12 @@ use rustc_target::spec::abi::Abi;
 
 use crate::errors;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-pub fn find_native_static_library(
+pub fn find_native_static_library<'a>(
     name: &str,
     verbatim: bool,
-    search_paths: &[PathBuf],
+    search_paths: impl Iterator<Item = &'a Path>,
     sess: &Session,
 ) -> PathBuf {
     let formats = if verbatim {
@@ -60,7 +60,7 @@ fn find_bundled_library(
         && (sess.opts.unstable_opts.packed_bundled_libs || has_cfg || whole_archive == Some(true))
     {
         let verbatim = verbatim.unwrap_or(false);
-        let search_paths = &sess.target_filesearch(PathKind::Native).search_path_dirs();
+        let search_paths = sess.target_filesearch(PathKind::Native).search_path_dirs();
         return find_native_static_library(name.as_str(), verbatim, search_paths, sess)
             .file_name()
             .and_then(|s| s.to_str())

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -47,8 +47,8 @@ impl<'a> FileSearch<'a> {
     }
 
     /// Returns just the directories within the search paths.
-    pub fn search_path_dirs(&self) -> Vec<PathBuf> {
-        self.search_paths().map(|sp| sp.dir.to_path_buf()).collect()
+    pub fn search_path_dirs(&self) -> impl Iterator<Item = &'a Path> {
+        self.search_paths().map(|sp| &*sp.dir)
     }
 }
 


### PR DESCRIPTION
This is more a cleanup than actual optimization.