### PR TITLE
Fix revisions syntax in cfg(ub_checks) test

### DIFF
--- a/tests/ui/precondition-checks/cfg-ub-checks-default.rs
+++ b/tests/ui/precondition-checks/cfg-ub-checks-default.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ revisions YES NO
+//@ revisions: YES NO
 //@ [YES] compile-flags: -Cdebug-assertions=yes
 //@ [NO] compile-flags: -Cdebug-assertions=no
 


### PR DESCRIPTION
`//@ revisions YES NO` doesn't do anything without the `:`.  Thanks for pointing this out to me.

r? jieyouxu 