### PR TITLE
Remove `From` impls for unstable types that break inference

### DIFF
--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -165,8 +165,8 @@ impl_from!(u16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0"
 impl_from!(u32 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 
 // float -> float
-impl_from!(f16 => f32, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(f16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+// FIXME(f16_f128): adding additional `From` impls for existing types breaks inference. See
+// <https://github.com/rust-lang/rust/issues/123824>
 impl_from!(f16 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(f32 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(f32 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);

--- a/tests/ui/inference/untyped-primitives.rs
+++ b/tests/ui/inference/untyped-primitives.rs
@@ -1,0 +1,9 @@
+//@ check-pass
+// issue: rust-lang/rust#123824
+// This test is a sanity check and does not enforce any stable API, so may be
+// removed at a future point.
+
+fn main() {
+    let x = f32::from(3.14);
+    let y = f64::from(3.14);
+}


### PR DESCRIPTION
Adding additional `From` implementations that fit `f32::from(<unaffixed float>)` broke inference. Remove these for now.

I added a test to make sure this doesn't quietly change in the future, even though the behavior is not technically guaranteed https://github.com/rust-lang/rust/issues/123824#issuecomment-2050628184

Fixes: <https://github.com/rust-lang/rust/issues/123824>