### PR TITLE
Update stdarch submodule

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -111,6 +111,7 @@
 // tidy-alphabetical-start
 #![cfg_attr(bootstrap, feature(associated_type_bounds))]
 #![feature(array_ptr_get)]
+#![feature(asm_experimental_arch)]
 #![feature(char_indices_offset)]
 #![feature(const_align_of_val)]
 #![feature(const_align_of_val_raw)]


### PR DESCRIPTION
`asm_experimental_arch` is required in `core` as we're now using unstable inline assembly when building Arm64EC.

Brings in the fix for <https://github.com/rust-lang/stdarch/issues/1555> (cc @tslnc04).

r? @Amanieu 