### PR TITLE
Add an intrinsic for `ptr::from_raw_parts(_mut)`

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1315,7 +1315,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     }
                     AggregateKind::Adt(..)
                     | AggregateKind::Array(..)
-                    | AggregateKind::Tuple { .. } => (),
+                    | AggregateKind::Tuple { .. }
+                    | AggregateKind::RawPtr(..) => (),
                 }
 
                 for operand in operands {

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1921,7 +1921,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 }
             }
             AggregateKind::Array(ty) => Ok(ty),
-            AggregateKind::Tuple => {
+            AggregateKind::Tuple | AggregateKind::RawPtr(..) => {
                 unreachable!("This should have been covered in check_rvalues");
             }
         }
@@ -2518,6 +2518,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 AggregateKind::Closure(_, _) => None,
                 AggregateKind::Coroutine(_, _) => None,
                 AggregateKind::CoroutineClosure(_, _) => None,
+                AggregateKind::RawPtr(_, _) => None,
             },
         }
     }
@@ -2537,6 +2538,10 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         if *aggregate_kind == AggregateKind::Tuple {
             // tuple rvalue field type is always the type of the op. Nothing to check here.
             return;
+        }
+
+        if let AggregateKind::RawPtr(..) = aggregate_kind {
+            bug!("RawPtr should only be in runtime MIR");
         }
 
         for (i, operand) in operands.iter_enumerated() {
@@ -2757,7 +2762,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 ),
             ),
 
-            AggregateKind::Array(_) | AggregateKind::Tuple => {
+            AggregateKind::Array(_) | AggregateKind::Tuple | AggregateKind::RawPtr(..) => {
                 (CRATE_DEF_ID.to_def_id(), ty::InstantiatedPredicates::empty())
             }
         };

--- a/compiler/rustc_codegen_cranelift/src/value_and_place.rs
+++ b/compiler/rustc_codegen_cranelift/src/value_and_place.rs
@@ -94,6 +94,23 @@ impl<'tcx> CValue<'tcx> {
         CValue(CValueInner::ByValPair(value, extra), layout)
     }
 
+    /// For `AggregateKind::RawPtr`, create a pointer from its parts.
+    ///
+    /// Panics if the `layout` is not a raw pointer.
+    pub(crate) fn pointer_from_data_and_meta(
+        data: CValue<'tcx>,
+        meta: CValue<'tcx>,
+        layout: TyAndLayout<'tcx>,
+    ) -> CValue<'tcx> {
+        assert!(layout.ty.is_unsafe_ptr());
+        let inner = match (data.0, meta.0) {
+            (CValueInner::ByVal(p), CValueInner::ByVal(m)) => CValueInner::ByValPair(p, m),
+            (p @ CValueInner::ByVal(_), CValueInner::ByRef(..)) if meta.1.is_zst() => p,
+            _ => bug!("RawPtr operands {data:?} {meta:?}"),
+        };
+        CValue(inner, layout)
+    }
+
     pub(crate) fn layout(&self) -> TyAndLayout<'tcx> {
         self.1
     }

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -603,17 +603,6 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         Ok(self.read_immediate(op)?.to_scalar())
     }
 
-    pub fn read_mem_place_meta(
-        &self,
-        op: &impl Readable<'tcx, M::Provenance>,
-    ) -> InterpResult<'tcx, MemPlaceMeta<M::Provenance>> {
-        Ok(if op.layout().is_zst() {
-            MemPlaceMeta::None
-        } else {
-            MemPlaceMeta::Meta(self.read_scalar(op)?)
-        })
-    }
-
     // Pointer-sized reads are fairly common and need target layout access, so we wrap them in
     // convenience functions.
 

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -603,6 +603,17 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         Ok(self.read_immediate(op)?.to_scalar())
     }
 
+    pub fn read_mem_place_meta(
+        &self,
+        op: &impl Readable<'tcx, M::Provenance>,
+    ) -> InterpResult<'tcx, MemPlaceMeta<M::Provenance>> {
+        Ok(if op.layout().is_zst() {
+            MemPlaceMeta::None
+        } else {
+            MemPlaceMeta::Meta(self.read_scalar(op)?)
+        })
+    }
+
     // Pointer-sized reads are fairly common and need target layout access, so we wrap them in
     // convenience functions.
 

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -9,7 +9,9 @@ use rustc_middle::mir;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_target::abi::{FieldIdx, FIRST_VARIANT};
 
-use super::{ImmTy, Immediate, InterpCx, InterpResult, Machine, PlaceTy, Projectable, Scalar};
+use super::{
+    ImmTy, Immediate, InterpCx, InterpResult, Machine, MemPlaceMeta, PlaceTy, Projectable, Scalar,
+};
 use crate::util;
 
 impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
@@ -304,15 +306,21 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 (variant_index, variant_dest, active_field_index)
             }
             mir::AggregateKind::RawPtr(..) => {
-                // Trying to `project_field` into pointers tends not to work,
-                // so build the `Immediate` from the parts directly.
+                // Pointers don't have "fields" in the normal sense, so the
+                // projection-based code below would either fail in projection
+                // or in type mismatches. Instead, build an `Immediate` from
+                // the parts and write that to the destination.
                 let [data, meta] = &operands.raw else {
                     bug!("{kind:?} should have 2 operands, had {operands:?}");
                 };
                 let data = self.eval_operand(data, None)?;
                 let data = self.read_pointer(&data)?;
                 let meta = self.eval_operand(meta, None)?;
-                let meta = self.read_mem_place_meta(&meta)?;
+                let meta = if meta.layout.is_zst() {
+                    MemPlaceMeta::None
+                } else {
+                    MemPlaceMeta::Meta(self.read_scalar(&meta)?)
+                };
                 let ptr_imm = Immediate::new_pointer_with_meta(data, meta, self);
                 let ptr = ImmTy::from_immediate(ptr_imm, dest.layout);
                 self.copy_op(&ptr, dest)?;

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -946,7 +946,10 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                                 self.fail(location, "input pointer must be thin");
                             }
                         } else {
-                            self.fail(location, "first operand to raw pointer aggregate must be a raw pointer");
+                            self.fail(
+                                location,
+                                "first operand to raw pointer aggregate must be a raw pointer",
+                            );
                         }
 
                         // FIXME: Check metadata more generally

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -923,6 +923,44 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                         }
                     }
                 }
+                AggregateKind::RawPtr(pointee_ty, mutability) => {
+                    if !matches!(self.mir_phase, MirPhase::Runtime(_)) {
+                        // It would probably be fine to support this in earlier phases,
+                        // but at the time of writing it's only ever introduced from intrinsic lowering,
+                        // so earlier things just `bug!` on it.
+                        self.fail(location, "RawPtr should be in runtime MIR only");
+                    }
+
+                    if fields.len() != 2 {
+                        self.fail(location, "raw pointer aggregate must have 2 fields");
+                    } else {
+                        let data_ptr_ty = fields.raw[0].ty(self.body, self.tcx);
+                        let metadata_ty = fields.raw[1].ty(self.body, self.tcx);
+                        if let ty::RawPtr(in_pointee, in_mut) = data_ptr_ty.kind() {
+                            if *in_mut != mutability {
+                                self.fail(location, "input and output mutability must match");
+                            }
+
+                            // FIXME: check `Thin` instead of `Sized`
+                            if !in_pointee.is_sized(self.tcx, self.param_env) {
+                                self.fail(location, "input pointer must be thin");
+                            }
+                        } else {
+                            self.fail(location, "first operand to raw pointer aggregate must be a raw pointer");
+                        }
+
+                        // FIXME: Check metadata more generally
+                        if pointee_ty.is_slice() {
+                            if !self.mir_assign_valid_types(metadata_ty, self.tcx.types.usize) {
+                                self.fail(location, "slice metadata must be usize");
+                            }
+                        } else if pointee_ty.is_sized(self.tcx, self.param_env) {
+                            if metadata_ty != self.tcx.types.unit {
+                                self.fail(location, "metadata for pointer-to-thin must be unit");
+                            }
+                        }
+                    }
+                }
             },
             Rvalue::Ref(_, BorrowKind::Fake, _) => {
                 if self.mir_phase >= MirPhase::Runtime(RuntimePhase::Initial) {

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -128,6 +128,7 @@ pub fn intrinsic_operation_unsafety(tcx: TyCtxt<'_>, intrinsic_id: LocalDefId) -
         | sym::variant_count
         | sym::is_val_statically_known
         | sym::ptr_mask
+        | sym::aggregate_raw_ptr
         | sym::ub_checks
         | sym::fadd_algebraic
         | sym::fsub_algebraic
@@ -573,6 +574,10 @@ pub fn check_intrinsic_type(
             sym::vtable_size | sym::vtable_align => {
                 (0, 0, vec![Ty::new_imm_ptr(tcx, Ty::new_unit(tcx))], tcx.types.usize)
             }
+
+            // This type check is not particularly useful, but the `where` bounds
+            // on the definition in `core` do the heavy lifting for checking it.
+            sym::aggregate_raw_ptr => (3, 1, vec![param(1), param(2)], param(0)),
 
             sym::ub_checks => (0, 1, Vec::new(), tcx.types.bool),
 

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -1094,6 +1094,15 @@ impl<'tcx> Debug for Rvalue<'tcx> {
 
                         struct_fmt.finish()
                     }),
+
+                    AggregateKind::RawPtr(pointee_ty, mutability) => {
+                        let kind_str = match mutability {
+                            Mutability::Mut => "mut",
+                            Mutability::Not => "const",
+                        };
+                        with_no_trimmed_paths!(write!(fmt, "*{kind_str} {pointee_ty} from "))?;
+                        fmt_tuple(fmt, "")
+                    }
                 }
             }
 

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -1351,6 +1351,21 @@ pub enum AggregateKind<'tcx> {
     Closure(DefId, GenericArgsRef<'tcx>),
     Coroutine(DefId, GenericArgsRef<'tcx>),
     CoroutineClosure(DefId, GenericArgsRef<'tcx>),
+
+    /// Construct a raw pointer from the data pointer and metadata.
+    ///
+    /// The `Ty` here is the type of the *pointee*, not the pointer itself.
+    /// The `Mutability` indicates whether this produces a `*const` or `*mut`.
+    ///
+    /// The [`Rvalue::Aggregate`] operands for thus must be
+    ///
+    /// 0. A raw pointer of matching mutability with any [`core::ptr::Thin`] pointee
+    /// 1. A value of the appropriate [`core::ptr::Pointee::Metadata`] type
+    ///
+    /// *Both* operands must always be included, even the unit value if this is
+    /// creating a thin pointer. If you're just converting between thin pointers,
+    /// you may want an [`Rvalue::Cast`] with [`CastKind::PtrToPtr`] instead.
+    RawPtr(Ty<'tcx>, Mutability),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, HashStable)]

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -206,6 +206,7 @@ impl<'tcx> Rvalue<'tcx> {
                 AggregateKind::CoroutineClosure(did, args) => {
                     Ty::new_coroutine_closure(tcx, did, args)
                 }
+                AggregateKind::RawPtr(ty, mutability) => Ty::new_ptr(tcx, ty, mutability),
             },
             Rvalue::ShallowInitBox(_, ty) => Ty::new_box(tcx, ty),
             Rvalue::CopyForDeref(ref place) => place.ty(local_decls, tcx).ty,

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -751,6 +751,9 @@ macro_rules! make_mir_visitor {
                             ) => {
                                 self.visit_args(coroutine_closure_args, location);
                             }
+                            AggregateKind::RawPtr(ty, _) => {
+                                self.visit_ty($(& $mutability)? *ty, TyContext::Location(location));
+                            }
                         }
 
                         for operand in operands {

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -885,6 +885,7 @@ impl<'body, 'tcx> VnState<'body, 'tcx> {
                 AggregateKind::Adt(did, ..) => tcx.def_kind(did) != DefKind::Enum,
                 // Coroutines are never ZST, as they at least contain the implicit states.
                 AggregateKind::Coroutine(..) => false,
+                AggregateKind::RawPtr(..) => bug!("MIR for RawPtr aggregate must have 2 fields"),
             };
 
             if is_zst {
@@ -910,6 +911,8 @@ impl<'body, 'tcx> VnState<'body, 'tcx> {
             }
             // Do not track unions.
             AggregateKind::Adt(_, _, _, _, Some(_)) => return None,
+            // FIXME: Do the extra work to GVN `from_raw_parts`
+            AggregateKind::RawPtr(..) => return None,
         };
 
         let fields: Option<Vec<_>> = fields

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -36,6 +36,7 @@ impl<'tcx> MirPass<'tcx> for InstSimplify {
                         ctx.simplify_bool_cmp(&statement.source_info, rvalue);
                         ctx.simplify_ref_deref(&statement.source_info, rvalue);
                         ctx.simplify_len(&statement.source_info, rvalue);
+                        ctx.simplify_ptr_aggregate(&statement.source_info, rvalue);
                         ctx.simplify_cast(rvalue);
                     }
                     _ => {}
@@ -58,8 +59,17 @@ struct InstSimplifyContext<'tcx, 'a> {
 
 impl<'tcx> InstSimplifyContext<'tcx, '_> {
     fn should_simplify(&self, source_info: &SourceInfo, rvalue: &Rvalue<'tcx>) -> bool {
+        self.should_simplify_custom(source_info, "Rvalue", rvalue)
+    }
+
+    fn should_simplify_custom(
+        &self,
+        source_info: &SourceInfo,
+        label: &str,
+        value: impl std::fmt::Debug,
+    ) -> bool {
         self.tcx.consider_optimizing(|| {
-            format!("InstSimplify - Rvalue: {rvalue:?} SourceInfo: {source_info:?}")
+            format!("InstSimplify - {label}: {value:?} SourceInfo: {source_info:?}")
         })
     }
 
@@ -143,6 +153,30 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
                 let const_ = Const::from_ty_const(len, self.tcx);
                 let constant = ConstOperand { span: source_info.span, const_, user_ty: None };
                 *rvalue = Rvalue::Use(Operand::Constant(Box::new(constant)));
+            }
+        }
+    }
+
+    /// Transform "Aggregate(RawPtr, \[p, ()\])" ==> "Cast(PtrToPtr, p)".
+    fn simplify_ptr_aggregate(&self, source_info: &SourceInfo, rvalue: &mut Rvalue<'tcx>) {
+        if let Rvalue::Aggregate(box AggregateKind::RawPtr(pointee_ty, mutability), fields) = rvalue
+        {
+            let meta_ty = fields.raw[1].ty(self.local_decls, self.tcx);
+            if meta_ty.is_unit() {
+                // The mutable borrows we're holding prevent printing `rvalue` here
+                if !self.should_simplify_custom(
+                    source_info,
+                    "Aggregate::RawPtr",
+                    (&pointee_ty, *mutability, &fields),
+                ) {
+                    return;
+                }
+
+                let mut fields = std::mem::take(fields);
+                let _meta = fields.pop().unwrap();
+                let data = fields.pop().unwrap();
+                let ptr_ty = Ty::new_ptr(self.tcx, *pointee_ty, *mutability);
+                *rvalue = Rvalue::Cast(CastKind::PtrToPtr, data, ptr_ty);
             }
         }
     }

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -121,7 +121,7 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
         if a.const_.ty().is_bool() { a.const_.try_to_bool() } else { None }
     }
 
-    /// Transform "&(*a)" ==> "a".
+    /// Transform `&(*a)` ==> `a`.
     fn simplify_ref_deref(&self, source_info: &SourceInfo, rvalue: &mut Rvalue<'tcx>) {
         if let Rvalue::Ref(_, _, place) = rvalue {
             if let Some((base, ProjectionElem::Deref)) = place.as_ref().last_projection() {
@@ -141,7 +141,7 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
         }
     }
 
-    /// Transform "Len([_; N])" ==> "N".
+    /// Transform `Len([_; N])` ==> `N`.
     fn simplify_len(&self, source_info: &SourceInfo, rvalue: &mut Rvalue<'tcx>) {
         if let Rvalue::Len(ref place) = *rvalue {
             let place_ty = place.ty(self.local_decls, self.tcx).ty;
@@ -157,7 +157,7 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
         }
     }
 
-    /// Transform "Aggregate(RawPtr, \[p, ()\])" ==> "Cast(PtrToPtr, p)".
+    /// Transform `Aggregate(RawPtr, [p, ()])` ==> `Cast(PtrToPtr, p)`.
     fn simplify_ptr_aggregate(&self, source_info: &SourceInfo, rvalue: &mut Rvalue<'tcx>) {
         if let Rvalue::Aggregate(box AggregateKind::RawPtr(pointee_ty, mutability), fields) = rvalue
         {

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -603,6 +603,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                         AggregateKind::Adt(_, variant, _, _, _) => variant,
                         AggregateKind::Array(_)
                         | AggregateKind::Tuple
+                        | AggregateKind::RawPtr(_, _)
                         | AggregateKind::Closure(_, _)
                         | AggregateKind::Coroutine(_, _)
                         | AggregateKind::CoroutineClosure(_, _) => VariantIdx::ZERO,

--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -543,6 +543,9 @@ impl<'tcx> Stable<'tcx> for mir::AggregateKind<'tcx> {
             mir::AggregateKind::CoroutineClosure(..) => {
                 todo!("FIXME(async_closures): Lower these to SMIR")
             }
+            mir::AggregateKind::RawPtr(ty, mutability) => {
+                stable_mir::mir::AggregateKind::RawPtr(ty.stable(tables), mutability.stable(tables))
+            }
         }
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -361,6 +361,7 @@ symbols! {
         adt_const_params,
         advanced_slice_patterns,
         adx_target_feature,
+        aggregate_raw_ptr,
         alias,
         align,
         align_offset,

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -602,6 +602,7 @@ impl Rvalue {
                 AggregateKind::Coroutine(def, ref args, mov) => {
                     Ok(Ty::new_coroutine(def, args.clone(), mov))
                 }
+                AggregateKind::RawPtr(ty, mutability) => Ok(Ty::new_ptr(ty, mutability)),
             },
             Rvalue::ShallowInitBox(_, ty) => Ok(Ty::new_box(*ty)),
             Rvalue::CopyForDeref(place) => place.ty(locals),
@@ -617,6 +618,7 @@ pub enum AggregateKind {
     Closure(ClosureDef, GenericArgs),
     // FIXME(stable_mir): Movability here is redundant
     Coroutine(CoroutineDef, GenericArgs, Movability),
+    RawPtr(Ty, Mutability),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2791,7 +2791,8 @@ pub unsafe fn vtable_align(_ptr: *const ()) -> usize {
 #[rustc_intrinsic_must_be_overridden]
 #[cfg(not(bootstrap))]
 pub const fn aggregate_raw_ptr<P: AggregateRawPtr<D, Metadata = M>, D, M>(_data: D, _meta: M) -> P {
-    // No fallback because `libcore` doesn't want to know the layout
+    // To implement a fallback we'd have to assume the layout of the pointer,
+    // but the whole point of this intrinsic is that we shouldn't do that.
     unreachable!()
 }
 

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2786,6 +2786,7 @@ pub unsafe fn vtable_align(_ptr: *const ()) -> usize {
 /// change the possible layouts of pointers.
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_const_unstable(feature = "ptr_metadata", issue = "81513")]
 #[rustc_intrinsic]
 #[rustc_intrinsic_must_be_overridden]
 #[cfg(not(bootstrap))]

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2779,6 +2779,32 @@ pub unsafe fn vtable_align(_ptr: *const ()) -> usize {
     unreachable!()
 }
 
+/// Lowers in MIR to `Rvalue::Aggregate` with `AggregateKind::RawPtr`.
+///
+/// This is used to implement functions like `slice::from_raw_parts_mut` and
+/// `ptr::from_raw_parts` in a way compatible with the compiler being able to
+/// change the possible layouts of pointers.
+#[rustc_nounwind]
+#[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_intrinsic]
+#[rustc_intrinsic_must_be_overridden]
+#[cfg(not(bootstrap))]
+pub const fn aggregate_raw_ptr<P: AggregateRawPtr<D, Metadata = M>, D, M>(_data: D, _meta: M) -> P {
+    // No fallback because `libcore` doesn't want to know the layout
+    unreachable!()
+}
+
+#[unstable(feature = "core_intrinsics", issue = "none")]
+pub trait AggregateRawPtr<D> {
+    type Metadata: Copy;
+}
+impl<P: ?Sized, T: ptr::Thin> AggregateRawPtr<*const T> for *const P {
+    type Metadata = <P as ptr::Pointee>::Metadata;
+}
+impl<P: ?Sized, T: ptr::Thin> AggregateRawPtr<*mut T> for *mut P {
+    type Metadata = <P as ptr::Pointee>::Metadata;
+}
+
 // Some functions are defined here because they accidentally got made
 // available in this module on stable. See <https://github.com/rust-lang/rust/issues/15702>.
 // (`transmute` also falls into this category, but it cannot be wrapped due to the

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -2,6 +2,8 @@
 
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
+#[cfg(not(bootstrap))]
+use crate::intrinsics::aggregate_raw_ptr;
 use crate::marker::Freeze;
 
 /// Provides the pointer metadata type of any pointed-to type.
@@ -113,10 +115,17 @@ pub const fn from_raw_parts<T: ?Sized>(
     data_pointer: *const (),
     metadata: <T as Pointee>::Metadata,
 ) -> *const T {
-    // SAFETY: Accessing the value from the `PtrRepr` union is safe since *const T
-    // and PtrComponents<T> have the same memory layouts. Only std can make this
-    // guarantee.
-    unsafe { PtrRepr { components: PtrComponents { data_pointer, metadata } }.const_ptr }
+    #[cfg(bootstrap)]
+    {
+        // SAFETY: Accessing the value from the `PtrRepr` union is safe since *const T
+        // and PtrComponents<T> have the same memory layouts. Only std can make this
+        // guarantee.
+        unsafe { PtrRepr { components: PtrComponents { data_pointer, metadata } }.const_ptr }
+    }
+    #[cfg(not(bootstrap))]
+    {
+        aggregate_raw_ptr(data_pointer, metadata)
+    }
 }
 
 /// Performs the same functionality as [`from_raw_parts`], except that a
@@ -130,10 +139,17 @@ pub const fn from_raw_parts_mut<T: ?Sized>(
     data_pointer: *mut (),
     metadata: <T as Pointee>::Metadata,
 ) -> *mut T {
-    // SAFETY: Accessing the value from the `PtrRepr` union is safe since *const T
-    // and PtrComponents<T> have the same memory layouts. Only std can make this
-    // guarantee.
-    unsafe { PtrRepr { components: PtrComponents { data_pointer, metadata } }.mut_ptr }
+    #[cfg(bootstrap)]
+    {
+        // SAFETY: Accessing the value from the `PtrRepr` union is safe since *const T
+        // and PtrComponents<T> have the same memory layouts. Only std can make this
+        // guarantee.
+        unsafe { PtrRepr { components: PtrComponents { data_pointer, metadata } }.mut_ptr }
+    }
+    #[cfg(not(bootstrap))]
+    {
+        aggregate_raw_ptr(data_pointer, metadata)
+    }
 }
 
 #[repr(C)]

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -1163,3 +1163,11 @@ fn test_null_array_as_slice() {
     assert!(ptr.is_null());
     assert_eq!(ptr.len(), 4);
 }
+
+#[test]
+fn test_ptr_from_raw_parts_in_const() {
+    const EMPTY_SLICE_PTR: *const [i32] =
+        std::ptr::slice_from_raw_parts(std::ptr::without_provenance(123), 456);
+    assert_eq!(EMPTY_SLICE_PTR.addr(), 123);
+    assert_eq!(EMPTY_SLICE_PTR.len(), 456);
+}

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2678,3 +2678,16 @@ fn test_get_many_mut_duplicate() {
     let mut v = vec![1, 2, 3, 4, 5];
     assert!(v.get_many_mut([1, 3, 3, 4]).is_err());
 }
+
+#[test]
+fn test_slice_from_raw_parts_in_const() {
+    static FANCY: i32 = 4;
+    static FANCY_SLICE: &[i32] = unsafe { std::slice::from_raw_parts(&FANCY, 1) };
+    assert_eq!(FANCY_SLICE.as_ptr(), std::ptr::addr_of!(FANCY));
+    assert_eq!(FANCY_SLICE.len(), 1);
+
+    const EMPTY_SLICE: &[i32] =
+        unsafe { std::slice::from_raw_parts(std::ptr::without_provenance(123456), 0) };
+    assert_eq!(EMPTY_SLICE.as_ptr().addr(), 123456);
+    assert_eq!(EMPTY_SLICE.len(), 0);
+}

--- a/tests/mir-opt/instsimplify/casts.rs
+++ b/tests/mir-opt/instsimplify/casts.rs
@@ -1,6 +1,7 @@
 //@ test-mir-pass: InstSimplify
 //@ compile-flags: -Zinline-mir
 #![crate_type = "lib"]
+#![feature(core_intrinsics)]
 
 #[inline(always)]
 fn generic_cast<T, U>(x: *const T) -> *const U {
@@ -22,4 +23,12 @@ pub fn roundtrip(x: *const u8) -> *const u8 {
     // CHECK: _3 = move _4 as *mut u8 (PtrToPtr);
     // CHECK: _2 = move _3 as *const u8 (PointerCoercion(MutToConstPointer));
     x as *mut u8 as *const u8
+}
+
+// EMIT_MIR casts.roundtrip.InstSimplify.diff
+pub fn cast_thin_via_aggregate(x: *const u8) -> *const () {
+    // CHECK-LABEL: fn cast_thin_via_aggregate(
+    // CHECK: _2 = _1;
+    // CHECK: _0 = move _2 as *const () (PtrToPtr);
+    std::intrinsics::aggregate_raw_ptr(x, ())
 }

--- a/tests/mir-opt/lower_intrinsics.make_pointers.LowerIntrinsics.panic-abort.diff
+++ b/tests/mir-opt/lower_intrinsics.make_pointers.LowerIntrinsics.panic-abort.diff
@@ -1,0 +1,95 @@
+- // MIR for `make_pointers` before LowerIntrinsics
++ // MIR for `make_pointers` after LowerIntrinsics
+  
+  fn make_pointers(_1: *const u8, _2: *mut (), _3: usize) -> () {
+      debug a => _1;
+      debug b => _2;
+      debug n => _3;
+      let mut _0: ();
+      let _4: *const i32;
+      let mut _5: *const u8;
+      let mut _6: ();
+      let mut _8: *mut ();
+      let mut _9: ();
+      let mut _11: *const u8;
+      let mut _12: usize;
+      let mut _14: *mut ();
+      let mut _15: usize;
+      scope 1 {
+          debug _thin_const => _4;
+          let _7: *mut u8;
+          scope 2 {
+              debug _thin_mut => _7;
+              let _10: *const [u16];
+              scope 3 {
+                  debug _slice_const => _10;
+                  let _13: *mut [u64];
+                  scope 4 {
+                      debug _slice_mut => _13;
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_4);
+          StorageLive(_5);
+          _5 = _1;
+          StorageLive(_6);
+          _6 = ();
+-         _4 = aggregate_raw_ptr::<*const i32, *const u8, ()>(move _5, move _6) -> [return: bb1, unwind unreachable];
++         _4 = *const i32 from (move _5, move _6);
++         goto -> bb1;
+      }
+  
+      bb1: {
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageLive(_7);
+          StorageLive(_8);
+          _8 = _2;
+          StorageLive(_9);
+          _9 = ();
+-         _7 = aggregate_raw_ptr::<*mut u8, *mut (), ()>(move _8, move _9) -> [return: bb2, unwind unreachable];
++         _7 = *mut u8 from (move _8, move _9);
++         goto -> bb2;
+      }
+  
+      bb2: {
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageLive(_10);
+          StorageLive(_11);
+          _11 = _1;
+          StorageLive(_12);
+          _12 = _3;
+-         _10 = aggregate_raw_ptr::<*const [u16], *const u8, usize>(move _11, move _12) -> [return: bb3, unwind unreachable];
++         _10 = *const [u16] from (move _11, move _12);
++         goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_12);
+          StorageDead(_11);
+          StorageLive(_13);
+          StorageLive(_14);
+          _14 = _2;
+          StorageLive(_15);
+          _15 = _3;
+-         _13 = aggregate_raw_ptr::<*mut [u64], *mut (), usize>(move _14, move _15) -> [return: bb4, unwind unreachable];
++         _13 = *mut [u64] from (move _14, move _15);
++         goto -> bb4;
+      }
+  
+      bb4: {
+          StorageDead(_15);
+          StorageDead(_14);
+          _0 = const ();
+          StorageDead(_13);
+          StorageDead(_10);
+          StorageDead(_7);
+          StorageDead(_4);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/lower_intrinsics.make_pointers.LowerIntrinsics.panic-unwind.diff
+++ b/tests/mir-opt/lower_intrinsics.make_pointers.LowerIntrinsics.panic-unwind.diff
@@ -1,0 +1,95 @@
+- // MIR for `make_pointers` before LowerIntrinsics
++ // MIR for `make_pointers` after LowerIntrinsics
+  
+  fn make_pointers(_1: *const u8, _2: *mut (), _3: usize) -> () {
+      debug a => _1;
+      debug b => _2;
+      debug n => _3;
+      let mut _0: ();
+      let _4: *const i32;
+      let mut _5: *const u8;
+      let mut _6: ();
+      let mut _8: *mut ();
+      let mut _9: ();
+      let mut _11: *const u8;
+      let mut _12: usize;
+      let mut _14: *mut ();
+      let mut _15: usize;
+      scope 1 {
+          debug _thin_const => _4;
+          let _7: *mut u8;
+          scope 2 {
+              debug _thin_mut => _7;
+              let _10: *const [u16];
+              scope 3 {
+                  debug _slice_const => _10;
+                  let _13: *mut [u64];
+                  scope 4 {
+                      debug _slice_mut => _13;
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_4);
+          StorageLive(_5);
+          _5 = _1;
+          StorageLive(_6);
+          _6 = ();
+-         _4 = aggregate_raw_ptr::<*const i32, *const u8, ()>(move _5, move _6) -> [return: bb1, unwind unreachable];
++         _4 = *const i32 from (move _5, move _6);
++         goto -> bb1;
+      }
+  
+      bb1: {
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageLive(_7);
+          StorageLive(_8);
+          _8 = _2;
+          StorageLive(_9);
+          _9 = ();
+-         _7 = aggregate_raw_ptr::<*mut u8, *mut (), ()>(move _8, move _9) -> [return: bb2, unwind unreachable];
++         _7 = *mut u8 from (move _8, move _9);
++         goto -> bb2;
+      }
+  
+      bb2: {
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageLive(_10);
+          StorageLive(_11);
+          _11 = _1;
+          StorageLive(_12);
+          _12 = _3;
+-         _10 = aggregate_raw_ptr::<*const [u16], *const u8, usize>(move _11, move _12) -> [return: bb3, unwind unreachable];
++         _10 = *const [u16] from (move _11, move _12);
++         goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_12);
+          StorageDead(_11);
+          StorageLive(_13);
+          StorageLive(_14);
+          _14 = _2;
+          StorageLive(_15);
+          _15 = _3;
+-         _13 = aggregate_raw_ptr::<*mut [u64], *mut (), usize>(move _14, move _15) -> [return: bb4, unwind unreachable];
++         _13 = *mut [u64] from (move _14, move _15);
++         goto -> bb4;
+      }
+  
+      bb4: {
+          StorageDead(_15);
+          StorageDead(_14);
+          _0 = const ();
+          StorageDead(_13);
+          StorageDead(_10);
+          StorageDead(_7);
+          StorageDead(_4);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/lower_intrinsics.rs
+++ b/tests/mir-opt/lower_intrinsics.rs
@@ -248,3 +248,13 @@ pub fn three_way_compare_signed(a: i16, b: i16) {
 pub fn three_way_compare_unsigned(a: u32, b: u32) {
     let _x = core::intrinsics::three_way_compare(a, b);
 }
+
+// EMIT_MIR lower_intrinsics.make_pointers.LowerIntrinsics.diff
+pub fn make_pointers(a: *const u8, b: *mut (), n: usize) {
+    use std::intrinsics::aggregate_raw_ptr;
+
+    let _thin_const: *const i32 = aggregate_raw_ptr(a, ());
+    let _thin_mut: *mut u8 = aggregate_raw_ptr(b, ());
+    let _slice_const: *const [u16] = aggregate_raw_ptr(a, n);
+    let _slice_mut: *mut [u64] = aggregate_raw_ptr(b, n);
+}

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-abort.mir
@@ -28,8 +28,6 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
             scope 6 (inlined std::ptr::from_raw_parts::<[u32]>) {
                 debug data_pointer => _5;
                 debug metadata => _7;
-                let mut _8: std::ptr::metadata::PtrComponents<[u32]>;
-                let mut _9: std::ptr::metadata::PtrRepr<[u32]>;
             }
         }
     }
@@ -47,13 +45,7 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
         _6 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: _1 };
         _7 = ((_6.2: std::ptr::metadata::PtrComponents<[u32]>).1: usize);
         StorageDead(_6);
-        StorageLive(_9);
-        StorageLive(_8);
-        _8 = std::ptr::metadata::PtrComponents::<[u32]> { data_pointer: _5, metadata: _7 };
-        _9 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _8 };
-        StorageDead(_8);
-        _0 = (_9.0: *const [u32]);
-        StorageDead(_9);
+        _0 = *const [u32] from (_5, _7);
         StorageDead(_7);
         StorageDead(_5);
         StorageDead(_4);

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-abort.mir
@@ -5,29 +5,19 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
     debug n => _2;
     let mut _0: *const [u32];
     scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::byte_add) {
-        debug self => _1;
-        debug count => _2;
         let mut _3: *const u8;
         let mut _4: *const u8;
         scope 2 (inlined std::ptr::const_ptr::<impl *const [u32]>::cast::<u8>) {
-            debug self => _1;
         }
         scope 3 (inlined std::ptr::const_ptr::<impl *const u8>::add) {
-            debug self => _3;
-            debug count => _2;
         }
         scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<[u32]>) {
-            debug self => _4;
-            debug meta => _1;
             let mut _5: *const ();
             let mut _7: usize;
             scope 5 (inlined std::ptr::metadata::<[u32]>) {
-                debug ptr => _1;
                 let mut _6: std::ptr::metadata::PtrRepr<[u32]>;
             }
             scope 6 (inlined std::ptr::from_raw_parts::<[u32]>) {
-                debug data_pointer => _5;
-                debug metadata => _7;
             }
         }
     }

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,62 @@
+// MIR for `demo_byte_add_fat` after PreCodegen
+
+fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
+    debug p => _1;
+    debug n => _2;
+    let mut _0: *const [u32];
+    scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::byte_add) {
+        debug self => _1;
+        debug count => _2;
+        let mut _3: *const u8;
+        let mut _4: *const u8;
+        scope 2 (inlined std::ptr::const_ptr::<impl *const [u32]>::cast::<u8>) {
+            debug self => _1;
+        }
+        scope 3 (inlined std::ptr::const_ptr::<impl *const u8>::add) {
+            debug self => _3;
+            debug count => _2;
+        }
+        scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<[u32]>) {
+            debug self => _4;
+            debug meta => _1;
+            let mut _5: *const ();
+            let mut _7: usize;
+            scope 5 (inlined std::ptr::metadata::<[u32]>) {
+                debug ptr => _1;
+                let mut _6: std::ptr::metadata::PtrRepr<[u32]>;
+            }
+            scope 6 (inlined std::ptr::from_raw_parts::<[u32]>) {
+                debug data_pointer => _5;
+                debug metadata => _7;
+                let mut _8: std::ptr::metadata::PtrComponents<[u32]>;
+                let mut _9: std::ptr::metadata::PtrRepr<[u32]>;
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_4);
+        StorageLive(_3);
+        _3 = _1 as *const u8 (PtrToPtr);
+        _4 = Offset(_3, _2);
+        StorageDead(_3);
+        StorageLive(_5);
+        _5 = _4 as *const () (PtrToPtr);
+        StorageLive(_7);
+        StorageLive(_6);
+        _6 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: _1 };
+        _7 = ((_6.2: std::ptr::metadata::PtrComponents<[u32]>).1: usize);
+        StorageDead(_6);
+        StorageLive(_9);
+        StorageLive(_8);
+        _8 = std::ptr::metadata::PtrComponents::<[u32]> { data_pointer: _5, metadata: _7 };
+        _9 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _8 };
+        StorageDead(_8);
+        _0 = (_9.0: *const [u32]);
+        StorageDead(_9);
+        StorageDead(_7);
+        StorageDead(_5);
+        StorageDead(_4);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-unwind.mir
@@ -28,8 +28,6 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
             scope 6 (inlined std::ptr::from_raw_parts::<[u32]>) {
                 debug data_pointer => _5;
                 debug metadata => _7;
-                let mut _8: std::ptr::metadata::PtrComponents<[u32]>;
-                let mut _9: std::ptr::metadata::PtrRepr<[u32]>;
             }
         }
     }
@@ -47,13 +45,7 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
         _6 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: _1 };
         _7 = ((_6.2: std::ptr::metadata::PtrComponents<[u32]>).1: usize);
         StorageDead(_6);
-        StorageLive(_9);
-        StorageLive(_8);
-        _8 = std::ptr::metadata::PtrComponents::<[u32]> { data_pointer: _5, metadata: _7 };
-        _9 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _8 };
-        StorageDead(_8);
-        _0 = (_9.0: *const [u32]);
-        StorageDead(_9);
+        _0 = *const [u32] from (_5, _7);
         StorageDead(_7);
         StorageDead(_5);
         StorageDead(_4);

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-unwind.mir
@@ -5,29 +5,19 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
     debug n => _2;
     let mut _0: *const [u32];
     scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::byte_add) {
-        debug self => _1;
-        debug count => _2;
         let mut _3: *const u8;
         let mut _4: *const u8;
         scope 2 (inlined std::ptr::const_ptr::<impl *const [u32]>::cast::<u8>) {
-            debug self => _1;
         }
         scope 3 (inlined std::ptr::const_ptr::<impl *const u8>::add) {
-            debug self => _3;
-            debug count => _2;
         }
         scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<[u32]>) {
-            debug self => _4;
-            debug meta => _1;
             let mut _5: *const ();
             let mut _7: usize;
             scope 5 (inlined std::ptr::metadata::<[u32]>) {
-                debug ptr => _1;
                 let mut _6: std::ptr::metadata::PtrRepr<[u32]>;
             }
             scope 6 (inlined std::ptr::from_raw_parts::<[u32]>) {
-                debug data_pointer => _5;
-                debug metadata => _7;
             }
         }
     }

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,62 @@
+// MIR for `demo_byte_add_fat` after PreCodegen
+
+fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
+    debug p => _1;
+    debug n => _2;
+    let mut _0: *const [u32];
+    scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::byte_add) {
+        debug self => _1;
+        debug count => _2;
+        let mut _3: *const u8;
+        let mut _4: *const u8;
+        scope 2 (inlined std::ptr::const_ptr::<impl *const [u32]>::cast::<u8>) {
+            debug self => _1;
+        }
+        scope 3 (inlined std::ptr::const_ptr::<impl *const u8>::add) {
+            debug self => _3;
+            debug count => _2;
+        }
+        scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<[u32]>) {
+            debug self => _4;
+            debug meta => _1;
+            let mut _5: *const ();
+            let mut _7: usize;
+            scope 5 (inlined std::ptr::metadata::<[u32]>) {
+                debug ptr => _1;
+                let mut _6: std::ptr::metadata::PtrRepr<[u32]>;
+            }
+            scope 6 (inlined std::ptr::from_raw_parts::<[u32]>) {
+                debug data_pointer => _5;
+                debug metadata => _7;
+                let mut _8: std::ptr::metadata::PtrComponents<[u32]>;
+                let mut _9: std::ptr::metadata::PtrRepr<[u32]>;
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_4);
+        StorageLive(_3);
+        _3 = _1 as *const u8 (PtrToPtr);
+        _4 = Offset(_3, _2);
+        StorageDead(_3);
+        StorageLive(_5);
+        _5 = _4 as *const () (PtrToPtr);
+        StorageLive(_7);
+        StorageLive(_6);
+        _6 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: _1 };
+        _7 = ((_6.2: std::ptr::metadata::PtrComponents<[u32]>).1: usize);
+        StorageDead(_6);
+        StorageLive(_9);
+        StorageLive(_8);
+        _8 = std::ptr::metadata::PtrComponents::<[u32]> { data_pointer: _5, metadata: _7 };
+        _9 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _8 };
+        StorageDead(_8);
+        _0 = (_9.0: *const [u32]);
+        StorageDead(_9);
+        StorageDead(_7);
+        StorageDead(_5);
+        StorageDead(_4);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,54 @@
+// MIR for `demo_byte_add_thin` after PreCodegen
+
+fn demo_byte_add_thin(_1: *const u32, _2: usize) -> *const u32 {
+    debug p => _1;
+    debug n => _2;
+    let mut _0: *const u32;
+    scope 1 (inlined std::ptr::const_ptr::<impl *const u32>::byte_add) {
+        debug self => _1;
+        debug count => _2;
+        let mut _3: *const u8;
+        let mut _4: *const u8;
+        scope 2 (inlined std::ptr::const_ptr::<impl *const u32>::cast::<u8>) {
+            debug self => _1;
+        }
+        scope 3 (inlined std::ptr::const_ptr::<impl *const u8>::add) {
+            debug self => _3;
+            debug count => _2;
+        }
+        scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<u32>) {
+            debug self => _4;
+            debug meta => _1;
+            let mut _5: *const ();
+            scope 5 (inlined std::ptr::metadata::<u32>) {
+                debug ptr => _1;
+            }
+            scope 6 (inlined std::ptr::from_raw_parts::<u32>) {
+                debug data_pointer => _5;
+                debug metadata => const ();
+                let mut _6: std::ptr::metadata::PtrComponents<u32>;
+                let mut _7: std::ptr::metadata::PtrRepr<u32>;
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_4);
+        StorageLive(_3);
+        _3 = _1 as *const u8 (PtrToPtr);
+        _4 = Offset(_3, _2);
+        StorageDead(_3);
+        StorageLive(_5);
+        _5 = _4 as *const () (PtrToPtr);
+        StorageLive(_7);
+        StorageLive(_6);
+        _6 = std::ptr::metadata::PtrComponents::<u32> { data_pointer: _5, metadata: const () };
+        _7 = std::ptr::metadata::PtrRepr::<u32> { const_ptr: move _6 };
+        StorageDead(_6);
+        _0 = (_7.0: *const u32);
+        StorageDead(_7);
+        StorageDead(_5);
+        StorageDead(_4);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-abort.mir
@@ -5,27 +5,16 @@ fn demo_byte_add_thin(_1: *const u32, _2: usize) -> *const u32 {
     debug n => _2;
     let mut _0: *const u32;
     scope 1 (inlined std::ptr::const_ptr::<impl *const u32>::byte_add) {
-        debug self => _1;
-        debug count => _2;
         let mut _3: *const u8;
         let mut _4: *const u8;
         scope 2 (inlined std::ptr::const_ptr::<impl *const u32>::cast::<u8>) {
-            debug self => _1;
         }
         scope 3 (inlined std::ptr::const_ptr::<impl *const u8>::add) {
-            debug self => _3;
-            debug count => _2;
         }
         scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<u32>) {
-            debug self => _4;
-            debug meta => _1;
-            let mut _5: *const ();
             scope 5 (inlined std::ptr::metadata::<u32>) {
-                debug ptr => _1;
             }
             scope 6 (inlined std::ptr::from_raw_parts::<u32>) {
-                debug data_pointer => _5;
-                debug metadata => const ();
             }
         }
     }
@@ -35,10 +24,7 @@ fn demo_byte_add_thin(_1: *const u32, _2: usize) -> *const u32 {
         _3 = _1 as *const u8 (PtrToPtr);
         _4 = Offset(_3, _2);
         StorageDead(_3);
-        StorageLive(_5);
-        _5 = _4 as *const () (PtrToPtr);
         _0 = _4 as *const u32 (PtrToPtr);
-        StorageDead(_5);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-abort.mir
@@ -26,29 +26,19 @@ fn demo_byte_add_thin(_1: *const u32, _2: usize) -> *const u32 {
             scope 6 (inlined std::ptr::from_raw_parts::<u32>) {
                 debug data_pointer => _5;
                 debug metadata => const ();
-                let mut _6: std::ptr::metadata::PtrComponents<u32>;
-                let mut _7: std::ptr::metadata::PtrRepr<u32>;
             }
         }
     }
 
     bb0: {
-        StorageLive(_4);
         StorageLive(_3);
         _3 = _1 as *const u8 (PtrToPtr);
         _4 = Offset(_3, _2);
         StorageDead(_3);
         StorageLive(_5);
         _5 = _4 as *const () (PtrToPtr);
-        StorageLive(_7);
-        StorageLive(_6);
-        _6 = std::ptr::metadata::PtrComponents::<u32> { data_pointer: _5, metadata: const () };
-        _7 = std::ptr::metadata::PtrRepr::<u32> { const_ptr: move _6 };
-        StorageDead(_6);
-        _0 = (_7.0: *const u32);
-        StorageDead(_7);
+        _0 = _4 as *const u32 (PtrToPtr);
         StorageDead(_5);
-        StorageDead(_4);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,54 @@
+// MIR for `demo_byte_add_thin` after PreCodegen
+
+fn demo_byte_add_thin(_1: *const u32, _2: usize) -> *const u32 {
+    debug p => _1;
+    debug n => _2;
+    let mut _0: *const u32;
+    scope 1 (inlined std::ptr::const_ptr::<impl *const u32>::byte_add) {
+        debug self => _1;
+        debug count => _2;
+        let mut _3: *const u8;
+        let mut _4: *const u8;
+        scope 2 (inlined std::ptr::const_ptr::<impl *const u32>::cast::<u8>) {
+            debug self => _1;
+        }
+        scope 3 (inlined std::ptr::const_ptr::<impl *const u8>::add) {
+            debug self => _3;
+            debug count => _2;
+        }
+        scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<u32>) {
+            debug self => _4;
+            debug meta => _1;
+            let mut _5: *const ();
+            scope 5 (inlined std::ptr::metadata::<u32>) {
+                debug ptr => _1;
+            }
+            scope 6 (inlined std::ptr::from_raw_parts::<u32>) {
+                debug data_pointer => _5;
+                debug metadata => const ();
+                let mut _6: std::ptr::metadata::PtrComponents<u32>;
+                let mut _7: std::ptr::metadata::PtrRepr<u32>;
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_4);
+        StorageLive(_3);
+        _3 = _1 as *const u8 (PtrToPtr);
+        _4 = Offset(_3, _2);
+        StorageDead(_3);
+        StorageLive(_5);
+        _5 = _4 as *const () (PtrToPtr);
+        StorageLive(_7);
+        StorageLive(_6);
+        _6 = std::ptr::metadata::PtrComponents::<u32> { data_pointer: _5, metadata: const () };
+        _7 = std::ptr::metadata::PtrRepr::<u32> { const_ptr: move _6 };
+        StorageDead(_6);
+        _0 = (_7.0: *const u32);
+        StorageDead(_7);
+        StorageDead(_5);
+        StorageDead(_4);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-unwind.mir
@@ -5,27 +5,16 @@ fn demo_byte_add_thin(_1: *const u32, _2: usize) -> *const u32 {
     debug n => _2;
     let mut _0: *const u32;
     scope 1 (inlined std::ptr::const_ptr::<impl *const u32>::byte_add) {
-        debug self => _1;
-        debug count => _2;
         let mut _3: *const u8;
         let mut _4: *const u8;
         scope 2 (inlined std::ptr::const_ptr::<impl *const u32>::cast::<u8>) {
-            debug self => _1;
         }
         scope 3 (inlined std::ptr::const_ptr::<impl *const u8>::add) {
-            debug self => _3;
-            debug count => _2;
         }
         scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<u32>) {
-            debug self => _4;
-            debug meta => _1;
-            let mut _5: *const ();
             scope 5 (inlined std::ptr::metadata::<u32>) {
-                debug ptr => _1;
             }
             scope 6 (inlined std::ptr::from_raw_parts::<u32>) {
-                debug data_pointer => _5;
-                debug metadata => const ();
             }
         }
     }
@@ -35,10 +24,7 @@ fn demo_byte_add_thin(_1: *const u32, _2: usize) -> *const u32 {
         _3 = _1 as *const u8 (PtrToPtr);
         _4 = Offset(_3, _2);
         StorageDead(_3);
-        StorageLive(_5);
-        _5 = _4 as *const () (PtrToPtr);
         _0 = _4 as *const u32 (PtrToPtr);
-        StorageDead(_5);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-unwind.mir
@@ -26,29 +26,19 @@ fn demo_byte_add_thin(_1: *const u32, _2: usize) -> *const u32 {
             scope 6 (inlined std::ptr::from_raw_parts::<u32>) {
                 debug data_pointer => _5;
                 debug metadata => const ();
-                let mut _6: std::ptr::metadata::PtrComponents<u32>;
-                let mut _7: std::ptr::metadata::PtrRepr<u32>;
             }
         }
     }
 
     bb0: {
-        StorageLive(_4);
         StorageLive(_3);
         _3 = _1 as *const u8 (PtrToPtr);
         _4 = Offset(_3, _2);
         StorageDead(_3);
         StorageLive(_5);
         _5 = _4 as *const () (PtrToPtr);
-        StorageLive(_7);
-        StorageLive(_6);
-        _6 = std::ptr::metadata::PtrComponents::<u32> { data_pointer: _5, metadata: const () };
-        _7 = std::ptr::metadata::PtrRepr::<u32> { const_ptr: move _6 };
-        StorageDead(_6);
-        _0 = (_7.0: *const u32);
-        StorageDead(_7);
+        _0 = _4 as *const u32 (PtrToPtr);
         StorageDead(_5);
-        StorageDead(_4);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/ptr_offset.rs
+++ b/tests/mir-opt/pre-codegen/ptr_offset.rs
@@ -1,0 +1,16 @@
+// skip-filecheck
+//@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2 -Zinline-mir
+//@ ignore-debug: precondition checks are under cfg(debug_assertions)
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+
+#![crate_type = "lib"]
+
+// EMIT_MIR ptr_offset.demo_byte_add_thin.PreCodegen.after.mir
+pub unsafe fn demo_byte_add_thin(p: *const u32, n: usize) -> *const u32 {
+    p.byte_add(n)
+}
+
+// EMIT_MIR ptr_offset.demo_byte_add_fat.PreCodegen.after.mir
+pub unsafe fn demo_byte_add_fat(p: *const [u32], n: usize) -> *const [u32] {
+    p.byte_add(n)
+}

--- a/tests/mir-opt/pre-codegen/slice_index.rs
+++ b/tests/mir-opt/pre-codegen/slice_index.rs
@@ -3,6 +3,7 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![crate_type = "lib"]
+#![feature(slice_ptr_get)]
 
 use std::ops::Range;
 
@@ -24,4 +25,12 @@ pub fn slice_index_range(slice: &[u32], index: Range<usize>) -> &[u32] {
 // EMIT_MIR slice_index.slice_get_unchecked_mut_range.PreCodegen.after.mir
 pub unsafe fn slice_get_unchecked_mut_range(slice: &mut [u32], index: Range<usize>) -> &mut [u32] {
     slice.get_unchecked_mut(index)
+}
+
+// EMIT_MIR slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.mir
+pub unsafe fn slice_ptr_get_unchecked_range(
+    slice: *const [u32],
+    index: Range<usize>,
+) -> *const [u32] {
+    slice.get_unchecked(index)
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-abort.mir
@@ -7,42 +7,25 @@ fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -
     let mut _3: usize;
     let mut _4: usize;
     scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::get_unchecked::<std::ops::Range<usize>>) {
-        debug self => _1;
-        debug ((index: std::ops::Range<usize>).0: usize) => _3;
-        debug ((index: std::ops::Range<usize>).1: usize) => _4;
         scope 2 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked) {
-            debug ((self: std::ops::Range<usize>).0: usize) => _3;
-            debug ((self: std::ops::Range<usize>).1: usize) => _4;
-            debug slice => _1;
             let _5: usize;
             let mut _6: *const u32;
             let mut _7: *const u32;
             scope 3 {
-                debug new_len => _5;
                 scope 6 (inlined std::ptr::const_ptr::<impl *const [u32]>::as_ptr) {
-                    debug self => _1;
                 }
                 scope 7 (inlined std::ptr::const_ptr::<impl *const u32>::add) {
-                    debug self => _6;
-                    debug count => _3;
                 }
                 scope 8 (inlined slice_from_raw_parts::<u32>) {
-                    debug data => _7;
-                    debug len => _5;
                     let mut _8: *const ();
                     scope 9 (inlined std::ptr::const_ptr::<impl *const u32>::cast::<()>) {
-                        debug self => _7;
                     }
                     scope 10 (inlined std::ptr::from_raw_parts::<[u32]>) {
-                        debug data_pointer => _8;
-                        debug metadata => _5;
                     }
                 }
             }
             scope 4 (inlined std::ptr::const_ptr::<impl *const [u32]>::len) {
-                debug self => _1;
                 scope 5 (inlined std::ptr::metadata::<[u32]>) {
-                    debug ptr => _1;
                 }
             }
         }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-abort.mir
@@ -4,16 +4,66 @@ fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -
     debug slice => _1;
     debug index => _2;
     let mut _0: *const [u32];
+    let mut _3: usize;
+    let mut _4: usize;
     scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::get_unchecked::<std::ops::Range<usize>>) {
         debug self => _1;
-        debug index => _2;
+        debug ((index: std::ops::Range<usize>).0: usize) => _3;
+        debug ((index: std::ops::Range<usize>).1: usize) => _4;
+        scope 2 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked) {
+            debug ((self: std::ops::Range<usize>).0: usize) => _3;
+            debug ((self: std::ops::Range<usize>).1: usize) => _4;
+            debug slice => _1;
+            let _5: usize;
+            let mut _6: *const u32;
+            let mut _7: *const u32;
+            scope 3 {
+                debug new_len => _5;
+                scope 6 (inlined std::ptr::const_ptr::<impl *const [u32]>::as_ptr) {
+                    debug self => _1;
+                }
+                scope 7 (inlined std::ptr::const_ptr::<impl *const u32>::add) {
+                    debug self => _6;
+                    debug count => _3;
+                }
+                scope 8 (inlined slice_from_raw_parts::<u32>) {
+                    debug data => _7;
+                    debug len => _5;
+                    let mut _8: *const ();
+                    scope 9 (inlined std::ptr::const_ptr::<impl *const u32>::cast::<()>) {
+                        debug self => _7;
+                    }
+                    scope 10 (inlined std::ptr::from_raw_parts::<[u32]>) {
+                        debug data_pointer => _8;
+                        debug metadata => _5;
+                    }
+                }
+            }
+            scope 4 (inlined std::ptr::const_ptr::<impl *const [u32]>::len) {
+                debug self => _1;
+                scope 5 (inlined std::ptr::metadata::<[u32]>) {
+                    debug ptr => _1;
+                }
+            }
+        }
     }
 
     bb0: {
-        _0 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked(move _2, move _1) -> [return: bb1, unwind unreachable];
-    }
-
-    bb1: {
+        _3 = move (_2.0: usize);
+        _4 = move (_2.1: usize);
+        StorageLive(_5);
+        _5 = SubUnchecked(_4, _3);
+        StorageLive(_7);
+        StorageLive(_6);
+        _6 = _1 as *const u32 (PtrToPtr);
+        _7 = Offset(_6, _3);
+        StorageDead(_6);
+        StorageLive(_8);
+        _8 = _7 as *const () (PtrToPtr);
+        _0 = *const [u32] from (_8, _5);
+        StorageDead(_8);
+        StorageDead(_7);
+        StorageDead(_5);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,19 @@
+// MIR for `slice_ptr_get_unchecked_range` after PreCodegen
+
+fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -> *const [u32] {
+    debug slice => _1;
+    debug index => _2;
+    let mut _0: *const [u32];
+    scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::get_unchecked::<std::ops::Range<usize>>) {
+        debug self => _1;
+        debug index => _2;
+    }
+
+    bb0: {
+        _0 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked(move _2, move _1) -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-unwind.mir
@@ -4,16 +4,66 @@ fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -
     debug slice => _1;
     debug index => _2;
     let mut _0: *const [u32];
+    let mut _3: usize;
+    let mut _4: usize;
     scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::get_unchecked::<std::ops::Range<usize>>) {
         debug self => _1;
-        debug index => _2;
+        debug ((index: std::ops::Range<usize>).0: usize) => _3;
+        debug ((index: std::ops::Range<usize>).1: usize) => _4;
+        scope 2 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked) {
+            debug ((self: std::ops::Range<usize>).0: usize) => _3;
+            debug ((self: std::ops::Range<usize>).1: usize) => _4;
+            debug slice => _1;
+            let _5: usize;
+            let mut _6: *const u32;
+            let mut _7: *const u32;
+            scope 3 {
+                debug new_len => _5;
+                scope 6 (inlined std::ptr::const_ptr::<impl *const [u32]>::as_ptr) {
+                    debug self => _1;
+                }
+                scope 7 (inlined std::ptr::const_ptr::<impl *const u32>::add) {
+                    debug self => _6;
+                    debug count => _3;
+                }
+                scope 8 (inlined slice_from_raw_parts::<u32>) {
+                    debug data => _7;
+                    debug len => _5;
+                    let mut _8: *const ();
+                    scope 9 (inlined std::ptr::const_ptr::<impl *const u32>::cast::<()>) {
+                        debug self => _7;
+                    }
+                    scope 10 (inlined std::ptr::from_raw_parts::<[u32]>) {
+                        debug data_pointer => _8;
+                        debug metadata => _5;
+                    }
+                }
+            }
+            scope 4 (inlined std::ptr::const_ptr::<impl *const [u32]>::len) {
+                debug self => _1;
+                scope 5 (inlined std::ptr::metadata::<[u32]>) {
+                    debug ptr => _1;
+                }
+            }
+        }
     }
 
     bb0: {
-        _0 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked(move _2, move _1) -> [return: bb1, unwind continue];
-    }
-
-    bb1: {
+        _3 = move (_2.0: usize);
+        _4 = move (_2.1: usize);
+        StorageLive(_5);
+        _5 = SubUnchecked(_4, _3);
+        StorageLive(_7);
+        StorageLive(_6);
+        _6 = _1 as *const u32 (PtrToPtr);
+        _7 = Offset(_6, _3);
+        StorageDead(_6);
+        StorageLive(_8);
+        _8 = _7 as *const () (PtrToPtr);
+        _0 = *const [u32] from (_8, _5);
+        StorageDead(_8);
+        StorageDead(_7);
+        StorageDead(_5);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-unwind.mir
@@ -7,42 +7,25 @@ fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -
     let mut _3: usize;
     let mut _4: usize;
     scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::get_unchecked::<std::ops::Range<usize>>) {
-        debug self => _1;
-        debug ((index: std::ops::Range<usize>).0: usize) => _3;
-        debug ((index: std::ops::Range<usize>).1: usize) => _4;
         scope 2 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked) {
-            debug ((self: std::ops::Range<usize>).0: usize) => _3;
-            debug ((self: std::ops::Range<usize>).1: usize) => _4;
-            debug slice => _1;
             let _5: usize;
             let mut _6: *const u32;
             let mut _7: *const u32;
             scope 3 {
-                debug new_len => _5;
                 scope 6 (inlined std::ptr::const_ptr::<impl *const [u32]>::as_ptr) {
-                    debug self => _1;
                 }
                 scope 7 (inlined std::ptr::const_ptr::<impl *const u32>::add) {
-                    debug self => _6;
-                    debug count => _3;
                 }
                 scope 8 (inlined slice_from_raw_parts::<u32>) {
-                    debug data => _7;
-                    debug len => _5;
                     let mut _8: *const ();
                     scope 9 (inlined std::ptr::const_ptr::<impl *const u32>::cast::<()>) {
-                        debug self => _7;
                     }
                     scope 10 (inlined std::ptr::from_raw_parts::<[u32]>) {
-                        debug data_pointer => _8;
-                        debug metadata => _5;
                     }
                 }
             }
             scope 4 (inlined std::ptr::const_ptr::<impl *const [u32]>::len) {
-                debug self => _1;
                 scope 5 (inlined std::ptr::metadata::<[u32]>) {
-                    debug ptr => _1;
                 }
             }
         }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,19 @@
+// MIR for `slice_ptr_get_unchecked_range` after PreCodegen
+
+fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -> *const [u32] {
+    debug slice => _1;
+    debug index => _2;
+    let mut _0: *const [u32];
+    scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::get_unchecked::<std::ops::Range<usize>>) {
+        debug self => _1;
+        debug index => _2;
+    }
+
+    bb0: {
+        _0 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked(move _2, move _1) -> [return: bb1, unwind continue];
+    }
+
+    bb1: {
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/vec_deref.rs
+++ b/tests/mir-opt/pre-codegen/vec_deref.rs
@@ -1,0 +1,13 @@
+// skip-filecheck
+//@ compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=2
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+
+#![crate_type = "lib"]
+
+// Added after it stopped inlining in a nightly; see
+// <https://github.com/rust-lang/rust/issues/123174>
+
+// EMIT_MIR vec_deref.vec_deref_to_slice.PreCodegen.after.mir
+pub fn vec_deref_to_slice(v: &Vec<u8>) -> &[u8] {
+    v
+}

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,14 @@
+// MIR for `vec_deref_to_slice` after PreCodegen
+
+fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
+    debug v => _1;
+    let mut _0: &[u8];
+
+    bb0: {
+        _0 = <Vec<u8> as Deref>::deref(move _1) -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
@@ -3,12 +3,70 @@
 fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
     debug v => _1;
     let mut _0: &[u8];
-
-    bb0: {
-        _0 = <Vec<u8> as Deref>::deref(move _1) -> [return: bb1, unwind unreachable];
+    scope 1 (inlined <Vec<u8> as Deref>::deref) {
+        debug self => _1;
+        let mut _4: *const u8;
+        let mut _5: usize;
+        scope 2 (inlined Vec::<u8>::as_ptr) {
+            debug self => _1;
+            let mut _2: &alloc::raw_vec::RawVec<u8>;
+            scope 3 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
+                debug self => _2;
+                let mut _3: std::ptr::NonNull<u8>;
+                scope 4 (inlined Unique::<u8>::as_ptr) {
+                    debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _3;
+                    debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
+                    scope 5 (inlined NonNull::<u8>::as_ptr) {
+                        debug self => _3;
+                    }
+                }
+            }
+        }
+        scope 6 (inlined std::slice::from_raw_parts::<'_, u8>) {
+            debug data => _4;
+            debug len => _5;
+            let _7: *const [u8];
+            scope 7 (inlined core::ub_checks::check_language_ub) {
+                scope 8 (inlined core::ub_checks::check_language_ub::runtime) {
+                }
+            }
+            scope 9 (inlined std::mem::size_of::<u8>) {
+            }
+            scope 10 (inlined align_of::<u8>) {
+            }
+            scope 11 (inlined slice_from_raw_parts::<u8>) {
+                debug data => _4;
+                debug len => _5;
+                let mut _6: *const ();
+                scope 12 (inlined std::ptr::const_ptr::<impl *const u8>::cast::<()>) {
+                    debug self => _4;
+                }
+                scope 13 (inlined std::ptr::from_raw_parts::<[u8]>) {
+                    debug data_pointer => _6;
+                    debug metadata => _5;
+                }
+            }
+        }
     }
 
-    bb1: {
+    bb0: {
+        StorageLive(_4);
+        StorageLive(_2);
+        _2 = &((*_1).0: alloc::raw_vec::RawVec<u8>);
+        StorageLive(_3);
+        _3 = ((((*_1).0: alloc::raw_vec::RawVec<u8>).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
+        _4 = (_3.0: *const u8);
+        StorageDead(_3);
+        StorageDead(_2);
+        StorageLive(_5);
+        _5 = ((*_1).1: usize);
+        StorageLive(_6);
+        _6 = _4 as *const () (PtrToPtr);
+        _7 = *const [u8] from (_6, _5);
+        StorageDead(_6);
+        StorageDead(_5);
+        StorageDead(_4);
+        _0 = &(*_7);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,14 @@
+// MIR for `vec_deref_to_slice` after PreCodegen
+
+fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
+    debug v => _1;
+    let mut _0: &[u8];
+
+    bb0: {
+        _0 = <Vec<u8> as Deref>::deref(move _1) -> [return: bb1, unwind continue];
+    }
+
+    bb1: {
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
@@ -3,12 +3,70 @@
 fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
     debug v => _1;
     let mut _0: &[u8];
-
-    bb0: {
-        _0 = <Vec<u8> as Deref>::deref(move _1) -> [return: bb1, unwind continue];
+    scope 1 (inlined <Vec<u8> as Deref>::deref) {
+        debug self => _1;
+        let mut _4: *const u8;
+        let mut _5: usize;
+        scope 2 (inlined Vec::<u8>::as_ptr) {
+            debug self => _1;
+            let mut _2: &alloc::raw_vec::RawVec<u8>;
+            scope 3 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
+                debug self => _2;
+                let mut _3: std::ptr::NonNull<u8>;
+                scope 4 (inlined Unique::<u8>::as_ptr) {
+                    debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _3;
+                    debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
+                    scope 5 (inlined NonNull::<u8>::as_ptr) {
+                        debug self => _3;
+                    }
+                }
+            }
+        }
+        scope 6 (inlined std::slice::from_raw_parts::<'_, u8>) {
+            debug data => _4;
+            debug len => _5;
+            let _7: *const [u8];
+            scope 7 (inlined core::ub_checks::check_language_ub) {
+                scope 8 (inlined core::ub_checks::check_language_ub::runtime) {
+                }
+            }
+            scope 9 (inlined std::mem::size_of::<u8>) {
+            }
+            scope 10 (inlined align_of::<u8>) {
+            }
+            scope 11 (inlined slice_from_raw_parts::<u8>) {
+                debug data => _4;
+                debug len => _5;
+                let mut _6: *const ();
+                scope 12 (inlined std::ptr::const_ptr::<impl *const u8>::cast::<()>) {
+                    debug self => _4;
+                }
+                scope 13 (inlined std::ptr::from_raw_parts::<[u8]>) {
+                    debug data_pointer => _6;
+                    debug metadata => _5;
+                }
+            }
+        }
     }
 
-    bb1: {
+    bb0: {
+        StorageLive(_4);
+        StorageLive(_2);
+        _2 = &((*_1).0: alloc::raw_vec::RawVec<u8>);
+        StorageLive(_3);
+        _3 = ((((*_1).0: alloc::raw_vec::RawVec<u8>).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
+        _4 = (_3.0: *const u8);
+        StorageDead(_3);
+        StorageDead(_2);
+        StorageLive(_5);
+        _5 = ((*_1).1: usize);
+        StorageLive(_6);
+        _6 = _4 as *const () (PtrToPtr);
+        _7 = *const [u8] from (_6, _5);
+        StorageDead(_6);
+        StorageDead(_5);
+        StorageDead(_4);
+        _0 = &(*_7);
         return;
     }
 }


### PR DESCRIPTION
Fixes #123174 
cc @CAD97 @saethlin 
r? @cjgillot 

As suggested in https://github.com/rust-lang/rust/pull/123190#issuecomment-2028717967, this adds a new `AggregateKind::RawPtr` for creating a pointer from its data pointer and its metadata.

That means that `slice::from_raw_parts` and friends no longer need to hard-code pointer layout into `libcore`, and because it no longer does union hacks the MIR is shorter and more amenable to optimizations.

