### PR TITLE
[mir-inlining] Count `&T` ↔ `*const T` conversions as free

### DIFF
--- a/tests/mir-opt/pre-codegen/vec_deref.rs
+++ b/tests/mir-opt/pre-codegen/vec_deref.rs
@@ -1,0 +1,13 @@
+// skip-filecheck
+//@ compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=2
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+
+#![crate_type = "lib"]
+
+// Added after it stopped inlining in a nightly; see
+// <https://github.com/rust-lang/rust/issues/123174>
+
+// EMIT_MIR vec_deref.vec_deref_to_slice.PreCodegen.after.mir
+pub fn vec_deref_to_slice(v: &Vec<u8>) -> &[u8] {
+    v
+}

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,14 @@
+// MIR for `vec_deref_to_slice` after PreCodegen
+
+fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
+    debug v => _1;
+    let mut _0: &[u8];
+
+    bb0: {
+        _0 = <Vec<u8> as Deref>::deref(move _1) -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
@@ -3,12 +3,78 @@
 fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
     debug v => _1;
     let mut _0: &[u8];
-
-    bb0: {
-        _0 = <Vec<u8> as Deref>::deref(move _1) -> [return: bb1, unwind unreachable];
+    scope 1 (inlined <Vec<u8> as Deref>::deref) {
+        debug self => _1;
+        let mut _4: *const u8;
+        let mut _5: usize;
+        scope 2 (inlined Vec::<u8>::as_ptr) {
+            debug self => _1;
+            let mut _2: &alloc::raw_vec::RawVec<u8>;
+            scope 3 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
+                debug self => _2;
+                let mut _3: std::ptr::NonNull<u8>;
+                scope 4 (inlined Unique::<u8>::as_ptr) {
+                    debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _3;
+                    debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
+                    scope 5 (inlined NonNull::<u8>::as_ptr) {
+                        debug self => _3;
+                    }
+                }
+            }
+        }
+        scope 6 (inlined std::slice::from_raw_parts::<'_, u8>) {
+            debug data => _4;
+            debug len => _5;
+            let _9: *const [u8];
+            scope 7 (inlined core::ub_checks::check_language_ub) {
+                scope 8 (inlined core::ub_checks::check_language_ub::runtime) {
+                }
+            }
+            scope 9 (inlined std::mem::size_of::<u8>) {
+            }
+            scope 10 (inlined align_of::<u8>) {
+            }
+            scope 11 (inlined slice_from_raw_parts::<u8>) {
+                debug data => _4;
+                debug len => _5;
+                let mut _6: *const ();
+                scope 12 (inlined std::ptr::const_ptr::<impl *const u8>::cast::<()>) {
+                    debug self => _4;
+                }
+                scope 13 (inlined std::ptr::from_raw_parts::<[u8]>) {
+                    debug data_pointer => _6;
+                    debug metadata => _5;
+                    let mut _7: std::ptr::metadata::PtrComponents<[u8]>;
+                    let mut _8: std::ptr::metadata::PtrRepr<[u8]>;
+                }
+            }
+        }
     }
 
-    bb1: {
+    bb0: {
+        StorageLive(_4);
+        StorageLive(_2);
+        _2 = &((*_1).0: alloc::raw_vec::RawVec<u8>);
+        StorageLive(_3);
+        _3 = ((((*_1).0: alloc::raw_vec::RawVec<u8>).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
+        _4 = (_3.0: *const u8);
+        StorageDead(_3);
+        StorageDead(_2);
+        StorageLive(_5);
+        _5 = ((*_1).1: usize);
+        StorageLive(_6);
+        _6 = _4 as *const () (PtrToPtr);
+        StorageLive(_8);
+        StorageLive(_7);
+        _7 = std::ptr::metadata::PtrComponents::<[u8]> { data_pointer: _6, metadata: _5 };
+        _8 = std::ptr::metadata::PtrRepr::<[u8]> { const_ptr: move _7 };
+        StorageDead(_7);
+        _9 = (_8.0: *const [u8]);
+        StorageDead(_8);
+        StorageDead(_6);
+        StorageDead(_5);
+        StorageDead(_4);
+        _0 = &(*_9);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,14 @@
+// MIR for `vec_deref_to_slice` after PreCodegen
+
+fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
+    debug v => _1;
+    let mut _0: &[u8];
+
+    bb0: {
+        _0 = <Vec<u8> as Deref>::deref(move _1) -> [return: bb1, unwind continue];
+    }
+
+    bb1: {
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
@@ -3,12 +3,78 @@
 fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
     debug v => _1;
     let mut _0: &[u8];
-
-    bb0: {
-        _0 = <Vec<u8> as Deref>::deref(move _1) -> [return: bb1, unwind continue];
+    scope 1 (inlined <Vec<u8> as Deref>::deref) {
+        debug self => _1;
+        let mut _4: *const u8;
+        let mut _5: usize;
+        scope 2 (inlined Vec::<u8>::as_ptr) {
+            debug self => _1;
+            let mut _2: &alloc::raw_vec::RawVec<u8>;
+            scope 3 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
+                debug self => _2;
+                let mut _3: std::ptr::NonNull<u8>;
+                scope 4 (inlined Unique::<u8>::as_ptr) {
+                    debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _3;
+                    debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
+                    scope 5 (inlined NonNull::<u8>::as_ptr) {
+                        debug self => _3;
+                    }
+                }
+            }
+        }
+        scope 6 (inlined std::slice::from_raw_parts::<'_, u8>) {
+            debug data => _4;
+            debug len => _5;
+            let _9: *const [u8];
+            scope 7 (inlined core::ub_checks::check_language_ub) {
+                scope 8 (inlined core::ub_checks::check_language_ub::runtime) {
+                }
+            }
+            scope 9 (inlined std::mem::size_of::<u8>) {
+            }
+            scope 10 (inlined align_of::<u8>) {
+            }
+            scope 11 (inlined slice_from_raw_parts::<u8>) {
+                debug data => _4;
+                debug len => _5;
+                let mut _6: *const ();
+                scope 12 (inlined std::ptr::const_ptr::<impl *const u8>::cast::<()>) {
+                    debug self => _4;
+                }
+                scope 13 (inlined std::ptr::from_raw_parts::<[u8]>) {
+                    debug data_pointer => _6;
+                    debug metadata => _5;
+                    let mut _7: std::ptr::metadata::PtrComponents<[u8]>;
+                    let mut _8: std::ptr::metadata::PtrRepr<[u8]>;
+                }
+            }
+        }
     }
 
-    bb1: {
+    bb0: {
+        StorageLive(_4);
+        StorageLive(_2);
+        _2 = &((*_1).0: alloc::raw_vec::RawVec<u8>);
+        StorageLive(_3);
+        _3 = ((((*_1).0: alloc::raw_vec::RawVec<u8>).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
+        _4 = (_3.0: *const u8);
+        StorageDead(_3);
+        StorageDead(_2);
+        StorageLive(_5);
+        _5 = ((*_1).1: usize);
+        StorageLive(_6);
+        _6 = _4 as *const () (PtrToPtr);
+        StorageLive(_8);
+        StorageLive(_7);
+        _7 = std::ptr::metadata::PtrComponents::<[u8]> { data_pointer: _6, metadata: _5 };
+        _8 = std::ptr::metadata::PtrRepr::<[u8]> { const_ptr: move _7 };
+        StorageDead(_7);
+        _9 = (_8.0: *const [u8]);
+        StorageDead(_8);
+        StorageDead(_6);
+        StorageDead(_5);
+        StorageDead(_4);
+        _0 = &(*_9);
         return;
     }
 }


### PR DESCRIPTION
Let's see if it's worth it...

r? ghost