### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5580,7 +5580,6 @@ dependencies = [
 name = "tidy"
 version = "0.1.0"
 dependencies = [
- "cargo-platform",
  "cargo_metadata 0.15.4",
  "ignore",
  "lazy_static",

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -165,8 +165,8 @@ impl_from!(u16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0"
 impl_from!(u32 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 
 // float -> float
-impl_from!(f16 => f32, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(f16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+// FIXME(f16_f128): adding additional `From` impls for existing types breaks inference. See
+// <https://github.com/rust-lang/rust/issues/123824>
 impl_from!(f16 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(f32 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(f32 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1198,7 +1198,7 @@ impl<Ptr: Deref<Target: Unpin>> Pin<Ptr> {
     /// Unwraps this `Pin<Ptr>`, returning the underlying pointer.
     ///
     /// Doing this operation safely requires that the data pointed at by this pinning pointer
-    /// implemts [`Unpin`] so that we can ignore the pinning invariants when unwrapping it.
+    /// implements [`Unpin`] so that we can ignore the pinning invariants when unwrapping it.
     ///
     /// # Examples
     ///

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -6,7 +6,6 @@ autobins = false
 
 [dependencies]
 cargo_metadata = "0.15"
-cargo-platform = "0.1.2"
 regex = "1"
 miropt-test-tools = { path = "../miropt-test-tools" }
 lazy_static = "1"

--- a/tests/ui/inference/untyped-primitives.rs
+++ b/tests/ui/inference/untyped-primitives.rs
@@ -1,0 +1,9 @@
+//@ check-pass
+// issue: rust-lang/rust#123824
+// This test is a sanity check and does not enforce any stable API, so may be
+// removed at a future point.
+
+fn main() {
+    let x = f32::from(3.14);
+    let y = f64::from(3.14);
+}


### PR DESCRIPTION
Successful merges:

 - #123796 (Remove unused cargo-platform dependency from tidy)
 - #123830 (Remove `From` impls for unstable types that break inference)
 - #123842 (fix typo in pin.rs)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=123796,123830,123842)
<!-- homu-ignore:end -->