### PR TITLE
Add constants for f16 and f128

### DIFF
--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -15,7 +15,116 @@ use crate::mem;
 
 /// Basic mathematical constants.
 #[unstable(feature = "f128", issue = "116909")]
-pub mod consts {}
+pub mod consts {
+    // FIXME: replace with mathematical constants from cmath.
+
+    /// Archimedes' constant (π)
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const PI: f128 = 3.14159265358979323846264338327950288419716939937510582097494_f128;
+
+    /// The full circle constant (τ)
+    ///
+    /// Equal to 2π.
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const TAU: f128 = 6.28318530717958647692528676655900576839433879875021164194989_f128;
+
+    /// The golden ratio (φ)
+    #[unstable(feature = "f128", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const PHI: f128 = 1.61803398874989484820458683436563811772030917980576286213545_f128;
+
+    /// The Euler-Mascheroni constant (γ)
+    #[unstable(feature = "f128", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const EGAMMA: f128 = 0.577215664901532860606512090082402431042159335939923598805767_f128;
+
+    /// π/2
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_PI_2: f128 = 1.57079632679489661923132169163975144209858469968755291048747_f128;
+
+    /// π/3
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_PI_3: f128 = 1.04719755119659774615421446109316762806572313312503527365831_f128;
+
+    /// π/4
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_PI_4: f128 = 0.785398163397448309615660845819875721049292349843776455243736_f128;
+
+    /// π/6
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_PI_6: f128 = 0.523598775598298873077107230546583814032861566562517636829157_f128;
+
+    /// π/8
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_PI_8: f128 = 0.392699081698724154807830422909937860524646174921888227621868_f128;
+
+    /// 1/π
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_1_PI: f128 = 0.318309886183790671537767526745028724068919291480912897495335_f128;
+
+    /// 1/sqrt(π)
+    #[unstable(feature = "f128", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const FRAC_1_SQRT_PI: f128 =
+        0.564189583547756286948079451560772585844050629328998856844086_f128;
+
+    /// 2/π
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_2_PI: f128 = 0.636619772367581343075535053490057448137838582961825794990669_f128;
+
+    /// 2/sqrt(π)
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_2_SQRT_PI: f128 =
+        1.12837916709551257389615890312154517168810125865799771368817_f128;
+
+    /// sqrt(2)
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const SQRT_2: f128 = 1.41421356237309504880168872420969807856967187537694807317668_f128;
+
+    /// 1/sqrt(2)
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_1_SQRT_2: f128 =
+        0.707106781186547524400844362104849039284835937688474036588340_f128;
+
+    /// sqrt(3)
+    #[unstable(feature = "f128", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const SQRT_3: f128 = 1.73205080756887729352744634150587236694280525381038062805581_f128;
+
+    /// 1/sqrt(3)
+    #[unstable(feature = "f128", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const FRAC_1_SQRT_3: f128 =
+        0.577350269189625764509148780501957455647601751270126876018602_f128;
+
+    /// Euler's number (e)
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const E: f128 = 2.71828182845904523536028747135266249775724709369995957496697_f128;
+
+    /// log<sub>2</sub>(10)
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const LOG2_10: f128 = 3.32192809488736234787031942948939017586483139302458061205476_f128;
+
+    /// log<sub>2</sub>(e)
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const LOG2_E: f128 = 1.44269504088896340735992468100189213742664595415298593413545_f128;
+
+    /// log<sub>10</sub>(2)
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const LOG10_2: f128 = 0.301029995663981195213738894724493026768189881462108541310427_f128;
+
+    /// log<sub>10</sub>(e)
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const LOG10_E: f128 = 0.434294481903251827651128918916605082294397005803666566114454_f128;
+
+    /// ln(2)
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const LN_2: f128 = 0.693147180559945309417232121458176568075500134360255254120680_f128;
+
+    /// ln(10)
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const LN_10: f128 = 2.30258509299404568401799145468436420760110148862877297603333_f128;
+}
 
 #[cfg(not(test))]
 impl f128 {

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -19,8 +19,90 @@ pub mod consts {}
 
 #[cfg(not(test))]
 impl f128 {
-    // FIXME(f16_f128): almost everything in this `impl` is missing examples and a const
+    // FIXME(f16_f128): almost all methods in this `impl` are missing examples and a const
     // implementation. Add these once we can run code on all platforms and have f16/f128 in CTFE.
+
+    /// The radix or base of the internal representation of `f128`.
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const RADIX: u32 = 2;
+
+    /// Number of significant digits in base 2.
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const MANTISSA_DIGITS: u32 = 113;
+
+    /// Approximate number of significant digits in base 10.
+    ///
+    /// This is the maximum <i>x</i> such that any decimal number with <i>x</i>
+    /// significant digits can be converted to `f128` and back without loss.
+    ///
+    /// Equal to floor(log<sub>10</sub>&nbsp;2<sup>[`MANTISSA_DIGITS`]&nbsp;&minus;&nbsp;1</sup>).
+    ///
+    /// [`MANTISSA_DIGITS`]: f128::MANTISSA_DIGITS
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const DIGITS: u32 = 33;
+
+    /// [Machine epsilon] value for `f128`.
+    ///
+    /// This is the difference between `1.0` and the next larger representable number.
+    ///
+    /// Equal to 2<sup>1&nbsp;&minus;&nbsp;[`MANTISSA_DIGITS`]</sup>.
+    ///
+    /// [Machine epsilon]: https://en.wikipedia.org/wiki/Machine_epsilon
+    /// [`MANTISSA_DIGITS`]: f128::MANTISSA_DIGITS
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const EPSILON: f128 = 1.92592994438723585305597794258492731e-34_f128;
+
+    /// Smallest finite `f128` value.
+    ///
+    /// Equal to &minus;[`MAX`].
+    ///
+    /// [`MAX`]: f128::MAX
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const MIN: f128 = -1.18973149535723176508575932662800701e+4932_f128;
+    /// Smallest positive normal `f128` value.
+    ///
+    /// Equal to 2<sup>[`MIN_EXP`]&nbsp;&minus;&nbsp;1</sup>.
+    ///
+    /// [`MIN_EXP`]: f128::MIN_EXP
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const MIN_POSITIVE: f128 = 3.36210314311209350626267781732175260e-4932_f128;
+    /// Largest finite `f128` value.
+    ///
+    /// Equal to
+    /// (1&nbsp;&minus;&nbsp;2<sup>&minus;[`MANTISSA_DIGITS`]</sup>)&nbsp;2<sup>[`MAX_EXP`]</sup>.
+    ///
+    /// [`MANTISSA_DIGITS`]: f128::MANTISSA_DIGITS
+    /// [`MAX_EXP`]: f128::MAX_EXP
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const MAX: f128 = 1.18973149535723176508575932662800701e+4932_f128;
+
+    /// One greater than the minimum possible normal power of 2 exponent.
+    ///
+    /// If <i>x</i>&nbsp;=&nbsp;`MIN_EXP`, then normal numbers
+    /// ≥&nbsp;0.5&nbsp;×&nbsp;2<sup><i>x</i></sup>.
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const MIN_EXP: i32 = -16_381;
+    /// Maximum possible power of 2 exponent.
+    ///
+    /// If <i>x</i>&nbsp;=&nbsp;`MAX_EXP`, then normal numbers
+    /// &lt;&nbsp;1&nbsp;×&nbsp;2<sup><i>x</i></sup>.
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const MAX_EXP: i32 = 16_384;
+
+    /// Minimum <i>x</i> for which 10<sup><i>x</i></sup> is normal.
+    ///
+    /// Equal to ceil(log<sub>10</sub>&nbsp;[`MIN_POSITIVE`]).
+    ///
+    /// [`MIN_POSITIVE`]: f128::MIN_POSITIVE
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const MIN_10_EXP: i32 = -4_931;
+    /// Maximum <i>x</i> for which 10<sup><i>x</i></sup> is normal.
+    ///
+    /// Equal to floor(log<sub>10</sub>&nbsp;[`MAX`]).
+    ///
+    /// [`MAX`]: f128::MAX
+    #[unstable(feature = "f128", issue = "116909")]
+    pub const MAX_10_EXP: i32 = 4_932;
 
     /// Returns `true` if this value is NaN.
     #[inline]

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -19,8 +19,90 @@ pub mod consts {}
 
 #[cfg(not(test))]
 impl f16 {
-    // FIXME(f16_f128): almost everything in this `impl` is missing examples and a const
+    // FIXME(f16_f128): almost all methods in this `impl` are missing examples and a const
     // implementation. Add these once we can run code on all platforms and have f16/f128 in CTFE.
+
+    /// The radix or base of the internal representation of `f16`.
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const RADIX: u32 = 2;
+
+    /// Number of significant digits in base 2.
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const MANTISSA_DIGITS: u32 = 11;
+
+    /// Approximate number of significant digits in base 10.
+    ///
+    /// This is the maximum <i>x</i> such that any decimal number with <i>x</i>
+    /// significant digits can be converted to `f16` and back without loss.
+    ///
+    /// Equal to floor(log<sub>10</sub>&nbsp;2<sup>[`MANTISSA_DIGITS`]&nbsp;&minus;&nbsp;1</sup>).
+    ///
+    /// [`MANTISSA_DIGITS`]: f16::MANTISSA_DIGITS
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const DIGITS: u32 = 3;
+
+    /// [Machine epsilon] value for `f16`.
+    ///
+    /// This is the difference between `1.0` and the next larger representable number.
+    ///
+    /// Equal to 2<sup>1&nbsp;&minus;&nbsp;[`MANTISSA_DIGITS`]</sup>.
+    ///
+    /// [Machine epsilon]: https://en.wikipedia.org/wiki/Machine_epsilon
+    /// [`MANTISSA_DIGITS`]: f16::MANTISSA_DIGITS
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const EPSILON: f16 = 9.7656e-4_f16;
+
+    /// Smallest finite `f16` value.
+    ///
+    /// Equal to &minus;[`MAX`].
+    ///
+    /// [`MAX`]: f16::MAX
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const MIN: f16 = -6.5504e+4_f16;
+    /// Smallest positive normal `f16` value.
+    ///
+    /// Equal to 2<sup>[`MIN_EXP`]&nbsp;&minus;&nbsp;1</sup>.
+    ///
+    /// [`MIN_EXP`]: f16::MIN_EXP
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const MIN_POSITIVE: f16 = 6.1035e-5_f16;
+    /// Largest finite `f16` value.
+    ///
+    /// Equal to
+    /// (1&nbsp;&minus;&nbsp;2<sup>&minus;[`MANTISSA_DIGITS`]</sup>)&nbsp;2<sup>[`MAX_EXP`]</sup>.
+    ///
+    /// [`MANTISSA_DIGITS`]: f16::MANTISSA_DIGITS
+    /// [`MAX_EXP`]: f16::MAX_EXP
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const MAX: f16 = 6.5504e+4_f16;
+
+    /// One greater than the minimum possible normal power of 2 exponent.
+    ///
+    /// If <i>x</i>&nbsp;=&nbsp;`MIN_EXP`, then normal numbers
+    /// ≥&nbsp;0.5&nbsp;×&nbsp;2<sup><i>x</i></sup>.
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const MIN_EXP: i32 = -13;
+    /// Maximum possible power of 2 exponent.
+    ///
+    /// If <i>x</i>&nbsp;=&nbsp;`MAX_EXP`, then normal numbers
+    /// &lt;&nbsp;1&nbsp;×&nbsp;2<sup><i>x</i></sup>.
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const MAX_EXP: i32 = 16;
+
+    /// Minimum <i>x</i> for which 10<sup><i>x</i></sup> is normal.
+    ///
+    /// Equal to ceil(log<sub>10</sub>&nbsp;[`MIN_POSITIVE`]).
+    ///
+    /// [`MIN_POSITIVE`]: f16::MIN_POSITIVE
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const MIN_10_EXP: i32 = -4;
+    /// Maximum <i>x</i> for which 10<sup><i>x</i></sup> is normal.
+    ///
+    /// Equal to floor(log<sub>10</sub>&nbsp;[`MAX`]).
+    ///
+    /// [`MAX`]: f16::MAX
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const MAX_10_EXP: i32 = 4;
 
     /// Returns `true` if this value is NaN.
     #[inline]

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -15,7 +15,112 @@ use crate::mem;
 
 /// Basic mathematical constants.
 #[unstable(feature = "f16", issue = "116909")]
-pub mod consts {}
+pub mod consts {
+    // FIXME: replace with mathematical constants from cmath.
+
+    /// Archimedes' constant (π)
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const PI: f16 = 3.14159265358979323846264338327950288_f16;
+
+    /// The full circle constant (τ)
+    ///
+    /// Equal to 2π.
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const TAU: f16 = 6.28318530717958647692528676655900577_f16;
+
+    /// The golden ratio (φ)
+    #[unstable(feature = "f16", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const PHI: f16 = 1.618033988749894848204586834365638118_f16;
+
+    /// The Euler-Mascheroni constant (γ)
+    #[unstable(feature = "f16", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const EGAMMA: f16 = 0.577215664901532860606512090082402431_f16;
+
+    /// π/2
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_PI_2: f16 = 1.57079632679489661923132169163975144_f16;
+
+    /// π/3
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_PI_3: f16 = 1.04719755119659774615421446109316763_f16;
+
+    /// π/4
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_PI_4: f16 = 0.785398163397448309615660845819875721_f16;
+
+    /// π/6
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_PI_6: f16 = 0.52359877559829887307710723054658381_f16;
+
+    /// π/8
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_PI_8: f16 = 0.39269908169872415480783042290993786_f16;
+
+    /// 1/π
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_1_PI: f16 = 0.318309886183790671537767526745028724_f16;
+
+    /// 1/sqrt(π)
+    #[unstable(feature = "f16", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const FRAC_1_SQRT_PI: f16 = 0.564189583547756286948079451560772586_f16;
+
+    /// 2/π
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_2_PI: f16 = 0.636619772367581343075535053490057448_f16;
+
+    /// 2/sqrt(π)
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_2_SQRT_PI: f16 = 1.12837916709551257389615890312154517_f16;
+
+    /// sqrt(2)
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const SQRT_2: f16 = 1.41421356237309504880168872420969808_f16;
+
+    /// 1/sqrt(2)
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_1_SQRT_2: f16 = 0.707106781186547524400844362104849039_f16;
+
+    /// sqrt(3)
+    #[unstable(feature = "f16", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const SQRT_3: f16 = 1.732050807568877293527446341505872367_f16;
+
+    /// 1/sqrt(3)
+    #[unstable(feature = "f16", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const FRAC_1_SQRT_3: f16 = 0.577350269189625764509148780501957456_f16;
+
+    /// Euler's number (e)
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const E: f16 = 2.71828182845904523536028747135266250_f16;
+
+    /// log<sub>2</sub>(10)
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const LOG2_10: f16 = 3.32192809488736234787031942948939018_f16;
+
+    /// log<sub>2</sub>(e)
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const LOG2_E: f16 = 1.44269504088896340735992468100189214_f16;
+
+    /// log<sub>10</sub>(2)
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const LOG10_2: f16 = 0.301029995663981195213738894724493027_f16;
+
+    /// log<sub>10</sub>(e)
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const LOG10_E: f16 = 0.434294481903251827651128918916605082_f16;
+
+    /// ln(2)
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const LN_2: f16 = 0.693147180559945309417232121458176568_f16;
+
+    /// ln(10)
+    #[unstable(feature = "f16", issue = "116909")]
+    pub const LN_10: f16 = 2.30258509299404568401799145468436421_f16;
+}
 
 #[cfg(not(test))]
 impl f16 {

--- a/tests/ui/resolve/issue-50599.stderr
+++ b/tests/ui/resolve/issue-50599.stderr
@@ -6,6 +6,10 @@ LL |     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize;
    |
 help: consider importing one of these items
    |
+LL + use std::f128::consts::LOG10_2;
+   |
+LL + use std::f16::consts::LOG10_2;
+   |
 LL + use std::f32::consts::LOG10_2;
    |
 LL + use std::f64::consts::LOG10_2;

--- a/tests/ui/resolve/issue-73427.stderr
+++ b/tests/ui/resolve/issue-73427.stderr
@@ -107,6 +107,10 @@ LL |     (E::TupleWithFields(/* fields */)).foo();
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 help: consider importing one of these items instead
    |
+LL + use std::f128::consts::E;
+   |
+LL + use std::f16::consts::E;
+   |
 LL + use std::f32::consts::E;
    |
 LL + use std::f64::consts::E;

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -84,6 +84,10 @@ LL |     let _: E = m::f;
    |                   ~
 help: consider importing one of these items instead
    |
+LL + use std::f128::consts::E;
+   |
+LL + use std::f16::consts::E;
+   |
 LL + use std::f32::consts::E;
    |
 LL + use std::f64::consts::E;
@@ -120,6 +124,10 @@ help: alternatively, the following enum variant is available
 LL |     let _: E = (E::Fn(/* fields */));
    |                ~~~~~~~~~~~~~~~~~~~~~
 help: consider importing one of these items instead
+   |
+LL + use std::f128::consts::E;
+   |
+LL + use std::f16::consts::E;
    |
 LL + use std::f32::consts::E;
    |


### PR DESCRIPTION
- Commit 1 adds associated constants for `f16`, excluding NaN and infinities as these are implemented using arithmetic for `f32` and `f64`.
- Commit 2 adds associated constants for `f128`, excluding NaN and infinities.
- Commit 3 adds constants in `std::f16::consts`.
- Commit 4 adds constants in `std::f128::consts`.