### PR TITLE
fix typo in library/std/src/lib.rs

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -221,7 +221,7 @@
         issue = "none",
         reason = "You have attempted to use a standard library built for a platform that it doesn't \
             know how to support. Consider building it for a known environment, disabling it with \
-            `#![no_std]` or overriding this warning by enabling this feature".
+            `#![no_std]` or overriding this warning by enabling this feature."
     )
 )]
 #![cfg_attr(not(bootstrap), rustc_preserve_ub_checks)]


### PR DESCRIPTION
I found typo in literal.
I got an error by this typo when build std.

```
salacia@Vega:~/fat12rs$ cargo build -Zbuild-std
   Compiling compiler_builtins v0.1.108
   Compiling core v0.0.0 (/home/salacia/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
   Compiling libc v0.2.153
   Compiling memchr v2.5.0
   Compiling std v0.0.0 (/home/salacia/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std)
   Compiling rustc-std-workspace-core v1.99.0 (/home/salacia/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling alloc v0.0.0 (/home/salacia/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc)
   Compiling cfg-if v1.0.0
   Compiling unwind v0.0.0 (/home/salacia/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/unwind)
   Compiling adler v1.0.2
   Compiling rustc-demangle v0.1.23
   Compiling rustc-std-workspace-alloc v1.99.0 (/home/salacia/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-alloc)
   Compiling gimli v0.28.1
   Compiling object v0.32.2
   Compiling addr2line v0.21.0
   Compiling miniz_oxide v0.7.2
   Compiling std_detect v0.1.5 (/home/salacia/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/stdarch/crates/std_detect)
   Compiling hashbrown v0.14.3
   Compiling panic_abort v0.0.0 (/home/salacia/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/panic_abort)
   Compiling panic_unwind v0.0.0 (/home/salacia/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/panic_unwind)
error: expected `,`, found `.`
   --> /home/salacia/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/lib.rs:224:78
    |
224 |             `#![no_std]` or overriding this warning by enabling this feature".
    |                                                                              ^ expected `,`

error: could not compile `std` (lib) due to 1 previous error
:224:78
    |
224 |             `#![no_std]` or overriding this warning by enabling this feature".
    |                                                                              ^ expected `,`

error: could not compile `std` (lib) due to 1 previous error
```
