### PR TITLE
zkvm: fix path to cmath in zkvm module

### DIFF
--- a/library/std/src/sys/pal/zkvm/mod.rs
+++ b/library/std/src/sys/pal/zkvm/mod.rs
@@ -12,8 +12,6 @@ const WORD_SIZE: usize = core::mem::size_of::<u32>();
 pub mod alloc;
 #[path = "../zkvm/args.rs"]
 pub mod args;
-#[path = "../unix/cmath.rs"]
-pub mod cmath;
 pub mod env;
 #[path = "../unsupported/fs.rs"]
 pub mod fs;


### PR DESCRIPTION
I don't know why the original author decided to use relative paths.

I think it would be better to use `use crate::sys::cmath;`

The according issue can be found here https://github.com/risc0/risc0/issues/1647