### PR TITLE
Don't Fold Self-Referential ADTs in `check_inferred_predicates()`

### DIFF
--- a/tests/ui/regions/regions-outlives-for-recursive-types.rs
+++ b/tests/ui/regions/regions-outlives-for-recursive-types.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+
+#![allow(dead_code)]
+
+trait Bound {
+    type Assoc: Bound;
+}
+
+struct Recurse<'a, T: Bound> {
+    first: &'a T,
+    value: &'a Recurse<'a, T::Assoc>,
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #118163, #118449

The I-hang was caused by the compiler trying to instantiate a predicate for self-referential ADTs.

This PR fixes it by not instantiating a predicate when an ADT's field refers to the ADT itself.