### PR TITLE
Merge cuviper in the mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -307,6 +307,8 @@ Joseph T. Lyons <JosephTLyons@gmail.com> <JosephTLyons@users.noreply.github.com>
 Josh Cotton <jcotton42@outlook.com>
 Josh Driver <keeperofdakeys@gmail.com>
 Josh Holmer <jholmer.in@gmail.com>
+Josh Stone <cuviper@gmail.com> <jistone@redhat.com>
+Josh Stone <cuviper@gmail.com> <jistone@fedoraproject.org>
 Julian Knodt <julianknodt@gmail.com>
 jumbatm <jumbatm@gmail.com> <30644300+jumbatm@users.noreply.github.com>
 Junyoung Cho <june0.cho@samsung.com>


### PR DESCRIPTION
These emails are associated with my GitHub account already, but I might as well
combine my activity for stuff like the Thanks page too.
