### PR TITLE
rustdoc: check redundant explicit links with correct itemid

### DIFF
--- a/tests/rustdoc-ui/redundant-explicit-links-123677.rs
+++ b/tests/rustdoc-ui/redundant-explicit-links-123677.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+#![deny(rustdoc::redundant_explicit_links)]
+
+mod bar {
+    /// [`Rc`](std::rc::Rc)
+    pub enum Baz {}
+}
+
+pub use bar::*;
+
+use std::rc::Rc;
+
+/// [`Rc::allocator`] [foo](std::rc::Rc)
+pub fn winit_runner() {}


### PR DESCRIPTION
Fixes #123677 (a regression caused by #120702)