### PR TITLE
Use the rustc_private libc less in tests

### DIFF
--- a/tests/ui-fulldeps/regions-mock-tcx.rs
+++ b/tests/ui-fulldeps/regions-mock-tcx.rs
@@ -9,10 +9,9 @@
 // - Multiple lifetime parameters
 // - Arenas
 
-#![feature(rustc_private, libc)]
+#![feature(rustc_private)]
 
 extern crate rustc_arena;
-extern crate libc;
 
 // Necessary to pull in object code as the rest of the rustc crates are shipped only as rmeta
 // files.

--- a/tests/ui/abi/c-stack-returning-int64.rs
+++ b/tests/ui/abi/c-stack-returning-int64.rs
@@ -1,14 +1,10 @@
 //@ run-pass
 //@ ignore-sgx no libc
 
-#![feature(rustc_private)]
-
-extern crate libc;
-
 use std::ffi::CString;
 
 mod mlibc {
-    use libc::{c_char, c_long, c_longlong};
+    use std::ffi::{c_char, c_long, c_longlong};
 
     extern "C" {
         pub fn atol(x: *const c_char) -> c_long;

--- a/tests/ui/abi/statics/static-mut-foreign.rs
+++ b/tests/ui/abi/statics/static-mut-foreign.rs
@@ -3,19 +3,17 @@
 // statics cannot. This ensures that there's some form of error if this is
 // attempted.
 
-#![feature(rustc_private)]
-
-extern crate libc;
+use std::ffi::c_int;
 
 #[link(name = "rust_test_helpers", kind = "static")]
 extern "C" {
-    static mut rust_dbg_static_mut: libc::c_int;
+    static mut rust_dbg_static_mut: c_int;
     pub fn rust_dbg_static_mut_check_four();
 }
 
-unsafe fn static_bound(_: &'static libc::c_int) {}
+unsafe fn static_bound(_: &'static c_int) {}
 
-fn static_bound_set(a: &'static mut libc::c_int) {
+fn static_bound_set(a: &'static mut c_int) {
     *a = 3;
 }
 

--- a/tests/ui/abi/statics/static-mut-foreign.stderr
+++ b/tests/ui/abi/statics/static-mut-foreign.stderr
@@ -1,5 +1,5 @@
 warning: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-foreign.rs:33:18
+  --> $DIR/static-mut-foreign.rs:31:18
    |
 LL |     static_bound(&rust_dbg_static_mut);
    |                  ^^^^^^^^^^^^^^^^^^^^ shared reference to mutable static
@@ -14,7 +14,7 @@ LL |     static_bound(addr_of!(rust_dbg_static_mut));
    |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 warning: creating a mutable reference to mutable static is discouraged
-  --> $DIR/static-mut-foreign.rs:35:22
+  --> $DIR/static-mut-foreign.rs:33:22
    |
 LL |     static_bound_set(&mut rust_dbg_static_mut);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static

--- a/tests/ui/array-slice-vec/vec-macro-no-std.rs
+++ b/tests/ui/array-slice-vec/vec-macro-no-std.rs
@@ -7,8 +7,6 @@
 
 extern crate std as other;
 
-extern crate libc;
-
 #[macro_use]
 extern crate alloc;
 

--- a/tests/ui/auxiliary/check_static_recursion_foreign_helper.rs
+++ b/tests/ui/auxiliary/check_static_recursion_foreign_helper.rs
@@ -5,7 +5,7 @@
 #![crate_name = "check_static_recursion_foreign_helper"]
 #![crate_type = "lib"]
 
-extern crate libc;
+use std::ffi::c_int;
 
 #[no_mangle]
-pub static test_static: libc::c_int = 0;
+pub static test_static: c_int = 0;

--- a/tests/ui/check-static-recursion-foreign.rs
+++ b/tests/ui/check-static-recursion-foreign.rs
@@ -6,12 +6,9 @@
 
 //@ pretty-expanded FIXME #23616
 
-#![feature(rustc_private)]
-
 extern crate check_static_recursion_foreign_helper;
-extern crate libc;
 
-use libc::c_int;
+use std::ffi::c_int;
 
 extern "C" {
     static test_static: c_int;

--- a/tests/ui/extern/extern-const.fixed
+++ b/tests/ui/extern/extern-const.fixed
@@ -6,12 +6,12 @@
 
 //@ run-rustfix
 //@ compile-flags: -g
-#![feature(rustc_private)]
-extern crate libc;
+
+use std::ffi::c_int;
 
 #[link(name = "rust_test_helpers", kind = "static")]
 extern "C" {
-    static rust_dbg_static_mut: libc::c_int; //~ ERROR extern items cannot be `const`
+    static rust_dbg_static_mut: c_int; //~ ERROR extern items cannot be `const`
 }
 
 fn main() {

--- a/tests/ui/extern/extern-const.rs
+++ b/tests/ui/extern/extern-const.rs
@@ -6,12 +6,12 @@
 
 //@ run-rustfix
 //@ compile-flags: -g
-#![feature(rustc_private)]
-extern crate libc;
+
+use std::ffi::c_int;
 
 #[link(name = "rust_test_helpers", kind = "static")]
 extern "C" {
-    const rust_dbg_static_mut: libc::c_int; //~ ERROR extern items cannot be `const`
+    const rust_dbg_static_mut: c_int; //~ ERROR extern items cannot be `const`
 }
 
 fn main() {

--- a/tests/ui/extern/extern-const.stderr
+++ b/tests/ui/extern/extern-const.stderr
@@ -1,7 +1,7 @@
 error: extern items cannot be `const`
   --> $DIR/extern-const.rs:14:11
    |
-LL |     const rust_dbg_static_mut: libc::c_int;
+LL |     const rust_dbg_static_mut: c_int;
    |     ------^^^^^^^^^^^^^^^^^^^
    |     |
    |     help: try using a static value: `static`

--- a/tests/ui/internal-lints/existing_doc_keyword.rs
+++ b/tests/ui/internal-lints/existing_doc_keyword.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -Z unstable-options
 
-#![feature(rustc_private)]
 #![feature(rustdoc_internals)]
 
 #![crate_type = "lib"]

--- a/tests/ui/internal-lints/existing_doc_keyword.stderr
+++ b/tests/ui/internal-lints/existing_doc_keyword.stderr
@@ -1,12 +1,12 @@
 error: found non-existing keyword `tadam` used in `#[doc(keyword = "...")]`
-  --> $DIR/existing_doc_keyword.rs:10:1
+  --> $DIR/existing_doc_keyword.rs:9:1
    |
 LL | #[doc(keyword = "tadam")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: only existing keywords are allowed in core/std
 note: the lint level is defined here
-  --> $DIR/existing_doc_keyword.rs:8:9
+  --> $DIR/existing_doc_keyword.rs:7:9
    |
 LL | #![deny(rustc::existing_doc_keyword)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/issues/issue-13259-windows-tcb-trash.rs
+++ b/tests/ui/issues/issue-13259-windows-tcb-trash.rs
@@ -1,7 +1,4 @@
 //@ run-pass
-#![feature(rustc_private)]
-
-extern crate libc;
 
 #[cfg(windows)]
 mod imp {

--- a/tests/ui/issues/issue-22034.rs
+++ b/tests/ui/issues/issue-22034.rs
@@ -1,7 +1,3 @@
-#![feature(rustc_private)]
-
-extern crate libc;
-
 fn main() {
     let ptr: *mut () = core::ptr::null_mut();
     let _: &mut dyn Fn() = unsafe {

--- a/tests/ui/issues/issue-22034.stderr
+++ b/tests/ui/issues/issue-22034.stderr
@@ -1,5 +1,5 @@
 error[E0277]: expected a `Fn()` closure, found `()`
-  --> $DIR/issue-22034.rs:8:16
+  --> $DIR/issue-22034.rs:4:16
    |
 LL |         &mut *(ptr as *mut dyn Fn())
    |                ^^^ expected an `Fn()` closure, found `()`

--- a/tests/ui/issues/issue-2214.rs
+++ b/tests/ui/issues/issue-2214.rs
@@ -1,11 +1,8 @@
 //@ run-pass
 //@ ignore-wasm32 wasi-libc does not have lgamma
 //@ ignore-sgx no libc
-#![feature(rustc_private)]
 
-extern crate libc;
-
-use libc::{c_double, c_int};
+use std::ffi::{c_double, c_int};
 use std::mem;
 
 fn to_c_int(v: &mut isize) -> &mut c_int {
@@ -19,8 +16,7 @@ fn lgamma(n: c_double, value: &mut isize) -> c_double {
 }
 
 mod m {
-    use libc::{c_double, c_int};
-
+    use std::ffi::{c_double, c_int};
     extern "C" {
         #[cfg(all(unix, not(target_os = "vxworks")))]
         #[link_name="lgamma_r"]

--- a/tests/ui/issues/issue-3656.rs
+++ b/tests/ui/issues/issue-3656.rs
@@ -6,10 +6,8 @@
 // the alignment of elements into account.
 
 //@ pretty-expanded FIXME #23616
-#![feature(rustc_private)]
 
-extern crate libc;
-use libc::{c_uint, c_void};
+use std::ffi::{c_uint, c_void};
 
 pub struct KEYGEN {
     hash_algorithm: [c_uint; 2],

--- a/tests/ui/lint/lint-ctypes-fn.rs
+++ b/tests/ui/lint/lint-ctypes-fn.rs
@@ -1,12 +1,9 @@
-#![feature(rustc_private)]
-
 #![allow(private_interfaces)]
 #![deny(improper_ctypes_definitions)]
 
-extern crate libc;
-
 use std::default::Default;
 use std::marker::PhantomData;
+use std::ffi::{c_int, c_uint};
 
 trait Trait {}
 
@@ -165,10 +162,10 @@ pub extern "C" fn good17(p: TransparentCustomZst) { }
 pub extern "C" fn good18(_: &String) { }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub extern "C" fn good1(size: *const libc::c_int) { }
+pub extern "C" fn good1(size: *const c_int) { }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub extern "C" fn good2(size: *const libc::c_uint) { }
+pub extern "C" fn good2(size: *const c_uint) { }
 
 pub extern "C" fn unused_generic1<T>(size: *const Foo) { }
 

--- a/tests/ui/lint/lint-ctypes-fn.stderr
+++ b/tests/ui/lint/lint-ctypes-fn.stderr
@@ -1,5 +1,5 @@
 error: `extern` fn uses type `[u32]`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:73:33
+  --> $DIR/lint-ctypes-fn.rs:70:33
    |
 LL | pub extern "C" fn slice_type(p: &[u32]) { }
    |                                 ^^^^^^ not FFI-safe
@@ -7,13 +7,13 @@ LL | pub extern "C" fn slice_type(p: &[u32]) { }
    = help: consider using a raw pointer instead
    = note: slices have no C equivalent
 note: the lint level is defined here
-  --> $DIR/lint-ctypes-fn.rs:4:9
+  --> $DIR/lint-ctypes-fn.rs:2:9
    |
 LL | #![deny(improper_ctypes_definitions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern` fn uses type `str`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:76:31
+  --> $DIR/lint-ctypes-fn.rs:73:31
    |
 LL | pub extern "C" fn str_type(p: &str) { }
    |                               ^^^^ not FFI-safe
@@ -22,7 +22,7 @@ LL | pub extern "C" fn str_type(p: &str) { }
    = note: string slices have no C equivalent
 
 error: `extern` fn uses type `Box<[u8]>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:83:34
+  --> $DIR/lint-ctypes-fn.rs:80:34
    |
 LL | pub extern "C" fn boxed_slice(p: Box<[u8]>) { }
    |                                  ^^^^^^^^^ not FFI-safe
@@ -30,7 +30,7 @@ LL | pub extern "C" fn boxed_slice(p: Box<[u8]>) { }
    = note: box cannot be represented as a single pointer
 
 error: `extern` fn uses type `Box<str>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:86:35
+  --> $DIR/lint-ctypes-fn.rs:83:35
    |
 LL | pub extern "C" fn boxed_string(p: Box<str>) { }
    |                                   ^^^^^^^^ not FFI-safe
@@ -38,7 +38,7 @@ LL | pub extern "C" fn boxed_string(p: Box<str>) { }
    = note: box cannot be represented as a single pointer
 
 error: `extern` fn uses type `Box<dyn Trait>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:89:34
+  --> $DIR/lint-ctypes-fn.rs:86:34
    |
 LL | pub extern "C" fn boxed_trait(p: Box<dyn Trait>) { }
    |                                  ^^^^^^^^^^^^^^ not FFI-safe
@@ -46,7 +46,7 @@ LL | pub extern "C" fn boxed_trait(p: Box<dyn Trait>) { }
    = note: box cannot be represented as a single pointer
 
 error: `extern` fn uses type `char`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:92:32
+  --> $DIR/lint-ctypes-fn.rs:89:32
    |
 LL | pub extern "C" fn char_type(p: char) { }
    |                                ^^^^ not FFI-safe
@@ -55,7 +55,7 @@ LL | pub extern "C" fn char_type(p: char) { }
    = note: the `char` type has no C equivalent
 
 error: `extern` fn uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:95:32
+  --> $DIR/lint-ctypes-fn.rs:92:32
    |
 LL | pub extern "C" fn i128_type(p: i128) { }
    |                                ^^^^ not FFI-safe
@@ -63,7 +63,7 @@ LL | pub extern "C" fn i128_type(p: i128) { }
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` fn uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:98:32
+  --> $DIR/lint-ctypes-fn.rs:95:32
    |
 LL | pub extern "C" fn u128_type(p: u128) { }
    |                                ^^^^ not FFI-safe
@@ -71,7 +71,7 @@ LL | pub extern "C" fn u128_type(p: u128) { }
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:101:33
+  --> $DIR/lint-ctypes-fn.rs:98:33
    |
 LL | pub extern "C" fn tuple_type(p: (i32, i32)) { }
    |                                 ^^^^^^^^^^ not FFI-safe
@@ -80,7 +80,7 @@ LL | pub extern "C" fn tuple_type(p: (i32, i32)) { }
    = note: tuples have unspecified layout
 
 error: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:104:34
+  --> $DIR/lint-ctypes-fn.rs:101:34
    |
 LL | pub extern "C" fn tuple_type2(p: I32Pair) { }
    |                                  ^^^^^^^ not FFI-safe
@@ -89,7 +89,7 @@ LL | pub extern "C" fn tuple_type2(p: I32Pair) { }
    = note: tuples have unspecified layout
 
 error: `extern` fn uses type `ZeroSize`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:107:32
+  --> $DIR/lint-ctypes-fn.rs:104:32
    |
 LL | pub extern "C" fn zero_size(p: ZeroSize) { }
    |                                ^^^^^^^^ not FFI-safe
@@ -97,26 +97,26 @@ LL | pub extern "C" fn zero_size(p: ZeroSize) { }
    = help: consider adding a member to this struct
    = note: this struct has no fields
 note: the type is defined here
-  --> $DIR/lint-ctypes-fn.rs:28:1
+  --> $DIR/lint-ctypes-fn.rs:25:1
    |
 LL | pub struct ZeroSize;
    | ^^^^^^^^^^^^^^^^^^^
 
 error: `extern` fn uses type `ZeroSizeWithPhantomData`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:110:40
+  --> $DIR/lint-ctypes-fn.rs:107:40
    |
 LL | pub extern "C" fn zero_size_phantom(p: ZeroSizeWithPhantomData) { }
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
 note: the type is defined here
-  --> $DIR/lint-ctypes-fn.rs:63:1
+  --> $DIR/lint-ctypes-fn.rs:60:1
    |
 LL | pub struct ZeroSizeWithPhantomData(PhantomData<i32>);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern` fn uses type `PhantomData<bool>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:113:51
+  --> $DIR/lint-ctypes-fn.rs:110:51
    |
 LL | pub extern "C" fn zero_size_phantom_toplevel() -> PhantomData<bool> {
    |                                                   ^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -124,7 +124,7 @@ LL | pub extern "C" fn zero_size_phantom_toplevel() -> PhantomData<bool> {
    = note: composed only of `PhantomData`
 
 error: `extern` fn uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:118:30
+  --> $DIR/lint-ctypes-fn.rs:115:30
    |
 LL | pub extern "C" fn fn_type(p: RustFn) { }
    |                              ^^^^^^ not FFI-safe
@@ -133,7 +133,7 @@ LL | pub extern "C" fn fn_type(p: RustFn) { }
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` fn uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:121:31
+  --> $DIR/lint-ctypes-fn.rs:118:31
    |
 LL | pub extern "C" fn fn_type2(p: fn()) { }
    |                               ^^^^ not FFI-safe
@@ -142,7 +142,7 @@ LL | pub extern "C" fn fn_type2(p: fn()) { }
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` fn uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:126:39
+  --> $DIR/lint-ctypes-fn.rs:123:39
    |
 LL | pub extern "C" fn transparent_i128(p: TransparentI128) { }
    |                                       ^^^^^^^^^^^^^^^ not FFI-safe
@@ -150,7 +150,7 @@ LL | pub extern "C" fn transparent_i128(p: TransparentI128) { }
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` fn uses type `str`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:129:38
+  --> $DIR/lint-ctypes-fn.rs:126:38
    |
 LL | pub extern "C" fn transparent_str(p: TransparentStr) { }
    |                                      ^^^^^^^^^^^^^^ not FFI-safe
@@ -159,7 +159,7 @@ LL | pub extern "C" fn transparent_str(p: TransparentStr) { }
    = note: string slices have no C equivalent
 
 error: `extern` fn uses type `PhantomData<bool>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:175:43
+  --> $DIR/lint-ctypes-fn.rs:172:43
    |
 LL | pub extern "C" fn unused_generic2<T>() -> PhantomData<bool> {
    |                                           ^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -167,7 +167,7 @@ LL | pub extern "C" fn unused_generic2<T>() -> PhantomData<bool> {
    = note: composed only of `PhantomData`
 
 error: `extern` fn uses type `Vec<T>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:188:39
+  --> $DIR/lint-ctypes-fn.rs:185:39
    |
 LL | pub extern "C" fn used_generic4<T>(x: Vec<T>) { }
    |                                       ^^^^^^ not FFI-safe
@@ -176,7 +176,7 @@ LL | pub extern "C" fn used_generic4<T>(x: Vec<T>) { }
    = note: this struct has unspecified layout
 
 error: `extern` fn uses type `Vec<T>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-fn.rs:191:41
+  --> $DIR/lint-ctypes-fn.rs:188:41
    |
 LL | pub extern "C" fn used_generic5<T>() -> Vec<T> {
    |                                         ^^^^^^ not FFI-safe

--- a/tests/ui/lint/lint-ctypes.rs
+++ b/tests/ui/lint/lint-ctypes.rs
@@ -3,10 +3,9 @@
 #![allow(private_interfaces)]
 #![deny(improper_ctypes)]
 
-extern crate libc;
-
 use std::cell::UnsafeCell;
 use std::marker::PhantomData;
+use std::ffi::{c_int, c_uint};
 
 trait Bar { }
 trait Mirror { type It: ?Sized; }
@@ -110,8 +109,8 @@ extern "C" {
 
 #[cfg(not(target_arch = "wasm32"))]
 extern "C" {
-    pub fn good1(size: *const libc::c_int);
-    pub fn good2(size: *const libc::c_uint);
+    pub fn good1(size: *const c_int);
+    pub fn good2(size: *const c_uint);
 }
 
 fn main() {

--- a/tests/ui/lint/lint-ctypes.stderr
+++ b/tests/ui/lint/lint-ctypes.stderr
@@ -1,5 +1,5 @@
 error: `extern` block uses type `Foo`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:48:28
+  --> $DIR/lint-ctypes.rs:47:28
    |
 LL |     pub fn ptr_type1(size: *const Foo);
    |                            ^^^^^^^^^^ not FFI-safe
@@ -7,7 +7,7 @@ LL |     pub fn ptr_type1(size: *const Foo);
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
 note: the type is defined here
-  --> $DIR/lint-ctypes.rs:26:1
+  --> $DIR/lint-ctypes.rs:25:1
    |
 LL | pub struct Foo;
    | ^^^^^^^^^^^^^^
@@ -18,7 +18,7 @@ LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
 
 error: `extern` block uses type `Foo`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:49:28
+  --> $DIR/lint-ctypes.rs:48:28
    |
 LL |     pub fn ptr_type2(size: *const Foo);
    |                            ^^^^^^^^^^ not FFI-safe
@@ -26,13 +26,13 @@ LL |     pub fn ptr_type2(size: *const Foo);
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
 note: the type is defined here
-  --> $DIR/lint-ctypes.rs:26:1
+  --> $DIR/lint-ctypes.rs:25:1
    |
 LL | pub struct Foo;
    | ^^^^^^^^^^^^^^
 
 error: `extern` block uses type `((),)`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:51:25
+  --> $DIR/lint-ctypes.rs:50:25
    |
 LL |     pub fn ptr_tuple(p: *const ((),));
    |                         ^^^^^^^^^^^^ not FFI-safe
@@ -41,7 +41,7 @@ LL |     pub fn ptr_tuple(p: *const ((),));
    = note: tuples have unspecified layout
 
 error: `extern` block uses type `[u32]`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:52:26
+  --> $DIR/lint-ctypes.rs:51:26
    |
 LL |     pub fn slice_type(p: &[u32]);
    |                          ^^^^^^ not FFI-safe
@@ -50,7 +50,7 @@ LL |     pub fn slice_type(p: &[u32]);
    = note: slices have no C equivalent
 
 error: `extern` block uses type `str`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:53:24
+  --> $DIR/lint-ctypes.rs:52:24
    |
 LL |     pub fn str_type(p: &str);
    |                        ^^^^ not FFI-safe
@@ -59,7 +59,7 @@ LL |     pub fn str_type(p: &str);
    = note: string slices have no C equivalent
 
 error: `extern` block uses type `Box<u32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:54:24
+  --> $DIR/lint-ctypes.rs:53:24
    |
 LL |     pub fn box_type(p: Box<u32>);
    |                        ^^^^^^^^ not FFI-safe
@@ -68,7 +68,7 @@ LL |     pub fn box_type(p: Box<u32>);
    = note: this struct has unspecified layout
 
 error: `extern` block uses type `Option<Box<u32>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:55:28
+  --> $DIR/lint-ctypes.rs:54:28
    |
 LL |     pub fn opt_box_type(p: Option<Box<u32>>);
    |                            ^^^^^^^^^^^^^^^^ not FFI-safe
@@ -77,7 +77,7 @@ LL |     pub fn opt_box_type(p: Option<Box<u32>>);
    = note: enum has no representation hint
 
 error: `extern` block uses type `char`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:57:25
+  --> $DIR/lint-ctypes.rs:56:25
    |
 LL |     pub fn char_type(p: char);
    |                         ^^^^ not FFI-safe
@@ -86,7 +86,7 @@ LL |     pub fn char_type(p: char);
    = note: the `char` type has no C equivalent
 
 error: `extern` block uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:58:25
+  --> $DIR/lint-ctypes.rs:57:25
    |
 LL |     pub fn i128_type(p: i128);
    |                         ^^^^ not FFI-safe
@@ -94,7 +94,7 @@ LL |     pub fn i128_type(p: i128);
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:59:25
+  --> $DIR/lint-ctypes.rs:58:25
    |
 LL |     pub fn u128_type(p: u128);
    |                         ^^^^ not FFI-safe
@@ -102,7 +102,7 @@ LL |     pub fn u128_type(p: u128);
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `dyn Bar`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:60:26
+  --> $DIR/lint-ctypes.rs:59:26
    |
 LL |     pub fn trait_type(p: &dyn Bar);
    |                          ^^^^^^^^ not FFI-safe
@@ -110,7 +110,7 @@ LL |     pub fn trait_type(p: &dyn Bar);
    = note: trait objects have no C equivalent
 
 error: `extern` block uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:61:26
+  --> $DIR/lint-ctypes.rs:60:26
    |
 LL |     pub fn tuple_type(p: (i32, i32));
    |                          ^^^^^^^^^^ not FFI-safe
@@ -119,7 +119,7 @@ LL |     pub fn tuple_type(p: (i32, i32));
    = note: tuples have unspecified layout
 
 error: `extern` block uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:62:27
+  --> $DIR/lint-ctypes.rs:61:27
    |
 LL |     pub fn tuple_type2(p: I32Pair);
    |                           ^^^^^^^ not FFI-safe
@@ -128,7 +128,7 @@ LL |     pub fn tuple_type2(p: I32Pair);
    = note: tuples have unspecified layout
 
 error: `extern` block uses type `ZeroSize`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:63:25
+  --> $DIR/lint-ctypes.rs:62:25
    |
 LL |     pub fn zero_size(p: ZeroSize);
    |                         ^^^^^^^^ not FFI-safe
@@ -136,26 +136,26 @@ LL |     pub fn zero_size(p: ZeroSize);
    = help: consider adding a member to this struct
    = note: this struct has no fields
 note: the type is defined here
-  --> $DIR/lint-ctypes.rs:22:1
+  --> $DIR/lint-ctypes.rs:21:1
    |
 LL | pub struct ZeroSize;
    | ^^^^^^^^^^^^^^^^^^^
 
 error: `extern` block uses type `ZeroSizeWithPhantomData`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:64:33
+  --> $DIR/lint-ctypes.rs:63:33
    |
 LL |     pub fn zero_size_phantom(p: ZeroSizeWithPhantomData);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
 note: the type is defined here
-  --> $DIR/lint-ctypes.rs:45:1
+  --> $DIR/lint-ctypes.rs:44:1
    |
 LL | pub struct ZeroSizeWithPhantomData(::std::marker::PhantomData<i32>);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern` block uses type `PhantomData<bool>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:67:12
+  --> $DIR/lint-ctypes.rs:66:12
    |
 LL |         -> ::std::marker::PhantomData<bool>;
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -163,7 +163,7 @@ LL |         -> ::std::marker::PhantomData<bool>;
    = note: composed only of `PhantomData`
 
 error: `extern` block uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:68:23
+  --> $DIR/lint-ctypes.rs:67:23
    |
 LL |     pub fn fn_type(p: RustFn);
    |                       ^^^^^^ not FFI-safe
@@ -172,7 +172,7 @@ LL |     pub fn fn_type(p: RustFn);
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` block uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:69:24
+  --> $DIR/lint-ctypes.rs:68:24
    |
 LL |     pub fn fn_type2(p: fn());
    |                        ^^^^ not FFI-safe
@@ -181,7 +181,7 @@ LL |     pub fn fn_type2(p: fn());
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` block uses type `Box<u32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:70:28
+  --> $DIR/lint-ctypes.rs:69:28
    |
 LL |     pub fn fn_contained(p: RustBadRet);
    |                            ^^^^^^^^^^ not FFI-safe
@@ -190,7 +190,7 @@ LL |     pub fn fn_contained(p: RustBadRet);
    = note: this struct has unspecified layout
 
 error: `extern` block uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:71:32
+  --> $DIR/lint-ctypes.rs:70:32
    |
 LL |     pub fn transparent_i128(p: TransparentI128);
    |                                ^^^^^^^^^^^^^^^ not FFI-safe
@@ -198,7 +198,7 @@ LL |     pub fn transparent_i128(p: TransparentI128);
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `str`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:72:31
+  --> $DIR/lint-ctypes.rs:71:31
    |
 LL |     pub fn transparent_str(p: TransparentStr);
    |                               ^^^^^^^^^^^^^^ not FFI-safe
@@ -207,7 +207,7 @@ LL |     pub fn transparent_str(p: TransparentStr);
    = note: string slices have no C equivalent
 
 error: `extern` block uses type `Box<u32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:73:30
+  --> $DIR/lint-ctypes.rs:72:30
    |
 LL |     pub fn transparent_fn(p: TransparentBadFn);
    |                              ^^^^^^^^^^^^^^^^ not FFI-safe
@@ -216,7 +216,7 @@ LL |     pub fn transparent_fn(p: TransparentBadFn);
    = note: this struct has unspecified layout
 
 error: `extern` block uses type `[u8; 8]`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:74:27
+  --> $DIR/lint-ctypes.rs:73:27
    |
 LL |     pub fn raw_array(arr: [u8; 8]);
    |                           ^^^^^^^ not FFI-safe
@@ -225,7 +225,7 @@ LL |     pub fn raw_array(arr: [u8; 8]);
    = note: passing raw arrays by value is not FFI-safe
 
 error: `extern` block uses type `Option<UnsafeCell<extern "C" fn()>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:76:26
+  --> $DIR/lint-ctypes.rs:75:26
    |
 LL |     pub fn no_niche_a(a: Option<UnsafeCell<extern fn()>>);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -234,7 +234,7 @@ LL |     pub fn no_niche_a(a: Option<UnsafeCell<extern fn()>>);
    = note: enum has no representation hint
 
 error: `extern` block uses type `Option<UnsafeCell<&i32>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:78:26
+  --> $DIR/lint-ctypes.rs:77:26
    |
 LL |     pub fn no_niche_b(b: Option<UnsafeCell<&i32>>);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -243,7 +243,7 @@ LL |     pub fn no_niche_b(b: Option<UnsafeCell<&i32>>);
    = note: enum has no representation hint
 
 error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:81:34
+  --> $DIR/lint-ctypes.rs:80:34
    |
 LL |     pub static static_u128_type: u128;
    |                                  ^^^^ not FFI-safe
@@ -251,7 +251,7 @@ LL |     pub static static_u128_type: u128;
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:82:40
+  --> $DIR/lint-ctypes.rs:81:40
    |
 LL |     pub static static_u128_array_type: [u128; 16];
    |                                        ^^^^^^^^^^ not FFI-safe

--- a/tests/ui/non-copyable-void.rs
+++ b/tests/ui/non-copyable-void.rs
@@ -1,10 +1,8 @@
-#![feature(rustc_private)]
-
-extern crate libc;
+use std::ffi::c_void;
 
 fn main() {
     let x : *const Vec<isize> = &vec![1,2,3];
-    let y : *const libc::c_void = x as *const libc::c_void;
+    let y : *const c_void = x as *const c_void;
     unsafe {
         let _z = (*y).clone();
         //~^ ERROR no method named `clone` found

--- a/tests/ui/non-copyable-void.stderr
+++ b/tests/ui/non-copyable-void.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `clone` found for enum `c_void` in the current scope
-  --> $DIR/non-copyable-void.rs:9:23
+  --> $DIR/non-copyable-void.rs:7:23
    |
 LL |         let _z = (*y).clone();
    |                       ^^^^^ method not found in `c_void`

--- a/tests/ui/process/core-run-destroy.rs
+++ b/tests/ui/process/core-run-destroy.rs
@@ -14,10 +14,6 @@
 // memory, which makes for some *confusing* logs. That's why these are here
 // instead of in std.
 
-#![feature(rustc_private, duration)]
-
-extern crate libc;
-
 use std::process::{self, Command, Child, Output, Stdio};
 use std::str;
 use std::sync::mpsc::channel;

--- a/tests/ui/process/process-panic-after-fork.rs
+++ b/tests/ui/process/process-panic-after-fork.rs
@@ -14,13 +14,12 @@
 extern crate libc;
 
 use std::alloc::{GlobalAlloc, Layout};
+use std::ffi::c_int;
 use std::fmt;
 use std::panic::{self, panic_any};
 use std::os::unix::process::{CommandExt, ExitStatusExt};
 use std::process::{self, Command, ExitStatus};
 use std::sync::atomic::{AtomicU32, Ordering};
-
-use libc::c_int;
 
 /// This stunt allocator allows us to spot heap allocations in the child.
 struct PidChecking<A> {


### PR DESCRIPTION
I started looking into our use of `rustc_private` + `extern crate libc;` in tests because of https://github.com/rust-lang/rust/pull/123938 and it looks like some fraction of the users of libc simply don't need the libc crate anymore.