### PR TITLE
Reserve guarded string literals (RFC 3593)

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -740,6 +740,9 @@ lint_reserved_prefix = prefix `{$prefix}` is unknown
     .label = unknown prefix
     .suggestion = insert whitespace here to avoid this being parsed as a prefix in Rust 2021
 
+lint_reserved_string = will be parsed as a guarded string in Rust 2024
+    .suggestion = insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+
 lint_shadowed_into_iter =
     this method call resolves to `<&{$target} as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<{$target} as IntoIterator>::into_iter` in Rust {$edition}
     .use_iter_suggestion = use `.iter()` instead of `.into_iter()` to avoid ambiguity

--- a/compiler/rustc_lint/src/context/diagnostics.rs
+++ b/compiler/rustc_lint/src/context/diagnostics.rs
@@ -176,6 +176,9 @@ pub(super) fn decorate_lint(sess: &Session, diagnostic: BuiltinLintDiag, diag: &
             lints::RawPrefix { label: label_span, suggestion: label_span.shrink_to_hi() }
                 .decorate_lint(diag);
         }
+        BuiltinLintDiag::ReservedString(suggestion) => {
+            lints::ReservedString { suggestion }.decorate_lint(diag);
+        }
         BuiltinLintDiag::UnusedBuiltinAttribute { attr_name, macro_name, invoc_span } => {
             lints::UnusedBuiltinAttribute { invoc_span, attr_name, macro_name }.decorate_lint(diag);
         }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3053,3 +3053,10 @@ pub(crate) enum MutRefSugg {
 #[derive(LintDiagnostic)]
 #[diag(lint_unqualified_local_imports)]
 pub(crate) struct UnqualifiedLocalImportsDiag {}
+
+#[derive(LintDiagnostic)]
+#[diag(lint_reserved_string)]
+pub(crate) struct ReservedString {
+    #[suggestion(code = " ", applicability = "machine-applicable")]
+    pub suggestion: Span,
+}

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -92,6 +92,7 @@ declare_lint_pass! {
         RUST_2021_INCOMPATIBLE_OR_PATTERNS,
         RUST_2021_PREFIXES_INCOMPATIBLE_SYNTAX,
         RUST_2021_PRELUDE_COLLISIONS,
+        RUST_2024_GUARDED_STRING_INCOMPATIBLE_SYNTAX,
         RUST_2024_INCOMPATIBLE_PAT,
         RUST_2024_PRELUDE_COLLISIONS,
         SELF_CONSTRUCTOR_FROM_OUTER_ITEM,
@@ -4995,4 +4996,44 @@ declare_lint! {
     pub PTR_TO_INTEGER_TRANSMUTE_IN_CONSTS,
     Warn,
     "detects pointer to integer transmutes in const functions and associated constants",
+}
+
+declare_lint! {
+    /// The `rust_2024_guarded_string_incompatible_syntax` lint detects `#` tokens
+    /// that will be parsed as part of a guarded string literal in Rust 2024.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,edition2021,compile_fail
+    /// #![deny(rust_2024_guarded_string_incompatible_syntax)]
+    ///
+    /// macro_rules! m {
+    ///     (# $x:expr #) => ();
+    ///     (# $x:expr) => ();
+    /// }
+    ///
+    /// m!(#"hey"#);
+    /// m!(#"hello");
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Prior to Rust 2024, `#"hey"#` is three tokens: the first `#`
+    /// followed by the string literal `"hey"` then the final `#`.
+    /// In Rust 2024, the whole sequence is considered a single token.
+    ///
+    /// This lint suggests to add whitespace between the leading `#`
+    /// and the string to keep them separated in Rust 2024.
+    // Allow this lint -- rustdoc doesn't yet support threading edition into this lint's parser.
+    #[allow(rustdoc::invalid_rust_codeblocks)]
+    pub RUST_2024_GUARDED_STRING_INCOMPATIBLE_SYNTAX,
+    Allow,
+    "will be parsed as a guarded string in Rust 2024",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
+        reference: "issue #123735 <https://github.com/rust-lang/rust/issues/123735>",
+    };
+    crate_level_only
 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -614,6 +614,8 @@ pub enum BuiltinLintDiag {
     ReservedPrefix(Span, String),
     /// `'r#` in edition < 2021.
     RawPrefix(Span),
+    /// `##` or `#"` is edition < 2024.
+    ReservedString(Span),
     TrailingMacro(bool, Ident),
     BreakWithLabelAndLoop(Span),
     UnicodeTextFlow(Span, String),

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -706,6 +706,10 @@ parse_require_colon_after_labeled_expression = labeled expression must be follow
     .label = the label
     .suggestion = add `:` after the label
 
+parse_reserved_string = invalid string literal
+    .note = unprefixed guarded string literals are reserved for future use since Rust 2024
+    .suggestion_whitespace = consider inserting whitespace here
+
 parse_return_types_use_thin_arrow = return types are denoted using `->`
     .suggestion = use `->` instead
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2111,6 +2111,24 @@ pub(crate) enum UnknownPrefixSugg {
 }
 
 #[derive(Diagnostic)]
+#[diag(parse_reserved_string)]
+#[note]
+pub(crate) struct ReservedString {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: Option<GuardedStringSugg>,
+}
+#[derive(Subdiagnostic)]
+#[suggestion(
+    parse_suggestion_whitespace,
+    code = " ",
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
+pub(crate) struct GuardedStringSugg(#[primary_span] pub Span);
+
+#[derive(Diagnostic)]
 #[diag(parse_too_many_hashes)]
 pub(crate) struct TooManyHashes {
     #[primary_span]

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -845,6 +845,7 @@ impl<'src> Classifier<'src> {
                 // Number literals.
                 LiteralKind::Float { .. } | LiteralKind::Int { .. } => Class::Number,
             },
+            TokenKind::GuardedStrPrefix => return no_highlight(sink),
             TokenKind::Ident | TokenKind::RawIdent if lookahead == Some(TokenKind::Bang) => {
                 self.in_macro = true;
                 sink(Highlight::EnterSpan { class: Class::Macro(self.new_span(before, text)) });

--- a/src/tools/rust-analyzer/crates/parser/src/lexed_str.rs
+++ b/src/tools/rust-analyzer/crates/parser/src/lexed_str.rs
@@ -187,6 +187,12 @@ impl<'a> Converter<'a> {
                 }
 
                 rustc_lexer::TokenKind::RawIdent => IDENT,
+
+                rustc_lexer::TokenKind::GuardedStrPrefix => {
+                    err = "Invalid string literal (reserved syntax)";
+                    ERROR
+                },
+
                 rustc_lexer::TokenKind::Literal { kind, .. } => {
                     self.extend_literal(token_text.len(), kind);
                     return;

--- a/tests/ui/rust-2024/auxiliary/reserved-guarded-strings-macro-2021.rs
+++ b/tests/ui/rust-2024/auxiliary/reserved-guarded-strings-macro-2021.rs
@@ -1,0 +1,20 @@
+//@ force-host
+//@ edition:2021
+//@ no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use std::str::FromStr;
+
+#[proc_macro]
+pub fn number_of_tokens_in_a_guarded_string_literal(_: TokenStream) -> TokenStream {
+    TokenStream::from_str("#\"abc\"#").unwrap().into_iter().count().to_string().parse().unwrap()
+}
+
+#[proc_macro]
+pub fn number_of_tokens_in_a_guarded_unterminated_string_literal(_: TokenStream) -> TokenStream {
+    TokenStream::from_str("#\"abc\"").unwrap().into_iter().count().to_string().parse().unwrap()
+}

--- a/tests/ui/rust-2024/auxiliary/reserved-guarded-strings-macro-2024.rs
+++ b/tests/ui/rust-2024/auxiliary/reserved-guarded-strings-macro-2024.rs
@@ -1,0 +1,21 @@
+//@ force-host
+//@ compile-flags: -Zunstable-options
+//@ edition:2024
+//@ no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use std::str::FromStr;
+
+#[proc_macro]
+pub fn number_of_tokens_in_a_guarded_string_literal(_: TokenStream) -> TokenStream {
+    TokenStream::from_str("#\"abc\"#").unwrap().into_iter().count().to_string().parse().unwrap()
+}
+
+#[proc_macro]
+pub fn number_of_tokens_in_a_guarded_unterminated_string_literal(_: TokenStream) -> TokenStream {
+    TokenStream::from_str("#\"abc\"").unwrap().into_iter().count().to_string().parse().unwrap()
+}

--- a/tests/ui/rust-2024/reserved-guarded-strings-lexing.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings-lexing.rs
@@ -1,0 +1,80 @@
+//@ edition:2021
+// ignore-tidy-linelength
+
+#![warn(rust_2024_guarded_string_incompatible_syntax)]
+
+macro_rules! demo2 {
+    ( $a:tt $b:tt ) => { println!("two tokens") };
+}
+
+macro_rules! demo3 {
+    ( $a:tt $b:tt $c:tt ) => { println!("three tokens") };
+}
+
+macro_rules! demo4 {
+    ( $a:tt $b:tt $c:tt $d:tt ) => { println!("four tokens") };
+}
+
+macro_rules! demo5 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt ) => { println!("five tokens") };
+}
+
+macro_rules! demo7 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt ) => { println!("seven tokens") };
+}
+
+
+fn main() {
+    demo3!(## "foo");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo4!(### "foo");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo4!(## "foo"#);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo7!(### "foo"###);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+
+    demo5!(###"foo"#);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo5!(#"foo"###);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo4!("foo"###);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+
+    // Non-ascii identifiers
+    demo2!(Ñ"foo");
+    //~^ ERROR prefix `Ñ` is unknown
+    demo4!(Ñ#""#);
+    //~^ ERROR prefix `Ñ` is unknown
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo3!(🙃#"");
+    //~^ ERROR identifiers cannot contain emoji
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+}

--- a/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
@@ -1,0 +1,271 @@
+error: prefix `Ñ` is unknown
+  --> $DIR/reserved-guarded-strings-lexing.rs:70:12
+   |
+LL |     demo2!(Ñ"foo");
+   |            ^ unknown prefix
+   |
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo2!(Ñ "foo");
+   |             +
+
+error: prefix `Ñ` is unknown
+  --> $DIR/reserved-guarded-strings-lexing.rs:72:12
+   |
+LL |     demo4!(Ñ#""#);
+   |            ^ unknown prefix
+   |
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo4!(Ñ #""#);
+   |             +
+
+error: identifiers cannot contain emoji: `🙃`
+  --> $DIR/reserved-guarded-strings-lexing.rs:76:12
+   |
+LL |     demo3!(🙃#"");
+   |            ^^
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:28:12
+   |
+LL |     demo3!(## "foo");
+   |            ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+note: the lint level is defined here
+  --> $DIR/reserved-guarded-strings-lexing.rs:4:9
+   |
+LL | #![warn(rust_2024_guarded_string_incompatible_syntax)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo3!(# # "foo");
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:31:12
+   |
+LL |     demo4!(### "foo");
+   |            ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!(# ## "foo");
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:31:13
+   |
+LL |     demo4!(### "foo");
+   |             ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!(## # "foo");
+   |              +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:36:12
+   |
+LL |     demo4!(## "foo"#);
+   |            ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!(# # "foo"#);
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:39:12
+   |
+LL |     demo7!(### "foo"###);
+   |            ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo7!(# ## "foo"###);
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:39:13
+   |
+LL |     demo7!(### "foo"###);
+   |             ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo7!(## # "foo"###);
+   |              +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:39:21
+   |
+LL |     demo7!(### "foo"###);
+   |                     ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo7!(### "foo"# ##);
+   |                      +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:39:22
+   |
+LL |     demo7!(### "foo"###);
+   |                      ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo7!(### "foo"## #);
+   |                       +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:49:12
+   |
+LL |     demo5!(###"foo"#);
+   |            ^^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo5!(# ##"foo"#);
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:49:13
+   |
+LL |     demo5!(###"foo"#);
+   |             ^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo5!(## #"foo"#);
+   |              +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:49:14
+   |
+LL |     demo5!(###"foo"#);
+   |              ^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo5!(### "foo"#);
+   |               +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:56:12
+   |
+LL |     demo5!(#"foo"###);
+   |            ^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo5!(# "foo"###);
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:56:18
+   |
+LL |     demo5!(#"foo"###);
+   |                  ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo5!(#"foo"# ##);
+   |                   +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:56:19
+   |
+LL |     demo5!(#"foo"###);
+   |                   ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo5!(#"foo"## #);
+   |                    +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:63:17
+   |
+LL |     demo4!("foo"###);
+   |                 ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!("foo"# ##);
+   |                  +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:63:18
+   |
+LL |     demo4!("foo"###);
+   |                  ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!("foo"## #);
+   |                   +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:72:13
+   |
+LL |     demo4!(Ñ#""#);
+   |             ^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!(Ñ# ""#);
+   |              +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:76:13
+   |
+LL |     demo3!(🙃#"");
+   |              ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo3!(🙃# "");
+   |               +
+
+error: aborting due to 3 previous errors; 18 warnings emitted
+

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.fixed
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.fixed
@@ -1,0 +1,99 @@
+//@ check-pass
+//@ run-rustfix
+//@ edition:2021
+
+#![warn(rust_2024_guarded_string_incompatible_syntax)]
+
+macro_rules! demo1 {
+    ( $a:tt ) => { println!("one tokens") };
+}
+
+macro_rules! demo2 {
+    ( $a:tt $b:tt ) => { println!("two tokens") };
+}
+
+macro_rules! demo3 {
+    ( $a:tt $b:tt $c:tt ) => { println!("three tokens") };
+}
+
+macro_rules! demo4 {
+    ( $a:tt $b:tt $c:tt $d:tt ) => { println!("four tokens") };
+}
+
+macro_rules! demo5 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt ) => { println!("five tokens") };
+}
+
+macro_rules! demo6 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt ) => { println!("six tokens") };
+}
+
+
+fn main() {
+    demo1!("");
+    demo2!(# "");
+    demo3!(# ""#);
+    demo2!(# "foo");
+    demo3!(# "foo"#);
+    demo2!("foo"#);
+
+    demo3!(# # "foo");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo4!(# # # "foo");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo4!(# # "foo"#);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo6!(# # # "foo"# #);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+
+    demo4!("foo"# # #);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+
+    demo2!(# "");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo3!(# ""#);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo3!(# # "");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo2!(# "foo");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo3!(# # "foo");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo3!(# "foo"#);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo4!(# # "foo"#);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo5!(# # "foo"# #);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+}

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.rs
@@ -1,0 +1,99 @@
+//@ check-pass
+//@ run-rustfix
+//@ edition:2021
+
+#![warn(rust_2024_guarded_string_incompatible_syntax)]
+
+macro_rules! demo1 {
+    ( $a:tt ) => { println!("one tokens") };
+}
+
+macro_rules! demo2 {
+    ( $a:tt $b:tt ) => { println!("two tokens") };
+}
+
+macro_rules! demo3 {
+    ( $a:tt $b:tt $c:tt ) => { println!("three tokens") };
+}
+
+macro_rules! demo4 {
+    ( $a:tt $b:tt $c:tt $d:tt ) => { println!("four tokens") };
+}
+
+macro_rules! demo5 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt ) => { println!("five tokens") };
+}
+
+macro_rules! demo6 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt ) => { println!("six tokens") };
+}
+
+
+fn main() {
+    demo1!("");
+    demo2!(# "");
+    demo3!(# ""#);
+    demo2!(# "foo");
+    demo3!(# "foo"#);
+    demo2!("foo"#);
+
+    demo3!(## "foo");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo4!(### "foo");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo4!(## "foo"#);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo6!(### "foo"##);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+
+    demo4!("foo"###);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+
+    demo2!(#"");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo3!(#""#);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo3!(##"");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo2!(#"foo");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo3!(##"foo");
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo3!(#"foo"#);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo4!(##"foo"#);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo5!(##"foo"##);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+}

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
@@ -1,0 +1,293 @@
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:40:12
+   |
+LL |     demo3!(## "foo");
+   |            ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+note: the lint level is defined here
+  --> $DIR/reserved-guarded-strings-migration.rs:5:9
+   |
+LL | #![warn(rust_2024_guarded_string_incompatible_syntax)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo3!(# # "foo");
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:43:12
+   |
+LL |     demo4!(### "foo");
+   |            ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!(# ## "foo");
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:43:13
+   |
+LL |     demo4!(### "foo");
+   |             ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!(## # "foo");
+   |              +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:48:12
+   |
+LL |     demo4!(## "foo"#);
+   |            ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!(# # "foo"#);
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:51:12
+   |
+LL |     demo6!(### "foo"##);
+   |            ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo6!(# ## "foo"##);
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:51:13
+   |
+LL |     demo6!(### "foo"##);
+   |             ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo6!(## # "foo"##);
+   |              +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:51:21
+   |
+LL |     demo6!(### "foo"##);
+   |                     ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo6!(### "foo"# #);
+   |                      +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:59:17
+   |
+LL |     demo4!("foo"###);
+   |                 ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!("foo"# ##);
+   |                  +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:59:18
+   |
+LL |     demo4!("foo"###);
+   |                  ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!("foo"## #);
+   |                   +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:65:12
+   |
+LL |     demo2!(#"");
+   |            ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo2!(# "");
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:68:12
+   |
+LL |     demo3!(#""#);
+   |            ^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo3!(# ""#);
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:71:12
+   |
+LL |     demo3!(##"");
+   |            ^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo3!(# #"");
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:71:13
+   |
+LL |     demo3!(##"");
+   |             ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo3!(## "");
+   |              +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:76:12
+   |
+LL |     demo2!(#"foo");
+   |            ^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo2!(# "foo");
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:79:12
+   |
+LL |     demo3!(##"foo");
+   |            ^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo3!(# #"foo");
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:79:13
+   |
+LL |     demo3!(##"foo");
+   |             ^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo3!(## "foo");
+   |              +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:84:12
+   |
+LL |     demo3!(#"foo"#);
+   |            ^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo3!(# "foo"#);
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:87:12
+   |
+LL |     demo4!(##"foo"#);
+   |            ^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!(# #"foo"#);
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:87:13
+   |
+LL |     demo4!(##"foo"#);
+   |             ^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo4!(## "foo"#);
+   |              +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:92:12
+   |
+LL |     demo5!(##"foo"##);
+   |            ^^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo5!(# #"foo"##);
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:92:13
+   |
+LL |     demo5!(##"foo"##);
+   |             ^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo5!(## "foo"##);
+   |              +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:92:19
+   |
+LL |     demo5!(##"foo"##);
+   |                   ^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo5!(##"foo"# #);
+   |                    +
+
+warning: 22 warnings emitted
+

--- a/tests/ui/rust-2024/reserved-guarded-strings-via-macro-2.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings-via-macro-2.rs
@@ -1,0 +1,18 @@
+//@ edition:2021
+//@ aux-build:reserved-guarded-strings-macro-2021.rs
+//@ aux-build:reserved-guarded-strings-macro-2024.rs
+
+extern crate reserved_guarded_strings_macro_2021 as m2021;
+extern crate reserved_guarded_strings_macro_2024 as m2024;
+
+fn main() {
+    // Ok:
+    m2021::number_of_tokens_in_a_guarded_string_literal!();
+    m2021::number_of_tokens_in_a_guarded_unterminated_string_literal!();
+
+    // Error, even though *this* crate is 2021:
+    m2024::number_of_tokens_in_a_guarded_string_literal!();
+    //~^ ERROR invalid string literal
+    m2024::number_of_tokens_in_a_guarded_unterminated_string_literal!();
+    //~^ ERROR invalid string literal
+}

--- a/tests/ui/rust-2024/reserved-guarded-strings-via-macro-2.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-via-macro-2.stderr
@@ -1,0 +1,20 @@
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings-via-macro-2.rs:14:5
+   |
+LL |     m2024::number_of_tokens_in_a_guarded_string_literal!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+   = note: this error originates in the macro `m2024::number_of_tokens_in_a_guarded_string_literal` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings-via-macro-2.rs:16:5
+   |
+LL |     m2024::number_of_tokens_in_a_guarded_unterminated_string_literal!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+   = note: this error originates in the macro `m2024::number_of_tokens_in_a_guarded_unterminated_string_literal` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/rust-2024/reserved-guarded-strings-via-macro.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings-via-macro.rs
@@ -1,0 +1,12 @@
+//@ run-pass
+//@ compile-flags: -Zunstable-options
+//@ edition:2024
+//@ aux-build:reserved-guarded-strings-macro-2021.rs
+
+extern crate reserved_guarded_strings_macro_2021 as m2021;
+
+fn main() {
+    // Ok, even though *this* crate is 2024:
+    assert_eq!(m2021::number_of_tokens_in_a_guarded_string_literal!(), 3);
+    assert_eq!(m2021::number_of_tokens_in_a_guarded_unterminated_string_literal!(), 2);
+}

--- a/tests/ui/rust-2024/reserved-guarded-strings.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings.rs
@@ -1,0 +1,74 @@
+//@ compile-flags: -Zunstable-options
+//@ edition:2024
+// ignore-tidy-linelength
+
+macro_rules! demo1 {
+    ( $a:tt ) => { println!("one tokens") };
+}
+
+macro_rules! demo2 {
+    ( $a:tt $b:tt ) => { println!("two tokens") };
+}
+
+macro_rules! demo3 {
+    ( $a:tt $b:tt $c:tt ) => { println!("three tokens") };
+}
+
+macro_rules! demo4 {
+    ( $a:tt $b:tt $c:tt $d:tt ) => { println!("four tokens") };
+}
+
+macro_rules! demo5 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt ) => { println!("five tokens") };
+}
+
+macro_rules! demo6 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt ) => { println!("six tokens") };
+}
+
+macro_rules! demo7 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt ) => { println!("seven tokens") };
+}
+
+macro_rules! demon {
+    ( $($n:tt)* ) => { println!("unknown number of tokens") };
+}
+
+fn main() {
+    demo1!("");
+    demo2!(# "");
+    demo3!(# ""#);
+    demo2!(# "foo");
+    demo3!(# "foo"#);
+    demo2!("foo"#);
+
+    demo2!(blah"xx"); //~ ERROR prefix `blah` is unknown
+    demo2!(blah#"xx"#);
+    //~^ ERROR prefix `blah` is unknown
+    //~| ERROR invalid string literal
+
+    demo2!(## "foo"); //~ ERROR invalid string literal
+    demo3!("foo"###); //~ ERROR invalid string literal
+    demo3!(### "foo"); //~ ERROR invalid string literal
+    demo3!(## "foo"#); //~ ERROR invalid string literal
+    demo5!(### "foo"###);
+    //~^ ERROR invalid string literal
+    //~| ERROR invalid string literal
+
+    demo1!(#""); //~ ERROR invalid string literal
+    demo1!(#""#); //~ ERROR invalid string literal
+    demo1!(####""); //~ ERROR invalid string literal
+    demo1!(#"foo"); //~ ERROR invalid string literal
+    demo1!(###"foo"); //~ ERROR invalid string literal
+    demo1!(#"foo"#); //~ ERROR invalid string literal
+    demo1!(###"foo"#); //~ ERROR invalid string literal
+    demo1!(###"foo"##); //~ ERROR invalid string literal
+    demo1!(###"foo"###); //~ ERROR invalid string literal
+    demo2!(#"foo"###);
+    //~^ ERROR invalid string literal
+    //~| ERROR invalid string literal
+
+    // More than 255 hashes
+    demon!(####################################################################################################################################################################################################################################################################"foo");
+    //~^ ERROR invalid string literal
+}

--- a/tests/ui/rust-2024/reserved-guarded-strings.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings.stderr
@@ -1,0 +1,254 @@
+error: prefix `blah` is unknown
+  --> $DIR/reserved-guarded-strings.rs:45:12
+   |
+LL |     demo2!(blah"xx");
+   |            ^^^^ unknown prefix
+   |
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo2!(blah "xx");
+   |                +
+
+error: prefix `blah` is unknown
+  --> $DIR/reserved-guarded-strings.rs:46:12
+   |
+LL |     demo2!(blah#"xx"#);
+   |            ^^^^ unknown prefix
+   |
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo2!(blah #"xx"#);
+   |                +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:46:16
+   |
+LL |     demo2!(blah#"xx"#);
+   |                ^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo2!(blah# "xx"#);
+   |                 +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:50:12
+   |
+LL |     demo2!(## "foo");
+   |            ^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo2!(# # "foo");
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:51:17
+   |
+LL |     demo3!("foo"###);
+   |                 ^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo3!("foo"# ##);
+   |                  +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:52:12
+   |
+LL |     demo3!(### "foo");
+   |            ^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo3!(# ## "foo");
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:53:12
+   |
+LL |     demo3!(## "foo"#);
+   |            ^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo3!(# # "foo"#);
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:54:12
+   |
+LL |     demo5!(### "foo"###);
+   |            ^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo5!(# ## "foo"###);
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:54:21
+   |
+LL |     demo5!(### "foo"###);
+   |                     ^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo5!(### "foo"# ##);
+   |                      +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:58:12
+   |
+LL |     demo1!(#"");
+   |            ^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# "");
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:59:12
+   |
+LL |     demo1!(#""#);
+   |            ^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# ""#);
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:60:12
+   |
+LL |     demo1!(####"");
+   |            ^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# ###"");
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:61:12
+   |
+LL |     demo1!(#"foo");
+   |            ^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# "foo");
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:62:12
+   |
+LL |     demo1!(###"foo");
+   |            ^^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# ##"foo");
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:63:12
+   |
+LL |     demo1!(#"foo"#);
+   |            ^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# "foo"#);
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:64:12
+   |
+LL |     demo1!(###"foo"#);
+   |            ^^^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# ##"foo"#);
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:65:12
+   |
+LL |     demo1!(###"foo"##);
+   |            ^^^^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# ##"foo"##);
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:66:12
+   |
+LL |     demo1!(###"foo"###);
+   |            ^^^^^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# ##"foo"###);
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:67:12
+   |
+LL |     demo2!(#"foo"###);
+   |            ^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo2!(# "foo"###);
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:67:19
+   |
+LL |     demo2!(#"foo"###);
+   |                   ^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo2!(#"foo"## #);
+   |                    +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:72:12
+   |
+LL | ...n!(####################################################################################################################################################################################################################################################################"foo...
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demon!(# ###################################################################################################################################################################################################################################################################"foo");
+   |             +
+
+error: aborting due to 21 previous errors
+


### PR DESCRIPTION
Implementation for RFC 3593, including:
- lexer / parser changes
- diagnostics
- migration lint
- tests

We reserve `#"`, `##"`, `###"`, `####`, and any other string of four or more repeated `#`. This avoids infinite lookahead in the lexer, though we still use infinite lookahead in the parser to provide better forward compatibility diagnostics.

This PR does not implement any special lexing of the string internals:
- strings preceded by one or more `#` are denied
- regardless of the number of trailing `#`
- string contents are lexed as if it was just a bare `"string"`

Tracking issue: #123735
RFC: rust-lang/rfcs#3593