### PR TITLE
Disable two debuginfo tests failing under the future GDB 15 release

### DIFF
--- a/tests/debuginfo/include_string.rs
+++ b/tests/debuginfo/include_string.rs
@@ -1,4 +1,6 @@
 //@ min-lldb-version: 310
+//@ ignore-gdb-version: 15.0 - 99.0
+// ^ test temporarily disabled as it fails under gdb 15
 
 //@ compile-flags:-g
 // gdb-command:run

--- a/tests/debuginfo/vec-slices.rs
+++ b/tests/debuginfo/vec-slices.rs
@@ -1,4 +1,6 @@
 //@ min-lldb-version: 310
+//@ ignore-gdb-version: 15.0 - 99.0
+// ^ test temporarily disabled as it fails under gdb 15
 
 //@ compile-flags:-g
 


### PR DESCRIPTION
As seen in #123960, it seems two of our debuginfo tests started failing on gdb 15, which is also already in use in the `x86_64-gnu-llvm-18` builder: CI will randomly start to fail whenever this cached docker image expires.

This PR disables the following two tests under gdb 15+, to prevent future CI failures. 

- `tests/debuginfo/include_string.rs`
- `tests/debuginfo/vec-slices.rs`

This seems very much related to https://sourceware.org/bugzilla/show_bug.cgi?id=30330 and https://sourceware.org/bugzilla/show_bug.cgi?id=31517 -- and I just now saw #122751 as well, where one of these bugzilla issues and one of the two test failures here was previously mentioned.

I don't know whether these are unexpected gdb changes, or if we need to change our tests as it seems some of the gdb changes are definitely intentional, so I'll just cc @rust-lang/wg-debugging and @tromey.

(In the same area, `tests/debuginfo/unsized.rs` was previously disabled due to https://sourceware.org/bugzilla/show_bug.cgi?id=30330. This issue has been fixed but I don't believe our test passes, so it's in the same boat as the 2 above regarding whether this test is expected to work or needs changes as well)

r? wg-debugging

I've confirmed this is enough to have CI pass on gdb 15 with the llvm 18 builder.