### PR TITLE
zkvm: fix references to `os_str` module

### DIFF
--- a/library/std/src/sys/pal/zkvm/args.rs
+++ b/library/std/src/sys/pal/zkvm/args.rs
@@ -1,6 +1,7 @@
 use super::{abi, WORD_SIZE};
 use crate::ffi::OsString;
 use crate::fmt;
+use crate::sys::os_str;
 use crate::sys_common::FromInner;
 
 pub struct Args {
@@ -33,7 +34,7 @@ impl Args {
         // "os_str".
         let arg_bytes: &[u8] =
             unsafe { crate::slice::from_raw_parts(words.cast() as *const u8, arg_len) };
-        OsString::from_inner(super::os_str::Buf { inner: arg_bytes.to_vec() })
+        OsString::from_inner(os_str::Buf { inner: arg_bytes.to_vec() })
     }
 }
 

--- a/library/std/src/sys/pal/zkvm/os.rs
+++ b/library/std/src/sys/pal/zkvm/os.rs
@@ -5,6 +5,7 @@ use crate::fmt;
 use crate::io;
 use crate::marker::PhantomData;
 use crate::path::{self, PathBuf};
+use crate::sys::os_str;
 use crate::sys_common::FromInner;
 
 pub fn errno() -> i32 {
@@ -111,7 +112,7 @@ pub fn getenv(varname: &OsStr) -> Option<OsString> {
     // reimplement "os_str" instead of just using the generic unix
     // "os_str".
     let u8s: &[u8] = unsafe { crate::slice::from_raw_parts(words.cast() as *const u8, nbytes) };
-    Some(OsString::from_inner(super::os_str::Buf { inner: u8s.to_vec() }))
+    Some(OsString::from_inner(os_str::Buf { inner: u8s.to_vec() }))
 }
 
 pub fn setenv(_: &OsStr, _: &OsStr) -> io::Result<()> {


### PR DESCRIPTION
The `os_str` module has been moved to `sys`. This change fixes build issues by changing `use` to point to `crate::sys::os_str`. 