### PR TITLE
zkvm/args: fix wrong os_string import

### DIFF
--- a/library/std/src/sys/pal/zkvm/args.rs
+++ b/library/std/src/sys/pal/zkvm/args.rs
@@ -1,4 +1,5 @@
 use super::{abi, WORD_SIZE};
+use crate::sys::os_string;
 use crate::ffi::OsString;
 use crate::fmt;
 use crate::sys_common::FromInner;
@@ -33,7 +34,7 @@ impl Args {
         // "os_str".
         let arg_bytes: &[u8] =
             unsafe { crate::slice::from_raw_parts(words.cast() as *const u8, arg_len) };
-        OsString::from_inner(super::os_str::Buf { inner: arg_bytes.to_vec() })
+        OsString::from_inner(os_str::Buf { inner: arg_bytes.to_vec() })
     }
 }
 


### PR DESCRIPTION
```Console
$ cargo build -Z build-std --target riscv32im-risc0-zkvm-elf
   Compiling std v0.0.0 (/nix/store/7b93qrzs6dxkhqrzbi8adhdpyqxf95xs-rust-default-1.79.0-nightly-2024-04-15/lib/rustlib/src/rust/library/std)
error[E0433]: failed to resolve: could not find `os_str` in `super`
  --> /nix/store/7b93qrzs6dxkhqrzbi8adhdpyqxf95xs-rust-default-1.79.0-nightly-2024-04-15/lib/rustlib/src/rust/library/std/src/sys/pal/zkvm/../zkvm/args.rs:36:37
   |
36 |         OsString::from_inner(super::os_str::Buf { inner: arg_bytes.to_vec() })
   |                                     ^^^^^^ could not find `os_str` in `super`
   |
help: consider importing one of these items
   |
1  + use crate::ffi::os_str;
   |
1  + use crate::sys::os_str;
   |
help: if you import `os_str`, refer to it directly
   |
36 -         OsString::from_inner(super::os_str::Buf { inner: arg_bytes.to_vec() })
36 +         OsString::from_inner(os_str::Buf { inner: arg_bytes.to_vec() })
```