### PR TITLE
Use fake libc in core test

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -537,7 +537,11 @@ impl () {}
 /// ## 4. Get it from C.
 ///
 /// ```
-/// # #![feature(rustc_private)]
+/// # mod libc {
+/// # pub unsafe fn malloc(_size: usize) -> *mut core::ffi::c_void { core::ptr::NonNull::dangling().as_ptr() }
+/// # pub unsafe fn free(_ptr: *mut core::ffi::c_void) {}
+/// # }
+/// # #[cfg(any())]
 /// #[allow(unused_extern_crates)]
 /// extern crate libc;
 ///
@@ -548,7 +552,7 @@ impl () {}
 ///     if my_num.is_null() {
 ///         panic!("failed to allocate memory");
 ///     }
-///     libc::free(my_num as *mut libc::c_void);
+///     libc::free(my_num as *mut core::ffi::c_void);
 /// }
 /// ```
 ///


### PR DESCRIPTION
The war on libc continues.

Some platforms may not need to link to the libc crate (and it's possible some may not even have a libc), therefore we shouldn't require it for tests. This creates dummy `malloc` and `free` implementations for use in the pointer docs, but, keeps the public documentation looking the same as before.