### PR TITLE
CI: add script for installing NodeJS and update it to v20

### DIFF
--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -21,9 +21,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://nodejs.org/dist/v16.9.0/node-v16.9.0-linux-x64.tar.xz | tar -xJ
-ENV PATH="/node-v16.9.0-linux-x64/bin:${PATH}"
 ENV RUST_CONFIGURE_ARGS="--set rust.validate-mir-opts=3"
+
+COPY scripts/nodejs.sh /scripts/
+RUN sh /scripts/nodejs.sh /node
+ENV PATH="/node/bin:${PATH}"
 
 # Install es-check
 # Pin its version to prevent unrelated CI failures due to future es-check versions.

--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -28,8 +28,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   qemu-system-x86 \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-x64.tar.xz | \
-  tar -xJ
+COPY scripts/nodejs.sh /scripts/
+RUN sh /scripts/nodejs.sh /node
+ENV PATH="/node/bin:${PATH}"
 
 WORKDIR /build/
 COPY scripts/musl-toolchain.sh /build/
@@ -45,7 +46,6 @@ ENV WASI_SDK_PATH=/wasi-sdk-22.0
 
 ENV RUST_CONFIGURE_ARGS \
   --musl-root-x86_64=/usr/local/x86_64-linux-musl \
-  --set build.nodejs=/node-v18.12.0-linux-x64/bin/node \
   --set rust.lld
 
 # Some run-make tests have assertions about code size, and enabling debug

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -72,9 +72,9 @@ ENV GCC_EXEC_PREFIX="/usr/lib/gcc/"
 
 COPY host-x86_64/x86_64-gnu-tools/checktools.sh /tmp/
 
-RUN curl -sL https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-x64.tar.xz | tar -xJ
-ENV NODE_FOLDER=/node-v14.20.0-linux-x64/bin
-ENV PATH="$NODE_FOLDER:${PATH}"
+COPY scripts/nodejs.sh /scripts/
+RUN sh /scripts/nodejs.sh /node
+ENV PATH="/node/bin:${PATH}"
 
 COPY host-x86_64/x86_64-gnu-tools/browser-ui-test.version /tmp/
 

--- a/src/ci/docker/scripts/nodejs.sh
+++ b/src/ci/docker/scripts/nodejs.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+
+NODEJS_VERSION=v20.12.2
+INSTALL_PATH=${1:-/node}
+
+url="https://nodejs.org/dist/${NODEJS_VERSION}/node-${NODEJS_VERSION}-linux-x64.tar.xz"
+curl -sL "$url" | tar -xJ
+mv node-${NODEJS_VERSION}-linux-x64 "${INSTALL_PATH}"


### PR DESCRIPTION
I centralized the installation on a single place to make it simple to update the NodeJS version across the board.

Fixes: https://github.com/rust-lang/rust/issues/123965

r? @Mark-Simulacrum