### PR TITLE
Just use `type_dependent_def_id` to figure out what the method is for an expr

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1813,32 +1813,31 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let tcx = self.infcx.tcx;
         let hir = tcx.hir();
         let Some(body_id) = tcx.hir_node(self.mir_hir_id()).body_id() else { return };
-        struct FindUselessClone<'hir> {
-            tcx: TyCtxt<'hir>,
-            def_id: DefId,
-            pub clones: Vec<&'hir hir::Expr<'hir>>,
+
+        struct FindUselessClone<'tcx> {
+            tcx: TyCtxt<'tcx>,
+            typeck_results: &'tcx ty::TypeckResults<'tcx>,
+            pub clones: Vec<&'tcx hir::Expr<'tcx>>,
         }
-        impl<'hir> FindUselessClone<'hir> {
-            pub fn new(tcx: TyCtxt<'hir>, def_id: DefId) -> Self {
-                Self { tcx, def_id, clones: vec![] }
+        impl<'tcx> FindUselessClone<'tcx> {
+            pub fn new(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Self {
+                Self { tcx, typeck_results: tcx.typeck(def_id), clones: vec![] }
             }
         }
-
-        impl<'v> Visitor<'v> for FindUselessClone<'v> {
-            fn visit_expr(&mut self, ex: &'v hir::Expr<'v>) {
-                if let hir::ExprKind::MethodCall(segment, _rcvr, args, _span) = ex.kind
-                    && segment.ident.name == sym::clone
-                    && args.len() == 0
-                    && let Some(def_id) = self.def_id.as_local()
-                    && let Some(method) = self.tcx.lookup_method_for_diagnostic((def_id, ex.hir_id))
-                    && Some(self.tcx.parent(method)) == self.tcx.lang_items().clone_trait()
+        impl<'tcx> Visitor<'tcx> for FindUselessClone<'tcx> {
+            fn visit_expr(&mut self, ex: &'tcx hir::Expr<'tcx>) {
+                if let hir::ExprKind::MethodCall(..) = ex.kind
+                    && let Some(method_def_id) =
+                        self.typeck_results.type_dependent_def_id(ex.hir_id)
+                    && self.tcx.lang_items().clone_trait() == Some(self.tcx.parent(method_def_id))
                 {
                     self.clones.push(ex);
                 }
                 hir::intravisit::walk_expr(self, ex);
             }
         }
-        let mut expr_finder = FindUselessClone::new(tcx, self.mir_def_id().into());
+
+        let mut expr_finder = FindUselessClone::new(tcx, self.mir_def_id());
 
         let body = hir.body(body_id).value;
         expr_finder.visit_expr(body);

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -1131,17 +1131,12 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         };
         // The found `Self` type of the method call.
         let Some(possible_rcvr_ty) = tables.node_type_opt(rcvr.hir_id) else { return };
-
-        // The `MethodCall` expression is `Res::Err`, so we search for the method on the `rcvr_ty`.
-        let Some(method) = tcx.lookup_method_for_diagnostic((self.mir_def_id(), expr.hir_id))
-        else {
-            return;
-        };
+        let Some(method_def_id) = tables.type_dependent_def_id(expr.hir_id) else { return };
 
         // Get the type for the parameter corresponding to the argument the closure with the
         // lifetime error we had.
         let Some(input) = tcx
-            .fn_sig(method)
+            .fn_sig(method_def_id)
             .instantiate_identity()
             .inputs()
             .skip_binder()
@@ -1156,7 +1151,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         let ty::Param(closure_param) = input.kind() else { return };
 
         // Get the arguments for the found method, only specifying that `Self` is the receiver type.
-        let args = GenericArgs::for_item(tcx, method, |param, _| {
+        let args = GenericArgs::for_item(tcx, method_def_id, |param, _| {
             if param.index == 0 {
                 possible_rcvr_ty.into()
             } else if param.index == closure_param.index {
@@ -1166,7 +1161,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             }
         });
 
-        let preds = tcx.predicates_of(method).instantiate(tcx, args);
+        let preds = tcx.predicates_of(method_def_id).instantiate(tcx, args);
 
         let ocx = ObligationCtxt::new(&self.infcx);
         ocx.register_obligations(preds.iter().map(|(pred, span)| {

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -56,7 +56,7 @@ use rustc_data_structures::unord::UnordSet;
 use rustc_errors::{codes::*, struct_span_code_err, ErrorGuaranteed};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::intravisit::{Map, Visitor};
+use rustc_hir::intravisit::Visitor;
 use rustc_hir::{HirIdMap, Node};
 use rustc_hir_analysis::check::check_abi;
 use rustc_hir_analysis::hir_ty_lowering::HirTyLowerer;
@@ -436,28 +436,6 @@ fn fatally_break_rust(tcx: TyCtxt<'_>, span: Span) -> ! {
     diag.emit()
 }
 
-pub fn lookup_method_for_diagnostic<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    (def_id, hir_id): (LocalDefId, hir::HirId),
-) -> Option<DefId> {
-    let root_ctxt = TypeckRootCtxt::new(tcx, def_id);
-    let param_env = tcx.param_env(def_id);
-    let fn_ctxt = FnCtxt::new(&root_ctxt, param_env, def_id);
-    let hir::Node::Expr(expr) = tcx.hir().hir_node(hir_id) else {
-        return None;
-    };
-    let hir::ExprKind::MethodCall(segment, rcvr, _, _) = expr.kind else {
-        return None;
-    };
-    let tables = tcx.typeck(def_id);
-    // The found `Self` type of the method call.
-    let possible_rcvr_ty = tables.node_type_opt(rcvr.hir_id)?;
-    fn_ctxt
-        .lookup_method_for_diagnostic(possible_rcvr_ty, segment, expr.span, expr, rcvr)
-        .ok()
-        .map(|method| method.def_id)
-}
-
 pub fn provide(providers: &mut Providers) {
     method::provide(providers);
     *providers = Providers {
@@ -465,7 +443,6 @@ pub fn provide(providers: &mut Providers) {
         diagnostic_only_typeck,
         has_typeck_results,
         used_trait_imports,
-        lookup_method_for_diagnostic: lookup_method_for_diagnostic,
         ..*providers
     };
 }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -983,9 +983,6 @@ rustc_queries! {
     query diagnostic_only_typeck(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
         desc { |tcx| "type-checking `{}`", tcx.def_path_str(key) }
     }
-    query lookup_method_for_diagnostic((def_id, hir_id): (LocalDefId, hir::HirId)) -> Option<DefId> {
-        desc { |tcx| "lookup_method_for_diagnostics `{}`", tcx.def_path_str(def_id) }
-    }
 
     query used_trait_imports(key: LocalDefId) -> &'tcx UnordSet<LocalDefId> {
         desc { |tcx| "finding used_trait_imports `{}`", tcx.def_path_str(key) }


### PR DESCRIPTION
The calls to `lookup_method_for_diagnostic` are overkill.

r? oli-obk