### PR TITLE
Delay span bug when `Self` kw resolves to `DefKind::{Mod,Trait}`

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -1879,6 +1879,17 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 self.set_tainted_by_errors(e);
                 Ty::new_error(self.tcx(), e)
             }
+            Res::Def(..) => {
+                assert_eq!(
+                    path.segments.get(0).map(|seg| seg.ident.name),
+                    Some(kw::SelfUpper),
+                    "only expected incorrect resolution for `Self`"
+                );
+                Ty::new_error(
+                    self.tcx(),
+                    self.tcx().dcx().span_delayed_bug(span, "incorrect resolution for `Self`"),
+                )
+            }
             _ => span_bug!(span, "unexpected resolution: {:?}", path.res),
         }
     }

--- a/tests/ui/resolve/incorrect-self-res.rs
+++ b/tests/ui/resolve/incorrect-self-res.rs
@@ -1,0 +1,17 @@
+fn module() {
+    fn test(&mut self) {
+    //~^ ERROR `self` parameter is only allowed in associated functions
+    }
+    mod Self {}
+    //~^ ERROR expected identifier, found keyword `Self`
+}
+
+fn trait_() {
+    fn test(&mut self) {
+    //~^ ERROR `self` parameter is only allowed in associated functions
+    }
+    trait Self {}
+    //~^ ERROR expected identifier, found keyword `Self`
+}
+
+fn main() {}

--- a/tests/ui/resolve/incorrect-self-res.stderr
+++ b/tests/ui/resolve/incorrect-self-res.stderr
@@ -1,0 +1,30 @@
+error: expected identifier, found keyword `Self`
+  --> $DIR/incorrect-self-res.rs:5:9
+   |
+LL |     mod Self {}
+   |         ^^^^ expected identifier, found keyword
+
+error: expected identifier, found keyword `Self`
+  --> $DIR/incorrect-self-res.rs:13:11
+   |
+LL |     trait Self {}
+   |           ^^^^ expected identifier, found keyword
+
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/incorrect-self-res.rs:2:13
+   |
+LL |     fn test(&mut self) {
+   |             ^^^^^^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/incorrect-self-res.rs:10:13
+   |
+LL |     fn test(&mut self) {
+   |             ^^^^^^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Catch the case where `kw::Self` is recovered in the parser and causes us to subsequently resolve `&self`'s implicit type to something that's not a type.

This check could be made more accurate, though I'm not sure how hard we have to try here.

Fixes #123988