### PR TITLE
Use `/* value */` as a placeholder

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -4550,7 +4550,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             self.type_implements_trait(default_trait, [ty], param_env).must_apply_modulo_regions()
         };
 
-        Some(match ty.kind() {
+        Some(match *ty.kind() {
             ty::Never | ty::Error(_) => return None,
             ty::Bool => "false".to_string(),
             ty::Char => "\'x\'".to_string(),
@@ -4577,12 +4577,19 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 if let (ty::Str, hir::Mutability::Not) = (ty.kind(), mutability) {
                     "\"\"".to_string()
                 } else {
-                    let ty = self.ty_kind_suggestion(param_env, *ty)?;
+                    let ty = self.ty_kind_suggestion(param_env, ty)?;
                     format!("&{}{ty}", mutability.prefix_str())
                 }
             }
             ty::Array(ty, len) if let Some(len) = len.try_eval_target_usize(tcx, param_env) => {
-                format!("[{}; {}]", self.ty_kind_suggestion(param_env, *ty)?, len)
+                if len == 0 {
+                    "[]".to_string()
+                } else if self.type_is_copy_modulo_regions(param_env, ty) || len == 1 {
+                    // Can only suggest `[ty; 0]` if sz == 1 or copy
+                    format!("[{}; {}]", self.ty_kind_suggestion(param_env, ty)?, len)
+                } else {
+                    "/* value */".to_string()
+                }
             }
             ty::Tuple(tys) => format!(
                 "({}{})",

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -4592,7 +4592,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     .join(", "),
                 if tys.len() == 1 { "," } else { "" }
             ),
-            _ => "value".to_string(),
+            _ => "/* value */".to_string(),
         })
     }
 }

--- a/tests/ui/borrowck/borrowck-init-in-fru.stderr
+++ b/tests/ui/borrowck/borrowck-init-in-fru.stderr
@@ -8,8 +8,8 @@ LL |     origin = Point { x: 10, ..origin };
    |
 help: consider assigning a value
    |
-LL |     let mut origin: Point = value;
-   |                           +++++++
+LL |     let mut origin: Point = /* value */;
+   |                           +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-uninit-ref-chain.stderr
+++ b/tests/ui/borrowck/borrowck-uninit-ref-chain.stderr
@@ -21,8 +21,8 @@ LL |     let _y = &**x;
    |
 help: consider assigning a value
    |
-LL |     let x: &&S<i32, i32> = &&value;
-   |                          +++++++++
+LL |     let x: &&S<i32, i32> = &&/* value */;
+   |                          +++++++++++++++
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/borrowck-uninit-ref-chain.rs:14:14

--- a/tests/ui/borrowck/issue-103250.stderr
+++ b/tests/ui/borrowck/issue-103250.stderr
@@ -9,8 +9,8 @@ LL |         Err(last_error)
    |
 help: consider assigning a value
    |
-LL |         let mut last_error: Box<dyn std::error::Error> = Box::new(value);
-   |                                                        +++++++++++++++++
+LL |         let mut last_error: Box<dyn std::error::Error> = Box::new(/* value */);
+   |                                                        +++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/suggest-assign-rvalue.stderr
+++ b/tests/ui/borrowck/suggest-assign-rvalue.stderr
@@ -50,8 +50,8 @@ LL |     println!("demo_no: {:?}", demo_no);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let demo_no: DemoNoDef = value;
-   |                            +++++++
+LL |     let demo_no: DemoNoDef = /* value */;
+   |                            +++++++++++++
 
 error[E0381]: used binding `arr` isn't initialized
   --> $DIR/suggest-assign-rvalue.rs:34:27

--- a/tests/ui/consts/value-suggestion-ice-123906.stderr
+++ b/tests/ui/consts/value-suggestion-ice-123906.stderr
@@ -10,8 +10,8 @@ LL |         break;
    |
 help: give the `break` a value of the expected type
    |
-LL |         break value;
-   |               +++++
+LL |         break /* value */;
+   |               +++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/loops/loop-break-value.stderr
+++ b/tests/ui/loops/loop-break-value.stderr
@@ -246,8 +246,8 @@ LL |         break;
    |
 help: give the `break` a value of the expected type
    |
-LL |         break value;
-   |               +++++
+LL |         break /* value */;
+   |               +++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:112:9
@@ -260,8 +260,8 @@ LL |         break;
    |
 help: give the `break` a value of the expected type
    |
-LL |         break value;
-   |               +++++
+LL |         break /* value */;
+   |               +++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:124:9
@@ -274,8 +274,8 @@ LL |         break 'a;
    |
 help: give the `break` a value of the expected type
    |
-LL |         break 'a value;
-   |                  +++++
+LL |         break 'a /* value */;
+   |                  +++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:135:15
@@ -297,8 +297,8 @@ LL |                 break 'a;
    |
 help: give the `break` a value of the expected type
    |
-LL |                 break 'a value;
-   |                          +++++
+LL |                 break 'a /* value */;
+   |                          +++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:147:15
@@ -320,8 +320,8 @@ LL |                 break 'a;
    |
 help: give the `break` a value of the expected type
    |
-LL |                 break 'a value;
-   |                          +++++
+LL |                 break 'a /* value */;
+   |                          +++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:159:15

--- a/tests/ui/moves/issue-72649-uninit-in-loop.stderr
+++ b/tests/ui/moves/issue-72649-uninit-in-loop.stderr
@@ -80,8 +80,8 @@ LL |         let _used = value;
    |
 help: consider assigning a value
    |
-LL |         let value: NonCopy = value;
-   |                            +++++++
+LL |         let value: NonCopy = /* value */;
+   |                            +++++++++++++
 
 error[E0381]: used binding `value` isn't initialized
   --> $DIR/issue-72649-uninit-in-loop.rs:73:21
@@ -94,8 +94,8 @@ LL |         let _used = value;
    |
 help: consider assigning a value
    |
-LL |     let mut value: NonCopy = value;
-   |                            +++++++
+LL |     let mut value: NonCopy = /* value */;
+   |                            +++++++++++++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/moves/move-into-dead-array-1.stderr
+++ b/tests/ui/moves/move-into-dead-array-1.stderr
@@ -8,8 +8,8 @@ LL |     a[i] = d();
    |
 help: consider assigning a value
    |
-LL |     let mut a: [D; 4] = [/* value */; 4];
-   |                       ++++++++++++++++++
+LL |     let mut a: [D; 4] = /* value */;
+   |                       +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/moves/move-into-dead-array-1.stderr
+++ b/tests/ui/moves/move-into-dead-array-1.stderr
@@ -8,8 +8,8 @@ LL |     a[i] = d();
    |
 help: consider assigning a value
    |
-LL |     let mut a: [D; 4] = [value; 4];
-   |                       ++++++++++++
+LL |     let mut a: [D; 4] = [/* value */; 4];
+   |                       ++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/moves/move-of-addr-of-mut.stderr
+++ b/tests/ui/moves/move-of-addr-of-mut.stderr
@@ -9,8 +9,8 @@ LL |     std::ptr::addr_of_mut!(x);
    = note: this error originates in the macro `std::ptr::addr_of_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider assigning a value
    |
-LL |     let mut x: S = value;
-   |                  +++++++
+LL |     let mut x: S = /* value */;
+   |                  +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/match-on-borrowed.stderr
+++ b/tests/ui/nll/match-on-borrowed.stderr
@@ -43,8 +43,8 @@ LL |     match n {}
    |
 help: consider assigning a value
    |
-LL |     let n: Never = value;
-   |                  +++++++
+LL |     let n: Never = /* value */;
+   |                  +++++++++++++
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
The expression `value` isn't a valid suggestion; let's use `/* value */` as a placeholder (which is also invalid) since it more clearly signals to the user that they need to fill it in with something meaningful. This parallels the suggestions we have in a couple other places, like arguments.

We could also print the type name instead of `/* value */`, especially if it's suggestable, but I don't care strongly about that.