### PR TITLE
Fix docs for unstable_features lint.

### DIFF
--- a/src/tools/lint-docs/src/lib.rs
+++ b/src/tools/lint-docs/src/lib.rs
@@ -270,7 +270,6 @@ impl<'a> LintExtractor<'a> {
         if matches!(
             lint.name.as_str(),
             "unused_features" // broken lint
-            | "unstable_features" // deprecated
         ) {
             return Ok(());
         }


### PR DESCRIPTION
This fixes the `unstable_features` lint documentation (at https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unstable-features) so that it correctly displays the output (instead of showing `{{produces}}`). The lint was undeprecated in https://github.com/rust-lang/rust/pull/118639, but this little part was missed when that happened.

