### PR TITLE
Make `to_degrees` and `to_radians` const

### DIFF
--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -880,8 +880,9 @@ impl f32 {
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[stable(feature = "f32_deg_rad_conversions", since = "1.7.0")]
+    #[rustc_const_unstable(feature = "const_to_degrees_and_to_radians", issue = "none")]
     #[inline]
-    pub fn to_degrees(self) -> f32 {
+    pub const fn to_degrees(self) -> f32 {
         // Use a constant for better precision.
         const PIS_IN_180: f32 = 57.2957795130823208767981548141051703_f32;
         self * PIS_IN_180
@@ -899,8 +900,9 @@ impl f32 {
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[stable(feature = "f32_deg_rad_conversions", since = "1.7.0")]
+    #[rustc_const_unstable(feature = "const_to_degrees_and_to_radians", issue = "none")]
     #[inline]
-    pub fn to_radians(self) -> f32 {
+    pub const fn to_radians(self) -> f32 {
         let value: f32 = consts::PI;
         self * (value / 180.0f32)
     }

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -890,8 +890,9 @@ impl f64 {
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_to_degrees_and_to_radians", issue = "none")]
     #[inline]
-    pub fn to_degrees(self) -> f64 {
+    pub const fn to_degrees(self) -> f64 {
         // The division here is correctly rounded with respect to the true
         // value of 180/π. (This differs from f32, where a constant must be
         // used to ensure a correctly rounded result.)
@@ -910,8 +911,9 @@ impl f64 {
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_to_degrees_and_to_radians", issue = "none")]
     #[inline]
-    pub fn to_radians(self) -> f64 {
+    pub const fn to_radians(self) -> f64 {
         let value: f64 = consts::PI;
         self * (value / 180.0)
     }


### PR DESCRIPTION
Make the `to_degrees` and `to_radians` methods const on `f32` and `f64`