### PR TITLE
Stabilize `binary_heap_as_slice`

### DIFF
--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -1207,7 +1207,6 @@ impl<T, A: Allocator> BinaryHeap<T, A> {
     /// Basic usage:
     ///
     /// ```
-    /// #![feature(binary_heap_as_slice)]
     /// use std::collections::BinaryHeap;
     /// use std::io::{self, Write};
     ///
@@ -1216,7 +1215,7 @@ impl<T, A: Allocator> BinaryHeap<T, A> {
     /// io::sink().write(heap.as_slice()).unwrap();
     /// ```
     #[must_use]
-    #[unstable(feature = "binary_heap_as_slice", issue = "83659")]
+    #[stable(feature = "binary_heap_as_slice", since = "CURRENT_RUSTC_VERSION")]
     pub fn as_slice(&self) -> &[T] {
         self.data.as_slice()
     }

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -26,7 +26,6 @@
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_drain_sorted)]
 #![feature(slice_ptr_get)]
-#![feature(binary_heap_as_slice)]
 #![feature(inplace_iteration)]
 #![feature(iter_advance_by)]
 #![feature(iter_next_chunk)]


### PR DESCRIPTION
This PR stabilizes `binary_heap_as_slice`:

```rust
// std::collections::BinaryHeap

impl BinaryHeap<T> {
    pub fn as_slice(&self) -> &[T]
}
```

<br>

Tracking issue: https://github.com/rust-lang/rust/issues/83659.
Implementation PR: https://github.com/rust-lang/rust/pull/82331.

FCPs already completed in the tracking issue.

Closes https://github.com/rust-lang/rust/issues/83659.

r? libs-api