### PR TITLE
Box::into_raw: make Miri understand that this is a box-to-raw cast

### DIFF
--- a/src/tools/miri/tests/fail/both_borrows/newtype_pair_retagging.stack.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/newtype_pair_retagging.stack.stderr
@@ -6,7 +6,7 @@ LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-help: <TAG> was created by a Unique retag at offsets [0x0..0x4]
+help: <TAG> was created by a SharedReadWrite retag at offsets [0x0..0x4]
   --> $DIR/newtype_pair_retagging.rs:LL:CC
    |
 LL |     let ptr = Box::into_raw(Box::new(0i32));

--- a/src/tools/miri/tests/fail/both_borrows/newtype_retagging.stack.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/newtype_retagging.stack.stderr
@@ -6,7 +6,7 @@ LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-help: <TAG> was created by a Unique retag at offsets [0x0..0x4]
+help: <TAG> was created by a SharedReadWrite retag at offsets [0x0..0x4]
   --> $DIR/newtype_retagging.rs:LL:CC
    |
 LL |     let ptr = Box::into_raw(Box::new(0i32));

--- a/src/tools/miri/tests/pass/issues/issue-miri-3473.rs
+++ b/src/tools/miri/tests/pass/issues/issue-miri-3473.rs
@@ -1,0 +1,28 @@
+//@revisions: stack tree
+//@[tree]compile-flags: -Zmiri-tree-borrows
+use std::cell::UnsafeCell;
+
+#[repr(C)]
+#[derive(Default)]
+struct Node {
+    _meta: UnsafeCell<usize>,
+    value: usize,
+}
+
+impl Node {
+    fn value(&self) -> &usize {
+        &self.value
+    }
+}
+
+/// This used to cause Stacked Borrows errors because of trouble around conversion
+/// from Box to raw pointer.
+fn main() {
+    unsafe {
+        let a = Box::into_raw(Box::new(Node::default()));
+        let ptr = &*a;
+        *UnsafeCell::raw_get(a.cast::<UnsafeCell<usize>>()) = 2;
+        assert_eq!(*ptr.value(), 0);
+        drop(Box::from_raw(a));
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/124013)*
<!-- homu-ignore:end -->

Turns out https://github.com/rust-lang/rust/pull/122647 went a bit too far in cleaning up `Box`... we still need a hack in `Box::into_raw`. The nicer fix would be to make Stacked Borrows not care about reference-to-raw-pointer casts, but it's unclear whether that will ever be possible without going to full Tree Borrows.

Fixes https://github.com/rust-lang/miri/issues/3473.