### PR TITLE
Change a diagnostics-path-only `DefineOpaqueTypes` to `Yes`.

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1696,7 +1696,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                 if let ProbeResult::Match = result
                     && self
                         .at(&ObligationCause::dummy(), self.param_env)
-                        .sup(DefineOpaqueTypes::No, return_ty, xform_ret_ty)
+                        .sup(DefineOpaqueTypes::Yes, return_ty, xform_ret_ty)
                         .is_err()
                 {
                     result = ProbeResult::BadReturnType;


### PR DESCRIPTION
This can't possibly affect compilation, so it's safe to flip, even if I couldn't come up with an affected test

r? @compiler-errors 