### PR TITLE
Allow workproducts without object files.

### DIFF
--- a/tests/run-make/artifact-incr-cache-no-obj/lib.rs
+++ b/tests/run-make/artifact-incr-cache-no-obj/lib.rs
@@ -1,0 +1,6 @@
+#![crate_name = "foo"]
+
+#[inline(never)]
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}

--- a/tests/run-make/artifact-incr-cache-no-obj/rmake.rs
+++ b/tests/run-make/artifact-incr-cache-no-obj/rmake.rs
@@ -1,0 +1,23 @@
+// emitting an object file is not necessary if user didn't ask for one
+//
+// This test is similar to run-make/artifact-incr-cache but it doesn't
+// require to emit an object file
+//
+// Fixes: rust-lang/rust#123234
+
+extern crate run_make_support;
+
+use run_make_support::{rustc, tmp_dir};
+
+fn main() {
+    let inc_dir = tmp_dir();
+
+    for _ in 0..=1 {
+        rustc()
+            .input("lib.rs")
+            .crate_type("lib")
+            .emit("asm,dep-info,link,mir,llvm-ir,llvm-bc")
+            .incremental(&inc_dir)
+            .run();
+    }
+}


### PR DESCRIPTION
This pull request partially reverts changes from e16c3b4a4421

Original motivation for this assert was described with "A WorkProduct without a saved file is useless"
which was true at the time but now it is possible to have work products with other types of files
(llvm-ir, asm, etc) and there are bugreports for this failure:

For example: https://github.com/rust-lang/rust/issues/123695

Fixes https://github.com/rust-lang/rust/issues/123234

Now existing `assert` and `.unwrap_or_else` are unified into a single
check that emits slightly more user friendly error message if an object
files was meant to be produced but it's missing
