### PR TITLE
Remove `default_hidden_visibility: false` from wasm targets

### DIFF
--- a/compiler/rustc_target/src/spec/base/wasm.rs
+++ b/compiler/rustc_target/src/spec/base/wasm.rs
@@ -80,9 +80,6 @@ pub fn options() -> TargetOptions {
         // threaded model which will legalize atomics to normal operations.
         singlethread: true,
 
-        // no dynamic linking, no need for default visibility!
-        default_hidden_visibility: true,
-
         // Symbol visibility takes care of this for the WebAssembly.
         // Additionally the only known linker, LLD, doesn't support the script
         // arguments just yet


### PR DESCRIPTION
To the best of my ability I believe that this is no longer necessary. I don't fully recall why this was first added but I believe it had to do with symbols all being exported by default and this was required to undo that. Regardless nowadays the default output of rustc seems suitable so it seems best to keep wasm in line with other targets.