### PR TITLE
Fix empty-set symbol in comments

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -51,7 +51,7 @@ pub enum Delimiter {
     Brace,
     /// `[ ... ]`
     Bracket,
-    /// `Ø ... Ø`
+    /// `∅ ... ∅`
     /// An invisible delimiter, that may, for example, appear around tokens coming from a
     /// "macro variable" `$var`. It is important to preserve operator priorities in cases like
     /// `$var * 3` where `$var` is `1 + 2`.

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1063,7 +1063,7 @@ impl<'a> Parser<'a> {
     /// Parses a `UseTreeKind::Nested(list)`.
     ///
     /// ```text
-    /// USE_TREE_LIST = Ø | (USE_TREE `,`)* USE_TREE [`,`]
+    /// USE_TREE_LIST = ∅ | (USE_TREE `,`)* USE_TREE [`,`]
     /// ```
     fn parse_use_tree_list(&mut self) -> PResult<'a, ThinVec<(UseTree, ast::NodeId)>> {
         self.parse_delim_comma_seq(Delimiter::Brace, |p| {

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -811,7 +811,7 @@ pub enum Delimiter {
     /// `[ ... ]`
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     Bracket,
-    /// `Ø ... Ø`
+    /// `∅ ... ∅`
     /// An invisible delimiter, that may, for example, appear around tokens coming from a
     /// "macro variable" `$var`. It is important to preserve operator priorities in cases like
     /// `$var * 3` where `$var` is `1 + 2`.


### PR DESCRIPTION
The symbol in the original code is U+00D8 "LATIN CAPITAL LETTER O WITH STROKE" (https://en.wikipedia.org/wiki/%C3%98) which is an uppercase letter in Danish, Norwegian, Faroese, and Southern Sámi alphabets.

The symbol that was intended is U+2205 "EMPTY SET" (https://en.wikipedia.org/wiki/Empty_set#Notation).

| Before | After |
|---|---|
| ![Screenshot from 2024-04-16 18-25-01](https://github.com/rust-lang/rust/assets/1940490/9b8b0624-cfa5-4b89-84e5-4c2b39c2cb8f) | ![Screenshot from 2024-04-16 18-25-05](https://github.com/rust-lang/rust/assets/1940490/6f6b34c3-0e47-4ba0-856d-be1dc164c94c) |