### PR TITLE
Move confusing comment about otherwise blocks in `lower_match_tree`

### DIFF
--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -385,15 +385,15 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let fake_borrows = match_has_guard
             .then(|| util::FakeBorrowCollector::collect_fake_borrows(self, candidates));
 
+        // See the doc comment on `match_candidates` for why we have an
+        // otherwise block. Match checking will ensure this is actually
+        // unreachable.
         let otherwise_block = self.cfg.start_new_block();
 
         // This will generate code to test scrutinee_place and
         // branch to the appropriate arm block
         self.match_candidates(match_start_span, scrutinee_span, block, otherwise_block, candidates);
 
-        // See the doc comment on `match_candidates` for why we may have an
-        // otherwise block. Match checking will ensure this is actually
-        // unreachable.
         let source_info = self.source_info(scrutinee_span);
 
         // Matching on a `scrutinee_place` with an uninhabited type doesn't


### PR DESCRIPTION
This comment was historically inside a block guarded by `if let Some(otherwise_block) = otherwise`.

When #120978 made the “otherwise block” non-optional, it also flattened that region of code. Doing so left this comment awkwardly stranded above an unrelated line of code, without its original context.

We can restore that context by moving it above the declaration of `otherwise`.

r? @Nadrieril 