### PR TITLE
Remove libc from more tests

### DIFF
--- a/tests/ui/abi/segfault-no-out-of-stack.rs
+++ b/tests/ui/abi/segfault-no-out-of-stack.rs
@@ -1,31 +1,29 @@
 //@ run-pass
-
-#![allow(unused_imports)]
 //@ ignore-wasm32 can't run commands
 //@ ignore-sgx no processes
 //@ ignore-fuchsia must translate zircon signal to SIGSEGV/SIGBUS, FIXME (#58590)
+
 #![feature(rustc_private)]
 
-extern crate libc;
-
 use std::env;
+use std::ffi::c_char;
 use std::process::{Command, ExitStatus};
 
 #[link(name = "rust_test_helpers", kind = "static")]
 extern "C" {
-    fn rust_get_null_ptr() -> *mut ::libc::c_char;
+    fn rust_get_null_ptr() -> *mut c_char;
 }
 
 #[cfg(unix)]
-fn check_status(status: std::process::ExitStatus) {
-    use libc;
+fn check_status(status: ExitStatus) {
+    extern crate libc;
     use std::os::unix::process::ExitStatusExt;
 
     assert!(status.signal() == Some(libc::SIGSEGV) || status.signal() == Some(libc::SIGBUS));
 }
 
 #[cfg(not(unix))]
-fn check_status(status: std::process::ExitStatus) {
+fn check_status(status: ExitStatus) {
     assert!(!status.success());
 }
 

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-and-child-processes.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-and-child-processes.rs
@@ -11,10 +11,8 @@
 // processes with and without the attribute. Search for
 // `unix_sigpipe_attr_specified()` in the code base to learn more.
 
-#![feature(rustc_private)]
 #![cfg_attr(any(sig_dfl, sig_ign, inherit), feature(unix_sigpipe))]
 
-extern crate libc;
 extern crate sigpipe_utils;
 
 use sigpipe_utils::*;

--- a/tests/ui/extern-flag/auxiliary/panic_handler.rs
+++ b/tests/ui/extern-flag/auxiliary/panic_handler.rs
@@ -1,13 +1,6 @@
 #![feature(lang_items)]
 #![no_std]
 
-// Since `rustc` generally passes `-nodefaultlibs` to the linker,
-// Rust programs link necessary system libraries via `#[link()]`
-// attributes in the `libc` crate. `libc` is a dependency of `std`,
-// but as we are `#![no_std]`, we need to include it manually.
-#![feature(rustc_private)]
-extern crate libc;
-
 #[panic_handler]
 pub fn begin_panic_handler(_info: &core::panic::PanicInfo<'_>) -> ! {
     loop {}

--- a/tests/ui/extern-flag/auxiliary/panic_handler.rs
+++ b/tests/ui/extern-flag/auxiliary/panic_handler.rs
@@ -1,6 +1,15 @@
 #![feature(lang_items)]
 #![no_std]
 
+// Since `rustc` generally passes `-nodefaultlibs` to the linker,
+// Rust programs link necessary system libraries via `#[link()]`
+// attributes in the `libc` crate. `libc` is a dependency of `std`,
+// but as we are `#![no_std]`, we need to include it manually.
+// Except on windows-msvc.
+#![feature(rustc_private)]
+#[cfg(not(all(windows, target_env = "msvc")))]
+extern crate libc;
+
 #[panic_handler]
 pub fn begin_panic_handler(_info: &core::panic::PanicInfo<'_>) -> ! {
     loop {}

--- a/tests/ui/rfcs/rfc-1014-stdout-existential-crisis/rfc-1014-2.rs
+++ b/tests/ui/rfcs/rfc-1014-stdout-existential-crisis/rfc-1014-2.rs
@@ -1,31 +1,28 @@
+// Test that println! to a closed stdout does not panic.
+// On Windows, close via SetStdHandle to 0.
 //@ run-pass
-#![allow(dead_code)]
 
 #![feature(rustc_private)]
 
-extern crate libc;
-
-type DWORD = u32;
-type HANDLE = *mut u8;
-type BOOL = i32;
-
-#[cfg(windows)]
-extern "system" {
-    fn SetStdHandle(nStdHandle: DWORD, nHandle: HANDLE) -> BOOL;
-}
-
 #[cfg(windows)]
 fn close_stdout() {
+    type DWORD = u32;
+    type HANDLE = *mut u8;
+    type BOOL = i32;
+
+    extern "system" {
+        fn SetStdHandle(nStdHandle: DWORD, nHandle: HANDLE) -> BOOL;
+    }
+
     const STD_OUTPUT_HANDLE: DWORD = -11i32 as DWORD;
     unsafe { SetStdHandle(STD_OUTPUT_HANDLE, 0 as HANDLE); }
 }
 
-#[cfg(windows)]
+#[cfg(not(windows))]
+fn close_stdout() {}
+
 fn main() {
     close_stdout();
     println!("hello");
     println!("world");
 }
-
-#[cfg(not(windows))]
-fn main() {}

--- a/tests/ui/rfcs/rfc-1014-stdout-existential-crisis/rfc-1014.rs
+++ b/tests/ui/rfcs/rfc-1014-stdout-existential-crisis/rfc-1014.rs
@@ -1,28 +1,27 @@
+// Test that println! to a closed stdout does not panic.
+// On Windows, close via CloseHandle.
 //@ run-pass
-#![allow(dead_code)]
 //@ ignore-sgx no libc
 
 #![feature(rustc_private)]
 
-extern crate libc;
-
-type DWORD = u32;
-type HANDLE = *mut u8;
-
-#[cfg(windows)]
-extern "system" {
-    fn GetStdHandle(which: DWORD) -> HANDLE;
-    fn CloseHandle(handle: HANDLE) -> i32;
-}
-
 #[cfg(windows)]
 fn close_stdout() {
+    type DWORD = u32;
+    type HANDLE = *mut u8;
+
+    extern "system" {
+        fn GetStdHandle(which: DWORD) -> HANDLE;
+        fn CloseHandle(handle: HANDLE) -> i32;
+    }
+
     const STD_OUTPUT_HANDLE: DWORD = -11i32 as DWORD;
     unsafe { CloseHandle(GetStdHandle(STD_OUTPUT_HANDLE)); }
 }
 
 #[cfg(not(windows))]
 fn close_stdout() {
+    extern crate libc;
     unsafe { libc::close(1); }
 }
 


### PR DESCRIPTION
The goal here is to trim down the number of tests that depend on libc from the sysroot to make https://github.com/rust-lang/rust/pull/123938 more plausible.

This PR is a few simple cases that I missed in https://github.com/rust-lang/rust/pull/123943.