### PR TITLE
Update AST validation module docs

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -2,8 +2,15 @@
 //!
 //! This pass intends to check that the constructed AST is *syntactically valid* to allow the rest
 //! of the compiler to assume that the AST is valid. These checks cannot be performed during parsing
-//! because attribute macros are allowed to accept certain pieces of invalid syntax such as `async
-//! fn` within a trait (before async-fn-in-trait was introduced).
+//! because attribute macros are allowed to accept certain pieces of invalid syntax such as a
+//! function without body outside of a trait definition:
+//!
+//! ```ignore (illustrative)
+//! #[my_attribute]
+//! mod foo {
+//!     fn missing_body();
+//! }
+//! ```
 //!
 //! These checks are run post-expansion, after AST is frozen, to be able to check for erroneous
 //! constructions produced by proc macros. This pass is only intended for simple checks that do not

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1,10 +1,13 @@
-// Validate AST before lowering it to HIR.
-//
-// This pass is supposed to catch things that fit into AST data structures,
-// but not permitted by the language. It runs after expansion when AST is frozen,
-// so it can check for erroneous constructions produced by syntax extensions.
-// This pass is supposed to perform only simple checks not requiring name resolution
-// or type checking or some other kind of complex analysis.
+//! Validate AST before lowering it to HIR.
+//!
+//! This pass intends to check that the constructed AST is *syntactically valid* to allow the rest
+//! of the compiler to assume that the AST is valid. These checks cannot be performed during parsing
+//! because attribute macros are allowed to accept certain pieces of invalid syntax such as `async
+//! fn` within a trait (before async-fn-in-trait was introduced).
+//!
+//! These checks are run post-expansion, after AST is frozen, to be able to check for erroneous
+//! constructions produced by proc macros. This pass is only intended for simple checks that do not
+//! require name resolution or type checking, or other kinds of complex analysis.
 
 use itertools::{Either, Itertools};
 use rustc_ast::ptr::P;


### PR DESCRIPTION
Drive-by doc update for AST validation pass:

- Syntax extensions are replaced by proc macros.
- Add rationale for why AST validation pass need to be run
  post-expansion and why the pass is needed in the first place.

This was discussed during this week's [rustc-dev-guide reading club](https://rust-lang.zulipchat.com/#narrow/stream/196385-t-compiler.2Fwg-rustc-dev-guide), and the rationale was explained by cc @bjorn3.