### PR TITLE
std::thread: follow-up #123913 removing unsafe on success for glibc.

### DIFF
--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -717,7 +717,7 @@ unsafe fn min_stack_size(attr: *const libc::pthread_attr_t) -> usize {
 
     match __pthread_get_minstack.get() {
         None => libc::PTHREAD_STACK_MIN,
-        Some(f) => unsafe { f(attr) },
+        Some(f) => f(attr),
     }
 }
 


### PR DESCRIPTION
follow up #123913