### PR TITLE
rustdoc: link sibling where possible, even when not One True Path

### DIFF
--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -808,6 +808,15 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                 if let Some(def_id) = item.def_id()
                     && let Some(name) = item.name
                 {
+                    if let Some((path, item_type)) = self.cache().paths.get(&def_id)
+                        && *item_type == item.type_()
+                        && &path[path.len() - 1..] == &self.current[..]
+                    {
+                        // Avoid populating this list with no-ops.
+                        // If this module is already the One True Path,
+                        // that's sufficient.
+                        continue;
+                    }
                     self.current_module_linkable_items.insert(def_id, (item.type_(), name));
                 }
             }

--- a/tests/rustdoc/intra-doc/glob-inline-siblings.rs
+++ b/tests/rustdoc/intra-doc/glob-inline-siblings.rs
@@ -1,0 +1,45 @@
+#![deny(rustdoc::broken_intra_doc_links)]
+#![allow(nonstandard_style)]
+
+// Reduced case from `core::arch::{arm, aarch64}`.
+// Both versions of arm should link to the struct that they inlined.
+// aarch64 should not link to the inlined copy in arm 32.
+
+mod arm_shared {
+    pub struct uint32x4_t;
+    pub struct uint32x4x2_t(pub uint32x4_t, pub uint32x4_t);
+    pub fn vabaq_u32(
+        _a: uint32x4_t,
+        _b: uint32x4_t,
+        _c: uint32x4_t
+    ) -> uint32x4_t {
+        uint32x4_t
+    }
+}
+
+pub mod arm {
+    pub use crate::arm_shared::*;
+    // @has glob_inline_siblings/arm/fn.vabaq_u32.html '//a[@href="struct.uint32x4_t.html"]' 'uint32x4_t'
+    // @has glob_inline_siblings/arm/struct.uint32x4x2_t.html '//a[@href="struct.uint32x4_t.html"]' 'uint32x4_t'
+    // @!has glob_inline_siblings/arm/fn.vabaq_u32.html '//a[@href="../aarch64/struct.uint32x4_t.html"]' 'uint32x4_t'
+    // @!has glob_inline_siblings/arm/struct.uint32x4x2_t.html '//a[@href="../aarch64/struct.uint32x4_t.html"]' 'uint32x4_t'
+
+    /// [uint32x4_t]
+    // @has glob_inline_siblings/arm/struct.LocalThing.html '//a[@href="struct.uint32x4_t.html"]' 'uint32x4_t'
+    // @!has glob_inline_siblings/arm/struct.LocalThing.html '//a[@href="../aarch64/struct.uint32x4_t.html"]' 'uint32x4_t'
+    pub struct LocalThing;
+}
+
+
+pub mod aarch64 {
+    pub use crate::arm_shared::*;
+    // @has glob_inline_siblings/aarch64/fn.vabaq_u32.html '//a[@href="struct.uint32x4_t.html"]' 'uint32x4_t'
+    // @has glob_inline_siblings/aarch64/struct.uint32x4x2_t.html '//a[@href="struct.uint32x4_t.html"]' 'uint32x4_t'
+    // @!has glob_inline_siblings/aarch64/fn.vabaq_u32.html '//a[@href="../arm/struct.uint32x4_t.html"]' 'uint32x4_t'
+    // @!has glob_inline_siblings/aarch64/struct.uint32x4x2_t.html '//a[@href="../arm/struct.uint32x4_t.html"]' 'uint32x4_t'
+
+    /// [uint32x4_t]
+    // @has glob_inline_siblings/aarch64/struct.LocalThing.html '//a[@href="struct.uint32x4_t.html"]' 'uint32x4_t'
+    // @!has glob_inline_siblings/aarch64/struct.LocalThing.html '//a[@href="../arm/struct.uint32x4_t.html"]' 'uint32x4_t'
+    pub struct LocalThing;
+}


### PR DESCRIPTION
This is, first of all, a size hack aimed at the `core::arch` modules that share items (x86-64/x86, aarch64/x86). They inline a lot of items from shared modules, and if we can avoid writing `../arm/WHATEVER` all over the aarch64 module, we can shave a few bytes off every link.

Also, clicking a link in the 64 bit module and landing in the 32 bit module makes no sense.
