### PR TITLE
Improve std::fs::Metadata Debug representation

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -214,7 +214,7 @@ pub struct Permissions(fs_imp::FilePermissions);
 /// A structure representing a type of file with accessors for each file type.
 /// It is returned by [`Metadata::file_type`] method.
 #[stable(feature = "file_type", since = "1.1.0")]
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(not(test), rustc_diagnostic_item = "FileType")]
 pub struct FileType(fs_imp::FileType);
 
@@ -1410,15 +1410,20 @@ impl Metadata {
 #[stable(feature = "std_debug", since = "1.16.0")]
 impl fmt::Debug for Metadata {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Metadata")
-            .field("file_type", &self.file_type())
-            .field("is_dir", &self.is_dir())
-            .field("is_file", &self.is_file())
-            .field("permissions", &self.permissions())
-            .field("modified", &self.modified())
-            .field("accessed", &self.accessed())
-            .field("created", &self.created())
-            .finish_non_exhaustive()
+        let mut debug = f.debug_struct("Metadata");
+        debug.field("file_type", &self.file_type());
+        debug.field("permissions", &self.permissions());
+        debug.field("len", &self.len());
+        if let Ok(modified) = self.modified() {
+            debug.field("modified", &modified);
+        }
+        if let Ok(accessed) = self.accessed() {
+            debug.field("accessed", &accessed);
+        }
+        if let Ok(created) = self.created() {
+            debug.field("created", &created);
+        }
+        debug.finish_non_exhaustive()
     }
 }
 
@@ -1681,6 +1686,17 @@ impl FileType {
     #[stable(feature = "file_type", since = "1.1.0")]
     pub fn is_symlink(&self) -> bool {
         self.0.is_symlink()
+    }
+}
+
+#[stable(feature = "std_debug", since = "1.16.0")]
+impl fmt::Debug for FileType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FileType")
+            .field("is_file", &self.is_file())
+            .field("is_dir", &self.is_dir())
+            .field("is_symlink", &self.is_symlink())
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
- Remove duplication of `mode` between `file_type` and `permissions`, which both involve operating on the same mode_t integer
- Add `is_symlink`
- Add `len` in bytes
- Remove Ok wrapping around `modified`, `accessed`, `created`, which eliminates 6 useless lines

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

```console
Metadata {
    file_type: FileType(
        FileType {
            mode: 0o100600 (-rw-------),
        },
    ),
    is_dir: false,
    is_file: true,
    permissions: Permissions(
        FilePermissions {
            mode: 0o100600 (-rw-------),
        },
    ),
    modified: Ok(
        SystemTime {
            tv_sec: 1713402981,
            tv_nsec: 682983531,
        },
    ),
    accessed: Ok(
        SystemTime {
            tv_sec: 1713402983,
            tv_nsec: 206999623,
        },
    ),
    created: Ok(
        SystemTime {
            tv_sec: 1713402981,
            tv_nsec: 682983531,
        },
    ),
    ..
}
```
</td><td>

```console
Metadata {
    file_type: FileType {
        is_file: true,
        is_dir: false,
        is_symlink: false,
        ..
    },
    permissions: Permissions(
        FilePermissions {
            mode: 0o100600 (-rw-------),
        },
    ),
    len: 2096,
    modified: SystemTime {
        tv_sec: 1713402981,
        tv_nsec: 682983531,
    },
    accessed: SystemTime {
        tv_sec: 1713402983,
        tv_nsec: 206999623,
    },
    created: SystemTime {
        tv_sec: 1713402981,
        tv_nsec: 682983531,
    },
    ..
}







```
</td></tr></table>

Generated by:

```rust
fn main() {
    println!("{:#?}", std::fs::metadata("Cargo.toml").unwrap());
}
```