### PR TITLE
Fix capturing duplicated lifetimes via parent in `precise_captures` (`impl use<'...>`)

### DIFF
--- a/tests/ui/impl-trait/precise-capturing/capture-parent-arg.rs
+++ b/tests/ui/impl-trait/precise-capturing/capture-parent-arg.rs
@@ -1,0 +1,38 @@
+#![feature(precise_capturing)]
+//~^ WARN the feature `precise_capturing` is incomplete
+
+trait Tr {
+    type Assoc;
+}
+
+struct W<'a>(&'a ());
+
+impl Tr for W<'_> {
+    type Assoc = ();
+}
+
+// The normal way of capturing `'a`...
+impl<'a> W<'a> {
+    fn good1() -> impl use<'a> Into<<W<'a> as Tr>::Assoc> {}
+}
+
+// This ensures that we don't error when we capture the *parent* copy of `'a`,
+// since the opaque captures that rather than the duplicated `'a` lifetime
+// synthesized from mentioning `'a` directly in the bounds.
+impl<'a> W<'a> {
+    fn good2() -> impl use<'a> Into<<Self as Tr>::Assoc> {}
+}
+
+// The normal way of capturing `'a`... but not mentioned in the bounds.
+impl<'a> W<'a> {
+    fn bad1() -> impl use<> Into<<W<'a> as Tr>::Assoc> {}
+    //~^ ERROR `impl Trait` captures lifetime parameter, but it is not mentioned in `use<...>` precise captures list
+}
+
+// But also make sure that we error here...
+impl<'a> W<'a> {
+//~^ ERROR `impl Trait` captures lifetime parameter, but it is not mentioned in `use<...>` precise captures list
+    fn bad2() -> impl use<> Into<<Self as Tr>::Assoc> {}
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/capture-parent-arg.stderr
+++ b/tests/ui/impl-trait/precise-capturing/capture-parent-arg.stderr
@@ -1,0 +1,28 @@
+warning: the feature `precise_capturing` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/capture-parent-arg.rs:1:12
+   |
+LL | #![feature(precise_capturing)]
+   |            ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #123432 <https://github.com/rust-lang/rust/issues/123432> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: `impl Trait` captures lifetime parameter, but it is not mentioned in `use<...>` precise captures list
+  --> $DIR/capture-parent-arg.rs:28:37
+   |
+LL | impl<'a> W<'a> {
+   |      -- this lifetime parameter is captured
+LL |     fn bad1() -> impl use<> Into<<W<'a> as Tr>::Assoc> {}
+   |                  -------------------^^---------------- lifetime captured due to being mentioned in the bounds of the `impl Trait`
+
+error: `impl Trait` captures lifetime parameter, but it is not mentioned in `use<...>` precise captures list
+  --> $DIR/capture-parent-arg.rs:33:6
+   |
+LL | impl<'a> W<'a> {
+   |      ^^
+LL |
+LL |     fn bad2() -> impl use<> Into<<Self as Tr>::Assoc> {}
+   |                  ------------------------------------ lifetime captured due to being mentioned in the bounds of the `impl Trait`
+
+error: aborting due to 2 previous errors; 1 warning emitted
+


### PR DESCRIPTION
For technical reasons related to the way that `Self` and `T::Assoc` are lowered from HIR -> `rustc_middle::ty`, an opaque may mention in its bounds both the original early-bound lifetime from the parent `impl`/`fn`, *and* the *duplicated* early-bound lifetime on the opaque.

This is fine -- and has been fine since @cjgillot rewrote the way we handled opaque lifetime captures, and we went further to allow this behavior explicitly in https://github.com/rust-lang/rust/pull/115659. It's worthwhile to read this PR's technical section to recall how this duplication works and when it acts surprisingly.

The problem here is that the check that make sure that `impl use<'a, 'b>` lists all of the opaque's captured lifetimes wasn't smart enough to consider both these captured lifetimes and the original lifetimes they're duplicated from to be equal. This PR fixes that.

r? oli-obk