### PR TITLE
Don't repeatedly duplicate TAIT lifetimes for each subsequently nested TAIT

### DIFF
--- a/tests/ui/type-alias-impl-trait/variance.rs
+++ b/tests/ui/type-alias-impl-trait/variance.rs
@@ -52,4 +52,28 @@ impl<'i> Foo<'i> for () {
     //~^ ERROR: unconstrained opaque type
 }
 
+trait Nesting<'a> {
+    type Output;
+}
+impl<'a> Nesting<'a> for &'a () {
+    type Output = &'a ();
+}
+type NestedDeeply<'a> =
+    impl Nesting< //~ [*, o]
+        'a,
+        Output = impl Nesting< //~ [*, o]
+            'a,
+            Output = impl Nesting< //~ [*, o]
+                'a,
+                Output = impl Nesting< //~ [*, o]
+                    'a,
+                    Output = impl Nesting<'a> //~ [*, o]
+                >
+            >,
+        >,
+    >;
+fn test<'a>() -> NestedDeeply<'a> {
+    &()
+}
+
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/variance.stderr
+++ b/tests/ui/type-alias-impl-trait/variance.stderr
@@ -176,6 +176,60 @@ error: [*, *, o, o]
 LL |     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>;
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 24 previous errors
+error: [*, o]
+  --> $DIR/variance.rs:62:5
+   |
+LL | /     impl Nesting<
+LL | |         'a,
+LL | |         Output = impl Nesting<
+LL | |             'a,
+...  |
+LL | |         >,
+LL | |     >;
+   | |_____^
+
+error: [*, o]
+  --> $DIR/variance.rs:64:18
+   |
+LL |           Output = impl Nesting<
+   |  __________________^
+LL | |             'a,
+LL | |             Output = impl Nesting<
+LL | |                 'a,
+...  |
+LL | |             >,
+LL | |         >,
+   | |_________^
+
+error: [*, o]
+  --> $DIR/variance.rs:66:22
+   |
+LL |               Output = impl Nesting<
+   |  ______________________^
+LL | |                 'a,
+LL | |                 Output = impl Nesting<
+LL | |                     'a,
+LL | |                     Output = impl Nesting<'a>
+LL | |                 >
+LL | |             >,
+   | |_____________^
+
+error: [*, o]
+  --> $DIR/variance.rs:68:26
+   |
+LL |                   Output = impl Nesting<
+   |  __________________________^
+LL | |                     'a,
+LL | |                     Output = impl Nesting<'a>
+LL | |                 >
+   | |_________________^
+
+error: [*, o]
+  --> $DIR/variance.rs:70:30
+   |
+LL |                     Output = impl Nesting<'a>
+   |                              ^^^^^^^^^^^^^^^^
+
+error: aborting due to 29 previous errors
 
 For more information about this error, try `rustc --explain E0657`.


### PR DESCRIPTION
Make it so that nested TAITs inherit the lifetimes from their parent item, not their parent TAIT. This is because we don't need to re-duplicate lifetimes for nested TAITs over and over, since the only lifetimes they can capture are from the parent item anyways.

This mirrors how RPITs work. This is **not** a functional change that should be observable, since the whole point of duplicating lifetimes and marking the shadowed ones (and uncaptured ones) as bivariant is designed to *not* be observable.

r? oli-obk