### PR TITLE
Add ExactSizeIterator implementation to Chain

### DIFF
--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -273,6 +273,18 @@ where
 {
 }
 
+#[stable(feature = "impl_exact_size_iterator_for_chain", since = "CURRENT_RUSTC_VERSION")]
+impl<A, B> ExactSizeIterator for Chain<A, B>
+where
+    A: ExactSizeIterator,
+    B: ExactSizeIterator<Item = A::Item>,
+{
+    fn len(&self) -> usize {
+        self.a.as_ref().map(|i| i.len()).unwrap_or_default()
+            + self.b.as_ref().map(|i| i.len()).unwrap_or_default()
+    }
+}
+
 #[stable(feature = "default_iters", since = "1.70.0")]
 impl<A: Default, B: Default> Default for Chain<A, B> {
     /// Creates a `Chain` from the default values for `A` and `B`.


### PR DESCRIPTION
Adds an implementation of `ExactSizeIterator` for `Chain` when both iterators implement `ExactSizeIterator`. `Chain` already implements `TrustedLen` this way so I think it makes sense to have this as well.

This change is insta-stable from what I could understand from the docs so it doesn't need an RFC or a ACP from what I could understand from the docs.

This is my first contribution to the standard library that actually changes the API surface of std (specifically core), so sorry if I missed something :sweat_smile: 