### PR TITLE
 Don't perform unsigned comparisons for signed integers 

### DIFF
--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -399,7 +399,10 @@ impl<'tcx> SimplifyMatch<'tcx> for SimplifyToExp {
                             if ((f_c.const_.ty().is_signed() || discr_ty.is_signed())
                                 && int_equal(f, first_val, discr_size)
                                 && int_equal(s, second_val, discr_size))
-                                || (Some(f) == ScalarInt::try_from_uint(first_val, f.size())
+                                || (!f_c.const_.ty().is_signed()
+                                    && !discr_ty.is_signed()
+                                    && Some(f)
+                                        == ScalarInt::try_from_uint(first_val, f.size())
                                     && Some(s)
                                         == ScalarInt::try_from_uint(second_val, s.size())) =>
                         {
@@ -449,7 +452,10 @@ impl<'tcx> SimplifyMatch<'tcx> for SimplifyToExp {
                         {
                             continue;
                         }
-                        if Some(f) == ScalarInt::try_from_uint(other_val, f.size()) {
+                        if !is_signed
+                            && !s_c.const_.ty().is_signed()
+                            && Some(f) == ScalarInt::try_from_uint(other_val, f.size())
+                        {
                             continue;
                         }
                         return None;

--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -368,6 +368,8 @@ impl<'tcx> SimplifyMatch<'tcx> for SimplifyToExp {
             return None;
         }
 
+        // For signed comparisons, we need to consider different bit widths,
+        // so we need to transform to i128 for comparison.
         fn int_equal(l: ScalarInt, r: impl Into<u128>, size: Size) -> bool {
             l.try_to_int(l.size()).unwrap()
                 == ScalarInt::try_from_uint(r, size).unwrap().try_to_int(size).unwrap()

--- a/tests/mir-opt/matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
@@ -5,42 +5,37 @@
       debug i => _1;
       let mut _0: u128;
       let mut _2: i128;
-+     let mut _3: i128;
   
       bb0: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [1: bb3, 2: bb4, 3: bb5, 340282366920938463463374607431768211455: bb2, otherwise: bb1];
--     }
-- 
--     bb1: {
--         unreachable;
--     }
-- 
--     bb2: {
--         _0 = const core::num::<impl u128>::MAX;
--         goto -> bb6;
--     }
-- 
--     bb3: {
--         _0 = const 1_u128;
--         goto -> bb6;
--     }
-- 
--     bb4: {
--         _0 = const 2_u128;
--         goto -> bb6;
--     }
-- 
--     bb5: {
--         _0 = const 3_u128;
--         goto -> bb6;
--     }
-- 
--     bb6: {
-+         StorageLive(_3);
-+         _3 = move _2;
-+         _0 = _3 as u128 (IntToInt);
-+         StorageDead(_3);
+          switchInt(move _2) -> [1: bb3, 2: bb4, 3: bb5, 340282366920938463463374607431768211455: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const core::num::<impl u128>::MAX;
+          goto -> bb6;
+      }
+  
+      bb3: {
+          _0 = const 1_u128;
+          goto -> bb6;
+      }
+  
+      bb4: {
+          _0 = const 2_u128;
+          goto -> bb6;
+      }
+  
+      bb5: {
+          _0 = const 3_u128;
+          goto -> bb6;
+      }
+  
+      bb6: {
           return;
       }
   }

--- a/tests/mir-opt/matches_reduce_branches.match_i8_i16_failed_2_a.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i8_i16_failed_2_a.MatchBranchSimplification.diff
@@ -1,0 +1,37 @@
+- // MIR for `match_i8_i16_failed_2_a` before MatchBranchSimplification
++ // MIR for `match_i8_i16_failed_2_a` after MatchBranchSimplification
+  
+  fn match_i8_i16_failed_2_a(_1: EnumAi8) -> i16 {
+      debug i => _1;
+      let mut _0: i16;
+      let mut _2: i8;
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [255: bb3, 2: bb4, 253: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const -3_i16;
+          goto -> bb5;
+      }
+  
+      bb3: {
+          _0 = const 255_i16;
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _0 = const 2_i16;
+          goto -> bb5;
+      }
+  
+      bb5: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_i8_i16_failed_2_b.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i8_i16_failed_2_b.MatchBranchSimplification.diff
@@ -1,0 +1,37 @@
+- // MIR for `match_i8_i16_failed_2_b` before MatchBranchSimplification
++ // MIR for `match_i8_i16_failed_2_b` after MatchBranchSimplification
+  
+  fn match_i8_i16_failed_2_b(_1: EnumAi8) -> i16 {
+      debug i => _1;
+      let mut _0: i16;
+      let mut _2: i8;
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [255: bb3, 2: bb4, 253: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const 253_i16;
+          goto -> bb5;
+      }
+  
+      bb3: {
+          _0 = const -1_i16;
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _0 = const 2_i16;
+          goto -> bb5;
+      }
+  
+      bb5: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.rs
+++ b/tests/mir-opt/matches_reduce_branches.rs
@@ -225,6 +225,30 @@ fn match_i8_i16_failed(i: EnumAi8) -> i16 {
     }
 }
 
+// We cannot transform it, even though `-1i8` and `255i16` are the same in terms of bits,
+// what we actually require is that they are considered equal in a signed comparison.
+// EMIT_MIR matches_reduce_branches.match_i8_i16_failed_2_a.MatchBranchSimplification.diff
+fn match_i8_i16_failed_2_a(i: EnumAi8) -> i16 {
+    // CHECK-LABEL: fn match_i8_i16_failed_2_a(
+    // CHECK: switchInt
+    match i {
+        EnumAi8::A => 255,
+        EnumAi8::B => 2,
+        EnumAi8::C => -3,
+    }
+}
+
+// EMIT_MIR matches_reduce_branches.match_i8_i16_failed_2_b.MatchBranchSimplification.diff
+fn match_i8_i16_failed_2_b(i: EnumAi8) -> i16 {
+    // CHECK-LABEL: fn match_i8_i16_failed_2_b(
+    // CHECK: switchInt
+    match i {
+        EnumAi8::A => -1,
+        EnumAi8::B => 2,
+        EnumAi8::C => 253,
+    }
+}
+
 #[repr(i16)]
 enum EnumAi16 {
     A = -1,
@@ -253,12 +277,11 @@ enum EnumAi128 {
     D = -1,
 }
 
+// FIXME: This transform is reasonable.
 // EMIT_MIR matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
 fn match_i128_u128(i: EnumAi128) -> u128 {
     // CHECK-LABEL: fn match_i128_u128(
-    // CHECK-NOT: switchInt
-    // CHECK: _0 = _3 as u128 (IntToInt);
-    // CHECH: return
+    // CHECK: switchInt
     match i {
         EnumAi128::A => 1,
         EnumAi128::B => 2,

--- a/tests/mir-opt/matches_reduce_branches.rs
+++ b/tests/mir-opt/matches_reduce_branches.rs
@@ -226,7 +226,8 @@ fn match_i8_i16_failed(i: EnumAi8) -> i16 {
 }
 
 // We cannot transform it, even though `-1i8` and `255i16` are the same in terms of bits,
-// what we actually require is that they are considered equal in a signed comparison.
+// what we actually require is that they are considered equal in a signed comparison,
+// after sign-extending to the larger type.
 // EMIT_MIR matches_reduce_branches.match_i8_i16_failed_2_a.MatchBranchSimplification.diff
 fn match_i8_i16_failed_2_a(i: EnumAi8) -> i16 {
     // CHECK-LABEL: fn match_i8_i16_failed_2_a(


### PR DESCRIPTION
Fixes (partial) #124150. (There are still some potential miscompilation with unsigned and signed integer transformation.)

Fixes a mis-compilation mentioned in https://github.com/rust-lang/rust/pull/120614#discussion_r1570778396. We must handle signed and unsigned comparisons separately. We cannot cast  `-1i8` to `255i16`.

This PR breaks the test case for unsigned and signed transformation, but I think this could go into a separate PR.

r? RalfJung or mir-opt