### PR TITLE
Abort a process when FD ownership is violated

### DIFF
--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -176,7 +176,16 @@ impl Drop for OwnedFd {
             // something like EINTR), we might close another valid file descriptor
             // opened after we closed ours.
             #[cfg(not(target_os = "hermit"))]
-            let _ = libc::close(self.fd);
+            {
+                match cvt(libc::close(self.fd)) {
+                    Err(e) if e.raw_os_error() == Some(libc::EBADF) => {
+                        rtabort!(
+                            "IO Safety violation: owned file descriptor already closed (EBADF)"
+                        );
+                    }
+                    _ => {}
+                }
+            }
             #[cfg(target_os = "hermit")]
             let _ = hermit_abi::close(self.fd);
         }


### PR DESCRIPTION
When an EBADF happens then something else already touched an FD in ways it is not allowed to. At that point things can already be arbitrarily bad, e.g. clobbered mmaps. Recovery is not possible.
All we can do is hasten the fire.

It could help with the investigation in #124105. Currently only `Drop for Dir` panics while `OwnedFd` closes silently. If we make `OwnedFd` fail loudly too then it should tell us whether the bug is specific to `Dir` or there's more general FD-clobbering going on.