### PR TITLE
Add target docs for aarch64-apple-darwin (M1/M2 macs)

### DIFF
--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -86,7 +86,7 @@ so Rustup may install the documentation for a similar tier 1 target instead.
 
 target | notes
 -------|-------
-`aarch64-apple-darwin` | ARM64 macOS (11.0+, Big Sur+)
+[`aarch64-apple-darwin`](platform-support/aarch64-apple-darwin.md) | ARM64 macOS (11.0+, Big Sur+)
 `aarch64-pc-windows-msvc` | ARM64 Windows MSVC
 `aarch64-unknown-linux-musl` | ARM64 Linux with musl 1.2.3
 `arm-unknown-linux-gnueabi` | ARMv6 Linux (kernel 3.2, glibc 2.17)

--- a/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
@@ -37,7 +37,4 @@ The Rust test suite can be run for this target on such hardware.
 
 ## Cross-compilation toolchains and C code
 
-Does the target support C code? If so, what toolchain target should users use
-to build compatible C code? (This may match the target triple, or it may be a
-toolchain for a different target triple, potentially with specific options or
-caveats.)
+This target supports C code. To build compatible C code, you should use a toolchain targeting aarch64-apple-darwin, such as Xcode on a Mac or GCC. The toolchain target triple matches this Rust target triple.

--- a/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
@@ -21,7 +21,7 @@ The default binary format is Mach-O, the executable format used on Apple's platf
 ## Building the target
 
 Just add it to the `target` with:
-```
+```sh
 rustup target add aarch64-apple-darwin
 ```
 

--- a/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
@@ -2,7 +2,7 @@
 
 **Tier: 2 with host tools**
 
-One-sentence description of the target (e.g. CPU, OS)
+64-bit ARM-based Apple devices running macOS, Macs with Apple Silicon M1 or M2 chips. M3 is [`arm64e-apple-darwin`](platform-support/arm64e-apple-darwin.md).
 
 ## Target maintainers
 
@@ -10,39 +10,30 @@ One-sentence description of the target (e.g. CPU, OS)
 
 ## Requirements
 
-Does the target support host tools, or only cross-compilation? Does the target
-support std, or alloc (either with a default allocator, or if the user supplies
-an allocator)?
+This target supports host tools and cross-compilation. It provides the full standard library including std and alloc.
 
-Document the expectations of binaries built for the target. Do they assume
-specific minimum features beyond the baseline of the CPU/environment/etc? What
-version of the OS or environment do they expect?
+Binaries built for this target expect a Apple Silicon Mac.
 
-Are there notable `#[target_feature(...)]` or `-C target-feature=` values that
-programs may wish to use?
+### Format
 
-What calling convention does `extern "C"` use on the target?
-
-What format do binaries use by default? ELF, PE, something else?
+The default binary format is Mach-O, the executable format used on Apple's platforms.
 
 ## Building the target
 
-If Rust doesn't build the target by default, how can users build it? Can users
-just add it to the `target` list in `config.toml`?
+Just add it to the `target` with: 
+```
+rustup target add aarch64-apple-darwin
+```
 
 ## Building Rust programs
 
-Rust does not yet ship pre-compiled artifacts for this target. To compile for
-this target, you will either need to build Rust with the target enabled (see
-"Building the target" above), or build your own copy of `core` by using
-`build-std` or similar.
+Rust ships pre-compiled artifacts for this target or build your own copy of `core` by using
+`build-std`.
 
 ## Testing
 
-Does the target support running binaries, or do binaries have varying
-expectations that prevent having a standard way to run them? If users can run
-binaries, can they do so in some common emulator, or do they need native
-hardware? Does the target support running the Rust testsuite?
+Binaries produced for this target can be run directly on Apple Silicon Macs natively. 
+The Rust test suite can be run for this target on such hardware.
 
 ## Cross-compilation toolchains and C code
 

--- a/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
@@ -1,0 +1,52 @@
+# `aarch64-apple-darwin`
+
+**Tier: 2 with host tools**
+
+One-sentence description of the target (e.g. CPU, OS)
+
+## Target maintainers
+
+- ???
+
+## Requirements
+
+Does the target support host tools, or only cross-compilation? Does the target
+support std, or alloc (either with a default allocator, or if the user supplies
+an allocator)?
+
+Document the expectations of binaries built for the target. Do they assume
+specific minimum features beyond the baseline of the CPU/environment/etc? What
+version of the OS or environment do they expect?
+
+Are there notable `#[target_feature(...)]` or `-C target-feature=` values that
+programs may wish to use?
+
+What calling convention does `extern "C"` use on the target?
+
+What format do binaries use by default? ELF, PE, something else?
+
+## Building the target
+
+If Rust doesn't build the target by default, how can users build it? Can users
+just add it to the `target` list in `config.toml`?
+
+## Building Rust programs
+
+Rust does not yet ship pre-compiled artifacts for this target. To compile for
+this target, you will either need to build Rust with the target enabled (see
+"Building the target" above), or build your own copy of `core` by using
+`build-std` or similar.
+
+## Testing
+
+Does the target support running binaries, or do binaries have varying
+expectations that prevent having a standard way to run them? If users can run
+binaries, can they do so in some common emulator, or do they need native
+hardware? Does the target support running the Rust testsuite?
+
+## Cross-compilation toolchains and C code
+
+Does the target support C code? If so, what toolchain target should users use
+to build compatible C code? (This may match the target triple, or it may be a
+toolchain for a different target triple, potentially with specific options or
+caveats.)

--- a/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
@@ -20,7 +20,7 @@ The default binary format is Mach-O, the executable format used on Apple's platf
 
 ## Building the target
 
-Just add it to the `target` with: 
+Just add it to the `target` with:
 ```
 rustup target add aarch64-apple-darwin
 ```
@@ -32,9 +32,10 @@ Rust ships pre-compiled artifacts for this target or build your own copy of `cor
 
 ## Testing
 
-Binaries produced for this target can be run directly on Apple Silicon Macs natively. 
+Binaries produced for this target can be run directly on Apple Silicon Macs natively.
 The Rust test suite can be run for this target on such hardware.
 
 ## Cross-compilation toolchains and C code
 
-This target supports C code. To build compatible C code, you should use a toolchain targeting aarch64-apple-darwin, such as Xcode on a Mac or GCC. The toolchain target triple matches this Rust target triple.
+This target supports C code. To build compatible C code, you should use a toolchain targeting aarch64-apple-darwin, such as Xcode on a Mac or GCC.
+The toolchain target triple matches this Rust target triple.

--- a/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
@@ -2,7 +2,7 @@
 
 **Tier: 2 with host tools**
 
-64-bit ARM-based Apple devices running macOS, Macs with M1 or M2 Apple Silicon chips. M3 or higher is [`arm64e-apple-darwin`](platform-support/arm64e-apple-darwin.md).
+64-bit Arm-based Apple devices running macOS: Macs with M1-family or later Apple Silicon CPUs.
 
 ## Target maintainers
 

--- a/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/aarch64-apple-darwin.md
@@ -2,7 +2,7 @@
 
 **Tier: 2 with host tools**
 
-64-bit ARM-based Apple devices running macOS, Macs with Apple Silicon M1 or M2 chips. M3 is [`arm64e-apple-darwin`](platform-support/arm64e-apple-darwin.md).
+64-bit ARM-based Apple devices running macOS, Macs with M1 or M2 Apple Silicon chips. M3 or higher is [`arm64e-apple-darwin`](platform-support/arm64e-apple-darwin.md).
 
 ## Target maintainers
 
@@ -12,7 +12,7 @@
 
 This target supports host tools and cross-compilation. It provides the full standard library including std and alloc.
 
-Binaries built for this target expect a Apple Silicon Mac.
+Binaries built for this target expect a Apple Silicon Mac on macOS 11.0 Big Sur+.
 
 ### Format
 


### PR DESCRIPTION
Add target documentation for `aarch64-apple-darwin`;  64-bit ARM-based macs running macOS, specifically Macs with "M" series Apple Silicon chips.
"M" series macs are quite popular so it would be useful to have some docs.