### PR TITLE
Match hyphen in multi-revision comment matchers

### DIFF
--- a/src/tools/compiletest/src/errors.rs
+++ b/src/tools/compiletest/src/errors.rs
@@ -118,7 +118,7 @@ fn parse_expected(
     //     //[rev1]~
     //     //[rev1,rev2]~^^
     static RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"//(?:\[(?P<revs>[\w,]+)])?~(?P<adjust>\||\^*)").unwrap());
+        Lazy::new(|| Regex::new(r"//(?:\[(?P<revs>[\w\-,]+)])?~(?P<adjust>\||\^*)").unwrap());
 
     let captures = RE.captures(line)?;
 
@@ -178,3 +178,6 @@ fn parse_expected(
     );
     Some((which, Error { line_num, kind, msg }))
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/tools/compiletest/src/errors/tests.rs
+++ b/src/tools/compiletest/src/errors/tests.rs
@@ -1,0 +1,12 @@
+use super::*;
+
+#[test]
+fn test_parse_expected_matching() {
+    // Ensure that we correctly extract expected revisions
+    let d1 = "//[rev1,rev2]~^ ERROR foo";
+    let d2 = "//[rev1,rev2-foo]~^ ERROR foo";
+    assert!(parse_expected(None, 1, d1, Some("rev1")).is_some());
+    assert!(parse_expected(None, 1, d1, Some("rev2")).is_some());
+    assert!(parse_expected(None, 1, d2, Some("rev1")).is_some());
+    assert!(parse_expected(None, 1, d2, Some("rev2-foo")).is_some());
+}


### PR DESCRIPTION
Currently, the matcher `//[rev-foo,rev-bar]~` does not get selected by the regex. Change the matcher to include `-`.