### PR TITLE
Ignore LLVM ABI in dlltool tests since those targets don't use dlltool

### DIFF
--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -120,16 +120,6 @@ pub(super) fn handle_needs(
             ignore_reason: "ignored on targets without Rust's LLDB",
         },
         Need {
-            name: "needs-i686-dlltool",
-            condition: cache.i686_dlltool,
-            ignore_reason: "ignored when dlltool for i686 is not present",
-        },
-        Need {
-            name: "needs-x86_64-dlltool",
-            condition: cache.x86_64_dlltool,
-            ignore_reason: "ignored when dlltool for x86_64 is not present",
-        },
-        Need {
             name: "needs-dlltool",
             condition: cache.dlltool,
             ignore_reason: "ignored when dlltool for the current architecture is not present",
@@ -218,27 +208,11 @@ pub(super) struct CachedNeedsConditions {
     profiler_support: bool,
     xray: bool,
     rust_lld: bool,
-    i686_dlltool: bool,
-    x86_64_dlltool: bool,
     dlltool: bool,
 }
 
 impl CachedNeedsConditions {
     pub(super) fn load(config: &Config) -> Self {
-        let path = std::env::var_os("PATH").expect("missing PATH environment variable");
-        let path = std::env::split_paths(&path).collect::<Vec<_>>();
-
-        // On Windows, dlltool.exe is used for all architectures.
-        #[cfg(windows)]
-        let dlltool = path.iter().any(|dir| dir.join("dlltool.exe").is_file());
-
-        // For non-Windows, there are architecture specific dlltool binaries.
-        #[cfg(not(windows))]
-        let i686_dlltool = path.iter().any(|dir| dir.join("i686-w64-mingw32-dlltool").is_file());
-        #[cfg(not(windows))]
-        let x86_64_dlltool =
-            path.iter().any(|dir| dir.join("x86_64-w64-mingw32-dlltool").is_file());
-
         let target = &&*config.target;
         let sanitizers = &config.target_cfg().sanitizers;
         Self {
@@ -278,26 +252,25 @@ impl CachedNeedsConditions {
                 .join(if config.host.contains("windows") { "rust-lld.exe" } else { "rust-lld" })
                 .exists(),
 
-            #[cfg(windows)]
-            i686_dlltool: dlltool,
-            #[cfg(windows)]
-            x86_64_dlltool: dlltool,
-            #[cfg(windows)]
-            dlltool,
-
-            // For non-Windows, there are architecture specific dlltool binaries.
-            #[cfg(not(windows))]
-            i686_dlltool,
-            #[cfg(not(windows))]
-            x86_64_dlltool,
-            #[cfg(not(windows))]
-            dlltool: if config.matches_arch("x86") {
-                i686_dlltool
-            } else if config.matches_arch("x86_64") {
-                x86_64_dlltool
-            } else {
-                false
-            },
+            dlltool: find_dlltool(&config),
         }
     }
+}
+
+fn find_dlltool(config: &Config) -> bool {
+    let path = std::env::var_os("PATH").expect("missing PATH environment variable");
+    let path = std::env::split_paths(&path).collect::<Vec<_>>();
+
+    // On Windows, dlltool.exe is used for all architectures.
+    // For non-Windows, there are architecture specific dlltool binaries.
+    let dlltool_found = if cfg!(windows) {
+        path.iter().any(|dir| dir.join("dlltool.exe").is_file())
+    } else if config.matches_arch("i686") {
+        path.iter().any(|dir| dir.join("i686-w64-mingw32-dlltool").is_file())
+    } else if config.matches_arch("x86_64") {
+        path.iter().any(|dir| dir.join("x86_64-w64-mingw32-dlltool").is_file())
+    } else {
+        false
+    };
+    dlltool_found
 }

--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -261,6 +261,11 @@ fn find_dlltool(config: &Config) -> bool {
     let path = std::env::var_os("PATH").expect("missing PATH environment variable");
     let path = std::env::split_paths(&path).collect::<Vec<_>>();
 
+    // dlltool is used ony by GNU based `*-*-windows-gnu`
+    if !(config.matches_os("windows") && config.matches_env("gnu") && config.matches_abi("")) {
+        return false;
+    }
+
     // On Windows, dlltool.exe is used for all architectures.
     // For non-Windows, there are architecture specific dlltool binaries.
     let dlltool_found = if cfg!(windows) {

--- a/tests/run-make/raw-dylib-cross-compilation/Makefile
+++ b/tests/run-make/raw-dylib-cross-compilation/Makefile
@@ -1,8 +1,6 @@
 # Tests that raw-dylib cross compilation works correctly
 
-# only-gnu
-# needs-i686-dlltool
-# needs-x86_64-dlltool
+# needs-dlltool
 
 # i686 dlltool.exe can't product x64 binaries.
 # ignore-i686-pc-windows-gnu

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/dlltool-failed.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/dlltool-failed.rs
@@ -1,7 +1,5 @@
 // Tests that dlltool failing to generate an import library will raise an error.
 
-//@ only-gnu
-//@ only-windows
 //@ needs-dlltool
 //@ compile-flags: --crate-type lib --emit link
 //@ normalize-stderr-test: "[^ ']*/dlltool.exe" -> "$$DLLTOOL"

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/invalid-dlltool.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/invalid-dlltool.rs
@@ -1,7 +1,6 @@
 // Tests that failing to run dlltool will raise an error.
 
-//@ only-gnu
-//@ only-windows
+//@ needs-dlltool
 //@ compile-flags: --crate-type lib --emit link -Cdlltool=does_not_exit.exe
 #[link(name = "foo", kind = "raw-dylib")]
 extern "C" {


### PR DESCRIPTION
Otherwise those two tests fail when running `./x.py test` with this target.