### PR TITLE
Triagebot: Rename `macos` ping group to `apple`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -106,10 +106,16 @@ resolved/implemented on Fuchsia. Could one of you weigh in?
 """
 label = "O-fuchsia"
 
-[ping.macos]
+[ping.apple]
+alias = ["macos", "ios", "tvos", "watchos", "visionos"]
 message = """\
-Hey MacOS Group! This issue or PR could use some MacOS-specific guidance. Could one
-of you weigh in? Thanks <3
+Hey Apple notification group! This issue or PR could use some Apple-specific
+guidance. Could one of you weigh in? Thanks <3
+
+(In case it's useful, here are some [instructions] for tackling these sorts of
+issues).
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/apple.html
 """
 label = "O-macos"
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -227,7 +227,9 @@ trigger_files = [
 
 [autolabel."O-macos"]
 trigger_files = [
-    "library/std/src/os/macos"
+    "library/std/src/os/macos",
+    "library/std/src/sys/pal/unix/thread_parking/darwin.rs",
+    "compiler/rustc_target/src/spec/base/apple",
 ]
 
 [autolabel."O-netbsd"]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -117,7 +117,7 @@ issues).
 
 [instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/apple.html
 """
-label = "O-macos"
+label = "O-apple"
 
 [prioritize]
 label = "I-prioritize"


### PR DESCRIPTION
Expand the scope of the macOS ping group to all Apple targets.

Blocked on https://github.com/rust-lang/team/pull/1436 (rename in `team` repo)
Blocked on https://github.com/rust-lang/rustc-dev-guide/pull/1964 (referenced documentation link)

@rustbot label O-macos O-ios O-tvos O-watchos O-visionos
