### PR TITLE
rustdoc-search: fix description on aliases in results

### DIFF
--- a/tests/rustdoc-js-std/alias-1.js
+++ b/tests/rustdoc-js-std/alias-1.js
@@ -1,6 +1,10 @@
 const EXPECTED = {
     'query': '&',
     'others': [
-        { 'path': 'std', 'name': 'reference' },
+        {
+            'path': 'std',
+            'name': 'reference',
+            'desc': "References, <code>&amp;T</code> and <code>&amp;mut T</code>.",
+        },
     ],
 };


### PR DESCRIPTION
This needs to start downloading the descriptions after aliases have been added to the result set.