### PR TITLE
Disable SimplifyToExp in MatchBranchSimplification

### DIFF
--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -41,7 +41,10 @@ impl<'tcx> MirPass<'tcx> for MatchBranchSimplification {
                 should_cleanup = true;
                 continue;
             }
-            if SimplifyToExp::default().simplify(tcx, body, bb_idx, param_env).is_some() {
+            // unsound: https://github.com/rust-lang/rust/issues/124150
+            if tcx.sess.opts.unstable_opts.unsound_mir_opts
+                && SimplifyToExp::default().simplify(tcx, body, bb_idx, param_env).is_some()
+            {
                 should_cleanup = true;
                 continue;
             }

--- a/tests/mir-opt/matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
@@ -5,42 +5,37 @@
       debug i => _1;
       let mut _0: u128;
       let mut _2: i128;
-+     let mut _3: i128;
   
       bb0: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [1: bb3, 2: bb4, 3: bb5, 340282366920938463463374607431768211455: bb2, otherwise: bb1];
--     }
-- 
--     bb1: {
--         unreachable;
--     }
-- 
--     bb2: {
--         _0 = const core::num::<impl u128>::MAX;
--         goto -> bb6;
--     }
-- 
--     bb3: {
--         _0 = const 1_u128;
--         goto -> bb6;
--     }
-- 
--     bb4: {
--         _0 = const 2_u128;
--         goto -> bb6;
--     }
-- 
--     bb5: {
--         _0 = const 3_u128;
--         goto -> bb6;
--     }
-- 
--     bb6: {
-+         StorageLive(_3);
-+         _3 = move _2;
-+         _0 = _3 as u128 (IntToInt);
-+         StorageDead(_3);
+          switchInt(move _2) -> [1: bb3, 2: bb4, 3: bb5, 340282366920938463463374607431768211455: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const core::num::<impl u128>::MAX;
+          goto -> bb6;
+      }
+  
+      bb3: {
+          _0 = const 1_u128;
+          goto -> bb6;
+      }
+  
+      bb4: {
+          _0 = const 2_u128;
+          goto -> bb6;
+      }
+  
+      bb5: {
+          _0 = const 3_u128;
+          goto -> bb6;
+      }
+  
+      bb6: {
           return;
       }
   }

--- a/tests/mir-opt/matches_reduce_branches.match_i16_i8.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i16_i8.MatchBranchSimplification.diff
@@ -5,37 +5,32 @@
       debug i => _1;
       let mut _0: i8;
       let mut _2: i16;
-+     let mut _3: i16;
   
       bb0: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [65535: bb3, 2: bb4, 65533: bb2, otherwise: bb1];
--     }
-- 
--     bb1: {
--         unreachable;
--     }
-- 
--     bb2: {
--         _0 = const -3_i8;
--         goto -> bb5;
--     }
-- 
--     bb3: {
--         _0 = const -1_i8;
--         goto -> bb5;
--     }
-- 
--     bb4: {
--         _0 = const 2_i8;
--         goto -> bb5;
--     }
-- 
--     bb5: {
-+         StorageLive(_3);
-+         _3 = move _2;
-+         _0 = _3 as i8 (IntToInt);
-+         StorageDead(_3);
+          switchInt(move _2) -> [65535: bb3, 2: bb4, 65533: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const -3_i8;
+          goto -> bb5;
+      }
+  
+      bb3: {
+          _0 = const -1_i8;
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _0 = const 2_i8;
+          goto -> bb5;
+      }
+  
+      bb5: {
           return;
       }
   }

--- a/tests/mir-opt/matches_reduce_branches.match_i8_i16.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i8_i16.MatchBranchSimplification.diff
@@ -5,37 +5,32 @@
       debug i => _1;
       let mut _0: i16;
       let mut _2: i8;
-+     let mut _3: i8;
   
       bb0: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [255: bb3, 2: bb4, 253: bb2, otherwise: bb1];
--     }
-- 
--     bb1: {
--         unreachable;
--     }
-- 
--     bb2: {
--         _0 = const -3_i16;
--         goto -> bb5;
--     }
-- 
--     bb3: {
--         _0 = const -1_i16;
--         goto -> bb5;
--     }
-- 
--     bb4: {
--         _0 = const 2_i16;
--         goto -> bb5;
--     }
-- 
--     bb5: {
-+         StorageLive(_3);
-+         _3 = move _2;
-+         _0 = _3 as i16 (IntToInt);
-+         StorageDead(_3);
+          switchInt(move _2) -> [255: bb3, 2: bb4, 253: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const -3_i16;
+          goto -> bb5;
+      }
+  
+      bb3: {
+          _0 = const -1_i16;
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _0 = const 2_i16;
+          goto -> bb5;
+      }
+  
+      bb5: {
           return;
       }
   }

--- a/tests/mir-opt/matches_reduce_branches.match_u8_i16.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_i16.MatchBranchSimplification.diff
@@ -5,32 +5,27 @@
       debug i => _1;
       let mut _0: i16;
       let mut _2: u8;
-+     let mut _3: u8;
   
       bb0: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [1: bb3, 2: bb2, otherwise: bb1];
--     }
-- 
--     bb1: {
--         unreachable;
--     }
-- 
--     bb2: {
--         _0 = const 2_i16;
--         goto -> bb4;
--     }
-- 
--     bb3: {
--         _0 = const 1_i16;
--         goto -> bb4;
--     }
-- 
--     bb4: {
-+         StorageLive(_3);
-+         _3 = move _2;
-+         _0 = _3 as i16 (IntToInt);
-+         StorageDead(_3);
+          switchInt(move _2) -> [1: bb3, 2: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const 2_i16;
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _0 = const 1_i16;
+          goto -> bb4;
+      }
+  
+      bb4: {
           return;
       }
   }

--- a/tests/mir-opt/matches_reduce_branches.match_u8_u16.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_u16.MatchBranchSimplification.diff
@@ -5,37 +5,32 @@
       debug i => _1;
       let mut _0: u16;
       let mut _2: u8;
-+     let mut _3: u8;
   
       bb0: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [1: bb3, 2: bb4, 5: bb2, otherwise: bb1];
--     }
-- 
--     bb1: {
--         unreachable;
--     }
-- 
--     bb2: {
--         _0 = const 5_u16;
--         goto -> bb5;
--     }
-- 
--     bb3: {
--         _0 = const 1_u16;
--         goto -> bb5;
--     }
-- 
--     bb4: {
--         _0 = const 2_u16;
--         goto -> bb5;
--     }
-- 
--     bb5: {
-+         StorageLive(_3);
-+         _3 = move _2;
-+         _0 = _3 as u16 (IntToInt);
-+         StorageDead(_3);
+          switchInt(move _2) -> [1: bb3, 2: bb4, 5: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const 5_u16;
+          goto -> bb5;
+      }
+  
+      bb3: {
+          _0 = const 1_u16;
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _0 = const 2_u16;
+          goto -> bb5;
+      }
+  
+      bb5: {
           return;
       }
   }

--- a/tests/mir-opt/matches_reduce_branches.rs
+++ b/tests/mir-opt/matches_reduce_branches.rs
@@ -75,9 +75,7 @@ enum EnumAu8 {
 // EMIT_MIR matches_reduce_branches.match_u8_i16.MatchBranchSimplification.diff
 fn match_u8_i16(i: EnumAu8) -> i16 {
     // CHECK-LABEL: fn match_u8_i16(
-    // CHECK-NOT: switchInt
-    // CHECK: _0 = _3 as i16 (IntToInt);
-    // CHECH: return
+    // CHECK: switchInt
     match i {
         EnumAu8::A => 1,
         EnumAu8::B => 2,
@@ -146,9 +144,7 @@ enum EnumBu8 {
 // EMIT_MIR matches_reduce_branches.match_u8_u16.MatchBranchSimplification.diff
 fn match_u8_u16(i: EnumBu8) -> u16 {
     // CHECK-LABEL: fn match_u8_u16(
-    // CHECK-NOT: switchInt
-    // CHECK: _0 = _3 as u16 (IntToInt);
-    // CHECH: return
+    // CHECK: switchInt
     match i {
         EnumBu8::A => 1,
         EnumBu8::B => 2,
@@ -204,9 +200,7 @@ enum EnumAi8 {
 // EMIT_MIR matches_reduce_branches.match_i8_i16.MatchBranchSimplification.diff
 fn match_i8_i16(i: EnumAi8) -> i16 {
     // CHECK-LABEL: fn match_i8_i16(
-    // CHECK-NOT: switchInt
-    // CHECK: _0 = _3 as i16 (IntToInt);
-    // CHECH: return
+    // CHECK: switchInt
     match i {
         EnumAi8::A => -1,
         EnumAi8::B => 2,
@@ -235,9 +229,7 @@ enum EnumAi16 {
 // EMIT_MIR matches_reduce_branches.match_i16_i8.MatchBranchSimplification.diff
 fn match_i16_i8(i: EnumAi16) -> i8 {
     // CHECK-LABEL: fn match_i16_i8(
-    // CHECK-NOT: switchInt
-    // CHECK: _0 = _3 as i8 (IntToInt);
-    // CHECH: return
+    // CHECK: switchInt
     match i {
         EnumAi16::A => -1,
         EnumAi16::B => 2,
@@ -256,9 +248,7 @@ enum EnumAi128 {
 // EMIT_MIR matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
 fn match_i128_u128(i: EnumAi128) -> u128 {
     // CHECK-LABEL: fn match_i128_u128(
-    // CHECK-NOT: switchInt
-    // CHECK: _0 = _3 as u128 (IntToInt);
-    // CHECH: return
+    // CHECK: switchInt
     match i {
         EnumAi128::A => 1,
         EnumAi128::B => 2,

--- a/tests/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.diff
@@ -5,32 +5,27 @@
       debug e => _1;
       let mut _0: u8;
       let mut _2: isize;
-+     let mut _3: isize;
   
       bb0: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
--     }
-- 
--     bb1: {
--         unreachable;
--     }
-- 
--     bb2: {
--         _0 = const 1_u8;
--         goto -> bb4;
--     }
-- 
--     bb3: {
--         _0 = const 0_u8;
--         goto -> bb4;
--     }
-- 
--     bb4: {
-+         StorageLive(_3);
-+         _3 = move _2;
-+         _0 = _3 as u8 (IntToInt);
-+         StorageDead(_3);
+          switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const 1_u8;
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _0 = const 0_u8;
+          goto -> bb4;
+      }
+  
+      bb4: {
           return;
       }
   }

--- a/tests/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.diff
@@ -5,32 +5,27 @@
       debug e => _1;
       let mut _0: i8;
       let mut _2: isize;
-+     let mut _3: isize;
   
       bb0: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
--     }
-- 
--     bb1: {
--         unreachable;
--     }
-- 
--     bb2: {
--         _0 = const 1_i8;
--         goto -> bb4;
--     }
-- 
--     bb3: {
--         _0 = const 0_i8;
--         goto -> bb4;
--     }
-- 
--     bb4: {
-+         StorageLive(_3);
-+         _3 = move _2;
-+         _0 = _3 as i8 (IntToInt);
-+         StorageDead(_3);
+          switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const 1_i8;
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _0 = const 0_i8;
+          goto -> bb4;
+      }
+  
+      bb4: {
           return;
       }
   }


### PR DESCRIPTION
Due to the miscompilation mentioned in #124150, We need to disable MatchBranchSimplification temporarily.

To fully resolve this issue, my plan is:
1. Disable SimplifyToExp in MatchBranchSimplification (this PR).
2. Remove all potentially unclear transforms in #124122.
3. Gradually add back the removed transforms (possibly multiple PRs).

r? @Nilstrieb or @oli-obk