### PR TITLE
libstd: Use std::array::from_fn to implement Default for arrays larger than 32 elements.

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -428,29 +428,12 @@ impl<T: Copy> SpecArrayClone for T {
     }
 }
 
-// The Default impls cannot be done with const generics because `[T; 0]` doesn't
-// require Default to be implemented, and having different impl blocks for
-// different numbers isn't supported yet.
-
-macro_rules! array_impl_default {
-    {$n:expr, $t:ident $($ts:ident)*} => {
-        #[stable(since = "1.4.0", feature = "array_default")]
-        impl<T> Default for [T; $n] where T: Default {
-            fn default() -> [T; $n] {
-                [$t::default(), $($ts::default()),*]
-            }
-        }
-        array_impl_default!{($n - 1), $($ts)*}
-    };
-    {$n:expr,} => {
-        #[stable(since = "1.4.0", feature = "array_default")]
-        impl<T> Default for [T; $n] {
-            fn default() -> [T; $n] { [] }
-        }
-    };
+#[stable(feature = "default_array_lib", since = "1.79.0")]
+impl<T, const N: usize> Default for [T; N] where T: Default {
+    fn default() -> [T; N] {
+        from_fn::<T, N, _>(|_| T::default())
+    }
 }
-
-array_impl_default! {32, T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T}
 
 impl<T, const N: usize> [T; N] {
     /// Returns an array of the same size as `self`, with function `f` applied to each element

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -589,15 +589,12 @@ mod prim_pointer {}
 /// - [`Copy`]
 /// - [`Clone`]
 /// - [`Debug`]
+/// - [`Default`]
 /// - [`IntoIterator`] (implemented for `[T; N]`, `&[T; N]` and `&mut [T; N]`)
 /// - [`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`]
 /// - [`Hash`]
 /// - [`AsRef`], [`AsMut`]
 /// - [`Borrow`], [`BorrowMut`]
-///
-/// Arrays of sizes from 0 to 32 (inclusive) implement the [`Default`] trait
-/// if the element type allows it. As a stopgap, trait implementations are
-/// statically generated up to size 32.
 ///
 /// Arrays of sizes from 1 to 12 (inclusive) implement [`From<Tuple>`], where `Tuple`
 /// is a homogeneous [prim@tuple] of appropriate length.

--- a/tests/ui/const-generics/array-impls/core-traits-impls-length-32.rs
+++ b/tests/ui/const-generics/array-impls/core-traits-impls-length-32.rs
@@ -63,4 +63,8 @@ pub fn yes_ord() -> impl Ord {
     [0; 32]
 }
 
+pub fn yes_default() -> impl Default {
+    [0; 32]
+}
+
 fn main() {}

--- a/tests/ui/const-generics/array-impls/core-traits-impls-length-33.rs
+++ b/tests/ui/const-generics/array-impls/core-traits-impls-length-33.rs
@@ -63,4 +63,8 @@ pub fn yes_ord() -> impl Ord {
     [0; 33]
 }
 
+pub fn yes_default() -> impl Default {
+    [0; 33]
+}
+
 fn main() {}


### PR DESCRIPTION
Much like #74060 did for every other trait.

This avoids tools like rust-bindgen having to painfully work around this limitations, sometimes incorrectly like in
https://github.com/rust-lang/rust-bindgen/issues/2803