### PR TITLE
Let inherent associated types constrain opaque types during projection

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -641,7 +641,7 @@ pub fn compute_inherent_assoc_ty_args<'a, 'b, 'tcx>(
         );
     }
 
-    match selcx.infcx.at(&cause, param_env).eq(DefineOpaqueTypes::No, impl_ty, self_ty) {
+    match selcx.infcx.at(&cause, param_env).eq(DefineOpaqueTypes::Yes, impl_ty, self_ty) {
         Ok(mut ok) => obligations.append(&mut ok.obligations),
         Err(_) => {
             tcx.dcx().span_bug(

--- a/tests/ui/associated-inherent-types/constrain_opaque_types_during_projection.rs
+++ b/tests/ui/associated-inherent-types/constrain_opaque_types_during_projection.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+
+#![feature(inherent_associated_types, type_alias_impl_trait)]
+#![allow(incomplete_features)]
+
+struct Foo<T>(T);
+
+impl Foo<i32> {
+    type Assoc = u32;
+}
+
+type Tait = impl Sized;
+
+fn bar(_: Tait) {
+    let x: Foo<Tait>::Assoc = 42;
+}
+
+fn main() {}


### PR DESCRIPTION
r? @compiler-errors

The same test ICEs on master: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=f4ff62663a5a3a0e16d00953ee7414d5