### PR TITLE
Don't fatal when calling `expect_one_of` when recovering arg in `parse_seq`

### DIFF
--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -898,6 +898,7 @@ impl<'a> Parser<'a> {
                             }
 
                             // Attempt to keep parsing if it was an omitted separator.
+                            self.last_unexpected_token_span = None;
                             match f(self) {
                                 Ok(t) => {
                                     // Parsed successfully, therefore most probably the code only

--- a/tests/ui/impl-trait/precise-capturing/unexpected-token.rs
+++ b/tests/ui/impl-trait/precise-capturing/unexpected-token.rs
@@ -1,0 +1,9 @@
+// We used to fatal error without any useful diagnostic when we had an unexpected
+// token due to a strange interaction between the sequence parsing code and the
+// param/lifetime parsing code.
+
+fn hello() -> impl use<'a {}> Sized {}
+//~^ ERROR expected one of `,` or `>`, found `{`
+//~| ERROR expected item, found `>`
+
+fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/unexpected-token.stderr
+++ b/tests/ui/impl-trait/precise-capturing/unexpected-token.stderr
@@ -1,0 +1,16 @@
+error: expected one of `,` or `>`, found `{`
+  --> $DIR/unexpected-token.rs:5:27
+   |
+LL | fn hello() -> impl use<'a {}> Sized {}
+   |                           ^ expected one of `,` or `>`
+
+error: expected item, found `>`
+  --> $DIR/unexpected-token.rs:5:29
+   |
+LL | fn hello() -> impl use<'a {}> Sized {}
+   |                             ^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
In `parse_seq`, when parsing a sequence of token-separated items, if we don't see a separator, we try to parse another item eagerly in order to give a good diagnostic and recover from a missing separator:
https://github.com/rust-lang/rust/blob/d1a0fa5ed3ffe52d72f761d3c95cbeb0a9cdfe66/compiler/rustc_parse/src/parser/mod.rs#L900-L901

If parsing the item itself calls `expect_one_of`, then we will fatal because of #58903:
https://github.com/rust-lang/rust/blob/d1a0fa5ed3ffe52d72f761d3c95cbeb0a9cdfe66/compiler/rustc_parse/src/parser/mod.rs#L513-L516

For `precise_capturing` feature I implemented, we do end up calling `expected_one_of`:
https://github.com/rust-lang/rust/blob/d1a0fa5ed3ffe52d72f761d3c95cbeb0a9cdfe66/compiler/rustc_parse/src/parser/ty.rs#L712-L714

This leads the compiler to fatal *before* having emitted the first error, leading to absolutely no useful information for the user about what happened in the parser.

This PR makes it so that we stop doing that.

Fixes #124195