### PR TITLE
proposal to support raw_attribute with raw pointer

### DIFF
--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -4,6 +4,8 @@
 
 #![stable(feature = "process_extensions", since = "1.2.0")]
 
+use core::ffi::c_void;
+
 use crate::ffi::OsStr;
 use crate::os::windows::io::{
     AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, IntoRawHandle, OwnedHandle, RawHandle,
@@ -368,6 +370,14 @@ pub trait CommandExt: Sealed {
         attribute: usize,
         value: T,
     ) -> &mut process::Command;
+
+    #[unstable(feature = "windows_process_extensions_raw_attribute", issue = "114854")]
+    unsafe fn raw_attribute_ptr(
+        &mut self,
+        attribute: usize,
+        value_ptr: *const c_void,
+        value_size: usize,
+    ) -> &mut process::Command;
 }
 
 #[stable(feature = "windows_process_extensions", since = "1.16.0")]
@@ -407,6 +417,18 @@ impl CommandExt for process::Command {
         value: T,
     ) -> &mut process::Command {
         unsafe { self.as_inner_mut().raw_attribute(attribute, value) };
+        self
+    }
+
+    unsafe fn raw_attribute_ptr(
+        &mut self,
+        attribute: usize,
+        value_ptr: *const c_void,
+        value_size: usize,
+    ) -> &mut process::Command {
+        unsafe {
+            self.as_inner_mut().raw_attribute_ptr(attribute, value_ptr, value_size);
+        }
         self
     }
 }


### PR DESCRIPTION
Hello rust community,

I'm still rather new to rust, but I collected experience with rust in the [uutils](https://github.com/uutils/coreutils) project.
There I'm currently trying to make use of the conpty windows feature and stumbled across the same topic as discussion in #114854.

This was my solution to it and I found that its probably simpler as all other solutions I've seen on the discussion topic (#121951, #123604). And thus its easier to understand, use and therefor might take less discussions to get it approved.

The key element is, that I don't change the existing approach for normal data attributes with the Box::new(). I just extend the API with a second variant that takes raw pointers.

Just let me know what you think.
If there is positive feedback, I will adapt documentation and tests.

I also added a change (force_use_std_handles) that will be needed to have a proper support of the PSEUDOCONSOLE / conpty.
Its clear that this should be in a different PR. I will split it as needed after some feedback.