### PR TITLE
MIR: Stop needing an explicit BB for `otherwise:unreachable`

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -135,6 +135,7 @@ pub(crate) fn codegen_fn<'tcx>(
         bcx,
         block_map,
         local_map: IndexVec::with_capacity(mir.local_decls.len()),
+        shared_unreachable: None,
         caller_location: None, // set by `codegen_fn_prelude`
 
         clif_comments,
@@ -441,7 +442,7 @@ fn codegen_fn_body(fx: &mut FunctionCx<'_, '_, '_>, start_block: Block) {
                     assert_eq!(targets.iter().count(), 1);
                     let (then_value, then_block) = targets.iter().next().unwrap();
                     let then_block = fx.get_block(then_block);
-                    let else_block = fx.get_block(targets.otherwise());
+                    let else_block = fx.get_switch_block(targets.otherwise());
                     let test_zero = match then_value {
                         0 => true,
                         1 => false,
@@ -472,7 +473,7 @@ fn codegen_fn_body(fx: &mut FunctionCx<'_, '_, '_>, start_block: Block) {
                         let block = fx.get_block(block);
                         switch.set_entry(value, block);
                     }
-                    let otherwise_block = fx.get_block(targets.otherwise());
+                    let otherwise_block = fx.get_switch_block(targets.otherwise());
                     switch.emit(&mut fx.bcx, discr, otherwise_block);
                 }
             }
@@ -560,6 +561,11 @@ fn codegen_fn_body(fx: &mut FunctionCx<'_, '_, '_>, start_block: Block) {
                 crate::abi::codegen_drop(fx, source_info, drop_place, *target);
             }
         };
+    }
+
+    if let Some(unreachable) = fx.shared_unreachable {
+        fx.bcx.switch_to_block(unreachable);
+        fx.bcx.ins().trap(TrapCode::user(1 /* unreachable */).unwrap());
     }
 }
 

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -478,12 +478,15 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         &ImmTy::from_uint(const_int, discr.layout),
                     )?;
                     if res.to_scalar().to_bool()? {
-                        target_block = target;
+                        target_block = mir::SwitchAction::Goto(target);
                         break;
                     }
                 }
 
-                self.go_to_block(target_block);
+                match target_block {
+                    mir::SwitchAction::Goto(target) => self.go_to_block(target),
+                    mir::SwitchAction::Unreachable => throw_ub!(Unreachable),
+                }
             }
 
             Call {

--- a/compiler/rustc_middle/src/mir/basic_blocks.rs
+++ b/compiler/rustc_middle/src/mir/basic_blocks.rs
@@ -9,7 +9,9 @@ use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use smallvec::SmallVec;
 
 use crate::mir::traversal::Postorder;
-use crate::mir::{BasicBlock, BasicBlockData, START_BLOCK, Terminator, TerminatorKind};
+use crate::mir::{
+    BasicBlock, BasicBlockData, START_BLOCK, SwitchAction, Terminator, TerminatorKind,
+};
 
 #[derive(Clone, TyEncodable, TyDecodable, Debug, HashStable, TypeFoldable, TypeVisitable)]
 pub struct BasicBlocks<'tcx> {
@@ -84,7 +86,9 @@ impl<'tcx> BasicBlocks<'tcx> {
                     for (value, target) in targets.iter() {
                         switch_sources.entry((target, bb)).or_default().push(Some(value));
                     }
-                    switch_sources.entry((targets.otherwise(), bb)).or_default().push(None);
+                    if let SwitchAction::Goto(otherwise) = targets.otherwise() {
+                        switch_sources.entry((otherwise, bb)).or_default().push(None);
+                    }
                 }
             }
             switch_sources
@@ -121,6 +125,13 @@ impl<'tcx> BasicBlocks<'tcx> {
     /// themselves, thereby avoiding any risk of accidentally cache invalidation.
     pub fn invalidate_cfg_cache(&mut self) {
         self.cache = Cache::default();
+    }
+
+    pub fn is_empty_unreachable(&self, action: SwitchAction) -> bool {
+        match action {
+            SwitchAction::Goto(bb) => self[bb].is_empty_unreachable(),
+            SwitchAction::Unreachable => true,
+        }
     }
 }
 

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -1015,12 +1015,14 @@ impl<'tcx> TerminatorKind<'tcx> {
             | Unreachable
             | CoroutineDrop => vec![],
             Goto { .. } => vec!["".into()],
-            SwitchInt { ref targets, .. } => targets
-                .values
-                .iter()
-                .map(|&u| Cow::Owned(u.to_string()))
-                .chain(iter::once("otherwise".into()))
-                .collect(),
+            SwitchInt { ref targets, .. } => {
+                let mut labels: Vec<_> =
+                    targets.values.iter().map(|&u| Cow::Owned(u.to_string())).collect();
+                if let SwitchAction::Goto(_) = targets.otherwise() {
+                    labels.push("otherwise".into());
+                }
+                labels
+            }
             Call { target: Some(_), unwind: UnwindAction::Cleanup(_), .. } => {
                 vec!["return".into(), "unwind".into()]
             }

--- a/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
@@ -163,7 +163,7 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
             targets.push(self.parse_block(arm.body)?);
         }
 
-        Ok(SwitchTargets::new(values.into_iter().zip(targets), otherwise))
+        Ok(SwitchTargets::new(values.into_iter().zip(targets), SwitchAction::Goto(otherwise)))
     }
 
     fn parse_call(&self, args: &[ExprId]) -> PResult<TerminatorKind<'tcx>> {

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -92,7 +92,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             None
                         }
                     }),
-                    otherwise_block,
+                    SwitchAction::Goto(otherwise_block),
                 );
                 debug!("num_enum_variants: {}", adt_def.variants().len());
                 let discr_ty = adt_def.repr().discr_type().to_ty(self.tcx);
@@ -124,7 +124,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             None
                         }
                     }),
-                    otherwise_block,
+                    SwitchAction::Goto(otherwise_block),
                 );
                 let terminator = TerminatorKind::SwitchInt {
                     discr: Operand::Copy(place),

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -591,6 +591,10 @@ where
         succ: BasicBlock,
         unwind: Unwind,
     ) -> BasicBlock {
+        // FIXME: the arguments here are still using the manual-unreachable;
+        // consider changing them to allow `SwitchAction::Unreachable` somehow.
+        debug_assert_eq!(blocks.len(), values.len() + 1);
+
         // If there are multiple variants, then if something
         // is present within the enum the discriminant, tracked
         // by the rest path, must be initialized.
@@ -609,7 +613,7 @@ where
                     discr: Operand::Move(discr),
                     targets: SwitchTargets::new(
                         values.iter().copied().zip(blocks.iter().copied()),
-                        *blocks.last().unwrap(),
+                        SwitchAction::Goto(*blocks.last().unwrap()),
                     ),
                 },
             }),

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -1039,8 +1039,10 @@ fn insert_switch<'tcx>(
 ) {
     let default_block = insert_term_block(body, default);
     let (assign, discr) = transform.get_discr(body);
-    let switch_targets =
-        SwitchTargets::new(cases.iter().map(|(i, bb)| ((*i) as u128, *bb)), default_block);
+    let switch_targets = SwitchTargets::new(
+        cases.iter().map(|(i, bb)| ((*i) as u128, *bb)),
+        SwitchAction::Goto(default_block),
+    );
     let switch = TerminatorKind::SwitchInt { discr: Operand::Move(discr), targets: switch_targets };
 
     let source_info = SourceInfo::outermost(body.span);

--- a/compiler/rustc_mir_transform/src/coverage/tests.rs
+++ b/compiler/rustc_mir_transform/src/coverage/tests.rs
@@ -110,7 +110,9 @@ impl<'tcx> MockBlocks<'tcx> {
                 let otherwise = if branch_index == branches.len() {
                     to_block
                 } else {
-                    let old_otherwise = targets.otherwise();
+                    let SwitchAction::Goto(old_otherwise) = targets.otherwise() else {
+                        bug!("these tests always have explicit otherwise blocks");
+                    };
                     if branch_index > branches.len() {
                         branches.push((branches.len() as u128, old_otherwise));
                         while branches.len() < branch_index {
@@ -122,7 +124,7 @@ impl<'tcx> MockBlocks<'tcx> {
                         old_otherwise
                     }
                 };
-                *targets = SwitchTargets::new(branches.into_iter(), otherwise);
+                *targets = SwitchTargets::new(branches.into_iter(), SwitchAction::Goto(otherwise));
             }
             ref invalid => bug!("Invalid BasicBlock kind or no to_block: {:?}", invalid),
         }

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -523,9 +523,11 @@ impl<'a, 'tcx> ConstAnalysis<'a, 'tcx> {
             FlatSet::Bottom => TerminatorEdges::None,
             FlatSet::Elem(scalar) => {
                 if let Ok(scalar_int) = scalar.try_to_scalar_int() {
-                    TerminatorEdges::Single(
-                        targets.target_for_value(scalar_int.to_bits_unchecked()),
-                    )
+                    let choice = scalar_int.to_bits_unchecked();
+                    match targets.target_for_value(choice) {
+                        SwitchAction::Goto(bb) => TerminatorEdges::Single(bb),
+                        SwitchAction::Unreachable => TerminatorEdges::None,
+                    }
                 } else {
                     TerminatorEdges::SwitchInt { discr, targets }
                 }

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -771,9 +771,10 @@ impl<'tcx> Visitor<'tcx> for ConstPropagator<'_, 'tcx> {
                     && let Some(constant) = value_const.to_bits(value_const.size()).discard_err()
                 {
                     // We managed to evaluate the discriminant, so we know we only need to visit
-                    // one target.
-                    let target = targets.target_for_value(constant);
-                    self.worklist.push(target);
+                    // one target, or none if this value is unreachable.
+                    if let SwitchAction::Goto(target) = targets.target_for_value(constant) {
+                        self.worklist.push(target);
+                    }
                     return;
                 }
                 // We failed to evaluate the discriminant, fallback to visiting all successors.

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -650,7 +650,7 @@ impl<'tcx> CloneShimBuilder<'tcx> {
         let switch = self.block(vec![], TerminatorKind::Unreachable, false);
         let unwind = self.clone_fields(dest, src, switch, unwind, args.upvar_tys());
         let target = self.block(vec![], TerminatorKind::Return, false);
-        let unreachable = self.block(vec![], TerminatorKind::Unreachable, false);
+        let unreachable = SwitchAction::Unreachable;
         let mut cases = Vec::with_capacity(args.state_tys(coroutine_def_id, self.tcx).count());
         for (index, state_tys) in args.state_tys(coroutine_def_id, self.tcx).enumerate() {
             let variant_index = VariantIdx::new(index);

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -283,9 +283,9 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
 pub(super) fn simplify_duplicate_switch_targets(terminator: &mut Terminator<'_>) {
     if let TerminatorKind::SwitchInt { targets, .. } = &mut terminator.kind {
         let otherwise = targets.otherwise();
-        if targets.iter().any(|t| t.1 == otherwise) {
+        if targets.iter().any(|t| SwitchAction::Goto(t.1) == otherwise) {
             *targets = SwitchTargets::new(
-                targets.iter().filter(|t| t.1 != otherwise),
+                targets.iter().filter(|t| SwitchAction::Goto(t.1) != otherwise),
                 targets.otherwise(),
             );
         }

--- a/compiler/rustc_mir_transform/src/simplify_branches.rs
+++ b/compiler/rustc_mir_transform/src/simplify_branches.rs
@@ -45,7 +45,7 @@ impl<'tcx> crate::MirPass<'tcx> for SimplifyConstCondition {
                     let constant = c.const_.try_eval_bits(tcx, typing_env);
                     if let Some(constant) = constant {
                         let target = targets.target_for_value(constant);
-                        TerminatorKind::Goto { target }
+                        target.into_terminator()
                     } else {
                         continue;
                     }

--- a/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
+++ b/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
@@ -3,8 +3,8 @@ use std::iter;
 use rustc_middle::bug;
 use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::mir::{
-    BasicBlock, BinOp, Body, Operand, Place, Rvalue, Statement, StatementKind, SwitchTargets,
-    TerminatorKind,
+    BasicBlock, BinOp, Body, Operand, Place, Rvalue, Statement, StatementKind, SwitchAction,
+    SwitchTargets, TerminatorKind,
 };
 use rustc_middle::ty::{Ty, TyCtxt};
 use tracing::trace;
@@ -125,7 +125,10 @@ impl<'tcx> crate::MirPass<'tcx> for SimplifyComparisonIntegral {
                 e => bug!("expected 2 switch targets, got: {:?}", e),
             };
 
-            let targets = SwitchTargets::new(iter::once((new_value, bb_cond)), bb_otherwise);
+            let targets = SwitchTargets::new(
+                iter::once((new_value, bb_cond)),
+                SwitchAction::Goto(bb_otherwise),
+            );
 
             let terminator = bb.terminator_mut();
             terminator.kind =

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -344,10 +344,9 @@ impl<'a, 'tcx> Visitor<'tcx> for CfgChecker<'a, 'tcx> {
                 self.check_edge(location, *target, EdgeKind::Normal);
             }
             TerminatorKind::SwitchInt { targets, discr: _ } => {
-                for (_, target) in targets.iter() {
+                for &target in targets.all_targets() {
                     self.check_edge(location, target, EdgeKind::Normal);
                 }
-                self.check_edge(location, targets.otherwise(), EdgeKind::Normal);
 
                 self.value_cache.clear();
                 self.value_cache.extend(targets.iter().map(|(value, _)| value));

--- a/compiler/rustc_smir/src/rustc_internal/mod.rs
+++ b/compiler/rustc_smir/src/rustc_internal/mod.rs
@@ -223,6 +223,8 @@ where
         ty_consts: IndexMap::default(),
         mir_consts: IndexMap::default(),
         layouts: IndexMap::default(),
+        synthetic_unreachable_block: usize::MAX,
+        unreachable_block_span: None,
     }));
     stable_mir::compiler_interface::run(&tables, || init(&tables, f))
 }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -37,6 +37,8 @@ pub struct Tables<'tcx> {
     pub(crate) ty_consts: IndexMap<ty::Const<'tcx>, TyConstId>,
     pub(crate) mir_consts: IndexMap<mir::Const<'tcx>, MirConstId>,
     pub(crate) layouts: IndexMap<rustc_abi::Layout<'tcx>, Layout>,
+    pub(crate) synthetic_unreachable_block: stable_mir::mir::BasicBlockIdx,
+    pub(crate) unreachable_block_span: Option<Span>,
 }
 
 impl<'tcx> Tables<'tcx> {

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-abort.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-abort.diff
@@ -67,7 +67,7 @@
           StorageLive(_6);
           _6 = copy (((*_1).0: std::fmt::FormattingOptions).4: std::option::Option<usize>);
           _7 = discriminant(_6);
-          switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb9];
+          switchInt(move _7) -> [1: bb4, 0: bb6];
       }
   
       bb4: {
@@ -132,10 +132,6 @@
           StorageDead(_4);
           StorageDead(_6);
           return;
-      }
-  
-      bb9: {
-          unreachable;
       }
   }
   

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-unwind.diff
@@ -67,7 +67,7 @@
           StorageLive(_6);
           _6 = copy (((*_1).0: std::fmt::FormattingOptions).4: std::option::Option<usize>);
           _7 = discriminant(_6);
-          switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb9];
+          switchInt(move _7) -> [1: bb4, 0: bb6];
       }
   
       bb4: {
@@ -132,10 +132,6 @@
           StorageDead(_4);
           StorageDead(_6);
           return;
-      }
-  
-      bb9: {
-          unreachable;
       }
   }
   

--- a/tests/mir-opt/inline/inline_coroutine.main.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_coroutine.main.Inline.panic-abort.diff
@@ -41,7 +41,7 @@
 +         StorageLive(_7);
 +         _6 = copy (_2.0: &mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8});
 +         _7 = discriminant((*_6));
-+         switchInt(move _7) -> [0: bb3, 1: bb7, 3: bb8, otherwise: bb9];
++         switchInt(move _7) -> [0: bb3, 1: bb7, 3: bb8];
       }
   
       bb1: {
@@ -101,10 +101,6 @@
 +         _1 = CoroutineState::<i32, bool>::Complete(copy _5);
 +         discriminant((*_6)) = 1;
 +         goto -> bb2;
-+     }
-+ 
-+     bb9: {
-+         unreachable;
       }
   }
   

--- a/tests/mir-opt/inline/inline_coroutine.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_coroutine.main.Inline.panic-unwind.diff
@@ -41,7 +41,7 @@
 +         StorageLive(_7);
 +         _6 = copy (_2.0: &mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8});
 +         _7 = discriminant((*_6));
-+         switchInt(move _7) -> [0: bb5, 1: bb9, 3: bb10, otherwise: bb11];
++         switchInt(move _7) -> [0: bb5, 1: bb9, 3: bb10];
       }
   
       bb1: {
@@ -115,10 +115,6 @@
 +         _1 = CoroutineState::<i32, bool>::Complete(copy _5);
 +         discriminant((*_6)) = 1;
 +         goto -> bb4;
-+     }
-+ 
-+     bb11: {
-+         unreachable;
       }
   }
   

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
@@ -26,7 +26,7 @@
 +         StorageLive(_3);
 +         StorageLive(_5);
 +         _3 = discriminant(_2);
-+         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
++         switchInt(move _3) -> [0: bb2, 1: bb3];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
@@ -26,7 +26,7 @@
 +         StorageLive(_3);
 +         StorageLive(_5);
 +         _3 = discriminant(_2);
-+         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
++         switchInt(move _3) -> [0: bb2, 1: bb3];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-abort.mir
@@ -18,16 +18,16 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
     bb0: {
         StorageLive(_2);
         _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb2, 1: bb1, otherwise: bb2];
+        switchInt(move _2) -> [0: bb1, 1: bb2];
     }
 
     bb1: {
-        _0 = copy ((_1 as Some).0: T);
-        StorageDead(_2);
-        return;
+        unreachable;
     }
 
     bb2: {
-        unreachable;
+        _0 = copy ((_1 as Some).0: T);
+        StorageDead(_2);
+        return;
     }
 }

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-unwind.mir
@@ -18,16 +18,16 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
     bb0: {
         StorageLive(_2);
         _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb2, 1: bb1, otherwise: bb2];
+        switchInt(move _2) -> [0: bb1, 1: bb2];
     }
 
     bb1: {
-        _0 = copy ((_1 as Some).0: T);
-        StorageDead(_2);
-        return;
+        unreachable;
     }
 
     bb2: {
-        unreachable;
+        _0 = copy ((_1 as Some).0: T);
+        StorageDead(_2);
+        return;
     }
 }

--- a/tests/mir-opt/instsimplify/ub_check.unwrap_unchecked.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/ub_check.unwrap_unchecked.InstSimplify-after-simplifycfg.diff
@@ -25,7 +25,7 @@
           StorageLive(_3);
           StorageLive(_5);
           _3 = discriminant(_2);
-          switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
+          switchInt(move _3) -> [0: bb2, 1: bb3];
       }
   
       bb1: {

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-abort.mir
@@ -26,7 +26,7 @@ fn num_to_digit(_1: char) -> u32 {
         StorageLive(_3);
         _3 = discriminant(_2);
         StorageDead(_2);
-        switchInt(move _3) -> [1: bb2, otherwise: bb7];
+        switchInt(move _3) -> [1: bb2, otherwise: bb6];
     }
 
     bb2: {
@@ -38,7 +38,7 @@ fn num_to_digit(_1: char) -> u32 {
     bb3: {
         StorageLive(_5);
         _5 = discriminant(_4);
-        switchInt(move _5) -> [0: bb4, 1: bb5, otherwise: bb6];
+        switchInt(move _5) -> [0: bb4, 1: bb5];
     }
 
     bb4: {
@@ -49,20 +49,16 @@ fn num_to_digit(_1: char) -> u32 {
         _0 = move ((_4 as Some).0: u32);
         StorageDead(_5);
         StorageDead(_4);
-        goto -> bb8;
+        goto -> bb7;
     }
 
     bb6: {
-        unreachable;
+        StorageDead(_3);
+        _0 = const 0_u32;
+        goto -> bb7;
     }
 
     bb7: {
-        StorageDead(_3);
-        _0 = const 0_u32;
-        goto -> bb8;
-    }
-
-    bb8: {
         return;
     }
 }

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
@@ -26,7 +26,7 @@ fn num_to_digit(_1: char) -> u32 {
         StorageLive(_3);
         _3 = discriminant(_2);
         StorageDead(_2);
-        switchInt(move _3) -> [1: bb2, otherwise: bb7];
+        switchInt(move _3) -> [1: bb2, otherwise: bb6];
     }
 
     bb2: {
@@ -38,7 +38,7 @@ fn num_to_digit(_1: char) -> u32 {
     bb3: {
         StorageLive(_5);
         _5 = discriminant(_4);
-        switchInt(move _5) -> [0: bb4, 1: bb5, otherwise: bb6];
+        switchInt(move _5) -> [0: bb4, 1: bb5];
     }
 
     bb4: {
@@ -49,20 +49,16 @@ fn num_to_digit(_1: char) -> u32 {
         _0 = move ((_4 as Some).0: u32);
         StorageDead(_5);
         StorageDead(_4);
-        goto -> bb8;
+        goto -> bb7;
     }
 
     bb6: {
-        unreachable;
+        StorageDead(_3);
+        _0 = const 0_u32;
+        goto -> bb7;
     }
 
     bb7: {
-        StorageDead(_3);
-        _0 = const 0_u32;
-        goto -> bb8;
-    }
-
-    bb8: {
         return;
     }
 }

--- a/tests/mir-opt/jump_threading.identity.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.identity.JumpThreading.panic-abort.diff
@@ -50,7 +50,7 @@
           StorageLive(_11);
           StorageLive(_12);
           _10 = discriminant(_4);
-          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb1];
+          switchInt(move _10) -> [0: bb7, 1: bb6];
       }
   
       bb1: {

--- a/tests/mir-opt/jump_threading.identity.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.identity.JumpThreading.panic-unwind.diff
@@ -50,7 +50,7 @@
           StorageLive(_11);
           StorageLive(_12);
           _10 = discriminant(_4);
-          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb1];
+          switchInt(move _10) -> [0: bb7, 1: bb6];
       }
   
       bb1: {

--- a/tests/mir-opt/jump_threading.rs
+++ b/tests/mir-opt/jump_threading.rs
@@ -49,7 +49,7 @@ fn identity(x: Result<i32, i32>) -> Result<i32, i32> {
     // CHECK-LABEL: fn identity(
     // CHECK: bb0: {
     // CHECK:     [[x:_.*]] = copy _1;
-    // CHECK:     switchInt(move {{_.*}}) -> [0: bb7, 1: bb6, otherwise: bb1];
+    // CHECK:     switchInt(move {{_.*}}) -> [0: bb7, 1: bb6];
     // CHECK: bb1: {
     // CHECK:     unreachable;
     // CHECK: bb2: {

--- a/tests/mir-opt/pre-codegen/clone_as_copy.enum_clone_as_copy.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/clone_as_copy.enum_clone_as_copy.PreCodegen.after.mir
@@ -31,7 +31,7 @@ fn enum_clone_as_copy(_1: &Enum1) -> Enum1 {
         StorageLive(_3);
         StorageLive(_4);
         _2 = discriminant((*_1));
-        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
+        switchInt(move _2) -> [0: bb1, 1: bb2];
     }
 
     bb1: {
@@ -54,9 +54,5 @@ fn enum_clone_as_copy(_1: &Enum1) -> Enum1 {
         StorageDead(_3);
         StorageDead(_2);
         return;
-    }
-
-    bb4: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/duplicate_switch_targets.ub_if_b.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/duplicate_switch_targets.ub_if_b.PreCodegen.after.mir
@@ -13,7 +13,7 @@ fn ub_if_b(_1: Thing) -> Thing {
 
     bb0: {
         _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb2];
+        switchInt(move _2) -> [0: bb1, 1: bb2];
     }
 
     bb1: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -48,20 +48,16 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb1];
+-         switchInt(move _10) -> [0: bb1, 1: bb2];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb1];
++         switchInt(const 0_isize) -> [0: bb1, 1: bb2];
       }
   
       bb1: {
-          unreachable;
-      }
-  
-      bb2: {
           _11 = option::unwrap_failed() -> unwind unreachable;
       }
   
-      bb3: {
+      bb2: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -75,28 +71,28 @@
           _7 = copy _9;
           StorageLive(_8);
 -         _8 = copy _1;
--         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb4, unwind unreachable];
+-         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb3, unwind unreachable];
 +         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }};
-+         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb4, unwind unreachable];
++         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb3, unwind unreachable];
       }
   
-      bb4: {
+      bb3: {
           StorageDead(_8);
           StorageDead(_7);
           StorageLive(_12);
           StorageLive(_16);
           _12 = discriminant(_6);
-          switchInt(move _12) -> [0: bb6, 1: bb5, otherwise: bb1];
+          switchInt(move _12) -> [0: bb5, 1: bb4];
       }
   
-      bb5: {
+      bb4: {
           StorageLive(_15);
           _16 = &_13;
           _15 = copy _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
           _14 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _15) -> unwind unreachable;
       }
   
-      bb6: {
+      bb5: {
           _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
           StorageDead(_16);
           StorageDead(_12);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
@@ -37,9 +37,9 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb3, 1: bb4, otherwise: bb2];
+-         switchInt(move _10) -> [0: bb2, 1: bb3];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb4, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb2, 1: bb3];
       }
   
       bb1: {
@@ -55,14 +55,10 @@
       }
   
       bb2: {
-          unreachable;
-      }
-  
-      bb3: {
           _11 = option::unwrap_failed() -> unwind continue;
       }
   
-      bb4: {
+      bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -76,12 +72,12 @@
           _7 = copy _9;
           StorageLive(_8);
 -         _8 = copy _1;
--         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb5, unwind continue];
+-         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb4, unwind continue];
 +         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }};
-+         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb5, unwind continue];
++         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb4, unwind continue];
       }
   
-      bb5: {
+      bb4: {
           StorageDead(_8);
           StorageDead(_7);
           _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -48,20 +48,16 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb1];
+-         switchInt(move _10) -> [0: bb1, 1: bb2];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb1];
++         switchInt(const 0_isize) -> [0: bb1, 1: bb2];
       }
   
       bb1: {
-          unreachable;
-      }
-  
-      bb2: {
           _11 = option::unwrap_failed() -> unwind unreachable;
       }
   
-      bb3: {
+      bb2: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -75,28 +71,28 @@
           _7 = copy _9;
           StorageLive(_8);
 -         _8 = copy _1;
--         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb4, unwind unreachable];
+-         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb3, unwind unreachable];
 +         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
-+         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb4, unwind unreachable];
++         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb3, unwind unreachable];
       }
   
-      bb4: {
+      bb3: {
           StorageDead(_8);
           StorageDead(_7);
           StorageLive(_12);
           StorageLive(_16);
           _12 = discriminant(_6);
-          switchInt(move _12) -> [0: bb6, 1: bb5, otherwise: bb1];
+          switchInt(move _12) -> [0: bb5, 1: bb4];
       }
   
-      bb5: {
+      bb4: {
           StorageLive(_15);
           _16 = &_13;
           _15 = copy _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
           _14 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _15) -> unwind unreachable;
       }
   
-      bb6: {
+      bb5: {
           _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
           StorageDead(_16);
           StorageDead(_12);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -37,9 +37,9 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb3, 1: bb4, otherwise: bb2];
+-         switchInt(move _10) -> [0: bb2, 1: bb3];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb4, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb2, 1: bb3];
       }
   
       bb1: {
@@ -55,14 +55,10 @@
       }
   
       bb2: {
-          unreachable;
-      }
-  
-      bb3: {
           _11 = option::unwrap_failed() -> unwind continue;
       }
   
-      bb4: {
+      bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -76,12 +72,12 @@
           _7 = copy _9;
           StorageLive(_8);
 -         _8 = copy _1;
--         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb5, unwind continue];
+-         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb4, unwind continue];
 +         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
-+         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb5, unwind continue];
++         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb4, unwind continue];
       }
   
-      bb5: {
+      bb4: {
           StorageDead(_8);
           StorageDead(_7);
           _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];

--- a/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.filter_mapped.PreCodegen.after.mir
@@ -43,14 +43,14 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
         _6 = &mut (_4.0: impl Iterator<Item = T>);
         StorageLive(_7);
         _7 = &mut (_4.1: impl Fn(T) -> Option<U>);
-        _8 = <impl Iterator<Item = T> as Iterator>::find_map::<U, &mut impl Fn(T) -> Option<U>>(move _6, move _7) -> [return: bb3, unwind: bb9];
+        _8 = <impl Iterator<Item = T> as Iterator>::find_map::<U, &mut impl Fn(T) -> Option<U>>(move _6, move _7) -> [return: bb3, unwind: bb8];
     }
 
     bb3: {
         StorageDead(_7);
         StorageDead(_6);
         _9 = discriminant(_8);
-        switchInt(move _9) -> [0: bb4, 1: bb6, otherwise: bb8];
+        switchInt(move _9) -> [0: bb4, 1: bb6];
     }
 
     bb4: {
@@ -65,7 +65,7 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
 
     bb6: {
         _10 = move ((_8 as Some).0: U);
-        _11 = opaque::<U>(move _10) -> [return: bb7, unwind: bb9];
+        _11 = opaque::<U>(move _10) -> [return: bb7, unwind: bb8];
     }
 
     bb7: {
@@ -73,15 +73,11 @@ fn filter_mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> Option<U>) -> ()
         goto -> bb2;
     }
 
-    bb8: {
-        unreachable;
+    bb8 (cleanup): {
+        drop(_4) -> [return: bb9, unwind terminate(cleanup)];
     }
 
     bb9 (cleanup): {
-        drop(_4) -> [return: bb10, unwind terminate(cleanup)];
-    }
-
-    bb10 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/pre-codegen/loops.mapped.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.mapped.PreCodegen.after.mir
@@ -54,7 +54,7 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
         StorageLive(_7);
         StorageLive(_6);
         _6 = &mut (_4.0: impl Iterator<Item = T>);
-        _7 = <impl Iterator<Item = T> as Iterator>::next(move _6) -> [return: bb3, unwind: bb10];
+        _7 = <impl Iterator<Item = T> as Iterator>::next(move _6) -> [return: bb3, unwind: bb9];
     }
 
     bb3: {
@@ -63,7 +63,7 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
         StorageLive(_9);
         StorageLive(_10);
         _9 = discriminant(_7);
-        switchInt(move _9) -> [0: bb4, 1: bb6, otherwise: bb9];
+        switchInt(move _9) -> [0: bb4, 1: bb6];
     }
 
     bb4: {
@@ -85,7 +85,7 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
         StorageLive(_12);
         StorageLive(_11);
         _11 = (copy _10,);
-        _12 = <&mut impl Fn(T) -> U as FnOnce<(T,)>>::call_once(move _8, move _11) -> [return: bb7, unwind: bb10];
+        _12 = <&mut impl Fn(T) -> U as FnOnce<(T,)>>::call_once(move _8, move _11) -> [return: bb7, unwind: bb9];
     }
 
     bb7: {
@@ -97,7 +97,7 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
         StorageDead(_7);
         StorageDead(_8);
         _14 = move ((_13 as Some).0: U);
-        _15 = opaque::<U>(move _14) -> [return: bb8, unwind: bb10];
+        _15 = opaque::<U>(move _14) -> [return: bb8, unwind: bb9];
     }
 
     bb8: {
@@ -105,15 +105,11 @@ fn mapped(_1: impl Iterator<Item = T>, _2: impl Fn(T) -> U) -> () {
         goto -> bb2;
     }
 
-    bb9: {
-        unreachable;
+    bb9 (cleanup): {
+        drop(_4) -> [return: bb10, unwind terminate(cleanup)];
     }
 
     bb10 (cleanup): {
-        drop(_4) -> [return: bb11, unwind terminate(cleanup)];
-    }
-
-    bb11 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
@@ -31,12 +31,12 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
     bb2: {
         StorageLive(_5);
         _4 = &mut _3;
-        _5 = <std::vec::IntoIter<impl Sized> as Iterator>::next(move _4) -> [return: bb3, unwind: bb9];
+        _5 = <std::vec::IntoIter<impl Sized> as Iterator>::next(move _4) -> [return: bb3, unwind: bb8];
     }
 
     bb3: {
         _6 = discriminant(_5);
-        switchInt(move _6) -> [0: bb4, 1: bb6, otherwise: bb8];
+        switchInt(move _6) -> [0: bb4, 1: bb6];
     }
 
     bb4: {
@@ -52,7 +52,7 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
 
     bb6: {
         _7 = move ((_5 as Some).0: impl Sized);
-        _8 = opaque::<impl Sized>(move _7) -> [return: bb7, unwind: bb9];
+        _8 = opaque::<impl Sized>(move _7) -> [return: bb7, unwind: bb8];
     }
 
     bb7: {
@@ -60,15 +60,11 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
         goto -> bb2;
     }
 
-    bb8: {
-        unreachable;
+    bb8 (cleanup): {
+        drop(_3) -> [return: bb9, unwind terminate(cleanup)];
     }
 
     bb9 (cleanup): {
-        drop(_3) -> [return: bb10, unwind terminate(cleanup)];
-    }
-
-    bb10 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-abort.mir
@@ -42,7 +42,7 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
 
     bb2: {
         _8 = discriminant(_7);
-        switchInt(move _8) -> [0: bb3, 1: bb5, otherwise: bb7];
+        switchInt(move _8) -> [0: bb3, 1: bb5];
     }
 
     bb3: {
@@ -69,9 +69,5 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
         StorageDead(_10);
         StorageDead(_7);
         goto -> bb1;
-    }
-
-    bb7: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
@@ -37,12 +37,12 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     bb1: {
         StorageLive(_7);
         _6 = &mut _5;
-        _7 = <RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(move _6) -> [return: bb2, unwind: bb8];
+        _7 = <RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(move _6) -> [return: bb2, unwind: bb7];
     }
 
     bb2: {
         _8 = discriminant(_7);
-        switchInt(move _8) -> [0: bb3, 1: bb5, otherwise: bb7];
+        switchInt(move _8) -> [0: bb3, 1: bb5];
     }
 
     bb3: {
@@ -61,7 +61,7 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
         _10 = &_3;
         StorageLive(_11);
         _11 = (copy _9,);
-        _12 = <impl Fn(u32) as Fn<(u32,)>>::call(move _10, move _11) -> [return: bb6, unwind: bb8];
+        _12 = <impl Fn(u32) as Fn<(u32,)>>::call(move _10, move _11) -> [return: bb6, unwind: bb7];
     }
 
     bb6: {
@@ -71,15 +71,11 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
         goto -> bb1;
     }
 
-    bb7: {
-        unreachable;
+    bb7 (cleanup): {
+        drop(_3) -> [return: bb8, unwind terminate(cleanup)];
     }
 
     bb8 (cleanup): {
-        drop(_3) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
@@ -16,7 +16,7 @@ fn ezmap(_1: Option<i32>) -> Option<i32> {
     bb0: {
         StorageLive(_2);
         _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
+        switchInt(move _2) -> [0: bb1, 1: bb2];
     }
 
     bb1: {
@@ -36,10 +36,6 @@ fn ezmap(_1: Option<i32>) -> Option<i32> {
     bb3: {
         StorageDead(_2);
         return;
-    }
-
-    bb4: {
-        unreachable;
     }
 }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
@@ -155,7 +155,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         StorageDead(_16);
         StorageLive(_18);
         _18 = discriminant(_17);
-        switchInt(move _18) -> [0: bb6, 1: bb8, otherwise: bb11];
+        switchInt(move _18) -> [0: bb6, 1: bb8];
     }
 
     bb6: {
@@ -203,9 +203,5 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         StorageDead(_26);
         StorageDead(_23);
         goto -> bb4;
-    }
-
-    bb11: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -119,12 +119,12 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     bb4: {
         StorageLive(_17);
         _16 = &mut _15;
-        _17 = <Enumerate<std::slice::Iter<'_, T>> as Iterator>::next(move _16) -> [return: bb5, unwind: bb11];
+        _17 = <Enumerate<std::slice::Iter<'_, T>> as Iterator>::next(move _16) -> [return: bb5, unwind: bb10];
     }
 
     bb5: {
         _18 = discriminant(_17);
-        switchInt(move _18) -> [0: bb6, 1: bb8, otherwise: bb10];
+        switchInt(move _18) -> [0: bb6, 1: bb8];
     }
 
     bb6: {
@@ -144,7 +144,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         _21 = &_2;
         StorageLive(_22);
         _22 = (copy _19, copy _20);
-        _23 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _21, move _22) -> [return: bb9, unwind: bb11];
+        _23 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _21, move _22) -> [return: bb9, unwind: bb10];
     }
 
     bb9: {
@@ -154,15 +154,11 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         goto -> bb4;
     }
 
-    bb10: {
-        unreachable;
+    bb10 (cleanup): {
+        drop(_2) -> [return: bb11, unwind terminate(cleanup)];
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate(cleanup)];
-    }
-
-    bb12 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -114,7 +114,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
 
     bb5: {
         _17 = discriminant(_16);
-        switchInt(move _17) -> [0: bb6, 1: bb8, otherwise: bb10];
+        switchInt(move _17) -> [0: bb6, 1: bb8];
     }
 
     bb6: {
@@ -141,9 +141,5 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_19);
         StorageDead(_16);
         goto -> bb4;
-    }
-
-    bb10: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -109,12 +109,12 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     bb4: {
         StorageLive(_16);
         _15 = &mut _14;
-        _16 = <std::slice::Iter<'_, T> as Iterator>::next(move _15) -> [return: bb5, unwind: bb11];
+        _16 = <std::slice::Iter<'_, T> as Iterator>::next(move _15) -> [return: bb5, unwind: bb10];
     }
 
     bb5: {
         _17 = discriminant(_16);
-        switchInt(move _17) -> [0: bb6, 1: bb8, otherwise: bb10];
+        switchInt(move _17) -> [0: bb6, 1: bb8];
     }
 
     bb6: {
@@ -133,7 +133,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         _19 = &_2;
         StorageLive(_20);
         _20 = (copy _18,);
-        _21 = <impl Fn(&T) as Fn<(&T,)>>::call(move _19, move _20) -> [return: bb9, unwind: bb11];
+        _21 = <impl Fn(&T) as Fn<(&T,)>>::call(move _19, move _20) -> [return: bb9, unwind: bb10];
     }
 
     bb9: {
@@ -143,15 +143,11 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         goto -> bb4;
     }
 
-    bb10: {
-        unreachable;
+    bb10 (cleanup): {
+        drop(_2) -> [return: bb11, unwind terminate(cleanup)];
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate(cleanup)];
-    }
-
-    bb12 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
@@ -126,7 +126,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     bb5: {
         StorageDead(_16);
         _18 = discriminant(_17);
-        switchInt(move _18) -> [0: bb6, 1: bb8, otherwise: bb10];
+        switchInt(move _18) -> [0: bb6, 1: bb8];
     }
 
     bb6: {
@@ -153,9 +153,5 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_20);
         StorageDead(_17);
         goto -> bb4;
-    }
-
-    bb10: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -120,13 +120,13 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageLive(_17);
         StorageLive(_16);
         _16 = &mut (_15.0: std::slice::Iter<'_, T>);
-        _17 = <std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back(move _16) -> [return: bb5, unwind: bb11];
+        _17 = <std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back(move _16) -> [return: bb5, unwind: bb10];
     }
 
     bb5: {
         StorageDead(_16);
         _18 = discriminant(_17);
-        switchInt(move _18) -> [0: bb6, 1: bb8, otherwise: bb10];
+        switchInt(move _18) -> [0: bb6, 1: bb8];
     }
 
     bb6: {
@@ -145,7 +145,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         _20 = &_2;
         StorageLive(_21);
         _21 = (copy _19,);
-        _22 = <impl Fn(&T) as Fn<(&T,)>>::call(move _20, move _21) -> [return: bb9, unwind: bb11];
+        _22 = <impl Fn(&T) as Fn<(&T,)>>::call(move _20, move _21) -> [return: bb9, unwind: bb10];
     }
 
     bb9: {
@@ -155,15 +155,11 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         goto -> bb4;
     }
 
-    bb10: {
-        unreachable;
+    bb10 (cleanup): {
+        drop(_2) -> [return: bb11, unwind terminate(cleanup)];
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate(cleanup)];
-    }
-
-    bb12 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/pre-codegen/try_identity.new.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/try_identity.new.PreCodegen.after.mir
@@ -25,7 +25,7 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
     bb0: {
         StorageLive(_4);
         _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
+        switchInt(move _2) -> [0: bb1, 1: bb2];
     }
 
     bb1: {
@@ -48,9 +48,5 @@ fn new(_1: Result<T, E>) -> Result<T, E> {
 
     bb3: {
         return;
-    }
-
-    bb4: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/try_identity.old.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/try_identity.old.PreCodegen.after.mir
@@ -15,7 +15,7 @@ fn old(_1: Result<T, E>) -> Result<T, E> {
 
     bb0: {
         _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
+        switchInt(move _2) -> [0: bb1, 1: bb2];
     }
 
     bb1: {
@@ -32,9 +32,5 @@ fn old(_1: Result<T, E>) -> Result<T, E> {
 
     bb3: {
         return;
-    }
-
-    bb4: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/separate_const_switch.identity.JumpThreading.diff
+++ b/tests/mir-opt/separate_const_switch.identity.JumpThreading.diff
@@ -42,21 +42,17 @@
           StorageLive(_7);
           StorageLive(_8);
           _6 = discriminant(_1);
-          switchInt(move _6) -> [0: bb6, 1: bb5, otherwise: bb1];
+          switchInt(move _6) -> [0: bb5, 1: bb4];
       }
   
       bb1: {
-          unreachable;
-      }
-  
-      bb2: {
           _5 = copy ((_2 as Continue).0: i32);
           _0 = Result::<i32, i32>::Ok(copy _5);
           StorageDead(_2);
           return;
       }
   
-      bb3: {
+      bb2: {
           _4 = copy ((_2 as Break).0: std::result::Result<std::convert::Infallible, i32>);
           _10 = copy ((_4 as Err).0: i32);
           _0 = Result::<i32, i32>::Err(copy _10);
@@ -64,37 +60,37 @@
           return;
       }
   
-      bb4: {
+      bb3: {
           StorageDead(_8);
           StorageDead(_7);
           StorageDead(_6);
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
-+         goto -> bb2;
+-         switchInt(move _3) -> [0: bb1, 1: bb2];
++         goto -> bb1;
       }
   
-      bb5: {
+      bb4: {
           _8 = copy ((_1 as Err).0: i32);
           StorageLive(_9);
           _9 = Result::<Infallible, i32>::Err(copy _8);
           _2 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _9);
           StorageDead(_9);
--         goto -> bb4;
-+         goto -> bb7;
+-         goto -> bb3;
++         goto -> bb6;
       }
   
-      bb6: {
+      bb5: {
           _7 = copy ((_1 as Ok).0: i32);
           _2 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _7);
-          goto -> bb4;
+          goto -> bb3;
 +     }
 + 
-+     bb7: {
++     bb6: {
 +         StorageDead(_8);
 +         StorageDead(_7);
 +         StorageDead(_6);
 +         _3 = discriminant(_2);
-+         goto -> bb3;
++         goto -> bb2;
       }
   }
   

--- a/tests/mir-opt/separate_const_switch.too_complex.JumpThreading.diff
+++ b/tests/mir-opt/separate_const_switch.too_complex.JumpThreading.diff
@@ -27,54 +27,50 @@
       bb0: {
           StorageLive(_2);
           _3 = discriminant(_1);
-          switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
+          switchInt(move _3) -> [0: bb2, 1: bb1];
       }
   
       bb1: {
-          unreachable;
+          _5 = copy ((_1 as Err).0: usize);
+          _2 = ControlFlow::<usize, i32>::Break(copy _5);
+-         goto -> bb3;
++         goto -> bb7;
       }
   
       bb2: {
-          _5 = copy ((_1 as Err).0: usize);
-          _2 = ControlFlow::<usize, i32>::Break(copy _5);
--         goto -> bb4;
-+         goto -> bb8;
+          _4 = copy ((_1 as Ok).0: i32);
+          _2 = ControlFlow::<usize, i32>::Continue(copy _4);
+          goto -> bb3;
       }
   
       bb3: {
-          _4 = copy ((_1 as Ok).0: i32);
-          _2 = ControlFlow::<usize, i32>::Continue(copy _4);
-          goto -> bb4;
+          _6 = discriminant(_2);
+-         switchInt(move _6) -> [0: bb5, 1: bb4];
++         goto -> bb5;
       }
   
       bb4: {
-          _6 = discriminant(_2);
--         switchInt(move _6) -> [0: bb6, 1: bb5, otherwise: bb1];
-+         goto -> bb6;
-      }
-  
-      bb5: {
           StorageLive(_8);
           _8 = copy ((_2 as Break).0: usize);
           _0 = const Option::<i32>::None;
           StorageDead(_8);
-          goto -> bb7;
+          goto -> bb6;
+      }
+  
+      bb5: {
+          _7 = copy ((_2 as Continue).0: i32);
+          _0 = Option::<i32>::Some(copy _7);
+          goto -> bb6;
       }
   
       bb6: {
-          _7 = copy ((_2 as Continue).0: i32);
-          _0 = Option::<i32>::Some(copy _7);
-          goto -> bb7;
-      }
-  
-      bb7: {
           StorageDead(_2);
           return;
 +     }
 + 
-+     bb8: {
++     bb7: {
 +         _6 = discriminant(_2);
-+         goto -> bb5;
++         goto -> bb4;
       }
   }
   


### PR DESCRIPTION
So many places to update :D

Zulip conversation: <https://rust-lang.zulipchat.com/#narrow/stream/189540-t-compiler.2Fwg-mir-opt/topic/Pondering.20the.20SwitchInt.20.26.20unreachable/near/432988457>

For this PR I tried to keep things doing essentially the same thing as before.  No new passes to try to use it more, no change to MIR building for exhaustive matches, etc.

That said, `UnreachableProp` still picks it up, and thus there's still a bunch of `otherwise` arms removed and `unreachable` blocks that no longer show.

r? ghost
cc @JakobDegen @saethlin @cuviper @wesleywiser 
