### PR TITLE
mir-opt tests: rename unit-test -> test-mir-pass

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -244,7 +244,7 @@ mod directives {
     pub const STDERR_PER_BITWIDTH: &'static str = "stderr-per-bitwidth";
     pub const INCREMENTAL: &'static str = "incremental";
     pub const KNOWN_BUG: &'static str = "known-bug";
-    pub const MIR_UNIT_TEST: &'static str = "unit-test";
+    pub const TEST_MIR_PASS: &'static str = "test-mir-pass";
     pub const REMAP_SRC_BASE: &'static str = "remap-src-base";
     pub const COMPARE_OUTPUT_LINES_BY_SUBSET: &'static str = "compare-output-lines-by-subset";
     pub const LLVM_COV_FLAGS: &'static str = "llvm-cov-flags";
@@ -549,7 +549,7 @@ impl TestProps {
 
                     config.set_name_value_directive(
                         ln,
-                        MIR_UNIT_TEST,
+                        TEST_MIR_PASS,
                         &mut self.mir_unit_test,
                         |s| s.trim().to_string(),
                     );
@@ -922,7 +922,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "should-fail",
     "should-ice",
     "stderr-per-bitwidth",
-    "unit-test",
+    "test-mir-pass",
     "unset-exec-env",
     "unset-rustc-env",
     // tidy-alphabetical-end

--- a/tests/mir-opt/README.md
+++ b/tests/mir-opt/README.md
@@ -14,17 +14,18 @@ presence of pointers in constants or other bit width dependent things. In that c
 
 to your test, causing separate files to be generated for 32bit and 64bit systems.
 
-## Unit testing
+## Testing a particular MIR pass
 
 If you are only testing the behavior of a particular mir-opt pass on some specific input (as is
 usually the case), you should add
 
 ```
-// unit-test: PassName
+//@ test-mir-pass: PassName
 ```
 
 to the top of the file. This makes sure that other passes don't run which means you'll get the input
-you expected and your test won't break when other code changes.
+you expected and your test won't break when other code changes. This also lets you test passes
+that are disabled by default.
 
 ## Emit a diff of the mir for a specific optimization
 

--- a/tests/mir-opt/array_index_is_temporary.rs
+++ b/tests/mir-opt/array_index_is_temporary.rs
@@ -1,4 +1,4 @@
-//@ unit-test: SimplifyCfg-pre-optimizations
+//@ test-mir-pass: SimplifyCfg-pre-optimizations
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // Retagging (from Stacked Borrows) relies on the array index being a fresh
 // temporary, so that side-effects cannot change it.

--- a/tests/mir-opt/basic_assignment.rs
+++ b/tests/mir-opt/basic_assignment.rs
@@ -1,4 +1,4 @@
-//@ unit-test: ElaborateDrops
+//@ test-mir-pass: ElaborateDrops
 //@ needs-unwind
 // this tests move up progration, which is not yet implemented
 

--- a/tests/mir-opt/box_expr.rs
+++ b/tests/mir-opt/box_expr.rs
@@ -1,4 +1,4 @@
-//@ unit-test: ElaborateDrops
+//@ test-mir-pass: ElaborateDrops
 //@ needs-unwind
 
 #![feature(rustc_attrs, stmt_expr_attributes)]

--- a/tests/mir-opt/const_allocation.rs
+++ b/tests/mir-opt/const_allocation.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ ignore-endian-big
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 static FOO: &[(Option<i32>, &[&str])] =

--- a/tests/mir-opt/const_allocation2.rs
+++ b/tests/mir-opt/const_allocation2.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ ignore-endian-big
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR const_allocation2.main.GVN.after.mir

--- a/tests/mir-opt/const_allocation3.rs
+++ b/tests/mir-opt/const_allocation3.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ ignore-endian-big
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR const_allocation3.main.GVN.after.mir

--- a/tests/mir-opt/const_debuginfo.rs
+++ b/tests/mir-opt/const_debuginfo.rs
@@ -1,4 +1,4 @@
-//@ unit-test: ConstDebugInfo
+//@ test-mir-pass: ConstDebugInfo
 //@ compile-flags: -C overflow-checks=no -Zmir-enable-passes=+GVN
 
 struct Point {

--- a/tests/mir-opt/const_prop/address_of_pair.rs
+++ b/tests/mir-opt/const_prop/address_of_pair.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // EMIT_MIR address_of_pair.fn0.GVN.diff
 pub fn fn0() -> bool {

--- a/tests/mir-opt/const_prop/aggregate.rs
+++ b/tests/mir-opt/const_prop/aggregate.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -O
 
 // EMIT_MIR aggregate.main.GVN.diff

--- a/tests/mir-opt/const_prop/array_index.rs
+++ b/tests/mir-opt/const_prop/array_index.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 

--- a/tests/mir-opt/const_prop/bad_op_div_by_zero.rs
+++ b/tests/mir-opt/const_prop/bad_op_div_by_zero.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 // EMIT_MIR bad_op_div_by_zero.main.GVN.diff

--- a/tests/mir-opt/const_prop/bad_op_mod_by_zero.rs
+++ b/tests/mir-opt/const_prop/bad_op_mod_by_zero.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 // EMIT_MIR bad_op_mod_by_zero.main.GVN.diff

--- a/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.rs
+++ b/tests/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 

--- a/tests/mir-opt/const_prop/boolean_identities.rs
+++ b/tests/mir-opt/const_prop/boolean_identities.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // EMIT_MIR boolean_identities.test.GVN.diff
 pub fn test(x: bool, y: bool) -> bool {

--- a/tests/mir-opt/const_prop/boxes.rs
+++ b/tests/mir-opt/const_prop/boxes.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -O
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/const_prop/cast.rs
+++ b/tests/mir-opt/const_prop/cast.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR cast.main.GVN.diff
 
 fn main() {

--- a/tests/mir-opt/const_prop/checked_add.rs
+++ b/tests/mir-opt/const_prop/checked_add.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -C overflow-checks=on
 
 // EMIT_MIR checked_add.main.GVN.diff

--- a/tests/mir-opt/const_prop/control_flow_simplification.rs
+++ b/tests/mir-opt/const_prop/control_flow_simplification.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -Zmir-opt-level=1
 
 trait NeedsDrop: Sized {

--- a/tests/mir-opt/const_prop/discriminant.rs
+++ b/tests/mir-opt/const_prop/discriminant.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // FIXME(wesleywiser): Ideally, we could const-prop away all of this and just be left with
 // `let x = 42` but that doesn't work because const-prop doesn't support `Operand::Indirect`

--- a/tests/mir-opt/const_prop/indirect.rs
+++ b/tests/mir-opt/const_prop/indirect.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -C overflow-checks=on
 
 // EMIT_MIR indirect.main.GVN.diff

--- a/tests/mir-opt/const_prop/indirect_mutation.rs
+++ b/tests/mir-opt/const_prop/indirect_mutation.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // Check that we do not propagate past an indirect mutation.
 #![feature(raw_ref_op)]
 

--- a/tests/mir-opt/const_prop/inherit_overflow.rs
+++ b/tests/mir-opt/const_prop/inherit_overflow.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -Zmir-enable-passes=+Inline
 
 // After inlining, this will contain a `CheckedBinaryOp`.

--- a/tests/mir-opt/const_prop/invalid_constant.rs
+++ b/tests/mir-opt/const_prop/invalid_constant.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -Zmir-enable-passes=+RemoveZsts
 // Verify that we can pretty print invalid constants.
 

--- a/tests/mir-opt/const_prop/issue_66971.rs
+++ b/tests/mir-opt/const_prop/issue_66971.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // Due to a bug in propagating scalar pairs the assertion below used to fail. In the expected
 // outputs below, after GVN this is how _2 would look like with the bug:

--- a/tests/mir-opt/const_prop/issue_67019.rs
+++ b/tests/mir-opt/const_prop/issue_67019.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // This used to ICE in const-prop
 

--- a/tests/mir-opt/const_prop/large_array_index.rs
+++ b/tests/mir-opt/const_prop/large_array_index.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 

--- a/tests/mir-opt/const_prop/mult_by_zero.rs
+++ b/tests/mir-opt/const_prop/mult_by_zero.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // EMIT_MIR mult_by_zero.test.GVN.diff
 fn test(x: i32) -> i32 {

--- a/tests/mir-opt/const_prop/mutable_variable.rs
+++ b/tests/mir-opt/const_prop/mutable_variable.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // EMIT_MIR mutable_variable.main.GVN.diff
 fn main() {

--- a/tests/mir-opt/const_prop/mutable_variable_aggregate.rs
+++ b/tests/mir-opt/const_prop/mutable_variable_aggregate.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // EMIT_MIR mutable_variable_aggregate.main.GVN.diff
 fn main() {

--- a/tests/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.rs
+++ b/tests/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // EMIT_MIR mutable_variable_aggregate_mut_ref.main.GVN.diff
 fn main() {

--- a/tests/mir-opt/const_prop/mutable_variable_aggregate_partial_read.rs
+++ b/tests/mir-opt/const_prop/mutable_variable_aggregate_partial_read.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // EMIT_MIR mutable_variable_aggregate_partial_read.main.GVN.diff
 fn main() {

--- a/tests/mir-opt/const_prop/mutable_variable_no_prop.rs
+++ b/tests/mir-opt/const_prop/mutable_variable_no_prop.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // Verify that we do not propagate the contents of this mutable static.
 static mut STATIC: u32 = 0x42424242;

--- a/tests/mir-opt/const_prop/mutable_variable_unprop_assign.rs
+++ b/tests/mir-opt/const_prop/mutable_variable_unprop_assign.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // EMIT_MIR mutable_variable_unprop_assign.main.GVN.diff
 fn main() {

--- a/tests/mir-opt/const_prop/offset_of.rs
+++ b/tests/mir-opt/const_prop/offset_of.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![feature(offset_of_enum, offset_of_nested)]

--- a/tests/mir-opt/const_prop/overwrite_with_const_with_params.rs
+++ b/tests/mir-opt/const_prop/overwrite_with_const_with_params.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -O
 
 // Regression test for https://github.com/rust-lang/rust/issues/118328

--- a/tests/mir-opt/const_prop/pointer_expose_provenance.rs
+++ b/tests/mir-opt/const_prop/pointer_expose_provenance.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 #[inline(never)]
 fn read(_: usize) { }

--- a/tests/mir-opt/const_prop/read_immutable_static.rs
+++ b/tests/mir-opt/const_prop/read_immutable_static.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 static FOO: u8 = 2;
 

--- a/tests/mir-opt/const_prop/ref_deref.rs
+++ b/tests/mir-opt/const_prop/ref_deref.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // EMIT_MIR ref_deref.main.GVN.diff
 fn main() {

--- a/tests/mir-opt/const_prop/ref_deref_project.rs
+++ b/tests/mir-opt/const_prop/ref_deref_project.rs
@@ -1,5 +1,5 @@
 // This does not currently propagate (#67862)
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 // EMIT_MIR ref_deref_project.main.GVN.diff
 fn main() {

--- a/tests/mir-opt/const_prop/reify_fn_ptr.rs
+++ b/tests/mir-opt/const_prop/reify_fn_ptr.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR reify_fn_ptr.main.GVN.diff
 
 fn main() {

--- a/tests/mir-opt/const_prop/repeat.rs
+++ b/tests/mir-opt/const_prop/repeat.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 

--- a/tests/mir-opt/const_prop/return_place.rs
+++ b/tests/mir-opt/const_prop/return_place.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //@ compile-flags: -C overflow-checks=on
 

--- a/tests/mir-opt/const_prop/scalar_literal_propagation.rs
+++ b/tests/mir-opt/const_prop/scalar_literal_propagation.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 // EMIT_MIR scalar_literal_propagation.main.GVN.diff

--- a/tests/mir-opt/const_prop/slice_len.rs
+++ b/tests/mir-opt/const_prop/slice_len.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -Zmir-enable-passes=+InstSimplify
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH

--- a/tests/mir-opt/const_prop/switch_int.rs
+++ b/tests/mir-opt/const_prop/switch_int.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -Zmir-enable-passes=+SimplifyConstCondition-after-const-prop
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/const_prop/transmute.rs
+++ b/tests/mir-opt/const_prop/transmute.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -O --crate-type=lib
 //@ ignore-endian-big
 // EMIT_MIR_FOR_EACH_BIT_WIDTH

--- a/tests/mir-opt/const_prop/tuple_literal_propagation.rs
+++ b/tests/mir-opt/const_prop/tuple_literal_propagation.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR tuple_literal_propagation.main.GVN.diff
 

--- a/tests/mir-opt/const_prop/while_let_loops.rs
+++ b/tests/mir-opt/const_prop/while_let_loops.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR while_let_loops.change_loop_body.GVN.diff
 
 pub fn change_loop_body() {

--- a/tests/mir-opt/copy-prop/borrowed_local.rs
+++ b/tests/mir-opt/copy-prop/borrowed_local.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 
 #![feature(custom_mir, core_intrinsics)]
 #![allow(unused_assignments)]

--- a/tests/mir-opt/copy-prop/branch.rs
+++ b/tests/mir-opt/copy-prop/branch.rs
@@ -1,7 +1,7 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //! Tests that we bail out when there are multiple assignments to the same local.
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 fn val() -> i32 {
     1
 }

--- a/tests/mir-opt/copy-prop/calls.rs
+++ b/tests/mir-opt/copy-prop/calls.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 // Check that CopyProp does propagate return values of call terminators.
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 //@ needs-unwind
 
 #![feature(custom_mir, core_intrinsics)]

--- a/tests/mir-opt/copy-prop/copy_propagation_arg.rs
+++ b/tests/mir-opt/copy-prop/copy_propagation_arg.rs
@@ -2,7 +2,7 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // Check that CopyProp does not propagate an assignment to a function argument
 // (doing so can break usages of the original argument value)
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 fn dummy(x: u8) -> u8 {
     x
 }

--- a/tests/mir-opt/copy-prop/custom_move_arg.rs
+++ b/tests/mir-opt/copy-prop/custom_move_arg.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 
 #![feature(custom_mir, core_intrinsics)]
 #![allow(unused_assignments)]

--- a/tests/mir-opt/copy-prop/cycle.rs
+++ b/tests/mir-opt/copy-prop/cycle.rs
@@ -1,7 +1,7 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //! Tests that cyclic assignments don't hang CopyProp, and result in reasonable code.
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 fn val() -> i32 {
     1
 }

--- a/tests/mir-opt/copy-prop/dead_stores_79191.rs
+++ b/tests/mir-opt/copy-prop/dead_stores_79191.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 
 fn id<T>(x: T) -> T {
     x

--- a/tests/mir-opt/copy-prop/dead_stores_better.rs
+++ b/tests/mir-opt/copy-prop/dead_stores_better.rs
@@ -3,7 +3,7 @@
 // This is a copy of the `dead_stores_79191` test, except that we turn on DSE. This demonstrates
 // that that pass enables this one to do more optimizations.
 
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 //@ compile-flags: -Zmir-enable-passes=+DeadStoreElimination
 
 fn id<T>(x: T) -> T {

--- a/tests/mir-opt/copy-prop/issue_107511.rs
+++ b/tests/mir-opt/copy-prop/issue_107511.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 
 // EMIT_MIR issue_107511.main.CopyProp.diff
 fn main() {

--- a/tests/mir-opt/copy-prop/move_arg.rs
+++ b/tests/mir-opt/copy-prop/move_arg.rs
@@ -1,7 +1,7 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // Test that we do not move multiple times from the same local.
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 
 // EMIT_MIR move_arg.f.CopyProp.diff
 pub fn f<T: Copy>(a: T) {

--- a/tests/mir-opt/copy-prop/move_projection.rs
+++ b/tests/mir-opt/copy-prop/move_projection.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 
 #![feature(custom_mir, core_intrinsics)]
 #![allow(unused_assignments)]

--- a/tests/mir-opt/copy-prop/mutate_through_pointer.rs
+++ b/tests/mir-opt/copy-prop/mutate_through_pointer.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 //
 // This attempts to mutate `a` via a pointer derived from `addr_of!(a)`. That is UB
 // according to Miri. However, the decision to make this UB - and to allow

--- a/tests/mir-opt/copy-prop/non_dominate.rs
+++ b/tests/mir-opt/copy-prop/non_dominate.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 
 #![feature(custom_mir, core_intrinsics)]
 #![allow(unused_assignments)]

--- a/tests/mir-opt/copy-prop/partial_init.rs
+++ b/tests/mir-opt/copy-prop/partial_init.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 // Verify that we do not ICE on partial initializations.
 
 #![feature(custom_mir, core_intrinsics)]

--- a/tests/mir-opt/copy-prop/reborrow.rs
+++ b/tests/mir-opt/copy-prop/reborrow.rs
@@ -1,7 +1,7 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // Check that CopyProp considers reborrows as not mutating the pointer.
-//@ unit-test: CopyProp
+//@ test-mir-pass: CopyProp
 
 #![feature(raw_ref_op)]
 

--- a/tests/mir-opt/dataflow-const-prop/array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/array_index.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR array_index.main.DataflowConstProp.diff

--- a/tests/mir-opt/dataflow-const-prop/boolean_identities.rs
+++ b/tests/mir-opt/dataflow-const-prop/boolean_identities.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 
 // EMIT_MIR boolean_identities.test.DataflowConstProp.diff
 

--- a/tests/mir-opt/dataflow-const-prop/cast.rs
+++ b/tests/mir-opt/dataflow-const-prop/cast.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 
 // EMIT_MIR cast.main.DataflowConstProp.diff
 

--- a/tests/mir-opt/dataflow-const-prop/checked.rs
+++ b/tests/mir-opt/dataflow-const-prop/checked.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 //@ compile-flags: -Coverflow-checks=on
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 //@ compile-flags: -Zmir-enable-passes=+GVN,+Inline
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 #![feature(custom_mir, core_intrinsics, rustc_attrs)]

--- a/tests/mir-opt/dataflow-const-prop/if.rs
+++ b/tests/mir-opt/dataflow-const-prop/if.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 
 // EMIT_MIR if.main.DataflowConstProp.diff
 // CHECK-LABEL: fn main(

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.rs
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 //@ compile-flags: -Zmir-enable-passes=+Inline
 
 // EMIT_MIR inherit_overflow.main.DataflowConstProp.diff

--- a/tests/mir-opt/dataflow-const-prop/issue_81605.rs
+++ b/tests/mir-opt/dataflow-const-prop/issue_81605.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 
 // EMIT_MIR issue_81605.f.DataflowConstProp.diff
 

--- a/tests/mir-opt/dataflow-const-prop/large_array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/large_array_index.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 

--- a/tests/mir-opt/dataflow-const-prop/mult_by_zero.rs
+++ b/tests/mir-opt/dataflow-const-prop/mult_by_zero.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 
 // EMIT_MIR mult_by_zero.test.DataflowConstProp.diff
 // CHECK-LABEL: fn test(

--- a/tests/mir-opt/dataflow-const-prop/offset_of.rs
+++ b/tests/mir-opt/dataflow-const-prop/offset_of.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![feature(offset_of_nested)]

--- a/tests/mir-opt/dataflow-const-prop/ref_without_sb.rs
+++ b/tests/mir-opt/dataflow-const-prop/ref_without_sb.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 
 #[inline(never)]
 fn escape<T>(x: &T) {}

--- a/tests/mir-opt/dataflow-const-prop/repeat.rs
+++ b/tests/mir-opt/dataflow-const-prop/repeat.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 

--- a/tests/mir-opt/dataflow-const-prop/repr_transparent.rs
+++ b/tests/mir-opt/dataflow-const-prop/repr_transparent.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 
 // The struct has scalar ABI, but is not a scalar type.
 // Make sure that we handle this correctly.

--- a/tests/mir-opt/dataflow-const-prop/self_assign.rs
+++ b/tests/mir-opt/dataflow-const-prop/self_assign.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 
 // EMIT_MIR self_assign.main.DataflowConstProp.diff
 

--- a/tests/mir-opt/dataflow-const-prop/self_assign_add.rs
+++ b/tests/mir-opt/dataflow-const-prop/self_assign_add.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 
 // EMIT_MIR self_assign_add.main.DataflowConstProp.diff
 

--- a/tests/mir-opt/dataflow-const-prop/sibling_ptr.rs
+++ b/tests/mir-opt/dataflow-const-prop/sibling_ptr.rs
@@ -6,7 +6,7 @@
 // used to modify `x.1` - if it did not, then it might incorrectly assume that it
 // can infer the value of `x.1` at the end of this function.
 
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 
 // EMIT_MIR sibling_ptr.main.DataflowConstProp.diff
 

--- a/tests/mir-opt/dataflow-const-prop/slice_len.rs
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 //@ compile-flags: -Zmir-enable-passes=+InstSimplify
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 

--- a/tests/mir-opt/dataflow-const-prop/struct.rs
+++ b/tests/mir-opt/dataflow-const-prop/struct.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 #[derive(Copy, Clone)]

--- a/tests/mir-opt/dataflow-const-prop/terminator.rs
+++ b/tests/mir-opt/dataflow-const-prop/terminator.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 
 fn foo(n: i32) {}
 

--- a/tests/mir-opt/dataflow-const-prop/transmute.rs
+++ b/tests/mir-opt/dataflow-const-prop/transmute.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 //@ compile-flags: -O --crate-type=lib
 //@ ignore-endian-big
 // EMIT_MIR_FOR_EACH_BIT_WIDTH

--- a/tests/mir-opt/dataflow-const-prop/tuple.rs
+++ b/tests/mir-opt/dataflow-const-prop/tuple.rs
@@ -1,4 +1,4 @@
-//@ unit-test: DataflowConstProp
+//@ test-mir-pass: DataflowConstProp
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR tuple.main.DataflowConstProp.diff

--- a/tests/mir-opt/dead-store-elimination/call_arg_copy.rs
+++ b/tests/mir-opt/dead-store-elimination/call_arg_copy.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: DeadStoreElimination-final
+//@ test-mir-pass: DeadStoreElimination-final
 //@ compile-flags: -Zmir-enable-passes=+CopyProp
 
 #![feature(core_intrinsics)]

--- a/tests/mir-opt/dead-store-elimination/cycle.rs
+++ b/tests/mir-opt/dead-store-elimination/cycle.rs
@@ -2,7 +2,7 @@
 // report that *all* of these stores are live.
 //
 //@ needs-unwind
-//@ unit-test: DeadStoreElimination-initial
+//@ test-mir-pass: DeadStoreElimination-initial
 
 #![feature(core_intrinsics, custom_mir)]
 use std::intrinsics::mir::*;

--- a/tests/mir-opt/dead-store-elimination/place_mention.rs
+++ b/tests/mir-opt/dead-store-elimination/place_mention.rs
@@ -1,7 +1,7 @@
 // Verify that we account for the `PlaceMention` statement as a use of the tuple,
 // and don't remove it as a dead store.
 //
-//@ unit-test: DeadStoreElimination-initial
+//@ test-mir-pass: DeadStoreElimination-initial
 //@ compile-flags: -Zmir-keep-place-mention
 
 // EMIT_MIR place_mention.main.DeadStoreElimination-initial.diff

--- a/tests/mir-opt/dead-store-elimination/provenance_soundness.rs
+++ b/tests/mir-opt/dead-store-elimination/provenance_soundness.rs
@@ -1,5 +1,5 @@
 // Test that we don't remove pointer to int casts or retags
-//@ unit-test: DeadStoreElimination-initial
+//@ test-mir-pass: DeadStoreElimination-initial
 //@ compile-flags: -Zmir-emit-retag
 
 // EMIT_MIR provenance_soundness.pointer_to_int.DeadStoreElimination-initial.diff

--- a/tests/mir-opt/deduplicate_blocks.rs
+++ b/tests/mir-opt/deduplicate_blocks.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: DeduplicateBlocks
+//@ test-mir-pass: DeduplicateBlocks
 
 // EMIT_MIR deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
 pub const fn is_line_doc_comment_2(s: &str) -> bool {

--- a/tests/mir-opt/derefer_complex_case.rs
+++ b/tests/mir-opt/derefer_complex_case.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: Derefer
+//@ test-mir-pass: Derefer
 // EMIT_MIR derefer_complex_case.main.Derefer.diff
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/derefer_inline_test.rs
+++ b/tests/mir-opt/derefer_inline_test.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: Derefer
+//@ test-mir-pass: Derefer
 // EMIT_MIR derefer_inline_test.main.Derefer.diff
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/derefer_terminator_test.rs
+++ b/tests/mir-opt/derefer_terminator_test.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: Derefer
+//@ test-mir-pass: Derefer
 // EMIT_MIR derefer_terminator_test.main.Derefer.diff
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/derefer_test.rs
+++ b/tests/mir-opt/derefer_test.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: Derefer
+//@ test-mir-pass: Derefer
 // EMIT_MIR derefer_test.main.Derefer.diff
 fn main() {
     let mut a = (42,43);

--- a/tests/mir-opt/derefer_test_multiple.rs
+++ b/tests/mir-opt/derefer_test_multiple.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: Derefer
+//@ test-mir-pass: Derefer
 // EMIT_MIR derefer_test_multiple.main.Derefer.diff
 fn main () {
     let mut a = (42, 43);

--- a/tests/mir-opt/dest-prop/branch.rs
+++ b/tests/mir-opt/dest-prop/branch.rs
@@ -1,7 +1,7 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //! Tests that assignment in both branches of an `if` are eliminated.
-//@ unit-test: DestinationPropagation
+//@ test-mir-pass: DestinationPropagation
 fn val() -> i32 {
     1
 }

--- a/tests/mir-opt/dest-prop/copy_propagation_arg.rs
+++ b/tests/mir-opt/dest-prop/copy_propagation_arg.rs
@@ -2,7 +2,7 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // Check that DestinationPropagation does not propagate an assignment to a function argument
 // (doing so can break usages of the original argument value)
-//@ unit-test: DestinationPropagation
+//@ test-mir-pass: DestinationPropagation
 fn dummy(x: u8) -> u8 {
     x
 }

--- a/tests/mir-opt/dest-prop/cycle.rs
+++ b/tests/mir-opt/dest-prop/cycle.rs
@@ -1,7 +1,7 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //! Tests that cyclic assignments don't hang DestinationPropagation, and result in reasonable code.
-//@ unit-test: DestinationPropagation
+//@ test-mir-pass: DestinationPropagation
 fn val() -> i32 {
     1
 }

--- a/tests/mir-opt/dest-prop/dead_stores_79191.rs
+++ b/tests/mir-opt/dest-prop/dead_stores_79191.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: DestinationPropagation
+//@ test-mir-pass: DestinationPropagation
 
 fn id<T>(x: T) -> T {
     x

--- a/tests/mir-opt/dest-prop/dead_stores_better.rs
+++ b/tests/mir-opt/dest-prop/dead_stores_better.rs
@@ -3,7 +3,7 @@
 // This is a copy of the `dead_stores_79191` test, except that we turn on DSE. This demonstrates
 // that that pass enables this one to do more optimizations.
 
-//@ unit-test: DestinationPropagation
+//@ test-mir-pass: DestinationPropagation
 //@ compile-flags: -Zmir-enable-passes=+DeadStoreElimination
 
 fn id<T>(x: T) -> T {

--- a/tests/mir-opt/dest-prop/simple.rs
+++ b/tests/mir-opt/dest-prop/simple.rs
@@ -1,7 +1,7 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //! Copy of `nrvo-simple.rs`, to ensure that full dest-prop handles it too.
-//@ unit-test: DestinationPropagation
+//@ test-mir-pass: DestinationPropagation
 // EMIT_MIR simple.nrvo.DestinationPropagation.diff
 fn nrvo(init: fn(&mut [u8; 1024])) -> [u8; 1024] {
     let mut buf = [0; 1024];

--- a/tests/mir-opt/dont_inline_type_id.rs
+++ b/tests/mir-opt/dont_inline_type_id.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: Inline
+//@ test-mir-pass: Inline
 //@ compile-flags: --crate-type=lib -C panic=abort
 
 use std::any::Any;

--- a/tests/mir-opt/early_otherwise_branch.rs
+++ b/tests/mir-opt/early_otherwise_branch.rs
@@ -1,4 +1,4 @@
-//@ unit-test: EarlyOtherwiseBranch
+//@ test-mir-pass: EarlyOtherwiseBranch
 //@ compile-flags: -Zmir-enable-passes=+UnreachableEnumBranching
 
 enum Option2<T> {

--- a/tests/mir-opt/early_otherwise_branch_3_element_tuple.rs
+++ b/tests/mir-opt/early_otherwise_branch_3_element_tuple.rs
@@ -1,4 +1,4 @@
-//@ unit-test: EarlyOtherwiseBranch
+//@ test-mir-pass: EarlyOtherwiseBranch
 //@ compile-flags: -Zmir-enable-passes=+UnreachableEnumBranching
 
 enum Option2<T> {

--- a/tests/mir-opt/early_otherwise_branch_68867.rs
+++ b/tests/mir-opt/early_otherwise_branch_68867.rs
@@ -1,4 +1,4 @@
-//@ unit-test: EarlyOtherwiseBranch
+//@ test-mir-pass: EarlyOtherwiseBranch
 //@ compile-flags: -Zmir-enable-passes=+UnreachableEnumBranching
 
 // FIXME: This test was broken by the derefer change.

--- a/tests/mir-opt/early_otherwise_branch_noopt.rs
+++ b/tests/mir-opt/early_otherwise_branch_noopt.rs
@@ -1,4 +1,4 @@
-//@ unit-test: EarlyOtherwiseBranch
+//@ test-mir-pass: EarlyOtherwiseBranch
 //@ compile-flags: -Zmir-enable-passes=+UnreachableEnumBranching
 
 // must not optimize as it does not follow the pattern of

--- a/tests/mir-opt/early_otherwise_branch_soundness.rs
+++ b/tests/mir-opt/early_otherwise_branch_soundness.rs
@@ -1,4 +1,4 @@
-//@ unit-test: EarlyOtherwiseBranch
+//@ test-mir-pass: EarlyOtherwiseBranch
 //@ compile-flags: -Zmir-enable-passes=+UnreachableEnumBranching
 
 // Tests various cases that the `early_otherwise_branch` opt should *not* optimize

--- a/tests/mir-opt/enum_opt.rs
+++ b/tests/mir-opt/enum_opt.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: EnumSizeOpt
+//@ test-mir-pass: EnumSizeOpt
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 //@ compile-flags: -Zunsound-mir-opts
 

--- a/tests/mir-opt/gvn.rs
+++ b/tests/mir-opt/gvn.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //@ only-64bit
 

--- a/tests/mir-opt/gvn_copy_moves.rs
+++ b/tests/mir-opt/gvn_copy_moves.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 
 #![feature(custom_mir, core_intrinsics)]
 extern crate core;

--- a/tests/mir-opt/gvn_uninhabited.rs
+++ b/tests/mir-opt/gvn_uninhabited.rs
@@ -1,4 +1,4 @@
-//@ unit-test: GVN
+//@ test-mir-pass: GVN
 //@ compile-flags: -O
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // skip-filecheck

--- a/tests/mir-opt/if_condition_int.rs
+++ b/tests/mir-opt/if_condition_int.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: SimplifyComparisonIntegral
+//@ test-mir-pass: SimplifyComparisonIntegral
 // EMIT_MIR if_condition_int.opt_u32.SimplifyComparisonIntegral.diff
 // EMIT_MIR if_condition_int.opt_negative.SimplifyComparisonIntegral.diff
 // EMIT_MIR if_condition_int.opt_char.SimplifyComparisonIntegral.diff

--- a/tests/mir-opt/inline/indirect_destination.rs
+++ b/tests/mir-opt/inline/indirect_destination.rs
@@ -1,6 +1,6 @@
 // Test for inlining with an indirect destination place.
 //
-//@ unit-test: Inline
+//@ test-mir-pass: Inline
 //@ edition: 2021
 //@ needs-unwind
 #![crate_type = "lib"]

--- a/tests/mir-opt/inline/inline_box_fn.rs
+++ b/tests/mir-opt/inline/inline_box_fn.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: Inline
+//@ test-mir-pass: Inline
 //@ compile-flags: --crate-type=lib
 
 // EMIT_MIR inline_box_fn.call.Inline.diff

--- a/tests/mir-opt/inline/unit_test.rs
+++ b/tests/mir-opt/inline/unit_test.rs
@@ -1,5 +1,5 @@
 // Check that `-Zmir-enable-passes=+Inline` does not ICE because of stolen MIR.
-//@ unit-test: Inline
+//@ test-mir-pass: Inline
 // skip-filecheck
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/inline_coroutine_body.rs
+++ b/tests/mir-opt/inline_coroutine_body.rs
@@ -1,6 +1,6 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // skip-filecheck
-//@ unit-test: Inline
+//@ test-mir-pass: Inline
 //@ edition: 2021
 //@ compile-flags: -Zinline-mir-hint-threshold=10000 -Zinline-mir-threshold=10000 --crate-type=lib
 

--- a/tests/mir-opt/inline_generically_if_sized.rs
+++ b/tests/mir-opt/inline_generically_if_sized.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: Inline
+//@ test-mir-pass: Inline
 //@ compile-flags: --crate-type=lib -C panic=abort
 
 trait Foo {

--- a/tests/mir-opt/instrument_coverage.rs
+++ b/tests/mir-opt/instrument_coverage.rs
@@ -2,7 +2,7 @@
 // The Coverage::CounterIncrement statements are later converted into LLVM
 // instrprof.increment intrinsics, during codegen.
 
-//@ unit-test: InstrumentCoverage
+//@ test-mir-pass: InstrumentCoverage
 //@ compile-flags: -Cinstrument-coverage -Zno-profiler-runtime
 
 // EMIT_MIR instrument_coverage.main.InstrumentCoverage.diff

--- a/tests/mir-opt/instrument_coverage_cleanup.rs
+++ b/tests/mir-opt/instrument_coverage_cleanup.rs
@@ -5,7 +5,7 @@
 // Removed statement kinds: BlockMarker, SpanMarker
 // Retained statement kinds: CounterIncrement, ExpressionUsed
 
-//@ unit-test: InstrumentCoverage
+//@ test-mir-pass: InstrumentCoverage
 //@ compile-flags: -Cinstrument-coverage -Zcoverage-options=branch -Zno-profiler-runtime
 
 // EMIT_MIR instrument_coverage_cleanup.main.InstrumentCoverage.diff

--- a/tests/mir-opt/instsimplify/bool_compare.rs
+++ b/tests/mir-opt/instsimplify/bool_compare.rs
@@ -1,4 +1,4 @@
-//@ unit-test: InstSimplify
+//@ test-mir-pass: InstSimplify
 
 // EMIT_MIR bool_compare.eq_true.InstSimplify.diff
 fn eq_true(x: bool) -> u32 {

--- a/tests/mir-opt/instsimplify/casts.rs
+++ b/tests/mir-opt/instsimplify/casts.rs
@@ -1,4 +1,4 @@
-//@ unit-test: InstSimplify
+//@ test-mir-pass: InstSimplify
 //@ compile-flags: -Zinline-mir
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/instsimplify/combine_array_len.rs
+++ b/tests/mir-opt/instsimplify/combine_array_len.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: InstSimplify
+//@ test-mir-pass: InstSimplify
 
 // EMIT_MIR combine_array_len.norm2.InstSimplify.diff
 fn norm2(x: [f32; 2]) -> f32 {

--- a/tests/mir-opt/instsimplify/combine_clone_of_primitives.rs
+++ b/tests/mir-opt/instsimplify/combine_clone_of_primitives.rs
@@ -1,4 +1,4 @@
-//@ unit-test: InstSimplify
+//@ test-mir-pass: InstSimplify
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 // EMIT_MIR combine_clone_of_primitives.{impl#0}-clone.InstSimplify.diff

--- a/tests/mir-opt/instsimplify/combine_transmutes.rs
+++ b/tests/mir-opt/instsimplify/combine_transmutes.rs
@@ -1,4 +1,4 @@
-//@ unit-test: InstSimplify
+//@ test-mir-pass: InstSimplify
 //@ compile-flags: -C panic=abort
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]

--- a/tests/mir-opt/instsimplify/duplicate_switch_targets.rs
+++ b/tests/mir-opt/instsimplify/duplicate_switch_targets.rs
@@ -1,4 +1,4 @@
-//@ unit-test: InstSimplify
+//@ test-mir-pass: InstSimplify
 
 #![feature(custom_mir, core_intrinsics)]
 #![crate_type = "lib"]

--- a/tests/mir-opt/instsimplify/intrinsic_asserts.rs
+++ b/tests/mir-opt/instsimplify/intrinsic_asserts.rs
@@ -1,4 +1,4 @@
-//@ unit-test: InstSimplify
+//@ test-mir-pass: InstSimplify
 
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]

--- a/tests/mir-opt/instsimplify/ub_check.rs
+++ b/tests/mir-opt/instsimplify/ub_check.rs
@@ -1,4 +1,4 @@
-//@ unit-test: InstSimplify
+//@ test-mir-pass: InstSimplify
 //@ compile-flags: -Cdebug-assertions=no -Zinline-mir
 
 // EMIT_MIR ub_check.unwrap_unchecked.InstSimplify.diff

--- a/tests/mir-opt/issue_101973.rs
+++ b/tests/mir-opt/issue_101973.rs
@@ -1,7 +1,7 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //@ compile-flags: -O -C debug-assertions=on
-// This needs inlining followed by GVN to reproduce, so we cannot use "unit-test".
+// This needs inlining followed by GVN to reproduce, so we cannot use "test-mir-pass".
 
 #[inline]
 pub fn imm8(x: u32) -> u32 {

--- a/tests/mir-opt/jump_threading.rs
+++ b/tests/mir-opt/jump_threading.rs
@@ -1,4 +1,4 @@
-//@ unit-test: JumpThreading
+//@ test-mir-pass: JumpThreading
 //@ compile-flags: -Zmir-enable-passes=+Inline
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 

--- a/tests/mir-opt/lower_array_len.rs
+++ b/tests/mir-opt/lower_array_len.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: NormalizeArrayLen
+//@ test-mir-pass: NormalizeArrayLen
 //@ compile-flags: -Zmir-enable-passes=+LowerSliceLenCalls
 
 // EMIT_MIR lower_array_len.array_bound.NormalizeArrayLen.diff

--- a/tests/mir-opt/lower_intrinsics.rs
+++ b/tests/mir-opt/lower_intrinsics.rs
@@ -1,4 +1,4 @@
-//@ unit-test: LowerIntrinsics
+//@ test-mir-pass: LowerIntrinsics
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![feature(core_intrinsics, intrinsics, rustc_attrs)]

--- a/tests/mir-opt/lower_slice_len.rs
+++ b/tests/mir-opt/lower_slice_len.rs
@@ -1,4 +1,4 @@
-//@ unit-test: LowerSliceLenCalls
+//@ test-mir-pass: LowerSliceLenCalls
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 // EMIT_MIR lower_slice_len.bound.LowerSliceLenCalls.diff

--- a/tests/mir-opt/matches_reduce_branches.rs
+++ b/tests/mir-opt/matches_reduce_branches.rs
@@ -1,4 +1,4 @@
-//@ unit-test: MatchBranchSimplification
+//@ test-mir-pass: MatchBranchSimplification
 
 #![feature(repr128)]
 #![feature(core_intrinsics)]

--- a/tests/mir-opt/matches_u8.rs
+++ b/tests/mir-opt/matches_u8.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: MatchBranchSimplification
+//@ test-mir-pass: MatchBranchSimplification
 
 
 // EMIT_MIR matches_u8.exhaustive_match.MatchBranchSimplification.diff

--- a/tests/mir-opt/nrvo_miscompile_111005.rs
+++ b/tests/mir-opt/nrvo_miscompile_111005.rs
@@ -1,7 +1,7 @@
 // skip-filecheck
 // This is a miscompilation, #111005 to track
 
-//@ unit-test: RenameReturnPlace
+//@ test-mir-pass: RenameReturnPlace
 
 #![feature(custom_mir, core_intrinsics)]
 extern crate core;

--- a/tests/mir-opt/nrvo_simple.rs
+++ b/tests/mir-opt/nrvo_simple.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: RenameReturnPlace
+//@ test-mir-pass: RenameReturnPlace
 
 // EMIT_MIR nrvo_simple.nrvo.RenameReturnPlace.diff
 fn nrvo(init: fn(&mut [u8; 1024])) -> [u8; 1024] {

--- a/tests/mir-opt/reference_prop.rs
+++ b/tests/mir-opt/reference_prop.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: -Zlint-mir=no
-//@ unit-test: ReferencePropagation
+//@ test-mir-pass: ReferencePropagation
 //@ needs-unwind
 
 #![feature(raw_ref_op)]

--- a/tests/mir-opt/remove_storage_markers.rs
+++ b/tests/mir-opt/remove_storage_markers.rs
@@ -1,5 +1,5 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: RemoveStorageMarkers
+//@ test-mir-pass: RemoveStorageMarkers
 
 // Checks that storage markers are removed at opt-level=0.
 //

--- a/tests/mir-opt/retag.rs
+++ b/tests/mir-opt/retag.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: AddRetag
+//@ test-mir-pass: AddRetag
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // ignore-tidy-linelength
 //@ compile-flags: -Z mir-emit-retag -Z mir-opt-level=0 -Z span_free_formats

--- a/tests/mir-opt/set_no_discriminant.rs
+++ b/tests/mir-opt/set_no_discriminant.rs
@@ -1,6 +1,6 @@
 // `SetDiscriminant` does not actually write anything if the chosen variant is the untagged variant
 // of a niche encoding. Verify that we do not thread over this case.
-//@ unit-test: JumpThreading
+//@ test-mir-pass: JumpThreading
 
 #![feature(custom_mir)]
 #![feature(core_intrinsics)]

--- a/tests/mir-opt/simplify_dead_blocks.rs
+++ b/tests/mir-opt/simplify_dead_blocks.rs
@@ -1,4 +1,4 @@
-//@ unit-test: SimplifyCfg-after-unreachable-enum-branching
+//@ test-mir-pass: SimplifyCfg-after-unreachable-enum-branching
 #![feature(custom_mir, core_intrinsics)]
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/simplify_locals.rs
+++ b/tests/mir-opt/simplify_locals.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: SimplifyLocals-before-const-prop
+//@ test-mir-pass: SimplifyLocals-before-const-prop
 
 
 #![feature(thread_local)]

--- a/tests/mir-opt/simplify_locals_removes_unused_consts.rs
+++ b/tests/mir-opt/simplify_locals_removes_unused_consts.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ unit-test: SimplifyLocals-before-const-prop
+//@ test-mir-pass: SimplifyLocals-before-const-prop
 //@ compile-flags: -C overflow-checks=no
 
 fn use_zst(_: ((), ())) {}

--- a/tests/mir-opt/simplify_locals_removes_unused_discriminant_reads.rs
+++ b/tests/mir-opt/simplify_locals_removes_unused_discriminant_reads.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ unit-test: SimplifyLocals-before-const-prop
+//@ test-mir-pass: SimplifyLocals-before-const-prop
 
 fn map(x: Option<Box<()>>) -> Option<Box<()>> {
     match x {

--- a/tests/mir-opt/sroa/lifetimes.rs
+++ b/tests/mir-opt/sroa/lifetimes.rs
@@ -1,4 +1,4 @@
-//@ unit-test: ScalarReplacementOfAggregates
+//@ test-mir-pass: ScalarReplacementOfAggregates
 //@ compile-flags: -Cpanic=abort
 //@ no-prefer-dynamic
 

--- a/tests/mir-opt/sroa/structs.rs
+++ b/tests/mir-opt/sroa/structs.rs
@@ -1,4 +1,4 @@
-//@ unit-test: ScalarReplacementOfAggregates
+//@ test-mir-pass: ScalarReplacementOfAggregates
 //@ compile-flags: -Cpanic=abort
 //@ no-prefer-dynamic
 

--- a/tests/mir-opt/unreachable.rs
+++ b/tests/mir-opt/unreachable.rs
@@ -1,4 +1,4 @@
-//@ unit-test: UnreachablePropagation
+//@ test-mir-pass: UnreachablePropagation
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 enum Empty {}

--- a/tests/mir-opt/unreachable_diverging.rs
+++ b/tests/mir-opt/unreachable_diverging.rs
@@ -1,4 +1,4 @@
-//@ unit-test: UnreachablePropagation
+//@ test-mir-pass: UnreachablePropagation
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 pub enum Empty {}

--- a/tests/mir-opt/unreachable_enum_branching.rs
+++ b/tests/mir-opt/unreachable_enum_branching.rs
@@ -1,4 +1,4 @@
-//@ unit-test: UnreachableEnumBranching
+//@ test-mir-pass: UnreachableEnumBranching
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 enum Empty {}


### PR DESCRIPTION
"unit-test" is extremely non-descriptive, no idea how one is supposed to read that and know that this specifies the MIR pass being tested.