### PR TITLE
Add `-lmingwex` second time in `mingw_libs`

### DIFF
--- a/compiler/rustc_target/src/spec/base/windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnu.rs
@@ -40,6 +40,9 @@ pub fn opts() -> TargetOptions {
         //
         // See https://github.com/rust-lang/rust/pull/47483 for some more details.
         "-lmsvcrt",
+        // Math functions missing in MSVCRT (they are present in UCRT) require
+        // this dependency cycle: `libmingwex.a` -> `libmsvcrt.a` -> `libmingwex.a`.
+        "-lmingwex",
         "-luser32",
         "-lkernel32",
     ];


### PR DESCRIPTION
Upcoming mingw-w64 releases will contain small math functions refactor which moved implementation around. As a result functions like `lgamma`
now depend on libraries in this order:
`libmingwex.a` -> `libmsvcrt.a` -> `libmingwex.a`.

Fixes #124221