### PR TITLE
Add comma at one place in `abs()` documentation

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3199,7 +3199,7 @@ macro_rules! int_impl {
         /// that code in debug mode will trigger a panic on this case and
         /// optimized code will return
         #[doc = concat!("`", stringify!($SelfT), "::MIN`")]
-        /// without a panic. If you do not want this behavior consider
+        /// without a panic. If you do not want this behavior, consider
         /// using [`unsigned_abs`](Self::unsigned_abs) instead.
         ///
         /// # Examples


### PR DESCRIPTION
As suggested  by @RalfJung here: https://github.com/rust-lang/rust/pull/124184#discussion_r1573670533