### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3199,7 +3199,7 @@ macro_rules! int_impl {
         /// that code in debug mode will trigger a panic on this case and
         /// optimized code will return
         #[doc = concat!("`", stringify!($SelfT), "::MIN`")]
-        /// without a panic. If you do not want this behavior consider
+        /// without a panic. If you do not want this behavior, consider
         /// using [`unsigned_abs`](Self::unsigned_abs) instead.
         ///
         /// # Examples

--- a/tests/crashes/123664.rs
+++ b/tests/crashes/123664.rs
@@ -1,0 +1,4 @@
+//@ known-bug: #123664
+#![feature(generic_const_exprs, effects)]
+const fn with_positive<F: ~const Fn()>() {}
+pub fn main() {}

--- a/tests/crashes/123955.rs
+++ b/tests/crashes/123955.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #123955
+//@ compile-flags: -Clto -Zvirtual-function-elimination
+//@ only-x86_64
+pub fn main() {
+    _ = Box::new(()) as Box<dyn Send>;
+}

--- a/tests/crashes/124092.rs
+++ b/tests/crashes/124092.rs
@@ -1,0 +1,7 @@
+//@ known-bug: #124092
+//@ compile-flags: -Zvirtual-function-elimination=true -Clto=true
+//@ only-x86_64
+const X: for<'b> fn(&'b ()) = |&()| ();
+fn main() {
+    let dyn_debug = Box::new(X) as Box<fn(&'static ())> as Box<dyn Send>;
+}

--- a/tests/crashes/124182.rs
+++ b/tests/crashes/124182.rs
@@ -1,0 +1,22 @@
+//@ known-bug: #124182
+struct LazyLock<T> {
+    data: (Copy, fn() -> T),
+}
+
+impl<T> LazyLock<T> {
+    pub const fn new(f: fn() -> T) -> LazyLock<T> {
+        LazyLock { data: (None, f) }
+    }
+}
+
+struct A<T = i32>(Option<T>);
+
+impl<T> Default for A<T> {
+    fn default() -> Self {
+        A(None)
+    }
+}
+
+static EMPTY_SET: LazyLock<A<i32>> = LazyLock::new(A::default);
+
+fn main() {}

--- a/tests/crashes/124189.rs
+++ b/tests/crashes/124189.rs
@@ -1,0 +1,14 @@
+//@ known-bug: #124189
+trait Trait {
+    type Type;
+}
+
+impl<T> Trait for T {
+    type Type = ();
+}
+
+fn f(_: <&Copy as Trait>::Type) {}
+
+fn main() {
+    f(());
+}

--- a/tests/crashes/124207.rs
+++ b/tests/crashes/124207.rs
@@ -1,0 +1,9 @@
+//@ known-bug: #124207
+#![feature(transmutability)]
+#![feature(type_alias_impl_trait)]
+trait OpaqueTrait {}
+type OpaqueType = impl OpaqueTrait;
+trait AnotherTrait {}
+impl<T: std::mem::BikeshedIntrinsicFrom<(), ()>> AnotherTrait for T {}
+impl AnotherTrait for OpaqueType {}
+pub fn main() {}

--- a/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.rs
+++ b/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.rs
@@ -1,0 +1,12 @@
+// issue rust-lang/rust#121463
+// ICE non-ADT in struct pattern
+#![feature(box_patterns)]
+
+fn main() {
+    let mut a = E::StructVar { boxed: Box::new(5_i32) };
+    //~^ ERROR failed to resolve: use of undeclared type `E`
+    match a {
+        E::StructVar { box boxed } => { }
+        //~^ ERROR failed to resolve: use of undeclared type `E`
+    }
+}

--- a/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.stderr
+++ b/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.stderr
@@ -1,0 +1,21 @@
+error[E0433]: failed to resolve: use of undeclared type `E`
+  --> $DIR/non-ADT-struct-pattern-box-pattern-ice-121463.rs:6:17
+   |
+LL |     let mut a = E::StructVar { boxed: Box::new(5_i32) };
+   |                 ^
+   |                 |
+   |                 use of undeclared type `E`
+   |                 help: a trait with a similar name exists: `Eq`
+
+error[E0433]: failed to resolve: use of undeclared type `E`
+  --> $DIR/non-ADT-struct-pattern-box-pattern-ice-121463.rs:9:9
+   |
+LL |         E::StructVar { box boxed } => { }
+   |         ^
+   |         |
+   |         use of undeclared type `E`
+   |         help: a trait with a similar name exists: `Eq`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/const-generics/generic_const_exprs/cannot-convert-refree-ice-114463.rs
+++ b/tests/ui/const-generics/generic_const_exprs/cannot-convert-refree-ice-114463.rs
@@ -1,0 +1,10 @@
+// issue: rust-lang/rust#114463
+// ICE cannot convert `ReFree ..` to a region vid
+#![feature(generic_const_exprs)]
+//~^ WARN the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+fn bug<'a>() {
+    [(); (|_: &'a u8| (), 0).1];
+    //~^ ERROR cannot capture late-bound lifetime in constant
+}
+
+pub fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/cannot-convert-refree-ice-114463.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/cannot-convert-refree-ice-114463.stderr
@@ -1,0 +1,19 @@
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/cannot-convert-refree-ice-114463.rs:3:12
+   |
+LL | #![feature(generic_const_exprs)]
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: cannot capture late-bound lifetime in constant
+  --> $DIR/cannot-convert-refree-ice-114463.rs:6:16
+   |
+LL | fn bug<'a>() {
+   |        -- lifetime defined here
+LL |     [(); (|_: &'a u8| (), 0).1];
+   |                ^^
+
+error: aborting due to 1 previous error; 1 warning emitted
+

--- a/tests/ui/consts/const_refs_to_static-ice-121413.rs
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.rs
@@ -1,0 +1,16 @@
+// ICE: ImmTy { imm: Scalar(alloc1), ty: *const dyn Sync } input to a fat-to-thin cast (*const dyn Sync -> *const usize
+// or with -Zextra-const-ub-checks: expected wide pointer extra data (e.g. slice length or trait object vtable)
+// issue: rust-lang/rust#121413
+//@ compile-flags: -Zextra-const-ub-checks
+// ignore-tidy-linelength
+#![feature(const_refs_to_static)]
+const REF_INTERIOR_MUT: &usize = {
+    static FOO: Sync = AtomicUsize::new(0);
+    //~^ ERROR failed to resolve: use of undeclared type `AtomicUsize`
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+    //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+    //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+    unsafe { &*(&FOO as *const _ as *const usize) }
+};
+pub fn main() {}

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -1,0 +1,46 @@
+error[E0433]: failed to resolve: use of undeclared type `AtomicUsize`
+  --> $DIR/const_refs_to_static-ice-121413.rs:8:24
+   |
+LL |     static FOO: Sync = AtomicUsize::new(0);
+   |                        ^^^^^^^^^^^ use of undeclared type `AtomicUsize`
+   |
+help: consider importing this struct
+   |
+LL + use std::sync::atomic::AtomicUsize;
+   |
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/const_refs_to_static-ice-121413.rs:8:17
+   |
+LL |     static FOO: Sync = AtomicUsize::new(0);
+   |                 ^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: `#[warn(bare_trait_objects)]` on by default
+help: if this is an object-safe trait, use `dyn`
+   |
+LL |     static FOO: dyn Sync = AtomicUsize::new(0);
+   |                 +++
+
+error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+  --> $DIR/const_refs_to_static-ice-121413.rs:8:17
+   |
+LL |     static FOO: Sync = AtomicUsize::new(0);
+   |                 ^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+
+error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+  --> $DIR/const_refs_to_static-ice-121413.rs:8:24
+   |
+LL |     static FOO: Sync = AtomicUsize::new(0);
+   |                        ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+   = note: constant expressions must have a statically known size
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0277, E0433.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #124236 (crashes: add a couple more ICE tests)
 - #124240 (add a couple tests for fixed ICEs.)
 - #124246 (Add comma at one place in `abs()` documentation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=124236,124240,124246)
<!-- homu-ignore:end -->