### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3199,7 +3199,7 @@ macro_rules! int_impl {
         /// that code in debug mode will trigger a panic on this case and
         /// optimized code will return
         #[doc = concat!("`", stringify!($SelfT), "::MIN`")]
-        /// without a panic. If you do not want this behavior consider
+        /// without a panic. If you do not want this behavior, consider
         /// using [`unsigned_abs`](Self::unsigned_abs) instead.
         ///
         /// # Examples

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -394,7 +394,7 @@ macro_rules! tool_check_step {
         impl Step for $name {
             type Output = ();
             const ONLY_HOSTS: bool = true;
-            // don't ever check out-of-tree tools by default, they'll fail when toolstate is broken
+            /// don't ever check out-of-tree tools by default, they'll fail when toolstate is broken
             const DEFAULT: bool = matches!($source_type, SourceType::InTree) $( && $default )?;
 
             fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -24,7 +24,7 @@ use super::compile::std_cargo;
 use super::tool::prepare_tool_cargo;
 use super::tool::SourceType;
 
-// Disable the most spammy clippy lints
+/// Disable the most spammy clippy lints
 const IGNORED_RULES_FOR_STD_AND_RUSTC: &[&str] = &[
     "many_single_char_names", // there are a lot in stdarch
     "collapsible_if",

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -835,13 +835,13 @@ impl Rustc {
 }
 
 impl Step for Rustc {
-    // We return the stage of the "actual" compiler (not the uplifted one).
-    //
-    // By "actual" we refer to the uplifting logic where we may not compile the requested stage;
-    // instead, we uplift it from the previous stages. Which can lead to bootstrap failures in
-    // specific situations where we request stage X from other steps. However we may end up
-    // uplifting it from stage Y, causing the other stage to fail when attempting to link with
-    // stage X which was never actually built.
+    /// We return the stage of the "actual" compiler (not the uplifted one).
+    ///
+    /// By "actual" we refer to the uplifting logic where we may not compile the requested stage;
+    /// instead, we uplift it from the previous stages. Which can lead to bootstrap failures in
+    /// specific situations where we request stage X from other steps. However we may end up
+    /// uplifting it from stage Y, causing the other stage to fail when attempting to link with
+    /// stage X which was never actually built.
     type Output = u32;
     const ONLY_HOSTS: bool = true;
     const DEFAULT: bool = false;
@@ -1302,7 +1302,7 @@ fn is_codegen_cfg_needed(path: &TaskPath, run: &RunConfig<'_>) -> bool {
 impl Step for CodegenBackend {
     type Output = ();
     const ONLY_HOSTS: bool = true;
-    // Only the backends specified in the `codegen-backends` entry of `config.toml` are built.
+    /// Only the backends specified in the `codegen-backends` entry of `config.toml` are built.
     const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2272,9 +2272,9 @@ impl Step for LlvmBitcodeLinker {
     }
 }
 
-// Tarball intended for internal consumption to ease rustc/std development.
-//
-// Should not be considered stable by end users.
+/// Tarball intended for internal consumption to ease rustc/std development.
+///
+/// Should not be considered stable by end users.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RustDev {
     pub target: TargetSelection,
@@ -2356,9 +2356,9 @@ impl Step for RustDev {
     }
 }
 
-// Tarball intended for internal consumption to ease rustc/std development.
-//
-// Should not be considered stable by end users.
+/// Tarball intended for internal consumption to ease rustc/std development.
+///
+/// Should not be considered stable by end users.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Bootstrap {
     pub target: TargetSelection,

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -506,7 +506,7 @@ impl Step for SharedAssets {
         run.never()
     }
 
-    // Generate shared resources used by other pieces of documentation.
+    /// Generate shared resources used by other pieces of documentation.
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let out = builder.doc_out(self.target);
 

--- a/src/bootstrap/src/core/build_steps/install.rs
+++ b/src/bootstrap/src/core/build_steps/install.rs
@@ -20,8 +20,8 @@ const SHELL: &str = "bash";
 #[cfg(not(target_os = "illumos"))]
 const SHELL: &str = "sh";
 
-// We have to run a few shell scripts, which choke quite a bit on both `\`
-// characters and on `C:\` paths, so normalize both of them away.
+/// We have to run a few shell scripts, which choke quite a bit on both `\`
+/// characters and on `C:\` paths, so normalize both of them away.
 fn sanitize_sh(path: &Path) -> String {
     let path = path.to_str().unwrap().replace('\\', "/");
     return change_drive(unc_to_lfs(&path)).unwrap_or(path);

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -56,14 +56,14 @@ impl LlvmBuildStatus {
     }
 }
 
-// Linker flags to pass to LLVM's CMake invocation.
+/// Linker flags to pass to LLVM's CMake invocation.
 #[derive(Debug, Clone, Default)]
 struct LdFlags {
-    // CMAKE_EXE_LINKER_FLAGS
+    /// CMAKE_EXE_LINKER_FLAGS
     exe: OsString,
-    // CMAKE_SHARED_LINKER_FLAGS
+    /// CMAKE_SHARED_LINKER_FLAGS
     shared: OsString,
-    // CMAKE_MODULE_LINKER_FLAGS
+    /// CMAKE_MODULE_LINKER_FLAGS
     module: OsString,
 }
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1433,8 +1433,8 @@ host_test!(RustdocJson { path: "tests/rustdoc-json", mode: "rustdoc-json", suite
 
 host_test!(Pretty { path: "tests/pretty", mode: "pretty", suite: "pretty" });
 
-// Special-handling is needed for `run-make`, so don't use `default_test` for defining `RunMake`
-// tests.
+/// Special-handling is needed for `run-make`, so don't use `default_test` for defining `RunMake`
+/// tests.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct RunMake {
     pub compiler: Compiler,
@@ -1527,10 +1527,10 @@ impl Coverage {
 
 impl Step for Coverage {
     type Output = ();
-    // We rely on the individual CoverageMap/CoverageRun steps to run themselves.
+    /// We rely on the individual CoverageMap/CoverageRun steps to run themselves.
     const DEFAULT: bool = false;
-    // When manually invoked, try to run as much as possible.
-    // Compiletest will automatically skip the "coverage-run" tests if necessary.
+    /// When manually invoked, try to run as much as possible.
+    /// Compiletest will automatically skip the "coverage-run" tests if necessary.
     const ONLY_HOSTS: bool = false;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {

--- a/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.rs
+++ b/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.rs
@@ -1,0 +1,12 @@
+// issue rust-lang/rust#121463
+// ICE non-ADT in struct pattern
+#![feature(box_patterns)]
+
+fn main() {
+    let mut a = E::StructVar { boxed: Box::new(5_i32) };
+    //~^ ERROR failed to resolve: use of undeclared type `E`
+    match a {
+        E::StructVar { box boxed } => { }
+        //~^ ERROR failed to resolve: use of undeclared type `E`
+    }
+}

--- a/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.stderr
+++ b/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.stderr
@@ -1,0 +1,21 @@
+error[E0433]: failed to resolve: use of undeclared type `E`
+  --> $DIR/non-ADT-struct-pattern-box-pattern-ice-121463.rs:6:17
+   |
+LL |     let mut a = E::StructVar { boxed: Box::new(5_i32) };
+   |                 ^
+   |                 |
+   |                 use of undeclared type `E`
+   |                 help: a trait with a similar name exists: `Eq`
+
+error[E0433]: failed to resolve: use of undeclared type `E`
+  --> $DIR/non-ADT-struct-pattern-box-pattern-ice-121463.rs:9:9
+   |
+LL |         E::StructVar { box boxed } => { }
+   |         ^
+   |         |
+   |         use of undeclared type `E`
+   |         help: a trait with a similar name exists: `Eq`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/const-generics/generic_const_exprs/cannot-convert-refree-ice-114463.rs
+++ b/tests/ui/const-generics/generic_const_exprs/cannot-convert-refree-ice-114463.rs
@@ -1,0 +1,10 @@
+// issue: rust-lang/rust#114463
+// ICE cannot convert `ReFree ..` to a region vid
+#![feature(generic_const_exprs)]
+//~^ WARN the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+fn bug<'a>() {
+    [(); (|_: &'a u8| (), 0).1];
+    //~^ ERROR cannot capture late-bound lifetime in constant
+}
+
+pub fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/cannot-convert-refree-ice-114463.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/cannot-convert-refree-ice-114463.stderr
@@ -1,0 +1,19 @@
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/cannot-convert-refree-ice-114463.rs:3:12
+   |
+LL | #![feature(generic_const_exprs)]
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: cannot capture late-bound lifetime in constant
+  --> $DIR/cannot-convert-refree-ice-114463.rs:6:16
+   |
+LL | fn bug<'a>() {
+   |        -- lifetime defined here
+LL |     [(); (|_: &'a u8| (), 0).1];
+   |                ^^
+
+error: aborting due to 1 previous error; 1 warning emitted
+

--- a/tests/ui/consts/const_refs_to_static-ice-121413.rs
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.rs
@@ -1,0 +1,16 @@
+// ICE: ImmTy { imm: Scalar(alloc1), ty: *const dyn Sync } input to a fat-to-thin cast (*const dyn Sync -> *const usize
+// or with -Zextra-const-ub-checks: expected wide pointer extra data (e.g. slice length or trait object vtable)
+// issue: rust-lang/rust#121413
+//@ compile-flags: -Zextra-const-ub-checks
+// ignore-tidy-linelength
+#![feature(const_refs_to_static)]
+const REF_INTERIOR_MUT: &usize = {
+    static FOO: Sync = AtomicUsize::new(0);
+    //~^ ERROR failed to resolve: use of undeclared type `AtomicUsize`
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+    //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+    //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+    unsafe { &*(&FOO as *const _ as *const usize) }
+};
+pub fn main() {}

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -1,0 +1,46 @@
+error[E0433]: failed to resolve: use of undeclared type `AtomicUsize`
+  --> $DIR/const_refs_to_static-ice-121413.rs:8:24
+   |
+LL |     static FOO: Sync = AtomicUsize::new(0);
+   |                        ^^^^^^^^^^^ use of undeclared type `AtomicUsize`
+   |
+help: consider importing this struct
+   |
+LL + use std::sync::atomic::AtomicUsize;
+   |
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/const_refs_to_static-ice-121413.rs:8:17
+   |
+LL |     static FOO: Sync = AtomicUsize::new(0);
+   |                 ^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: `#[warn(bare_trait_objects)]` on by default
+help: if this is an object-safe trait, use `dyn`
+   |
+LL |     static FOO: dyn Sync = AtomicUsize::new(0);
+   |                 +++
+
+error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+  --> $DIR/const_refs_to_static-ice-121413.rs:8:17
+   |
+LL |     static FOO: Sync = AtomicUsize::new(0);
+   |                 ^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+
+error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+  --> $DIR/const_refs_to_static-ice-121413.rs:8:24
+   |
+LL |     static FOO: Sync = AtomicUsize::new(0);
+   |                        ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+   = note: constant expressions must have a statically known size
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0277, E0433.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #124240 (add a couple tests for fixed ICEs.)
 - #124245 (bootstrap: Promote some build_steps comments to docs)
 - #124246 (Add comma at one place in `abs()` documentation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=124240,124245,124246)
<!-- homu-ignore:end -->