### PR TITLE
Add an intrinsic for `ptr::metadata`

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -619,22 +619,34 @@ fn codegen_stmt<'tcx>(
                 Rvalue::UnaryOp(un_op, ref operand) => {
                     let operand = codegen_operand(fx, operand);
                     let layout = operand.layout();
-                    let val = operand.load_scalar(fx);
                     let res = match un_op {
-                        UnOp::Not => match layout.ty.kind() {
-                            ty::Bool => {
-                                let res = fx.bcx.ins().icmp_imm(IntCC::Equal, val, 0);
-                                CValue::by_val(res, layout)
+                        UnOp::Not => {
+                            let val = operand.load_scalar(fx);
+                            match layout.ty.kind() {
+                                ty::Bool => {
+                                    let res = fx.bcx.ins().icmp_imm(IntCC::Equal, val, 0);
+                                    CValue::by_val(res, layout)
+                                }
+                                ty::Uint(_) | ty::Int(_) => {
+                                    CValue::by_val(fx.bcx.ins().bnot(val), layout)
+                                }
+                                _ => unreachable!("un op Not for {:?}", layout.ty),
                             }
-                            ty::Uint(_) | ty::Int(_) => {
-                                CValue::by_val(fx.bcx.ins().bnot(val), layout)
+                        }
+                        UnOp::Neg => {
+                            let val = operand.load_scalar(fx);
+                            match layout.ty.kind() {
+                                ty::Int(_) => CValue::by_val(fx.bcx.ins().ineg(val), layout),
+                                ty::Float(_) => CValue::by_val(fx.bcx.ins().fneg(val), layout),
+                                _ => unreachable!("un op Neg for {:?}", layout.ty),
                             }
-                            _ => unreachable!("un op Not for {:?}", layout.ty),
-                        },
-                        UnOp::Neg => match layout.ty.kind() {
-                            ty::Int(_) => CValue::by_val(fx.bcx.ins().ineg(val), layout),
-                            ty::Float(_) => CValue::by_val(fx.bcx.ins().fneg(val), layout),
-                            _ => unreachable!("un op Neg for {:?}", layout.ty),
+                        }
+                        UnOp::PtrMetadata => match layout.abi {
+                            Abi::Scalar(_) => CValue::zst(dest_layout),
+                            Abi::ScalarPair(_, _) => {
+                                CValue::by_val(operand.load_scalar_pair(fx).1, dest_layout)
+                            }
+                            _ => bug!("Unexpected `PtrToMetadata` operand: {operand:?}"),
                         },
                     };
                     lval.write_cvalue(fx, res);

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -100,7 +100,7 @@ pub(crate) fn codegen_const_value<'tcx>(
     assert!(layout.is_sized(), "unsized const value");
 
     if layout.is_zst() {
-        return CValue::by_ref(crate::Pointer::dangling(layout.align.pref), layout);
+        return CValue::zst(layout);
     }
 
     match const_val {

--- a/compiler/rustc_codegen_cranelift/src/value_and_place.rs
+++ b/compiler/rustc_codegen_cranelift/src/value_and_place.rs
@@ -95,6 +95,14 @@ impl<'tcx> CValue<'tcx> {
         CValue(CValueInner::ByValPair(value, extra), layout)
     }
 
+    /// Create an instance of a ZST
+    ///
+    /// The is represented by a dangling pointer of suitable alignment.
+    pub(crate) fn zst(layout: TyAndLayout<'tcx>) -> CValue<'tcx> {
+        assert!(layout.is_zst());
+        CValue::by_ref(crate::Pointer::dangling(layout.align.pref), layout)
+    }
+
     pub(crate) fn layout(&self) -> TyAndLayout<'tcx> {
         self.1
     }

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -565,6 +565,11 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 for elem in place_ref.projection.iter() {
                     match elem {
                         mir::ProjectionElem::Field(ref f, _) => {
+                            debug_assert!(
+                                !o.layout.ty.is_any_ptr(),
+                                "Bad PlaceRef: destructing pointers should use cast/PtrMetadata, \
+                                 but tried to access field {f:?} of pointer {o:?}",
+                            );
                             o = o.extract_field(bx, f.index());
                         }
                         mir::ProjectionElem::Index(_)

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -480,6 +480,11 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             cg_base = match *elem {
                 mir::ProjectionElem::Deref => bx.load_operand(cg_base).deref(bx.cx()),
                 mir::ProjectionElem::Field(ref field, _) => {
+                    debug_assert!(
+                        !cg_base.layout.ty.is_any_ptr(),
+                        "Bad PlaceRef: destructing pointers should use cast/PtrMetadata, \
+                         but tried to access field {field:?} of pointer {cg_base:?}",
+                    );
                     cg_base.project_field(bx, field.index())
                 }
                 mir::ProjectionElem::OpaqueCast(ty) => {

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -207,7 +207,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         assert!(cast_to.ty.is_unsafe_ptr());
         // Handle casting any ptr to raw ptr (might be a fat ptr).
         if cast_to.size == src.layout.size {
-            // Thin or fat pointer that just hast the ptr kind of target type changed.
+            // Thin or fat pointer that just has the ptr kind of target type changed.
             return Ok(ImmTy::from_immediate(**src, cast_to));
         } else {
             // Casting the metadata away from a fat ptr.

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -130,6 +130,7 @@ pub fn intrinsic_operation_unsafety(tcx: TyCtxt<'_>, intrinsic_id: LocalDefId) -
         | sym::is_val_statically_known
         | sym::ptr_mask
         | sym::aggregate_raw_ptr
+        | sym::ptr_metadata
         | sym::ub_checks
         | sym::fadd_algebraic
         | sym::fsub_algebraic
@@ -576,6 +577,7 @@ pub fn check_intrinsic_type(
             // This type check is not particularly useful, but the `where` bounds
             // on the definition in `core` do the heavy lifting for checking it.
             sym::aggregate_raw_ptr => (3, 1, vec![param(1), param(2)], param(0)),
+            sym::ptr_metadata => (2, 1, vec![Ty::new_imm_ptr(tcx, param(0))], param(1)),
 
             sym::ub_checks => (0, 1, Vec::new(), tcx.types.bool),
 

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -1434,6 +1434,13 @@ pub enum UnOp {
     Not,
     /// The `-` operator for negation
     Neg,
+    /// Get the metadata `M` from a `*const/mut impl Pointee<Metadata = M>`.
+    ///
+    /// For example, this will give a `()` from `*const i32`, a `usize` from
+    /// `*mut [u8]`, or a pointer to a vtable from a `*const dyn Foo`.
+    ///
+    /// Allowed only in [`MirPhase::Runtime`]; earlier it's an intrinsic.
+    PtrMetadata,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1579,8 +1579,10 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 let formatted_op = match op {
                     UnOp::Not => "!",
                     UnOp::Neg => "-",
+                    UnOp::PtrMetadata => "PtrMetadata",
                 };
                 let parenthesized = match ct.kind() {
+                    _ if op == UnOp::PtrMetadata => true,
                     ty::ConstKind::Expr(Expr::UnOp(c_op, ..)) => c_op != op,
                     ty::ConstKind::Expr(_) => true,
                     _ => false,

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -212,6 +212,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
                 Ok(Rvalue::BinaryOp(BinOp::Offset, Box::new((ptr, offset))))
             },
             @call(mir_len, args) => Ok(Rvalue::Len(self.parse_place(args[0])?)),
+            @call(mir_ptr_metadata, args) => Ok(Rvalue::UnaryOp(UnOp::PtrMetadata, self.parse_operand(args[0])?)),
             @call(mir_copy_for_deref, args) => Ok(Rvalue::CopyForDeref(self.parse_place(args[0])?)),
             ExprKind::Borrow { borrow_kind, arg } => Ok(
                 Rvalue::Ref(self.tcx.lifetimes.re_erased, *borrow_kind, self.parse_place(*arg)?)

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -464,7 +464,7 @@ impl<'tcx> Validator<'_, 'tcx> {
             Rvalue::UnaryOp(op, operand) => {
                 match op {
                     // These operations can never fail.
-                    UnOp::Neg | UnOp::Not => {}
+                    UnOp::Neg | UnOp::Not | UnOp::PtrMetadata => {}
                 }
 
                 self.validate_operand(operand)?;

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -1109,6 +1109,16 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             ty::Int(..) | ty::Uint(..) | ty::Bool
                         );
                     }
+                    UnOp::PtrMetadata => {
+                        if !matches!(self.mir_phase, MirPhase::Runtime(_)) {
+                            // It would probably be fine to support this in earlier phases,
+                            // but at the time of writing it's only ever introduced from intrinsic lowering,
+                            // so earlier things can just `bug!` on it.
+                            self.fail(location, "PtrMetadata should be in runtime MIR only");
+                        }
+
+                        check_kinds!(a, "Cannot PtrMetadata non-pointer type {:?}", ty::RawPtr(..));
+                    }
                 }
             }
             Rvalue::ShallowInitBox(operand, _) => {

--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -10,7 +10,7 @@ use rustc_span::Symbol;
 use stable_mir::abi::Layout;
 use stable_mir::mir::alloc::AllocId;
 use stable_mir::mir::mono::{Instance, MonoItem, StaticDef};
-use stable_mir::mir::{BinOp, Mutability, Place, ProjectionElem, Safety};
+use stable_mir::mir::{BinOp, Mutability, Place, ProjectionElem, Safety, UnOp};
 use stable_mir::ty::{
     Abi, AdtDef, Binder, BoundRegionKind, BoundTyKind, BoundVariableKind, ClosureKind, Const,
     DynKind, ExistentialPredicate, ExistentialProjection, ExistentialTraitRef, FloatTy, FnSig,
@@ -578,6 +578,18 @@ impl RustcInternal for BinOp {
             BinOp::Gt => rustc_middle::mir::BinOp::Gt,
             BinOp::Cmp => rustc_middle::mir::BinOp::Cmp,
             BinOp::Offset => rustc_middle::mir::BinOp::Offset,
+        }
+    }
+}
+
+impl RustcInternal for UnOp {
+    type T<'tcx> = rustc_middle::mir::UnOp;
+
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
+        match self {
+            UnOp::Not => rustc_middle::mir::UnOp::Not,
+            UnOp::Neg => rustc_middle::mir::UnOp::Neg,
+            UnOp::PtrMetadata => rustc_middle::mir::UnOp::PtrMetadata,
         }
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -19,7 +19,7 @@ use stable_mir::abi::{FnAbi, Layout, LayoutShape};
 use stable_mir::compiler_interface::Context;
 use stable_mir::mir::alloc::GlobalAlloc;
 use stable_mir::mir::mono::{InstanceDef, StaticDef};
-use stable_mir::mir::{BinOp, Body, Place};
+use stable_mir::mir::{BinOp, Body, Place, UnOp};
 use stable_mir::target::{MachineInfo, MachineSize};
 use stable_mir::ty::{
     AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FieldDef, FnDef, ForeignDef,
@@ -698,6 +698,14 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         let rhs_internal = rhs.internal(&mut *tables, tcx);
         let lhs_internal = lhs.internal(&mut *tables, tcx);
         let ty = bin_op.internal(&mut *tables, tcx).ty(tcx, rhs_internal, lhs_internal);
+        ty.stable(&mut *tables)
+    }
+
+    fn unop_ty(&self, un_op: UnOp, arg: Ty) -> Ty {
+        let mut tables = self.0.borrow_mut();
+        let tcx = tables.tcx;
+        let arg_internal = arg.internal(&mut *tables, tcx);
+        let ty = un_op.internal(&mut *tables, tcx).ty(tcx, arg_internal);
         ty.stable(&mut *tables)
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -526,6 +526,7 @@ impl<'tcx> Stable<'tcx> for mir::UnOp {
         match self {
             UnOp::Not => stable_mir::mir::UnOp::Not,
             UnOp::Neg => stable_mir::mir::UnOp::Neg,
+            UnOp::PtrMetadata => stable_mir::mir::UnOp::PtrMetadata,
         }
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1179,6 +1179,7 @@ symbols! {
         mir_make_place,
         mir_move,
         mir_offset,
+        mir_ptr_metadata,
         mir_retag,
         mir_return,
         mir_return_to,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1433,6 +1433,7 @@ symbols! {
         ptr_guaranteed_cmp,
         ptr_is_null,
         ptr_mask,
+        ptr_metadata,
         ptr_null,
         ptr_null_mut,
         ptr_offset_from,

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -94,7 +94,7 @@ fn check_binop(op: mir::BinOp) -> bool {
 fn check_unop(op: mir::UnOp) -> bool {
     use mir::UnOp::*;
     match op {
-        Not | Neg => true,
+        Not | Neg | PtrMetadata => true,
     }
 }
 

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -8,7 +8,7 @@ use std::cell::Cell;
 use crate::abi::{FnAbi, Layout, LayoutShape};
 use crate::mir::alloc::{AllocId, GlobalAlloc};
 use crate::mir::mono::{Instance, InstanceDef, StaticDef};
-use crate::mir::{BinOp, Body, Place};
+use crate::mir::{BinOp, Body, Place, UnOp};
 use crate::target::MachineInfo;
 use crate::ty::{
     AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FieldDef, FnDef, ForeignDef,
@@ -226,6 +226,9 @@ pub trait Context {
 
     /// Get the resulting type of binary operation.
     fn binop_ty(&self, bin_op: BinOp, rhs: Ty, lhs: Ty) -> Ty;
+
+    /// Get the resulting type of unary operation.
+    fn unop_ty(&self, un_op: UnOp, arg: Ty) -> Ty;
 }
 
 // A thread local variable that stores a pointer to the tables mapping between TyCtxt

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2821,6 +2821,21 @@ impl<P: ?Sized, T: ptr::Thin> AggregateRawPtr<*mut T> for *mut P {
     type Metadata = <P as ptr::Pointee>::Metadata;
 }
 
+/// Lowers in MIR to `Rvalue::UnaryOp` with `UnOp::PtrMetadata`.
+///
+/// This is used to implement functions like `ptr::metadata`.
+#[rustc_nounwind]
+#[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_const_unstable(feature = "ptr_metadata", issue = "81513")]
+#[rustc_intrinsic]
+#[rustc_intrinsic_must_be_overridden]
+#[cfg(not(bootstrap))]
+pub const fn ptr_metadata<P: ptr::Pointee<Metadata = M> + ?Sized, M>(_ptr: *const P) -> M {
+    // To implement a fallback we'd have to assume the layout of the pointer,
+    // but the whole point of this intrinsic is that we shouldn't do that.
+    unreachable!()
+}
+
 // Some functions are defined here because they accidentally got made
 // available in this module on stable. See <https://github.com/rust-lang/rust/issues/15702>.
 // (`transmute` also falls into this category, but it cannot be wrapped due to the

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -360,6 +360,10 @@ define!("mir_assume", fn Assume(operand: bool));
 define!("mir_deinit", fn Deinit<T>(place: T));
 define!("mir_checked", fn Checked<T>(binop: T) -> (T, bool));
 define!("mir_len", fn Len<T>(place: T) -> usize);
+define!(
+    "mir_ptr_metadata",
+    fn PtrMetadata<P: ?Sized>(place: *const P) -> <P as ::core::ptr::Pointee>::Metadata
+);
 define!("mir_copy_for_deref", fn CopyForDeref<T>(place: T) -> T);
 define!("mir_retag", fn Retag<T>(place: T));
 define!("mir_move", fn Move<T>(place: T) -> T);

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -3,6 +3,8 @@
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
 use crate::intrinsics::aggregate_raw_ptr;
+#[cfg(not(bootstrap))]
+use crate::intrinsics::ptr_metadata;
 use crate::marker::Freeze;
 
 /// Provides the pointer metadata type of any pointed-to type.
@@ -94,10 +96,17 @@ pub trait Thin = Pointee<Metadata = ()>;
 #[rustc_const_unstable(feature = "ptr_metadata", issue = "81513")]
 #[inline]
 pub const fn metadata<T: ?Sized>(ptr: *const T) -> <T as Pointee>::Metadata {
-    // SAFETY: Accessing the value from the `PtrRepr` union is safe since *const T
-    // and PtrComponents<T> have the same memory layouts. Only std can make this
-    // guarantee.
-    unsafe { PtrRepr { const_ptr: ptr }.components.metadata }
+    #[cfg(bootstrap)]
+    {
+        // SAFETY: Accessing the value from the `PtrRepr` union is safe since *const T
+        // and PtrComponents<T> have the same memory layouts. Only std can make this
+        // guarantee.
+        unsafe { PtrRepr { const_ptr: ptr }.components.metadata }
+    }
+    #[cfg(not(bootstrap))]
+    {
+        ptr_metadata(ptr)
+    }
 }
 
 /// Forms a (possibly-wide) raw pointer from a data pointer and metadata.
@@ -132,6 +141,7 @@ pub const fn from_raw_parts_mut<T: ?Sized>(
 }
 
 #[repr(C)]
+#[cfg(bootstrap)]
 union PtrRepr<T: ?Sized> {
     const_ptr: *const T,
     mut_ptr: *mut T,
@@ -139,15 +149,18 @@ union PtrRepr<T: ?Sized> {
 }
 
 #[repr(C)]
+#[cfg(bootstrap)]
 struct PtrComponents<T: ?Sized> {
     data_pointer: *const (),
     metadata: <T as Pointee>::Metadata,
 }
 
 // Manual impl needed to avoid `T: Copy` bound.
+#[cfg(bootstrap)]
 impl<T: ?Sized> Copy for PtrComponents<T> {}
 
 // Manual impl needed to avoid `T: Clone` bound.
+#[cfg(bootstrap)]
 impl<T: ?Sized> Clone for PtrComponents<T> {
     fn clone(&self) -> Self {
         *self

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -1171,3 +1171,15 @@ fn test_ptr_from_raw_parts_in_const() {
     assert_eq!(EMPTY_SLICE_PTR.addr(), 123);
     assert_eq!(EMPTY_SLICE_PTR.len(), 456);
 }
+
+#[test]
+fn test_ptr_metadata_in_const() {
+    use std::fmt::Debug;
+
+    const ARRAY_META: () = std::ptr::metadata::<[u16; 3]>(&[1, 2, 3]);
+    const SLICE_META: usize = std::ptr::metadata::<[u16]>(&[1, 2, 3]);
+    const DYN_META: DynMetadata<dyn Debug> = std::ptr::metadata::<dyn Debug>(&[0_u8; 42]);
+    assert_eq!(ARRAY_META, ());
+    assert_eq!(SLICE_META, 3);
+    assert_eq!(DYN_META.size_of(), 42);
+}

--- a/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_slice_data.rs
+++ b/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_slice_data.rs
@@ -1,0 +1,22 @@
+//@compile-flags: -Zmiri-disable-validation
+#![feature(core_intrinsics, custom_mir)]
+use std::intrinsics::mir::*;
+
+// This disables validation and uses custom MIR hit exactly the UB in the intrinsic,
+// rather than getting UB from the typed load or parameter passing.
+
+#[custom_mir(dialect = "runtime")]
+pub unsafe fn deref_meta(p: *const *const [i32]) -> usize {
+    mir!({
+        RET = PtrMetadata(*p); //~ ERROR: Undefined Behavior: using uninitialized data
+        Return()
+    })
+}
+
+fn main() {
+    let mut p = std::mem::MaybeUninit::<*const [i32]>::uninit();
+    unsafe {
+        (*p.as_mut_ptr().cast::<[usize; 2]>())[1] = 4;
+        let _meta = deref_meta(p.as_ptr().cast());
+    }
+}

--- a/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_slice_data.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_slice_data.stderr
@@ -1,0 +1,20 @@
+error: Undefined Behavior: using uninitialized data, but this operation requires initialized memory
+  --> $DIR/ptr_metadata_uninit_slice_data.rs:LL:CC
+   |
+LL |         RET = PtrMetadata(*p);
+   |         ^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `deref_meta` at $DIR/ptr_metadata_uninit_slice_data.rs:LL:CC
+note: inside `main`
+  --> $DIR/ptr_metadata_uninit_slice_data.rs:LL:CC
+   |
+LL |         let _meta = deref_meta(p.as_ptr().cast());
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_slice_len.rs
+++ b/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_slice_len.rs
@@ -1,0 +1,22 @@
+//@compile-flags: -Zmiri-disable-validation
+#![feature(core_intrinsics, custom_mir)]
+use std::intrinsics::mir::*;
+
+// This disables validation and uses custom MIR hit exactly the UB in the intrinsic,
+// rather than getting UB from the typed load or parameter passing.
+
+#[custom_mir(dialect = "runtime")]
+pub unsafe fn deref_meta(p: *const *const [i32]) -> usize {
+    mir!({
+        RET = PtrMetadata(*p); //~ ERROR: Undefined Behavior: using uninitialized data
+        Return()
+    })
+}
+
+fn main() {
+    let mut p = std::mem::MaybeUninit::<*const [i32]>::uninit();
+    unsafe {
+        (*p.as_mut_ptr().cast::<[*const i32; 2]>())[0] = 4 as *const i32;
+        let _meta = deref_meta(p.as_ptr().cast());
+    }
+}

--- a/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_slice_len.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_slice_len.stderr
@@ -1,0 +1,35 @@
+warning: integer-to-pointer cast
+  --> $DIR/ptr_metadata_uninit_slice_len.rs:LL:CC
+   |
+LL |         (*p.as_mut_ptr().cast::<[*const i32; 2]>())[0] = 4 as *const i32;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ integer-to-pointer cast
+   |
+   = help: This program is using integer-to-pointer casts or (equivalently) `ptr::with_exposed_provenance`,
+   = help: which means that Miri might miss pointer bugs in this program.
+   = help: See https://doc.rust-lang.org/nightly/std/ptr/fn.with_exposed_provenance.html for more details on that operation.
+   = help: To ensure that Miri does not miss bugs in your program, use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead.
+   = help: You can then pass the `-Zmiri-strict-provenance` flag to Miri, to ensure you are not relying on `with_exposed_provenance` semantics.
+   = help: Alternatively, the `-Zmiri-permissive-provenance` flag disables this warning.
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/ptr_metadata_uninit_slice_len.rs:LL:CC
+
+error: Undefined Behavior: using uninitialized data, but this operation requires initialized memory
+  --> $DIR/ptr_metadata_uninit_slice_len.rs:LL:CC
+   |
+LL |         RET = PtrMetadata(*p);
+   |         ^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `deref_meta` at $DIR/ptr_metadata_uninit_slice_len.rs:LL:CC
+note: inside `main`
+  --> $DIR/ptr_metadata_uninit_slice_len.rs:LL:CC
+   |
+LL |         let _meta = deref_meta(p.as_ptr().cast());
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error; 1 warning emitted
+

--- a/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_thin.rs
+++ b/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_thin.rs
@@ -1,0 +1,23 @@
+//@compile-flags: -Zmiri-disable-validation
+#![feature(core_intrinsics, custom_mir)]
+use std::intrinsics::mir::*;
+
+// This disables validation and uses custom MIR hit exactly the UB in the intrinsic,
+// rather than getting UB from the typed load or parameter passing.
+
+#[custom_mir(dialect = "runtime")]
+pub unsafe fn deref_meta(p: *const *const i32) -> () {
+    mir!({
+        RET = PtrMetadata(*p); //~ ERROR: Undefined Behavior: using uninitialized data
+        Return()
+    })
+}
+
+fn main() {
+    // Even though the meta is the trivially-valid `()`, this is still UB
+
+    let p = std::mem::MaybeUninit::<*const i32>::uninit();
+    unsafe {
+        let _meta = deref_meta(p.as_ptr());
+    }
+}

--- a/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_thin.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/ptr_metadata_uninit_thin.stderr
@@ -1,0 +1,20 @@
+error: Undefined Behavior: using uninitialized data, but this operation requires initialized memory
+  --> $DIR/ptr_metadata_uninit_thin.rs:LL:CC
+   |
+LL |         RET = PtrMetadata(*p);
+   |         ^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `deref_meta` at $DIR/ptr_metadata_uninit_thin.rs:LL:CC
+note: inside `main`
+  --> $DIR/ptr_metadata_uninit_thin.rs:LL:CC
+   |
+LL |         let _meta = deref_meta(p.as_ptr());
+   |                     ^^^^^^^^^^^^^^^^^^^^^^
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/src/tools/miri/tests/pass/intrinsics/intrinsics.rs
+++ b/src/tools/miri/tests/pass/intrinsics/intrinsics.rs
@@ -1,5 +1,5 @@
 //@compile-flags: -Zmiri-permissive-provenance
-#![feature(core_intrinsics, layout_for_ptr)]
+#![feature(core_intrinsics, layout_for_ptr, ptr_metadata)]
 //! Tests for various intrinsics that do not fit anywhere else.
 
 use std::intrinsics;
@@ -57,4 +57,10 @@ fn main() {
     // Make sure that even if the discriminant is stored together with data, the intrinsic returns
     // only the discriminant, nothing about the data.
     assert_eq!(discriminant(&Some(false)), discriminant(&Some(true)));
+
+    let () = intrinsics::ptr_metadata(&[1, 2, 3]);
+    let len = intrinsics::ptr_metadata(&[1, 2, 3][..]);
+    assert_eq!(len, 3);
+    let dyn_meta = intrinsics::ptr_metadata(&[1, 2, 3] as &dyn std::fmt::Debug);
+    assert_eq!(dyn_meta.size_of(), 12);
 }

--- a/tests/codegen/intrinsics/ptr_metadata.rs
+++ b/tests/codegen/intrinsics/ptr_metadata.rs
@@ -1,0 +1,36 @@
+//@ compile-flags: -O -C no-prepopulate-passes -Z inline-mir
+//@ only-64bit (so I don't need to worry about usize)
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics)]
+
+use std::intrinsics::ptr_metadata;
+
+// CHECK-LABEL: @thin_metadata(
+#[no_mangle]
+pub fn thin_metadata(p: *const ()) {
+    // CHECK: start
+    // CHECK-NEXT: ret void
+    ptr_metadata(p)
+}
+
+// CHECK-LABEL: @slice_metadata(
+#[no_mangle]
+pub fn slice_metadata(p: *const [u8]) -> usize {
+    // CHECK: start
+    // CHECK-NEXT: ret i64 %p.1
+    ptr_metadata(p)
+}
+
+// CHECK-LABEL: @dyn_byte_offset(
+#[no_mangle]
+pub unsafe fn dyn_byte_offset(
+    p: *const dyn std::fmt::Debug,
+    n: usize,
+) -> *const dyn std::fmt::Debug {
+    // CHECK: %[[Q:.+]] = getelementptr inbounds i8, ptr %p.0, i64 %n
+    // CHECK: %[[TEMP1:.+]] = insertvalue { ptr, ptr } poison, ptr %[[Q]], 0
+    // CHECK: %[[TEMP2:.+]] = insertvalue { ptr, ptr } %[[TEMP1]], ptr %p.1, 1
+    // CHECK: ret { ptr, ptr } %[[TEMP2]]
+    p.byte_add(n)
+}

--- a/tests/mir-opt/building/custom/operators.g.runtime.after.mir
+++ b/tests/mir-opt/building/custom/operators.g.runtime.after.mir
@@ -1,0 +1,13 @@
+// MIR for `g` after runtime
+
+fn g(_1: *const i32, _2: *const [i32]) -> () {
+    let mut _0: ();
+    let mut _3: ();
+    let mut _4: usize;
+
+    bb0: {
+        _3 = PtrMetadata(_1);
+        _4 = PtrMetadata(_2);
+        return;
+    }
+}

--- a/tests/mir-opt/building/custom/operators.rs
+++ b/tests/mir-opt/building/custom/operators.rs
@@ -30,3 +30,13 @@ pub fn f(a: i32, b: bool) -> i32 {
         Return()
     })
 }
+
+// EMIT_MIR operators.g.runtime.after.mir
+#[custom_mir(dialect = "runtime")]
+pub fn g(p: *const i32, q: *const [i32]) {
+    mir!({
+        let a = PtrMetadata(p);
+        let b = PtrMetadata(q);
+        Return()
+    })
+}

--- a/tests/mir-opt/lower_intrinsics.get_metadata.LowerIntrinsics.panic-abort.diff
+++ b/tests/mir-opt/lower_intrinsics.get_metadata.LowerIntrinsics.panic-abort.diff
@@ -1,0 +1,63 @@
+- // MIR for `get_metadata` before LowerIntrinsics
++ // MIR for `get_metadata` after LowerIntrinsics
+  
+  fn get_metadata(_1: *const i32, _2: *const [u8], _3: *const dyn Debug) -> () {
+      debug a => _1;
+      debug b => _2;
+      debug c => _3;
+      let mut _0: ();
+      let _4: ();
+      let mut _5: *const i32;
+      let mut _7: *const [u8];
+      let mut _9: *const dyn std::fmt::Debug;
+      scope 1 {
+          debug _unit => _4;
+          let _6: usize;
+          scope 2 {
+              debug _usize => _6;
+              let _8: std::ptr::DynMetadata<dyn std::fmt::Debug>;
+              scope 3 {
+                  debug _vtable => _8;
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_4);
+          StorageLive(_5);
+          _5 = _1;
+-         _4 = ptr_metadata::<i32, ()>(move _5) -> [return: bb1, unwind unreachable];
++         _4 = PtrMetadata(move _5);
++         goto -> bb1;
+      }
+  
+      bb1: {
+          StorageDead(_5);
+          StorageLive(_6);
+          StorageLive(_7);
+          _7 = _2;
+-         _6 = ptr_metadata::<[u8], usize>(move _7) -> [return: bb2, unwind unreachable];
++         _6 = PtrMetadata(move _7);
++         goto -> bb2;
+      }
+  
+      bb2: {
+          StorageDead(_7);
+          StorageLive(_8);
+          StorageLive(_9);
+          _9 = _3;
+-         _8 = ptr_metadata::<dyn Debug, DynMetadata<dyn Debug>>(move _9) -> [return: bb3, unwind unreachable];
++         _8 = PtrMetadata(move _9);
++         goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_9);
+          _0 = const ();
+          StorageDead(_8);
+          StorageDead(_6);
+          StorageDead(_4);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/lower_intrinsics.get_metadata.LowerIntrinsics.panic-unwind.diff
+++ b/tests/mir-opt/lower_intrinsics.get_metadata.LowerIntrinsics.panic-unwind.diff
@@ -1,0 +1,63 @@
+- // MIR for `get_metadata` before LowerIntrinsics
++ // MIR for `get_metadata` after LowerIntrinsics
+  
+  fn get_metadata(_1: *const i32, _2: *const [u8], _3: *const dyn Debug) -> () {
+      debug a => _1;
+      debug b => _2;
+      debug c => _3;
+      let mut _0: ();
+      let _4: ();
+      let mut _5: *const i32;
+      let mut _7: *const [u8];
+      let mut _9: *const dyn std::fmt::Debug;
+      scope 1 {
+          debug _unit => _4;
+          let _6: usize;
+          scope 2 {
+              debug _usize => _6;
+              let _8: std::ptr::DynMetadata<dyn std::fmt::Debug>;
+              scope 3 {
+                  debug _vtable => _8;
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_4);
+          StorageLive(_5);
+          _5 = _1;
+-         _4 = ptr_metadata::<i32, ()>(move _5) -> [return: bb1, unwind unreachable];
++         _4 = PtrMetadata(move _5);
++         goto -> bb1;
+      }
+  
+      bb1: {
+          StorageDead(_5);
+          StorageLive(_6);
+          StorageLive(_7);
+          _7 = _2;
+-         _6 = ptr_metadata::<[u8], usize>(move _7) -> [return: bb2, unwind unreachable];
++         _6 = PtrMetadata(move _7);
++         goto -> bb2;
+      }
+  
+      bb2: {
+          StorageDead(_7);
+          StorageLive(_8);
+          StorageLive(_9);
+          _9 = _3;
+-         _8 = ptr_metadata::<dyn Debug, DynMetadata<dyn Debug>>(move _9) -> [return: bb3, unwind unreachable];
++         _8 = PtrMetadata(move _9);
++         goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_9);
+          _0 = const ();
+          StorageDead(_8);
+          StorageDead(_6);
+          StorageDead(_4);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/lower_intrinsics.rs
+++ b/tests/mir-opt/lower_intrinsics.rs
@@ -258,3 +258,12 @@ pub fn make_pointers(a: *const u8, b: *mut (), n: usize) {
     let _slice_const: *const [u16] = aggregate_raw_ptr(a, n);
     let _slice_mut: *mut [u64] = aggregate_raw_ptr(b, n);
 }
+
+// EMIT_MIR lower_intrinsics.get_metadata.LowerIntrinsics.diff
+pub fn get_metadata(a: *const i32, b: *const [u8], c: *const dyn std::fmt::Debug) {
+    use std::intrinsics::ptr_metadata;
+
+    let _unit = ptr_metadata(a);
+    let _usize = ptr_metadata(b);
+    let _vtable = ptr_metadata(c);
+}

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-abort.mir
@@ -13,9 +13,8 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
         }
         scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<[u32]>) {
             let mut _5: *const ();
-            let mut _7: usize;
+            let mut _6: usize;
             scope 5 (inlined std::ptr::metadata::<[u32]>) {
-                let mut _6: std::ptr::metadata::PtrRepr<[u32]>;
             }
             scope 6 (inlined std::ptr::from_raw_parts::<[u32]>) {
             }
@@ -30,13 +29,10 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
         StorageDead(_3);
         StorageLive(_5);
         _5 = _4 as *const () (PtrToPtr);
-        StorageLive(_7);
         StorageLive(_6);
-        _6 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: _1 };
-        _7 = ((_6.2: std::ptr::metadata::PtrComponents<[u32]>).1: usize);
+        _6 = PtrMetadata(_1);
+        _0 = *const [u32] from (_5, _6);
         StorageDead(_6);
-        _0 = *const [u32] from (_5, _7);
-        StorageDead(_7);
         StorageDead(_5);
         StorageDead(_4);
         return;

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-unwind.mir
@@ -13,9 +13,8 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
         }
         scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<[u32]>) {
             let mut _5: *const ();
-            let mut _7: usize;
+            let mut _6: usize;
             scope 5 (inlined std::ptr::metadata::<[u32]>) {
-                let mut _6: std::ptr::metadata::PtrRepr<[u32]>;
             }
             scope 6 (inlined std::ptr::from_raw_parts::<[u32]>) {
             }
@@ -30,13 +29,10 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
         StorageDead(_3);
         StorageLive(_5);
         _5 = _4 as *const () (PtrToPtr);
-        StorageLive(_7);
         StorageLive(_6);
-        _6 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: _1 };
-        _7 = ((_6.2: std::ptr::metadata::PtrComponents<[u32]>).1: usize);
+        _6 = PtrMetadata(_1);
+        _0 = *const [u32] from (_5, _6);
         StorageDead(_6);
-        _0 = *const [u32] from (_5, _7);
-        StorageDead(_7);
         StorageDead(_5);
         StorageDead(_4);
         return;


### PR DESCRIPTION
The follow-up to #123840, so we can remove `PtrComponents` and `PtrRepr` from libcore entirely (well, after a bootstrap update).

As discussed in <https://rust-lang.zulipchat.com/#narrow/stream/189540-t-compiler.2Fwg-mir-opt/topic/.60ptr_metadata.60.20in.20MIR/near/435637808>, this introduces `UnOp::PtrMetadata` taking a raw pointer and returning the associated metadata value.

By no longer going through a `union`, this should also help future PRs better optimize pointer operations.

r? @oli-obk 
