### PR TITLE
remove an unused type from the reentrant lock tests

### DIFF
--- a/library/std/src/sync/reentrant_lock/tests.rs
+++ b/library/std/src/sync/reentrant_lock/tests.rs
@@ -1,4 +1,4 @@
-use super::{ReentrantLock, ReentrantLockGuard};
+use super::ReentrantLock;
 use crate::cell::RefCell;
 use crate::sync::Arc;
 use crate::thread;
@@ -50,11 +50,4 @@ fn trylock_works() {
     .join()
     .unwrap();
     let _lock3 = l.try_lock();
-}
-
-pub struct Answer<'a>(pub ReentrantLockGuard<'a, RefCell<u32>>);
-impl Drop for Answer<'_> {
-    fn drop(&mut self) {
-        *self.0.borrow_mut() = 42;
-    }
 }


### PR DESCRIPTION
At least it seems unused. This was added back in 45aa6c8d1bc2f7863c92da6643de4642bb2d83bf together with a test related to poisoning; when the test got removed, it seems like it was forgotten to also remove this type.