### PR TITLE
miri libstd tests: test windows-msvc instead of windows-gnu

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -76,10 +76,11 @@ check-aux:
 		$(BOOTSTRAP) miri --stage 2 library/std \
 		--doc -- \
 		--skip fs:: --skip net:: --skip process:: --skip sys::pal::
-	# Also test some very target-specific modules on other targets.
+	# Also test some very target-specific modules on other targets
+	# (making sure to cover an i686 target as well).
 	$(Q)MIRIFLAGS="-Zmiri-disable-isolation" BOOTSTRAP_SKIP_TARGET_SANITY=1 \
 		$(BOOTSTRAP) miri --stage 2 library/std \
-		--target aarch64-apple-darwin,i686-pc-windows-gnu \
+		--target aarch64-apple-darwin,i686-pc-windows-msvc \
 		--no-doc -- \
 		time:: sync:: thread:: env::
 dist:


### PR DESCRIPTION
This avoids https://github.com/rust-lang/rust/issues/123583. MSVC is the more widely used target anyway AFAIK, so probably makes more sense to cover that.