### PR TITLE
Improved code with clippy

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -630,7 +630,7 @@ impl Cursor<'_> {
                 // with a number
                 self.bump();
                 let mut empty_exponent = false;
-                if self.first().is_digit(10) {
+                if self.first().is_ascii_digit() {
                     self.eat_decimal_digits();
                     match self.first() {
                         'e' | 'E' => {
@@ -661,7 +661,7 @@ impl Cursor<'_> {
             // If the first symbol is valid for identifier, it can be a lifetime.
             // Also check if it's a number for a better error reporting (so '0 will
             // be reported as invalid lifetime and not as unterminated char literal).
-            is_id_start(self.first()) || self.first().is_digit(10)
+            is_id_start(self.first()) || self.first().is_ascii_digit()
         };
 
         if !can_be_a_lifetime {
@@ -677,7 +677,7 @@ impl Cursor<'_> {
         // Either a lifetime or a character literal with
         // length greater than 1.
 
-        let starts_with_number = self.first().is_digit(10);
+        let starts_with_number = self.first().is_ascii_digit();
 
         // Skip the literal contents.
         // First symbol can be a number (which isn't a valid identifier start),

--- a/compiler/rustc_lexer/src/unescape.rs
+++ b/compiler/rustc_lexer/src/unescape.rs
@@ -259,7 +259,7 @@ fn scan_escape<T: From<char> + From<u8>>(
             } else {
                 // This may be a high byte, but that will only happen if `T` is
                 // `MixedUnit`, because of the `allow_high_bytes` check above.
-                Ok(T::from(value as u8))
+                Ok(T::from(value))
             };
         }
         'u' => return scan_unicode(chars, mode.allow_unicode_escapes()).map(T::from),
@@ -300,7 +300,7 @@ fn scan_unicode(chars: &mut Chars<'_>, allow_unicode_escapes: bool) -> Result<ch
                     return Err(EscapeError::UnicodeEscapeInByte);
                 }
 
-                break std::char::from_u32(value).ok_or_else(|| {
+                break std::char::from_u32(value).ok_or({
                     if value > 0x10FFFF {
                         EscapeError::OutOfRangeUnicodeEscape
                     } else {

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -50,7 +50,7 @@ fn detect_llvm_link() -> (&'static str, &'static str) {
 fn restore_library_path() {
     let key = tracked_env_var_os("REAL_LIBRARY_PATH_VAR").expect("REAL_LIBRARY_PATH_VAR");
     if let Some(env) = tracked_env_var_os("REAL_LIBRARY_PATH") {
-        env::set_var(&key, &env);
+        env::set_var(&key, env);
     } else {
         env::remove_var(&key);
     }

--- a/compiler/rustc_macros/build.rs
+++ b/compiler/rustc_macros/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=RUSTC_BOOTSTRAP");
-    if !std::env::var("RUSTC_BOOTSTRAP").is_ok() {
+    if std::env::var("RUSTC_BOOTSTRAP").is_err() {
         eprintln!(
             "error: you are attempting to build the compiler without going through bootstrap"
         );


### PR DESCRIPTION
I haven't used the bootstrapped compiler, but I think I have made some improvements using clippy. I have already made the following changes to the compiler:
Replaced `self.first().is_digit(10)` with `self.first().is_ascii_digit()` on lines 633, 664, and 680 of compiler/rust_lexer/src/lib.rs.

Removed unnecessary cast on line 262 of compiler/rustc_lexer/src/unescape.rs

Replaced ok_or_else with ok_or on line 303 of compiler/rustc_lexer/src/unescape.rs

Replaced `!std::env::var("RUSTC_BOOTSTRAP").is_ok()` with `std::env::var("RUSTC_BOOTSTRAP").is_err()` on line 4 of compiler/rustc_macros/build.rs 

Removed needless borrow for generic argument `env`on line 53 of compiler/rust_llvm/build.rs