### PR TITLE
Allow coercing functions whose signature differs in opaque types in their defining scope into a shared function pointer type

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1189,7 +1189,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let sig = self
                 .at(cause, self.param_env)
                 .trace(prev_ty, new_ty)
-                .lub(DefineOpaqueTypes::No, a_sig, b_sig)
+                .lub(DefineOpaqueTypes::Yes, a_sig, b_sig)
                 .map(|ok| self.register_infer_ok_obligations(ok))?;
 
             // Reify both sides and return the reified fn pointer type.

--- a/tests/ui/fn/fn_def_opaque_coercion_to_fn_ptr.rs
+++ b/tests/ui/fn/fn_def_opaque_coercion_to_fn_ptr.rs
@@ -1,0 +1,57 @@
+//! Test that coercing between function items of different functions works,
+//! as long as their signatures match. The resulting value is a function pointer.
+
+#![feature(type_alias_impl_trait)]
+
+fn foo<T>(t: T) -> T {
+    t
+}
+
+fn bar<T>(t: T) -> T {
+    t
+}
+
+type F = impl Sized;
+
+fn f(a: F) {
+    let mut x = bar::<F>;
+    x = foo::<()>; //~ ERROR: mismatched types
+    x(a);
+    x(());
+}
+
+type I = impl Sized;
+
+fn i(a: I) {
+    let mut x = bar::<()>;
+    x = foo::<I>; //~ ERROR: mismatched types
+    x(a);
+    x(());
+}
+
+type J = impl Sized;
+
+fn j(a: J) {
+    let x = match true {
+        true => bar::<J>,
+        false => foo::<()>, //~ ERROR: incompatible types
+    };
+    x(a);
+    x(());
+}
+
+fn k() -> impl Sized {
+    fn bind<T, F: FnOnce(T) -> T>(_: T, f: F) -> F {
+        f
+    }
+    let x = match true {
+        true => {
+            let f = foo;
+            bind(k(), f)
+        }
+        false => bar::<()>, //~ ERROR: incompatible types
+    };
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui/fn/fn_def_opaque_coercion_to_fn_ptr.rs
+++ b/tests/ui/fn/fn_def_opaque_coercion_to_fn_ptr.rs
@@ -34,7 +34,7 @@ type J = impl Sized;
 fn j(a: J) {
     let x = match true {
         true => bar::<J>,
-        false => foo::<()>, //~ ERROR: incompatible types
+        false => foo::<()>,
     };
     x(a);
     x(());
@@ -49,7 +49,7 @@ fn k() -> impl Sized {
             let f = foo;
             bind(k(), f)
         }
-        false => bar::<()>, //~ ERROR: incompatible types
+        false => bar::<()>,
     };
     todo!()
 }

--- a/tests/ui/fn/fn_def_opaque_coercion_to_fn_ptr.stderr
+++ b/tests/ui/fn/fn_def_opaque_coercion_to_fn_ptr.stderr
@@ -33,45 +33,6 @@ help: use parentheses to call this function
 LL |     x = foo::<I>(/* I */);
    |                 +++++++++
 
-error[E0308]: `match` arms have incompatible types
-  --> $DIR/fn_def_opaque_coercion_to_fn_ptr.rs:37:18
-   |
-LL |   type J = impl Sized;
-   |            ---------- the expected opaque type
-...
-LL |       let x = match true {
-   |  _____________-
-LL | |         true => bar::<J>,
-   | |                 -------- this is found to be of type `fn(J) -> J {bar::<J>}`
-LL | |         false => foo::<()>,
-   | |                  ^^^^^^^^^ expected opaque type, found `()`
-LL | |     };
-   | |_____- `match` arms have incompatible types
-   |
-   = note: expected fn item `fn(J) -> J {bar::<J>}`
-              found fn item `fn(()) {foo::<()>}`
-
-error[E0308]: `match` arms have incompatible types
-  --> $DIR/fn_def_opaque_coercion_to_fn_ptr.rs:52:18
-   |
-LL |   fn k() -> impl Sized {
-   |             ---------- the expected opaque type
-...
-LL |       let x = match true {
-   |  _____________-
-LL | |         true => {
-LL | |             let f = foo;
-LL | |             bind(k(), f)
-   | |             ------------ this is found to be of type `fn(impl Sized) -> impl Sized {foo::<impl Sized>}`
-LL | |         }
-LL | |         false => bar::<()>,
-   | |                  ^^^^^^^^^ expected opaque type, found `()`
-LL | |     };
-   | |_____- `match` arms have incompatible types
-   |
-   = note: expected fn item `fn(impl Sized) -> impl Sized {foo::<impl Sized>}`
-              found fn item `fn(()) {bar::<()>}`
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/fn/fn_def_opaque_coercion_to_fn_ptr.stderr
+++ b/tests/ui/fn/fn_def_opaque_coercion_to_fn_ptr.stderr
@@ -1,0 +1,77 @@
+error[E0308]: mismatched types
+  --> $DIR/fn_def_opaque_coercion_to_fn_ptr.rs:18:9
+   |
+LL | type F = impl Sized;
+   |          ---------- the expected opaque type
+...
+LL |     let mut x = bar::<F>;
+   |                 -------- expected due to this value
+LL |     x = foo::<()>;
+   |         ^^^^^^^^^ expected fn item, found a different fn item
+   |
+   = note: expected fn item `fn(F) -> F {bar::<F>}`
+              found fn item `fn(()) {foo::<()>}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn_def_opaque_coercion_to_fn_ptr.rs:27:9
+   |
+LL | fn foo<T>(t: T) -> T {
+   | -------------------- function `foo` defined here
+...
+LL | type I = impl Sized;
+   |          ---------- the found opaque type
+...
+LL |     let mut x = bar::<()>;
+   |                 --------- expected due to this value
+LL |     x = foo::<I>;
+   |         ^^^^^^^^ expected fn item, found a different fn item
+   |
+   = note: expected fn item `fn(()) {bar::<()>}`
+              found fn item `fn(I) -> I {foo::<I>}`
+help: use parentheses to call this function
+   |
+LL |     x = foo::<I>(/* I */);
+   |                 +++++++++
+
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/fn_def_opaque_coercion_to_fn_ptr.rs:37:18
+   |
+LL |   type J = impl Sized;
+   |            ---------- the expected opaque type
+...
+LL |       let x = match true {
+   |  _____________-
+LL | |         true => bar::<J>,
+   | |                 -------- this is found to be of type `fn(J) -> J {bar::<J>}`
+LL | |         false => foo::<()>,
+   | |                  ^^^^^^^^^ expected opaque type, found `()`
+LL | |     };
+   | |_____- `match` arms have incompatible types
+   |
+   = note: expected fn item `fn(J) -> J {bar::<J>}`
+              found fn item `fn(()) {foo::<()>}`
+
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/fn_def_opaque_coercion_to_fn_ptr.rs:52:18
+   |
+LL |   fn k() -> impl Sized {
+   |             ---------- the expected opaque type
+...
+LL |       let x = match true {
+   |  _____________-
+LL | |         true => {
+LL | |             let f = foo;
+LL | |             bind(k(), f)
+   | |             ------------ this is found to be of type `fn(impl Sized) -> impl Sized {foo::<impl Sized>}`
+LL | |         }
+LL | |         false => bar::<()>,
+   | |                  ^^^^^^^^^ expected opaque type, found `()`
+LL | |     };
+   | |_____- `match` arms have incompatible types
+   |
+   = note: expected fn item `fn(impl Sized) -> impl Sized {foo::<impl Sized>}`
+              found fn item `fn(()) {bar::<()>}`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
r? @compiler-errors 

This accepts more code on stable. It is now possible to have match arms return a function item `foo` and a different function item `bar` in another, and that will constrain OpaqueTypeInDefiningScope to have the hidden type ConcreteType and make the type of the match arms a function pointer that matches the signature. So the following function will now compile, but on master it errors with a type mismatch on the second match arm

```rust
fn foo<T>(t: T) -> T {
    t
}

fn bar<T>(t: T) -> T {
    t
}

fn k() -> impl Sized {
    fn bind<T, F: FnOnce(T) -> T>(_: T, f: F) -> F {
        f
    }
    let x = match true {
        true => {
            let f = foo;
            bind(k(), f)
        }
        false => bar::<()>,
    };
    todo!()
}
```

cc https://github.com/rust-lang/rust/issues/116652

This is very similar to https://github.com/rust-lang/rust/pull/123794, and with the same rationale:

> this is for consistency with `-Znext-solver`. the new solver does not have the concept of "non-defining use of opaque" right now and we would like to ideally keep it that way. Moving to `DefineOpaqueTypes::Yes` in more cases removes subtlety from the type system. Right now we have to be careful when relating `Opaque` with another type as the behavior changes depending on whether we later use the `Opaque` or its hidden type directly (even though they are equal), if that later use is with `DefineOpaqueTypes::No`*