### PR TITLE
Add diagnostic item for `std::iter::Enumerate`

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -192,6 +192,7 @@ symbols! {
         Duration,
         Encodable,
         Encoder,
+        Enumerate,
         Eq,
         Equal,
         Err,

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -15,6 +15,7 @@ use crate::ops::Try;
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "Enumerate")]
 pub struct Enumerate<I> {
     iter: I,
     count: usize,


### PR DESCRIPTION
This adds a diagnostic item for `std::iter::Enumerate`.  The change will be used by the clippy `unused_enumerate_index` lint to move away from type paths to using diagnostic items.

see: https://github.com/rust-lang/rust-clippy/issues/5393