### PR TITLE
Add support for run-make-support unit tests to be run with bootstrap

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -817,6 +817,7 @@ impl<'a> Builder<'a> {
                 test::Clippy,
                 test::RustDemangler,
                 test::CompiletestTest,
+                test::CrateRunMakeSupport,
                 test::RustdocJSStd,
                 test::RustdocJSNotStd,
                 test::RustdocGUI,


### PR DESCRIPTION
The `run-make-support` library needs to run its unit tests to ensure it is correct.

Close #124267