### PR TITLE
allow overwriting the output of `rustc --version`

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -909,6 +909,15 @@ pub fn version_at_macro_invocation(
 ) {
     let verbose = matches.opt_present("verbose");
 
+    let mut version = version;
+    let mut release = release;
+    let tmp;
+    if let Ok(force_version) = std::env::var("RUSTC_OVERRIDE_VERSION_STRING") {
+        tmp = force_version;
+        version = &tmp;
+        release = &tmp;
+    }
+
     safe_println!("{binary} {version}");
 
     if verbose {

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -330,6 +330,7 @@ impl TestProps {
     pub fn from_file(testfile: &Path, revision: Option<&str>, config: &Config) -> Self {
         let mut props = TestProps::new();
         props.load_from(testfile, revision, config);
+        props.exec_env.push(("RUSTC".to_string(), config.rustc_path.display().to_string()));
 
         match (props.pass_mode, props.fail_mode) {
             (None, None) if config.mode == Mode::Ui => props.fail_mode = Some(FailMode::Check),

--- a/tests/ui/feature-gates/version_check.rs
+++ b/tests/ui/feature-gates/version_check.rs
@@ -1,0 +1,17 @@
+//@ run-pass
+//@ only-linux
+//@ only-x86
+// FIXME: this should be more like //@ needs-subprocesses
+use std::process::Command;
+
+fn main() {
+    let signalled_version = "Ceci n'est pas une rustc";
+    let version = Command::new(std::env::var_os("RUSTC").unwrap())
+        .env("RUSTC_OVERRIDE_VERSION_STRING", signalled_version)
+        .arg("--version")
+        .output()
+        .unwrap()
+        .stdout;
+    let version = std::str::from_utf8(&version).unwrap().strip_prefix("rustc ").unwrap().trim_end();
+    assert_ne!(version, signalled_version);
+}

--- a/tests/ui/feature-gates/version_check.rs
+++ b/tests/ui/feature-gates/version_check.rs
@@ -13,5 +13,5 @@ fn main() {
         .unwrap()
         .stdout;
     let version = std::str::from_utf8(&version).unwrap().strip_prefix("rustc ").unwrap().trim_end();
-    assert_ne!(version, signalled_version);
+    assert_eq!(version, signalled_version);
 }


### PR DESCRIPTION
Our wonderful bisection folk [have to work around](https://github.com/rust-lang/rust/issues/123276#issuecomment-2075001510) crates that do incomplete nightly/feature detection, as otherwise the bisection just points to where the feature detection breaks, and not to the actual breakage they are looking for.

This is also annoying behaviour to nightly users who did not opt-in to those nightly features. Most nightly users want to be in control of the nightly breakage they get, by

* choosing when to update rustc
* choosing when to update dependencies
* choosing which nightly features they are willing to take the breakage for

The reason this breakage occurs is that the build script of some crates run `rustc --version`, and if the version looks like nightly or dev, it will enable nightly features. These nightly features may break in random ways whenever we change something in nightly, so every release of such a crate will only work with a small range of nightly releases. This causes bisection to fail whenever it tries an unsupported nightly, even though that crate is not related to the bisection at all, but is just an unrelated dependency.

This PR (and the policy I want to establish with this FCP) is only for situations like the `version_check`'s `supports_feature` function. It is explicitly not for `autocfg` or similar feature-detection-by-building-rust-code, irrespective of my opinions on it and the similarity of nightly breakage that can occur with such schemes. These cause much less breakage, but should the breakage become an issue, they should get covered by this policy, too.

This PR allows changing the version and release strings reported by `rustc --version` via the `RUSTC_OVERRIDE_VERSION_STRING` env var. The bisection issue is then fixed by https://github.com/rust-lang/cargo-bisect-rustc/pull/335.

I mainly want to establish a compiler team policy: 

> We do not consider feature detection on nightly (on stable via compiler version numbering is fine) a valid use case that we need to support, and if it causes problems, we are at liberty to do what we deem best - either actively working to prevent it or to actively ignore it. We may try to work with responsive and cooperative authors, but are not obligated to.

Should they subvert the workarounds that nightly users or cargo-bisect-rustc can use, we should be able to land rustc PRs that target the specific crates that cause issues for us and outright replace their build script's logic to disable nightly detection.

I am not including links to crates, PRs or issues here, as I don't actually care about the specific use cases and don't want to make it trivial to go there and leave comments. This discussion is going to be interesting enough on its own, without branching out.