### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -28,6 +28,8 @@ Tracking issues are used to record the overall progress of implementation.
 They are also used as hubs connecting to other relevant issues, e.g., bugs or open design questions.
 A tracking issue is however *not* meant for large scale discussion, questions, or bug reports about a feature.
 Instead, open a dedicated issue for the specific matter and add the relevant feature gate label.
+Discussion comments will get marked as off-topic or deleted.
+Repeated discussions on the tracking issue may lead to the tracking issue getting locked.
 
 ### Steps
 <!--

--- a/compiler/rustc_fs_util/src/lib.rs
+++ b/compiler/rustc_fs_util/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(absolute_path)]
-
 use std::ffi::CString;
 use std::fs;
 use std::io;

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1888,9 +1888,12 @@ fn collect_print_requests(
                 let prints =
                     PRINT_KINDS.iter().map(|(name, _)| format!("`{name}`")).collect::<Vec<_>>();
                 let prints = prints.join(", ");
-                early_dcx.early_fatal(format!(
-                    "unknown print request `{req}`. Valid print requests are: {prints}"
-                ));
+
+                let mut diag =
+                    early_dcx.early_struct_fatal(format!("unknown print request: `{req}`"));
+                #[allow(rustc::diagnostic_outside_of_impl)]
+                diag.help(format!("valid print requests are: {prints}"));
+                diag.emit()
             }
         };
 

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -1251,7 +1251,7 @@ struct HygieneDecodeContextInner {
     // global `HygieneData`. When we deserialize a `SyntaxContext`, we need to create
     // a new id in the global `HygieneData`. This map tracks the ID we end up picking,
     // so that multiple occurrences of the same serialized id are decoded to the same
-    // `SyntaxContext`. This only stores `SyntaxContext`s which are completly decoded.
+    // `SyntaxContext`. This only stores `SyntaxContext`s which are completely decoded.
     remapped_ctxts: Vec<Option<SyntaxContext>>,
 
     /// Maps serialized `SyntaxContext` ids that are currently being decoded to a `SyntaxContext`.

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -227,7 +227,7 @@ pub enum TyKind<I: Interner> {
     /// A placeholder type, used during higher ranked subtyping to instantiate
     /// bound variables.
     ///
-    /// It is conventional to render anonymous placeholer types like `!N` or `!U_N`,
+    /// It is conventional to render anonymous placeholder types like `!N` or `!U_N`,
     /// where `N` is the placeholder variable's anonymous index (which corresponds
     /// to the bound variable's index from the binder from which it was instantiated),
     /// and `U` is the universe index in which it is instantiated, or totally omitted

--- a/library/core/src/fmt/rt.rs
+++ b/library/core/src/fmt/rt.rs
@@ -153,7 +153,7 @@ impl<'a> Argument<'a> {
     ///
     /// # Safety
     ///
-    /// This argument must actually be a placeholer argument.
+    /// This argument must actually be a placeholder argument.
     ///
     // FIXME: Transmuting formatter in new and indirectly branching to/calling
     // it here is an explicit CFI violation.

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3332,7 +3332,6 @@ impl Error for StripPrefixError {
 /// ## Posix paths
 ///
 /// ```
-/// #![feature(absolute_path)]
 /// # #[cfg(unix)]
 /// fn main() -> std::io::Result<()> {
 ///   use std::path::{self, Path};
@@ -3357,7 +3356,6 @@ impl Error for StripPrefixError {
 /// ## Windows paths
 ///
 /// ```
-/// #![feature(absolute_path)]
 /// # #[cfg(windows)]
 /// fn main() -> std::io::Result<()> {
 ///   use std::path::{self, Path};
@@ -3382,7 +3380,7 @@ impl Error for StripPrefixError {
 ///
 /// [posix-semantics]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13
 /// [windows-path]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfullpathnamew
-#[unstable(feature = "absolute_path", issue = "92750")]
+#[stable(feature = "absolute_path", since = "CURRENT_RUSTC_VERSION")]
 pub fn absolute<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref();
     if path.as_os_str().is_empty() {

--- a/src/doc/rustc/src/platform-support/arm64ec-pc-windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/arm64ec-pc-windows-msvc.md
@@ -73,7 +73,7 @@ Tests can be run on AArch64 Windows 11 devices.
 
 ## Cross-compilation toolchains and C code
 
-C code can be built using the Arm64-targetting MSVC or Clang toolchain.
+C code can be built using the Arm64-targeting MSVC or Clang toolchain.
 
 To compile:
 

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1.md
@@ -59,7 +59,7 @@ languages compiled to WebAssembly, for example C/C++. Any ABI differences or
 mismatches are considered bugs that need to be fixed.
 
 By default the WASI targets in Rust ship in rustup with a precompiled copy of
-[`wasi-libc`] meaning that a WebAssembly-targetting-Clang is not required to
+[`wasi-libc`] meaning that a WebAssembly-targeting-Clang is not required to
 use the WASI targets from Rust.  If there is no actual interoperation with C
 then `rustup target add wasm32-wasip1` is all that's needed to get
 started with WASI.

--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -417,7 +417,7 @@ warning: 1 warning emitted
 
 This lint is **warn-by-default**. It detects explicit links that are the same
 as computed automatic links.
-This usually means the explicit links are removeable. For example:
+This usually means the explicit links are removable. For example:
 
 ```rust
 #![warn(rustdoc::redundant_explicit_links)] // note: unnecessary - warns by default.

--- a/src/doc/rustdoc/src/write-documentation/linking-to-items-by-name.md
+++ b/src/doc/rustdoc/src/write-documentation/linking-to-items-by-name.md
@@ -168,4 +168,4 @@ render differently in this case:
 ```
 
 `1.` and `2.` will be displayed as is in the rendered documentation (ie, `[a]` and `[b][c]`)
-whereas `3.` and `4.` will be replaced by a link targetting `e` for `[d](e)` and `g` for `[f]`.
+whereas `3.` and `4.` will be replaced by a link targeting `e` for `[d](e)` and `g` for `[f]`.

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -187,7 +187,7 @@ declare_rustdoc_lint! {
 
 declare_rustdoc_lint! {
     /// This lint is **warn-by-default**. It detects explicit links that are the same
-    /// as computed automatic links. This usually means the explicit links are removeable.
+    /// as computed automatic links. This usually means the explicit links are removable.
     /// This is a `rustdoc` only lint, see the documentation in the [rustdoc book].
     ///
     /// [rustdoc book]: ../../../rustdoc/lints.html#redundant_explicit_links

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -314,7 +314,7 @@ pub enum StructKind {
     /// All [`Id`]'s will point to [`ItemEnum::StructField`]. Private and
     /// `#[doc(hidden)]` fields will be given as `None`
     Tuple(Vec<Option<Id>>),
-    /// A struct with nammed fields.
+    /// A struct with named fields.
     ///
     /// ```rust
     /// pub struct PlainStruct { x: i32 }

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -12,7 +12,6 @@
 #![feature(let_chains)]
 #![feature(lint_reasons)]
 #![feature(trait_upcasting)]
-#![feature(absolute_path)]
 // Configure clippy and other lints
 #![allow(
     clippy::collapsible_else_if,

--- a/src/tools/miri/tests/pass/shims/path.rs
+++ b/src/tools/miri/tests/pass/shims/path.rs
@@ -1,5 +1,4 @@
 //@compile-flags: -Zmiri-disable-isolation
-#![feature(absolute_path)]
 use std::path::{absolute, Path};
 
 #[track_caller]

--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -317,7 +317,6 @@ run-make/unstable-flag-required/Makefile
 run-make/use-suggestions-rust-2018/Makefile
 run-make/used-cdylib-macos/Makefile
 run-make/used/Makefile
-run-make/valid-print-requests/Makefile
 run-make/volatile-intrinsics/Makefile
 run-make/wasm-exceptions-nostd/Makefile
 run-make/wasm-override-linker/Makefile

--- a/tests/run-make/valid-print-requests/Makefile
+++ b/tests/run-make/valid-print-requests/Makefile
@@ -1,4 +1,0 @@
-include ../tools.mk
-
-all:
-	$(RUSTC) --print uwu 2>&1 | diff - valid-print-requests.stderr

--- a/tests/run-make/valid-print-requests/valid-print-requests.stderr
+++ b/tests/run-make/valid-print-requests/valid-print-requests.stderr
@@ -1,2 +1,0 @@
-error: unknown print request `uwu`. Valid print requests are: `all-target-specs-json`, `calling-conventions`, `cfg`, `code-models`, `crate-name`, `deployment-target`, `file-names`, `link-args`, `native-static-libs`, `relocation-models`, `split-debuginfo`, `stack-protector-strategies`, `sysroot`, `target-cpus`, `target-features`, `target-libdir`, `target-list`, `target-spec-json`, `tls-models`
-

--- a/tests/ui/codemap_tests/huge_multispan_highlight.rs
+++ b/tests/ui/codemap_tests/huge_multispan_highlight.rs
@@ -1,7 +1,5 @@
 //@ compile-flags: --error-format=human --color=always
 //@ ignore-windows
-// Temporary until next release:
-//@ ignore-stage2
 fn main() {
     let _ = match true {
         true => (

--- a/tests/ui/codemap_tests/huge_multispan_highlight.svg
+++ b/tests/ui/codemap_tests/huge_multispan_highlight.svg
@@ -1,4 +1,4 @@
-<svg width="750px" height="848px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="848px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-ansi256-009 bold">error[E0308]</tspan><tspan class="bold">: `match` arms have incompatible types</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/huge_multispan_highlight.rs:98:18</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/huge_multispan_highlight.rs:96:18</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
@@ -59,7 +59,7 @@
 </tspan>
     <tspan x="10px" y="370px"><tspan class="fg-ansi256-009 bold">error[E0308]</tspan><tspan class="bold">: `match` arms have incompatible types</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/huge_multispan_highlight.rs:215:18</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/huge_multispan_highlight.rs:213:18</tspan>
 </tspan>
     <tspan x="10px" y="406px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>

--- a/tests/ui/diagnostic-flags/colored-session-opt-error.rs
+++ b/tests/ui/diagnostic-flags/colored-session-opt-error.rs
@@ -1,6 +1,4 @@
 //@ check-pass
 //@ ignore-windows
 //@ compile-flags: -Cremark=foo --error-format=human --color=always
-// Temporary until next release:
-//@ ignore-stage2
 fn main() {}

--- a/tests/ui/error-emitter/highlighting.rs
+++ b/tests/ui/error-emitter/highlighting.rs
@@ -3,8 +3,6 @@
 //@ compile-flags: --error-format=human --color=always
 //@ error-pattern:[35mfor<'a> [0m
 //@ edition:2018
-// Temporary until next release:
-//@ ignore-stage2
 
 use core::pin::Pin;
 use core::future::Future;

--- a/tests/ui/error-emitter/highlighting.svg
+++ b/tests/ui/error-emitter/highlighting.svg
@@ -23,7 +23,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-ansi256-009 bold">error[E0308]</tspan><tspan class="bold">: mismatched types</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/highlighting.rs:24:11</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/highlighting.rs:22:11</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
@@ -43,7 +43,7 @@
 </tspan>
     <tspan x="10px" y="208px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: function defined here</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/highlighting.rs:13:4</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/highlighting.rs:11:4</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>

--- a/tests/ui/error-emitter/multiline-multipart-suggestion.rs
+++ b/tests/ui/error-emitter/multiline-multipart-suggestion.rs
@@ -1,7 +1,5 @@
 //@ compile-flags: --error-format=human --color=always
 //@ error-pattern: missing lifetime specifier
-// Temporary until next release:
-//@ ignore-stage2
 
 fn short(foo_bar: &Vec<&i32>) -> &i32 {
     &12

--- a/tests/ui/error-emitter/multiline-multipart-suggestion.svg
+++ b/tests/ui/error-emitter/multiline-multipart-suggestion.svg
@@ -23,7 +23,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-ansi256-009 bold">error[E0106]</tspan><tspan class="bold">: missing lifetime specifier</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-multipart-suggestion.rs:6:34</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-multipart-suggestion.rs:4:34</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
@@ -47,7 +47,7 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan class="fg-ansi256-009 bold">error[E0106]</tspan><tspan class="bold">: missing lifetime specifier</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-multipart-suggestion.rs:13:6</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-multipart-suggestion.rs:11:6</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
@@ -83,7 +83,7 @@
 </tspan>
     <tspan x="10px" y="568px"><tspan class="fg-ansi256-009 bold">error[E0106]</tspan><tspan class="bold">: missing lifetime specifier</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-multipart-suggestion.rs:18:29</tspan>
+    <tspan x="10px" y="586px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-multipart-suggestion.rs:16:29</tspan>
 </tspan>
     <tspan x="10px" y="604px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>

--- a/tests/ui/invalid-compile-flags/print.rs
+++ b/tests/ui/invalid-compile-flags/print.rs
@@ -1,0 +1,1 @@
+//@ compile-flags: --print yyyy

--- a/tests/ui/invalid-compile-flags/print.stderr
+++ b/tests/ui/invalid-compile-flags/print.stderr
@@ -1,0 +1,4 @@
+error: unknown print request: `yyyy`
+  |
+  = help: valid print requests are: `all-target-specs-json`, `calling-conventions`, `cfg`, `code-models`, `crate-name`, `deployment-target`, `file-names`, `link-args`, `native-static-libs`, `relocation-models`, `split-debuginfo`, `stack-protector-strategies`, `sysroot`, `target-cpus`, `target-features`, `target-libdir`, `target-list`, `target-spec-json`, `tls-models`
+


### PR DESCRIPTION
Successful merges:

 - #124322 (chore: fix some typos in comments)
 - #124326 (tests: remove few ignore-stage2)
 - #124333 (Improve diagnostic for unknown `--print` request)
 - #124334 (Strengthen tracking issue policy with consequences)
 - #124335 (Stabilize `std::path::absolute`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=124322,124326,124333,124334,124335)
<!-- homu-ignore:end -->