### PR TITLE
Enable `--check-cfg` by default in UI tests

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -208,6 +208,8 @@ pub struct TestProps {
     pub llvm_cov_flags: Vec<String>,
     /// Extra flags to pass to LLVM's `filecheck` tool, in tests that use it.
     pub filecheck_flags: Vec<String>,
+    /// Don't automatically insert any `--check-cfg` args
+    pub no_auto_check_cfg: bool,
 }
 
 mod directives {
@@ -249,6 +251,7 @@ mod directives {
     pub const COMPARE_OUTPUT_LINES_BY_SUBSET: &'static str = "compare-output-lines-by-subset";
     pub const LLVM_COV_FLAGS: &'static str = "llvm-cov-flags";
     pub const FILECHECK_FLAGS: &'static str = "filecheck-flags";
+    pub const NO_AUTO_CHECK_CFG: &'static str = "no-auto-check-cfg";
     // This isn't a real directive, just one that is probably mistyped often
     pub const INCORRECT_COMPILER_FLAGS: &'static str = "compiler-flags";
 }
@@ -304,6 +307,7 @@ impl TestProps {
             remap_src_base: false,
             llvm_cov_flags: vec![],
             filecheck_flags: vec![],
+            no_auto_check_cfg: false,
         }
     }
 
@@ -567,6 +571,8 @@ impl TestProps {
                     if let Some(flags) = config.parse_name_value_directive(ln, FILECHECK_FLAGS) {
                         self.filecheck_flags.extend(split_flags(&flags));
                     }
+
+                    config.set_name_directive(ln, NO_AUTO_CHECK_CFG, &mut self.no_auto_check_cfg);
                 },
             );
 
@@ -860,6 +866,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "needs-unwind",
     "needs-wasmtime",
     "needs-xray",
+    "no-auto-check-cfg",
     "no-prefer-dynamic",
     "normalize-stderr-32bit",
     "normalize-stderr-64bit",

--- a/tests/codegen/instrument-coverage/instrument-coverage-off.rs
+++ b/tests/codegen/instrument-coverage/instrument-coverage-off.rs
@@ -1,22 +1,19 @@
 // Test that `-Cinstrument-coverage=off` does not add coverage instrumentation to LLVM IR.
 
-//@ needs-profiler-support
-//@ revisions: n no off false zero
+//@ revisions: n no off false_ zero
 //@ [n] compile-flags: -Cinstrument-coverage=n
 //@ [no] compile-flags: -Cinstrument-coverage=no
 //@ [off] compile-flags: -Cinstrument-coverage=off
-//@ [false] compile-flags: -Cinstrument-coverage=false
+//@ [false_] compile-flags: -Cinstrument-coverage=false
 //@ [zero] compile-flags: -Cinstrument-coverage=0
 
 // CHECK-NOT: __llvm_profile_filename
 // CHECK-NOT: __llvm_coverage_mapping
 
-#![crate_type="lib"]
+#![crate_type = "lib"]
 
 #[inline(never)]
-fn some_function() {
-
-}
+fn some_function() {}
 
 pub fn some_other_function() {
     some_function();

--- a/tests/codegen/instrument-coverage/instrument-coverage.rs
+++ b/tests/codegen/instrument-coverage/instrument-coverage.rs
@@ -1,12 +1,12 @@
 // Test that `-Cinstrument-coverage` creates expected __llvm_profile_filename symbol in LLVM IR.
 
 //@ needs-profiler-support
-//@ revisions: default y yes on true all
+//@ revisions: default y yes on true_ all
 //@ [default] compile-flags: -Cinstrument-coverage
 //@ [y] compile-flags: -Cinstrument-coverage=y
 //@ [yes] compile-flags: -Cinstrument-coverage=yes
 //@ [on] compile-flags: -Cinstrument-coverage=on
-//@ [true] compile-flags: -Cinstrument-coverage=true
+//@ [true_] compile-flags: -Cinstrument-coverage=true
 //@ [all] compile-flags: -Cinstrument-coverage=all
 
 // CHECK: @__llvm_profile_filename = {{.*}}"default_%m_%p.profraw\00"{{.*}}

--- a/tests/rustdoc-ui/argfile/commandline-argfile.rs
+++ b/tests/rustdoc-ui/argfile/commandline-argfile.rs
@@ -1,7 +1,8 @@
 // Check to see if we can get parameters from an @argsfile file
 //
 //@ check-pass
-//@ compile-flags: --cfg cmdline_set @{{src-base}}/argfile/commandline-argfile.args
+//@ compile-flags: --cfg cmdline_set --check-cfg=cfg(cmdline_set,unbroken)
+//@ compile-flags: @{{src-base}}/argfile/commandline-argfile.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");
@@ -9,5 +10,4 @@ compile_error!("cmdline_set not set");
 #[cfg(not(unbroken))]
 compile_error!("unbroken not set");
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/argfile/commandline-argfile.rs
+++ b/tests/ui/argfile/commandline-argfile.rs
@@ -1,7 +1,8 @@
 // Check to see if we can get parameters from an @argsfile file
 //
 //@ build-pass
-//@ compile-flags: --cfg cmdline_set @{{src-base}}/argfile/commandline-argfile.args
+//@ compile-flags: --cfg cmdline_set --check-cfg=cfg(cmdline_set,unbroken)
+//@ compile-flags: @{{src-base}}/argfile/commandline-argfile.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");
@@ -9,5 +10,4 @@ compile_error!("cmdline_set not set");
 #[cfg(not(unbroken))]
 compile_error!("unbroken not set");
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/cfg/cfg-in-crate-1.rs
+++ b/tests/ui/cfg/cfg-in-crate-1.rs
@@ -1,5 +1,6 @@
 //@ run-pass
-//@ compile-flags: --cfg bar -D warnings
+//@ compile-flags: --cfg bar --check-cfg=cfg(bar) -D warnings
+
 #![cfg(bar)]
 
 fn main() {}

--- a/tests/ui/cfg/cfg-macros-foo.rs
+++ b/tests/ui/cfg/cfg-macros-foo.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ compile-flags: --cfg foo
+//@ compile-flags: --cfg foo --check-cfg=cfg(foo)
 
 // check that cfg correctly chooses between the macro impls (see also
 // cfg-macros-notfoo.rs)

--- a/tests/ui/cfg/cfg-path-error.rs
+++ b/tests/ui/cfg/cfg-path-error.rs
@@ -1,5 +1,7 @@
 //@ check-fail
 
+#![allow(unexpected_cfgs)] // invalid cfgs
+
 #[cfg(any(foo, foo::bar))]
 //~^ERROR `cfg` predicate key must be an identifier
 fn foo1() {}

--- a/tests/ui/cfg/cfg-path-error.stderr
+++ b/tests/ui/cfg/cfg-path-error.stderr
@@ -1,23 +1,23 @@
 error: `cfg` predicate key must be an identifier
-  --> $DIR/cfg-path-error.rs:3:16
+  --> $DIR/cfg-path-error.rs:5:16
    |
 LL | #[cfg(any(foo, foo::bar))]
    |                ^^^^^^^^
 
 error: `cfg` predicate key must be an identifier
-  --> $DIR/cfg-path-error.rs:7:11
+  --> $DIR/cfg-path-error.rs:9:11
    |
 LL | #[cfg(any(foo::bar, foo))]
    |           ^^^^^^^^
 
 error: `cfg` predicate key must be an identifier
-  --> $DIR/cfg-path-error.rs:11:16
+  --> $DIR/cfg-path-error.rs:13:16
    |
 LL | #[cfg(all(foo, foo::bar))]
    |                ^^^^^^^^
 
 error: `cfg` predicate key must be an identifier
-  --> $DIR/cfg-path-error.rs:15:11
+  --> $DIR/cfg-path-error.rs:17:11
    |
 LL | #[cfg(all(foo::bar, foo))]
    |           ^^^^^^^^

--- a/tests/ui/cfg/cfg_attr.rs
+++ b/tests/ui/cfg/cfg_attr.rs
@@ -1,6 +1,8 @@
 //@ run-pass
 //@ compile-flags:--cfg set1 --cfg set2
-#![allow(dead_code)]
+
+#![allow(dead_code, unexpected_cfgs)]
+
 use std::fmt::Debug;
 
 struct NotDebugable;

--- a/tests/ui/cfg/cfgs-on-items.rs
+++ b/tests/ui/cfg/cfgs-on-items.rs
@@ -1,8 +1,7 @@
 //@ run-pass
-//@ compile-flags: --cfg fooA --cfg fooB
+//@ compile-flags: --cfg fooA --cfg fooB --check-cfg=cfg(fooA,fooB,fooC,bar)
 
 // fooA AND !bar
-
 #[cfg(all(fooA, not(bar)))]
 fn foo1() -> isize { 1 }
 

--- a/tests/ui/cfg/diagnostics-not-a-def.rs
+++ b/tests/ui/cfg/diagnostics-not-a-def.rs
@@ -1,4 +1,7 @@
+#![feature(lint_reasons)]
+
 pub mod inner {
+    #[expect(unexpected_cfgs)]
     pub fn i_am_here() {
         #[cfg(feature = "another one that doesn't exist")]
         loop {}

--- a/tests/ui/cfg/diagnostics-not-a-def.stderr
+++ b/tests/ui/cfg/diagnostics-not-a-def.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find function `i_am_not` in module `inner`
-  --> $DIR/diagnostics-not-a-def.rs:11:12
+  --> $DIR/diagnostics-not-a-def.rs:14:12
    |
 LL |     inner::i_am_not();
    |            ^^^^^^^^ not found in `inner`

--- a/tests/ui/cfg/diagnostics-same-crate.rs
+++ b/tests/ui/cfg/diagnostics-same-crate.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)] // since we want to recognize them as unexpected
+
 pub mod inner {
     #[cfg(FALSE)]
     pub fn uwu() {}

--- a/tests/ui/cfg/diagnostics-same-crate.stderr
+++ b/tests/ui/cfg/diagnostics-same-crate.stderr
@@ -1,72 +1,72 @@
 error[E0432]: unresolved import `super::inner::doesnt_exist`
-  --> $DIR/diagnostics-same-crate.rs:28:9
+  --> $DIR/diagnostics-same-crate.rs:30:9
    |
 LL |     use super::inner::doesnt_exist;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ no `doesnt_exist` in `inner`
    |
 note: found an item that was configured out
-  --> $DIR/diagnostics-same-crate.rs:7:13
+  --> $DIR/diagnostics-same-crate.rs:9:13
    |
 LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
 
 error[E0432]: unresolved import `super::inner::doesnt_exist`
-  --> $DIR/diagnostics-same-crate.rs:31:23
+  --> $DIR/diagnostics-same-crate.rs:33:23
    |
 LL |     use super::inner::doesnt_exist::hi;
    |                       ^^^^^^^^^^^^ could not find `doesnt_exist` in `inner`
    |
 note: found an item that was configured out
-  --> $DIR/diagnostics-same-crate.rs:7:13
+  --> $DIR/diagnostics-same-crate.rs:9:13
    |
 LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
 
 error[E0433]: failed to resolve: could not find `doesnt_exist` in `inner`
-  --> $DIR/diagnostics-same-crate.rs:50:12
+  --> $DIR/diagnostics-same-crate.rs:52:12
    |
 LL |     inner::doesnt_exist::hello();
    |            ^^^^^^^^^^^^ could not find `doesnt_exist` in `inner`
    |
 note: found an item that was configured out
-  --> $DIR/diagnostics-same-crate.rs:7:13
+  --> $DIR/diagnostics-same-crate.rs:9:13
    |
 LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
 
 error[E0425]: cannot find function `uwu` in module `inner`
-  --> $DIR/diagnostics-same-crate.rs:45:12
+  --> $DIR/diagnostics-same-crate.rs:47:12
    |
 LL |     inner::uwu();
    |            ^^^ not found in `inner`
    |
 note: found an item that was configured out
-  --> $DIR/diagnostics-same-crate.rs:3:12
+  --> $DIR/diagnostics-same-crate.rs:5:12
    |
 LL |     pub fn uwu() {}
    |            ^^^
 
 error[E0425]: cannot find function `meow` in module `inner::right`
-  --> $DIR/diagnostics-same-crate.rs:54:19
+  --> $DIR/diagnostics-same-crate.rs:56:19
    |
 LL |     inner::right::meow();
    |                   ^^^^ not found in `inner::right`
    |
 note: found an item that was configured out
-  --> $DIR/diagnostics-same-crate.rs:22:16
+  --> $DIR/diagnostics-same-crate.rs:24:16
    |
 LL |         pub fn meow() {}
    |                ^^^^
    = note: the item is gated behind the `what-a-cool-feature` feature
 
 error[E0425]: cannot find function `uwu` in this scope
-  --> $DIR/diagnostics-same-crate.rs:41:5
+  --> $DIR/diagnostics-same-crate.rs:43:5
    |
 LL |     uwu();
    |     ^^^ not found in this scope
 
 error[E0425]: cannot find function `vanished` in this scope
-  --> $DIR/diagnostics-same-crate.rs:61:5
+  --> $DIR/diagnostics-same-crate.rs:63:5
    |
 LL |     vanished();
    |     ^^^^^^^^ not found in this scope

--- a/tests/ui/cfg/expanded-cfg.rs
+++ b/tests/ui/cfg/expanded-cfg.rs
@@ -1,5 +1,7 @@
 //@ check-pass
 
+#![allow(unexpected_cfgs)] // since we different cfgs
+
 macro_rules! mac {
     {} => {
         #[cfg(attr)]

--- a/tests/ui/cfg/future-compat-crate-attributes-using-cfg_attr.rs
+++ b/tests/ui/cfg/future-compat-crate-attributes-using-cfg_attr.rs
@@ -1,5 +1,5 @@
 //@ check-fail
-//@ compile-flags:--cfg foo
+//@ compile-flags:--cfg foo --check-cfg=cfg(foo)
 
 #![cfg_attr(foo, crate_type="bin")]
 //~^ERROR `crate_type` within

--- a/tests/ui/check-cfg/allow-at-crate-level.rs
+++ b/tests/ui/check-cfg/allow-at-crate-level.rs
@@ -1,6 +1,7 @@
 // This test check that #![allow(unexpected_cfgs)] works with --cfg
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --cfg=unexpected --check-cfg=cfg()
 
 #![allow(unexpected_cfgs)]

--- a/tests/ui/check-cfg/allow-macro-cfg.rs
+++ b/tests/ui/check-cfg/allow-macro-cfg.rs
@@ -1,6 +1,7 @@
 // This test check that local #[allow(unexpected_cfgs)] works
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
 #[allow(unexpected_cfgs)]

--- a/tests/ui/check-cfg/allow-same-level.rs
+++ b/tests/ui/check-cfg/allow-same-level.rs
@@ -1,6 +1,7 @@
 // This test check that #[allow(unexpected_cfgs)] doesn't work if put on the same level
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
 #[allow(unexpected_cfgs)]

--- a/tests/ui/check-cfg/allow-same-level.stderr
+++ b/tests/ui/check-cfg/allow-same-level.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `FALSE`
-  --> $DIR/allow-same-level.rs:7:7
+  --> $DIR/allow-same-level.rs:8:7
    |
 LL | #[cfg(FALSE)]
    |       ^^^^^

--- a/tests/ui/check-cfg/allow-top-level.rs
+++ b/tests/ui/check-cfg/allow-top-level.rs
@@ -1,6 +1,7 @@
 // This test check that a top-level #![allow(unexpected_cfgs)] works
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
 #![allow(unexpected_cfgs)]

--- a/tests/ui/check-cfg/allow-upper-level.rs
+++ b/tests/ui/check-cfg/allow-upper-level.rs
@@ -1,6 +1,7 @@
 // This test check that #[allow(unexpected_cfgs)] work if put on an upper level
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
 #[allow(unexpected_cfgs)]

--- a/tests/ui/check-cfg/cargo-feature.none.stderr
+++ b/tests/ui/check-cfg/cargo-feature.none.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `serde`
-  --> $DIR/cargo-feature.rs:13:7
+  --> $DIR/cargo-feature.rs:14:7
    |
 LL | #[cfg(feature = "serde")]
    |       ^^^^^^^^^^^^^^^^^ help: remove the condition
@@ -10,7 +10,7 @@ LL | #[cfg(feature = "serde")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: (none)
-  --> $DIR/cargo-feature.rs:17:7
+  --> $DIR/cargo-feature.rs:18:7
    |
 LL | #[cfg(feature)]
    |       ^^^^^^^ help: remove the condition
@@ -20,7 +20,7 @@ LL | #[cfg(feature)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `tokio_unstable`
-  --> $DIR/cargo-feature.rs:21:7
+  --> $DIR/cargo-feature.rs:22:7
    |
 LL | #[cfg(tokio_unstable)]
    |       ^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ LL | #[cfg(tokio_unstable)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `CONFIG_NVME`
-  --> $DIR/cargo-feature.rs:25:7
+  --> $DIR/cargo-feature.rs:26:7
    |
 LL | #[cfg(CONFIG_NVME = "m")]
    |       ^^^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/cargo-feature.rs
+++ b/tests/ui/check-cfg/cargo-feature.rs
@@ -3,6 +3,7 @@
 // list of all the expected names
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ revisions: some none
 //@ rustc-env:CARGO_CRATE_NAME=foo
 //@ [none]compile-flags: --check-cfg=cfg(feature,values())

--- a/tests/ui/check-cfg/cargo-feature.some.stderr
+++ b/tests/ui/check-cfg/cargo-feature.some.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `serde`
-  --> $DIR/cargo-feature.rs:13:7
+  --> $DIR/cargo-feature.rs:14:7
    |
 LL | #[cfg(feature = "serde")]
    |       ^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | #[cfg(feature = "serde")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: (none)
-  --> $DIR/cargo-feature.rs:17:7
+  --> $DIR/cargo-feature.rs:18:7
    |
 LL | #[cfg(feature)]
    |       ^^^^^^^- help: specify a config value: `= "bitcode"`
@@ -20,7 +20,7 @@ LL | #[cfg(feature)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `tokio_unstable`
-  --> $DIR/cargo-feature.rs:21:7
+  --> $DIR/cargo-feature.rs:22:7
    |
 LL | #[cfg(tokio_unstable)]
    |       ^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ LL | #[cfg(tokio_unstable)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `m`
-  --> $DIR/cargo-feature.rs:25:7
+  --> $DIR/cargo-feature.rs:26:7
    |
 LL | #[cfg(CONFIG_NVME = "m")]
    |       ^^^^^^^^^^^^^^---

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.rs
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.rs
@@ -2,6 +2,7 @@
 // This test checks we won't suggest more than 3 span suggestions for cfg names
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg(foo,values("value")) --check-cfg=cfg(bar,values("value")) --check-cfg=cfg(bee,values("value")) --check-cfg=cfg(cow,values("value"))
 
 #[cfg(value)]

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.stderr
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `value`
-  --> $DIR/cfg-value-for-cfg-name-duplicate.rs:7:7
+  --> $DIR/cfg-value-for-cfg-name-duplicate.rs:8:7
    |
 LL | #[cfg(value)]
    |       ^^^^^

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.rs
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.rs
@@ -2,6 +2,7 @@
 // This test checks that when a single cfg has a value for user's specified name
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg(foo,values("my_value")) --check-cfg=cfg(bar,values("my_value"))
 
 #[cfg(my_value)]

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.stderr
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `my_value`
-  --> $DIR/cfg-value-for-cfg-name-multiple.rs:7:7
+  --> $DIR/cfg-value-for-cfg-name-multiple.rs:8:7
    |
 LL | #[cfg(my_value)]
    |       ^^^^^^^^

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name.rs
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name.rs
@@ -3,6 +3,7 @@
 // suggest to use `#[cfg(target_os = "linux")]` instead of `#[cfg(linux)]`
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
 #[cfg(linux)]

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name.stderr
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `linux`
-  --> $DIR/cfg-value-for-cfg-name.rs:8:7
+  --> $DIR/cfg-value-for-cfg-name.rs:9:7
    |
 LL | #[cfg(linux)]
    |       ^^^^^ help: found config with similar value: `target_os = "linux"`
@@ -10,7 +10,7 @@ LL | #[cfg(linux)]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition name: `linux`
-  --> $DIR/cfg-value-for-cfg-name.rs:13:7
+  --> $DIR/cfg-value-for-cfg-name.rs:14:7
    |
 LL | #[cfg(linux = "os-name")]
    |       ^^^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/compact-names.rs
+++ b/tests/ui/check-cfg/compact-names.rs
@@ -1,6 +1,7 @@
 // This test check that we correctly emit an warning for compact cfg
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
 #![feature(cfg_target_compact)]

--- a/tests/ui/check-cfg/compact-names.stderr
+++ b/tests/ui/check-cfg/compact-names.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `target_architecture`
-  --> $DIR/compact-names.rs:11:28
+  --> $DIR/compact-names.rs:12:28
    |
 LL | #[cfg(target(os = "linux", architecture = "arm"))]
    |                            ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/compact-values.rs
+++ b/tests/ui/check-cfg/compact-values.rs
@@ -1,6 +1,7 @@
 // This test check that we correctly emit an warning for compact cfg
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
 #![feature(cfg_target_compact)]

--- a/tests/ui/check-cfg/compact-values.stderr
+++ b/tests/ui/check-cfg/compact-values.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `X`
-  --> $DIR/compact-values.rs:11:28
+  --> $DIR/compact-values.rs:12:28
    |
 LL | #[cfg(target(os = "linux", pointer_width = "X"))]
    |                            ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/concat-values.rs
+++ b/tests/ui/check-cfg/concat-values.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg(my_cfg,values("foo")) --check-cfg=cfg(my_cfg,values("bar"))
 //@ compile-flags: --check-cfg=cfg(my_cfg,values())
 

--- a/tests/ui/check-cfg/concat-values.stderr
+++ b/tests/ui/check-cfg/concat-values.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: (none)
-  --> $DIR/concat-values.rs:5:7
+  --> $DIR/concat-values.rs:6:7
    |
 LL | #[cfg(my_cfg)]
    |       ^^^^^^
@@ -10,7 +10,7 @@ LL | #[cfg(my_cfg)]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `unk`
-  --> $DIR/concat-values.rs:9:7
+  --> $DIR/concat-values.rs:10:7
    |
 LL | #[cfg(my_cfg = "unk")]
    |       ^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/diagnotics.cargo.stderr
+++ b/tests/ui/check-cfg/diagnotics.cargo.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:7:7
+  --> $DIR/diagnotics.rs:8:7
    |
 LL | #[cfg(featur)]
    |       ^^^^^^ help: there is a config with a similar name: `feature`
@@ -9,7 +9,7 @@ LL | #[cfg(featur)]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:11:7
+  --> $DIR/diagnotics.rs:12:7
    |
 LL | #[cfg(featur = "foo")]
    |       ^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL | #[cfg(feature = "foo")]
    |       ~~~~~~~
 
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:15:7
+  --> $DIR/diagnotics.rs:16:7
    |
 LL | #[cfg(featur = "fo")]
    |       ^^^^^^^^^^^^^
@@ -34,7 +34,7 @@ LL | #[cfg(feature = "foo")]
    |       ~~~~~~~~~~~~~~~
 
 warning: unexpected `cfg` condition name: `no_value`
-  --> $DIR/diagnotics.rs:22:7
+  --> $DIR/diagnotics.rs:23:7
    |
 LL | #[cfg(no_value)]
    |       ^^^^^^^^ help: there is a config with a similar name: `no_values`
@@ -43,7 +43,7 @@ LL | #[cfg(no_value)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `no_value`
-  --> $DIR/diagnotics.rs:26:7
+  --> $DIR/diagnotics.rs:27:7
    |
 LL | #[cfg(no_value = "foo")]
    |       ^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL | #[cfg(no_values)]
    |       ~~~~~~~~~
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/diagnotics.rs:30:7
+  --> $DIR/diagnotics.rs:31:7
    |
 LL | #[cfg(no_values = "bar")]
    |       ^^^^^^^^^--------

--- a/tests/ui/check-cfg/diagnotics.rs
+++ b/tests/ui/check-cfg/diagnotics.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@ no-auto-check-cfg
 //@ revisions: cargo rustc
 //@ [rustc]unset-rustc-env:CARGO_CRATE_NAME
 //@ [cargo]rustc-env:CARGO_CRATE_NAME=foo

--- a/tests/ui/check-cfg/diagnotics.rustc.stderr
+++ b/tests/ui/check-cfg/diagnotics.rustc.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:7:7
+  --> $DIR/diagnotics.rs:8:7
    |
 LL | #[cfg(featur)]
    |       ^^^^^^ help: there is a config with a similar name: `feature`
@@ -10,7 +10,7 @@ LL | #[cfg(featur)]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:11:7
+  --> $DIR/diagnotics.rs:12:7
    |
 LL | #[cfg(featur = "foo")]
    |       ^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | #[cfg(feature = "foo")]
    |       ~~~~~~~
 
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:15:7
+  --> $DIR/diagnotics.rs:16:7
    |
 LL | #[cfg(featur = "fo")]
    |       ^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL | #[cfg(feature = "foo")]
    |       ~~~~~~~~~~~~~~~
 
 warning: unexpected `cfg` condition name: `no_value`
-  --> $DIR/diagnotics.rs:22:7
+  --> $DIR/diagnotics.rs:23:7
    |
 LL | #[cfg(no_value)]
    |       ^^^^^^^^ help: there is a config with a similar name: `no_values`
@@ -46,7 +46,7 @@ LL | #[cfg(no_value)]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `no_value`
-  --> $DIR/diagnotics.rs:26:7
+  --> $DIR/diagnotics.rs:27:7
    |
 LL | #[cfg(no_value = "foo")]
    |       ^^^^^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL | #[cfg(no_values)]
    |       ~~~~~~~~~
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/diagnotics.rs:30:7
+  --> $DIR/diagnotics.rs:31:7
    |
 LL | #[cfg(no_values = "bar")]
    |       ^^^^^^^^^--------

--- a/tests/ui/check-cfg/empty-values.rs
+++ b/tests/ui/check-cfg/empty-values.rs
@@ -1,6 +1,7 @@
 // Check that we detect unexpected value when none are allowed
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg(foo,values())
 
 #[cfg(foo = "foo")]

--- a/tests/ui/check-cfg/empty-values.stderr
+++ b/tests/ui/check-cfg/empty-values.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/empty-values.rs:6:7
+  --> $DIR/empty-values.rs:7:7
    |
 LL | #[cfg(foo = "foo")]
    |       ^^^^^^^^^^^ help: remove the condition
@@ -10,7 +10,7 @@ LL | #[cfg(foo = "foo")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: (none)
-  --> $DIR/empty-values.rs:10:7
+  --> $DIR/empty-values.rs:11:7
    |
 LL | #[cfg(foo)]
    |       ^^^ help: remove the condition

--- a/tests/ui/check-cfg/exhaustive-names-values.empty_cfg.stderr
+++ b/tests/ui/check-cfg/exhaustive-names-values.empty_cfg.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `unknown_key`
-  --> $DIR/exhaustive-names-values.rs:9:7
+  --> $DIR/exhaustive-names-values.rs:10:7
    |
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | #[cfg(unknown_key = "value")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `value`
-  --> $DIR/exhaustive-names-values.rs:13:7
+  --> $DIR/exhaustive-names-values.rs:14:7
    |
 LL | #[cfg(test = "value")]
    |       ^^^^----------
@@ -21,7 +21,7 @@ LL | #[cfg(test = "value")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `feature`
-  --> $DIR/exhaustive-names-values.rs:17:7
+  --> $DIR/exhaustive-names-values.rs:18:7
    |
 LL | #[cfg(feature = "unk")]
    |       ^^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ LL | #[cfg(feature = "unk")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `feature`
-  --> $DIR/exhaustive-names-values.rs:24:7
+  --> $DIR/exhaustive-names-values.rs:25:7
    |
 LL | #[cfg(feature = "std")]
    |       ^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/exhaustive-names-values.feature.stderr
+++ b/tests/ui/check-cfg/exhaustive-names-values.feature.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `unknown_key`
-  --> $DIR/exhaustive-names-values.rs:9:7
+  --> $DIR/exhaustive-names-values.rs:10:7
    |
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | #[cfg(unknown_key = "value")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `value`
-  --> $DIR/exhaustive-names-values.rs:13:7
+  --> $DIR/exhaustive-names-values.rs:14:7
    |
 LL | #[cfg(test = "value")]
    |       ^^^^----------
@@ -21,7 +21,7 @@ LL | #[cfg(test = "value")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `unk`
-  --> $DIR/exhaustive-names-values.rs:17:7
+  --> $DIR/exhaustive-names-values.rs:18:7
    |
 LL | #[cfg(feature = "unk")]
    |       ^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/exhaustive-names-values.full.stderr
+++ b/tests/ui/check-cfg/exhaustive-names-values.full.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `unknown_key`
-  --> $DIR/exhaustive-names-values.rs:9:7
+  --> $DIR/exhaustive-names-values.rs:10:7
    |
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | #[cfg(unknown_key = "value")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `value`
-  --> $DIR/exhaustive-names-values.rs:13:7
+  --> $DIR/exhaustive-names-values.rs:14:7
    |
 LL | #[cfg(test = "value")]
    |       ^^^^----------
@@ -21,7 +21,7 @@ LL | #[cfg(test = "value")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `unk`
-  --> $DIR/exhaustive-names-values.rs:17:7
+  --> $DIR/exhaustive-names-values.rs:18:7
    |
 LL | #[cfg(feature = "unk")]
    |       ^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/exhaustive-names-values.rs
+++ b/tests/ui/check-cfg/exhaustive-names-values.rs
@@ -1,6 +1,7 @@
 // Check warning for unexpected cfg in the code.
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ revisions: empty_cfg feature full
 //@ [empty_cfg]compile-flags: --check-cfg=cfg()
 //@ [feature]compile-flags: --check-cfg=cfg(feature,values("std"))

--- a/tests/ui/check-cfg/exhaustive-names.rs
+++ b/tests/ui/check-cfg/exhaustive-names.rs
@@ -1,6 +1,7 @@
 // Check warning for unexpected cfg
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
 #[cfg(unknown_key = "value")]

--- a/tests/ui/check-cfg/exhaustive-names.stderr
+++ b/tests/ui/check-cfg/exhaustive-names.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `unknown_key`
-  --> $DIR/exhaustive-names.rs:6:7
+  --> $DIR/exhaustive-names.rs:7:7
    |
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/exhaustive-values.empty_cfg.stderr
+++ b/tests/ui/check-cfg/exhaustive-values.empty_cfg.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `value`
-  --> $DIR/exhaustive-values.rs:8:7
+  --> $DIR/exhaustive-values.rs:9:7
    |
 LL | #[cfg(test = "value")]
    |       ^^^^----------

--- a/tests/ui/check-cfg/exhaustive-values.rs
+++ b/tests/ui/check-cfg/exhaustive-values.rs
@@ -1,6 +1,7 @@
 // Check warning for unexpected cfg value
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ revisions: empty_cfg without_names
 //@ [empty_cfg]compile-flags: --check-cfg=cfg()
 //@ [without_names]compile-flags: --check-cfg=cfg(any())

--- a/tests/ui/check-cfg/exhaustive-values.without_names.stderr
+++ b/tests/ui/check-cfg/exhaustive-values.without_names.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `value`
-  --> $DIR/exhaustive-values.rs:8:7
+  --> $DIR/exhaustive-values.rs:9:7
    |
 LL | #[cfg(test = "value")]
    |       ^^^^----------

--- a/tests/ui/check-cfg/invalid-arguments.rs
+++ b/tests/ui/check-cfg/invalid-arguments.rs
@@ -1,6 +1,7 @@
 // Check that invalid --check-cfg are rejected
 //
 //@ check-fail
+//@ no-auto-check-cfg
 //@ revisions: anything_else
 //@ revisions: string_for_name_1 string_for_name_2 multiple_any multiple_values
 //@ revisions: multiple_values_any not_empty_any not_empty_values_any

--- a/tests/ui/check-cfg/mix.rs
+++ b/tests/ui/check-cfg/mix.rs
@@ -3,6 +3,7 @@
 // we correctly lint on the `cfg!` macro and `cfg_attr` attribute.
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --cfg feature="bar" --cfg unknown_name
 //@ compile-flags: --check-cfg=cfg(feature,values("foo"))
 

--- a/tests/ui/check-cfg/mix.stderr
+++ b/tests/ui/check-cfg/mix.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `widnows`
-  --> $DIR/mix.rs:12:7
+  --> $DIR/mix.rs:13:7
    |
 LL | #[cfg(widnows)]
    |       ^^^^^^^ help: there is a config with a similar name: `windows`
@@ -9,7 +9,7 @@ LL | #[cfg(widnows)]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: (none)
-  --> $DIR/mix.rs:16:7
+  --> $DIR/mix.rs:17:7
    |
 LL | #[cfg(feature)]
    |       ^^^^^^^- help: specify a config value: `= "foo"`
@@ -19,7 +19,7 @@ LL | #[cfg(feature)]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/mix.rs:23:7
+  --> $DIR/mix.rs:24:7
    |
 LL | #[cfg(feature = "bar")]
    |       ^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL | #[cfg(feature = "bar")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:27:7
+  --> $DIR/mix.rs:28:7
    |
 LL | #[cfg(feature = "zebra")]
    |       ^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL | #[cfg(feature = "zebra")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `uu`
-  --> $DIR/mix.rs:31:12
+  --> $DIR/mix.rs:32:12
    |
 LL | #[cfg_attr(uu, test)]
    |            ^^
@@ -49,7 +49,7 @@ LL | #[cfg_attr(uu, test)]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `widnows`
-  --> $DIR/mix.rs:40:10
+  --> $DIR/mix.rs:41:10
    |
 LL |     cfg!(widnows);
    |          ^^^^^^^ help: there is a config with a similar name: `windows`
@@ -58,7 +58,7 @@ LL |     cfg!(widnows);
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/mix.rs:43:10
+  --> $DIR/mix.rs:44:10
    |
 LL |     cfg!(feature = "bar");
    |          ^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ LL |     cfg!(feature = "bar");
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:45:10
+  --> $DIR/mix.rs:46:10
    |
 LL |     cfg!(feature = "zebra");
    |          ^^^^^^^^^^^^^^^^^
@@ -78,7 +78,7 @@ LL |     cfg!(feature = "zebra");
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:47:10
+  --> $DIR/mix.rs:48:10
    |
 LL |     cfg!(xxx = "foo");
    |          ^^^^^^^^^^^
@@ -87,7 +87,7 @@ LL |     cfg!(xxx = "foo");
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:49:10
+  --> $DIR/mix.rs:50:10
    |
 LL |     cfg!(xxx);
    |          ^^^
@@ -96,7 +96,7 @@ LL |     cfg!(xxx);
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:51:14
+  --> $DIR/mix.rs:52:14
    |
 LL |     cfg!(any(xxx, windows));
    |              ^^^
@@ -105,7 +105,7 @@ LL |     cfg!(any(xxx, windows));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `bad`
-  --> $DIR/mix.rs:53:14
+  --> $DIR/mix.rs:54:14
    |
 LL |     cfg!(any(feature = "bad", windows));
    |              ^^^^^^^^^^^^^^^
@@ -115,7 +115,7 @@ LL |     cfg!(any(feature = "bad", windows));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:55:23
+  --> $DIR/mix.rs:56:23
    |
 LL |     cfg!(any(windows, xxx));
    |                       ^^^
@@ -124,7 +124,7 @@ LL |     cfg!(any(windows, xxx));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:57:20
+  --> $DIR/mix.rs:58:20
    |
 LL |     cfg!(all(unix, xxx));
    |                    ^^^
@@ -133,7 +133,7 @@ LL |     cfg!(all(unix, xxx));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `aa`
-  --> $DIR/mix.rs:59:14
+  --> $DIR/mix.rs:60:14
    |
 LL |     cfg!(all(aa, bb));
    |              ^^
@@ -142,7 +142,7 @@ LL |     cfg!(all(aa, bb));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `bb`
-  --> $DIR/mix.rs:59:18
+  --> $DIR/mix.rs:60:18
    |
 LL |     cfg!(all(aa, bb));
    |                  ^^
@@ -151,7 +151,7 @@ LL |     cfg!(all(aa, bb));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `aa`
-  --> $DIR/mix.rs:62:14
+  --> $DIR/mix.rs:63:14
    |
 LL |     cfg!(any(aa, bb));
    |              ^^
@@ -160,7 +160,7 @@ LL |     cfg!(any(aa, bb));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `bb`
-  --> $DIR/mix.rs:62:18
+  --> $DIR/mix.rs:63:18
    |
 LL |     cfg!(any(aa, bb));
    |                  ^^
@@ -169,7 +169,7 @@ LL |     cfg!(any(aa, bb));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:65:20
+  --> $DIR/mix.rs:66:20
    |
 LL |     cfg!(any(unix, feature = "zebra"));
    |                    ^^^^^^^^^^^^^^^^^
@@ -179,7 +179,7 @@ LL |     cfg!(any(unix, feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:67:14
+  --> $DIR/mix.rs:68:14
    |
 LL |     cfg!(any(xxx, feature = "zebra"));
    |              ^^^
@@ -188,7 +188,7 @@ LL |     cfg!(any(xxx, feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:67:19
+  --> $DIR/mix.rs:68:19
    |
 LL |     cfg!(any(xxx, feature = "zebra"));
    |                   ^^^^^^^^^^^^^^^^^
@@ -198,7 +198,7 @@ LL |     cfg!(any(xxx, feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:70:14
+  --> $DIR/mix.rs:71:14
    |
 LL |     cfg!(any(xxx, unix, xxx));
    |              ^^^
@@ -207,7 +207,7 @@ LL |     cfg!(any(xxx, unix, xxx));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:70:25
+  --> $DIR/mix.rs:71:25
    |
 LL |     cfg!(any(xxx, unix, xxx));
    |                         ^^^
@@ -216,7 +216,7 @@ LL |     cfg!(any(xxx, unix, xxx));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:73:14
+  --> $DIR/mix.rs:74:14
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    |              ^^^^^^^^^^^^^^^^^
@@ -226,7 +226,7 @@ LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:73:33
+  --> $DIR/mix.rs:74:33
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    |                                 ^^^^^^^^^^^^^^^^^
@@ -236,7 +236,7 @@ LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:73:52
+  --> $DIR/mix.rs:74:52
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    |                                                    ^^^^^^^^^^^^^^^^^
@@ -246,7 +246,7 @@ LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:77:10
+  --> $DIR/mix.rs:78:10
    |
 LL |     cfg!(target_feature = "zebra");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/no-expected-values.empty.stderr
+++ b/tests/ui/check-cfg/no-expected-values.empty.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:10:7
+  --> $DIR/no-expected-values.rs:11:7
    |
 LL | #[cfg(feature = "foo")]
    |       ^^^^^^^--------
@@ -12,7 +12,7 @@ LL | #[cfg(feature = "foo")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:14:7
+  --> $DIR/no-expected-values.rs:15:7
    |
 LL | #[cfg(test = "foo")]
    |       ^^^^--------

--- a/tests/ui/check-cfg/no-expected-values.mixed.stderr
+++ b/tests/ui/check-cfg/no-expected-values.mixed.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:10:7
+  --> $DIR/no-expected-values.rs:11:7
    |
 LL | #[cfg(feature = "foo")]
    |       ^^^^^^^--------
@@ -12,7 +12,7 @@ LL | #[cfg(feature = "foo")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:14:7
+  --> $DIR/no-expected-values.rs:15:7
    |
 LL | #[cfg(test = "foo")]
    |       ^^^^--------

--- a/tests/ui/check-cfg/no-expected-values.rs
+++ b/tests/ui/check-cfg/no-expected-values.rs
@@ -1,6 +1,7 @@
 // Check that we detect unexpected value when none are allowed
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ revisions: simple mixed empty
 //@ compile-flags: --check-cfg=cfg(values,simple,mixed,empty)
 //@ [simple]compile-flags: --check-cfg=cfg(test) --check-cfg=cfg(feature)

--- a/tests/ui/check-cfg/no-expected-values.simple.stderr
+++ b/tests/ui/check-cfg/no-expected-values.simple.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:10:7
+  --> $DIR/no-expected-values.rs:11:7
    |
 LL | #[cfg(feature = "foo")]
    |       ^^^^^^^--------
@@ -12,7 +12,7 @@ LL | #[cfg(feature = "foo")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:14:7
+  --> $DIR/no-expected-values.rs:15:7
    |
 LL | #[cfg(test = "foo")]
    |       ^^^^--------

--- a/tests/ui/check-cfg/order-independant.rs
+++ b/tests/ui/check-cfg/order-independant.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //
+//@ no-auto-check-cfg
 //@ revisions: values_before values_after
 //@ compile-flags: --check-cfg=cfg(values_before,values_after)
 //@ [values_before]compile-flags: --check-cfg=cfg(a,values("b")) --check-cfg=cfg(a)

--- a/tests/ui/check-cfg/order-independant.values_after.stderr
+++ b/tests/ui/check-cfg/order-independant.values_after.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `unk`
-  --> $DIR/order-independant.rs:11:7
+  --> $DIR/order-independant.rs:12:7
    |
 LL | #[cfg(a = "unk")]
    |       ^^^^^^^^^

--- a/tests/ui/check-cfg/order-independant.values_before.stderr
+++ b/tests/ui/check-cfg/order-independant.values_before.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `unk`
-  --> $DIR/order-independant.rs:11:7
+  --> $DIR/order-independant.rs:12:7
    |
 LL | #[cfg(a = "unk")]
    |       ^^^^^^^^^

--- a/tests/ui/check-cfg/stmt-no-ice.rs
+++ b/tests/ui/check-cfg/stmt-no-ice.rs
@@ -1,6 +1,7 @@
 // This test checks that there is no ICE with this code
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags:--check-cfg=cfg()
 
 fn main() {

--- a/tests/ui/check-cfg/stmt-no-ice.stderr
+++ b/tests/ui/check-cfg/stmt-no-ice.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `crossbeam_loom`
-  --> $DIR/stmt-no-ice.rs:7:11
+  --> $DIR/stmt-no-ice.rs:8:11
    |
 LL |     #[cfg(crossbeam_loom)]
    |           ^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/unexpected-cfg-name.rs
+++ b/tests/ui/check-cfg/unexpected-cfg-name.rs
@@ -1,6 +1,7 @@
 // Check warning for unexpected configuration name
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
 #[cfg(widnows)]

--- a/tests/ui/check-cfg/unexpected-cfg-name.stderr
+++ b/tests/ui/check-cfg/unexpected-cfg-name.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `widnows`
-  --> $DIR/unexpected-cfg-name.rs:6:7
+  --> $DIR/unexpected-cfg-name.rs:7:7
    |
 LL | #[cfg(widnows)]
    |       ^^^^^^^ help: there is a config with a similar name: `windows`

--- a/tests/ui/check-cfg/unexpected-cfg-value.rs
+++ b/tests/ui/check-cfg/unexpected-cfg-value.rs
@@ -1,6 +1,7 @@
 // Check for unexpected configuration value in the code.
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --cfg=feature="rand"
 //@ compile-flags: --check-cfg=cfg(feature,values("serde","full"))
 

--- a/tests/ui/check-cfg/unexpected-cfg-value.stderr
+++ b/tests/ui/check-cfg/unexpected-cfg-value.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `sedre`
-  --> $DIR/unexpected-cfg-value.rs:7:7
+  --> $DIR/unexpected-cfg-value.rs:8:7
    |
 LL | #[cfg(feature = "sedre")]
    |       ^^^^^^^^^^-------
@@ -12,7 +12,7 @@ LL | #[cfg(feature = "sedre")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `rand`
-  --> $DIR/unexpected-cfg-value.rs:14:7
+  --> $DIR/unexpected-cfg-value.rs:15:7
    |
 LL | #[cfg(feature = "rand")]
    |       ^^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/unknown-values.rs
+++ b/tests/ui/check-cfg/unknown-values.rs
@@ -1,6 +1,7 @@
 // Check that no warning is emitted for unknown cfg value
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ revisions: simple mixed with_values
 //@ compile-flags: --check-cfg=cfg(simple,mixed,with_values)
 //@ [simple]compile-flags: --check-cfg=cfg(foo,values(any()))

--- a/tests/ui/check-cfg/values-none.explicit.stderr
+++ b/tests/ui/check-cfg/values-none.explicit.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `too`
-  --> $DIR/values-none.rs:10:7
+  --> $DIR/values-none.rs:11:7
    |
 LL | #[cfg(foo = "too")]
    |       ^^^--------
@@ -12,7 +12,7 @@ LL | #[cfg(foo = "too")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/values-none.rs:15:7
+  --> $DIR/values-none.rs:16:7
    |
 LL | #[cfg(foo = "bar")]
    |       ^^^--------

--- a/tests/ui/check-cfg/values-none.implicit.stderr
+++ b/tests/ui/check-cfg/values-none.implicit.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `too`
-  --> $DIR/values-none.rs:10:7
+  --> $DIR/values-none.rs:11:7
    |
 LL | #[cfg(foo = "too")]
    |       ^^^--------
@@ -12,7 +12,7 @@ LL | #[cfg(foo = "too")]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/values-none.rs:15:7
+  --> $DIR/values-none.rs:16:7
    |
 LL | #[cfg(foo = "bar")]
    |       ^^^--------

--- a/tests/ui/check-cfg/values-none.rs
+++ b/tests/ui/check-cfg/values-none.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //
+//@ no-auto-check-cfg
 //@ revisions: explicit implicit
 //@ [explicit]compile-flags: --check-cfg=cfg(foo,values(none()))
 //@ [implicit]compile-flags: --check-cfg=cfg(foo)

--- a/tests/ui/check-cfg/values-target-json.rs
+++ b/tests/ui/check-cfg/values-target-json.rs
@@ -1,6 +1,7 @@
 // This test checks that we don't lint values defined by a custom target (target json)
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ needs-llvm-components: x86
 //@ compile-flags: --crate-type=lib --check-cfg=cfg() --target={{src-base}}/check-cfg/my-awesome-platform.json
 

--- a/tests/ui/check-cfg/well-known-names.rs
+++ b/tests/ui/check-cfg/well-known-names.rs
@@ -1,6 +1,7 @@
 // This test checks that we lint on non well known names and that we don't lint on well known names
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
 #[cfg(target_oz = "linux")]

--- a/tests/ui/check-cfg/well-known-names.stderr
+++ b/tests/ui/check-cfg/well-known-names.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `target_oz`
-  --> $DIR/well-known-names.rs:6:7
+  --> $DIR/well-known-names.rs:7:7
    |
 LL | #[cfg(target_oz = "linux")]
    |       ^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL | #[cfg(target_os = "linux")]
    |       ~~~~~~~~~
 
 warning: unexpected `cfg` condition name: `features`
-  --> $DIR/well-known-names.rs:13:7
+  --> $DIR/well-known-names.rs:14:7
    |
 LL | #[cfg(features = "foo")]
    |       ^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | #[cfg(features = "foo")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `feature`
-  --> $DIR/well-known-names.rs:17:7
+  --> $DIR/well-known-names.rs:18:7
    |
 LL | #[cfg(feature = "foo")]
    |       ^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL | #[cfg(feature = "foo")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `uniw`
-  --> $DIR/well-known-names.rs:21:7
+  --> $DIR/well-known-names.rs:22:7
    |
 LL | #[cfg(uniw)]
    |       ^^^^ help: there is a config with a similar name: `unix`

--- a/tests/ui/check-cfg/well-known-values.rs
+++ b/tests/ui/check-cfg/well-known-values.rs
@@ -5,6 +5,7 @@
 // values since the suggestion shows them.
 //
 //@ check-pass
+//@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 //@ compile-flags: -Zcheck-cfg-all-expected
 

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:27:5
+  --> $DIR/well-known-values.rs:28:5
    |
 LL |     clippy = "_UNEXPECTED_VALUE",
    |     ^^^^^^----------------------
@@ -11,7 +11,7 @@ LL |     clippy = "_UNEXPECTED_VALUE",
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:29:5
+  --> $DIR/well-known-values.rs:30:5
    |
 LL |     debug_assertions = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^----------------------
@@ -22,7 +22,7 @@ LL |     debug_assertions = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:31:5
+  --> $DIR/well-known-values.rs:32:5
    |
 LL |     doc = "_UNEXPECTED_VALUE",
    |     ^^^----------------------
@@ -33,7 +33,7 @@ LL |     doc = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:33:5
+  --> $DIR/well-known-values.rs:34:5
    |
 LL |     doctest = "_UNEXPECTED_VALUE",
    |     ^^^^^^^----------------------
@@ -44,7 +44,7 @@ LL |     doctest = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:35:5
+  --> $DIR/well-known-values.rs:36:5
    |
 LL |     miri = "_UNEXPECTED_VALUE",
    |     ^^^^----------------------
@@ -55,7 +55,7 @@ LL |     miri = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:37:5
+  --> $DIR/well-known-values.rs:38:5
    |
 LL |     overflow_checks = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^----------------------
@@ -66,7 +66,7 @@ LL |     overflow_checks = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:39:5
+  --> $DIR/well-known-values.rs:40:5
    |
 LL |     panic = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL |     panic = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:41:5
+  --> $DIR/well-known-values.rs:42:5
    |
 LL |     proc_macro = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^----------------------
@@ -86,7 +86,7 @@ LL |     proc_macro = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:43:5
+  --> $DIR/well-known-values.rs:44:5
    |
 LL |     relocation_model = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     relocation_model = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:45:5
+  --> $DIR/well-known-values.rs:46:5
    |
 LL |     sanitize = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,7 +104,7 @@ LL |     sanitize = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:47:5
+  --> $DIR/well-known-values.rs:48:5
    |
 LL |     target_abi = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -113,7 +113,7 @@ LL |     target_abi = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:49:5
+  --> $DIR/well-known-values.rs:50:5
    |
 LL |     target_arch = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -122,7 +122,7 @@ LL |     target_arch = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:51:5
+  --> $DIR/well-known-values.rs:52:5
    |
 LL |     target_endian = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     target_endian = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:53:5
+  --> $DIR/well-known-values.rs:54:5
    |
 LL |     target_env = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -140,7 +140,7 @@ LL |     target_env = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:55:5
+  --> $DIR/well-known-values.rs:56:5
    |
 LL |     target_family = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |     target_family = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:57:5
+  --> $DIR/well-known-values.rs:58:5
    |
 LL |     target_feature = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -158,7 +158,7 @@ LL |     target_feature = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:59:5
+  --> $DIR/well-known-values.rs:60:5
    |
 LL |     target_has_atomic = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -167,7 +167,7 @@ LL |     target_has_atomic = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:61:5
+  --> $DIR/well-known-values.rs:62:5
    |
 LL |     target_has_atomic_equal_alignment = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -176,7 +176,7 @@ LL |     target_has_atomic_equal_alignment = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:63:5
+  --> $DIR/well-known-values.rs:64:5
    |
 LL |     target_has_atomic_load_store = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -185,7 +185,7 @@ LL |     target_has_atomic_load_store = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:65:5
+  --> $DIR/well-known-values.rs:66:5
    |
 LL |     target_os = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -194,7 +194,7 @@ LL |     target_os = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:67:5
+  --> $DIR/well-known-values.rs:68:5
    |
 LL |     target_pointer_width = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -203,7 +203,7 @@ LL |     target_pointer_width = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:69:5
+  --> $DIR/well-known-values.rs:70:5
    |
 LL |     target_thread_local = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^----------------------
@@ -214,7 +214,7 @@ LL |     target_thread_local = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:71:5
+  --> $DIR/well-known-values.rs:72:5
    |
 LL |     target_vendor = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -223,7 +223,7 @@ LL |     target_vendor = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:73:5
+  --> $DIR/well-known-values.rs:74:5
    |
 LL |     test = "_UNEXPECTED_VALUE",
    |     ^^^^----------------------
@@ -234,7 +234,7 @@ LL |     test = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:75:5
+  --> $DIR/well-known-values.rs:76:5
    |
 LL |     ub_checks = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^----------------------
@@ -245,7 +245,7 @@ LL |     ub_checks = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:77:5
+  --> $DIR/well-known-values.rs:78:5
    |
 LL |     unix = "_UNEXPECTED_VALUE",
    |     ^^^^----------------------
@@ -256,7 +256,7 @@ LL |     unix = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:79:5
+  --> $DIR/well-known-values.rs:80:5
    |
 LL |     windows = "_UNEXPECTED_VALUE",
    |     ^^^^^^^----------------------
@@ -267,7 +267,7 @@ LL |     windows = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `linuz`
-  --> $DIR/well-known-values.rs:85:7
+  --> $DIR/well-known-values.rs:86:7
    |
 LL | #[cfg(target_os = "linuz")] // testing that we suggest `linux`
    |       ^^^^^^^^^^^^-------

--- a/tests/ui/conditional-compilation/cfg-attr-cfg-2.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-cfg-2.rs
@@ -1,6 +1,5 @@
-//
 //@ error-pattern: `main` function not found
-//@ compile-flags: --cfg foo
+//@ compile-flags: --cfg foo --check-cfg=cfg(foo,bar)
 
 // main is conditionally compiled, but the conditional compilation
 // is conditional too!

--- a/tests/ui/conditional-compilation/cfg-attr-cfg-2.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-cfg-2.stderr
@@ -1,5 +1,5 @@
 error[E0601]: `main` function not found in crate `cfg_attr_cfg_2`
-  --> $DIR/cfg-attr-cfg-2.rs:9:14
+  --> $DIR/cfg-attr-cfg-2.rs:8:14
    |
 LL | fn main() { }
    |              ^ consider adding a `main` function to `$DIR/cfg-attr-cfg-2.rs`

--- a/tests/ui/conditional-compilation/cfg-attr-crate-2.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-crate-2.rs
@@ -1,6 +1,6 @@
 // https://github.com/rust-lang/rust/issues/21833#issuecomment-72353044
 
-//@ compile-flags: --cfg broken
+//@ compile-flags: --cfg broken --check-cfg=cfg(broken)
 
 #![crate_type = "lib"]
 #![cfg_attr(broken, no_core)] //~ ERROR the `#[no_core]` attribute is an experimental feature

--- a/tests/ui/conditional-compilation/cfg-attr-multi-invalid-1.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-multi-invalid-1.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --cfg broken
+//@ compile-flags: --cfg broken --check-cfg=cfg(broken)
 
 #![crate_type = "lib"]
 #![cfg_attr(broken, no_core, no_std)]

--- a/tests/ui/conditional-compilation/cfg-attr-multi-invalid-2.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-multi-invalid-2.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --cfg broken
+//@ compile-flags: --cfg broken --check-cfg=cfg(broken)
 
 #![crate_type = "lib"]
 #![cfg_attr(broken, no_std, no_core)]

--- a/tests/ui/conditional-compilation/cfg-generic-params.rs
+++ b/tests/ui/conditional-compilation/cfg-generic-params.rs
@@ -1,4 +1,4 @@
-//@ compile-flags:--cfg yes
+//@ compile-flags:--cfg yes --check-cfg=cfg(yes,no)
 
 fn f_lt<#[cfg(yes)] 'a: 'a, #[cfg(FALSE)] T>() {}
 fn f_ty<#[cfg(FALSE)] 'a: 'a, #[cfg(yes)] T>() {}

--- a/tests/ui/conditional-compilation/test-cfg.rs
+++ b/tests/ui/conditional-compilation/test-cfg.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --cfg foo
+//@ compile-flags: --cfg foo --check-cfg=cfg(foo,bar)
 
 #[cfg(all(foo, bar))] // foo AND bar
 fn foo() {}

--- a/tests/ui/feature-gates/feature-gate-cfg-target-compact.rs
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-compact.rs
@@ -1,13 +1,13 @@
-#[cfg(target(os = "x"))] //~ ERROR compact `cfg(target(..))` is experimental
+#[cfg(target(os = "linux"))] //~ ERROR compact `cfg(target(..))` is experimental
 struct Foo(u64, u64);
 
-#[cfg_attr(target(os = "x"), x)] //~ ERROR compact `cfg(target(..))` is experimental
+#[cfg_attr(target(os = "linux"), non_exhaustive)] //~ ERROR compact `cfg(target(..))` is experimental
 struct Bar(u64, u64);
 
-#[cfg(not(any(all(target(os = "x")))))] //~ ERROR compact `cfg(target(..))` is experimental
+#[cfg(not(any(all(target(os = "linux")))))] //~ ERROR compact `cfg(target(..))` is experimental
 fn foo() {}
 
 fn main() {
-    cfg!(target(os = "x"));
+    cfg!(target(os = "linux"));
     //~^ ERROR compact `cfg(target(..))` is experimental and subject to change
 }

--- a/tests/ui/feature-gates/feature-gate-cfg-target-compact.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-compact.stderr
@@ -1,8 +1,8 @@
 error[E0658]: compact `cfg(target(..))` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-compact.rs:1:7
    |
-LL | #[cfg(target(os = "x"))]
-   |       ^^^^^^^^^^^^^^^^
+LL | #[cfg(target(os = "linux"))]
+   |       ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #96901 <https://github.com/rust-lang/rust/issues/96901> for more information
    = help: add `#![feature(cfg_target_compact)]` to the crate attributes to enable
@@ -11,8 +11,8 @@ LL | #[cfg(target(os = "x"))]
 error[E0658]: compact `cfg(target(..))` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-compact.rs:4:12
    |
-LL | #[cfg_attr(target(os = "x"), x)]
-   |            ^^^^^^^^^^^^^^^^
+LL | #[cfg_attr(target(os = "linux"), non_exhaustive)]
+   |            ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #96901 <https://github.com/rust-lang/rust/issues/96901> for more information
    = help: add `#![feature(cfg_target_compact)]` to the crate attributes to enable
@@ -21,8 +21,8 @@ LL | #[cfg_attr(target(os = "x"), x)]
 error[E0658]: compact `cfg(target(..))` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-compact.rs:7:19
    |
-LL | #[cfg(not(any(all(target(os = "x")))))]
-   |                   ^^^^^^^^^^^^^^^^
+LL | #[cfg(not(any(all(target(os = "linux")))))]
+   |                   ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #96901 <https://github.com/rust-lang/rust/issues/96901> for more information
    = help: add `#![feature(cfg_target_compact)]` to the crate attributes to enable
@@ -31,8 +31,8 @@ LL | #[cfg(not(any(all(target(os = "x")))))]
 error[E0658]: compact `cfg(target(..))` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-compact.rs:11:10
    |
-LL |     cfg!(target(os = "x"));
-   |          ^^^^^^^^^^^^^^^^
+LL |     cfg!(target(os = "linux"));
+   |          ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #96901 <https://github.com/rust-lang/rust/issues/96901> for more information
    = help: add `#![feature(cfg_target_compact)]` to the crate attributes to enable

--- a/tests/ui/imports/extern-prelude-extern-crate-cfg.rs
+++ b/tests/ui/imports/extern-prelude-extern-crate-cfg.rs
@@ -1,5 +1,5 @@
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ compile-flags:--cfg my_feature
+//@ compile-flags:--cfg my_feature --check-cfg=cfg(my_feature)
 
 #![no_std]
 

--- a/tests/ui/instrument-coverage/on-values.rs
+++ b/tests/ui/instrument-coverage/on-values.rs
@@ -1,11 +1,11 @@
 //@ check-pass
 //@ needs-profiler-support
-//@ revisions: default y yes on true all
+//@ revisions: default y yes on true_ all
 //@ [default] compile-flags: -Cinstrument-coverage
 //@ [y] compile-flags: -Cinstrument-coverage=y
 //@ [yes] compile-flags: -Cinstrument-coverage=yes
 //@ [on] compile-flags: -Cinstrument-coverage=on
-//@ [true] compile-flags: -Cinstrument-coverage=true
+//@ [true_] compile-flags: -Cinstrument-coverage=true
 //@ [all] compile-flags: -Cinstrument-coverage=all
 
 fn main() {}

--- a/tests/ui/issues/issue-11085.rs
+++ b/tests/ui/issues/issue-11085.rs
@@ -1,8 +1,7 @@
 //@ run-pass
-#![allow(dead_code)]
-//@ compile-flags: --cfg foo
-
 //@ pretty-expanded FIXME #23616
+
+#![allow(dead_code)]
 
 struct Foo {
     #[cfg(FALSE)]
@@ -11,7 +10,7 @@ struct Foo {
 }
 
 struct Foo2 {
-    #[cfg(foo)]
+    #[cfg(all())]
     foo: isize,
 }
 

--- a/tests/ui/issues/issue-24434.rs
+++ b/tests/ui/issues/issue-24434.rs
@@ -1,7 +1,6 @@
 //@ check-pass
-//@ compile-flags:--cfg set1
 
-#![cfg_attr(set1, feature(rustc_attrs))]
+#![cfg_attr(all(), feature(rustc_attrs))]
 #![rustc_dummy]
 
 fn main() {}

--- a/tests/ui/macros/macro-comma-support-rpass.rs
+++ b/tests/ui/macros/macro-comma-support-rpass.rs
@@ -51,6 +51,7 @@ fn assert_ne() {
 }
 
 #[test]
+#[allow(unexpected_cfgs)]
 fn cfg() {
     let _ = cfg!(pants);
     let _ = cfg!(pants,);

--- a/tests/ui/macros/macro-meta-items.rs
+++ b/tests/ui/macros/macro-meta-items.rs
@@ -16,7 +16,7 @@ macro_rules! emit {
 }
 
 // item
-compiles_fine!(bar);
+compiles_fine!(FALSE);
 emit!(foo);
 
 fn foo() {
@@ -25,7 +25,7 @@ fn foo() {
 
 pub fn main() {
     // statement
-    compiles_fine!(baz);
-    emit!(baz);
+    compiles_fine!(FALSE);
+    emit!(FALSE);
     println!("{}", MISTYPED);
 }

--- a/tests/ui/macros/macro-meta-items.rs
+++ b/tests/ui/macros/macro-meta-items.rs
@@ -1,6 +1,7 @@
 //@ run-pass
+//@ compile-flags: --cfg foo --check-cfg=cfg(foo)
+
 #![allow(dead_code)]
-//@ compile-flags: --cfg foo
 
 macro_rules! compiles_fine {
     ($at:meta) => {

--- a/tests/ui/macros/macro-with-attrs1.rs
+++ b/tests/ui/macros/macro-with-attrs1.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ compile-flags: --cfg foo
+//@ compile-flags: --cfg foo --check-cfg=cfg(foo)
 
 
 #[cfg(foo)]

--- a/tests/ui/macros/syntax-extension-cfg.rs
+++ b/tests/ui/macros/syntax-extension-cfg.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 //@ compile-flags: --cfg foo --cfg qux="foo"
-
+//@ compile-flags: --check-cfg=cfg(foo) --check-cfg=cfg(qux,values("foo"))
 
 pub fn main() {
     // check

--- a/tests/ui/macros/syntax-extension-cfg.rs
+++ b/tests/ui/macros/syntax-extension-cfg.rs
@@ -14,11 +14,11 @@ pub fn main() {
     if   cfg!(not(all(foo, qux="foo"))) { panic!() }
     if   cfg!(all(not(all(foo, qux="foo")))) { panic!() }
 
-    if cfg!(not_a_cfg) { panic!() }
-    if cfg!(all(not_a_cfg, foo, qux="foo")) { panic!() }
-    if cfg!(all(not_a_cfg, foo, qux="foo")) { panic!() }
-    if ! cfg!(any(not_a_cfg, foo)) { panic!() }
+    if cfg!(FALSE) { panic!() }
+    if cfg!(all(FALSE, foo, qux="foo")) { panic!() }
+    if cfg!(all(FALSE, foo, qux="foo")) { panic!() }
+    if ! cfg!(any(FALSE, foo)) { panic!() }
 
-    if ! cfg!(not(not_a_cfg)) { panic!() }
-    if ! cfg!(all(not(not_a_cfg), foo, qux="foo")) { panic!() }
+    if ! cfg!(not(FALSE)) { panic!() }
+    if ! cfg!(all(not(FALSE), foo, qux="foo")) { panic!() }
 }

--- a/tests/ui/methods/method-lookup-order.rs
+++ b/tests/ui/methods/method-lookup-order.rs
@@ -18,6 +18,9 @@
 
 //@ revisions: b00001 b00010 b00011 b00100 b00101 b00110 b00111 b01000 b01001 b01100 b01101 b10000 b10001 b10010 b10011 b10101 b10111 b11000 b11001 b11101
 
+//@ compile-flags: --check-cfg=cfg(inherent_mut,bar_for_foo,mutbar_for_foo)
+//@ compile-flags: --check-cfg=cfg(valbar_for_et_foo,valbar_for_etmut_foo)
+
 //@[b00001]compile-flags:  --cfg inherent_mut
 //@[b00010]compile-flags:                     --cfg bar_for_foo
 //@[b00011]compile-flags:  --cfg inherent_mut --cfg bar_for_foo

--- a/tests/ui/parser/attribute/attr-unquoted-ident.fixed
+++ b/tests/ui/parser/attribute/attr-unquoted-ident.fixed
@@ -1,6 +1,8 @@
 //@ compile-flags: -Zdeduplicate-diagnostics=yes
 //@ run-rustfix
 
+#![allow(unexpected_cfgs)]
+
 fn main() {
     #[cfg(key="foo")]
     //~^ ERROR expected unsuffixed literal, found `foo`

--- a/tests/ui/parser/attribute/attr-unquoted-ident.rs
+++ b/tests/ui/parser/attribute/attr-unquoted-ident.rs
@@ -1,6 +1,8 @@
 //@ compile-flags: -Zdeduplicate-diagnostics=yes
 //@ run-rustfix
 
+#![allow(unexpected_cfgs)]
+
 fn main() {
     #[cfg(key=foo)]
     //~^ ERROR expected unsuffixed literal, found `foo`

--- a/tests/ui/parser/attribute/attr-unquoted-ident.stderr
+++ b/tests/ui/parser/attribute/attr-unquoted-ident.stderr
@@ -1,5 +1,5 @@
 error: expected unsuffixed literal, found `foo`
-  --> $DIR/attr-unquoted-ident.rs:5:15
+  --> $DIR/attr-unquoted-ident.rs:7:15
    |
 LL |     #[cfg(key=foo)]
    |               ^^^
@@ -10,7 +10,7 @@ LL |     #[cfg(key="foo")]
    |               +   +
 
 error: expected unsuffixed literal, found `foo`
-  --> $DIR/attr-unquoted-ident.rs:11:15
+  --> $DIR/attr-unquoted-ident.rs:13:15
    |
 LL |     #[cfg(key=foo bar baz)]
    |               ^^^

--- a/tests/ui/regions/regions-refcell.rs
+++ b/tests/ui/regions/regions-refcell.rs
@@ -3,6 +3,7 @@
 // attempting to bootstrap librustc with new destructor lifetime
 // semantics.
 
+#![allow(unexpected_cfgs)] // for the cfg-as-descriptions
 
 use std::collections::HashMap;
 use std::cell::RefCell;

--- a/tests/ui/resolve/suggest-import-without-clobbering-attrs.fixed
+++ b/tests/ui/resolve/suggest-import-without-clobbering-attrs.fixed
@@ -1,8 +1,8 @@
 //@ run-rustfix
-//@ compile-flags: --cfg=whatever -Aunused
+//@ compile-flags: -Aunused
 
 use y::z;
-#[cfg(whatever)]
+#[cfg(all())]
 use y::Whatever;
 
 mod y {

--- a/tests/ui/resolve/suggest-import-without-clobbering-attrs.rs
+++ b/tests/ui/resolve/suggest-import-without-clobbering-attrs.rs
@@ -1,7 +1,7 @@
 //@ run-rustfix
-//@ compile-flags: --cfg=whatever -Aunused
+//@ compile-flags: -Aunused
 
-#[cfg(whatever)]
+#[cfg(all())]
 use y::Whatever;
 
 mod y {

--- a/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-allowed.rs
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-allowed.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ compile-flags: --cfg something
+//@ compile-flags: --cfg something --check-cfg=cfg(nothing,something)
 
 #![deny(unused_mut)]
 

--- a/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-cfg.rs
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-cfg.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --cfg something
+//@ compile-flags: --cfg something --check-cfg=cfg(nothing,something)
 //@ edition:2018
 
 #![feature(async_closure)]

--- a/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.fixed
+++ b/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.fixed
@@ -4,7 +4,7 @@
 //@ edition:2018
 
 #![deny(rust_2018_idioms)]
-#![allow(dead_code)]
+#![allow(dead_code, unexpected_cfgs)]
 
 // The suggestion span should include the attribute.
 

--- a/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.rs
+++ b/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.rs
@@ -4,7 +4,7 @@
 //@ edition:2018
 
 #![deny(rust_2018_idioms)]
-#![allow(dead_code)]
+#![allow(dead_code, unexpected_cfgs)]
 
 // The suggestion span should include the attribute.
 

--- a/tests/ui/shell-argfiles/shell-argfiles-via-argfile.rs
+++ b/tests/ui/shell-argfiles/shell-argfiles-via-argfile.rs
@@ -1,6 +1,7 @@
 // Check to see if we can get parameters from an @argsfile file
 //
 //@ build-pass
+//@ no-auto-check-cfg
 //@ compile-flags: @{{src-base}}/shell-argfiles/shell-argfiles-via-argfile.args @shell:{{src-base}}/shell-argfiles/shell-argfiles-via-argfile-shell.args
 
 #[cfg(not(shell_args_set))]

--- a/tests/ui/shell-argfiles/shell-argfiles.args
+++ b/tests/ui/shell-argfiles/shell-argfiles.args
@@ -1,3 +1,4 @@
 --cfg unquoted_set
 '--cfg' 'single_quoted_set'
 "--cfg" "double_quoted_set"
+--check-cfg 'cfg(cmdline_set, unquoted_set, single_quoted_set, double_quoted_set)'

--- a/tests/ui/sse2.rs
+++ b/tests/ui/sse2.rs
@@ -2,6 +2,7 @@
 
 #![allow(stable_features)]
 #![feature(cfg_target_feature)]
+#![feature(lint_reasons)]
 
 use std::env;
 
@@ -20,6 +21,7 @@ fn main() {
                 "SSE2 was not detected as available on an x86 platform");
     }
     // check a negative case too -- certainly not enabled by default
-    assert!(cfg!(not(target_feature = "ferris_wheel")),
-            "🎡 shouldn't be detected as available by default on any platform");
+    #[expect(unexpected_cfgs)]
+    { assert!(cfg!(not(target_feature = "ferris_wheel")),
+            "🎡 shouldn't be detected as available by default on any platform") };
 }

--- a/tests/ui/target-feature/no-llvm-leaks.rs
+++ b/tests/ui/target-feature/no-llvm-leaks.rs
@@ -6,7 +6,7 @@
 //@ build-pass
 #![no_core]
 #![crate_type = "rlib"]
-#![feature(intrinsics, rustc_attrs, no_core, lang_items, staged_api)]
+#![feature(intrinsics, rustc_attrs, no_core, lang_items, staged_api, lint_reasons)]
 #![stable(feature = "test", since = "1.0.0")]
 
 // Supporting minimal rust core code
@@ -43,22 +43,30 @@ macro_rules! assert {
 
 #[cfg(target_arch = "aarch64")]
 fn check_aarch64() {
-    // This checks that the rustc feature name is used, not the LLVM feature.
+    // These checks that the rustc feature name is used, not the LLVM feature.
+
     assert!(cfg!(target_feature = "neon"));
-    assert!(cfg!(not(target_feature = "fp-armv8")));
+    // #[expect(unexpected_cfgs)] except that 32-bit arm actually use fp-armv8
+    { assert!(cfg!(not(target_feature = "fp-armv8"))); }
+
     assert!(cfg!(target_feature = "fhm"));
-    assert!(cfg!(not(target_feature = "fp16fml")));
+    #[expect(unexpected_cfgs)]
+    { assert!(cfg!(not(target_feature = "fp16fml"))); }
+
     assert!(cfg!(target_feature = "fp16"));
-    assert!(cfg!(not(target_feature = "fullfp16")));
+    #[expect(unexpected_cfgs)]
+    { assert!(cfg!(not(target_feature = "fullfp16"))); }
 }
 
 #[cfg(target_arch = "x86_64")]
 fn check_x86_64() {
     // This checks that the rustc feature name is used, not the LLVM feature.
     assert!(cfg!(target_feature = "rdrand"));
-    assert!(cfg!(not(target_feature = "rdrnd")));
+    #[expect(unexpected_cfgs)]
+    { assert!(cfg!(not(target_feature = "rdrnd"))); }
 
     // Likewise: We enable LLVM's crc32 feature with SSE4.2, but Rust says it's just SSE4.2
     assert!(cfg!(target_feature = "sse4.2"));
-    assert!(cfg!(not(target_feature = "crc32")));
+    #[expect(unexpected_cfgs)]
+    { assert!(cfg!(not(target_feature = "crc32"))); }
 }


### PR DESCRIPTION
This PR enables-by-default `--check-cfg` in UI tests, now that it has become stable.

To do so this PR does 2 main things:
 - it introduce the `no-auto-check-cfg` directive to `compiletest`, to prevent any `--check-cfg` args (only to be used for `--check-cfg` tests)
 - it updates the _remaining_[^1] UI tests by either:
     - allowing the lint when neither expecting the lint nor giving the check-cfg args make sense
     - give the appropriate check-cfg args
     - or expect the lint, when it useful

[^1]: some preparation work was done in #123577 #123702

I highly recommend reviewing this PR commit-by-commit.

r? @jieyouxu 