### PR TITLE
Add support for downloading `libgccjit.so` file

### DIFF
--- a/compiler/rustc_codegen_gcc/build_system/src/config.rs
+++ b/compiler/rustc_codegen_gcc/build_system/src/config.rs
@@ -444,15 +444,17 @@ impl ConfigInfo {
             "build_sysroot/sysroot/lib/rustlib/{}/lib",
             self.target_triple,
         ));
-        let ld_library_path = format!(
-            "{target}:{sysroot}:{gcc_path}",
-            target = self.cargo_target_dir,
-            sysroot = sysroot.display(),
-            gcc_path = self.gcc_path,
-        );
-        env.insert("LIBRARY_PATH".to_string(), ld_library_path.clone());
-        env.insert("LD_LIBRARY_PATH".to_string(), ld_library_path.clone());
-        env.insert("DYLD_LIBRARY_PATH".to_string(), ld_library_path);
+        if !use_system_gcc {
+            let ld_library_path = format!(
+                "{target}:{sysroot}:{gcc_path}",
+                target = self.cargo_target_dir,
+                sysroot = sysroot.display(),
+                gcc_path = self.gcc_path,
+            );
+            env.insert("LIBRARY_PATH".to_string(), ld_library_path.clone());
+            env.insert("LD_LIBRARY_PATH".to_string(), ld_library_path.clone());
+            env.insert("DYLD_LIBRARY_PATH".to_string(), ld_library_path);
+        }
 
         // NOTE: To avoid the -fno-inline errors, use /opt/gcc/bin/gcc instead of cc.
         // To do so, add a symlink for cc to /opt/gcc/bin/gcc in our PATH.

--- a/config.example.toml
+++ b/config.example.toml
@@ -156,6 +156,13 @@
 #build-config = {}
 
 # =============================================================================
+# General configuration options for the GCC backend
+# =============================================================================
+[gcc]
+# Change to `true` if you want to use the version used in Rust CI.
+# download-gccjit = false
+
+# =============================================================================
 # General build configuration options
 # =============================================================================
 [build]

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3503,6 +3503,7 @@ impl Step for CodegenGCC {
             // Avoid incremental cache issues when changing rustc
             cargo.env("CARGO_BUILD_INCREMENTAL", "false");
             cargo.rustflag("-Cpanic=abort");
+            cargo.add_rustc_lib_path(builder);
 
             cargo
         };

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -21,8 +21,10 @@ use crate::core::config::flags::{Color, Subcommand};
 use crate::core::config::{DryRun, SplitDebuginfo, TargetSelection};
 use crate::prepare_behaviour_dump_dir;
 use crate::utils::cache::Cache;
-use crate::utils::helpers::{self, add_dylib_path, add_link_lib_path, exe, linker_args};
-use crate::utils::helpers::{check_cfg_arg, libdir, linker_flags, output, t, LldThreads};
+use crate::utils::helpers::{
+    self, add_dylib_path, add_link_lib_path, check_cfg_arg, detect_gccjit_sha, exe, libdir,
+    linker_args, linker_flags, output, t, LldThreads,
+};
 use crate::EXTRA_CHECK_CFGS;
 use crate::{Build, CLang, Crate, DocTests, GitRepo, Mode};
 
@@ -1195,6 +1197,10 @@ impl<'a> Builder<'a> {
         if self.config.llvm_from_ci {
             let ci_llvm_lib = self.out.join(&*compiler.host.triple).join("ci-llvm").join("lib");
             dylib_dirs.push(ci_llvm_lib);
+        }
+        if self.config.gcc_download_gccjit {
+            let libgccjit_path = self.config.libgccjit_folder(&detect_gccjit_sha());
+            dylib_dirs.push(libgccjit_path);
         }
 
         dylib_dirs

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -598,3 +598,22 @@ pub fn check_cfg_arg(name: &str, values: Option<&[&str]>) -> String {
     };
     format!("--check-cfg=cfg({name}{next})")
 }
+
+/// This retrieves the gccjit sha we use.
+pub fn detect_gccjit_sha() -> String {
+    // FIXME: This is absolutely ugly. Please find another way to do that.
+    let content = include_str!("../../../ci/docker/host-x86_64/dist-x86_64-linux/build-gccjit.sh");
+    if let Some(commit) = content
+        .lines()
+        .filter_map(|line| line.strip_prefix("GIT_COMMIT=\""))
+        .filter_map(|commit| commit.strip_suffix('"'))
+        .next()
+    {
+        if !commit.is_empty() {
+            return commit.to_string();
+        }
+    }
+
+    eprintln!("error: could not find commit hash for downloading libgccjit");
+    panic!();
+}


### PR DESCRIPTION
It'll greatly improve the experience for anyone wanting to work on the GCC backend from the compiler.

Should help with https://github.com/rust-lang/rust/issues/124172.

r? @onur-ozkan 