### PR TITLE
[EXPERIMENT] Crater adding `target_family = "linux"`

### DIFF
--- a/compiler/rustc_target/src/spec/base/android.rs
+++ b/compiler/rustc_target/src/spec/base/android.rs
@@ -1,5 +1,7 @@
 use crate::spec::{base, SanitizerSet, TargetOptions, TlsModel};
 
+use crate::spec::cvs;
+
 pub fn opts() -> TargetOptions {
     let mut base = base::linux::opts();
     base.os = "android".into();

--- a/compiler/rustc_target/src/spec/base/android.rs
+++ b/compiler/rustc_target/src/spec/base/android.rs
@@ -3,6 +3,8 @@ use crate::spec::{base, SanitizerSet, TargetOptions, TlsModel};
 pub fn opts() -> TargetOptions {
     let mut base = base::linux::opts();
     base.os = "android".into();
+    // listing families in different orders seems most chaotic. :^)
+    base.families = cvs!["unix, linux"];
     base.is_like_android = true;
     base.default_dwarf_version = 2;
     base.tls_model = TlsModel::Emulated;

--- a/compiler/rustc_target/src/spec/base/android.rs
+++ b/compiler/rustc_target/src/spec/base/android.rs
@@ -6,7 +6,7 @@ pub fn opts() -> TargetOptions {
     let mut base = base::linux::opts();
     base.os = "android".into();
     // listing families in different orders seems most chaotic. :^)
-    base.families = cvs!["unix, linux"];
+    base.families = cvs!["unix", "linux"];
     base.is_like_android = true;
     base.default_dwarf_version = 2;
     base.tls_model = TlsModel::Emulated;

--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -150,7 +150,7 @@ pub fn opts(os: &'static str, arch: Arch) -> TargetOptions {
         function_sections: false,
         dynamic_linking: true,
         pre_link_args: pre_link_args(os, arch, abi),
-        families: cvs!["unix"],
+        families: cvs!["apple", "unix"],
         is_like_osx: true,
         // LLVM notes that macOS 10.11+ and iOS 9+ default
         // to v4, so we do the same.

--- a/compiler/rustc_target/src/spec/base/linux.rs
+++ b/compiler/rustc_target/src/spec/base/linux.rs
@@ -5,7 +5,7 @@ pub fn opts() -> TargetOptions {
     TargetOptions {
         os: "linux".into(),
         dynamic_linking: true,
-        families: cvs!["unix"],
+        families: cvs!["linux", "unix"],
         has_rpath: true,
         position_independent_executables: true,
         relro_level: RelroLevel::Full,


### PR DESCRIPTION
The lang team proposed, a while back, [deprecating `target_vendor`](https://github.com/rust-lang/rust/issues/100343).

With five operating systems all from Apple, using very similar, unifying characteristics for each, it is untenable to ask people to `cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos", target_os = "tvos", target_os = "visionos"))`. It is commonly preferred to use `target_vendor = "apple"` for things that are true for all of these OS variants, and we have to offer a replacement that is equally parsimonious.

[The "obvious" choice is to add a `target_family = "apple"`](https://github.com/rust-lang/lang-team/issues/102#issue-936041579). However, [there is a concern that adding a `target_family = "apple"` won't work without massive ecosystem breakage, because of poorly-designed build scripts](https://github.com/rust-lang/lang-team/issues/102#issuecomment-1098231398). But we currently can't crater a test of that effectively, because most tests only test host compilation, and crater only runs on Linux.

We could, however, test adding a hypothetical `target_family = "linux"`! This would be a hypothetical `target_family` that unites both `target_os = "linux"` and `target_os = "android"` targets. This isn't necessarily an "apples to apples" comparison (more like "penguins to robots"?) but it seems worth trying.

Note that this is **not** a proposal to actually add such a `target_family`. I don't have any arguments about the merits beyond "it seems like a plausible target family we may one day add, it can be added in a way that disrupts relevant build scripts, and it impacts a 'high-value' target".

For maximum coverage I have in fact added the relevant `target_family = "apple"` and `target_family = "linux"` also just in case any test suites somehow run cross-compilation tests.