### PR TITLE
Cleanup: Replace item names referencing GitHub issues or error codes with something more meaningful

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -632,20 +632,19 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn emit_e0568(&self, span: Span, ident: Span) {
-        self.dcx().emit_err(errors::AutoTraitBounds { span, ident });
-    }
-
     fn deny_super_traits(&self, bounds: &GenericBounds, ident_span: Span) {
         if let [.., last] = &bounds[..] {
             let span = ident_span.shrink_to_hi().to(last.span());
-            self.emit_e0568(span, ident_span);
+            self.dcx().emit_err(errors::AutoTraitBounds { span, ident: ident_span });
         }
     }
 
     fn deny_where_clause(&self, where_clause: &WhereClause, ident_span: Span) {
         if !where_clause.predicates.is_empty() {
-            self.emit_e0568(where_clause.span, ident_span);
+            // FIXME: The current diagnostic is misleading since it only talks about
+            // super trait and lifetime bounds while we should just say “bounds”.
+            self.dcx()
+                .emit_err(errors::AutoTraitBounds { span: where_clause.span, ident: ident_span });
         }
     }
 

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -144,9 +144,9 @@ pub fn make_display(f: impl Fn(&mut fmt::Formatter<'_>) -> fmt::Result) -> impl 
     Printer { f }
 }
 
-// See comments in compiler/rustc_middle/src/tests.rs
+// See comment in compiler/rustc_middle/src/tests.rs and issue #27438.
 #[doc(hidden)]
-pub fn __noop_fix_for_27438() {}
+pub fn __noop_fix_for_windows_dllimport_issue() {}
 
 #[macro_export]
 macro_rules! external_bitflags_debug {

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -201,6 +201,12 @@ hir_analysis_inherent_ty_outside_relevant = cannot define inherent `impl` for a 
     .help = consider moving this inherent impl into the crate defining the type if possible
     .span_help = alternatively add `#[rustc_allow_incoherent_impl]` to the relevant impl items
 
+hir_analysis_invalid_receiver_ty = invalid `self` parameter type: `{$receiver_ty}`
+    .note = type of `self` must be `Self` or a type that dereferences to it
+
+hir_analysis_invalid_receiver_ty_help =
+    consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+
 hir_analysis_invalid_union_field =
     field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
     .note = union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1641,3 +1641,13 @@ pub struct NonConstRange {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_invalid_receiver_ty, code = E0307)]
+#[note]
+#[help(hir_analysis_invalid_receiver_ty_help)]
+pub struct InvalidReceiverTy<'tcx> {
+    #[primary_span]
+    pub span: Span,
+    pub receiver_ty: Ty<'tcx>,
+}

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -1228,16 +1228,22 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 );
             }
         } else {
-            // Pattern has wrong number of fields.
-            let e =
-                self.e0023(pat.span, res, qpath, subpats, &variant.fields.raw, expected, had_err);
+            let e = self.emit_err_pat_wrong_number_of_fields(
+                pat.span,
+                res,
+                qpath,
+                subpats,
+                &variant.fields.raw,
+                expected,
+                had_err,
+            );
             on_error(e);
             return Ty::new_error(tcx, e);
         }
         pat_ty
     }
 
-    fn e0023(
+    fn emit_err_pat_wrong_number_of_fields(
         &self,
         pat_span: Span,
         res: Res,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -847,8 +847,10 @@ rustc_queries! {
         separate_provide_extern
     }
 
-    query issue33140_self_ty(key: DefId) -> Option<ty::EarlyBinder<ty::Ty<'tcx>>> {
-        desc { |tcx| "computing Self type wrt issue #33140 `{}`", tcx.def_path_str(key) }
+    query self_ty_of_trait_impl_enabling_order_dep_trait_object_hack(
+        key: DefId
+    ) -> Option<ty::EarlyBinder<ty::Ty<'tcx>>> {
+        desc { |tcx| "computing self type wrt issue #33140 `{}`", tcx.def_path_str(key) }
     }
 
     /// Maps a `DefId` of a type to a list of its inherent impls.

--- a/compiler/rustc_middle/src/tests.rs
+++ b/compiler/rustc_middle/src/tests.rs
@@ -1,11 +1,9 @@
-// FIXME(#27438): right now the unit tests of rustc_middle don't refer to any actual
-//                functions generated in rustc_data_structures (all
-//                references are through generic functions), but statics are
-//                referenced from time to time. Due to this bug we won't
-//                actually correctly link in the statics unless we also
-//                reference a function, so be sure to reference a dummy
-//                function.
+// FIXME(#27438): Right now, the unit tests of `rustc_middle` don't refer to any actual functions
+//                generated in `rustc_data_structures` (all references are through generic functions),
+//                but statics are referenced from time to time. Due to this Windows `dllimport` bug
+//                we won't actually correctly link in the statics unless we also reference a function,
+//                so be sure to reference a dummy function.
 #[test]
 fn noop() {
-    rustc_data_structures::__noop_fix_for_27438();
+    rustc_data_structures::__noop_fix_for_windows_dllimport_issue();
 }

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -10,9 +10,7 @@ use rustc_arena::{DroplessArena, TypedArena};
 use rustc_ast::Mutability;
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_errors::{
-    codes::*, struct_span_code_err, Applicability, Diag, ErrorGuaranteed, MultiSpan,
-};
+use rustc_errors::{codes::*, struct_span_code_err, Applicability, ErrorGuaranteed, MultiSpan};
 use rustc_hir::def::*;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{self as hir, BindingMode, ByRef, HirId};
@@ -24,7 +22,6 @@ use rustc_middle::ty::{self, AdtDef, Ty, TyCtxt};
 use rustc_session::lint::builtin::{
     BINDINGS_WITH_VARIANT_NAME, IRREFUTABLE_LET_PATTERNS, UNREACHABLE_PATTERNS,
 };
-use rustc_session::Session;
 use rustc_span::hygiene::DesugaringKind;
 use rustc_span::{sym, Span};
 
@@ -62,10 +59,6 @@ pub(crate) fn check_match(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(), Err
         }
     }
     visitor.error
-}
-
-fn create_e0004(sess: &Session, sp: Span, error_message: String) -> Diag<'_> {
-    struct_span_code_err!(sess.dcx(), sp, E0004, "{}", &error_message)
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -975,10 +968,11 @@ fn report_non_exhaustive_match<'p, 'tcx>(
 
     // FIXME: migration of this diagnostic will require list support
     let joined_patterns = joined_uncovered_patterns(cx, &witnesses);
-    let mut err = create_e0004(
-        cx.tcx.sess,
+    let mut err = struct_span_code_err!(
+        cx.tcx.dcx(),
         sp,
-        format!("non-exhaustive patterns: {joined_patterns} not covered"),
+        E0004,
+        "non-exhaustive patterns: {joined_patterns} not covered"
     );
     err.span_label(
         sp,

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2001,7 +2001,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
                     // any associated items and there are no where-clauses.
                     //
                     // We can just arbitrarily drop one of the impls.
-                    Some(ty::ImplOverlapKind::Issue33140) => {
+                    Some(ty::ImplOverlapKind::FutureCompatOrderDepTraitObjects) => {
                         assert_eq!(other.evaluation, victim.evaluation);
                         DropVictim::Yes
                     }

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -453,7 +453,7 @@ fn report_conflicting_impls<'tcx>(
             overlap.trait_ref.print_trait_sugared(),
             overlap.self_ty.map_or_else(String::new, |ty| format!(" for type `{ty}`")),
             match used_to_be_allowed {
-                Some(FutureCompatOverlapErrorKind::Issue33140) => ": (E0119)",
+                Some(FutureCompatOverlapErrorKind::OrderDepTraitObjects) => ": (E0119)",
                 _ => "",
             }
         )
@@ -480,7 +480,7 @@ fn report_conflicting_impls<'tcx>(
         }
         Some(kind) => {
             let lint = match kind {
-                FutureCompatOverlapErrorKind::Issue33140 => ORDER_DEPENDENT_TRAIT_OBJECTS,
+                FutureCompatOverlapErrorKind::OrderDepTraitObjects => ORDER_DEPENDENT_TRAIT_OBJECTS,
                 FutureCompatOverlapErrorKind::LeakCheck => COHERENCE_LEAK_CHECK,
             };
             tcx.node_span_lint(

--- a/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
@@ -11,7 +11,7 @@ pub use rustc_middle::traits::specialization_graph::*;
 
 #[derive(Copy, Clone, Debug)]
 pub enum FutureCompatOverlapErrorKind {
-    Issue33140,
+    OrderDepTraitObjects,
     LeakCheck,
 }
 
@@ -150,10 +150,10 @@ impl<'tcx> Children {
                 {
                     match overlap_kind {
                         ty::ImplOverlapKind::Permitted { marker: _ } => {}
-                        ty::ImplOverlapKind::Issue33140 => {
+                        ty::ImplOverlapKind::FutureCompatOrderDepTraitObjects => {
                             *last_lint_mut = Some(FutureCompatOverlapError {
                                 error: create_overlap_error(overlap),
-                                kind: FutureCompatOverlapErrorKind::Issue33140,
+                                kind: FutureCompatOverlapErrorKind::OrderDepTraitObjects,
                             });
                         }
                     }

--- a/tests/ui/async-await/inference_var_self_argument.rs
+++ b/tests/ui/async-await/inference_var_self_argument.rs
@@ -4,7 +4,7 @@
 trait Foo {
     async fn foo(self: &dyn Foo) {
         //~^ ERROR: `Foo` cannot be made into an object
-        //~| ERROR invalid `self` parameter type: &dyn Foo
+        //~| ERROR invalid `self` parameter type: `&dyn Foo`
         todo!()
     }
 }

--- a/tests/ui/async-await/inference_var_self_argument.stderr
+++ b/tests/ui/async-await/inference_var_self_argument.stderr
@@ -13,7 +13,7 @@ LL |     async fn foo(self: &dyn Foo) {
    |              ^^^ ...because method `foo` is `async`
    = help: consider moving `foo` to another trait
 
-error[E0307]: invalid `self` parameter type: &dyn Foo
+error[E0307]: invalid `self` parameter type: `&dyn Foo`
   --> $DIR/inference_var_self_argument.rs:5:24
    |
 LL |     async fn foo(self: &dyn Foo) {

--- a/tests/ui/async-await/issue-66312.stderr
+++ b/tests/ui/async-await/issue-66312.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     if x.is_some() {
    |        ^^^^^^^^^^^ expected `bool`, found `()`
 
-error[E0307]: invalid `self` parameter type: T
+error[E0307]: invalid `self` parameter type: `T`
   --> $DIR/issue-66312.rs:4:22
    |
 LL |     fn is_some(self: T);

--- a/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-cell.rs
+++ b/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-cell.rs
@@ -3,7 +3,7 @@
 use std::cell::Cell;
 
 trait Trait{
-    fn cell(self: Cell<&Self>); //~ ERROR invalid `self` parameter type: Cell<&Self>
+    fn cell(self: Cell<&Self>); //~ ERROR invalid `self` parameter type: `Cell<&Self>`
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-cell.stderr
+++ b/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-cell.stderr
@@ -1,4 +1,4 @@
-error[E0307]: invalid `self` parameter type: Cell<&Self>
+error[E0307]: invalid `self` parameter type: `Cell<&Self>`
   --> $DIR/feature-gate-dispatch-from-dyn-cell.rs:6:19
    |
 LL |     fn cell(self: Cell<&Self>);

--- a/tests/ui/issues/issue-56806.stderr
+++ b/tests/ui/issues/issue-56806.stderr
@@ -1,4 +1,4 @@
-error[E0307]: invalid `self` parameter type: Box<(dyn Trait + 'static)>
+error[E0307]: invalid `self` parameter type: `Box<(dyn Trait + 'static)>`
   --> $DIR/issue-56806.rs:2:34
    |
 LL |     fn dyn_instead_of_self(self: Box<dyn Trait>);

--- a/tests/ui/self/arbitrary-self-opaque.rs
+++ b/tests/ui/self/arbitrary-self-opaque.rs
@@ -6,7 +6,7 @@ type Bar = impl Sized;
 
 impl Foo {
     fn foo(self: Bar) {}
-    //~^ ERROR: invalid `self` parameter type: Bar
+    //~^ ERROR: invalid `self` parameter type: `Bar`
 }
 
 fn main() {}

--- a/tests/ui/self/arbitrary-self-opaque.stderr
+++ b/tests/ui/self/arbitrary-self-opaque.stderr
@@ -6,7 +6,7 @@ LL | type Bar = impl Sized;
    |
    = note: `Bar` must be used in combination with a concrete type within the same module
 
-error[E0307]: invalid `self` parameter type: Bar
+error[E0307]: invalid `self` parameter type: `Bar`
   --> $DIR/arbitrary-self-opaque.rs:8:18
    |
 LL |     fn foo(self: Bar) {}

--- a/tests/ui/span/issue-27522.stderr
+++ b/tests/ui/span/issue-27522.stderr
@@ -1,4 +1,4 @@
-error[E0307]: invalid `self` parameter type: &SomeType
+error[E0307]: invalid `self` parameter type: `&SomeType`
   --> $DIR/issue-27522.rs:6:22
    |
 LL |     fn handler(self: &SomeType);

--- a/tests/ui/suggestions/object-unsafe-trait-should-use-where-sized.stderr
+++ b/tests/ui/suggestions/object-unsafe-trait-should-use-where-sized.stderr
@@ -26,7 +26,7 @@ help: consider changing method `bar`'s `self` parameter to be `&self`
 LL |     fn bar(self: &Self) {}
    |                  ~~~~~
 
-error[E0307]: invalid `self` parameter type: ()
+error[E0307]: invalid `self` parameter type: `()`
   --> $DIR/object-unsafe-trait-should-use-where-sized.rs:6:18
    |
 LL |     fn bar(self: ()) {}

--- a/tests/ui/traits/issue-78372.rs
+++ b/tests/ui/traits/issue-78372.rs
@@ -6,7 +6,7 @@ impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {} //~ ERROR cannot find type `U` 
 //~| ERROR the trait `DispatchFromDyn` may only be implemented for a coercion between structures
 trait Foo: X<u32> {}
 trait X<T> {
-    fn foo(self: Smaht<Self, T>); //~ ERROR: invalid `self`
+    fn foo(self: Smaht<Self, T>); //~ ERROR: invalid `self` parameter type
 }
 trait Marker {}
 impl Marker for dyn Foo {}

--- a/tests/ui/traits/issue-78372.stderr
+++ b/tests/ui/traits/issue-78372.stderr
@@ -79,7 +79,7 @@ LL | trait X<T> {
 LL |     fn foo(self: Smaht<Self, T>);
    |                  ^^^^^^^^^^^^^^ ...because method `foo`'s `self` parameter cannot be dispatched on
 
-error[E0307]: invalid `self` parameter type: Smaht<Self, T>
+error[E0307]: invalid `self` parameter type: `Smaht<Self, T>`
   --> $DIR/issue-78372.rs:9:18
    |
 LL |     fn foo(self: Smaht<Self, T>);

--- a/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
+++ b/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
@@ -15,7 +15,7 @@ LL |     fn dummy2(&self);
    = note: expected signature `fn(&&'a Bar<_>)`
               found signature `fn(&Bar<_>)`
 
-error[E0307]: invalid `self` parameter type: isize
+error[E0307]: invalid `self` parameter type: `isize`
   --> $DIR/ufcs-explicit-self-bad.rs:8:18
    |
 LL |     fn foo(self: isize, x: isize) -> isize {
@@ -24,7 +24,7 @@ LL |     fn foo(self: isize, x: isize) -> isize {
    = note: type of `self` must be `Self` or a type that dereferences to it
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error[E0307]: invalid `self` parameter type: Bar<isize>
+error[E0307]: invalid `self` parameter type: `Bar<isize>`
   --> $DIR/ufcs-explicit-self-bad.rs:19:18
    |
 LL |     fn foo(self: Bar<isize>, x: isize) -> isize {
@@ -33,7 +33,7 @@ LL |     fn foo(self: Bar<isize>, x: isize) -> isize {
    = note: type of `self` must be `Self` or a type that dereferences to it
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error[E0307]: invalid `self` parameter type: &Bar<usize>
+error[E0307]: invalid `self` parameter type: `&Bar<usize>`
   --> $DIR/ufcs-explicit-self-bad.rs:23:18
    |
 LL |     fn bar(self: &Bar<usize>, x: isize) -> isize {


### PR DESCRIPTION
**lcnr** in https://github.com/rust-lang/rust/pull/117164#pullrequestreview-1969935387:

> […] while I know that there's precendent to name things `Issue69420`, I really dislike this as it requires looking up the issue to figure out the purpose of such a variant. Actually referring to the underlying issue, e.g. `AliasMayNormToUncovered` or whatever and then linking to the issue in a doc comment feels a lot more desirable to me. We should ideally rename all the functions and enums which currently use issue numbers.

I've grepped through `compiler/` like crazy and think that I've found all instances of this pattern.
However, I haven't renamed `compute_2229_migrations_*`. Should I?

The first commit introduces an abhorrent and super long name for an item because naming is hard but also scary looking / unwelcoming names are good for things related to temporary-ish backcompat hacks. I'll let you discover it by yourself.

Contains a bit of drive-by cleanup and a diag migration bc that was the simplest option.

r? lcnr or compiler