### PR TITLE
bootstrap: Avoid `Invalid cross-device link (os error 18)` for downloads

### DIFF
--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -197,7 +197,9 @@ impl Config {
     fn download_file(&self, url: &str, dest_path: &Path, help_on_error: &str) {
         self.verbose(|| println!("download {url}"));
         // Use a temporary file in case we crash while downloading, to avoid a corrupt download in cache/.
-        let tempfile = self.tempdir().join(dest_path.file_name().unwrap());
+        // Download to the same directory as the final file to avoid having to move it across file systems.
+        let mut tempfile = dest_path.to_owned();
+        tempfile.set_extension("incomplete-bootstrap-download");
         // While bootstrap itself only supports http and https downloads, downstream forks might
         // need to download components from other protocols. The match allows them adding more
         // protocols without worrying about merge conflicts if we change the HTTP implementation.


### PR DESCRIPTION
When I do

    src/ci/docker/run.sh --dev armhf-gnu
    ../x test --target arm-unknown-linux-gnueabihf tests/ui/compiletest-self-test/test-aux-bin.rs

I get

    downloading https://static.rust-lang.org/dist/2024-03-19/rustfmt-nightly-x86_64-unknown-linux-gnu.tar.xz
    ################################################################################### 100.0%
    thread 'main' panicked at src/core/download.rs:211:9:
    std::fs::rename(&tempfile, dest_path) failed with Invalid cross-device link (os error 18) ("failed to rename \"/checkout/obj/build/tmp/rustfmt-nightly-x86_64-unknown-linux-gnu.tar.xz\" to \"/home/martin/.cache/x-cache/2024-03-19/rustfmt-nightly-x86_64-unknown-linux-gnu.tar.xz\"")
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    Build completed unsuccessfully in 0:00:00


in WSL2. Fix this by downloading the temp file to the same file system as the destination file.