### PR TITLE
[experiment] Build the compiler with panic=abort

### DIFF
--- a/compiler/rustc/src/main.rs
+++ b/compiler/rustc/src/main.rs
@@ -1,4 +1,6 @@
 #![feature(unix_sigpipe)]
+// We need this feature as it changes `dylib` linking behavior and allows us to link to `rustc_driver`.
+#![feature(rustc_private)]
 
 // A note about jemalloc: rustc uses jemalloc when built for CI and
 // distribution. The obvious way to do this is with the `#[global_allocator]`

--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -41,6 +41,9 @@ metadata_crate_dep_multiple =
 metadata_crate_dep_not_static =
     `{$crate_name}` was unavailable as a static crate, preventing fully static linking
 
+metadata_crate_dep_rustc_driver =
+    `feature(rustc_private)` is needed to link to the compiler's `rustc_driver` library
+
 metadata_crate_location_unknown_type =
     extern location for {$crate_name} is of an unknown type: {$path}
 

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -40,6 +40,8 @@ pub struct CrateDepMultiple {
     pub crate_name: Symbol,
     #[subdiagnostic]
     pub non_static_deps: Vec<NonStaticCrateDep>,
+    #[subdiagnostic]
+    pub rustc_driver_help: Option<RustcDriverHelp>,
 }
 
 #[derive(Subdiagnostic)]
@@ -47,6 +49,10 @@ pub struct CrateDepMultiple {
 pub struct NonStaticCrateDep {
     pub crate_name: Symbol,
 }
+
+#[derive(Subdiagnostic)]
+#[help(metadata_crate_dep_rustc_driver)]
+pub struct RustcDriverHelp;
 
 #[derive(Diagnostic)]
 #[diag(metadata_two_panic_runtimes)]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1573,6 +1573,7 @@ symbols! {
         rustc_dirty,
         rustc_do_not_const_check,
         rustc_doc_primitive,
+        rustc_driver,
         rustc_dummy,
         rustc_dump_env_program_clauses,
         rustc_dump_program_clauses,

--- a/src/bootstrap/src/bin/rustc.rs
+++ b/src/bootstrap/src/bin/rustc.rs
@@ -91,6 +91,23 @@ fn main() {
         rustc_real
     };
 
+    // Get the name of the crate we're compiling, if any.
+    let crate_name = arg("--crate-name");
+
+    // We want everything statically linked into `rustc_driver`, so remove `-C prefer-dynamic`
+    if crate_name == Some("rustc_driver") && stage != "0" {
+        // Remove `-C prefer-dynamic` to link `std` statically into `rustc_driver`
+        if let Some(pos) = args.iter().enumerate().position(|(i, a)| {
+            a == "-C" && args.get(i + 1).map(|a| a == "prefer-dynamic").unwrap_or(false)
+        }) {
+            args.remove(pos);
+            args.remove(pos);
+        }
+        if let Some(pos) = args.iter().position(|a| a == "-Cprefer-dynamic") {
+            args.remove(pos);
+        }
+    }
+
     let mut cmd = if let Some(wrapper) = env::var_os("RUSTC_WRAPPER_REAL") {
         let mut cmd = Command::new(wrapper);
         cmd.arg(rustc_driver);
@@ -99,9 +116,6 @@ fn main() {
         Command::new(rustc_driver)
     };
     cmd.args(&args).env(dylib_path_var(), env::join_paths(&dylib_path).unwrap());
-
-    // Get the name of the crate we're compiling, if any.
-    let crate_name = arg("--crate-name");
 
     if let Some(crate_name) = crate_name {
         if let Some(target) = env::var_os("RUSTC_TIME") {

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1081,6 +1081,7 @@ pub fn rustc_cargo(
 
     if compiler.stage != 0 {
         cargo.rustflag("-Cpanic=abort");
+        cargo.rustflag("-Cforce-unwind-tables=yes");
     }
 
     rustc_cargo_env(builder, cargo, target, compiler.stage);

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1780,7 +1780,12 @@ impl Step for Assemble {
         let src_libdir = builder.sysroot_libdir(build_compiler, host);
         for f in builder.read_dir(&src_libdir) {
             let filename = f.file_name().into_string().unwrap();
-            if (is_dylib(&filename) || is_debug_info(&filename)) && !proc_macros.contains(&filename)
+            let can_be_rustc_dep = filename.starts_with("rustc_driver-")
+                || filename.starts_with("librustc_driver-")
+                || build_compiler.stage == 0;
+            if can_be_rustc_dep
+                && (is_dylib(&filename) || is_debug_info(&filename))
+                && !proc_macros.contains(&filename)
             {
                 builder.copy_link(&f.path(), &rustc_libdir.join(&filename));
             }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1079,6 +1079,10 @@ pub fn rustc_cargo(
         ));
     }
 
+    if compiler.stage != 0 {
+        cargo.rustflag("-Cpanic=abort");
+    }
+
     rustc_cargo_env(builder, cargo, target, compiler.stage);
 }
 

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -166,6 +166,19 @@ pub fn prepare_tool_cargo(
         }
     }
 
+    if compiler.stage != 0 {
+        if path.ends_with("rls")
+            || path.ends_with("clippy")
+            || path.ends_with("miri")
+            || path.ends_with("rustfmt")
+            || path.ends_with("rustdoc")
+            || path.ends_with("rustdoc-tool")
+        {
+            cargo.rustflag("-Cpanic=abort");
+            cargo.rustflag("-Cforce-unwind-tables=yes");
+        }
+    }
+
     // clippy tests need to know about the stage sysroot. Set them consistently while building to
     // avoid rebuilding when running tests.
     cargo.env("SYSROOT", builder.sysroot(compiler));

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -2064,7 +2064,7 @@ impl<'a> Builder<'a> {
         // When we build Rust dylibs they're all intended for intermediate
         // usage, so make sure we pass the -Cprefer-dynamic flag instead of
         // linking all deps statically into the dylib.
-        if matches!(mode, Mode::Std | Mode::Rustc) {
+        if matches!(mode, Mode::Std) {
             rustflags.arg("-Cprefer-dynamic");
         }
 

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -84,7 +84,7 @@ pr:
 try:
   - image: dist-x86_64-linux
     env:
-      CODEGEN_BACKENDS: llvm,cranelift
+      CODEGEN_BACKENDS: llvm
     <<: *job-linux-16c
 
 # Main CI jobs that have to be green to merge a commit into master

--- a/src/tools/clippy/src/main.rs
+++ b/src/tools/clippy/src/main.rs
@@ -1,3 +1,6 @@
+// We need this feature as it changes `dylib` linking behavior and allows us to link to
+// `rustc_driver`.
+#![feature(rustc_private)]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 // warn on lints, that are included in `rust-lang/rust`s bootstrap
 #![warn(rust_2018_idioms, unused_lifetimes)]

--- a/src/tools/clippy/tests/compile-test.rs
+++ b/src/tools/clippy/tests/compile-test.rs
@@ -1,3 +1,6 @@
+// We need this feature as it changes `dylib` linking behavior and allows us to link to
+// `rustc_driver`.
+#![feature(rustc_private)]
 #![feature(lazy_cell)]
 #![feature(is_sorted)]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]

--- a/src/tools/rustdoc/main.rs
+++ b/src/tools/rustdoc/main.rs
@@ -1,4 +1,6 @@
 #![feature(unix_sigpipe)]
+// We need this feature as it changes `dylib` linking behavior and allows us to link to `rustc_driver`.
+#![feature(rustc_private)]
 
 #[unix_sigpipe = "sig_dfl"]
 fn main() {

--- a/src/tools/rustfmt/src/git-rustfmt/main.rs
+++ b/src/tools/rustfmt/src/git-rustfmt/main.rs
@@ -1,3 +1,7 @@
+// We need this feature as it changes `dylib` linking behavior and allows us to link to
+// `rustc_driver`.
+#![feature(rustc_private)]
+
 #[macro_use]
 extern crate tracing;
 


### PR DESCRIPTION
This wasn't possible until #122362 (which this is based on, still not merged), and I want to see what performance benefits there are.

This is only a proof-of-concept to get an upper bound. Some functionality around fatal errors needs to be restored using panic hooks, and without that it's likely that important code paths are being optimized out. About 4% of the ui tests are failing.

With that said, in my local stage 2 builds this cuts the size of librustc_driver by ~24%~ (edit: 13% with unwind tables still enabled). That's pretty in line with the results I observed when turning this on for Fuchsia – savings were around 20%.