### PR TITLE
Fix substitution parts having a shifted underline in some cases

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2019,7 +2019,7 @@ impl HumanEmitter {
                     let offset: isize = offsets
                         .iter()
                         .filter_map(
-                            |(start, v)| if span_start_pos <= *start { None } else { Some(v) },
+                            |(start, v)| if span_start_pos < *start { None } else { Some(v) },
                         )
                         .sum();
                     let underline_start = (span_start_pos + start) as isize + offset;
@@ -2028,7 +2028,7 @@ impl HumanEmitter {
                     let padding: usize = max_line_num_len + 3;
                     for p in underline_start..underline_end {
                         if let DisplaySuggestion::Underline = show_code_change {
-                            // If this is a replacement, underline with `^`, if this is an addition
+                            // If this is a replacement, underline with `~`, if this is an addition
                             // underline with `+`.
                             buffer.putc(
                                 row_num,

--- a/tests/ui/parser/issues/issue-32505.stderr
+++ b/tests/ui/parser/issues/issue-32505.stderr
@@ -9,7 +9,7 @@ LL |     foo(|_|)
 help: you might have meant to open the body of the closure
    |
 LL |     foo(|_| {})
-   |            ++
+   |             ++
 
 error[E0425]: cannot find function `foo` in this scope
   --> $DIR/issue-32505.rs:2:5


### PR DESCRIPTION
If two suggestions parts are side by side, the underline's offset:
(WIP PR as an example, not yet pushed)
```
error: expected a pattern, found an expression
 --> ./main.rs:4:9
  |
4 |         1 + 2 => 3
  |         ^^^^^ arbitrary expressions are not allowed in patterns
  |
help: check the value in an arm guard
  |
4 |         n if n == 1 + 2 => 3
  |         ~     +++++++++++++
```
The emitter didn't take into account that the string had shrunk/grown if two substitution parts were side-by-side (surprisingly, there was only one case in the ui testsuite.)

```
help: check the value in an arm guard
  |
4 |         n if n == 1 + 2 => 3
  |         ~ +++++++++++++
```

@rustbot label +A-suggestion-diagnostics