### PR TITLE
Mark fields used by debug format as used

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -562,10 +562,14 @@ impl<'tcx> Visitor<'tcx> for MarkSymbolVisitor<'tcx> {
                     && let [arg] = args
                 {
                     let arg_ty = self.typeck_results().expr_ty(arg);
-                    if let Some(adt) = arg_ty.peel_refs().ty_adt_def() {
+                    if let Some(adt) = arg_ty.peel_refs().ty_adt_def()
+                        && adt.is_enum()
+                    {
                         for variant in adt.variants() {
                             for field in &variant.fields {
-                                self.live_symbols.insert(field.did.expect_local());
+                                if let Some(local_id) = field.did.as_local() {
+                                    self.live_symbols.insert(local_id);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fix #123068

In the following code, a field value `ProcessError::Utf8.0` is used by `"{:?}"`.
However a "never read" warning is shown.

```rs
#[derive(Debug)]
enum ProcessError {
    Utf8(i32),
}

fn main() {
    println!("{:?}", ProcessError::Utf8(42));
}
```

```
warning: field `0` is never read
 --> test.rs:3:10
  |
3 |     Utf8(i32),
  |     ---- ^^^
  |     |
  |     field in this variant
  |
  = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
  |
3 |     Utf8(()),
  |          ~~

warning: 1 warning emitted
```

In this PR, I fixed to mark all enum (for now) fields used by `"{:?}"`.