### PR TITLE
Make Rust ABI return types up to two pointers in registers

### DIFF
--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -786,7 +786,7 @@ fn fn_abi_adjust_for_abi<'tcx>(
                     // an LLVM aggregate type for this leads to bad optimizations,
                     // so we pick an appropriately sized integer type instead.
                     arg.cast_to(Reg { kind: RegKind::Integer, size });
-                } else if size <= data_pointer_size * 2 && size.bytes() % 2 == 0 {
+                } else if size == data_pointer_size * 2 && size.bytes() % 2 == 0 {
                     // Aggregates like `[usize; 2]` or (on 64-bit arch) `[u128; 1]`
                     // can be passed as a scalar pair.
                     let part_size = Size::from_bytes(size.bytes() / 2);


### PR DESCRIPTION
Currently functions like 

```rust
fn returns_two_u64s() -> [u64; 2] {
    [1, 2]
}
```

or

```rust
fn returns_single_u128_wrapped_in_array() -> [u128; 1] {
    [42]
}
```

pass their return values via stack on `"Rust"` x86_64 ABI (but notably not on `"C"` ABI).

This PR allows aggregates up to two pointer sizes to be passed in registers, so these functions would be treated as if they returned `(u64, u64)` (treating the second one as if it returned `u128` would be cleaner, but I haven’t yet figured out how to do this and it doesn’t seem to make a difference).

This is a perf-motivated change, so I’d really like to see rustc-perf on this change. I’ll try to also do some benchmarks locally.