### PR TITLE
Don't ICE when `codegen_select_candidate` returns ambiguity in new solver

### DIFF
--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -101,18 +101,11 @@ fn resolve_associated_item<'tcx>(
 
     let vtbl = match tcx.codegen_select_candidate((param_env, trait_ref)) {
         Ok(vtbl) => vtbl,
-        Err(CodegenObligationError::Ambiguity) => {
-            let reported = tcx.dcx().span_delayed_bug(
-                tcx.def_span(trait_item_id),
-                format!(
-                    "encountered ambiguity selecting `{trait_ref:?}` during codegen, presuming due to \
-                     overflow or prior type error",
-                ),
-            );
-            return Err(reported);
-        }
-        Err(CodegenObligationError::Unimplemented) => return Ok(None),
-        Err(CodegenObligationError::FulfillmentError) => return Ok(None),
+        Err(
+            CodegenObligationError::Ambiguity
+            | CodegenObligationError::Unimplemented
+            | CodegenObligationError::FulfillmentError,
+        ) => return Ok(None),
     };
 
     // Now that we know which impl is being used, we can dispatch to

--- a/tests/ui/issues/issue-69602-type-err-during-codegen-ice.rs
+++ b/tests/ui/issues/issue-69602-type-err-during-codegen-ice.rs
@@ -19,5 +19,4 @@ impl TraitB for B { //~ ERROR not all trait items implemented, missing: `MyA`
 
 fn main() {
     let _ = [0; B::VALUE];
-    //~^ constant
 }

--- a/tests/ui/issues/issue-69602-type-err-during-codegen-ice.stderr
+++ b/tests/ui/issues/issue-69602-type-err-during-codegen-ice.stderr
@@ -13,12 +13,6 @@ LL |     type MyA: TraitA;
 LL | impl TraitB for B {
    | ^^^^^^^^^^^^^^^^^ missing `MyA` in implementation
 
-note: erroneous constant encountered
-  --> $DIR/issue-69602-type-err-during-codegen-ice.rs:21:17
-   |
-LL |     let _ = [0; B::VALUE];
-   |                 ^^^^^^^^
-
 error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0046, E0437.

--- a/tests/ui/traits/next-solver/ambiguous-impl-in-resolve.rs
+++ b/tests/ui/traits/next-solver/ambiguous-impl-in-resolve.rs
@@ -1,0 +1,17 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+trait Local {}
+
+trait Overlap { fn f(); }
+impl<T> Overlap for Option<T> where Self: Clone, { fn f() {} }
+impl<T> Overlap for Option<T> where Self: Local, { fn f() {} }
+
+fn test<T>()
+where
+    Option<T>: Clone + Local,
+{
+    <Option<T> as Overlap>::f();
+}
+
+fn main() {}


### PR DESCRIPTION
Because we merge identical candidates, we may have >1 impl candidate to in `codegen_select_error` but *not* have a trait error.

r? lcnr