### PR TITLE
Keep the LIB env var in the compiler-builtins test

### DIFF
--- a/tests/run-make/compiler-builtins/rmake.rs
+++ b/tests/run-make/compiler-builtins/rmake.rs
@@ -63,7 +63,10 @@ fn main() {
         .env("RUSTC", rustc)
         .env("RUSTFLAGS", "-Copt-level=0 -Cdebug-assertions=yes")
         .env("CARGO_TARGET_DIR", &target_dir)
-        .env("RUSTC_BOOTSTRAP", "1");
+        .env("RUSTC_BOOTSTRAP", "1")
+        // Visual Studio 2022 requires that the LIB env var be set so it can
+        // find the Windows SDK.
+        .env("LIB", std::env::var("LIB").unwrap_or_default());
     set_host_rpath(&mut cmd);
 
     let status = cmd.status().unwrap();


### PR DESCRIPTION
The `tests/run-make/compiler-builtins` test was failing for me with Visual Studio 2022, complaining that it couldn't find `kernel32.lib`.

For whatever reason, with VS 2022 we need to keep the `LIB` environment variable when invoking Cargo so that the linker can find the Windows SDK libs.