### PR TITLE
Remove special-casing for `SimplifiedType` for next solver

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -14,7 +14,7 @@ use rustc_middle::traits::solve::{
     CandidateSource, CanonicalResponse, Certainty, Goal, QueryResult,
 };
 use rustc_middle::traits::{BuiltinImplSource, Reveal};
-use rustc_middle::ty::fast_reject::{DeepRejectCtxt, TreatParams, TreatProjections};
+use rustc_middle::ty::fast_reject::{DeepRejectCtxt, TreatParams};
 use rustc_middle::ty::{self, ToPredicate, Ty, TyCtxt};
 use rustc_middle::ty::{TraitPredicate, TypeVisitableExt};
 use rustc_span::{ErrorGuaranteed, DUMMY_SP};
@@ -1045,6 +1045,12 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
                 }
             }
 
+            // If we still have an alias here, it must be rigid. For opaques, it's always
+            // okay to consider auto traits because that'll reveal its hidden type. For
+            // non-opaque aliases, we will not assemble any candidates since there's no way
+            // to further look into its type.
+            ty::Alias(..) => None,
+
             // For rigid types, any possible implementation that could apply to
             // the type (even if after unification and processing nested goals
             // it does not hold) will disqualify the built-in auto impl.
@@ -1072,15 +1078,11 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Tuple(_)
-            | ty::Adt(_, _)
-            // FIXME: Handling opaques here is kinda sus. Especially because we
-            // simplify them to SimplifiedType::Placeholder.
-            | ty::Alias(ty::Opaque, _) => {
+            | ty::Adt(_, _) => {
                 let mut disqualifying_impl = None;
-                self.tcx().for_each_relevant_impl_treating_projections(
+                self.tcx().for_each_relevant_impl(
                     goal.predicate.def_id(),
                     goal.predicate.self_ty(),
-                    TreatProjections::NextSolverLookup,
                     |impl_def_id| {
                         disqualifying_impl = Some(impl_def_id);
                     },


### PR DESCRIPTION
It's unnecessary due to the way that we fully normalize the self type before assembly begins.

r? lcnr