### PR TITLE
thread_local: be excruciatingly explicit in dtor code

### DIFF
--- a/library/std/src/sys/thread_local/mod.rs
+++ b/library/std/src/sys/thread_local/mod.rs
@@ -94,7 +94,7 @@ mod lazy {
         /// Watch out: unsynchronized internal mutability!
         ///
         /// # Safety
-        /// Unsound if called while any `&'static T` is active.
+        /// Causes UB if any reference to the value is used after this.
         #[allow(unused)]
         pub(crate) unsafe fn take(&self) -> Option<T> {
             let mutable: *mut _ = UnsafeCell::get(&self.inner);

--- a/library/std/src/sys/thread_local/mod.rs
+++ b/library/std/src/sys/thread_local/mod.rs
@@ -91,13 +91,15 @@ mod lazy {
             }
         }
 
-        /// The other methods hand out references while taking &self.
-        /// As such, callers of this method must ensure no `&` and `&mut` are
-        /// available and used at the same time.
+        /// Watch out: unsynchronized internal mutability!
+        ///
+        /// # Safety
+        /// Unsound if called while any `&'static T` is active.
         #[allow(unused)]
-        pub unsafe fn take(&mut self) -> Option<T> {
-            // SAFETY: See doc comment for this method.
-            unsafe { (*self.inner.get()).take() }
+        pub(crate) unsafe fn take(&self) -> Option<T> {
+            let mutable: *mut _ = UnsafeCell::get(&self.inner);
+            // SAFETY: That's the caller's problem.
+            unsafe { mutable.replace(None) }
         }
     }
 }


### PR DESCRIPTION
Use raw pointers to accomplish internal mutability, and clearly split references where applicable. This reduces the likelihood that any of these parts are misunderstood, either by humans or the compiler's optimizations.

Fixes #124317

r? @joboet 