### PR TITLE
Fix ICE on invalid const param types

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -386,6 +386,8 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
 
     fn ct_infer(&self, ty: Ty<'tcx>, _: Option<&ty::GenericParamDef>, span: Span) -> Const<'tcx> {
         let ty = self.tcx.fold_regions(ty, |r, _| match *r {
+            rustc_type_ir::RegionKind::ReStatic => r,
+
             // This is never reached in practice. If it ever is reached,
             // `ReErased` should be changed to `ReStatic`, and any other region
             // left alone.

--- a/tests/crashes/123863.rs
+++ b/tests/crashes/123863.rs
@@ -1,6 +1,0 @@
-//@ known-bug: #123863
-const fn concat_strs<const A: &'static str>() -> &'static str {
-    struct Inner<const A: &'static str>;
-    Inner::concat_strs::<"a">::A
-}
-pub fn main() {}

--- a/tests/ui/typeck/ice-unexpected-region-123863.rs
+++ b/tests/ui/typeck/ice-unexpected-region-123863.rs
@@ -1,0 +1,9 @@
+const fn concat_strs<const A: &'static str>() -> &'static str {
+//~^ ERROR &'static str` is forbidden as the type of a const generic parameter
+    struct Inner<const A: &'static str>;
+//~^ ERROR &'static str` is forbidden as the type of a const generic parameter
+    Inner::concat_strs::<"a">::A
+//~^ ERROR ambiguous associated type
+}
+
+pub fn main() {}

--- a/tests/ui/typeck/ice-unexpected-region-123863.stderr
+++ b/tests/ui/typeck/ice-unexpected-region-123863.stderr
@@ -1,0 +1,38 @@
+error: `&'static str` is forbidden as the type of a const generic parameter
+  --> $DIR/ice-unexpected-region-123863.rs:1:31
+   |
+LL | const fn concat_strs<const A: &'static str>() -> &'static str {
+   |                               ^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+   |
+LL + #![feature(adt_const_params)]
+   |
+
+error: `&'static str` is forbidden as the type of a const generic parameter
+  --> $DIR/ice-unexpected-region-123863.rs:3:27
+   |
+LL |     struct Inner<const A: &'static str>;
+   |                           ^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+   |
+LL + #![feature(adt_const_params)]
+   |
+
+error[E0223]: ambiguous associated type
+  --> $DIR/ice-unexpected-region-123863.rs:5:5
+   |
+LL |     Inner::concat_strs::<"a">::A
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `concat_strs` implemented for `Inner<_>`, you could use the fully-qualified path
+   |
+LL |     <Inner<_> as Example>::concat_strs::A
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0223`.


### PR DESCRIPTION
Fixes ICE #123863 which occurs because the const param has a type which is not a `bool`, `char` or an integral type. 

The ICEing code path begins here in `typeck_with_fallback`: https://github.com/rust-lang/rust/blob/cb3752d20e0f5d24348062211102a08d46fbecff/compiler/rustc_hir_typeck/src/lib.rs#L167

The `fallback` invokes the `type_of` query and that eventually ends up calling `ct_infer` from the lowering code over here: 
https://github.com/rust-lang/rust/blob/cb3752d20e0f5d24348062211102a08d46fbecff/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs#L561 and `ct_infer` ICEs at this location: https://github.com/rust-lang/rust/blob/cb3752d20e0f5d24348062211102a08d46fbecff/compiler/rustc_hir_analysis/src/collect.rs#L392

To fix the ICE it I'm triggering a `span_delayed_bug` before we hit `ct_infer` if the type of the const param is not one of the supported types

### Edit
On @lcnr's suggestion I've changed the approach to not let `ReStatic` region hit the `bug!` in `ct_infer` instead of triggering a `span_delayed_bug`.
