### PR TITLE
Added missing code example and improved semantics in error explanation text E0283.md

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0283.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0283.md
@@ -8,7 +8,7 @@ let x = "hello".chars().rev().collect();
 
 This error indicates that type inference did not result in one unique possible
 type, and extra information is required. In most cases this can be provided
-by adding a type annotation. Sometimes you need to specify a generic type
+by adding a type annotation. Sometimes you might need to specify a generic type
 parameter manually.
 
 A common example is the `collect` method on `Iterator`. It has a generic type
@@ -16,7 +16,11 @@ parameter with a `FromIterator` bound, which for a `char` iterator is
 implemented by `Vec` and `String` among others. Consider the following snippet
 that reverses the characters of a string:
 
-In the first code example, the compiler cannot infer what the type of `x` should
+```
+let x = "hello".chars().rev().collect();
+```
+
+In this code example, the compiler cannot infer what the type of `x` should
 be: `Vec<char>` and `String` are both suitable candidates. To specify which type
 to use, you can use a type annotation on `x`:
 


### PR DESCRIPTION
I think there's a missing example in the help text for error E0283. From what I've gathered, it's the same example as the one provided at the beginning of the text so I've added that to where the missing example should be. Also made minor grammatical changes to some sentences to help them flow better.