### PR TITLE
miri core/alloc tests: do not test a 2nd target

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -53,15 +53,12 @@ check-aux:
 		src/tools/cargotest \
 		$(BOOTSTRAP_ARGS)
 	# Run standard library tests in Miri.
-	# We use a 64bit little-endian and a 32bit big-endian target for max coverage.
 	$(Q)BOOTSTRAP_SKIP_TARGET_SANITY=1 \
 		$(BOOTSTRAP) miri --stage 2 \
-		--target x86_64-unknown-linux-gnu,mips-unknown-linux-gnu \
 		library/core \
 		library/alloc \
 		--no-doc
 	# Some doctests have intentional memory leaks.
-	# Also, they work only on the host.
 	$(Q)MIRIFLAGS="-Zmiri-ignore-leaks -Zmiri-disable-isolation" \
 		$(BOOTSTRAP) miri --stage 2 \
 		library/core \


### PR DESCRIPTION
check-aux seems to be one of the slowest runners since we started running standard library tests in Miri on it. So maybe it'd be better to reduce test coverage a bit by not doing cross-target testing of core and alloc? I don't recall finding target-specific issues in these libraries ever (and we still have the extra test coverage via our [out-of-tree nightly tests](https://github.com/rust-lang/miri-test-libstd)). This gives us more buffer to deal with the fact that the number of tests we run will only grow over time.

Cc @rust-lang/miri @rust-lang/infra 