### PR TITLE
Remove unused `[patch]` for clippy_lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,3 @@ strip = true
 rustc-std-workspace-core = { path = 'library/rustc-std-workspace-core' }
 rustc-std-workspace-alloc = { path = 'library/rustc-std-workspace-alloc' }
 rustc-std-workspace-std = { path = 'library/rustc-std-workspace-std' }
-
-[patch."https://github.com/rust-lang/rust-clippy"]
-clippy_lints = { path = "src/tools/clippy/clippy_lints" }


### PR DESCRIPTION
Looks like it was once used by RLS