### PR TITLE
Use a proof tree visitor to refine the `Obligation` for error reporting in new solver

### DIFF
--- a/compiler/rustc_middle/src/traits/solve.rs
+++ b/compiler/rustc_middle/src/traits/solve.rs
@@ -273,6 +273,8 @@ pub enum GoalSource {
     /// they are from an impl where-clause. This is necessary due to
     /// backwards compatability, cc trait-system-refactor-initiatitive#70.
     ImplWhereBound,
+    /// Instantiating a higher-ranked goal and re-proving it.
+    InstantiateHigherRanked,
 }
 
 /// Possible ways the given goal can be proven.

--- a/compiler/rustc_middle/src/traits/solve/inspect/format.rs
+++ b/compiler/rustc_middle/src/traits/solve/inspect/format.rs
@@ -127,6 +127,7 @@ impl<'a, 'b> ProofTreeFormatter<'a, 'b> {
                         let source = match source {
                             GoalSource::Misc => "misc",
                             GoalSource::ImplWhereBound => "impl where-bound",
+                            GoalSource::InstantiateHigherRanked => "higher-ranked goal",
                         };
                         writeln!(this.f, "ADDED GOAL ({source}): {goal:?}")?
                     }

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
@@ -90,6 +90,8 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         &mut self,
         certainty: Certainty,
     ) -> QueryResult<'tcx> {
+        self.inspect.make_canonical_response(certainty);
+
         let goals_certainty = self.try_evaluate_added_goals()?;
         assert_eq!(
             self.tainted,
@@ -97,8 +99,6 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             "EvalCtxt is tainted -- nested goals may have been dropped in a \
             previous call to `try_evaluate_added_goals!`"
         );
-
-        self.inspect.make_canonical_response(certainty);
 
         // When normalizing, we've replaced the expected term with an unconstrained
         // inference variable. This means that we dropped information which could

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
@@ -454,7 +454,7 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
         } else {
             self.infcx.enter_forall(kind, |kind| {
                 let goal = goal.with(self.tcx(), ty::Binder::dummy(kind));
-                self.add_goal(GoalSource::Misc, goal);
+                self.add_goal(GoalSource::ImplWhereBound, goal);
                 self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
             })
         }

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
@@ -454,7 +454,7 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
         } else {
             self.infcx.enter_forall(kind, |kind| {
                 let goal = goal.with(self.tcx(), ty::Binder::dummy(kind));
-                self.add_goal(GoalSource::ImplWhereBound, goal);
+                self.add_goal(GoalSource::InstantiateHigherRanked, goal);
                 self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
             })
         }

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -42,6 +42,7 @@ pub struct InspectGoal<'a, 'tcx> {
     result: Result<Certainty, NoSolution>,
     evaluation_kind: inspect::CanonicalGoalEvaluationKind<'tcx>,
     normalizes_to_term_hack: Option<NormalizesToTermHack<'tcx>>,
+    source: GoalSource,
 }
 
 /// The expected term of a `NormalizesTo` goal gets replaced
@@ -92,7 +93,7 @@ impl<'tcx> NormalizesToTermHack<'tcx> {
 pub struct InspectCandidate<'a, 'tcx> {
     goal: &'a InspectGoal<'a, 'tcx>,
     kind: inspect::ProbeKind<'tcx>,
-    nested_goals: Vec<inspect::CanonicalState<'tcx, Goal<'tcx, ty::Predicate<'tcx>>>>,
+    nested_goals: Vec<(GoalSource, inspect::CanonicalState<'tcx, Goal<'tcx, ty::Predicate<'tcx>>>)>,
     final_state: inspect::CanonicalState<'tcx, ()>,
     result: QueryResult<'tcx>,
     shallow_certainty: Certainty,
@@ -145,13 +146,16 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
         let instantiated_goals: Vec<_> = self
             .nested_goals
             .iter()
-            .map(|goal| {
-                canonical::instantiate_canonical_state(
-                    infcx,
-                    span,
-                    param_env,
-                    &mut orig_values,
-                    *goal,
+            .map(|(source, goal)| {
+                (
+                    *source,
+                    canonical::instantiate_canonical_state(
+                        infcx,
+                        span,
+                        param_env,
+                        &mut orig_values,
+                        *goal,
+                    ),
                 )
             })
             .collect();
@@ -173,7 +177,7 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
 
         instantiated_goals
             .into_iter()
-            .map(|goal| match goal.predicate.kind().no_bound_vars() {
+            .map(|(source, goal)| match goal.predicate.kind().no_bound_vars() {
                 Some(ty::PredicateKind::NormalizesTo(ty::NormalizesTo { alias, term })) => {
                     let unconstrained_term = match term.unpack() {
                         ty::TermKind::Ty(_) => infcx
@@ -197,6 +201,7 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                         self.goal.depth + 1,
                         proof_tree.unwrap(),
                         Some(NormalizesToTermHack { term, unconstrained_term }),
+                        source,
                     )
                 }
                 _ => InspectGoal::new(
@@ -204,6 +209,7 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                     self.goal.depth + 1,
                     infcx.evaluate_root_goal(goal, GenerateProofTree::Yes).1.unwrap(),
                     None,
+                    source,
                 ),
             })
             .collect()
@@ -229,16 +235,23 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
         self.result
     }
 
+    pub fn source(&self) -> GoalSource {
+        self.source
+    }
+
     fn candidates_recur(
         &'a self,
         candidates: &mut Vec<InspectCandidate<'a, 'tcx>>,
-        nested_goals: &mut Vec<inspect::CanonicalState<'tcx, Goal<'tcx, ty::Predicate<'tcx>>>>,
+        nested_goals: &mut Vec<(
+            GoalSource,
+            inspect::CanonicalState<'tcx, Goal<'tcx, ty::Predicate<'tcx>>>,
+        )>,
         probe: &inspect::Probe<'tcx>,
     ) {
         let mut shallow_certainty = None;
         for step in &probe.steps {
             match step {
-                &inspect::ProbeStep::AddGoal(_source, goal) => nested_goals.push(goal),
+                &inspect::ProbeStep::AddGoal(source, goal) => nested_goals.push((source, goal)),
                 inspect::ProbeStep::NestedProbe(ref probe) => {
                     // Nested probes have to prove goals added in their parent
                     // but do not leak them, so we truncate the added goals
@@ -321,6 +334,7 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
         depth: usize,
         root: inspect::GoalEvaluation<'tcx>,
         normalizes_to_term_hack: Option<NormalizesToTermHack<'tcx>>,
+        source: GoalSource,
     ) -> Self {
         let inspect::GoalEvaluation { uncanonicalized_goal, kind, evaluation } = root;
         let inspect::GoalEvaluationKind::Root { orig_values } = kind else { unreachable!() };
@@ -343,6 +357,7 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
             result,
             evaluation_kind: evaluation.kind,
             normalizes_to_term_hack,
+            source,
         }
     }
 }
@@ -369,6 +384,6 @@ impl<'tcx> InferCtxt<'tcx> {
     ) -> V::Result {
         let (_, proof_tree) = self.evaluate_root_goal(goal, GenerateProofTree::Yes);
         let proof_tree = proof_tree.unwrap();
-        visitor.visit_goal(&InspectGoal::new(self, 0, proof_tree, None))
+        visitor.visit_goal(&InspectGoal::new(self, 0, proof_tree, None, GoalSource::Misc))
     }
 }

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -128,10 +128,8 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
     /// back their inference constraints. This function modifies
     /// the state of the `infcx`.
     pub fn visit_nested_no_probe<V: ProofTreeVisitor<'tcx>>(&self, visitor: &mut V) -> V::Result {
-        if self.goal.depth < visitor.config().max_depth {
-            for goal in self.instantiate_nested_goals(visitor.span()) {
-                try_visit!(visitor.visit_goal(&goal));
-            }
+        for goal in self.instantiate_nested_goals(visitor.span()) {
+            try_visit!(goal.visit_with(visitor));
         }
 
         V::Result::output()
@@ -359,6 +357,14 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
             normalizes_to_term_hack,
             source,
         }
+    }
+
+    pub(crate) fn visit_with<V: ProofTreeVisitor<'tcx>>(&self, visitor: &mut V) -> V::Result {
+        if self.depth < visitor.config().max_depth {
+            try_visit!(visitor.visit_goal(self));
+        }
+
+        V::Result::output()
     }
 }
 

--- a/compiler/rustc_trait_selection/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalizes_to/mod.rs
@@ -389,7 +389,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for NormalizesTo<'tcx> {
             CandidateSource::BuiltinImpl(BuiltinImplSource::Misc),
             goal,
             pred,
-            [goal.with(tcx, output_is_sized_pred)],
+            [(GoalSource::ImplWhereBound, goal.with(tcx, output_is_sized_pred))],
         )
     }
 
@@ -473,7 +473,8 @@ impl<'tcx> assembly::GoalKind<'tcx> for NormalizesTo<'tcx> {
             pred,
             [goal.with(tcx, output_is_sized_pred)]
                 .into_iter()
-                .chain(nested_preds.into_iter().map(|pred| goal.with(tcx, pred))),
+                .chain(nested_preds.into_iter().map(|pred| goal.with(tcx, pred)))
+                .map(|goal| (GoalSource::ImplWhereBound, goal)),
         )
     }
 

--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -321,7 +321,7 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
             CandidateSource::BuiltinImpl(BuiltinImplSource::Misc),
             goal,
             pred,
-            [goal.with(tcx, output_is_sized_pred)],
+            [(GoalSource::ImplWhereBound, goal.with(tcx, output_is_sized_pred))],
         )
     }
 
@@ -367,7 +367,8 @@ impl<'tcx> assembly::GoalKind<'tcx> for TraitPredicate<'tcx> {
             pred,
             [goal.with(tcx, output_is_sized_pred)]
                 .into_iter()
-                .chain(nested_preds.into_iter().map(|pred| goal.with(tcx, pred))),
+                .chain(nested_preds.into_iter().map(|pred| goal.with(tcx, pred)))
+                .map(|goal| (GoalSource::ImplWhereBound, goal)),
         )
     }
 

--- a/tests/ui/coherence/occurs-check/opaques.next.stderr
+++ b/tests/ui/coherence/occurs-check/opaques.next.stderr
@@ -11,7 +11,7 @@ error[E0282]: type annotations needed
   --> $DIR/opaques.rs:13:20
    |
 LL |     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
-   |                    ^ cannot infer type for struct `Container<T, T>`
+   |                    ^ cannot infer type for associated type `<T as Trait<T>>::Assoc`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/for/issue-20605.next.stderr
+++ b/tests/ui/for/issue-20605.next.stderr
@@ -2,9 +2,14 @@ error[E0277]: `dyn Iterator<Item = &'a mut u8>` is not an iterator
   --> $DIR/issue-20605.rs:6:17
    |
 LL |     for item in *things { *item = 0 }
-   |                 ^^^^^^^ `dyn Iterator<Item = &'a mut u8>` is not an iterator
+   |                 ^^^^^^^ the trait `IntoIterator` is not implemented for `dyn Iterator<Item = &'a mut u8>`
    |
-   = help: the trait `IntoIterator` is not implemented for `dyn Iterator<Item = &'a mut u8>`
+   = note: the trait bound `dyn Iterator<Item = &'a mut u8>: IntoIterator` is not satisfied
+   = note: required for `dyn Iterator<Item = &'a mut u8>` to implement `IntoIterator`
+help: consider mutably borrowing here
+   |
+LL |     for item in &mut *things { *item = 0 }
+   |                 ++++
 
 error: the type `<dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter` is not well-formed
   --> $DIR/issue-20605.rs:6:17

--- a/tests/ui/higher-ranked/leak-check/leak-check-in-selection-3.next.stderr
+++ b/tests/ui/higher-ranked/leak-check/leak-check-in-selection-3.next.stderr
@@ -23,7 +23,20 @@ error[E0283]: type annotations needed
 LL |     impls_indirect_leak::<Box<_>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `impls_indirect_leak`
    |
-   = note: cannot satisfy `for<'a> Box<_>: IndirectLeak<'a>`
+note: multiple `impl`s satisfying `for<'a> Box<_>: Leak<'a>` found
+  --> $DIR/leak-check-in-selection-3.rs:9:1
+   |
+LL | impl Leak<'_> for Box<u32> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | impl Leak<'static> for Box<u16> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required for `Box<_>` to implement `for<'a> IndirectLeak<'a>`
+  --> $DIR/leak-check-in-selection-3.rs:23:23
+   |
+LL | impl<'a, T: Leak<'a>> IndirectLeak<'a> for T {}
+   |             --------  ^^^^^^^^^^^^^^^^     ^
+   |             |
+   |             unsatisfied trait bound introduced here
 note: required by a bound in `impls_indirect_leak`
   --> $DIR/leak-check-in-selection-3.rs:25:27
    |

--- a/tests/ui/traits/next-solver/auto-with-drop_tracking_mir.fail.stderr
+++ b/tests/ui/traits/next-solver/auto-with-drop_tracking_mir.fail.stderr
@@ -1,18 +1,26 @@
-error[E0277]: `impl Future<Output = ()>` cannot be sent between threads safely
+error: future cannot be sent between threads safely
   --> $DIR/auto-with-drop_tracking_mir.rs:25:13
    |
 LL |     is_send(foo());
-   |     ------- ^^^^^ `impl Future<Output = ()>` cannot be sent between threads safely
-   |     |
-   |     required by a bound introduced by this call
+   |             ^^^^^ future returned by `foo` is not `Send`
    |
-   = help: the trait `Send` is not implemented for `impl Future<Output = ()>`
+   = help: the trait `Sync` is not implemented for `impl Future<Output = ()>`, which is required by `impl Future<Output = ()>: Send`
+note: future is not `Send` as this value is used across an await
+  --> $DIR/auto-with-drop_tracking_mir.rs:16:11
+   |
+LL |     let x = &NotSync;
+   |         - has type `&NotSync` which is not `Send`
+LL |     bar().await;
+   |           ^^^^^ await occurs here, with `x` maybe used later
 note: required by a bound in `is_send`
   --> $DIR/auto-with-drop_tracking_mir.rs:24:24
    |
 LL |     fn is_send(_: impl Send) {}
    |                        ^^^^ required by this bound in `is_send`
+help: consider dereferencing here
+   |
+LL |     is_send(*foo());
+   |             +
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/next-solver/auto-with-drop_tracking_mir.rs
+++ b/tests/ui/traits/next-solver/auto-with-drop_tracking_mir.rs
@@ -23,5 +23,5 @@ async fn bar() {}
 fn main() {
     fn is_send(_: impl Send) {}
     is_send(foo());
-    //[fail]~^ ERROR `impl Future<Output = ()>` cannot be sent between threads safely
+    //[fail]~^ ERROR future cannot be sent between threads safely
 }

--- a/tests/ui/traits/next-solver/builtin-fn-must-return-sized.rs
+++ b/tests/ui/traits/next-solver/builtin-fn-must-return-sized.rs
@@ -13,5 +13,5 @@ fn foo<F: Fn<T>, T: Tuple>(f: Option<F>, t: T) {
 
 fn main() {
     foo::<fn() -> str, _>(None, ());
-    //~^ expected a `Fn<_>` closure, found `fn() -> str`
+    //~^ the size for values of type `str` cannot be known at compilation time
 }

--- a/tests/ui/traits/next-solver/builtin-fn-must-return-sized.stderr
+++ b/tests/ui/traits/next-solver/builtin-fn-must-return-sized.stderr
@@ -1,10 +1,11 @@
-error[E0277]: expected a `Fn<_>` closure, found `fn() -> str`
+error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/builtin-fn-must-return-sized.rs:15:11
    |
 LL |     foo::<fn() -> str, _>(None, ());
-   |           ^^^^^^^^^^^ expected an `Fn<_>` closure, found `fn() -> str`
+   |           ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Fn<_>` is not implemented for `fn() -> str`
+   = help: within `fn() -> str`, the trait `Sized` is not implemented for `str`, which is required by `fn() -> str: Fn<_>`
+   = note: required because it appears within the type `fn() -> str`
 note: required by a bound in `foo`
   --> $DIR/builtin-fn-must-return-sized.rs:10:11
    |

--- a/tests/ui/traits/next-solver/coherence/coherence-fulfill-overflow.stderr
+++ b/tests/ui/traits/next-solver/coherence/coherence-fulfill-overflow.stderr
@@ -6,7 +6,7 @@ LL | impl<T: ?Sized + TwoW> Trait for W<T> {}
 LL | impl<T: ?Sized + TwoW> Trait for T {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>>>>>>>>>`
    |
-   = note: overflow evaluating the requirement `W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>: TwoW`
+   = note: overflow evaluating the requirement `W<W<W<W<_>>>>: TwoW`
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "20"]` attribute to your crate (`coherence_fulfill_overflow`)
 
 error: aborting due to 1 previous error

--- a/tests/ui/traits/next-solver/coherence/coherence-fulfill-overflow.stderr
+++ b/tests/ui/traits/next-solver/coherence/coherence-fulfill-overflow.stderr
@@ -1,12 +1,12 @@
-error[E0119]: conflicting implementations of trait `Trait` for type `W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>>>>>>>>`
+error[E0119]: conflicting implementations of trait `Trait` for type `W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>>>>>>>>>`
   --> $DIR/coherence-fulfill-overflow.rs:12:1
    |
 LL | impl<T: ?Sized + TwoW> Trait for W<T> {}
    | ------------------------------------- first implementation here
 LL | impl<T: ?Sized + TwoW> Trait for T {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>>>>>>>>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>>>>>>>>>`
    |
-   = note: overflow evaluating the requirement `W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>>>>>>>>: TwoW`
+   = note: overflow evaluating the requirement `W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>: TwoW`
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "20"]` attribute to your crate (`coherence_fulfill_overflow`)
 
 error: aborting due to 1 previous error

--- a/tests/ui/traits/next-solver/cycles/coinduction/fixpoint-exponential-growth.stderr
+++ b/tests/ui/traits/next-solver/cycles/coinduction/fixpoint-exponential-growth.stderr
@@ -1,9 +1,16 @@
-error[E0275]: overflow evaluating the requirement `W<_>: Trait`
+error[E0275]: overflow evaluating the requirement `_: Sized`
   --> $DIR/fixpoint-exponential-growth.rs:33:13
    |
 LL |     impls::<W<_>>();
    |             ^^^^
    |
+note: required for `W<(W<_>, W<_>)>` to implement `Trait`
+  --> $DIR/fixpoint-exponential-growth.rs:23:12
+   |
+LL | impl<T, U> Trait for W<(W<T>, W<U>)>
+   |      -     ^^^^^     ^^^^^^^^^^^^^^^
+   |      |
+   |      unsatisfied trait bound introduced here
 note: required by a bound in `impls`
   --> $DIR/fixpoint-exponential-growth.rs:30:13
    |

--- a/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.rs
+++ b/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.rs
@@ -61,7 +61,7 @@ where
     // entering the cycle from `A` fails, but would work if we were to use the cache
     // result of `B<X>`.
     impls_trait::<A<X>, _, _, _>();
-    //~^ ERROR the trait bound `A<X>: Trait<_, _, _>` is not satisfied
+    //~^ ERROR the trait bound `X: IncompleteGuidance<_, _>` is not satisfied
 }
 
 fn main() {

--- a/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.stderr
+++ b/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.stderr
@@ -1,10 +1,21 @@
-error[E0277]: the trait bound `A<X>: Trait<_, _, _>` is not satisfied
+error[E0277]: the trait bound `X: IncompleteGuidance<_, _>` is not satisfied
   --> $DIR/incompleteness-unstable-result.rs:63:19
    |
 LL |     impls_trait::<A<X>, _, _, _>();
-   |                   ^^^^ the trait `Trait<_, _, _>` is not implemented for `A<X>`
+   |                   ^^^^ the trait `IncompleteGuidance<_, _>` is not implemented for `X`, which is required by `A<X>: Trait<_, _, _>`
    |
-   = help: the trait `Trait<U, V, D>` is implemented for `A<T>`
+   = help: the following other types implement trait `IncompleteGuidance<T, V>`:
+             <T as IncompleteGuidance<U, i16>>
+             <T as IncompleteGuidance<U, i8>>
+             <T as IncompleteGuidance<U, u8>>
+note: required for `A<X>` to implement `Trait<_, _, u8>`
+  --> $DIR/incompleteness-unstable-result.rs:32:50
+   |
+LL | impl<T: ?Sized, U: ?Sized, V: ?Sized, D: ?Sized> Trait<U, V, D> for A<T>
+   |                                                  ^^^^^^^^^^^^^^     ^^^^
+LL | where
+LL |     T: IncompleteGuidance<U, V>,
+   |        ------------------------ unsatisfied trait bound introduced here
 note: required by a bound in `impls_trait`
   --> $DIR/incompleteness-unstable-result.rs:51:28
    |

--- a/tests/ui/traits/next-solver/cycles/double-cycle-inductive-coinductive.stderr
+++ b/tests/ui/traits/next-solver/cycles/double-cycle-inductive-coinductive.stderr
@@ -1,16 +1,9 @@
-error[E0275]: overflow evaluating the requirement `(): Trait`
+error[E0275]: overflow evaluating the requirement `(): Inductive`
   --> $DIR/double-cycle-inductive-coinductive.rs:32:19
    |
 LL |     impls_trait::<()>();
    |                   ^^
    |
-note: required for `()` to implement `Inductive`
-  --> $DIR/double-cycle-inductive-coinductive.rs:12:16
-   |
-LL | impl<T: Trait> Inductive for T {}
-   |         -----  ^^^^^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
 note: required for `()` to implement `Trait`
   --> $DIR/double-cycle-inductive-coinductive.rs:9:34
    |
@@ -18,7 +11,14 @@ LL | impl<T: Inductive + Coinductive> Trait for T {}
    |         ---------                ^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: 2 redundant requirements hidden
+note: required for `()` to implement `Inductive`
+  --> $DIR/double-cycle-inductive-coinductive.rs:12:16
+   |
+LL | impl<T: Trait> Inductive for T {}
+   |         -----  ^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: 7 redundant requirements hidden
    = note: required for `()` to implement `Trait`
 note: required by a bound in `impls_trait`
   --> $DIR/double-cycle-inductive-coinductive.rs:17:19
@@ -26,19 +26,12 @@ note: required by a bound in `impls_trait`
 LL | fn impls_trait<T: Trait>() {}
    |                   ^^^^^ required by this bound in `impls_trait`
 
-error[E0275]: overflow evaluating the requirement `(): TraitRev`
+error[E0275]: overflow evaluating the requirement `(): CoinductiveRev`
   --> $DIR/double-cycle-inductive-coinductive.rs:35:23
    |
 LL |     impls_trait_rev::<()>();
    |                       ^^
    |
-note: required for `()` to implement `CoinductiveRev`
-  --> $DIR/double-cycle-inductive-coinductive.rs:27:19
-   |
-LL | impl<T: TraitRev> CoinductiveRev for T {}
-   |         --------  ^^^^^^^^^^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
 note: required for `()` to implement `TraitRev`
   --> $DIR/double-cycle-inductive-coinductive.rs:21:40
    |
@@ -46,7 +39,14 @@ LL | impl<T: CoinductiveRev + InductiveRev> TraitRev for T {}
    |         --------------                 ^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: 2 redundant requirements hidden
+note: required for `()` to implement `CoinductiveRev`
+  --> $DIR/double-cycle-inductive-coinductive.rs:27:19
+   |
+LL | impl<T: TraitRev> CoinductiveRev for T {}
+   |         --------  ^^^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: 7 redundant requirements hidden
    = note: required for `()` to implement `TraitRev`
 note: required by a bound in `impls_trait_rev`
   --> $DIR/double-cycle-inductive-coinductive.rs:29:23

--- a/tests/ui/traits/next-solver/cycles/double-cycle-inductive-coinductive.stderr
+++ b/tests/ui/traits/next-solver/cycles/double-cycle-inductive-coinductive.stderr
@@ -4,6 +4,22 @@ error[E0275]: overflow evaluating the requirement `(): Trait`
 LL |     impls_trait::<()>();
    |                   ^^
    |
+note: required for `()` to implement `Inductive`
+  --> $DIR/double-cycle-inductive-coinductive.rs:12:16
+   |
+LL | impl<T: Trait> Inductive for T {}
+   |         -----  ^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+note: required for `()` to implement `Trait`
+  --> $DIR/double-cycle-inductive-coinductive.rs:9:34
+   |
+LL | impl<T: Inductive + Coinductive> Trait for T {}
+   |         ---------                ^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: 2 redundant requirements hidden
+   = note: required for `()` to implement `Trait`
 note: required by a bound in `impls_trait`
   --> $DIR/double-cycle-inductive-coinductive.rs:17:19
    |
@@ -16,6 +32,22 @@ error[E0275]: overflow evaluating the requirement `(): TraitRev`
 LL |     impls_trait_rev::<()>();
    |                       ^^
    |
+note: required for `()` to implement `CoinductiveRev`
+  --> $DIR/double-cycle-inductive-coinductive.rs:27:19
+   |
+LL | impl<T: TraitRev> CoinductiveRev for T {}
+   |         --------  ^^^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+note: required for `()` to implement `TraitRev`
+  --> $DIR/double-cycle-inductive-coinductive.rs:21:40
+   |
+LL | impl<T: CoinductiveRev + InductiveRev> TraitRev for T {}
+   |         --------------                 ^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: 2 redundant requirements hidden
+   = note: required for `()` to implement `TraitRev`
 note: required by a bound in `impls_trait_rev`
   --> $DIR/double-cycle-inductive-coinductive.rs:29:23
    |

--- a/tests/ui/traits/next-solver/cycles/inductive-fixpoint-hang.stderr
+++ b/tests/ui/traits/next-solver/cycles/inductive-fixpoint-hang.stderr
@@ -4,6 +4,16 @@ error[E0275]: overflow evaluating the requirement `W<_>: Trait`
 LL |     impls_trait::<W<_>>();
    |                   ^^^^
    |
+note: required for `W<W<_>>` to implement `Trait`
+  --> $DIR/inductive-fixpoint-hang.rs:22:17
+   |
+LL | impl<T: ?Sized> Trait for W<W<T>>
+   |                 ^^^^^     ^^^^^^^
+LL | where
+LL |     W<T>: Trait,
+   |           ----- unsatisfied trait bound introduced here
+   = note: 3 redundant requirements hidden
+   = note: required for `W<W<W<W<W<_>>>>>` to implement `Trait`
 note: required by a bound in `impls_trait`
   --> $DIR/inductive-fixpoint-hang.rs:28:19
    |

--- a/tests/ui/traits/next-solver/cycles/inductive-fixpoint-hang.stderr
+++ b/tests/ui/traits/next-solver/cycles/inductive-fixpoint-hang.stderr
@@ -1,10 +1,10 @@
-error[E0275]: overflow evaluating the requirement `W<_>: Trait`
+error[E0275]: overflow evaluating the requirement `W<W<_>>: Trait`
   --> $DIR/inductive-fixpoint-hang.rs:31:19
    |
 LL |     impls_trait::<W<_>>();
    |                   ^^^^
    |
-note: required for `W<W<_>>` to implement `Trait`
+note: required for `W<W<W<_>>>` to implement `Trait`
   --> $DIR/inductive-fixpoint-hang.rs:22:17
    |
 LL | impl<T: ?Sized> Trait for W<W<T>>
@@ -12,8 +12,8 @@ LL | impl<T: ?Sized> Trait for W<W<T>>
 LL | where
 LL |     W<T>: Trait,
    |           ----- unsatisfied trait bound introduced here
-   = note: 3 redundant requirements hidden
-   = note: required for `W<W<W<W<W<_>>>>>` to implement `Trait`
+   = note: 8 redundant requirements hidden
+   = note: required for `W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>` to implement `Trait`
 note: required by a bound in `impls_trait`
   --> $DIR/inductive-fixpoint-hang.rs:28:19
    |

--- a/tests/ui/traits/next-solver/cycles/inductive-not-on-stack.rs
+++ b/tests/ui/traits/next-solver/cycles/inductive-not-on-stack.rs
@@ -39,8 +39,8 @@ fn impls_ar<T: AR>() {}
 
 fn main() {
     impls_a::<()>();
-    //~^ ERROR overflow evaluating the requirement `(): A`
+    //~^ ERROR overflow evaluating the requirement `(): B`
 
     impls_ar::<()>();
-    //~^ ERROR overflow evaluating the requirement `(): CR`
+    //~^ ERROR overflow evaluating the requirement `(): AR`
 }

--- a/tests/ui/traits/next-solver/cycles/inductive-not-on-stack.rs
+++ b/tests/ui/traits/next-solver/cycles/inductive-not-on-stack.rs
@@ -42,5 +42,5 @@ fn main() {
     //~^ ERROR overflow evaluating the requirement `(): A`
 
     impls_ar::<()>();
-    //~^ ERROR overflow evaluating the requirement `(): AR`
+    //~^ ERROR overflow evaluating the requirement `(): CR`
 }

--- a/tests/ui/traits/next-solver/cycles/inductive-not-on-stack.stderr
+++ b/tests/ui/traits/next-solver/cycles/inductive-not-on-stack.stderr
@@ -1,16 +1,9 @@
-error[E0275]: overflow evaluating the requirement `(): A`
+error[E0275]: overflow evaluating the requirement `(): B`
   --> $DIR/inductive-not-on-stack.rs:41:15
    |
 LL |     impls_a::<()>();
    |               ^^
    |
-note: required for `()` to implement `B`
-  --> $DIR/inductive-not-on-stack.rs:22:12
-   |
-LL | impl<T: A> B for T {}
-   |         -  ^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
 note: required for `()` to implement `A`
   --> $DIR/inductive-not-on-stack.rs:21:16
    |
@@ -18,7 +11,14 @@ LL | impl<T: B + C> A for T {}
    |         -      ^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: 2 redundant requirements hidden
+note: required for `()` to implement `B`
+  --> $DIR/inductive-not-on-stack.rs:22:12
+   |
+LL | impl<T: A> B for T {}
+   |         -  ^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: 7 redundant requirements hidden
    = note: required for `()` to implement `A`
 note: required by a bound in `impls_a`
   --> $DIR/inductive-not-on-stack.rs:25:15
@@ -26,19 +26,12 @@ note: required by a bound in `impls_a`
 LL | fn impls_a<T: A>() {}
    |               ^ required by this bound in `impls_a`
 
-error[E0275]: overflow evaluating the requirement `(): CR`
+error[E0275]: overflow evaluating the requirement `(): AR`
   --> $DIR/inductive-not-on-stack.rs:44:16
    |
 LL |     impls_ar::<()>();
    |                ^^
    |
-note: required for `()` to implement `AR`
-  --> $DIR/inductive-not-on-stack.rs:34:18
-   |
-LL | impl<T: CR + BR> AR for T {}
-   |         --       ^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
 note: required for `()` to implement `BR`
   --> $DIR/inductive-not-on-stack.rs:35:13
    |
@@ -53,7 +46,14 @@ LL | impl<T: BR> CR for T {}
    |         --  ^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: 1 redundant requirement hidden
+note: required for `()` to implement `AR`
+  --> $DIR/inductive-not-on-stack.rs:34:18
+   |
+LL | impl<T: CR + BR> AR for T {}
+   |         --       ^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: 6 redundant requirements hidden
    = note: required for `()` to implement `AR`
 note: required by a bound in `impls_ar`
   --> $DIR/inductive-not-on-stack.rs:38:16

--- a/tests/ui/traits/next-solver/cycles/inductive-not-on-stack.stderr
+++ b/tests/ui/traits/next-solver/cycles/inductive-not-on-stack.stderr
@@ -4,18 +4,57 @@ error[E0275]: overflow evaluating the requirement `(): A`
 LL |     impls_a::<()>();
    |               ^^
    |
+note: required for `()` to implement `B`
+  --> $DIR/inductive-not-on-stack.rs:22:12
+   |
+LL | impl<T: A> B for T {}
+   |         -  ^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+note: required for `()` to implement `A`
+  --> $DIR/inductive-not-on-stack.rs:21:16
+   |
+LL | impl<T: B + C> A for T {}
+   |         -      ^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: 2 redundant requirements hidden
+   = note: required for `()` to implement `A`
 note: required by a bound in `impls_a`
   --> $DIR/inductive-not-on-stack.rs:25:15
    |
 LL | fn impls_a<T: A>() {}
    |               ^ required by this bound in `impls_a`
 
-error[E0275]: overflow evaluating the requirement `(): AR`
+error[E0275]: overflow evaluating the requirement `(): CR`
   --> $DIR/inductive-not-on-stack.rs:44:16
    |
 LL |     impls_ar::<()>();
    |                ^^
    |
+note: required for `()` to implement `AR`
+  --> $DIR/inductive-not-on-stack.rs:34:18
+   |
+LL | impl<T: CR + BR> AR for T {}
+   |         --       ^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+note: required for `()` to implement `BR`
+  --> $DIR/inductive-not-on-stack.rs:35:13
+   |
+LL | impl<T: AR> BR for T {}
+   |         --  ^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+note: required for `()` to implement `CR`
+  --> $DIR/inductive-not-on-stack.rs:36:13
+   |
+LL | impl<T: BR> CR for T {}
+   |         --  ^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `()` to implement `AR`
 note: required by a bound in `impls_ar`
   --> $DIR/inductive-not-on-stack.rs:38:16
    |

--- a/tests/ui/traits/next-solver/cycles/mixed-cycles-1.rs
+++ b/tests/ui/traits/next-solver/cycles/mixed-cycles-1.rs
@@ -35,5 +35,5 @@ fn impls_a<T: A>() {}
 
 fn main() {
     impls_a::<()>();
-    //~^ ERROR overflow evaluating the requirement `(): C`
+    //~^ ERROR overflow evaluating the requirement `(): CInd`
 }

--- a/tests/ui/traits/next-solver/cycles/mixed-cycles-1.rs
+++ b/tests/ui/traits/next-solver/cycles/mixed-cycles-1.rs
@@ -35,5 +35,5 @@ fn impls_a<T: A>() {}
 
 fn main() {
     impls_a::<()>();
-    //~^ ERROR overflow evaluating the requirement `(): A`
+    //~^ ERROR overflow evaluating the requirement `(): C`
 }

--- a/tests/ui/traits/next-solver/cycles/mixed-cycles-1.stderr
+++ b/tests/ui/traits/next-solver/cycles/mixed-cycles-1.stderr
@@ -1,16 +1,9 @@
-error[E0275]: overflow evaluating the requirement `(): C`
+error[E0275]: overflow evaluating the requirement `(): CInd`
   --> $DIR/mixed-cycles-1.rs:37:15
    |
 LL |     impls_a::<()>();
    |               ^^
    |
-note: required for `()` to implement `CInd`
-  --> $DIR/mixed-cycles-1.rs:28:21
-   |
-LL | impl<T: ?Sized + C> CInd for T {}
-   |                  -  ^^^^     ^
-   |                  |
-   |                  unsatisfied trait bound introduced here
 note: required for `()` to implement `B`
   --> $DIR/mixed-cycles-1.rs:31:28
    |
@@ -18,6 +11,22 @@ LL | impl<T: ?Sized + CInd + C> B for T {}
    |                  ----      ^     ^
    |                  |
    |                  unsatisfied trait bound introduced here
+note: required for `()` to implement `C`
+  --> $DIR/mixed-cycles-1.rs:32:25
+   |
+LL | impl<T: ?Sized + B + A> C for T {}
+   |                  -      ^     ^
+   |                  |
+   |                  unsatisfied trait bound introduced here
+note: required for `()` to implement `CInd`
+  --> $DIR/mixed-cycles-1.rs:28:21
+   |
+LL | impl<T: ?Sized + C> CInd for T {}
+   |                  -  ^^^^     ^
+   |                  |
+   |                  unsatisfied trait bound introduced here
+   = note: 4 redundant requirements hidden
+   = note: required for `()` to implement `B`
 note: required for `()` to implement `BInd`
   --> $DIR/mixed-cycles-1.rs:23:21
    |

--- a/tests/ui/traits/next-solver/cycles/mixed-cycles-1.stderr
+++ b/tests/ui/traits/next-solver/cycles/mixed-cycles-1.stderr
@@ -1,9 +1,37 @@
-error[E0275]: overflow evaluating the requirement `(): A`
+error[E0275]: overflow evaluating the requirement `(): C`
   --> $DIR/mixed-cycles-1.rs:37:15
    |
 LL |     impls_a::<()>();
    |               ^^
    |
+note: required for `()` to implement `CInd`
+  --> $DIR/mixed-cycles-1.rs:28:21
+   |
+LL | impl<T: ?Sized + C> CInd for T {}
+   |                  -  ^^^^     ^
+   |                  |
+   |                  unsatisfied trait bound introduced here
+note: required for `()` to implement `B`
+  --> $DIR/mixed-cycles-1.rs:31:28
+   |
+LL | impl<T: ?Sized + CInd + C> B for T {}
+   |                  ----      ^     ^
+   |                  |
+   |                  unsatisfied trait bound introduced here
+note: required for `()` to implement `BInd`
+  --> $DIR/mixed-cycles-1.rs:23:21
+   |
+LL | impl<T: ?Sized + B> BInd for T {}
+   |                  -  ^^^^     ^
+   |                  |
+   |                  unsatisfied trait bound introduced here
+note: required for `()` to implement `A`
+  --> $DIR/mixed-cycles-1.rs:30:28
+   |
+LL | impl<T: ?Sized + BInd + C> A for T {}
+   |                  ----      ^     ^
+   |                  |
+   |                  unsatisfied trait bound introduced here
 note: required by a bound in `impls_a`
   --> $DIR/mixed-cycles-1.rs:34:15
    |

--- a/tests/ui/traits/next-solver/cycles/mixed-cycles-2.rs
+++ b/tests/ui/traits/next-solver/cycles/mixed-cycles-2.rs
@@ -28,5 +28,5 @@ fn impls_a<T: A>() {}
 
 fn main() {
     impls_a::<()>();
-    //~^ ERROR overflow evaluating the requirement `(): B`
+    //~^ ERROR overflow evaluating the requirement `(): BInd`
 }

--- a/tests/ui/traits/next-solver/cycles/mixed-cycles-2.rs
+++ b/tests/ui/traits/next-solver/cycles/mixed-cycles-2.rs
@@ -28,5 +28,5 @@ fn impls_a<T: A>() {}
 
 fn main() {
     impls_a::<()>();
-    //~^ ERROR overflow evaluating the requirement `(): A`
+    //~^ ERROR overflow evaluating the requirement `(): B`
 }

--- a/tests/ui/traits/next-solver/cycles/mixed-cycles-2.stderr
+++ b/tests/ui/traits/next-solver/cycles/mixed-cycles-2.stderr
@@ -1,16 +1,9 @@
-error[E0275]: overflow evaluating the requirement `(): B`
+error[E0275]: overflow evaluating the requirement `(): BInd`
   --> $DIR/mixed-cycles-2.rs:30:15
    |
 LL |     impls_a::<()>();
    |               ^^
    |
-note: required for `()` to implement `BInd`
-  --> $DIR/mixed-cycles-2.rs:22:21
-   |
-LL | impl<T: ?Sized + B> BInd for T {}
-   |                  -  ^^^^     ^
-   |                  |
-   |                  unsatisfied trait bound introduced here
 note: required for `()` to implement `B`
   --> $DIR/mixed-cycles-2.rs:25:24
    |
@@ -18,7 +11,14 @@ LL | impl<T: ?Sized + BInd> B for T {}
    |                  ----  ^     ^
    |                  |
    |                  unsatisfied trait bound introduced here
-   = note: 1 redundant requirement hidden
+note: required for `()` to implement `BInd`
+  --> $DIR/mixed-cycles-2.rs:22:21
+   |
+LL | impl<T: ?Sized + B> BInd for T {}
+   |                  -  ^^^^     ^
+   |                  |
+   |                  unsatisfied trait bound introduced here
+   = note: 6 redundant requirements hidden
    = note: required for `()` to implement `BInd`
 note: required for `()` to implement `A`
   --> $DIR/mixed-cycles-2.rs:24:28

--- a/tests/ui/traits/next-solver/cycles/mixed-cycles-2.stderr
+++ b/tests/ui/traits/next-solver/cycles/mixed-cycles-2.stderr
@@ -1,9 +1,32 @@
-error[E0275]: overflow evaluating the requirement `(): A`
+error[E0275]: overflow evaluating the requirement `(): B`
   --> $DIR/mixed-cycles-2.rs:30:15
    |
 LL |     impls_a::<()>();
    |               ^^
    |
+note: required for `()` to implement `BInd`
+  --> $DIR/mixed-cycles-2.rs:22:21
+   |
+LL | impl<T: ?Sized + B> BInd for T {}
+   |                  -  ^^^^     ^
+   |                  |
+   |                  unsatisfied trait bound introduced here
+note: required for `()` to implement `B`
+  --> $DIR/mixed-cycles-2.rs:25:24
+   |
+LL | impl<T: ?Sized + BInd> B for T {}
+   |                  ----  ^     ^
+   |                  |
+   |                  unsatisfied trait bound introduced here
+   = note: 1 redundant requirement hidden
+   = note: required for `()` to implement `BInd`
+note: required for `()` to implement `A`
+  --> $DIR/mixed-cycles-2.rs:24:28
+   |
+LL | impl<T: ?Sized + BInd + B> A for T {}
+   |                  ----      ^     ^
+   |                  |
+   |                  unsatisfied trait bound introduced here
 note: required by a bound in `impls_a`
   --> $DIR/mixed-cycles-2.rs:27:15
    |

--- a/tests/ui/traits/next-solver/env-shadows-impls/param-candidate-shadows-project.rs
+++ b/tests/ui/traits/next-solver/env-shadows-impls/param-candidate-shadows-project.rs
@@ -25,7 +25,7 @@ fn foo<T: Foo>() {
     //
     //     https://github.com/rust-lang/trait-system-refactor-initiative/issues/76
     require_bar::<T>();
-    //~^ ERROR the trait bound `T: Bar` is not satisfied
+    //~^ ERROR type mismatch resolving `<T as Foo>::Assoc == i32`
 }
 
 fn main() {}

--- a/tests/ui/traits/next-solver/env-shadows-impls/param-candidate-shadows-project.stderr
+++ b/tests/ui/traits/next-solver/env-shadows-impls/param-candidate-shadows-project.stderr
@@ -1,19 +1,25 @@
-error[E0277]: the trait bound `T: Bar` is not satisfied
+error[E0271]: type mismatch resolving `<T as Foo>::Assoc == i32`
   --> $DIR/param-candidate-shadows-project.rs:27:19
    |
 LL |     require_bar::<T>();
-   |                   ^ the trait `Bar` is not implemented for `T`
+   |                   ^ type mismatch resolving `<T as Foo>::Assoc == i32`
    |
+note: types differ
+  --> $DIR/param-candidate-shadows-project.rs:10:18
+   |
+LL |     type Assoc = i32;
+   |                  ^^^
+note: required for `T` to implement `Bar`
+  --> $DIR/param-candidate-shadows-project.rs:13:9
+   |
+LL | impl<T> Bar for T where T: Foo<Assoc = i32> {}
+   |         ^^^     ^              ----------- unsatisfied trait bound introduced here
 note: required by a bound in `require_bar`
   --> $DIR/param-candidate-shadows-project.rs:15:19
    |
 LL | fn require_bar<T: Bar>() {}
    |                   ^^^ required by this bound in `require_bar`
-help: consider further restricting this bound
-   |
-LL | fn foo<T: Foo + Bar>() {
-   |               +++++
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/traits/next-solver/more-object-bound.rs
+++ b/tests/ui/traits/next-solver/more-object-bound.rs
@@ -10,7 +10,7 @@ trait Trait: SuperTrait<A = <Self as SuperTrait>::B> {}
 
 fn transmute<A, B>(x: A) -> B {
     foo::<A, B, dyn Trait<A = A, B = B>>(x)
-    //~^ ERROR the trait bound `dyn Trait<A = A, B = B>: Trait` is not satisfied
+    //~^ ERROR type mismatch resolving `<dyn Trait<A = A, B = B> as SuperTrait>::A == B`
 }
 
 fn foo<A, B, T: ?Sized>(x: T::A) -> B

--- a/tests/ui/traits/next-solver/more-object-bound.stderr
+++ b/tests/ui/traits/next-solver/more-object-bound.stderr
@@ -1,9 +1,10 @@
-error[E0277]: the trait bound `dyn Trait<A = A, B = B>: Trait` is not satisfied
+error[E0271]: type mismatch resolving `<dyn Trait<A = A, B = B> as SuperTrait>::A == B`
   --> $DIR/more-object-bound.rs:12:5
    |
 LL |     foo::<A, B, dyn Trait<A = A, B = B>>(x)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `dyn Trait<A = A, B = B>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ
    |
+   = note: required because it appears within the type `dyn Trait<A = A, B = B>`
 note: required by a bound in `foo`
   --> $DIR/more-object-bound.rs:18:8
    |
@@ -12,11 +13,7 @@ LL | fn foo<A, B, T: ?Sized>(x: T::A) -> B
 LL | where
 LL |     T: Trait<B = B>,
    |        ^^^^^^^^^^^^ required by this bound in `foo`
-help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
-   |
-LL | fn transmute<A, B>(x: A) -> B where dyn Trait<A = A, B = B>: Trait {
-   |                               ++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/traits/next-solver/normalize/two-projection-param-candidates-are-ambiguous.rs
+++ b/tests/ui/traits/next-solver/normalize/two-projection-param-candidates-are-ambiguous.rs
@@ -24,7 +24,7 @@ fn needs_bar<T: Bar>() {}
 
 fn foo<T: Foo<Assoc = i32> + Foo<Assoc = u32>>() {
     needs_bar::<T>();
-    //~^ ERROR type annotations needed: cannot satisfy `T: Bar`
+    //~^ ERROR type annotations needed: cannot satisfy `<T as Foo>::Assoc == i32`
 }
 
 fn main() {}

--- a/tests/ui/traits/next-solver/normalize/two-projection-param-candidates-are-ambiguous.stderr
+++ b/tests/ui/traits/next-solver/normalize/two-projection-param-candidates-are-ambiguous.stderr
@@ -1,11 +1,14 @@
-error[E0283]: type annotations needed: cannot satisfy `T: Bar`
+error[E0284]: type annotations needed: cannot satisfy `<T as Foo>::Assoc == i32`
   --> $DIR/two-projection-param-candidates-are-ambiguous.rs:26:17
    |
 LL |     needs_bar::<T>();
-   |                 ^
+   |                 ^ cannot satisfy `<T as Foo>::Assoc == i32`
    |
-   = note: cannot satisfy `T: Bar`
-   = help: the trait `Bar` is implemented for `T`
+note: required for `T` to implement `Bar`
+  --> $DIR/two-projection-param-candidates-are-ambiguous.rs:21:9
+   |
+LL | impl<T> Bar for T where T: Foo<Assoc = i32> {}
+   |         ^^^     ^              ----------- unsatisfied trait bound introduced here
 note: required by a bound in `needs_bar`
   --> $DIR/two-projection-param-candidates-are-ambiguous.rs:23:17
    |
@@ -14,4 +17,4 @@ LL | fn needs_bar<T: Bar>() {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0283`.
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/traits/next-solver/object-unsafety.rs
+++ b/tests/ui/traits/next-solver/object-unsafety.rs
@@ -11,9 +11,9 @@ fn copy<U: Setup + ?Sized>(from: &U::From) -> U::From {
 pub fn copy_any<T>(t: &T) -> T {
     copy::<dyn Setup<From=T>>(t)
     //~^ ERROR the type `&<dyn Setup<From = T> as Setup>::From` is not well-formed
-    //~| ERROR the trait bound `dyn Setup<From = T>: Setup` is not satisfied
     //~| ERROR mismatched types
     //~| ERROR the type `<dyn Setup<From = T> as Setup>::From` is not well-formed
+    //~| ERROR the trait bound `T: Copy` is not satisfied
 
     // FIXME(-Znext-solver): These error messages are horrible and some of them
     // are even simple fallout from previous error.

--- a/tests/ui/traits/next-solver/object-unsafety.stderr
+++ b/tests/ui/traits/next-solver/object-unsafety.stderr
@@ -1,18 +1,19 @@
-error[E0277]: the trait bound `dyn Setup<From = T>: Setup` is not satisfied
+error[E0277]: the trait bound `T: Copy` is not satisfied in `dyn Setup<From = T>`
   --> $DIR/object-unsafety.rs:12:12
    |
 LL |     copy::<dyn Setup<From=T>>(t)
-   |            ^^^^^^^^^^^^^^^^^ the trait `Setup` is not implemented for `dyn Setup<From = T>`
+   |            ^^^^^^^^^^^^^^^^^ within `dyn Setup<From = T>`, the trait `Copy` is not implemented for `T`, which is required by `dyn Setup<From = T>: Setup`
    |
+   = note: required because it appears within the type `dyn Setup<From = T>`
 note: required by a bound in `copy`
   --> $DIR/object-unsafety.rs:7:12
    |
 LL | fn copy<U: Setup + ?Sized>(from: &U::From) -> U::From {
    |            ^^^^^ required by this bound in `copy`
-help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+help: consider restricting type parameter `T`
    |
-LL | pub fn copy_any<T>(t: &T) -> T where dyn Setup<From = T>: Setup {
-   |                                ++++++++++++++++++++++++++++++++
+LL | pub fn copy_any<T: std::marker::Copy>(t: &T) -> T {
+   |                  +++++++++++++++++++
 
 error: the type `&<dyn Setup<From = T> as Setup>::From` is not well-formed
   --> $DIR/object-unsafety.rs:12:31

--- a/tests/ui/traits/next-solver/overflow/exponential-trait-goals.rs
+++ b/tests/ui/traits/next-solver/overflow/exponential-trait-goals.rs
@@ -15,5 +15,5 @@ fn impls<T: Trait>() {}
 
 fn main() {
     impls::<W<_>>();
-    //~^ ERROR overflow evaluating the requirement `W<_>: Trait`
+    //~^ ERROR overflow evaluating the requirement `_: Sized`
 }

--- a/tests/ui/traits/next-solver/overflow/exponential-trait-goals.stderr
+++ b/tests/ui/traits/next-solver/overflow/exponential-trait-goals.stderr
@@ -1,9 +1,16 @@
-error[E0275]: overflow evaluating the requirement `W<_>: Trait`
+error[E0275]: overflow evaluating the requirement `_: Sized`
   --> $DIR/exponential-trait-goals.rs:17:13
    |
 LL |     impls::<W<_>>();
    |             ^^^^
    |
+note: required for `W<(W<_>, W<_>)>` to implement `Trait`
+  --> $DIR/exponential-trait-goals.rs:7:12
+   |
+LL | impl<T, U> Trait for W<(W<T>, W<U>)>
+   |      -     ^^^^^     ^^^^^^^^^^^^^^^
+   |      |
+   |      unsatisfied trait bound introduced here
 note: required by a bound in `impls`
   --> $DIR/exponential-trait-goals.rs:14:13
    |

--- a/tests/ui/traits/next-solver/overflow/global-cache.stderr
+++ b/tests/ui/traits/next-solver/overflow/global-cache.stderr
@@ -5,14 +5,14 @@ LL |     impls_trait::<Four<Four<Four<Four<()>>>>>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "18"]` attribute to your crate (`global_cache`)
-note: required for `Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<()>>>>>>>>>>>>>` to implement `Trait`
+note: required for `Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<()>>>>>>>>>>>` to implement `Trait`
   --> $DIR/global-cache.rs:12:16
    |
 LL | impl<T: Trait> Trait for Inc<T> {}
    |         -----  ^^^^^     ^^^^^^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: 3 redundant requirements hidden
+   = note: 5 redundant requirements hidden
    = note: required for `Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<()>>>>>>>>>>>>>>>>` to implement `Trait`
 note: required by a bound in `impls_trait`
   --> $DIR/global-cache.rs:15:19

--- a/tests/ui/traits/next-solver/overflow/global-cache.stderr
+++ b/tests/ui/traits/next-solver/overflow/global-cache.stderr
@@ -5,6 +5,15 @@ LL |     impls_trait::<Four<Four<Four<Four<()>>>>>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "18"]` attribute to your crate (`global_cache`)
+note: required for `Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<()>>>>>>>>>>>>>` to implement `Trait`
+  --> $DIR/global-cache.rs:12:16
+   |
+LL | impl<T: Trait> Trait for Inc<T> {}
+   |         -----  ^^^^^     ^^^^^^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: 3 redundant requirements hidden
+   = note: required for `Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<()>>>>>>>>>>>>>>>>` to implement `Trait`
 note: required by a bound in `impls_trait`
   --> $DIR/global-cache.rs:15:19
    |


### PR DESCRIPTION
With the magic of `ProofTreeVisitor`, we can close the gap that we have on `ObligationCause`s being not as descriptive in the new trait solver.

r? lcnr

Needs some work and obviously documentation.