### PR TITLE
Document never type fallback in `!`'s docs

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -270,8 +270,8 @@ mod prim_bool {}
 ///
 /// # Never type fallback
 ///
-/// When the compiler sees a value of type `!` in a [coercion site](https://doc.rust-lang.org/reference/type-coercions.html#coercion-sites), it implicitly inserts a coercion
-/// to allow the type checker to infer any type:
+/// When the compiler sees a value of type `!` in a [coercion site], it implicitly inserts a
+/// coercion to allow the type checker to infer any type:
 ///
 /// ```rust,ignore (illustrative-and-has-placeholders)
 /// // this
@@ -305,13 +305,15 @@ mod prim_bool {}
 ///
 /// This is what is known as "never type fallback".
 ///
-/// Historically, the fallback type was [`()`], causing confusing behavior where `!` spontaneously coerced
-/// to `()`, even when it would not infer `()` without the fallback. There are plans to
-/// change it in the [2024 edition](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html) (and possibly in all editions on a later date); see
+/// Historically, the fallback type was [`()`], causing confusing behavior where `!` spontaneously
+/// coerced to `()`, even when it would not infer `()` without the fallback. There are plans to
+/// change it in the [2024 edition] (and possibly in all editions on a later date); see
 /// [Tracking Issue for making `!` fall back to `!`][fallback-ti].
 ///
+/// [coercion site](https://doc.rust-lang.org/reference/type-coercions.html#coercion-sites)
 /// [`()`]: prim@unit
 /// [fallback-ti]: https://github.com/rust-lang/rust/issues/123748
+/// [2024 edition]: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html
 ///
 #[unstable(feature = "never_type", issue = "35121")]
 mod prim_never {}

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -268,6 +268,47 @@ mod prim_bool {}
 /// [`Debug`]: fmt::Debug
 /// [`default()`]: Default::default
 ///
+/// # Never type fallback
+///
+/// When the compiler sees a value of type `!` it implicitly inserts a coercion (if possible),
+/// to allow type check to infer any type:
+///
+/// ```rust,ignore (illustrative-and-has-placeholders)
+/// // this
+/// let x: u8 = panic!();
+///
+/// // is (essentially) turned by the compiler into
+/// let x: u8 = absurd(panic!());
+///
+/// // where absurd is a function with the following signature
+/// // (it's sound, because `!` always marks unreachable code):
+/// fn absurd<T>(_: !) -> T { ... }
+// FIXME: use `core::convert::absurd` here instead, once it's merged
+/// ```
+///
+/// While it's convenient to be able to use non-diverging code in one of the branches (like
+/// `if a { b } else { return }`) this could lead to compilation errors:
+///
+/// ```compile_fail
+/// // this
+/// { panic!() };
+///
+/// // gets turned into this
+/// { absurd(panic!()) }; // error: can't infer the type of `absurd`
+/// ```
+///
+/// To prevent such errors, compiler remembers where it inserted `absurd` calls, and if it can't
+/// infer their type, it sets the type to the fallback type. `{ absurd::<Fallback>(panic!()) };`.
+/// This is what is known as "never type fallback".
+///
+/// Historically fallback was [`()`], causing confusing behavior where `!` spontaneously coerced
+/// to `()`, even though `()` was never mentioned (because of the fallback). There are plans to
+/// change it in 2024 edition (and possibly in all editions on a later date), see
+/// [Tracking Issue for making `!` fall back to `!`][fallback-ti].
+///
+/// [`()`]: prim@unit
+/// [fallback-ti]: https://github.com/rust-lang/rust/issues/123748
+///
 #[unstable(feature = "never_type", issue = "35121")]
 mod prim_never {}
 

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -270,8 +270,8 @@ mod prim_bool {}
 ///
 /// # Never type fallback
 ///
-/// When the compiler sees a value of type `!` it implicitly inserts a coercion (if possible),
-/// to allow type check to infer any type:
+/// When the compiler sees a value of type `!` it implicitly inserts a coercion (if possible)
+/// to allow type checker to infer any type:
 ///
 /// ```rust,ignore (illustrative-and-has-placeholders)
 /// // this
@@ -297,8 +297,13 @@ mod prim_bool {}
 /// { absurd(panic!()) }; // error: can't infer the type of `absurd`
 /// ```
 ///
-/// To prevent such errors, compiler remembers where it inserted `absurd` calls, and if it can't
-/// infer their type, it sets the type to the fallback type. `{ absurd::<Fallback>(panic!()) };`.
+/// To prevent such errors, the compiler remembers where it inserted `absurd` calls, and
+/// if it can't infer their type, it sets the type to the fallback type:
+/// ```rust, ignore
+/// type Fallback = /* An arbitrarily selected type! */;
+/// { absurd::<Fallback>(panic!()) }
+/// ```
+///
 /// This is what is known as "never type fallback".
 ///
 /// Historically fallback was [`()`], causing confusing behavior where `!` spontaneously coerced

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -310,10 +310,10 @@ mod prim_bool {}
 /// change it in the [2024 edition] (and possibly in all editions on a later date); see
 /// [Tracking Issue for making `!` fall back to `!`][fallback-ti].
 ///
-/// [coercion site](https://doc.rust-lang.org/reference/type-coercions.html#coercion-sites)
+/// [coercion site]: <https://doc.rust-lang.org/reference/type-coercions.html#coercion-sites>
 /// [`()`]: prim@unit
-/// [fallback-ti]: https://github.com/rust-lang/rust/issues/123748
-/// [2024 edition]: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html
+/// [fallback-ti]: <https://github.com/rust-lang/rust/issues/123748>
+/// [2024 edition]: <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html>
 ///
 #[unstable(feature = "never_type", issue = "35121")]
 mod prim_never {}

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -270,8 +270,8 @@ mod prim_bool {}
 ///
 /// # Never type fallback
 ///
-/// When the compiler sees a value of type `!` it implicitly inserts a coercion (if possible)
-/// to allow type checker to infer any type:
+/// When the compiler sees a value of type `!` in a [coercion site](https://doc.rust-lang.org/reference/type-coercions.html#coercion-sites), it implicitly inserts a coercion
+/// to allow the type checker to infer any type:
 ///
 /// ```rust,ignore (illustrative-and-has-placeholders)
 /// // this
@@ -286,8 +286,7 @@ mod prim_bool {}
 // FIXME: use `core::convert::absurd` here instead, once it's merged
 /// ```
 ///
-/// While it's convenient to be able to use non-diverging code in one of the branches (like
-/// `if a { b } else { return }`) this could lead to compilation errors:
+/// This can lead to compilation errors if the type cannot be inferred:
 ///
 /// ```compile_fail
 /// // this
@@ -298,7 +297,7 @@ mod prim_bool {}
 /// ```
 ///
 /// To prevent such errors, the compiler remembers where it inserted `absurd` calls, and
-/// if it can't infer their type, it sets the type to the fallback type:
+/// if it can't infer the type, it uses the fallback type instead:
 /// ```rust, ignore
 /// type Fallback = /* An arbitrarily selected type! */;
 /// { absurd::<Fallback>(panic!()) }
@@ -306,9 +305,9 @@ mod prim_bool {}
 ///
 /// This is what is known as "never type fallback".
 ///
-/// Historically fallback was [`()`], causing confusing behavior where `!` spontaneously coerced
-/// to `()`, even though `()` was never mentioned (because of the fallback). There are plans to
-/// change it in 2024 edition (and possibly in all editions on a later date), see
+/// Historically, the fallback type was [`()`], causing confusing behavior where `!` spontaneously coerced
+/// to `()`, even when it would not infer `()` without the fallback. There are plans to
+/// change it in the [2024 edition](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html) (and possibly in all editions on a later date); see
 /// [Tracking Issue for making `!` fall back to `!`][fallback-ti].
 ///
 /// [`()`]: prim@unit


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/124419)*
<!-- homu-ignore:end -->

Pulled the documentation I've written for rust-lang/rust#123939.

I want a single place where never type fallback is explained, which can be referred in all the lints and migration materials.