### PR TITLE
Stop re-implementing slice iterators in `vec::IntoIter`

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -146,6 +146,7 @@
 #![feature(receiver_trait)]
 #![feature(set_ptr_value)]
 #![feature(sized_type_properties)]
+#![feature(slice_drain_raw_iter)]
 #![feature(slice_from_ptr_range)]
 #![feature(slice_index_methods)]
 #![feature(slice_ptr_get)]

--- a/library/alloc/src/vec/in_place_collect.rs
+++ b/library/alloc/src/vec/in_place_collect.rs
@@ -253,12 +253,14 @@ where
 {
     let (src_buf, src_ptr, src_cap, mut dst_buf, dst_end, dst_cap) = unsafe {
         let inner = iterator.as_inner().as_into_iter();
+        let inner_ptr = inner.ptr();
+        let inner_end = inner_ptr.add(inner.len());
         (
             inner.buf,
-            inner.ptr,
+            inner_ptr,
             inner.cap,
             inner.buf.cast::<T>(),
-            inner.end as *const T,
+            inner_end.as_ptr() as *const T,
             inner.cap * mem::size_of::<I::Src>() / mem::size_of::<T>(),
         )
     };
@@ -275,9 +277,9 @@ where
     // check InPlaceIterable contract. This is only possible if the iterator advanced the
     // source pointer at all. If it uses unchecked access via TrustedRandomAccess
     // then the source pointer will stay in its initial position and we can't use it as reference
-    if src.ptr != src_ptr {
+    if src.ptr() != src_ptr {
         debug_assert!(
-            unsafe { dst_buf.add(len).cast() } <= src.ptr,
+            unsafe { dst_buf.add(len).cast() } <= src.ptr(),
             "InPlaceIterable contract violation, write pointer advanced beyond read pointer"
         );
     }

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -11,7 +11,9 @@ use core::iter::{
     TrustedRandomAccessNoCoerce,
 };
 use core::marker::PhantomData;
-use core::mem::{ManuallyDrop, SizedTypeProperties};
+use core::mem::ManuallyDrop;
+#[cfg(not(no_global_oom_handling))]
+use core::mem::SizedTypeProperties;
 use core::num::NonZero;
 #[cfg(not(no_global_oom_handling))]
 use core::ops::Deref;
@@ -128,6 +130,7 @@ impl<T, A: Allocator> IntoIter<T, A> {
     }
 
     /// Forgets to Drop the remaining elements while still allowing the backing allocation to be freed.
+    #[cfg(not(no_global_oom_handling))]
     pub(crate) fn forget_remaining_elements(&mut self) {
         self.drain.forget_remaining();
     }

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -64,9 +64,7 @@ use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop, MaybeUninit, SizedTypeProperties};
 use core::ops::{self, Index, IndexMut, Range, RangeBounds};
 use core::ptr::{self, NonNull};
-#[cfg(not(no_global_oom_handling))]
-use core::slice::DrainRaw;
-use core::slice::{self, SliceIndex};
+use core::slice::{self, DrainRaw, SliceIndex};
 
 use crate::alloc::{Allocator, Global};
 use crate::borrow::{Cow, ToOwned};

--- a/library/alloc/src/vec/spec_from_iter.rs
+++ b/library/alloc/src/vec/spec_from_iter.rs
@@ -44,12 +44,12 @@ impl<T> SpecFromIter<T, IntoIter<T>> for Vec<T> {
         // than creating it through the generic FromIterator implementation would. That limitation
         // is not strictly necessary as Vec's allocation behavior is intentionally unspecified.
         // But it is a conservative choice.
-        let has_advanced = iterator.buf != iterator.ptr;
+        let has_advanced = iterator.buf != iterator.ptr();
         if !has_advanced || iterator.len() >= iterator.cap / 2 {
             unsafe {
                 let it = ManuallyDrop::new(iterator);
                 if has_advanced {
-                    ptr::copy(it.ptr.as_ptr(), it.buf.as_ptr(), it.len());
+                    ptr::copy(it.ptr().as_ptr(), it.buf.as_ptr(), it.len());
                 }
                 return Vec::from_nonnull(it.buf, it.len(), it.cap);
             }

--- a/library/alloc/src/vec/splice.rs
+++ b/library/alloc/src/vec/splice.rs
@@ -59,7 +59,7 @@ impl<I: Iterator, A: Allocator> Drop for Splice<'_, I, A> {
         // Which means we can replace the slice::Iter with pointers that won't point to deallocated
         // memory, so that Drain::drop is still allowed to call iter.len(), otherwise it would break
         // the ptr.sub_ptr contract.
-        self.drain.iter = (&[]).iter();
+        self.drain.iter = Default::default();
 
         unsafe {
             if self.drain.tail_len == 0 {

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -224,6 +224,7 @@
 #![feature(doc_cfg)]
 #![feature(doc_cfg_hide)]
 #![feature(doc_notable_trait)]
+#![feature(dropck_eyepatch)]
 #![feature(effects)]
 #![feature(extern_types)]
 #![feature(f128)]

--- a/library/core/src/slice/drain.rs
+++ b/library/core/src/slice/drain.rs
@@ -1,0 +1,250 @@
+use crate::array;
+use crate::fmt;
+use crate::iter::{
+    FusedIterator, TrustedFused, TrustedLen, TrustedRandomAccessNoCoerce, UncheckedIterator,
+};
+use crate::mem::MaybeUninit;
+use crate::num::NonZero;
+use crate::ptr::NonNull;
+use crate::slice::NonNullIter;
+
+/// An iterator which takes ownership of items out of a slice, dropping any
+/// remaining items when the iterator drops.
+///
+/// Note that, like a raw pointer, it's **up to you** to get the lifetime right.
+/// In some ways it's actually harder to get right, as the iterator interface
+/// appears safe, but as you promise when creating one of these, you still must
+/// ensure that the mentioned memory is usable the whole time this lives.
+///
+/// Ideally you won't be using this directly, but rather a version encapsulated
+/// in a safer interface, like `vec::IntoIter`.
+///
+/// This raw version may be removed in favour of a future language feature,
+/// such as using `unsafe<'a> Drain<'a, T>` instead of `DrainRaw<T>`.
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+pub struct DrainRaw<T>(NonNullIter<T>);
+
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+// `may_dangle` is needed for compatibility with `vec::IntoIter`
+unsafe impl<#[may_dangle] T> Drop for DrainRaw<T> {
+    fn drop(&mut self) {
+        // When used in things like `vec::IntoIter`, the memory over which we're
+        // iterating might have been deallocated once we're running this drop.
+        // At the time of writing, Miri doesn't like `sub_ptr` between pointers
+        // into a deallocated allocation.  So checking empty first -- which just
+        // needs pointer equality -- avoids that issue.
+        if !self.is_empty() {
+            let slice = self.as_nonnull_slice();
+            // SAFETY: By type invariant, we're allowed to drop the rest of the items.
+            unsafe { slice.drop_in_place() };
+        }
+    }
+}
+
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+impl<T: fmt::Debug> fmt::Debug for DrainRaw<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("DrainRaw").field(&self.0.make_shortlived_slice()).finish()
+    }
+}
+
+impl<T> DrainRaw<T> {
+    /// Creates a new iterator which moves the `len` items starting at `ptr`
+    /// while it's iterated, or drops them when the iterator is dropped.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` through `ptr.add(len)` must be a single allocated object
+    ///   such that that it's sound to `offset` through it.
+    /// - All those elements must be readable, including being sufficiently aligned.
+    /// - All those elements are valid for dropping.
+    #[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+    #[inline]
+    pub unsafe fn from_parts(ptr: NonNull<T>, len: usize) -> Self {
+        // SAFETY: this function's safety conditions are stricter than NonNullIter,
+        // and include allowing the type to drop the items in `Drop`.
+        Self(unsafe { NonNullIter::from_parts(ptr, len) })
+    }
+
+    /// Returns a pointer to the remaining elements of the iterator
+    #[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+    #[inline]
+    pub fn as_nonnull_slice(&self) -> NonNull<[T]> {
+        self.0.make_nonnull_slice()
+    }
+
+    /// Equivalent to exhausting the iterator normally, but faster.
+    #[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+    #[inline]
+    pub fn drop_remaining(&mut self) {
+        let all = self.forget_remaining();
+        // SAFETY: We "forgot" these elements so our `Drop` won't drop them,
+        // so it's ok to drop them here without risking double-frees.
+        unsafe { all.drop_in_place() }
+    }
+
+    /// Exhaust the iterator without actually dropping the rest of the items.
+    ///
+    /// Returns the forgotten items.
+    #[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+    #[inline]
+    pub fn forget_remaining(&mut self) -> NonNull<[T]> {
+        let all = self.as_nonnull_slice();
+        self.0.exhaust();
+        all
+    }
+}
+
+impl<T> UncheckedIterator for DrainRaw<T> {
+    #[inline]
+    unsafe fn next_unchecked(&mut self) -> T {
+        // SAFETY: we're a 1:1 mapping of the inner iterator, so if the caller
+        // proved we have another item, the inner iterator has another one too.
+        // Also, the `next_unchecked` means the returned item is no longer part
+        // of the inner iterator, and thus `read`ing it here -- and giving it
+        // to the caller who will (probably) drop  it -- is ok.
+        unsafe { self.0.next_unchecked().read() }
+    }
+}
+
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+impl<T> Iterator for DrainRaw<T> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<T> {
+        match self.0.next() {
+            // SAFETY: The `next` means the returned item is no longer part of
+            // the inner iterator, and thus `read`ing it here -- and giving it
+            // to the caller who will (probably) drop it -- is ok.
+            Some(ptr) => Some(unsafe { ptr.read() }),
+            None => None,
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    #[inline]
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        let clamped = self.len().min(n);
+        // SAFETY: By construction, `clamped` is always in-bounds.
+        // The skipped elements are removed from the inner iterator so won't be
+        // dropped in `Drop`, so dropping there here is fine.
+        unsafe {
+            let to_drop = self.0.skip_forward_unchecked(clamped);
+            to_drop.drop_in_place();
+        }
+        NonZero::new(n - clamped).map_or(Ok(()), Err)
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn next_chunk<const N: usize>(&mut self) -> Result<[T; N], core::array::IntoIter<T, N>> {
+        let len = self.len();
+        let clamped = len.min(N);
+
+        // SAFETY: By construction, `clamped` is always in-bounds.
+        let to_copy = unsafe { self.0.skip_forward_unchecked(clamped) };
+        if len >= N {
+            // SAFETY: If we have more elements than were requested, they can be
+            // read directly because arrays need no extra alignment.
+            Ok(unsafe { to_copy.cast::<[T; N]>().read() })
+        } else {
+            let mut raw_ary = MaybeUninit::uninit_array();
+            // SAFETY: If we don't have enough elements left, then copy all the
+            // ones we do have into the local array, which cannot overlap because
+            // new locals are always distinct storage.
+            Err(unsafe {
+                MaybeUninit::<T>::slice_as_mut_ptr(&mut raw_ary)
+                    .copy_from_nonoverlapping(to_copy.as_mut_ptr(), len);
+                array::IntoIter::new_unchecked(raw_ary, 0..len)
+            })
+        }
+    }
+
+    unsafe fn __iterator_get_unchecked(&mut self, i: usize) -> Self::Item
+    where
+        Self: TrustedRandomAccessNoCoerce,
+    {
+        // SAFETY: the caller must guarantee that `i` is in bounds of the slice,
+        // so the `get_unchecked_mut(i)` is guaranteed to pointer to an element
+        // and thus guaranteed to be valid to dereference.
+        //
+        // Also note the implementation of `Self: TrustedRandomAccess` requires
+        // that `T: Copy` so reading elements from the buffer doesn't invalidate
+        // them for `Drop`.
+        unsafe { self.as_nonnull_slice().get_unchecked_mut(i).read() }
+    }
+}
+
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+impl<T> DoubleEndedIterator for DrainRaw<T> {
+    #[inline]
+    fn next_back(&mut self) -> Option<T> {
+        match self.0.next_back() {
+            // SAFETY: The `next_back` means the returned item is no longer part of
+            // the inner iterator, and thus `read`ing it here -- and giving it
+            // to the caller who will (probably) drop  it -- is ok.
+            Some(ptr) => Some(unsafe { ptr.read() }),
+            None => None,
+        }
+    }
+
+    #[inline]
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        let clamped = self.len().min(n);
+        // SAFETY: By construction, `clamped` is always in-bounds.
+        // The skipped elements are removed from the inner iterator so won't be
+        // dropped in `Drop`, so dropping there here is fine.
+        unsafe {
+            let to_drop = self.0.skip_backward_unchecked(clamped);
+            to_drop.drop_in_place();
+        }
+        NonZero::new(n - clamped).map_or(Ok(()), Err)
+    }
+}
+
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+impl<T> ExactSizeIterator for DrainRaw<T> {
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+impl<T> FusedIterator for DrainRaw<T> {}
+
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+#[doc(hidden)]
+unsafe impl<T> TrustedFused for DrainRaw<T> {}
+
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+unsafe impl<T> TrustedLen for DrainRaw<T> {}
+
+#[doc(hidden)]
+#[unstable(issue = "none", feature = "std_internals")]
+#[rustc_unsafe_specialization_marker]
+pub trait NonDrop {}
+
+// T: Copy as approximation for !Drop since get_unchecked does not advance self.ptr
+// and thus we can't implement drop-handling
+#[unstable(issue = "none", feature = "std_internals")]
+impl<T: Copy> NonDrop for T {}
+
+// TrustedRandomAccess (without NoCoerce) must not be implemented because
+// subtypes/supertypes of `T` might not be `NonDrop`
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+unsafe impl<T: NonDrop> TrustedRandomAccessNoCoerce for DrainRaw<T> {
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
+}

--- a/library/core/src/slice/drain.rs
+++ b/library/core/src/slice/drain.rs
@@ -48,6 +48,21 @@ impl<T: fmt::Debug> fmt::Debug for DrainRaw<T> {
     }
 }
 
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+impl<T> Default for DrainRaw<T> {
+    /// Creates an empty slice iterator.
+    ///
+    /// ```
+    /// # use core::slice::IterMut;
+    /// let iter: IterMut<'_, u8> = Default::default();
+    /// assert_eq!(iter.len(), 0);
+    /// ```
+    fn default() -> Self {
+        // SAFETY: dangling is sufficiently-aligned so zero-length is always fine
+        unsafe { DrainRaw::from_parts(NonNull::dangling(), 0) }
+    }
+}
+
 impl<T> DrainRaw<T> {
     /// Creates a new iterator which moves the `len` items starting at `ptr`
     /// while it's iterated, or drops them when the iterator is dropped.

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -135,13 +135,23 @@ impl<'a, T> Iter<'a, T> {
         // SAFETY: the type invariant guarantees the pointer represents a valid reference
         unsafe { p.as_ref() }
     }
+}
 
-    fn empty() -> Self {
+#[stable(feature = "default_iters", since = "1.70.0")]
+impl<T> Default for Iter<'_, T> {
+    /// Creates an empty slice iterator.
+    ///
+    /// ```
+    /// # use core::slice::Iter;
+    /// let iter: Iter<'_, u8> = Default::default();
+    /// assert_eq!(iter.len(), 0);
+    /// ```
+    fn default() -> Self {
         (&[]).into_iter()
     }
 }
 
-iterator! {struct Iter -> *const T, &'a T, {
+iterator! {struct Iter<'a, T> => *const T, &'a T, {
     fn is_sorted_by<F>(self, mut compare: F) -> bool
     where
         Self: Sized,
@@ -365,8 +375,18 @@ impl<'a, T> IterMut<'a, T> {
         // SAFETY: the type invariant guarantees the pointer represents a valid item
         unsafe { p.as_mut() }
     }
+}
 
-    fn empty() -> Self {
+#[stable(feature = "default_iters", since = "1.70.0")]
+impl<T> Default for IterMut<'_, T> {
+    /// Creates an empty slice iterator.
+    ///
+    /// ```
+    /// # use core::slice::IterMut;
+    /// let iter: IterMut<'_, u8> = Default::default();
+    /// assert_eq!(iter.len(), 0);
+    /// ```
+    fn default() -> Self {
         (&mut []).into_iter()
     }
 }
@@ -386,7 +406,85 @@ impl<T> AsRef<[T]> for IterMut<'_, T> {
 //     }
 // }
 
-iterator! {struct IterMut -> *mut T, &'a mut T, {}}
+iterator! {struct IterMut<'a, T> => *mut T, &'a mut T, {}}
+
+/// Iterator over all the `NonNull<T>` pointers to the elements of a slice.
+#[unstable(feature = "slice_non_null_iter", issue = "none")]
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+pub struct NonNullIter<T> {
+    /// The pointer to the next element to return, or the past-the-end location
+    /// if the iterator is empty.
+    ///
+    /// This address will be used for all ZST elements, never changed.
+    ptr: NonNull<T>,
+    /// For non-ZSTs, the non-null pointer to the past-the-end element.
+    ///
+    /// For ZSTs, this is `ptr::without_provenance(len)`.
+    end_or_len: *const T,
+}
+
+#[unstable(feature = "slice_non_null_iter", issue = "none")]
+impl<T: fmt::Debug> fmt::Debug for NonNullIter<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("NonNullIter").field(&self.make_shortlived_slice()).finish()
+    }
+}
+
+impl<T> NonNullIter<T> {
+    /// Turn an iterator giving `&T`s into one giving `NonNull<T>`s.
+    #[unstable(feature = "slice_non_null_iter", issue = "none")]
+    pub fn from_slice_iter(Iter { ptr, end_or_len, .. }: Iter<'_, T>) -> Self {
+        Self { ptr, end_or_len }
+    }
+
+    /// Turn an iterator giving `&mut T`s into one giving `NonNull<T>`s.
+    #[unstable(feature = "slice_non_null_iter", issue = "none")]
+    pub fn from_slice_iter_mut(IterMut { ptr, end_or_len, .. }: IterMut<'_, T>) -> Self {
+        Self { ptr, end_or_len }
+    }
+
+    /// Creates a new iterator over the `len` items starting at `ptr`
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` through `ptr.add(len)` must be a single allocated object
+    ///   such that that it's sound to `offset` through it.
+    /// - All those elements must be readable
+    /// - The caller must ensure both as long as the iterator is in use.
+    #[unstable(feature = "slice_non_null_iter", issue = "none")]
+    #[inline]
+    pub unsafe fn from_parts(ptr: NonNull<T>, len: usize) -> Self {
+        // SAFETY: There are several things here:
+        //
+        // `ptr` has been obtained by `slice.as_ptr()` where `slice` is a valid
+        // reference thus it is non-NUL and safe to use and pass to
+        // `NonNull::new_unchecked` .
+        //
+        // Adding `slice.len()` to the starting pointer gives a pointer
+        // at the end of `slice`. `end` will never be dereferenced, only checked
+        // for direct pointer equality with `ptr` to check if the iterator is
+        // done.
+        //
+        // In the case of a ZST, the end pointer is just the length.  It's never
+        // used as a pointer at all, and thus it's fine to have no provenance.
+        //
+        // See the `next_unchecked!` and `is_empty!` macros as well as the
+        // `post_inc_start` method for more information.
+        unsafe {
+            let end_or_len =
+                if T::IS_ZST { without_provenance_mut(len) } else { ptr.as_ptr().add(len) };
+
+            Self { ptr, end_or_len }
+        }
+    }
+
+    #[inline]
+    unsafe fn non_null_to_item(p: NonNull<T>) -> <Self as Iterator>::Item {
+        p
+    }
+}
+
+iterator! {struct NonNullIter<T> => *const T, NonNull<T>, {}}
 
 /// An internal abstraction over the splitting iterators, so that
 /// splitn, splitn_mut etc can be implemented once.

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -75,7 +75,7 @@ pub struct Iter<'a, T: 'a> {
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
 impl<T: fmt::Debug> fmt::Debug for Iter<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Iter").field(&self.as_slice()).finish()
+        f.debug_tuple("Iter").field(&self.make_shortlived_slice()).finish()
     }
 }
 
@@ -126,11 +126,22 @@ impl<'a, T> Iter<'a, T> {
     #[stable(feature = "iter_to_slice", since = "1.4.0")]
     #[inline]
     pub fn as_slice(&self) -> &'a [T] {
-        self.make_slice()
+        // SAFETY: the type invariant guarantees the pointer represents a valid slice
+        unsafe { self.make_nonnull_slice().as_ref() }
+    }
+
+    #[inline]
+    unsafe fn non_null_to_item(p: NonNull<T>) -> <Self as Iterator>::Item {
+        // SAFETY: the type invariant guarantees the pointer represents a valid reference
+        unsafe { p.as_ref() }
+    }
+
+    fn empty() -> Self {
+        (&[]).into_iter()
     }
 }
 
-iterator! {struct Iter -> *const T, &'a T, const, {/* no mut */}, as_ref, {
+iterator! {struct Iter -> *const T, &'a T, {
     fn is_sorted_by<F>(self, mut compare: F) -> bool
     where
         Self: Sized,
@@ -198,7 +209,7 @@ pub struct IterMut<'a, T: 'a> {
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
 impl<T: fmt::Debug> fmt::Debug for IterMut<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("IterMut").field(&self.make_slice()).finish()
+        f.debug_tuple("IterMut").field(&self.make_shortlived_slice()).finish()
     }
 }
 
@@ -304,7 +315,8 @@ impl<'a, T> IterMut<'a, T> {
     #[stable(feature = "slice_iter_mut_as_slice", since = "1.53.0")]
     #[inline]
     pub fn as_slice(&self) -> &[T] {
-        self.make_slice()
+        // SAFETY: the type invariant guarantees the pointer represents a valid slice
+        unsafe { self.make_nonnull_slice().as_ref() }
     }
 
     /// Views the underlying data as a mutable subslice of the original data.
@@ -347,6 +359,16 @@ impl<'a, T> IterMut<'a, T> {
         // for `from_raw_parts_mut` are fulfilled.
         unsafe { from_raw_parts_mut(self.ptr.as_ptr(), len!(self)) }
     }
+
+    #[inline]
+    unsafe fn non_null_to_item(mut p: NonNull<T>) -> <Self as Iterator>::Item {
+        // SAFETY: the type invariant guarantees the pointer represents a valid item
+        unsafe { p.as_mut() }
+    }
+
+    fn empty() -> Self {
+        (&mut []).into_iter()
+    }
 }
 
 #[stable(feature = "slice_iter_mut_as_slice", since = "1.53.0")]
@@ -364,7 +386,7 @@ impl<T> AsRef<[T]> for IterMut<'_, T> {
 //     }
 // }
 
-iterator! {struct IterMut -> *mut T, &'a mut T, mut, {mut}, as_mut, {}}
+iterator! {struct IterMut -> *mut T, &'a mut T, {}}
 
 /// An internal abstraction over the splitting iterators, so that
 /// splitn, splitn_mut etc can be implemented once.

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -409,7 +409,6 @@ impl<T> AsRef<[T]> for IterMut<'_, T> {
 iterator! {struct IterMut<'a, T> => *mut T, &'a mut T, {}}
 
 /// Iterator over all the `NonNull<T>` pointers to the elements of a slice.
-#[unstable(feature = "slice_non_null_iter", issue = "none")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct NonNullIter<T> {
     /// The pointer to the next element to return, or the past-the-end location
@@ -423,7 +422,6 @@ pub struct NonNullIter<T> {
     end_or_len: *const T,
 }
 
-#[unstable(feature = "slice_non_null_iter", issue = "none")]
 impl<T: fmt::Debug> fmt::Debug for NonNullIter<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("NonNullIter").field(&self.make_shortlived_slice()).finish()
@@ -431,18 +429,6 @@ impl<T: fmt::Debug> fmt::Debug for NonNullIter<T> {
 }
 
 impl<T> NonNullIter<T> {
-    /// Turn an iterator giving `&T`s into one giving `NonNull<T>`s.
-    #[unstable(feature = "slice_non_null_iter", issue = "none")]
-    pub fn from_slice_iter(Iter { ptr, end_or_len, .. }: Iter<'_, T>) -> Self {
-        Self { ptr, end_or_len }
-    }
-
-    /// Turn an iterator giving `&mut T`s into one giving `NonNull<T>`s.
-    #[unstable(feature = "slice_non_null_iter", issue = "none")]
-    pub fn from_slice_iter_mut(IterMut { ptr, end_or_len, .. }: IterMut<'_, T>) -> Self {
-        Self { ptr, end_or_len }
-    }
-
     /// Creates a new iterator over the `len` items starting at `ptr`
     ///
     /// # Safety
@@ -451,7 +437,6 @@ impl<T> NonNullIter<T> {
     ///   such that that it's sound to `offset` through it.
     /// - All those elements must be readable
     /// - The caller must ensure both as long as the iterator is in use.
-    #[unstable(feature = "slice_non_null_iter", issue = "none")]
     #[inline]
     pub unsafe fn from_parts(ptr: NonNull<T>, len: usize) -> Self {
         // SAFETY: There are several things here:
@@ -479,7 +464,16 @@ impl<T> NonNullIter<T> {
     }
 
     #[inline]
-    unsafe fn non_null_to_item(p: NonNull<T>) -> <Self as Iterator>::Item {
+    pub fn exhaust(&mut self) {
+        if T::IS_ZST {
+            self.end_or_len = without_provenance_mut(0);
+        } else {
+            self.end_or_len = self.ptr.as_ptr();
+        }
+    }
+
+    #[inline]
+    fn non_null_to_item(p: NonNull<T>) -> <Self as Iterator>::Item {
         p
     }
 }

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -65,9 +65,6 @@ macro_rules! iterator {
     (
         struct $name:ident -> $ptr:ty,
         $elem:ty,
-        $raw_mut:tt,
-        {$( $mut_:tt )?},
-        $into_ref:ident,
         {$($extra:tt)*}
     ) => {
         impl<'a, T> $name<'a, T> {
@@ -80,16 +77,22 @@ macro_rules! iterator {
             unsafe fn next_back_unchecked(&mut self) -> $elem {
                 // SAFETY: the caller promised it's not empty, so
                 // the offsetting is in-bounds and there's an element to return.
-                unsafe { self.pre_dec_end(1).$into_ref() }
+                unsafe { Self::non_null_to_item(self.pre_dec_end(1)) }
             }
 
             // Helper function for creating a slice from the iterator.
-            #[inline(always)]
-            fn make_slice(&self) -> &'a [T] {
-                // SAFETY: the iterator was created from a slice with pointer
-                // `self.ptr` and length `len!(self)`. This guarantees that all
-                // the prerequisites for `from_raw_parts` are fulfilled.
-                unsafe { from_raw_parts(self.ptr.as_ptr(), len!(self)) }
+            #[inline]
+            pub(crate) fn make_nonnull_slice(&self) -> NonNull<[T]> {
+                NonNull::slice_from_raw_parts(self.ptr, len!(self))
+            }
+
+            #[inline]
+            pub(crate) fn make_shortlived_slice<'b>(&'b self) -> &'b [T] {
+                // SAFETY: Everything expanded with this macro is readable while
+                // the iterator exists and is unchanged, so by tying this to the
+                // shorter-than-`'a` self borrow we can make this safe to call.
+                // (Elision would be fine here, but using `'b` for emphasis.)
+                unsafe { self.make_nonnull_slice().as_ref() }
             }
 
             // Helper function for moving the start of the iterator forwards by `offset` elements,
@@ -227,7 +230,7 @@ macro_rules! iterator {
                 loop {
                     // SAFETY: the loop iterates `i in 0..len`, which always is in bounds of
                     // the slice allocation
-                    acc = f(acc, unsafe { & $( $mut_ )? *self.ptr.add(i).as_ptr() });
+                    acc = f(acc, unsafe { Self::non_null_to_item(self.ptr.add(i)) });
                     // SAFETY: `i` can't overflow since it'll only reach usize::MAX if the
                     // slice had that length, in which case we'll break out of the loop
                     // after the increment
@@ -378,7 +381,7 @@ macro_rules! iterator {
                 // that will access this subslice are called, so it is valid
                 // for the returned reference to be mutable in the case of
                 // `IterMut`
-                unsafe { & $( $mut_ )? * self.ptr.as_ptr().add(idx) }
+                unsafe { Self::non_null_to_item(self.ptr.add(idx)) }
             }
 
             $($extra)*
@@ -438,7 +441,7 @@ macro_rules! iterator {
             unsafe fn next_unchecked(&mut self) -> $elem {
                 // SAFETY: The caller promised there's at least one more item.
                 unsafe {
-                    self.post_inc_start(1).$into_ref()
+                    Self::non_null_to_item(self.post_inc_start(1))
                 }
             }
         }
@@ -453,7 +456,7 @@ macro_rules! iterator {
             /// assert_eq!(iter.len(), 0);
             /// ```
             fn default() -> Self {
-                (& $( $mut_ )? []).into_iter()
+                Self::empty()
             }
         }
     }

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -135,6 +135,26 @@ macro_rules! iterator {
                     },
                 )
             }
+
+            // This is not used on every type that uses this macro, but is more
+            // convenient to implement here so it can use `post_inc_start`.
+            #[allow(dead_code)]
+            #[inline]
+            pub(crate) unsafe fn skip_forward_unchecked(&mut self, offset: usize) -> NonNull<[T]> {
+                // SAFETY: The caller guarantees the provided offset is in-bounds.
+                let old_begin = unsafe { self.post_inc_start(offset) };
+                NonNull::slice_from_raw_parts(old_begin, offset)
+            }
+
+            // This is not used on every type that uses this macro, but is more
+            // convenient to implement here so it can use `pre_dec_end`.
+            #[allow(dead_code)]
+            #[inline]
+            pub(crate) unsafe fn skip_backward_unchecked(&mut self, offset: usize) -> NonNull<[T]> {
+                // SAFETY: The caller guarantees the provided offset is in-bounds.
+                let new_end = unsafe { self.pre_dec_end(offset) };
+                NonNull::slice_from_raw_parts(new_end, offset)
+            }
         }
 
         #[allow(unused_lifetimes)]

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -63,11 +63,12 @@ macro_rules! len {
 // The shared definition of the `Iter` and `IterMut` iterators
 macro_rules! iterator {
     (
-        struct $name:ident -> $ptr:ty,
+        struct $name:ty => $ptr:ty,
         $elem:ty,
         {$($extra:tt)*}
     ) => {
-        impl<'a, T> $name<'a, T> {
+        #[allow(unused_lifetimes)]
+        impl<'a, T> $name {
             /// Returns the last element and moves the end of the iterator backwards by 1.
             ///
             /// # Safety
@@ -136,8 +137,9 @@ macro_rules! iterator {
             }
         }
 
+        #[allow(unused_lifetimes)]
         #[stable(feature = "rust1", since = "1.0.0")]
-        impl<T> ExactSizeIterator for $name<'_, T> {
+        impl<'a, T> ExactSizeIterator for $name {
             #[inline(always)]
             fn len(&self) -> usize {
                 len!(self)
@@ -149,8 +151,9 @@ macro_rules! iterator {
             }
         }
 
+        #[allow(unused_lifetimes)]
         #[stable(feature = "rust1", since = "1.0.0")]
-        impl<'a, T> Iterator for $name<'a, T> {
+        impl<'a, T> Iterator for $name {
             type Item = $elem;
 
             #[inline]
@@ -387,8 +390,9 @@ macro_rules! iterator {
             $($extra)*
         }
 
+        #[allow(unused_lifetimes)]
         #[stable(feature = "rust1", since = "1.0.0")]
-        impl<'a, T> DoubleEndedIterator for $name<'a, T> {
+        impl<'a, T> DoubleEndedIterator for $name {
             #[inline]
             fn next_back(&mut self) -> Option<$elem> {
                 // could be implemented with slices, but this avoids bounds checks
@@ -430,33 +434,22 @@ macro_rules! iterator {
             }
         }
 
+        #[allow(unused_lifetimes)]
         #[stable(feature = "fused", since = "1.26.0")]
-        impl<T> FusedIterator for $name<'_, T> {}
+        impl<'a, T> FusedIterator for $name {}
 
+        #[allow(unused_lifetimes)]
         #[unstable(feature = "trusted_len", issue = "37572")]
-        unsafe impl<T> TrustedLen for $name<'_, T> {}
+        unsafe impl<'a, T> TrustedLen for $name {}
 
-        impl<'a, T> UncheckedIterator for $name<'a, T> {
+        #[allow(unused_lifetimes)]
+        impl<'a, T> UncheckedIterator for $name {
             #[inline]
             unsafe fn next_unchecked(&mut self) -> $elem {
                 // SAFETY: The caller promised there's at least one more item.
                 unsafe {
                     Self::non_null_to_item(self.post_inc_start(1))
                 }
-            }
-        }
-
-        #[stable(feature = "default_iters", since = "1.70.0")]
-        impl<T> Default for $name<'_, T> {
-            /// Creates an empty slice iterator.
-            ///
-            /// ```
-            #[doc = concat!("# use core::slice::", stringify!($name), ";")]
-            #[doc = concat!("let iter: ", stringify!($name<'_, u8>), " = Default::default();")]
-            /// assert_eq!(iter.len(), 0);
-            /// ```
-            fn default() -> Self {
-                Self::empty()
             }
         }
     }

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -35,6 +35,7 @@ pub mod sort;
 
 mod ascii;
 mod cmp;
+mod drain;
 pub(crate) mod index;
 mod iter;
 mod raw;
@@ -46,8 +47,6 @@ mod specialize;
 #[doc(hidden)]
 pub use ascii::is_ascii_simple;
 
-#[unstable(feature = "slice_non_null_iter", issue = "none")]
-pub use iter::NonNullIter;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use iter::{Chunks, ChunksMut, Windows};
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -72,6 +71,11 @@ pub use iter::ArrayWindows;
 
 #[stable(feature = "slice_group_by", since = "1.77.0")]
 pub use iter::{ChunkBy, ChunkByMut};
+
+use iter::NonNullIter;
+
+#[unstable(feature = "slice_drain_raw_iter", issue = "none")]
+pub use drain::DrainRaw;
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub use iter::{SplitInclusive, SplitInclusiveMut};

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -46,6 +46,8 @@ mod specialize;
 #[doc(hidden)]
 pub use ascii::is_ascii_simple;
 
+#[unstable(feature = "slice_non_null_iter", issue = "none")]
+pub use iter::NonNullIter;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use iter::{Chunks, ChunksMut, Windows};
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/tests/codegen/vec-iter.rs
+++ b/tests/codegen/vec-iter.rs
@@ -1,8 +1,11 @@
 //@ compile-flags: -O
+//@ min-llvm-version: 18 (which added `dead_on_unwind`)
 #![crate_type = "lib"]
 #![feature(exact_size_is_empty)]
+#![feature(iter_advance_by)]
+#![feature(iter_next_chunk)]
 
-use std::vec;
+use std::{array, vec};
 
 // CHECK-LABEL: @vec_iter_len_nonnull
 #[no_mangle]
@@ -55,4 +58,61 @@ pub fn vec_iter_next_back_nonnull(it: &mut vec::IntoIter<u8>) -> Option<u8> {
     // CHECK-SAME: !noundef
     // CHECK: ret
     it.next_back()
+}
+
+// CHECK-LABEL: @vec_iter_next_transfers_ownership
+#[no_mangle]
+pub fn vec_iter_next_transfers_ownership(it: &mut vec::IntoIter<Box<i32>>) -> Option<Box<i32>> {
+    // CHECK-NOT: __rust_dealloc
+    it.next()
+}
+
+// CHECK-LABEL: @vec_iter_advance_drops_item
+#[no_mangle]
+pub fn vec_iter_advance_drops_item(it: &mut vec::IntoIter<Box<i32>>) {
+    // CHECK-NOT: __rust_dealloc
+    // CHECK: call void @__rust_dealloc
+    // CHECK-SAME: noundef 4
+    // CHECK-SAME: noundef 4
+    // CHECK-NOT: __rust_dealloc
+    _ = it.advance_by(1);
+}
+
+// CHECK-LABEL: @vec_iter_next_chunk_short
+// CHECK-SAME: ptr{{.+}}%[[RET:.+]],
+#[no_mangle]
+pub fn vec_iter_next_chunk_short(
+    it: &mut vec::IntoIter<u8>,
+) -> Result<[u8; 4], array::IntoIter<u8, 4>> {
+    // CHECK-NOT: alloca
+    // CHECK: %[[ACTUAL_LEN:.+]] = sub nuw
+
+    // CHECK: %[[OUT1:.+]] = getelementptr inbounds i8, ptr %[[RET]]
+    // CHECK: call void @llvm.memcpy{{.+}}(ptr{{.+}}%[[OUT1]],{{.+}} %[[ACTUAL_LEN]], i1 false)
+    // CHECK: br
+
+    // CHECK: %[[FULL:.+]] = load i32,
+    // CHECK: %[[OUT2:.+]] = getelementptr inbounds i8, ptr %[[RET]]
+    // CHECK: store i32 %[[FULL]], ptr %[[OUT2]]
+    // CHECK: br
+    it.next_chunk::<4>()
+}
+
+// CHECK-LABEL: @vec_iter_next_chunk_long
+// CHECK-SAME: ptr{{.+}}%[[RET:.+]],
+#[no_mangle]
+pub fn vec_iter_next_chunk_long(
+    it: &mut vec::IntoIter<u8>,
+) -> Result<[u8; 123], array::IntoIter<u8, 123>> {
+    // CHECK-NOT: alloca
+    // CHECK: %[[ACTUAL_LEN:.+]] = sub nuw
+
+    // CHECK: %[[OUT1:.+]] = getelementptr inbounds i8, ptr %[[RET]]
+    // CHECK: call void @llvm.memcpy{{.+}}(ptr{{.+}}%[[OUT1]],{{.+}} %[[ACTUAL_LEN]], i1 false)
+    // CHECK: br
+
+    // CHECK: %[[OUT2:.+]] = getelementptr inbounds i8, ptr %[[RET]]
+    // CHECK: call void @llvm.memcpy{{.+}}(ptr{{.+}}%[[OUT2]],{{.+}} 123, i1 false)
+    // CHECK: br
+    it.next_chunk::<123>()
 }

--- a/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
@@ -6,14 +6,18 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
     let mut _2: std::vec::IntoIter<impl Sized>;
     let mut _3: std::vec::IntoIter<impl Sized>;
     let mut _4: &mut std::vec::IntoIter<impl Sized>;
-    let mut _5: std::option::Option<impl Sized>;
-    let mut _6: isize;
-    let _8: ();
+    let mut _6: std::option::Option<impl Sized>;
+    let mut _7: isize;
+    let _9: ();
     scope 1 {
         debug iter => _3;
-        let _7: impl Sized;
+        let _8: impl Sized;
         scope 2 {
-            debug x => _7;
+            debug x => _8;
+        }
+        scope 3 (inlined <std::vec::IntoIter<impl Sized> as Iterator>::next) {
+            debug self => _4;
+            let mut _5: &mut core::slice::drain::DrainRaw<impl Sized>;
         }
     }
 
@@ -29,20 +33,21 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
     }
 
     bb2: {
-        StorageLive(_5);
-        StorageLive(_4);
+        StorageLive(_6);
         _4 = &mut _3;
-        _5 = <std::vec::IntoIter<impl Sized> as Iterator>::next(move _4) -> [return: bb3, unwind: bb9];
+        StorageLive(_5);
+        _5 = &mut (_3.4: core::slice::drain::DrainRaw<impl Sized>);
+        _6 = <core::slice::drain::DrainRaw<impl Sized> as Iterator>::next(move _5) -> [return: bb3, unwind: bb9];
     }
 
     bb3: {
-        StorageDead(_4);
-        _6 = discriminant(_5);
-        switchInt(move _6) -> [0: bb4, 1: bb6, otherwise: bb8];
+        StorageDead(_5);
+        _7 = discriminant(_6);
+        switchInt(move _7) -> [0: bb4, 1: bb6, otherwise: bb8];
     }
 
     bb4: {
-        StorageDead(_5);
+        StorageDead(_6);
         drop(_3) -> [return: bb5, unwind continue];
     }
 
@@ -53,12 +58,12 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
     }
 
     bb6: {
-        _7 = move ((_5 as Some).0: impl Sized);
-        _8 = opaque::<impl Sized>(move _7) -> [return: bb7, unwind: bb9];
+        _8 = move ((_6 as Some).0: impl Sized);
+        _9 = opaque::<impl Sized>(move _8) -> [return: bb7, unwind: bb9];
     }
 
     bb7: {
-        StorageDead(_5);
+        StorageDead(_6);
         goto -> bb2;
     }
 


### PR DESCRIPTION
Today, `vec::IntoIter` has essentially an inlined copy of an out-of-date version of `slice::Iter`, including all the distinct `T::IS_ZST` checks and everything.  That's because it can't actually use `slice::Iter<'a, T>` due to the lifetime and the references.

But it's silly that it needs to reimplement all that logic, and that we thus end up needing things like #114205 to redo various optimizations on it after they're done on slice iterators.

This PR addresses that as follows:
- Makes a new internal `slice::NonNullIter<T>` implemented using the same `iterator!` macro that implements `Iterator` for `Iter` and `IterMut`, so that it'll have all the optimizations without needing to duplicate code, but without the problematic lifetime and SB/TB implications of references.
- Wraps that into a `slice::DrainRaw<T>` that moves/drops the items in the iterated range.
- Implements both `array::Drain<'a, T>` and `vec::IntoIter<T>` using `DrainRaw`, rather than them both needing to have the "read the pointer on next, drop_in_place on drop" logic.

Thus `vec::IntoIter`'s implementation gets a bunch shorter since it no longer has to worry about things like the best way to iterate a slice of ZSTs.  It can just focus on ensuring that the deallocating happens in the correct place & order.

(This intentionally leaves `slice::Iter` and `slice::ItemMut` almost entirely alone, as the details there are *very* hot.)
