### PR TITLE
Do not ICE on invalid consts when walking mono-reachable blocks

### DIFF
--- a/tests/ui/consts/mono-reachable-invalid-const.rs
+++ b/tests/ui/consts/mono-reachable-invalid-const.rs
@@ -1,0 +1,23 @@
+//@ build-fail
+
+struct Bar<const BITS: usize>;
+
+impl<const BITS: usize> Bar<BITS> {
+    const ASSERT: bool = {
+        let b = std::convert::identity(1);
+        ["oops"][b]; //~ ERROR evaluation of `Bar::<0>::ASSERT` failed
+        true
+    };
+
+    fn assert() {
+        let val = Self::ASSERT;
+        if val {
+            std::convert::identity(val);
+        }
+    }
+}
+
+
+fn main() {
+    Bar::<0>::assert();
+}

--- a/tests/ui/consts/mono-reachable-invalid-const.stderr
+++ b/tests/ui/consts/mono-reachable-invalid-const.stderr
@@ -1,0 +1,29 @@
+error[E0080]: evaluation of `Bar::<0>::ASSERT` failed
+  --> $DIR/mono-reachable-invalid-const.rs:8:9
+   |
+LL |         ["oops"][b];
+   |         ^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 1
+
+note: erroneous constant encountered
+  --> $DIR/mono-reachable-invalid-const.rs:13:19
+   |
+LL |         let val = Self::ASSERT;
+   |                   ^^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/mono-reachable-invalid-const.rs:13:19
+   |
+LL |         let val = Self::ASSERT;
+   |                   ^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: the above error was encountered while instantiating `fn Bar::<0>::assert`
+  --> $DIR/mono-reachable-invalid-const.rs:22:5
+   |
+LL |     Bar::<0>::assert();
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
The `bug!` here was written under the logic of "this condition is impossible, right?" except that of course, if the compiler is given code that results in an compile error, then the situation is possible.

So now we just direct errors into the already-existing path for when we can't do a mono-time optimization.