### PR TITLE
Relax `A: Clone` bound for `rc::Weak::into_raw_and_alloc`

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -3029,13 +3029,10 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     /// [`as_ptr`]: Weak::as_ptr
     #[inline]
     #[unstable(feature = "allocator_api", issue = "32838")]
-    pub fn into_raw_and_alloc(self) -> (*const T, A)
-    where
-        A: Clone,
-    {
-        let result = self.as_ptr();
-        let alloc = self.alloc.clone();
-        mem::forget(self);
+    pub fn into_raw_and_alloc(self) -> (*const T, A) {
+        let rc = mem::ManuallyDrop::new(self);
+        let result = rc.as_ptr();
+        let alloc = unsafe { ptr::read(&rc.alloc) };
         (result, alloc)
     }
 


### PR DESCRIPTION
Makes this method to behave the same way as [`Box::into_raw_with_allocator`](https://doc.rust-lang.org/1.77.2/alloc/boxed/struct.Box.html#method.into_raw_with_allocator) and [`Vec::into_raw_parts_with_alloc`](https://doc.rust-lang.org/1.77.2/alloc/vec/struct.Vec.html#method.into_raw_parts_with_alloc).

I have also noticed the inconsistent presence and naming, should probably be addressed in the future.