### PR TITLE
doc: Make the `mod.rs` in the comment point to the correct location

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1,6 +1,6 @@
 //! Type checking expressions.
 //!
-//! See `mod.rs` for more context on type checking in general.
+//! See [`rustc_hir_analysis::check`] for more context on type checking in general.
 
 use crate::cast;
 use crate::coercion::CoerceMany;


### PR DESCRIPTION
The origin `mod.rs` had moved to `rustc_hir_analysis::check`, but the annotation doesn't point to it.

See [the origin PR](https://github.com/rust-lang/rust/pull/61857/files#diff-b65997b61ccd8d8e08238c925d631207671aca506e93ce7c5cfa0bec134c0a8e).