### PR TITLE
Set default value `deny-warnings` for compiler/library/tools profiles to `false`

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -826,9 +826,18 @@
 # in the sysroot. It is required for running nvptx tests.
 #rust.llvm-bitcode-linker = false
 
-# Whether to deny warnings in crates. Set to `false` to avoid
-# error: warnings are denied by `build.warnings` configuration
-#rust.deny-warnings = true
+# Whether to deny warnings in crates.
+#
+# Set to `true` to fail the build if there are warnings in crates,
+# to not accidentally miss warnings in long build output.
+#
+# Set to `false` to avoid "error: warnings are denied by `build.warnings` configuration"
+# and have easier time iterating on your changes.
+#
+# This is set to `true` by default for the `dist` profile and to `false` otherwise.
+#
+# Note that CI denies warnings.
+#rust.deny-warnings = false
 
 # Print backtrace on internal compiler errors during bootstrap
 #rust.backtrace-on-ice = false

--- a/src/bootstrap/defaults/bootstrap.compiler.toml
+++ b/src/bootstrap/defaults/bootstrap.compiler.toml
@@ -25,6 +25,8 @@ frame-pointers = true
 # e.g. check that it builds locally and check the baseline behavior of a
 # compiler built from latest `main` commit.
 download-rustc = false
+# Don't fail compilation when there are warnings.
+deny-warnings = false
 
 [llvm]
 # Having this set to true disrupts compiler development workflows for people who use `llvm.download-ci-llvm = true`

--- a/src/bootstrap/defaults/bootstrap.dist.toml
+++ b/src/bootstrap/defaults/bootstrap.dist.toml
@@ -26,6 +26,8 @@ download-rustc = false
 llvm-bitcode-linker = true
 # Required to make builds reproducible.
 remap-debuginfo = true
+# Fail compilation when there are warnings.
+deny-warnings = true
 
 [dist]
 # Use better compression when preparing tarballs.

--- a/src/bootstrap/defaults/bootstrap.library.toml
+++ b/src/bootstrap/defaults/bootstrap.library.toml
@@ -14,6 +14,8 @@ lto = "off"
 # library development by skipping compiler builds.
 # FIXME: download-rustc is currently broken: https://github.com/rust-lang/rust/issues/142505
 download-rustc = false
+# Don't fail compilation when there are warnings.
+deny-warnings = false
 
 [llvm]
 # Will download LLVM from CI if available on your platform.

--- a/src/bootstrap/defaults/bootstrap.tools.toml
+++ b/src/bootstrap/defaults/bootstrap.tools.toml
@@ -6,6 +6,8 @@ incremental = true
 # Most commonly, tools contributors do not need to modify the compiler, so
 # downloading a CI rustc is a good default for tools profile.
 download-rustc = "if-unchanged"
+# Don't fail compilation when there are warnings.
+deny-warnings = false
 
 [build]
 # cargo and clippy tests don't pass on stage 1

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -626,4 +626,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "New `--verbose-run-make-subprocess-output` flag for `x.py test` (defaults to true). Set `--verbose-run-make-subprocess-output=false` to suppress verbose subprocess output for passing run-make tests when using `--no-capture`.",
     },
+    ChangeInfo {
+        change_id: 124439,
+        severity: ChangeSeverity::Info,
+        summary: "Default for `rust.deny-warnings` on `compiler`, `library` and `tools` profiles changed to `false`",
+    },
 ];


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/124439)*
<!-- homu-ignore:end -->

Denying warnings slows a down iteration times as you need to rebuild things after fixing/silencing warnings.

This is especially bad for new contributors who are
1. Less experienced with the code base and are thus more likely to need to experiment with half broken code
2. More likely have lower end hardware on which rebuilds are expensive time-wise

This PR changes the default to not deny warnings for all profiles except `dist`, i.e. all the profiles on which people do development.