### PR TITLE
String.truncate comment microfix (greater or equal)

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1382,7 +1382,7 @@ impl String {
 
     /// Shortens this `String` to the specified length.
     ///
-    /// If `new_len` is greater than the string's current length, this has no
+    /// If `new_len` is greater  than or equal to the string's current length, this has no
     /// effect.
     ///
     /// Note that this method has no effect on the allocated capacity

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1382,7 +1382,7 @@ impl String {
 
     /// Shortens this `String` to the specified length.
     ///
-    /// If `new_len` is greater  than or equal to the string's current length, this has no
+    /// If `new_len` is greater than or equal to the string's current length, this has no
     /// effect.
     ///
     /// Note that this method has no effect on the allocated capacity


### PR DESCRIPTION
String.truncate calls Vec.truncate, in turn, and that states "is greater or equal to". Beside common sense.