### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2019,7 +2019,7 @@ impl HumanEmitter {
                     let offset: isize = offsets
                         .iter()
                         .filter_map(
-                            |(start, v)| if span_start_pos <= *start { None } else { Some(v) },
+                            |(start, v)| if span_start_pos < *start { None } else { Some(v) },
                         )
                         .sum();
                     let underline_start = (span_start_pos + start) as isize + offset;
@@ -2028,7 +2028,7 @@ impl HumanEmitter {
                     let padding: usize = max_line_num_len + 3;
                     for p in underline_start..underline_end {
                         if let DisplaySuggestion::Underline = show_code_change {
-                            // If this is a replacement, underline with `^`, if this is an addition
+                            // If this is a replacement, underline with `~`, if this is an addition
                             // underline with `+`.
                             buffer.putc(
                                 row_num,

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1,6 +1,6 @@
 //! Type checking expressions.
 //!
-//! See `mod.rs` for more context on type checking in general.
+//! See [`rustc_hir_analysis::check`] for more context on type checking in general.
 
 use crate::cast;
 use crate::coercion::CoerceMany;

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -53,15 +53,12 @@ check-aux:
 		src/tools/cargotest \
 		$(BOOTSTRAP_ARGS)
 	# Run standard library tests in Miri.
-	# We use a 64bit little-endian and a 32bit big-endian target for max coverage.
 	$(Q)BOOTSTRAP_SKIP_TARGET_SANITY=1 \
 		$(BOOTSTRAP) miri --stage 2 \
-		--target x86_64-unknown-linux-gnu,mips-unknown-linux-gnu \
 		library/core \
 		library/alloc \
 		--no-doc
 	# Some doctests have intentional memory leaks.
-	# Also, they work only on the host.
 	$(Q)MIRIFLAGS="-Zmiri-ignore-leaks -Zmiri-disable-isolation" \
 		$(BOOTSTRAP) miri --stage 2 \
 		library/core \

--- a/tests/crashes/109812.rs
+++ b/tests/crashes/109812.rs
@@ -1,0 +1,22 @@
+//@ known-bug: #109812
+
+#![warn(rust_2021_incompatible_closure_captures)]
+
+enum Either {
+    One(X),
+    Two(X),
+}
+
+struct X(Y);
+
+struct Y;
+
+fn move_into_fnmut() {
+    let x = X(Y);
+
+    consume_fnmut(|| {
+        let Either::Two(ref mut _t) = x;
+
+        let X(mut _t) = x;
+    });
+}

--- a/tests/ui/const-generics/adt_const_params/opaque_type_with_non-universal_region_substs_ice-111911.rs
+++ b/tests/ui/const-generics/adt_const_params/opaque_type_with_non-universal_region_substs_ice-111911.rs
@@ -1,0 +1,13 @@
+//@ edition:2021
+// issues rust-lang/rust#111911
+// test for ICE opaque type with non-universal region substs
+
+#![feature(adt_const_params)]
+#![allow(incomplete_features)]
+
+pub async fn foo<const X: &'static str>() {}
+//~^ ERROR const parameter `X` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+//~| ERROR const parameter `X` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+fn bar<const N: &'static u8>() -> impl Sized {}
+
+pub fn main() {}

--- a/tests/ui/const-generics/adt_const_params/opaque_type_with_non-universal_region_substs_ice-111911.stderr
+++ b/tests/ui/const-generics/adt_const_params/opaque_type_with_non-universal_region_substs_ice-111911.stderr
@@ -1,0 +1,16 @@
+error: const parameter `X` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+  --> $DIR/opaque_type_with_non-universal_region_substs_ice-111911.rs:8:43
+   |
+LL | pub async fn foo<const X: &'static str>() {}
+   |                                           ^^
+
+error: const parameter `X` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+  --> $DIR/opaque_type_with_non-universal_region_substs_ice-111911.rs:8:43
+   |
+LL | pub async fn foo<const X: &'static str>() {}
+   |                                           ^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.rs
+++ b/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.rs
@@ -1,0 +1,32 @@
+// ICE Inconsistent rustc_transmute::is_transmutable(...) result, got Yes
+// issue: rust-lang/rust#110969
+#![feature(adt_const_params, generic_const_exprs, transmutability)]
+#![allow(incomplete_features, unstable_features)]
+
+mod assert {
+    use std::mem::BikeshedIntrinsicFrom;
+
+    pub fn is_transmutable<Src, Dst, Context, const ASSUME: std::mem::Assume>()
+    where
+        Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
+        //~^ ERROR trait takes at most 2 generic arguments but 3 generic arguments were supplied
+    {
+    }
+}
+
+fn via_associated_const() {
+    struct Context;
+    #[repr(C)]
+    struct Src;
+    #[repr(C)]
+    struct Dst;
+
+    trait Trait {
+        const FALSE: bool = assert::is_transmutable::<Src, Dst, Context, {}>();
+        //~^ ERROR mismatched types
+        //~| ERROR `Src` cannot be safely transmuted into `Dst`
+        //~| ERROR mismatched types
+    }
+}
+
+pub fn main() {}

--- a/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
+++ b/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
@@ -1,0 +1,39 @@
+error[E0107]: trait takes at most 2 generic arguments but 3 generic arguments were supplied
+  --> $DIR/transmutable-ice-110969.rs:11:14
+   |
+LL |         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
+   |              ^^^^^^^^^^^^^^^^^^^^^               ------ help: remove this generic argument
+   |              |
+   |              expected at most 2 generic arguments
+
+error[E0308]: mismatched types
+  --> $DIR/transmutable-ice-110969.rs:25:74
+   |
+LL |         const FALSE: bool = assert::is_transmutable::<Src, Dst, Context, {}>();
+   |                                                                          ^^ expected `Assume`, found `()`
+
+error[E0277]: `Src` cannot be safely transmuted into `Dst`
+  --> $DIR/transmutable-ice-110969.rs:25:60
+   |
+LL |         const FALSE: bool = assert::is_transmutable::<Src, Dst, Context, {}>();
+   |                                                            ^^^ `Dst` may carry safety invariants
+   |
+note: required by a bound in `is_transmutable`
+  --> $DIR/transmutable-ice-110969.rs:11:14
+   |
+LL |     pub fn is_transmutable<Src, Dst, Context, const ASSUME: std::mem::Assume>()
+   |            --------------- required by a bound in this function
+LL |     where
+LL |         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+
+error[E0308]: mismatched types
+  --> $DIR/transmutable-ice-110969.rs:25:29
+   |
+LL |         const FALSE: bool = assert::is_transmutable::<Src, Dst, Context, {}>();
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0277, E0308.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs
+++ b/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs
@@ -1,0 +1,23 @@
+// issue: rust-lang/rust#113776
+// ice: expected type of closure body to be a closure or coroutine
+//@ edition: 2021
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use core::ops::SubAssign;
+
+fn f<T>(
+    data: &[(); {
+         let f: F = async { 1 };
+         //~^ ERROR cannot find type `F` in this scope
+
+         1
+     }],
+) -> impl Iterator<Item = SubAssign> {
+//~^ ERROR the type parameter `Rhs` must be explicitly specified
+//~| ERROR `()` is not an iterator
+//~| ERROR trait objects must include the `dyn` keyword
+//~| ERROR the type parameter `Rhs` must be explicitly specified [E0393]
+}
+
+pub fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
@@ -1,0 +1,68 @@
+error[E0412]: cannot find type `F` in this scope
+  --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:11:17
+   |
+LL |          let f: F = async { 1 };
+   |                 ^
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+   |
+   = note: similarly named trait `Fn` defined here
+   |
+help: a trait with a similar name exists
+   |
+LL |          let f: Fn = async { 1 };
+   |                 ~~
+help: you might be missing a type parameter
+   |
+LL | fn f<T, F>(
+   |       +++
+
+error[E0393]: the type parameter `Rhs` must be explicitly specified
+  --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:16:27
+   |
+LL | ) -> impl Iterator<Item = SubAssign> {
+   |                           ^^^^^^^^^ help: set the type parameter to the desired type: `SubAssign<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: type parameter `Rhs` must be specified for this
+   |
+   = note: because of the default `Self` reference, type parameters must be specified on object types
+
+error[E0393]: the type parameter `Rhs` must be explicitly specified
+  --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:16:27
+   |
+LL | ) -> impl Iterator<Item = SubAssign> {
+   |                           ^^^^^^^^^ help: set the type parameter to the desired type: `SubAssign<Rhs>`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+   = note: type parameter `Rhs` must be specified for this
+   |
+   = note: because of the default `Self` reference, type parameters must be specified on object types
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: `()` is not an iterator
+  --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:16:6
+   |
+LL | ) -> impl Iterator<Item = SubAssign> {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `()`
+
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:16:27
+   |
+LL | ) -> impl Iterator<Item = SubAssign> {
+   |                           ^^^^^^^^^
+   |
+help: add `dyn` keyword before this trait
+   |
+LL | ) -> impl Iterator<Item = dyn SubAssign> {
+   |                           +++
+help: you might have meant to write a bound here
+   |
+LL | ) -> impl Iterator<Item: SubAssign> {
+   |                        ~
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0393, E0412, E0782.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/const-generics/generic_const_exprs/failed-to-resolve-instance-ice-111667.rs
+++ b/tests/ui/const-generics/generic_const_exprs/failed-to-resolve-instance-ice-111667.rs
@@ -1,0 +1,18 @@
+// issue rust-lang/rust#111667
+// ICE failed to resolve instance for <[f32; 2] as CrossProduct ..
+//@ check-pass
+
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+pub trait CrossProduct<'a, T, R> {
+    fn cross(&'a self, t: &'a T) -> R;
+}
+
+impl<'a, T, U, const N: usize> CrossProduct<'a, [U; N], [(&'a T, &'a U); N * N]> for [T; N] {
+    fn cross(&'a self, us: &'a [U; N]) -> [(&'a T, &'a U); N * N] {
+        std::array::from_fn(|i| (&self[i / N], &us[i % N]))
+    }
+}
+
+pub fn main() {}

--- a/tests/ui/consts/mono-reachable-invalid-const.rs
+++ b/tests/ui/consts/mono-reachable-invalid-const.rs
@@ -1,0 +1,23 @@
+//@ build-fail
+
+struct Bar<const BITS: usize>;
+
+impl<const BITS: usize> Bar<BITS> {
+    const ASSERT: bool = {
+        let b = std::convert::identity(1);
+        ["oops"][b]; //~ ERROR evaluation of `Bar::<0>::ASSERT` failed
+        true
+    };
+
+    fn assert() {
+        let val = Self::ASSERT;
+        if val {
+            std::convert::identity(val);
+        }
+    }
+}
+
+
+fn main() {
+    Bar::<0>::assert();
+}

--- a/tests/ui/consts/mono-reachable-invalid-const.stderr
+++ b/tests/ui/consts/mono-reachable-invalid-const.stderr
@@ -1,0 +1,29 @@
+error[E0080]: evaluation of `Bar::<0>::ASSERT` failed
+  --> $DIR/mono-reachable-invalid-const.rs:8:9
+   |
+LL |         ["oops"][b];
+   |         ^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 1
+
+note: erroneous constant encountered
+  --> $DIR/mono-reachable-invalid-const.rs:13:19
+   |
+LL |         let val = Self::ASSERT;
+   |                   ^^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/mono-reachable-invalid-const.rs:13:19
+   |
+LL |         let val = Self::ASSERT;
+   |                   ^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: the above error was encountered while instantiating `fn Bar::<0>::assert`
+  --> $DIR/mono-reachable-invalid-const.rs:22:5
+   |
+LL |     Bar::<0>::assert();
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/impl-trait/future-no-bound-vars-ice-112347.rs
+++ b/tests/ui/impl-trait/future-no-bound-vars-ice-112347.rs
@@ -1,0 +1,29 @@
+// issue: rust-lang/rust#112347
+// ICE future has no bound vars
+//@ edition:2021
+//@ check-pass
+
+#![feature(type_alias_impl_trait)]
+
+use std::future::Future;
+
+type Fut<'a> = impl Future<Output = ()> + 'a;
+
+fn foo<'a>(_: &()) -> Fut<'_> {
+    async {}
+}
+
+trait Test {
+    fn hello();
+}
+
+impl Test for ()
+where
+    for<'a> Fut<'a>: Future<Output = ()>,
+{
+    fn hello() {}
+}
+
+fn main() {
+    <()>::hello();
+}

--- a/tests/ui/parser/issues/issue-32505.stderr
+++ b/tests/ui/parser/issues/issue-32505.stderr
@@ -9,7 +9,7 @@ LL |     foo(|_|)
 help: you might have meant to open the body of the closure
    |
 LL |     foo(|_| {})
-   |            ++
+   |             ++
 
 error[E0425]: cannot find function `foo` in this scope
   --> $DIR/issue-32505.rs:2:5

--- a/tests/ui/unpretty/staged-api-invalid-path-108697.rs
+++ b/tests/ui/unpretty/staged-api-invalid-path-108697.rs
@@ -1,0 +1,9 @@
+// issue: rust-lang/rust#108697
+// ICE: tcx.resolutions(()) is not supported for local crate -Zunpretty=mir
+// on invalid module path with staged_api
+//@ compile-flags: -Zunpretty=mir
+
+#![feature(staged_api)]
+#[path = "lol"]
+mod foo;
+//~^ ERROR couldn't read

--- a/tests/ui/unpretty/staged-api-invalid-path-108697.stderr
+++ b/tests/ui/unpretty/staged-api-invalid-path-108697.stderr
@@ -1,0 +1,8 @@
+error: couldn't read $DIR/lol: No such file or directory (os error 2)
+  --> $DIR/staged-api-invalid-path-108697.rs:8:1
+   |
+LL | mod foo;
+   | ^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Successful merges:

 - #124370 (Fix substitution parts having a shifted underline in some cases)
 - #124405 (miri core/alloc tests: do not test a 2nd target)
 - #124425 (Do not ICE on invalid consts when walking mono-reachable blocks)
 - #124435 (add more tests)
 - #124437 (doc: Make the `mod.rs` in the comment point to the correct location)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=124370,124405,124425,124435,124437)
<!-- homu-ignore:end -->