### PR TITLE
bootstrap: Change `global(true)` to `global = true` for flags for consistency

### DIFF
--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -41,72 +41,72 @@ pub struct Flags {
     #[command(subcommand)]
     pub cmd: Subcommand,
 
-    #[arg(global(true), short, long, action = clap::ArgAction::Count)]
+    #[arg(global = true, short, long, action = clap::ArgAction::Count)]
     /// use verbose output (-vv for very verbose)
     pub verbose: u8, // each extra -v after the first is passed to Cargo
-    #[arg(global(true), short, long)]
+    #[arg(global = true, short, long)]
     /// use incremental compilation
     pub incremental: bool,
-    #[arg(global(true), long, value_hint = clap::ValueHint::FilePath, value_name = "FILE")]
+    #[arg(global = true, long, value_hint = clap::ValueHint::FilePath, value_name = "FILE")]
     /// TOML configuration file for build
     pub config: Option<PathBuf>,
-    #[arg(global(true), long, value_hint = clap::ValueHint::DirPath, value_name = "DIR")]
+    #[arg(global = true, long, value_hint = clap::ValueHint::DirPath, value_name = "DIR")]
     /// Build directory, overrides `build.build-dir` in `config.toml`
     pub build_dir: Option<PathBuf>,
 
-    #[arg(global(true), long, value_hint = clap::ValueHint::Other, value_name = "BUILD")]
+    #[arg(global = true, long, value_hint = clap::ValueHint::Other, value_name = "BUILD")]
     /// build target of the stage0 compiler
     pub build: Option<String>,
 
-    #[arg(global(true), long, value_hint = clap::ValueHint::Other, value_name = "HOST", value_parser = target_selection_list)]
+    #[arg(global = true, long, value_hint = clap::ValueHint::Other, value_name = "HOST", value_parser = target_selection_list)]
     /// host targets to build
     pub host: Option<TargetSelectionList>,
 
-    #[arg(global(true), long, value_hint = clap::ValueHint::Other, value_name = "TARGET", value_parser = target_selection_list)]
+    #[arg(global = true, long, value_hint = clap::ValueHint::Other, value_name = "TARGET", value_parser = target_selection_list)]
     /// target targets to build
     pub target: Option<TargetSelectionList>,
 
-    #[arg(global(true), long, value_name = "PATH")]
+    #[arg(global = true, long, value_name = "PATH")]
     /// build paths to exclude
     pub exclude: Vec<PathBuf>, // keeping for client backward compatibility
-    #[arg(global(true), long, value_name = "PATH")]
+    #[arg(global = true, long, value_name = "PATH")]
     /// build paths to skip
     pub skip: Vec<PathBuf>,
-    #[arg(global(true), long)]
+    #[arg(global = true, long)]
     /// include default paths in addition to the provided ones
     pub include_default_paths: bool,
 
-    #[arg(global(true), value_hint = clap::ValueHint::Other, long)]
+    #[arg(global = true, value_hint = clap::ValueHint::Other, long)]
     pub rustc_error_format: Option<String>,
 
-    #[arg(global(true), long, value_hint = clap::ValueHint::CommandString, value_name = "CMD")]
+    #[arg(global = true, long, value_hint = clap::ValueHint::CommandString, value_name = "CMD")]
     /// command to run on failure
     pub on_fail: Option<String>,
-    #[arg(global(true), long)]
+    #[arg(global = true, long)]
     /// dry run; don't build anything
     pub dry_run: bool,
     /// Indicates whether to dump the work done from bootstrap shims
-    #[arg(global(true), long)]
+    #[arg(global = true, long)]
     pub dump_bootstrap_shims: bool,
-    #[arg(global(true), value_hint = clap::ValueHint::Other, long, value_name = "N")]
+    #[arg(global = true, value_hint = clap::ValueHint::Other, long, value_name = "N")]
     /// stage to build (indicates compiler to use/test, e.g., stage 0 uses the
     /// bootstrap compiler, stage 1 the stage 0 rustc artifacts, etc.)
     pub stage: Option<u32>,
 
-    #[arg(global(true), value_hint = clap::ValueHint::Other, long, value_name = "N")]
+    #[arg(global = true, value_hint = clap::ValueHint::Other, long, value_name = "N")]
     /// stage(s) to keep without recompiling
     /// (pass multiple times to keep e.g., both stages 0 and 1)
     pub keep_stage: Vec<u32>,
-    #[arg(global(true), value_hint = clap::ValueHint::Other, long, value_name = "N")]
+    #[arg(global = true, value_hint = clap::ValueHint::Other, long, value_name = "N")]
     /// stage(s) of the standard library to keep without recompiling
     /// (pass multiple times to keep e.g., both stages 0 and 1)
     pub keep_stage_std: Vec<u32>,
-    #[arg(global(true), long, value_hint = clap::ValueHint::DirPath, value_name = "DIR")]
+    #[arg(global = true, long, value_hint = clap::ValueHint::DirPath, value_name = "DIR")]
     /// path to the root of the rust checkout
     pub src: Option<PathBuf>,
 
     #[arg(
-        global(true),
+        global = true,
         short,
         long,
         value_hint = clap::ValueHint::Other,
@@ -117,26 +117,26 @@ pub struct Flags {
     pub jobs: usize,
     // This overrides the deny-warnings configuration option,
     // which passes -Dwarnings to the compiler invocations.
-    #[arg(global(true), long)]
+    #[arg(global = true, long)]
     #[arg(value_enum, default_value_t=Warnings::Default, value_name = "deny|warn")]
     /// if value is deny, will deny warnings
     /// if value is warn, will emit warnings
     /// otherwise, use the default configured behaviour
     pub warnings: Warnings,
 
-    #[arg(global(true), value_hint = clap::ValueHint::Other, long, value_name = "FORMAT")]
+    #[arg(global = true, value_hint = clap::ValueHint::Other, long, value_name = "FORMAT")]
     /// rustc error format
     pub error_format: Option<String>,
-    #[arg(global(true), long)]
+    #[arg(global = true, long)]
     /// use message-format=json
     pub json_output: bool,
 
-    #[arg(global(true), long, value_name = "STYLE")]
+    #[arg(global = true, long, value_name = "STYLE")]
     #[arg(value_enum, default_value_t = Color::Auto)]
     /// whether to use color in cargo and rustc output
     pub color: Color,
 
-    #[arg(global(true), long)]
+    #[arg(global = true, long)]
     /// Bootstrap uses this value to decide whether it should bypass locking the build process.
     /// This is rarely needed (e.g., compiling the std library for different targets in parallel).
     ///
@@ -144,41 +144,41 @@ pub struct Flags {
     pub bypass_bootstrap_lock: bool,
 
     /// whether rebuilding llvm should be skipped, overriding `skip-rebuld` in config.toml
-    #[arg(global(true), long, value_name = "VALUE")]
+    #[arg(global = true, long, value_name = "VALUE")]
     pub llvm_skip_rebuild: Option<bool>,
     /// generate PGO profile with rustc build
-    #[arg(global(true), value_hint = clap::ValueHint::FilePath, long, value_name = "PROFILE")]
+    #[arg(global = true, value_hint = clap::ValueHint::FilePath, long, value_name = "PROFILE")]
     pub rust_profile_generate: Option<String>,
     /// use PGO profile for rustc build
-    #[arg(global(true), value_hint = clap::ValueHint::FilePath, long, value_name = "PROFILE")]
+    #[arg(global = true, value_hint = clap::ValueHint::FilePath, long, value_name = "PROFILE")]
     pub rust_profile_use: Option<String>,
     /// use PGO profile for LLVM build
-    #[arg(global(true), value_hint = clap::ValueHint::FilePath, long, value_name = "PROFILE")]
+    #[arg(global = true, value_hint = clap::ValueHint::FilePath, long, value_name = "PROFILE")]
     pub llvm_profile_use: Option<String>,
     // LLVM doesn't support a custom location for generating profile
     // information.
     //
     // llvm_out/build/profiles/ is the location this writes to.
     /// generate PGO profile with llvm built for rustc
-    #[arg(global(true), long)]
+    #[arg(global = true, long)]
     pub llvm_profile_generate: bool,
     /// Enable BOLT link flags
-    #[arg(global(true), long)]
+    #[arg(global = true, long)]
     pub enable_bolt_settings: bool,
     /// Skip stage0 compiler validation
-    #[arg(global(true), long)]
+    #[arg(global = true, long)]
     pub skip_stage0_validation: bool,
     /// Additional reproducible artifacts that should be added to the reproducible artifacts archive.
-    #[arg(global(true), long)]
+    #[arg(global = true, long)]
     pub reproducible_artifact: Vec<String>,
-    #[arg(global(true))]
+    #[arg(global = true)]
     /// paths for the subcommand
     pub paths: Vec<PathBuf>,
     /// override options in config.toml
-    #[arg(global(true), value_hint = clap::ValueHint::Other, long, value_name = "section.option=value")]
+    #[arg(global = true, value_hint = clap::ValueHint::Other, long, value_name = "section.option=value")]
     pub set: Vec<String>,
     /// arguments passed to subcommands
-    #[arg(global(true), last(true), value_name = "ARGS")]
+    #[arg(global = true, last(true), value_name = "ARGS")]
     pub free_args: Vec<String>,
 }
 
@@ -192,7 +192,7 @@ impl Flags {
         struct HelpVerboseOnly {
             #[arg(short, long)]
             help: bool,
-            #[arg(global(true), short, long, action = clap::ArgAction::Count)]
+            #[arg(global = true, short, long, action = clap::ArgAction::Count)]
             pub verbose: u8,
             #[arg(value_enum)]
             cmd: Kind,
@@ -260,16 +260,16 @@ pub enum Subcommand {
         #[arg(long, requires = "fix")]
         allow_staged: bool,
         /// clippy lints to allow
-        #[arg(global(true), short = 'A', action = clap::ArgAction::Append, value_name = "LINT")]
+        #[arg(global = true, short = 'A', action = clap::ArgAction::Append, value_name = "LINT")]
         allow: Vec<String>,
         /// clippy lints to deny
-        #[arg(global(true), short = 'D', action = clap::ArgAction::Append, value_name = "LINT")]
+        #[arg(global = true, short = 'D', action = clap::ArgAction::Append, value_name = "LINT")]
         deny: Vec<String>,
         /// clippy lints to warn on
-        #[arg(global(true), short = 'W', action = clap::ArgAction::Append, value_name = "LINT")]
+        #[arg(global = true, short = 'W', action = clap::ArgAction::Append, value_name = "LINT")]
         warn: Vec<String>,
         /// clippy lints to forbid
-        #[arg(global(true), short = 'F', action = clap::ArgAction::Append, value_name = "LINT")]
+        #[arg(global = true, short = 'F', action = clap::ArgAction::Append, value_name = "LINT")]
         forbid: Vec<String>,
     },
     /// Run cargo fix


### PR DESCRIPTION
All other arg properties use the `prop = value` style, which makes it slightly annoying to use the `prop(value)` only style for `global`. Change to `prop = value` also for `global` for consistency.