### PR TITLE
Rename `inhibit_union_abi_opt()` to `inhibits_union_abi_opt()`

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -251,7 +251,7 @@ pub trait LayoutCalculator {
         // If all the non-ZST fields have the same ABI and union ABI optimizations aren't
         // disabled, we can use that common ABI for the union as a whole.
         struct AbiMismatch;
-        let mut common_non_zst_abi_and_align = if repr.inhibit_union_abi_opt() {
+        let mut common_non_zst_abi_and_align = if repr.inhibits_union_abi_opt() {
             // Can't optimize
             Err(AbiMismatch)
         } else {

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -155,7 +155,7 @@ impl ReprOptions {
     }
 
     /// Returns `true` if this `#[repr()]` should inhibit union ABI optimisations.
-    pub fn inhibit_union_abi_opt(&self) -> bool {
+    pub fn inhibits_union_abi_opt(&self) -> bool {
         self.c()
     }
 }


### PR DESCRIPTION
`inihibit` seems to suggest that this function will inhibit optimizations whereas `inhibits` correctly indicates that it will merely _check_ that. With `inhibits` if conditions read more naturally e.g.: 

```rust
if repr.inhibits_union_abi_opt() {
}
```