### PR TITLE
Add tracking issue and unstable book page for `"vectorcall"` ABI

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -177,8 +177,6 @@ declare_features! (
 
     /// Allows using the `unadjusted` ABI; perma-unstable.
     (internal, abi_unadjusted, "1.16.0", None),
-    /// Allows using the `vectorcall` ABI.
-    (unstable, abi_vectorcall, "1.7.0", None),
     /// Allows using `#![needs_allocator]`, an implementation detail of `#[global_allocator]`.
     (internal, allocator_internals, "1.20.0", None),
     /// Allows using `#[allow_internal_unsafe]`. This is an
@@ -243,6 +241,8 @@ declare_features! (
     // feature-group-start: internal feature gates
     // -------------------------------------------------------------------------
 
+    /// Allows using the `vectorcall` ABI.
+    (unstable, abi_vectorcall, "1.7.0", Some(124485)),
     /// Allows features specific to auto traits.
     /// Renamed from `optin_builtin_traits`.
     (unstable, auto_traits, "1.50.0", Some(13231)),

--- a/src/doc/unstable-book/src/language-features/abi-vectorcall.md
+++ b/src/doc/unstable-book/src/language-features/abi-vectorcall.md
@@ -1,0 +1,19 @@
+# `abi_vectorcall`
+
+The tracking issue for this feature is: [#124485]
+
+[#124485]: https://github.com/rust-lang/rust/issues/124485
+
+------------------------
+
+Adds support for the Windows `"vectorcall"` ABI, the equivalent of `__vectorcall` in MSVC.
+
+```rust,ignore (only-windows-or-x86-or-x86-64)
+extern "vectorcall" {
+    fn add_f64s(x: f64, y: f64) -> f64;
+}
+
+fn main() {
+    println!("{}", add_f64s(2.0, 4.0));
+}
+```

--- a/tests/ui/feature-gates/feature-gate-vectorcall.stderr
+++ b/tests/ui/feature-gates/feature-gate-vectorcall.stderr
@@ -4,6 +4,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL | extern "vectorcall" fn f() {}
    |        ^^^^^^^^^^^^
    |
+   = note: see issue #124485 <https://github.com/rust-lang/rust/issues/124485> for more information
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -13,6 +14,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL |     extern "vectorcall" fn m();
    |            ^^^^^^^^^^^^
    |
+   = note: see issue #124485 <https://github.com/rust-lang/rust/issues/124485> for more information
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -22,6 +24,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL |     extern "vectorcall" fn dm() {}
    |            ^^^^^^^^^^^^
    |
+   = note: see issue #124485 <https://github.com/rust-lang/rust/issues/124485> for more information
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -31,6 +34,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL |     extern "vectorcall" fn m() {}
    |            ^^^^^^^^^^^^
    |
+   = note: see issue #124485 <https://github.com/rust-lang/rust/issues/124485> for more information
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -40,6 +44,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL |     extern "vectorcall" fn im() {}
    |            ^^^^^^^^^^^^
    |
+   = note: see issue #124485 <https://github.com/rust-lang/rust/issues/124485> for more information
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -49,6 +54,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL | type TA = extern "vectorcall" fn();
    |                  ^^^^^^^^^^^^
    |
+   = note: see issue #124485 <https://github.com/rust-lang/rust/issues/124485> for more information
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -58,6 +64,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL | extern "vectorcall" {}
    |        ^^^^^^^^^^^^
    |
+   = note: see issue #124485 <https://github.com/rust-lang/rust/issues/124485> for more information
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 


### PR DESCRIPTION
Originally added in 2015 by #30567, the Windows `"vectorcall"` ABI didn't have a tracking issue until now.

Tracking issue: #124485