### PR TITLE
Stabilize `non_null_convenience`

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -137,7 +137,6 @@
 #![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_uninit_array_transpose)]
-#![feature(non_null_convenience)]
 #![feature(panic_internals)]
 #![feature(pattern)]
 #![feature(ptr_internals)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -180,7 +180,6 @@
 #![feature(isqrt)]
 #![feature(link_cfg)]
 #![feature(maybe_uninit_uninit_array)]
-#![feature(non_null_convenience)]
 #![feature(offset_of_enum)]
 #![feature(offset_of_nested)]
 #![feature(panic_internals)]

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -512,7 +512,6 @@ impl<T: ?Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(non_null_convenience)]
     /// use std::ptr::NonNull;
     ///
     /// let mut s = [1, 2, 3];
@@ -523,12 +522,12 @@ impl<T: ?Sized> NonNull<T> {
     ///     println!("{}", ptr.offset(2).read());
     /// }
     /// ```
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
-    #[must_use = "returns a new pointer rather than modifying its argument"]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-    pub const unsafe fn offset(self, count: isize) -> NonNull<T>
+    #[must_use = "returns a new pointer rather than modifying its argument"]
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    pub const unsafe fn offset(self, count: isize) -> Self
     where
         T: Sized,
     {
@@ -549,11 +548,11 @@ impl<T: ?Sized> NonNull<T> {
     ///
     /// For non-`Sized` pointees this operation changes only the data pointer,
     /// leaving the metadata untouched.
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[must_use]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn byte_offset(self, count: isize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `offset` and `byte_offset` has
         // the same safety contract.
@@ -599,7 +598,6 @@ impl<T: ?Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(non_null_convenience)]
     /// use std::ptr::NonNull;
     ///
     /// let s: &str = "123";
@@ -610,11 +608,11 @@ impl<T: ?Sized> NonNull<T> {
     ///     println!("{}", ptr.add(2).read() as char);
     /// }
     /// ```
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
-    #[must_use = "returns a new pointer rather than modifying its argument"]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[must_use = "returns a new pointer rather than modifying its argument"]
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn add(self, count: usize) -> Self
     where
         T: Sized,
@@ -636,12 +634,12 @@ impl<T: ?Sized> NonNull<T> {
     ///
     /// For non-`Sized` pointees this operation changes only the data pointer,
     /// leaving the metadata untouched.
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[must_use]
     #[inline(always)]
-    #[rustc_allow_const_fn_unstable(set_ptr_value)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[rustc_allow_const_fn_unstable(set_ptr_value)]
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn byte_add(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `add` and `byte_add` has the same
         // safety contract.
@@ -688,7 +686,6 @@ impl<T: ?Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(non_null_convenience)]
     /// use std::ptr::NonNull;
     ///
     /// let s: &str = "123";
@@ -699,11 +696,11 @@ impl<T: ?Sized> NonNull<T> {
     ///     println!("{}", end.sub(2).read() as char);
     /// }
     /// ```
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
-    #[must_use = "returns a new pointer rather than modifying its argument"]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[must_use = "returns a new pointer rather than modifying its argument"]
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn sub(self, count: usize) -> Self
     where
         T: Sized,
@@ -730,12 +727,12 @@ impl<T: ?Sized> NonNull<T> {
     ///
     /// For non-`Sized` pointees this operation changes only the data pointer,
     /// leaving the metadata untouched.
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[must_use]
     #[inline(always)]
-    #[rustc_allow_const_fn_unstable(set_ptr_value)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[rustc_allow_const_fn_unstable(set_ptr_value)]
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn byte_sub(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `sub` and `byte_sub` has the same
         // safety contract.
@@ -816,7 +813,6 @@ impl<T: ?Sized> NonNull<T> {
     /// Basic usage:
     ///
     /// ```
-    /// #![feature(non_null_convenience)]
     /// use std::ptr::NonNull;
     ///
     /// let a = [0; 5];
@@ -833,7 +829,7 @@ impl<T: ?Sized> NonNull<T> {
     /// *Incorrect* usage:
     ///
     /// ```rust,no_run
-    /// #![feature(non_null_convenience, strict_provenance)]
+    /// #![feature(strict_provenance)]
     /// use std::ptr::NonNull;
     ///
     /// let ptr1 = NonNull::new(Box::into_raw(Box::new(0u8))).unwrap();
@@ -845,14 +841,13 @@ impl<T: ?Sized> NonNull<T> {
     /// // Since ptr2_other and ptr2 are derived from pointers to different objects,
     /// // computing their offset is undefined behavior, even though
     /// // they point to the same address!
-    /// unsafe {
-    ///     let zero = ptr2_other.offset_from(ptr2); // Undefined Behavior
-    /// }
+    ///
+    /// let zero = unsafe { ptr2_other.offset_from(ptr2) }; // Undefined Behavior
     /// ```
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn offset_from(self, origin: NonNull<T>) -> isize
     where
         T: Sized,
@@ -870,10 +865,10 @@ impl<T: ?Sized> NonNull<T> {
     ///
     /// For non-`Sized` pointees this operation considers only the data pointers,
     /// ignoring the metadata.
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn byte_offset_from<U: ?Sized>(self, origin: NonNull<U>) -> isize {
         // SAFETY: the caller must uphold the safety contract for `byte_offset_from`.
         unsafe { self.pointer.byte_offset_from(origin.pointer) }
@@ -897,7 +892,7 @@ impl<T: ?Sized> NonNull<T> {
     /// to [`sub`](#method.sub)).  The following are all equivalent, assuming
     /// that their safety preconditions are met:
     /// ```rust
-    /// # #![feature(non_null_convenience)]
+    /// # #![feature(ptr_sub_ptr)]
     /// # unsafe fn blah(ptr: std::ptr::NonNull<u32>, origin: std::ptr::NonNull<u32>, count: usize) -> bool {
     /// ptr.sub_ptr(origin) == count
     /// # &&
@@ -926,7 +921,7 @@ impl<T: ?Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(non_null_convenience)]
+    /// #![feature(ptr_sub_ptr)]
     /// use std::ptr::NonNull;
     ///
     /// let a = [0; 5];
@@ -942,12 +937,10 @@ impl<T: ?Sized> NonNull<T> {
     /// // This would be incorrect, as the pointers are not correctly ordered:
     /// // ptr1.sub_ptr(ptr2)
     /// ```
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
-    // #[unstable(feature = "ptr_sub_ptr", issue = "95892")]
-    // #[rustc_const_unstable(feature = "const_ptr_sub_ptr", issue = "95892")]
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[unstable(feature = "ptr_sub_ptr", issue = "95892")]
+    #[rustc_const_unstable(feature = "const_ptr_sub_ptr", issue = "95892")]
     pub const unsafe fn sub_ptr(self, subtracted: NonNull<T>) -> usize
     where
         T: Sized,
@@ -962,10 +955,10 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::read`] for safety concerns and examples.
     ///
     /// [`ptr::read`]: crate::ptr::read()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn read(self) -> T
     where
         T: Sized,
@@ -984,9 +977,9 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::read_volatile`] for safety concerns and examples.
     ///
     /// [`ptr::read_volatile`]: crate::ptr::read_volatile()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub unsafe fn read_volatile(self) -> T
     where
         T: Sized,
@@ -1003,10 +996,10 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::read_unaligned`] for safety concerns and examples.
     ///
     /// [`ptr::read_unaligned`]: crate::ptr::read_unaligned()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn read_unaligned(self) -> T
     where
         T: Sized,
@@ -1023,10 +1016,10 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::copy`] for safety concerns and examples.
     ///
     /// [`ptr::copy`]: crate::ptr::copy()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
     pub const unsafe fn copy_to(self, dest: NonNull<T>, count: usize)
     where
         T: Sized,
@@ -1043,10 +1036,10 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::copy_nonoverlapping`] for safety concerns and examples.
     ///
     /// [`ptr::copy_nonoverlapping`]: crate::ptr::copy_nonoverlapping()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
     pub const unsafe fn copy_to_nonoverlapping(self, dest: NonNull<T>, count: usize)
     where
         T: Sized,
@@ -1063,10 +1056,10 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::copy`] for safety concerns and examples.
     ///
     /// [`ptr::copy`]: crate::ptr::copy()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
     pub const unsafe fn copy_from(self, src: NonNull<T>, count: usize)
     where
         T: Sized,
@@ -1083,10 +1076,10 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::copy_nonoverlapping`] for safety concerns and examples.
     ///
     /// [`ptr::copy_nonoverlapping`]: crate::ptr::copy_nonoverlapping()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
     pub const unsafe fn copy_from_nonoverlapping(self, src: NonNull<T>, count: usize)
     where
         T: Sized,
@@ -1100,8 +1093,8 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::drop_in_place`] for safety concerns and examples.
     ///
     /// [`ptr::drop_in_place`]: crate::ptr::drop_in_place()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline(always)]
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub unsafe fn drop_in_place(self) {
         // SAFETY: the caller must uphold the safety contract for `drop_in_place`.
         unsafe { ptr::drop_in_place(self.as_ptr()) }
@@ -1113,11 +1106,10 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::write`] for safety concerns and examples.
     ///
     /// [`ptr::write`]: crate::ptr::write()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
-    //#[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
     pub const unsafe fn write(self, val: T)
     where
         T: Sized,
@@ -1132,12 +1124,11 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::write_bytes`] for safety concerns and examples.
     ///
     /// [`ptr::write_bytes`]: crate::ptr::write_bytes()
-    #[doc(alias = "memset")]
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
-    //#[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
     #[inline(always)]
+    #[doc(alias = "memset")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
     pub const unsafe fn write_bytes(self, val: u8, count: usize)
     where
         T: Sized,
@@ -1156,9 +1147,9 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::write_volatile`] for safety concerns and examples.
     ///
     /// [`ptr::write_volatile`]: crate::ptr::write_volatile()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub unsafe fn write_volatile(self, val: T)
     where
         T: Sized,
@@ -1175,11 +1166,10 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::write_unaligned`] for safety concerns and examples.
     ///
     /// [`ptr::write_unaligned`]: crate::ptr::write_unaligned()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
-    //#[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
     pub const unsafe fn write_unaligned(self, val: T)
     where
         T: Sized,
@@ -1194,8 +1184,8 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::replace`] for safety concerns and examples.
     ///
     /// [`ptr::replace`]: crate::ptr::replace()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
     #[inline(always)]
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
     pub unsafe fn replace(self, src: T) -> T
     where
         T: Sized,
@@ -1211,10 +1201,9 @@ impl<T: ?Sized> NonNull<T> {
     /// See [`ptr::swap`] for safety concerns and examples.
     ///
     /// [`ptr::swap`]: crate::ptr::swap()
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
-    //#[rustc_const_unstable(feature = "const_swap", issue = "83163")]
     #[inline(always)]
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_swap", issue = "83163")]
     pub const unsafe fn swap(self, with: NonNull<T>)
     where
         T: Sized,
@@ -1246,7 +1235,6 @@ impl<T: ?Sized> NonNull<T> {
     /// Accessing adjacent `u8` as `u16`
     ///
     /// ```
-    /// #![feature(non_null_convenience)]
     /// use std::mem::align_of;
     /// use std::ptr::NonNull;
     ///
@@ -1264,11 +1252,10 @@ impl<T: ?Sized> NonNull<T> {
     /// }
     /// # }
     /// ```
-    #[unstable(feature = "non_null_convenience", issue = "117691")]
-    #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
-    //#[rustc_const_unstable(feature = "const_align_offset", issue = "90962")]
-    #[must_use]
     #[inline]
+    #[must_use]
+    #[stable(feature = "non_null_convenience", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_align_offset", issue = "90962")]
     pub const fn align_offset(self, align: usize) -> usize
     where
         T: Sized,
@@ -1312,10 +1299,9 @@ impl<T: ?Sized> NonNull<T> {
     /// underlying allocation.
     ///
     /// ```
-    /// #![feature(const_pointer_is_aligned)]
-    /// #![feature(non_null_convenience)]
-    /// #![feature(const_option)]
     /// #![feature(const_nonnull_new)]
+    /// #![feature(const_option)]
+    /// #![feature(const_pointer_is_aligned)]
     /// use std::ptr::NonNull;
     ///
     /// // On some platforms, the alignment of primitives is less than their size.
@@ -1390,10 +1376,10 @@ impl<T: ?Sized> NonNull<T> {
     /// ```
     ///
     /// [tracking issue]: https://github.com/rust-lang/rust/issues/104203
+    #[inline]
+    #[must_use]
     #[stable(feature = "pointer_is_aligned", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_const_unstable(feature = "const_pointer_is_aligned", issue = "104203")]
-    #[must_use]
-    #[inline]
     pub const fn is_aligned(self) -> bool
     where
         T: Sized,
@@ -1505,10 +1491,10 @@ impl<T: ?Sized> NonNull<T> {
     /// ```
     ///
     /// [tracking issue]: https://github.com/rust-lang/rust/issues/104203
+    #[inline]
+    #[must_use]
     #[unstable(feature = "pointer_is_aligned_to", issue = "96284")]
     #[rustc_const_unstable(feature = "const_pointer_is_aligned", issue = "104203")]
-    #[must_use]
-    #[inline]
     pub const fn is_aligned_to(self, align: usize) -> bool {
         self.pointer.is_aligned_to(align)
     }


### PR DESCRIPTION
Fully stabilize the following API, including const where applicable:

```rust
impl <T> NonNull<T> {
    pub const unsafe fn offset(self, count: isize) -> Self;
    pub const unsafe fn add(self, count: usize) -> Self;
    pub const unsafe fn sub(self, count: usize) -> Self;
    pub const unsafe fn offset_from(self, origin: NonNull<T>) -> isize;
    pub const unsafe fn read(self) -> T;
    pub unsafe fn read_volatile(self) -> T;
    pub const unsafe fn read_unaligned(self) -> T;
    pub unsafe fn write_volatile(self, val: T);
    pub unsafe fn replace(self, src: T) -> T;
}

impl<T: ?Sized> NonNull<T> {
    pub const unsafe fn byte_offset(self, count: isize) -> Self;
    pub const unsafe fn byte_add(self, count: usize) -> Self;
    pub const unsafe fn byte_sub(self, count: usize) -> Self;
    pub const unsafe fn byte_offset_from<U: ?Sized>(self, origin: NonNull<U>) -> isize;
    pub unsafe fn drop_in_place(self);
}
```

Stabilize the following without const:

```rust
impl <T> NonNull<T> {
    // const under `const_intrinsic_copy`
    pub const unsafe fn copy_to(self, dest: NonNull<T>, count: usize);
    pub const unsafe fn copy_to_nonoverlapping(self, dest: NonNull<T>, count: usize);
    pub const unsafe fn copy_from(self, src: NonNull<T>, count: usize);
    pub const unsafe fn copy_from_nonoverlapping(self, src: NonNull<T>, count: usize);

    // const under `const_ptr_write`
    pub const unsafe fn write(self, val: T);
    pub const unsafe fn write_bytes(self, val: u8, count: usize);
    pub const unsafe fn write_unaligned(self, val: T);

    // const under `const_swap`
    pub const unsafe fn swap(self, with: NonNull<T>);

    // const under `const_align_offset`
    pub const fn align_offset(self, align: usize) -> usize;

    // const under `const_pointer_is_aligned`
    pub const fn is_aligned(self) -> bool;
}
```

Left the following unstable:

```rust
impl <T> NonNull<T> {
    // moved gate to `ptr_sub_ptr`
    pub const unsafe fn sub_ptr(self, subtracted: NonNull<T>) -> usize;
}

impl <T: ?Sized> NonNull<T> {
    // moved gate to `pointer_is_aligned_to`
    pub const fn is_aligned_to(self, align: usize) -> bool;
}
```

Fixes: https://github.com/rust-lang/rust/issues/117691