### PR TITLE
aux-bin: Avoid old .so files from old tests; clean auxiliary dir root

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2140,6 +2140,7 @@ impl<'test> TestCx<'test> {
 
         if !self.props.aux_bins.is_empty() {
             let aux_bin_dir = self.aux_bin_output_dir_name();
+            remove_and_create_dir_all(&aux_dir);
             remove_and_create_dir_all(&aux_bin_dir);
         }
 

--- a/tests/ui/attributes/unix_sigpipe/unix_sigpipe-inherit.rs
+++ b/tests/ui/attributes/unix_sigpipe/unix_sigpipe-inherit.rs
@@ -8,7 +8,7 @@
 
 extern crate libc;
 
-// By default the Rust runtime resets SIGPIPE to SIG_DFL before exec:ing child
+// By default the Rust runtime resets SIGPIPE to SIG_DFL before exec'ing child
 // processes so opt-out of that with `#[unix_sigpipe = "sig_dfl"]`. See
 // https://github.com/rust-lang/rust/blob/bf4de3a874753bbee3323081c8b0c133444fed2d/library/std/src/sys/pal/unix/process/process_unix.rs#L359-L384
 #[unix_sigpipe = "sig_dfl"]


### PR DESCRIPTION
Also fix the typo pointed out [here](https://github.com/rust-lang/rust/pull/123316/files#r1577081531).

Closes #124465