### PR TITLE
Fix ESP IDF build broken by #124210

### DIFF
--- a/library/std/src/sys/pal/unix/fs.rs
+++ b/library/std/src/sys/pal/unix/fs.rs
@@ -893,6 +893,7 @@ impl Drop for Dir {
             target_os = "nto",
             target_os = "vita",
             target_os = "hurd",
+            target_os = "espidf",
         )))]
         {
             let fd = unsafe { libc::dirfd(self.0) };


### PR DESCRIPTION
Subject says it all I hope.

Fix is trivial, thanks to the contributors of #124210 really considering these Tier 3 targets in their change-set (even if ESP IDF was accidentally omitted).
