### PR TITLE
Allow monomorphization time const eval failures if the cause is a type layout issue

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -2,7 +2,7 @@ use std::mem;
 
 use rustc_errors::{DiagArgName, DiagArgValue, DiagMessage, Diagnostic, IntoDiagArg};
 use rustc_hir::CRATE_HIR_ID;
-use rustc_middle::mir::interpret::Provenance;
+use rustc_middle::mir::interpret::{Provenance, ReportedErrorInfo};
 use rustc_middle::mir::AssertKind;
 use rustc_middle::query::TyCtxtAt;
 use rustc_middle::ty::TyCtxt;
@@ -139,9 +139,10 @@ where
             ErrorHandled::TooGeneric(span)
         }
         err_inval!(AlreadyReported(guar)) => ErrorHandled::Reported(guar, span),
-        err_inval!(Layout(LayoutError::ReferencesError(guar))) => {
-            ErrorHandled::Reported(guar.into(), span)
-        }
+        err_inval!(Layout(LayoutError::ReferencesError(guar))) => ErrorHandled::Reported(
+            ReportedErrorInfo::tainted_by_errors(guar),
+            span,
+        ),
         // Report remaining errors.
         _ => {
             let (our_span, frames) = get_span_and_frames();

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -66,6 +66,9 @@ impl ReportedErrorInfo {
     pub fn tainted_by_errors(error: ErrorGuaranteed) -> ReportedErrorInfo {
         ReportedErrorInfo { is_tainted_by_errors: true, error }
     }
+    pub fn is_tainted_by_errors(&self) -> bool {
+        self.is_tainted_by_errors
+    }
 }
 
 impl From<ErrorGuaranteed> for ReportedErrorInfo {

--- a/tests/crashes/124348.rs
+++ b/tests/crashes/124348.rs
@@ -1,7 +1,0 @@
-//@ known-bug: #124348
-enum Eek {
-    TheConst,
-    UnusedByTheConst(Sum),
-}
-
-const EEK_ZERO: &[Eek] = &[];

--- a/tests/ui/consts/erroneous_type_in_const_return_value.rs
+++ b/tests/ui/consts/erroneous_type_in_const_return_value.rs
@@ -1,0 +1,12 @@
+//! ICE test #124348
+//! We should not be running const eval if the layout has errors.
+
+enum Eek {
+    TheConst,
+    UnusedByTheConst(Sum),
+    //~^ ERROR cannot find type `Sum` in this scope
+}
+
+const EEK_ZERO: &[Eek] = &[];
+
+fn main() {}

--- a/tests/ui/consts/erroneous_type_in_const_return_value.stderr
+++ b/tests/ui/consts/erroneous_type_in_const_return_value.stderr
@@ -1,5 +1,5 @@
 error[E0412]: cannot find type `Sum` in this scope
-  --> $DIR/erroneous_type_in_promoted.rs:6:22
+  --> $DIR/erroneous_type_in_const_return_value.rs:6:22
    |
 LL |     UnusedByTheConst(Sum),
    |                      ^^^ not found in this scope

--- a/tests/ui/consts/erroneous_type_in_promoted.rs
+++ b/tests/ui/consts/erroneous_type_in_promoted.rs
@@ -1,0 +1,14 @@
+//! ICE test #124348
+//! We should not be running const eval if the layout has errors.
+
+enum Eek {
+    TheConst,
+    UnusedByTheConst(Sum),
+    //~^ ERROR cannot find type `Sum` in this scope
+}
+
+const fn foo() {
+    let x: &'static [Eek] = &[];
+}
+
+fn main() {}

--- a/tests/ui/consts/erroneous_type_in_promoted.stderr
+++ b/tests/ui/consts/erroneous_type_in_promoted.stderr
@@ -1,0 +1,28 @@
+error[E0412]: cannot find type `Sum` in this scope
+  --> $DIR/erroneous_type_in_promoted.rs:6:22
+   |
+LL |     UnusedByTheConst(Sum),
+   |                      ^^^ not found in this scope
+   |
+help: consider importing this trait
+   |
+LL + use std::iter::Sum;
+   |
+
+note: erroneous constant encountered
+  --> $DIR/erroneous_type_in_promoted.rs:11:29
+   |
+LL |     let x: &'static [Eek] = &[];
+   |                             ^^^
+
+note: erroneous constant encountered
+  --> $DIR/erroneous_type_in_promoted.rs:11:29
+   |
+LL |     let x: &'static [Eek] = &[];
+   |                             ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
r? @RalfJung 

fixes  #124348