### PR TITLE
[stable] 1.78 (round 2)

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4665,6 +4665,13 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
     }
 
     fn lint_unused_qualifications(&mut self, path: &[Segment], ns: Namespace, finalize: Finalize) {
+        // Don't lint on global paths because the user explicitly wrote out the full path.
+        if let Some(seg) = path.first()
+            && seg.ident.name == kw::PathRoot
+        {
+            return;
+        }
+
         if path.iter().any(|seg| seg.ident.span.from_expansion()) {
             return;
         }

--- a/tests/ui/lint/lint-qualification.fixed
+++ b/tests/ui/lint/lint-qualification.fixed
@@ -16,7 +16,6 @@ fn main() {
     let _ = || -> Result<(), ()> { try!(Ok(())); Ok(()) }; // issue #37345
 
     let _ = String::new(); //~ ERROR: unnecessary qualification
-    let _ = std::env::current_dir(); //~ ERROR: unnecessary qualification
 
     let _: Vec<String> = Vec::<String>::new();
     //~^ ERROR: unnecessary qualification
@@ -27,7 +26,7 @@ fn main() {
     let _: std::fmt::Result = Ok(());
     // don't report unnecessary qualification because fix(#122373) for issue #121331
 
-    let _ = <bool as Default>::default(); // issue #121999
+    let _ = <bool as Default>::default(); // issue #121999 (modified)
     //~^ ERROR: unnecessary qualification
 
     macro_rules! m { ($a:ident, $b:ident) => {

--- a/tests/ui/lint/lint-qualification.rs
+++ b/tests/ui/lint/lint-qualification.rs
@@ -16,7 +16,6 @@ fn main() {
     let _ = || -> Result<(), ()> { try!(Ok(())); Ok(()) }; // issue #37345
 
     let _ = std::string::String::new(); //~ ERROR: unnecessary qualification
-    let _ = ::std::env::current_dir(); //~ ERROR: unnecessary qualification
 
     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
     //~^ ERROR: unnecessary qualification
@@ -27,7 +26,7 @@ fn main() {
     let _: std::fmt::Result = Ok(());
     // don't report unnecessary qualification because fix(#122373) for issue #121331
 
-    let _ = <bool as ::std::default::Default>::default(); // issue #121999
+    let _ = <bool as std::default::Default>::default(); // issue #121999 (modified)
     //~^ ERROR: unnecessary qualification
 
     macro_rules! m { ($a:ident, $b:ident) => {

--- a/tests/ui/lint/lint-qualification.stderr
+++ b/tests/ui/lint/lint-qualification.stderr
@@ -40,19 +40,7 @@ LL +     let _ = String::new();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:19:13
-   |
-LL |     let _ = ::std::env::current_dir();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: remove the unnecessary path segments
-   |
-LL -     let _ = ::std::env::current_dir();
-LL +     let _ = std::env::current_dir();
-   |
-
-error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:21:12
+  --> $DIR/lint-qualification.rs:20:12
    |
 LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
    |            ^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +52,7 @@ LL +     let _: Vec<String> = std::vec::Vec::<String>::new();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:21:36
+  --> $DIR/lint-qualification.rs:20:36
    |
 LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,7 +64,7 @@ LL +     let _: std::vec::Vec<String> = Vec::<String>::new();
    |
 
 error: unused import: `std::fmt`
-  --> $DIR/lint-qualification.rs:25:9
+  --> $DIR/lint-qualification.rs:24:9
    |
 LL |     use std::fmt;
    |         ^^^^^^^^
@@ -88,16 +76,16 @@ LL | #![deny(unused_imports)]
    |         ^^^^^^^^^^^^^^
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:30:13
+  --> $DIR/lint-qualification.rs:29:13
    |
-LL |     let _ = <bool as ::std::default::Default>::default(); // issue #121999
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = <bool as std::default::Default>::default(); // issue #121999 (modified)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the unnecessary path segments
    |
-LL -     let _ = <bool as ::std::default::Default>::default(); // issue #121999
-LL +     let _ = <bool as Default>::default(); // issue #121999
+LL -     let _ = <bool as std::default::Default>::default(); // issue #121999 (modified)
+LL +     let _ = <bool as Default>::default(); // issue #121999 (modified)
    |
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/lint/unused-qualifications-global-paths.rs
+++ b/tests/ui/lint/unused-qualifications-global-paths.rs
@@ -1,0 +1,12 @@
+// Checks that `unused_qualifications` don't fire on explicit global paths.
+// Issue: <https://github.com/rust-lang/rust/issues/122374>.
+
+//@ check-pass
+
+#![deny(unused_qualifications)]
+
+pub fn bar() -> u64 {
+    ::std::default::Default::default()
+}
+
+fn main() {}


### PR DESCRIPTION
This backports "Don't trigger `unused_qualifications` on global paths" (https://github.com/rust-lang/rust/pull/122435).

r? @Mark-Simulacrum 