### PR TITLE
[Refactor] Rename `Lint` and `LintGroup`'s `is_loaded` to `is_externally_loaded` 

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -971,7 +971,7 @@ Available lint options:
 
     let lint_store = unerased_lint_store(sess);
     let (loaded, builtin): (Vec<_>, _) =
-        lint_store.get_lints().iter().cloned().partition(|&lint| lint.is_loaded);
+        lint_store.get_lints().iter().cloned().partition(|&lint| lint.is_externally_loaded);
     let loaded = sort_lints(sess, loaded);
     let builtin = sort_lints(sess, builtin);
 

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -110,7 +110,7 @@ struct LintAlias {
 
 struct LintGroup {
     lint_ids: Vec<LintId>,
-    is_loaded: bool,
+    is_externally_loaded: bool,
     depr: Option<LintAlias>,
 }
 
@@ -159,7 +159,9 @@ impl LintStore {
                 // Don't display deprecated lint groups.
                 depr.is_none()
             })
-            .map(|(k, LintGroup { lint_ids, is_loaded, .. })| (*k, lint_ids.clone(), *is_loaded))
+            .map(|(k, LintGroup { lint_ids, is_externally_loaded, .. })| {
+                (*k, lint_ids.clone(), *is_externally_loaded)
+            })
     }
 
     pub fn register_early_pass(
@@ -218,7 +220,7 @@ impl LintStore {
                         .entry(edition.lint_name())
                         .or_insert(LintGroup {
                             lint_ids: vec![],
-                            is_loaded: lint.is_loaded,
+                            is_externally_loaded: lint.is_externally_loaded,
                             depr: None,
                         })
                         .lint_ids
@@ -231,7 +233,7 @@ impl LintStore {
                         .entry("future_incompatible")
                         .or_insert(LintGroup {
                             lint_ids: vec![],
-                            is_loaded: lint.is_loaded,
+                            is_externally_loaded: lint.is_externally_loaded,
                             depr: None,
                         })
                         .lint_ids
@@ -246,7 +248,7 @@ impl LintStore {
             alias,
             LintGroup {
                 lint_ids: vec![],
-                is_loaded: false,
+                is_externally_loaded: false,
                 depr: Some(LintAlias { name: lint_name, silent: true }),
             },
         );
@@ -254,21 +256,21 @@ impl LintStore {
 
     pub fn register_group(
         &mut self,
-        is_loaded: bool,
+        is_externally_loaded: bool,
         name: &'static str,
         deprecated_name: Option<&'static str>,
         to: Vec<LintId>,
     ) {
         let new = self
             .lint_groups
-            .insert(name, LintGroup { lint_ids: to, is_loaded, depr: None })
+            .insert(name, LintGroup { lint_ids: to, is_externally_loaded, depr: None })
             .is_none();
         if let Some(deprecated) = deprecated_name {
             self.lint_groups.insert(
                 deprecated,
                 LintGroup {
                     lint_ids: vec![],
-                    is_loaded,
+                    is_externally_loaded,
                     depr: Some(LintAlias { name, silent: false }),
                 },
             );

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -323,7 +323,8 @@ pub struct Lint {
 
     pub future_incompatible: Option<FutureIncompatibleInfo>,
 
-    pub is_loaded: bool,
+    /// `true` if this lint is being loaded by another tool (e.g. Clippy).
+    pub is_externally_loaded: bool,
 
     /// `Some` if this lint is feature gated, otherwise `None`.
     pub feature_gate: Option<Symbol>,
@@ -468,7 +469,7 @@ impl Lint {
             default_level: Level::Forbid,
             desc: "",
             edition_lint_opts: None,
-            is_loaded: false,
+            is_externally_loaded: false,
             report_in_external_macro: false,
             future_incompatible: None,
             feature_gate: None,
@@ -817,7 +818,7 @@ macro_rules! declare_lint {
             name: stringify!($NAME),
             default_level: $crate::$Level,
             desc: $desc,
-            is_loaded: false,
+            is_externally_loaded: false,
             $($v: true,)*
             $(feature_gate: Some($gate),)?
             $(future_incompatible: Some($crate::FutureIncompatibleInfo {
@@ -859,7 +860,7 @@ macro_rules! declare_tool_lint {
             edition_lint_opts: None,
             report_in_external_macro: $external,
             future_incompatible: None,
-            is_loaded: true,
+            is_externally_loaded: true,
             $(feature_gate: Some($gate),)?
             crate_level_only: false,
             ..$crate::Lint::default_fields_for_macro()

--- a/tests/ui/statics/nested_struct.rs
+++ b/tests/ui/statics/nested_struct.rs
@@ -9,7 +9,7 @@ pub struct Lint {
     pub name: &'static str,
     pub desc: &'static str,
     pub report_in_external_macro: bool,
-    pub is_loaded: bool,
+    pub is_externally_loaded: bool,
     pub crate_level_only: bool,
 }
 
@@ -17,7 +17,7 @@ static FOO: &Lint = &Lint {
     name: &"foo",
     desc: "desc",
     report_in_external_macro: false,
-    is_loaded: true,
+    is_externally_loaded: true,
     crate_level_only: false,
 };
 


### PR DESCRIPTION
The field being named `is_loaded` was very confusing. Turns out it's true for lints that are registered by external tools like Clippy (I had to look at https://github.com/rust-lang/rust/pull/116412 to know what the variable meant). So I renamed `is_loaded` to `is_externally_loaded` and added some docs.