### PR TITLE
Fix Fuchsia build broken by #124210

### DIFF
--- a/library/std/src/sys/pal/unix/fs.rs
+++ b/library/std/src/sys/pal/unix/fs.rs
@@ -894,6 +894,7 @@ impl Drop for Dir {
             target_os = "vita",
             target_os = "hurd",
             target_os = "espidf",
+            target_os = "fuchsia",
         )))]
         {
             let fd = unsafe { libc::dirfd(self.0) };


### PR DESCRIPTION
Fuchsia doesn't support dirfd although we have a symbol stubbed for it.