### PR TITLE
return inner error of std:io::Error as source/cause

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -1043,7 +1043,7 @@ impl error::Error for Error {
             ErrorData::Os(..) => None,
             ErrorData::Simple(..) => None,
             ErrorData::SimpleMessage(..) => None,
-            ErrorData::Custom(c) => c.error.cause(),
+            ErrorData::Custom(c) => Some(c.error.as_ref()),
         }
     }
 
@@ -1052,7 +1052,7 @@ impl error::Error for Error {
             ErrorData::Os(..) => None,
             ErrorData::Simple(..) => None,
             ErrorData::SimpleMessage(..) => None,
-            ErrorData::Custom(c) => c.error.source(),
+            ErrorData::Custom(c) => Some(c.error.as_ref()),
         }
     }
 }


### PR DESCRIPTION
Proposed solution to close #124513

Not sure if this should be seen as a breaking change or not.

See for more context #124513.