### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -5,6 +5,7 @@ ast_lowering_abi_specified_multiple_times =
 
 ast_lowering_arbitrary_expression_in_pattern =
     arbitrary expressions aren't allowed in patterns
+    .pattern_from_macro_note = the :expr fragment specifier forces the metavariable's content to be an expression
 
 ast_lowering_argument = argument
 

--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -5,7 +5,7 @@ ast_lowering_abi_specified_multiple_times =
 
 ast_lowering_arbitrary_expression_in_pattern =
     arbitrary expressions aren't allowed in patterns
-    .pattern_from_macro_note = the :expr fragment specifier forces the metavariable's content to be an expression
+    .pattern_from_macro_note = the `expr` fragment specifier forces the metavariable's content to be an expression
 
 ast_lowering_argument = argument
 

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -368,6 +368,8 @@ pub struct NeverPatternWithGuard {
 pub struct ArbitraryExpressionInPattern {
     #[primary_span]
     pub span: Span,
+    #[note(ast_lowering_pattern_from_macro_note)]
+    pub pattern_from_macro_note: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -339,7 +339,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             ExprKind::Path(..) if allow_paths => {}
             ExprKind::Unary(UnOp::Neg, inner) if matches!(inner.kind, ExprKind::Lit(_)) => {}
             _ => {
-                let guar = self.dcx().emit_err(ArbitraryExpressionInPattern { span: expr.span });
+                let pattern_from_macro = expr.is_approximately_pattern();
+                let guar = self.dcx().emit_err(ArbitraryExpressionInPattern {
+                    span: expr.span,
+                    pattern_from_macro_note: pattern_from_macro,
+                });
                 return self.arena.alloc(self.expr_err(expr.span, guar));
             }
         }

--- a/compiler/rustc_borrowck/src/borrow_set.rs
+++ b/compiler/rustc_borrowck/src/borrow_set.rs
@@ -108,9 +108,7 @@ impl LocalsStateAtExit {
             has_storage_dead.visit_body(body);
             let mut has_storage_dead_or_moved = has_storage_dead.0;
             for move_out in &move_data.moves {
-                if let Some(index) = move_data.base_local(move_out.path) {
-                    has_storage_dead_or_moved.insert(index);
-                }
+                has_storage_dead_or_moved.insert(move_data.base_local(move_out.path));
             }
             LocalsStateAtExit::SomeAreInvalidated { has_storage_dead_or_moved }
         }

--- a/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
@@ -358,20 +358,15 @@ impl<'tcx> MoveData<'tcx> {
         builder::gather_moves(body, tcx, param_env, filter)
     }
 
-    /// For the move path `mpi`, returns the root local variable (if any) that starts the path.
-    /// (e.g., for a path like `a.b.c` returns `Some(a)`)
-    pub fn base_local(&self, mut mpi: MovePathIndex) -> Option<Local> {
+    /// For the move path `mpi`, returns the root local variable that starts the path.
+    /// (e.g., for a path like `a.b.c` returns `a`)
+    pub fn base_local(&self, mut mpi: MovePathIndex) -> Local {
         loop {
             let path = &self.move_paths[mpi];
             if let Some(l) = path.place.as_local() {
-                return Some(l);
+                return l;
             }
-            if let Some(parent) = path.parent {
-                mpi = parent;
-                continue;
-            } else {
-                return None;
-            }
+            mpi = path.parent.expect("root move paths should be locals");
         }
     }
 

--- a/library/std/src/sys/pal/unix/fs.rs
+++ b/library/std/src/sys/pal/unix/fs.rs
@@ -894,6 +894,7 @@ impl Drop for Dir {
             target_os = "vita",
             target_os = "hurd",
             target_os = "espidf",
+            target_os = "fuchsia",
         )))]
         {
             let fd = unsafe { libc::dirfd(self.0) };

--- a/tests/ui/issues/issue-43250.stderr
+++ b/tests/ui/issues/issue-43250.stderr
@@ -4,7 +4,7 @@ error: arbitrary expressions aren't allowed in patterns
 LL |     m!(y);
    |        ^
    |
-   = note: the :expr fragment specifier forces the metavariable's content to be an expression
+   = note: the `expr` fragment specifier forces the metavariable's content to be an expression
 
 error: arbitrary expressions aren't allowed in patterns
   --> $DIR/issue-43250.rs:11:8
@@ -12,7 +12,7 @@ error: arbitrary expressions aren't allowed in patterns
 LL |     m!(C);
    |        ^
    |
-   = note: the :expr fragment specifier forces the metavariable's content to be an expression
+   = note: the `expr` fragment specifier forces the metavariable's content to be an expression
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-43250.stderr
+++ b/tests/ui/issues/issue-43250.stderr
@@ -3,12 +3,16 @@ error: arbitrary expressions aren't allowed in patterns
    |
 LL |     m!(y);
    |        ^
+   |
+   = note: the :expr fragment specifier forces the metavariable's content to be an expression
 
 error: arbitrary expressions aren't allowed in patterns
   --> $DIR/issue-43250.rs:11:8
    |
 LL |     m!(C);
    |        ^
+   |
+   = note: the :expr fragment specifier forces the metavariable's content to be an expression
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lowering/expr-in-pat-issue-99380.rs
+++ b/tests/ui/lowering/expr-in-pat-issue-99380.rs
@@ -1,0 +1,11 @@
+macro_rules! foo {
+    ($p:expr) => {
+        if let $p = Some(42) {
+            return;
+        }
+    };
+}
+
+fn main() {
+    foo!(Some(3)); //~ ERROR arbitrary expressions aren't allowed in patterns
+}

--- a/tests/ui/lowering/expr-in-pat-issue-99380.stderr
+++ b/tests/ui/lowering/expr-in-pat-issue-99380.stderr
@@ -1,0 +1,10 @@
+error: arbitrary expressions aren't allowed in patterns
+  --> $DIR/expr-in-pat-issue-99380.rs:10:10
+   |
+LL |     foo!(Some(3));
+   |          ^^^^^^^
+   |
+   = note: the :expr fragment specifier forces the metavariable's content to be an expression
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lowering/expr-in-pat-issue-99380.stderr
+++ b/tests/ui/lowering/expr-in-pat-issue-99380.stderr
@@ -4,7 +4,7 @@ error: arbitrary expressions aren't allowed in patterns
 LL |     foo!(Some(3));
    |          ^^^^^^^
    |
-   = note: the :expr fragment specifier forces the metavariable's content to be an expression
+   = note: the `expr` fragment specifier forces the metavariable's content to be an expression
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/vec-macro-in-pattern.stderr
+++ b/tests/ui/macros/vec-macro-in-pattern.stderr
@@ -4,6 +4,7 @@ error: arbitrary expressions aren't allowed in patterns
 LL |         Some(vec![43]) => {}
    |              ^^^^^^^^
    |
+   = note: the :expr fragment specifier forces the metavariable's content to be an expression
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/macros/vec-macro-in-pattern.stderr
+++ b/tests/ui/macros/vec-macro-in-pattern.stderr
@@ -4,7 +4,7 @@ error: arbitrary expressions aren't allowed in patterns
 LL |         Some(vec![43]) => {}
    |              ^^^^^^^^
    |
-   = note: the :expr fragment specifier forces the metavariable's content to be an expression
+   = note: the `expr` fragment specifier forces the metavariable's content to be an expression
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/match/expr_before_ident_pat.stderr
+++ b/tests/ui/match/expr_before_ident_pat.stderr
@@ -9,6 +9,8 @@ error: arbitrary expressions aren't allowed in patterns
    |
 LL |     funny!(a, a);
    |            ^
+   |
+   = note: the :expr fragment specifier forces the metavariable's content to be an expression
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/match/expr_before_ident_pat.stderr
+++ b/tests/ui/match/expr_before_ident_pat.stderr
@@ -10,7 +10,7 @@ error: arbitrary expressions aren't allowed in patterns
 LL |     funny!(a, a);
    |            ^
    |
-   = note: the :expr fragment specifier forces the metavariable's content to be an expression
+   = note: the `expr` fragment specifier forces the metavariable's content to be an expression
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/pattern/issue-92074-macro-ice.stderr
+++ b/tests/ui/pattern/issue-92074-macro-ice.stderr
@@ -7,7 +7,7 @@ LL |     () => { force_expr!(Vec::new()) }
 LL |     assert!(matches!(x, En::A(make_vec!())));
    |                               ----------- in this macro invocation
    |
-   = note: the :expr fragment specifier forces the metavariable's content to be an expression
+   = note: the `expr` fragment specifier forces the metavariable's content to be an expression
    = note: this error originates in the macro `make_vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: arbitrary expressions aren't allowed in patterns
@@ -19,7 +19,7 @@ LL |     () => { force_pat!(get_usize(), get_usize()) }
 LL |     assert!(matches!(5, make_pat!()));
    |                         ----------- in this macro invocation
    |
-   = note: the :expr fragment specifier forces the metavariable's content to be an expression
+   = note: the `expr` fragment specifier forces the metavariable's content to be an expression
    = note: this error originates in the macro `make_pat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: arbitrary expressions aren't allowed in patterns
@@ -31,7 +31,7 @@ LL |     () => { force_pat!(get_usize(), get_usize()) }
 LL |     assert!(matches!(5, make_pat!()));
    |                         ----------- in this macro invocation
    |
-   = note: the :expr fragment specifier forces the metavariable's content to be an expression
+   = note: the `expr` fragment specifier forces the metavariable's content to be an expression
    = note: this error originates in the macro `make_pat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/tests/ui/pattern/issue-92074-macro-ice.stderr
+++ b/tests/ui/pattern/issue-92074-macro-ice.stderr
@@ -7,6 +7,7 @@ LL |     () => { force_expr!(Vec::new()) }
 LL |     assert!(matches!(x, En::A(make_vec!())));
    |                               ----------- in this macro invocation
    |
+   = note: the :expr fragment specifier forces the metavariable's content to be an expression
    = note: this error originates in the macro `make_vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: arbitrary expressions aren't allowed in patterns
@@ -18,6 +19,7 @@ LL |     () => { force_pat!(get_usize(), get_usize()) }
 LL |     assert!(matches!(5, make_pat!()));
    |                         ----------- in this macro invocation
    |
+   = note: the :expr fragment specifier forces the metavariable's content to be an expression
    = note: this error originates in the macro `make_pat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: arbitrary expressions aren't allowed in patterns
@@ -29,6 +31,7 @@ LL |     () => { force_pat!(get_usize(), get_usize()) }
 LL |     assert!(matches!(5, make_pat!()));
    |                         ----------- in this macro invocation
    |
+   = note: the :expr fragment specifier forces the metavariable's content to be an expression
    = note: this error originates in the macro `make_pat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
Successful merges:

 - #124185 (Remove optionality from MoveData::base_local)
 - #124488 (Add a note to the ArbitraryExpressionInPattern error)
 - #124530 (Fix Fuchsia build broken by #124210)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=124185,124488,124530)
<!-- homu-ignore:end -->