### PR TITLE
Consider inner modules to be local in the `non_local_definitions` lint

### DIFF
--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -356,7 +356,7 @@ fn path_has_local_parent(
 }
 
 /// Given a def id and a parent impl def id, this checks if the parent
-/// def id correspond to the def id of the parent impl definition.
+/// def id (modulo modules) correspond to the def id of the parent impl definition.
 #[inline]
 fn did_has_local_parent(
     did: DefId,
@@ -364,8 +364,14 @@ fn did_has_local_parent(
     impl_parent: DefId,
     impl_parent_parent: Option<DefId>,
 ) -> bool {
-    did.is_local() && {
-        let res_parent = tcx.parent(did);
-        res_parent == impl_parent || Some(res_parent) == impl_parent_parent
-    }
+    did.is_local()
+        && if let Some(did_parent) = tcx.opt_parent(did) {
+            did_parent == impl_parent
+                || Some(did_parent) == impl_parent_parent
+                || !did_parent.is_crate_root()
+                    && tcx.def_kind(did_parent) == DefKind::Mod
+                    && did_has_local_parent(did_parent, tcx, impl_parent, impl_parent_parent)
+        } else {
+            false
+        }
 }

--- a/tests/ui/lint/non-local-defs/module_as_local.rs
+++ b/tests/ui/lint/non-local-defs/module_as_local.rs
@@ -1,0 +1,38 @@
+//! This test checks that module are treated as if they were local
+//!
+//! https://github.com/rust-lang/rust/issues/124396
+
+//@ check-pass
+
+trait JoinTo {}
+
+fn simple_one() {
+    mod posts {
+        #[allow(non_camel_case_types)]
+        pub struct table {}
+    }
+
+    impl JoinTo for posts::table {}
+}
+
+fn simple_two() {
+    mod posts {
+        pub mod posts {
+            #[allow(non_camel_case_types)]
+            pub struct table {}
+        }
+    }
+
+    impl JoinTo for posts::posts::table {}
+}
+
+struct Global;
+fn trait_() {
+    mod posts {
+        pub trait AdjecentTo {}
+    }
+
+    impl posts::AdjecentTo for Global {}
+}
+
+fn main() {}


### PR DESCRIPTION
This PR implements the [proposed fix](https://github.com/rust-lang/rust/issues/124396#issuecomment-2079553642) for #124396, that is to consider inner modules to be local in the `non_local_definitions` lint.

This PR is voluntarily kept as minimal as possible so it can be backported easily. 

~~T-lang [nomination](https://github.com/rust-lang/rust/issues/124396#issuecomment-2079692820) will need to be removed before this can be merged.~~

Fixes *(nearly, needs backport)* https://github.com/rust-lang/rust/issues/124396