### PR TITLE
Give proof tree visitors the ability to instantiate nested goals directly

### DIFF
--- a/compiler/rustc_middle/src/traits/solve/inspect.rs
+++ b/compiler/rustc_middle/src/traits/solve/inspect.rs
@@ -60,14 +60,14 @@ pub struct GoalEvaluation<'tcx> {
     pub evaluation: CanonicalGoalEvaluation<'tcx>,
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct CanonicalGoalEvaluation<'tcx> {
     pub goal: CanonicalInput<'tcx>,
     pub kind: CanonicalGoalEvaluationKind<'tcx>,
     pub result: QueryResult<'tcx>,
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Debug)]
 pub enum CanonicalGoalEvaluationKind<'tcx> {
     Overflow,
     CycleInStack,
@@ -86,7 +86,7 @@ pub struct AddedGoalsEvaluation<'tcx> {
     pub result: Result<Certainty, NoSolution>,
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct GoalEvaluationStep<'tcx> {
     pub instantiated_goal: QueryInput<'tcx, ty::Predicate<'tcx>>,
 


### PR DESCRIPTION
Useful when we want to look at the nested goals but not necessarily visit them (e.g. in select).

r? lcnr