### PR TITLE
Add diagnostic item for `std::iter::Iterator::enumerate`

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -754,6 +754,7 @@ symbols! {
         enable,
         encode,
         end,
+        enumerate_method,
         env,
         env_CFG_RELEASE: env!("CFG_RELEASE"),
         eprint_macro,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -974,6 +974,7 @@ pub trait Iterator {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_do_not_const_check]
+    #[cfg_attr(not(test), rustc_diagnostic_item = "enumerate_method")]
     fn enumerate(self) -> Enumerate<Self>
     where
         Self: Sized,


### PR DESCRIPTION
Adds a diagnostic item for the `std::iter:Iterator::enumerate` trait method. This change, along with PR https://github.com/rust-lang/rust/pull/124308, will be used by the clippy `unused_enumerate_index` lint to move away from paths to using diagnostic items.

see: https://github.com/rust-lang/rust-clippy/issues/5393