### PR TITLE
codegen tests: Tolerate `range()` qualifications in enum tests

### DIFF
--- a/tests/codegen/enum/enum-match.rs
+++ b/tests/codegen/enum/enum-match.rs
@@ -11,7 +11,7 @@ pub enum Enum0 {
     B,
 }
 
-// CHECK: define noundef i8 @match0{{.*}}
+// CHECK: define noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match0{{.*}}
 // CHECK-NEXT: start:
 // CHECK-NEXT: %1 = icmp eq i8 %0, 2
 // CHECK-NEXT: %2 = and i8 %0, 1
@@ -32,7 +32,7 @@ pub enum Enum1 {
     C,
 }
 
-// CHECK: define noundef i8 @match1{{.*}}
+// CHECK: define noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match1{{.*}}
 // CHECK-NEXT: start:
 // CHECK-NEXT: %1 = add i8 %0, -2
 // CHECK-NEXT: %2 = zext i8 %1 to i64
@@ -91,7 +91,7 @@ pub enum Enum2 {
     E,
 }
 
-// CHECK: define noundef i8 @match2{{.*}}
+// CHECK: define noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match2{{.*}}
 // CHECK-NEXT: start:
 // CHECK-NEXT: %1 = add i8 %0, 2
 // CHECK-NEXT: %2 = zext i8 %1 to i64


### PR DESCRIPTION
Current LLVM can infer range bounds on the i8s involved with these tests, and annotates it. Accept these bounds if present.

@rustbot label: +llvm-main

cc @durin42