### PR TITLE
Update libc to 0.2.155

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,9 +2190,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -31,11 +31,10 @@ miniz_oxide = { version = "0.7.0", optional = true, default-features = false }
 addr2line = { version = "0.21.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
-libc = { version = "=0.2.153", default-features = false, features = ['rustc-dep-of-std'], public = true }
+libc = { version = "0.2.153", default-features = false, features = ['rustc-dep-of-std'], public = true }
 
-# Pin libc (pending https://github.com/rust-lang/rust/pull/124560)
 [target.'cfg(all(windows, target_env = "msvc"))'.dependencies]
-libc = { version = "=0.2.153", default-features = false }
+libc = { version = "0.2.153", default-features = false }
 
 [target.'cfg(all(not(target_os = "aix"), not(all(windows, target_env = "msvc", not(target_vendor = "uwp")))))'.dependencies]
 object = { version = "0.32.0", default-features = false, optional = true, features = ['read_core', 'elf', 'macho', 'pe', 'unaligned', 'archive'] }

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "linux-raw-sys"


### PR DESCRIPTION
Motivation: To fix `-Zbuild-std` / Xargo for visionOS targets.

EDIT: Blocked on ~https://github.com/rust-lang/libc/issues/3608 / https://github.com/rust-lang/libc/pull/3609~ ~https://github.com/rust-lang/libc/pull/3682 and https://github.com/rust-lang/libc/pull/3690~ No longer blocked.