### PR TITLE
Add `normalize()` in run-make `Diff` type

### DIFF
--- a/src/tools/run-make-support/src/diff/mod.rs
+++ b/src/tools/run-make-support/src/diff/mod.rs
@@ -1,3 +1,4 @@
+use regex::Regex;
 use similar::TextDiff;
 use std::path::Path;
 
@@ -14,12 +15,19 @@ pub struct Diff {
     expected_name: Option<String>,
     actual: Option<String>,
     actual_name: Option<String>,
+    normalizers: Vec<(String, String)>,
 }
 
 impl Diff {
     /// Construct a bare `diff` invocation.
     pub fn new() -> Self {
-        Self { expected: None, expected_name: None, actual: None, actual_name: None }
+        Self {
+            expected: None,
+            expected_name: None,
+            actual: None,
+            actual_name: None,
+            normalizers: Vec::new(),
+        }
     }
 
     /// Specify the expected output for the diff from a file.
@@ -58,15 +66,29 @@ impl Diff {
         self
     }
 
+    /// Specify a regex that should replace text in the "actual" text that will be compared.
+    pub fn normalize<R: Into<String>, I: Into<String>>(
+        &mut self,
+        regex: R,
+        replacement: I,
+    ) -> &mut Self {
+        self.normalizers.push((regex.into(), replacement.into()));
+        self
+    }
+
     /// Executes the diff process, prints any differences to the standard error.
     #[track_caller]
     pub fn run(&self) {
         let expected = self.expected.as_ref().expect("expected text not set");
-        let actual = self.actual.as_ref().expect("actual text not set");
+        let mut actual = self.actual.as_ref().expect("actual text not set").to_string();
         let expected_name = self.expected_name.as_ref().unwrap();
         let actual_name = self.actual_name.as_ref().unwrap();
+        for (regex, replacement) in &self.normalizers {
+            let re = Regex::new(regex).expect("bad regex in custom normalization rule");
+            actual = re.replace_all(&actual, replacement).into_owned();
+        }
 
-        let output = TextDiff::from_lines(expected, actual)
+        let output = TextDiff::from_lines(expected, &actual)
             .unified_diff()
             .header(expected_name, actual_name)
             .to_string();

--- a/src/tools/run-make-support/src/diff/tests.rs
+++ b/src/tools/run-make-support/src/diff/tests.rs
@@ -36,4 +36,26 @@ test failed: `EXPECTED_TEXT` is different from `ACTUAL_TEXT`
 
         assert_eq!(output.downcast_ref::<String>().unwrap(), expected_output);
     }
+
+    #[test]
+    fn test_normalize() {
+        let expected = "
+running 2 tests
+..
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+";
+        let actual = "
+running 2 tests
+..
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+";
+
+        diff()
+            .expected_text("EXPECTED_TEXT", expected)
+            .actual_text("ACTUAL_TEXT", actual)
+            .normalize(r#"finished in \d+\.\d+s"#, "finished in $$TIME")
+            .run();
+    }
 }


### PR DESCRIPTION
I need it to do the same as:

```
//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
```

in doctests.

I need it in particular for the https://github.com/rust-lang/rust/pull/123974 PR (which contains this commit until this PR current PR is merged).

cc @Urgau 
r? @jieyouxu