### PR TITLE
Use Server 2022 in CI for mingw jobs

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -25,10 +25,18 @@ runners:
     <<: *base-job
 
   - &job-windows-8c
-    os: windows-2019-8core-32gb
+    os: windows-2022-8core-32gb
     <<: *base-job
 
   - &job-windows-16c
+    os: windows-2022-16core-64gb
+    <<: *base-job
+
+  - &job-windows-2019-8c
+    os: windows-2019-8core-32gb
+    <<: *base-job
+
+  - &job-windows-2019-16c
     os: windows-2019-16core-64gb
     <<: *base-job
 
@@ -338,13 +346,13 @@ auto:
     env:
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
       SCRIPT: make ci-msvc
-    <<: *job-windows-8c
+    <<: *job-windows-2019-8c
 
   - image: i686-msvc
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
       SCRIPT: make ci-msvc
-    <<: *job-windows-8c
+    <<: *job-windows-2019-8c
 
   - image: x86_64-msvc-ext
     env:
@@ -352,7 +360,7 @@ auto:
       HOST_TARGET: x86_64-pc-windows-msvc
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld --save-toolstates=/tmp/toolstate/toolstates.json
       DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
-    <<: *job-windows-8c
+    <<: *job-windows-2019-8c
 
   # 32/64-bit MinGW builds.
   #
@@ -403,7 +411,7 @@ auto:
         --set rust.codegen-units=1
       SCRIPT: python x.py build --set rust.debug=true opt-dist && PGO_HOST=x86_64-pc-windows-msvc ./build/x86_64-pc-windows-msvc/stage0-tools-bin/opt-dist windows-ci -- python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
-    <<: *job-windows-8c
+    <<: *job-windows-2019-8c
 
   - image: dist-i686-msvc
     env:
@@ -415,7 +423,7 @@ auto:
         --enable-profiler
       SCRIPT: python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
-    <<: *job-windows-8c
+    <<: *job-windows-2019-8c
 
   - image: dist-aarch64-msvc
     env:
@@ -426,7 +434,7 @@ auto:
         --enable-profiler
       SCRIPT: python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
-    <<: *job-windows-8c
+    <<: *job-windows-2019-8c
 
   - image: dist-i686-mingw
     env:
@@ -460,4 +468,4 @@ auto:
     env:
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
       SCRIPT: python x.py dist bootstrap --include-default-paths
-    <<: *job-windows-8c
+    <<: *job-windows-2019-8c


### PR DESCRIPTION
From my [previous testing](https://github.com/rust-lang/rust/issues/92948#issuecomment-2077771347), there is nothing blocking using Server 2022 for the Windows MinGW jobs.

This change:
* Adds new `os` entries for Server 2022.
* Renamed the Server 2019 `os` entries (as we'll be removing these over time).
* Moves the mingw jobs to Server 2022 and leaves the msvc jobs on Server 2019.

Partially fixes #92948