### PR TITLE
run-make-support: preserve tooks.mk behavior for EXTRACXXFLAGS

### DIFF
--- a/src/tools/run-make-support/src/cc.rs
+++ b/src/tools/run-make-support/src/cc.rs
@@ -161,8 +161,9 @@ pub fn extra_cxx_flags() -> Vec<&'static str> {
     if is_windows() {
         if is_msvc() { vec![] } else { vec!["-lstdc++"] }
     } else {
-        match uname() {
-            n if n.contains("Darwin") => vec!["-lc++"],
+        match &uname()[..] {
+            "Darwin" => vec!["-lc++"],
+            "FreeBSD" | "SunOS" | "OpenBSD" => vec![],
             _ => vec!["-lstdc++"],
         }
     }


### PR DESCRIPTION
In #123149 when trying to add a command wrapper for `cc`, I didn't preserve the behavior of tools.mk completely: tools.mk had

```makefile
# Extra flags needed to compile a working executable with the standard library
ifdef IS_WINDOWS
ifdef IS_MSVC
	#EXTRACFLAGS := ws2_32.lib userenv.lib advapi32.lib bcrypt.lib ntdll.lib synchronization.lib
else
	#EXTRACFLAGS := -lws2_32 -luserenv -lbcrypt -lntdll -lsynchronization
	EXTRACXXFLAGS := -lstdc++
	#EXTRARSCXXFLAGS := -l static:-bundle=stdc++
endif
else
ifeq ($(UNAME),Darwin)
	#EXTRACFLAGS := -lresolv
	EXTRACXXFLAGS := -lc++
	#EXTRARSCXXFLAGS := -lc++
else
ifeq ($(UNAME),FreeBSD)
	#EXTRACFLAGS := -lm -lpthread -lgcc_s
else
ifeq ($(UNAME),SunOS)
	#EXTRACFLAGS := -lm -lpthread -lposix4 -lsocket -lresolv
else
ifeq ($(UNAME),OpenBSD)
	#EXTRACFLAGS := -lm -lpthread -lc++abi
	#RUSTC := $(RUSTC) -C linker="$(word 1,$(CC:ccache=))"
else
	#EXTRACFLAGS := -lm -lrt -ldl -lpthread
	EXTRACXXFLAGS := -lstdc++
	#EXTRARSCXXFLAGS := -lstdc++
endif
endif
endif
endif
endif
```

Note that for {`FreeBSD`, `SunOs`, `OpenBSD`} the `-lstdc++` flag is *not* passed, so `EXTRACXXFLAGS` for those platforms should be an empty `vec![]`.

r? ghost (testing this with PR CI)