### PR TITLE
Experiment: Reserve guarded string literal syntax (RFC 3593) on all editions

### DIFF
--- a/compiler/rustc_lexer/src/cursor.rs
+++ b/compiler/rustc_lexer/src/cursor.rs
@@ -4,6 +4,7 @@ use std::str::Chars;
 ///
 /// Next characters can be peeked via `first` method,
 /// and position can be shifted forward via `bump` method.
+#[derive(Clone)]
 pub struct Cursor<'a> {
     len_remaining: usize,
     /// Iterator over chars. Slightly faster than a &str.

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -672,6 +672,10 @@ parse_require_colon_after_labeled_expression = labeled expression must be follow
     .label = the label
     .suggestion = add `:` after the label
 
+parse_reserved_guarded_string = invalid string literal
+    .note = unprefixed guarded string literals are reserved for future use
+    .suggestion_whitespace = consider inserting whitespace here
+
 parse_return_types_use_thin_arrow = return types are denoted using `->`
     .suggestion = use `->` instead
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2010,6 +2010,24 @@ pub enum UnknownPrefixSugg {
 }
 
 #[derive(Diagnostic)]
+#[diag(parse_reserved_guarded_string)]
+#[note]
+pub struct ReservedGuardedString {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: Option<GuardedStringSugg>,
+}
+#[derive(Subdiagnostic)]
+#[suggestion(
+    parse_suggestion_whitespace,
+    code = " ",
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
+pub struct GuardedStringSugg(#[primary_span] pub Span);
+
+#[derive(Diagnostic)]
 #[diag(parse_too_many_hashes)]
 pub struct TooManyHashes {
     #[primary_span]

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -850,7 +850,8 @@ impl<'src> Classifier<'src> {
                 | LiteralKind::RawStr { .. }
                 | LiteralKind::RawByteStr { .. }
                 | LiteralKind::CStr { .. }
-                | LiteralKind::RawCStr { .. } => Class::String,
+                | LiteralKind::RawCStr { .. }
+                | LiteralKind::GuardedStr { .. } => Class::String,
                 // Number literals.
                 LiteralKind::Float { .. } | LiteralKind::Int { .. } => Class::Number,
             },

--- a/src/tools/rust-analyzer/crates/parser/src/lexed_str.rs
+++ b/src/tools/rust-analyzer/crates/parser/src/lexed_str.rs
@@ -331,6 +331,10 @@ impl<'a> Converter<'a> {
                 }
                 C_STRING
             }
+            rustc_lexer::LiteralKind::GuardedStr { .. } => {
+                err = "Invalid string literal";
+                STRING
+            }
         };
 
         let err = if err.is_empty() { None } else { Some(err) };

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
@@ -120,6 +120,7 @@ impl server::FreeFunctions for RaSpanServer {
                 3 + n_hashes.unwrap_or_default() as usize,
                 1 + n_hashes.unwrap_or_default() as usize,
             ),
+            LiteralKind::GuardedStr { .. } => return Err(()),
         };
 
         let (lit, suffix) = s.split_at(suffix_start as usize);

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server/token_id.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server/token_id.rs
@@ -113,6 +113,7 @@ impl server::FreeFunctions for TokenIdServer {
                 3 + n_hashes.unwrap_or_default() as usize,
                 1 + n_hashes.unwrap_or_default() as usize,
             ),
+            LiteralKind::GuardedStr { .. } => return Err(()),
         };
 
         let (lit, suffix) = s.split_at(suffix_start as usize);

--- a/tests/ui/lexer/reserved-guarded-strings.rs
+++ b/tests/ui/lexer/reserved-guarded-strings.rs
@@ -1,0 +1,60 @@
+//@ compile-flags: -Zunstable-options
+//@ edition:2024
+
+macro_rules! demo1 {
+    ( $a:tt ) => { println!("one tokens") };
+}
+
+macro_rules! demo2 {
+    ( $a:tt $b:tt ) => { println!("two tokens") };
+}
+
+macro_rules! demo3 {
+    ( $a:tt $b:tt $c:tt ) => { println!("three tokens") };
+}
+
+macro_rules! demo4 {
+    ( $a:tt $b:tt $c:tt $d:tt ) => { println!("four tokens") };
+}
+
+macro_rules! demo5 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt ) => { println!("five tokens") };
+}
+
+macro_rules! demo6 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt ) => { println!("six tokens") };
+}
+
+macro_rules! demo7 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt ) => { println!("seven tokens") };
+}
+
+fn main() {
+    demo1!("");
+    demo2!(# "");
+    demo3!(# ""#);
+    demo2!(# "foo");
+    demo3!(## "foo");
+    demo3!(# "foo"#);
+    demo4!(### "foo");
+    demo4!(## "foo"#);
+    demo7!(### "foo"###);
+
+    demo2!("foo"#);
+    demo4!("foo"###);
+
+    demo2!(blah"xx"); //~ ERROR prefix `blah` is unknown
+    demo2!(blah#"xx"#);
+    //~^ ERROR prefix `blah` is unknown
+    //~| ERROR invalid string literal
+
+    demo1!(#""); //~ ERROR invalid string literal
+    demo1!(#""#); //~ ERROR invalid string literal
+    demo1!(####""); //~ ERROR invalid string literal
+    demo1!(#"foo"); //~ ERROR invalid string literal
+    demo1!(###"foo"); //~ ERROR invalid string literal
+    demo1!(#"foo"#); //~ ERROR invalid string literal
+    demo1!(###"foo"#); //~ ERROR invalid string literal
+    demo1!(###"foo"##); //~ ERROR invalid string literal
+    demo1!(###"foo"###); //~ ERROR invalid string literal
+}

--- a/tests/ui/lexer/reserved-guarded-strings.stderr
+++ b/tests/ui/lexer/reserved-guarded-strings.stderr
@@ -1,0 +1,146 @@
+error: prefix `blah` is unknown
+  --> $DIR/reserved-guarded-strings.rs:46:12
+   |
+LL |     demo2!(blah"xx");
+   |            ^^^^ unknown prefix
+   |
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo2!(blah "xx");
+   |                +
+
+error: prefix `blah` is unknown
+  --> $DIR/reserved-guarded-strings.rs:47:12
+   |
+LL |     demo2!(blah#"xx"#);
+   |            ^^^^ unknown prefix
+   |
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo2!(blah #"xx"#);
+   |                +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:47:16
+   |
+LL |     demo2!(blah#"xx"#);
+   |                ^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use
+help: consider inserting whitespace here
+   |
+LL |     demo2!(blah# "xx"#);
+   |                 +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:51:12
+   |
+LL |     demo1!(#"");
+   |            ^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# "");
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:52:12
+   |
+LL |     demo1!(#""#);
+   |            ^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# ""#);
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:53:12
+   |
+LL |     demo1!(####"");
+   |            ^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use
+help: consider inserting whitespace here
+   |
+LL |     demo1!(#### "");
+   |                +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:54:12
+   |
+LL |     demo1!(#"foo");
+   |            ^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# "foo");
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:55:12
+   |
+LL |     demo1!(###"foo");
+   |            ^^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use
+help: consider inserting whitespace here
+   |
+LL |     demo1!(### "foo");
+   |               +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:56:12
+   |
+LL |     demo1!(#"foo"#);
+   |            ^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use
+help: consider inserting whitespace here
+   |
+LL |     demo1!(# "foo"#);
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:57:12
+   |
+LL |     demo1!(###"foo"#);
+   |            ^^^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use
+help: consider inserting whitespace here
+   |
+LL |     demo1!(### "foo"#);
+   |               +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:58:12
+   |
+LL |     demo1!(###"foo"##);
+   |            ^^^^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use
+help: consider inserting whitespace here
+   |
+LL |     demo1!(### "foo"##);
+   |               +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:59:12
+   |
+LL |     demo1!(###"foo"###);
+   |            ^^^^^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use
+help: consider inserting whitespace here
+   |
+LL |     demo1!(### "foo"###);
+   |               +
+
+error: aborting due to 12 previous errors
+


### PR DESCRIPTION
Purpose: crater run to see if we even need to make this change on an edition boundary.

This syntax change applies to all editions, because the particular syntax `#"foo"#` is unlikely to exist in the wild.

Subset of #123951

Tracking issue: https://github.com/rust-lang/rust/issues/123735
RFC: https://github.com/rust-lang/rfcs/pull/3593