### PR TITLE
Allow fmt to run on rmake.rs test files

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -13,7 +13,7 @@ ignore = [
 
     # tests for now are not formatted, as they are sometimes pretty-printing constrained
     # (and generally rustfmt can move around comments in UI-testing incompatible ways)
-    "/tests/",
+    "!/tests/run-make/*/rmake.rs",
 
     # do not format submodules
     # FIXME: sync submodule list with tidy/bootstrap/etc

--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -115,7 +115,11 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
     let rustfmt_config: RustfmtConfig = t!(toml::from_str(&rustfmt_config));
     let mut fmt_override = ignore::overrides::OverrideBuilder::new(&build.src);
     for ignore in rustfmt_config.ignore {
-        fmt_override.add(&format!("!{ignore}")).expect(&ignore);
+        if let Some(ignore) = ignore.strip_prefix('!') {
+            fmt_override.add(ignore).expect(ignore);
+        } else {
+            fmt_override.add(&format!("!{ignore}")).expect(&ignore);
+        }
     }
     let git_available = match Command::new("git")
         .arg("--version")

--- a/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
+++ b/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use run_make_support::{rustc, aux_build};
+use run_make_support::{aux_build, rustc};
 
 fn main() {
     aux_build().input("stable.rs").emit("metadata").run();
@@ -13,11 +13,7 @@ fn main() {
     let mut stable_path = PathBuf::from(env!("TMPDIR"));
     stable_path.push("libstable.rmeta");
 
-    let output = rustc()
-        .input("main.rs")
-        .emit("metadata")
-        .extern_("stable", &stable_path)
-        .output();
+    let output = rustc().input("main.rs").emit("metadata").extern_("stable", &stable_path).output();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     let version = include_str!(concat!(env!("S"), "/src/version"));

--- a/tests/run-make/compiler-builtins/rmake.rs
+++ b/tests/run-make/compiler-builtins/rmake.rs
@@ -49,22 +49,22 @@ fn main() {
     let bootstrap_cargo = std::env::var("BOOTSTRAP_CARGO").unwrap();
     let mut cmd = std::process::Command::new(bootstrap_cargo);
     cmd.args([
-            "build",
-            "--manifest-path",
-            manifest_path.to_str().unwrap(),
-            "-Zbuild-std=core",
-            "--target",
-            &target,
-        ])
-        .env_clear()
-        .env("PATH", path)
-        .env("RUSTC", rustc)
-        .env("RUSTFLAGS", "-Copt-level=0 -Cdebug-assertions=yes")
-        .env("CARGO_TARGET_DIR", &target_dir)
-        .env("RUSTC_BOOTSTRAP", "1")
-        // Visual Studio 2022 requires that the LIB env var be set so it can
-        // find the Windows SDK.
-        .env("LIB", std::env::var("LIB").unwrap_or_default());
+        "build",
+        "--manifest-path",
+        manifest_path.to_str().unwrap(),
+        "-Zbuild-std=core",
+        "--target",
+        &target,
+    ])
+    .env_clear()
+    .env("PATH", path)
+    .env("RUSTC", rustc)
+    .env("RUSTFLAGS", "-Copt-level=0 -Cdebug-assertions=yes")
+    .env("CARGO_TARGET_DIR", &target_dir)
+    .env("RUSTC_BOOTSTRAP", "1")
+    // Visual Studio 2022 requires that the LIB env var be set so it can
+    // find the Windows SDK.
+    .env("LIB", std::env::var("LIB").unwrap_or_default());
     set_host_rpath(&mut cmd);
 
     let status = cmd.status().unwrap();

--- a/tests/run-make/exit-code/rmake.rs
+++ b/tests/run-make/exit-code/rmake.rs
@@ -3,17 +3,11 @@
 use run_make_support::{rustc, rustdoc, tmp_dir};
 
 fn main() {
-    rustc()
-        .arg("success.rs")
-        .run();
+    rustc().arg("success.rs").run();
 
-    rustc()
-        .arg("--invalid-arg-foo")
-        .run_fail_assert_exit_code(1);
+    rustc().arg("--invalid-arg-foo").run_fail_assert_exit_code(1);
 
-    rustc()
-        .arg("compile-error.rs")
-        .run_fail_assert_exit_code(1);
+    rustc().arg("compile-error.rs").run_fail_assert_exit_code(1);
 
     rustc()
         .env("RUSTC_ICE", "0")
@@ -21,21 +15,11 @@ fn main() {
         .arg("compile-error.rs")
         .run_fail_assert_exit_code(101);
 
-    rustdoc()
-        .arg("success.rs")
-        .arg("-o")
-        .arg(tmp_dir().join("exit-code"))
-        .run();
+    rustdoc().arg("success.rs").arg("-o").arg(tmp_dir().join("exit-code")).run();
 
-    rustdoc()
-        .arg("--invalid-arg-foo")
-        .run_fail_assert_exit_code(1);
+    rustdoc().arg("--invalid-arg-foo").run_fail_assert_exit_code(1);
 
-    rustdoc()
-        .arg("compile-error.rs")
-        .run_fail_assert_exit_code(1);
+    rustdoc().arg("compile-error.rs").run_fail_assert_exit_code(1);
 
-    rustdoc()
-        .arg("lint-failure.rs")
-        .run_fail_assert_exit_code(1);
+    rustdoc().arg("lint-failure.rs").run_fail_assert_exit_code(1);
 }

--- a/tests/run-make/print-native-static-libs/rmake.rs
+++ b/tests/run-make/print-native-static-libs/rmake.rs
@@ -14,15 +14,11 @@
 
 use std::io::BufRead;
 
-use run_make_support::{rustc, is_msvc};
+use run_make_support::{is_msvc, rustc};
 
 fn main() {
     // build supporting crate
-    rustc()
-        .input("bar.rs")
-        .crate_type("rlib")
-        .arg("-lbar_cli")
-        .run();
+    rustc().input("bar.rs").crate_type("rlib").arg("-lbar_cli").run();
 
     // build main crate as staticlib
     let output = rustc()
@@ -37,7 +33,9 @@ fn main() {
     for l in output.stderr.lines() {
         let l = l.expect("utf-8 string");
 
-        let Some(args) = l.strip_prefix("note: native-static-libs:") else { continue; };
+        let Some(args) = l.strip_prefix("note: native-static-libs:") else {
+            continue;
+        };
         assert!(!found_note);
         found_note = true;
 
@@ -53,11 +51,11 @@ fn main() {
                 );
                 let found = $args.contains(&&*lib);
                 assert!(found, "unable to find lib `{}` in those linker args: {:?}", lib, $args);
-            }}
+            }};
         }
 
         assert_contains_lib!("glib-2.0" in args); // in bar.rs
-        assert_contains_lib!("systemd" in args);  // in foo.rs
+        assert_contains_lib!("systemd" in args); // in foo.rs
         assert_contains_lib!("bar_cli" in args);
         assert_contains_lib!("foo_cli" in args);
 

--- a/tests/run-make/print-to-output/rmake.rs
+++ b/tests/run-make/print-to-output/rmake.rs
@@ -13,11 +13,7 @@ struct Option<'a> {
 
 fn main() {
     // Printed from CodegenBackend trait impl in rustc_codegen_llvm/src/lib.rs
-    check(Option {
-        target: &target(),
-        option: "relocation-models",
-        includes: &["dynamic-no-pic"],
-    });
+    check(Option { target: &target(), option: "relocation-models", includes: &["dynamic-no-pic"] });
 
     // Printed by compiler/rustc_codegen_llvm/src/llvm_util.rs
     check(Option {

--- a/tests/run-make/wasm-custom-sections-opt/rmake.rs
+++ b/tests/run-make/wasm-custom-sections-opt/rmake.rs
@@ -1,6 +1,6 @@
 //@ only-wasm32-wasip1
 
-use run_make_support::{tmp_dir, wasmparser, rustc};
+use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/tests/run-make/wasm-export-all-symbols/rmake.rs
+++ b/tests/run-make/wasm-export-all-symbols/rmake.rs
@@ -1,6 +1,6 @@
 //@ only-wasm32-wasip1
 
-use run_make_support::{tmp_dir, wasmparser, rustc};
+use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::collections::HashMap;
 use std::path::Path;
 use wasmparser::ExternalKind::*;

--- a/tests/run-make/wasm-import-module/rmake.rs
+++ b/tests/run-make/wasm-import-module/rmake.rs
@@ -1,17 +1,12 @@
 //@ only-wasm32-wasip1
 
-use run_make_support::{tmp_dir, wasmparser, rustc};
+use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::collections::HashMap;
 use wasmparser::TypeRef::Func;
 
 fn main() {
     rustc().input("foo.rs").target("wasm32-wasip1").run();
-    rustc()
-        .input("bar.rs")
-        .target("wasm32-wasip1")
-        .arg("-Clto")
-        .opt()
-        .run();
+    rustc().input("bar.rs").target("wasm32-wasip1").arg("-Clto").opt().run();
 
     let file = std::fs::read(&tmp_dir().join("bar.wasm")).unwrap();
 


### PR DESCRIPTION
As discussed with @jieyouxu, `rmake.rs` from the `run-make` testsuite would benefit from being formatted as well.

Only thing needed to be done for it to work: allow support for `!` in our `rustfmt.toml` file parsing.

r? @onur-ozkan 