### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -456,6 +456,8 @@ lint_non_local_definitions_macro_rules = non-local `macro_rules!` definition, th
             [one] `{$body_name}`
            *[other] `{$body_name}` and up {$depth} bodies
         }
+    .help_doctest =
+        remove the `#[macro_export]` or make this doc-test a standalone test with its own `fn main() {"{"} ... {"}"}`
     .non_local = a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
     .exception = one exception to the rule are anon-const (`const _: () = {"{"} ... {"}"}`) at top-level module
 

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1350,14 +1350,18 @@ pub enum NonLocalDefinitionsDiag {
         const_anon: Option<Span>,
     },
     #[diag(lint_non_local_definitions_macro_rules)]
-    #[help]
-    #[note(lint_non_local)]
-    #[note(lint_exception)]
-    #[note(lint_non_local_definitions_deprecation)]
     MacroRules {
         depth: u32,
         body_kind_descr: &'static str,
         body_name: String,
+        #[help]
+        help: Option<()>,
+        #[help(lint_help_doctest)]
+        doctest_help: Option<()>,
+        #[note(lint_non_local)]
+        #[note(lint_exception)]
+        #[note(lint_non_local_definitions_deprecation)]
+        notes: (),
         #[subdiagnostic]
         cargo_update: Option<NonLocalDefinitionsCargoUpdateNote>,
     },

--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -232,6 +232,12 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
             ItemKind::Macro(_macro, MacroKind::Bang)
                 if cx.tcx.has_attr(item.owner_id.def_id, sym::macro_export) =>
             {
+                // determining we if are in a doctest context can't currently be determined
+                // by the code it-self (no specific attrs), but fortunatly rustdoc sets a
+                // perma-unstable env for libtest so we just re-use that env for now
+                let is_at_toplevel_doctest =
+                    self.body_depth == 2 && std::env::var("UNSTABLE_RUSTDOC_TEST_PATH").is_ok();
+
                 cx.emit_span_lint(
                     NON_LOCAL_DEFINITIONS,
                     item.span,
@@ -242,6 +248,9 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                             .map(|s| s.to_ident_string())
                             .unwrap_or_else(|| "<unnameable>".to_string()),
                         cargo_update: cargo_update(),
+                        help: (!is_at_toplevel_doctest).then_some(()),
+                        doctest_help: is_at_toplevel_doctest.then_some(()),
+                        notes: (),
                     },
                 )
             }

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -5,7 +5,6 @@ use std::{
 
 use rustc_errors::{codes::*, Diag, DiagCtxt, Diagnostic, EmissionGuarantee, Level};
 use rustc_macros::{Diagnostic, Subdiagnostic};
-use rustc_session::config;
 use rustc_span::{sym, Span, Symbol};
 use rustc_target::spec::{PanicStrategy, TargetTriple};
 
@@ -640,9 +639,7 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for CannotFindCrate {
         diag.arg("locator_triple", self.locator_triple.triple());
         diag.code(E0463);
         diag.span(self.span);
-        if (self.crate_name == sym::std || self.crate_name == sym::core)
-            && self.locator_triple != TargetTriple::from_triple(config::host_triple())
-        {
+        if self.crate_name == sym::std || self.crate_name == sym::core {
             if self.missing_core {
                 diag.note(fluent::metadata_target_not_installed);
             } else {

--- a/tests/assembly/simd-intrinsic-mask-reduce.rs
+++ b/tests/assembly/simd-intrinsic-mask-reduce.rs
@@ -1,6 +1,7 @@
 // verify that simd mask reductions do not introduce additional bit shift operations
 //@ revisions: x86 aarch64
 //@ [x86] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
+// Set the base cpu explicitly, in case the default has been changed.
 //@ [x86] compile-flags: -C target-cpu=x86-64
 //@ [x86] needs-llvm-components: x86
 //@ [aarch64] compile-flags: --target=aarch64-unknown-linux-gnu

--- a/tests/assembly/simd-intrinsic-mask-reduce.rs
+++ b/tests/assembly/simd-intrinsic-mask-reduce.rs
@@ -1,6 +1,7 @@
 // verify that simd mask reductions do not introduce additional bit shift operations
 //@ revisions: x86 aarch64
 //@ [x86] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
+//@ [x86] compile-flags: -C target-cpu=x86-64
 //@ [x86] needs-llvm-components: x86
 //@ [aarch64] compile-flags: --target=aarch64-unknown-linux-gnu
 //@ [aarch64] needs-llvm-components: aarch64

--- a/tests/assembly/x86_64-floating-point-clamp.rs
+++ b/tests/assembly/x86_64-floating-point-clamp.rs
@@ -2,7 +2,7 @@
 // so check to make sure that's what it's actually emitting.
 
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel
+//@ compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel -C target-cpu=x86-64
 //@ only-x86_64
 //@ ignore-sgx
 

--- a/tests/assembly/x86_64-floating-point-clamp.rs
+++ b/tests/assembly/x86_64-floating-point-clamp.rs
@@ -2,6 +2,7 @@
 // so check to make sure that's what it's actually emitting.
 
 //@ assembly-output: emit-asm
+// Set the base cpu explicitly, in case the default has been changed.
 //@ compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel -C target-cpu=x86-64
 //@ only-x86_64
 //@ ignore-sgx

--- a/tests/codegen/target-feature-inline-closure.rs
+++ b/tests/codegen/target-feature-inline-closure.rs
@@ -1,5 +1,5 @@
 //@ only-x86_64
-//@ compile-flags: -Copt-level=3
+//@ compile-flags: -Copt-level=3 -Ctarget-cpu=x86-64
 
 #![crate_type = "lib"]
 #![feature(target_feature_11)]

--- a/tests/codegen/target-feature-inline-closure.rs
+++ b/tests/codegen/target-feature-inline-closure.rs
@@ -1,4 +1,5 @@
 //@ only-x86_64
+// Set the base cpu explicitly, in case the default has been changed.
 //@ compile-flags: -Copt-level=3 -Ctarget-cpu=x86-64
 
 #![crate_type = "lib"]

--- a/tests/rustdoc-ui/doctest/non_local_defs.rs
+++ b/tests/rustdoc-ui/doctest/non_local_defs.rs
@@ -1,0 +1,10 @@
+//@ check-pass
+//@ compile-flags:--test --test-args --test-threads=1 --nocapture -Zunstable-options
+//@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stderr-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+//! ```
+//! #[macro_export]
+//! macro_rules! a_macro { () => {} }
+//! ```

--- a/tests/rustdoc-ui/doctest/non_local_defs.stderr
+++ b/tests/rustdoc-ui/doctest/non_local_defs.stderr
@@ -1,0 +1,14 @@
+warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
+  --> $DIR/non_local_defs.rs:9:1
+   |
+LL | macro_rules! a_macro { () => {} }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the `#[macro_export]` or make this doc-test a standalone test with its own `fn main() { ... }`
+   = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
+   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module
+   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
+   = note: `#[warn(non_local_definitions)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/rustdoc-ui/doctest/non_local_defs.stdout
+++ b/tests/rustdoc-ui/doctest/non_local_defs.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/non_local_defs.rs - (line 7) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/ui/asm/x86_64/target-feature-attr.rs
+++ b/tests/ui/asm/x86_64/target-feature-attr.rs
@@ -1,4 +1,5 @@
 //@ only-x86_64
+//@ compile-flags: -C target-cpu=x86-64
 
 #![feature(avx512_target_feature)]
 

--- a/tests/ui/asm/x86_64/target-feature-attr.rs
+++ b/tests/ui/asm/x86_64/target-feature-attr.rs
@@ -1,4 +1,5 @@
 //@ only-x86_64
+// Set the base cpu explicitly, in case the default has been changed.
 //@ compile-flags: -C target-cpu=x86-64
 
 #![feature(avx512_target_feature)]

--- a/tests/ui/asm/x86_64/target-feature-attr.stderr
+++ b/tests/ui/asm/x86_64/target-feature-attr.stderr
@@ -1,23 +1,23 @@
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:19:40
+  --> $DIR/target-feature-attr.rs:20:40
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                        ^^^^^^^^^^^^^
 
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:19:55
+  --> $DIR/target-feature-attr.rs:20:55
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                                       ^^^^^^^^^^^^^
 
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:19:70
+  --> $DIR/target-feature-attr.rs:20:70
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                                                      ^^^^^^^^^^^^^^^^^^
 
 error: register class `kreg` requires at least one of the following target features: avx512bw, avx512f
-  --> $DIR/target-feature-attr.rs:34:23
+  --> $DIR/target-feature-attr.rs:35:23
    |
 LL |     asm!("/* {0} */", in(kreg) x);
    |                       ^^^^^^^^^^

--- a/tests/ui/asm/x86_64/target-feature-attr.stderr
+++ b/tests/ui/asm/x86_64/target-feature-attr.stderr
@@ -1,23 +1,23 @@
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:18:40
+  --> $DIR/target-feature-attr.rs:19:40
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                        ^^^^^^^^^^^^^
 
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:18:55
+  --> $DIR/target-feature-attr.rs:19:55
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                                       ^^^^^^^^^^^^^
 
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:18:70
+  --> $DIR/target-feature-attr.rs:19:70
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                                                      ^^^^^^^^^^^^^^^^^^
 
 error: register class `kreg` requires at least one of the following target features: avx512bw, avx512f
-  --> $DIR/target-feature-attr.rs:33:23
+  --> $DIR/target-feature-attr.rs:34:23
    |
 LL |     asm!("/* {0} */", in(kreg) x);
    |                       ^^^^^^^^^^

--- a/tests/ui/consts/const-eval/const_fn_target_feature.rs
+++ b/tests/ui/consts/const-eval/const_fn_target_feature.rs
@@ -1,4 +1,5 @@
 //@ only-x86_64
+// Set the base cpu explicitly, in case the default has been changed.
 //@ compile-flags: -C target-cpu=x86-64 -C target-feature=+ssse3
 
 #![crate_type = "lib"]

--- a/tests/ui/consts/const-eval/const_fn_target_feature.rs
+++ b/tests/ui/consts/const-eval/const_fn_target_feature.rs
@@ -1,5 +1,5 @@
 //@ only-x86_64
-//@ compile-flags:-C target-feature=+ssse3
+//@ compile-flags: -C target-cpu=x86-64 -C target-feature=+ssse3
 
 #![crate_type = "lib"]
 

--- a/tests/ui/consts/const-eval/const_fn_target_feature.stderr
+++ b/tests/ui/consts/const-eval/const_fn_target_feature.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_fn_target_feature.rs:10:24
+  --> $DIR/const_fn_target_feature.rs:11:24
    |
 LL | const B: () = unsafe { avx2_fn() };
    |                        ^^^^^^^^^ calling a function that requires unavailable target features: avx2

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
@@ -1,4 +1,5 @@
 //@ only-x86_64
+//@ compile-flags: -C target-cpu=x86-64
 
 #![feature(target_feature_11)]
 

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
@@ -1,4 +1,5 @@
 //@ only-x86_64
+// Set the base cpu explicitly, in case the default has been changed.
 //@ compile-flags: -C target-cpu=x86-64
 
 #![feature(target_feature_11)]

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:26:5
+  --> $DIR/safe-calls.rs:27:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
@@ -8,7 +8,7 @@ LL |     sse2();
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 
 error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:28:5
+  --> $DIR/safe-calls.rs:29:5
    |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
@@ -16,7 +16,7 @@ LL |     avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target features: avx and bmi2
 
 error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:30:5
+  --> $DIR/safe-calls.rs:31:5
    |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
@@ -24,7 +24,7 @@ LL |     Quux.avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target features: avx and bmi2
 
 error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:36:5
+  --> $DIR/safe-calls.rs:37:5
    |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
@@ -32,7 +32,7 @@ LL |     avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target features: avx and bmi2
 
 error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:38:5
+  --> $DIR/safe-calls.rs:39:5
    |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
@@ -40,7 +40,7 @@ LL |     Quux.avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target features: avx and bmi2
 
 error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:44:5
+  --> $DIR/safe-calls.rs:45:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
@@ -49,7 +49,7 @@ LL |     sse2();
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 
 error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:46:5
+  --> $DIR/safe-calls.rs:47:5
    |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
@@ -57,7 +57,7 @@ LL |     avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target feature: bmi2
 
 error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:48:5
+  --> $DIR/safe-calls.rs:49:5
    |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
@@ -65,7 +65,7 @@ LL |     Quux.avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target feature: bmi2
 
 error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:55:5
+  --> $DIR/safe-calls.rs:56:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
@@ -74,7 +74,7 @@ LL |     sse2();
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 
 error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:59:15
+  --> $DIR/safe-calls.rs:60:15
    |
 LL | const _: () = sse2();
    |               ^^^^^^ call to function with `#[target_feature]`
@@ -83,7 +83,7 @@ LL | const _: () = sse2();
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 
 error[E0133]: call to function `sse2_and_fxsr` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:62:15
+  --> $DIR/safe-calls.rs:63:15
    |
 LL | const _: () = sse2_and_fxsr();
    |               ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
@@ -92,7 +92,7 @@ LL | const _: () = sse2_and_fxsr();
    = note: the fxsr and sse2 target features being enabled in the build configuration does not remove the requirement to list them in `#[target_feature]`
 
 error: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe block (error E0133)
-  --> $DIR/safe-calls.rs:69:5
+  --> $DIR/safe-calls.rs:70:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
@@ -101,12 +101,12 @@ LL |     sse2();
    = help: in order for the call to be safe, the context requires the following additional target feature: sse2
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 note: an unsafe function restricts its caller, but its body is safe by default
-  --> $DIR/safe-calls.rs:68:1
+  --> $DIR/safe-calls.rs:69:1
    |
 LL | unsafe fn needs_unsafe_block() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: the lint level is defined here
-  --> $DIR/safe-calls.rs:65:8
+  --> $DIR/safe-calls.rs:66:8
    |
 LL | #[deny(unsafe_op_in_unsafe_fn)]
    |        ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:25:5
+  --> $DIR/safe-calls.rs:26:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
@@ -8,7 +8,7 @@ LL |     sse2();
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 
 error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:27:5
+  --> $DIR/safe-calls.rs:28:5
    |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
@@ -16,7 +16,7 @@ LL |     avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target features: avx and bmi2
 
 error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:29:5
+  --> $DIR/safe-calls.rs:30:5
    |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
@@ -24,7 +24,7 @@ LL |     Quux.avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target features: avx and bmi2
 
 error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:35:5
+  --> $DIR/safe-calls.rs:36:5
    |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
@@ -32,7 +32,7 @@ LL |     avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target features: avx and bmi2
 
 error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:37:5
+  --> $DIR/safe-calls.rs:38:5
    |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
@@ -40,7 +40,7 @@ LL |     Quux.avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target features: avx and bmi2
 
 error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:43:5
+  --> $DIR/safe-calls.rs:44:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
@@ -49,7 +49,7 @@ LL |     sse2();
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 
 error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:45:5
+  --> $DIR/safe-calls.rs:46:5
    |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
@@ -57,7 +57,7 @@ LL |     avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target feature: bmi2
 
 error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:47:5
+  --> $DIR/safe-calls.rs:48:5
    |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
@@ -65,7 +65,7 @@ LL |     Quux.avx_bmi2();
    = help: in order for the call to be safe, the context requires the following additional target feature: bmi2
 
 error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:54:5
+  --> $DIR/safe-calls.rs:55:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
@@ -74,7 +74,7 @@ LL |     sse2();
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 
 error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:58:15
+  --> $DIR/safe-calls.rs:59:15
    |
 LL | const _: () = sse2();
    |               ^^^^^^ call to function with `#[target_feature]`
@@ -83,7 +83,7 @@ LL | const _: () = sse2();
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 
 error[E0133]: call to function `sse2_and_fxsr` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:61:15
+  --> $DIR/safe-calls.rs:62:15
    |
 LL | const _: () = sse2_and_fxsr();
    |               ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
@@ -92,7 +92,7 @@ LL | const _: () = sse2_and_fxsr();
    = note: the fxsr and sse2 target features being enabled in the build configuration does not remove the requirement to list them in `#[target_feature]`
 
 error: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe block (error E0133)
-  --> $DIR/safe-calls.rs:68:5
+  --> $DIR/safe-calls.rs:69:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
@@ -101,12 +101,12 @@ LL |     sse2();
    = help: in order for the call to be safe, the context requires the following additional target feature: sse2
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 note: an unsafe function restricts its caller, but its body is safe by default
-  --> $DIR/safe-calls.rs:67:1
+  --> $DIR/safe-calls.rs:68:1
    |
 LL | unsafe fn needs_unsafe_block() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: the lint level is defined here
-  --> $DIR/safe-calls.rs:64:8
+  --> $DIR/safe-calls.rs:65:8
    |
 LL | #[deny(unsafe_op_in_unsafe_fn)]
    |        ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/sse2.rs
+++ b/tests/ui/sse2.rs
@@ -19,7 +19,7 @@ fn main() {
         assert!(cfg!(target_feature = "sse2"),
                 "SSE2 was not detected as available on an x86 platform");
     }
-    // check a negative case too -- allowed on x86, but not enabled by default
-    assert!(cfg!(not(target_feature = "avx512f")),
-            "AVX512 shouldn't be detected as available by default on any platform");
+    // check a negative case too -- certainly not enabled by default
+    assert!(cfg!(not(target_feature = "ferris_wheel")),
+            "🎡 shouldn't be detected as available by default on any platform");
 }

--- a/tests/ui/sse2.rs
+++ b/tests/ui/sse2.rs
@@ -20,6 +20,6 @@ fn main() {
                 "SSE2 was not detected as available on an x86 platform");
     }
     // check a negative case too -- allowed on x86, but not enabled by default
-    assert!(cfg!(not(target_feature = "avx2")),
-            "AVX2 shouldn't be detected as available by default on any platform");
+    assert!(cfg!(not(target_feature = "avx512f")),
+            "AVX512 shouldn't be detected as available by default on any platform");
 }


### PR DESCRIPTION
Successful merges:

 - #124568 (Adjust `#[macro_export]`/doctest help suggestion for non_local_defs lint)
 - #124582 (always print nice 'std not found' error when std is not found)
 - #124597 (Use an explicit x86-64 cpu in tests that are sensitive to it)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=124568,124582,124597)
<!-- homu-ignore:end -->