### PR TITLE
Cleanup: Rid the `rmake` test runners of `extern crate run_make_support;`

### DIFF
--- a/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
+++ b/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
@@ -3,8 +3,6 @@
 // Check that the `CURRENT_RUSTC_VERSION` placeholder is correctly replaced by the current
 // `rustc` version and the `since` property in feature stability gating is properly respected.
 
-extern crate run_make_support;
-
 use std::path::PathBuf;
 
 use run_make_support::{rustc, aux_build};

--- a/tests/run-make/a-b-a-linker-guard/rmake.rs
+++ b/tests/run-make/a-b-a-linker-guard/rmake.rs
@@ -3,8 +3,6 @@
 // Test that if we build `b` against a version of `a` that has one set of types, it will not run
 // with a dylib that has a different set of types.
 
-extern crate run_make_support;
-
 use run_make_support::{run, run_fail, rustc};
 
 fn main() {

--- a/tests/run-make/arguments-non-c-like-enum/rmake.rs
+++ b/tests/run-make/arguments-non-c-like-enum/rmake.rs
@@ -1,8 +1,6 @@
 //! Check that non-trivial `repr(C)` enum in Rust has valid C layout.
 //@ ignore-cross-compile
 
-extern crate run_make_support;
-
 use run_make_support::{cc, extra_c_flags, extra_cxx_flags, run, rustc, static_lib};
 
 pub fn main() {

--- a/tests/run-make/artifact-incr-cache-no-obj/rmake.rs
+++ b/tests/run-make/artifact-incr-cache-no-obj/rmake.rs
@@ -5,8 +5,6 @@
 //
 // Fixes: rust-lang/rust#123234
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/artifact-incr-cache/rmake.rs
+++ b/tests/run-make/artifact-incr-cache/rmake.rs
@@ -7,8 +7,6 @@
 // Also see discussion at
 // <https://internals.rust-lang.org/t/interaction-between-incremental-compilation-and-emit/20551>
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/compiler-builtins/rmake.rs
+++ b/tests/run-make/compiler-builtins/rmake.rs
@@ -14,8 +14,6 @@
 
 #![deny(warnings)]
 
-extern crate run_make_support;
-
 use run_make_support::object;
 use run_make_support::object::read::archive::ArchiveFile;
 use run_make_support::object::read::Object;

--- a/tests/run-make/core-no-fp-fmt-parse/rmake.rs
+++ b/tests/run-make/core-no-fp-fmt-parse/rmake.rs
@@ -1,8 +1,6 @@
 // This test checks that the core library of Rust can be compiled without enabling
 // support for formatting and parsing floating-point numbers.
 
-extern crate run_make_support;
-
 use run_make_support::rustc;
 use std::path::PathBuf;
 

--- a/tests/run-make/cross-lang-lto-riscv-abi/rmake.rs
+++ b/tests/run-make/cross-lang-lto-riscv-abi/rmake.rs
@@ -2,7 +2,6 @@
 //! which requires extra `target-abi` metadata to be emitted.
 //@ needs-matching-clang
 //@ needs-llvm-components riscv
-extern crate run_make_support;
 
 use run_make_support::{bin_name, clang, llvm_readobj, rustc, tmp_dir};
 use std::{

--- a/tests/run-make/exit-code/rmake.rs
+++ b/tests/run-make/exit-code/rmake.rs
@@ -1,7 +1,5 @@
 // Test that we exit with the correct exit code for successful / unsuccessful / ICE compilations
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, rustdoc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/issue-107495-archive-permissions/rmake.rs
+++ b/tests/run-make/issue-107495-archive-permissions/rmake.rs
@@ -2,7 +2,6 @@
 
 #[cfg(unix)]
 extern crate libc;
-extern crate run_make_support;
 
 use run_make_support::{aux_build, tmp_dir};
 use std::fs;

--- a/tests/run-make/no-input-file/rmake.rs
+++ b/tests/run-make/no-input-file/rmake.rs
@@ -1,5 +1,3 @@
-extern crate run_make_support;
-
 use run_make_support::{diff, rustc};
 
 fn main() {

--- a/tests/run-make/non-unicode-env/rmake.rs
+++ b/tests/run-make/non-unicode-env/rmake.rs
@@ -1,5 +1,3 @@
-extern crate run_make_support;
-
 use run_make_support::rustc;
 
 fn main() {

--- a/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
+++ b/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
@@ -1,5 +1,3 @@
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/print-cfg/rmake.rs
+++ b/tests/run-make/print-cfg/rmake.rs
@@ -5,8 +5,6 @@
 //!
 //! It also checks that some targets have the correct set cfgs.
 
-extern crate run_make_support;
-
 use std::collections::HashSet;
 use std::ffi::OsString;
 use std::io::BufRead;

--- a/tests/run-make/print-native-static-libs/rmake.rs
+++ b/tests/run-make/print-native-static-libs/rmake.rs
@@ -12,8 +12,6 @@
 //@ ignore-cross-compile
 //@ ignore-wasm
 
-extern crate run_make_support;
-
 use std::io::BufRead;
 
 use run_make_support::{rustc, is_msvc};

--- a/tests/run-make/print-to-output/rmake.rs
+++ b/tests/run-make/print-to-output/rmake.rs
@@ -1,8 +1,6 @@
 //! This checks the output of some `--print` options when
 //! output to a file (instead of stdout)
 
-extern crate run_make_support;
-
 use std::ffi::OsString;
 
 use run_make_support::{rustc, target, tmp_dir};

--- a/tests/run-make/repr128-dwarf/rmake.rs
+++ b/tests/run-make/repr128-dwarf/rmake.rs
@@ -1,8 +1,6 @@
 //@ ignore-windows
 // This test should be replaced with one in tests/debuginfo once GDB or LLDB support 128-bit enums.
 
-extern crate run_make_support;
-
 use gimli::{AttributeValue, Dwarf, EndianRcSlice, Reader, RunTimeEndian};
 use object::{Object, ObjectSection};
 use run_make_support::{gimli, object, rustc, tmp_dir};

--- a/tests/run-make/rust-lld-custom-target/rmake.rs
+++ b/tests/run-make/rust-lld-custom-target/rmake.rs
@@ -8,8 +8,6 @@
 //@ needs-rust-lld
 //@ only-x86_64-unknown-linux-gnu
 
-extern crate run_make_support;
-
 use run_make_support::regex::Regex;
 use run_make_support::rustc;
 use std::process::Output;

--- a/tests/run-make/rust-lld/rmake.rs
+++ b/tests/run-make/rust-lld/rmake.rs
@@ -5,8 +5,6 @@
 //@ ignore-msvc
 //@ ignore-s390x lld does not yet support s390x as target
 
-extern crate run_make_support;
-
 use run_make_support::regex::Regex;
 use run_make_support::rustc;
 use std::process::Output;

--- a/tests/run-make/rustdoc-test-args/rmake.rs
+++ b/tests/run-make/rustdoc-test-args/rmake.rs
@@ -1,5 +1,3 @@
-extern crate run_make_support;
-
 use run_make_support::{rustdoc, tmp_dir};
 use std::path::Path;
 use std::{fs, iter};

--- a/tests/run-make/wasm-abi/rmake.rs
+++ b/tests/run-make/wasm-abi/rmake.rs
@@ -1,8 +1,6 @@
 //@ only-wasm32-wasip1
 //@ needs-wasmtime
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 use std::path::Path;
 use std::process::Command;

--- a/tests/run-make/wasm-custom-section/rmake.rs
+++ b/tests/run-make/wasm-custom-section/rmake.rs
@@ -1,5 +1,4 @@
 //@ only-wasm32-wasip1
-extern crate run_make_support;
 
 use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::collections::HashMap;

--- a/tests/run-make/wasm-custom-sections-opt/rmake.rs
+++ b/tests/run-make/wasm-custom-sections-opt/rmake.rs
@@ -1,5 +1,4 @@
 //@ only-wasm32-wasip1
-extern crate run_make_support;
 
 use run_make_support::{tmp_dir, wasmparser, rustc};
 use std::collections::HashMap;

--- a/tests/run-make/wasm-export-all-symbols/rmake.rs
+++ b/tests/run-make/wasm-export-all-symbols/rmake.rs
@@ -1,7 +1,5 @@
 //@ only-wasm32-wasip1
 
-extern crate run_make_support;
-
 use run_make_support::{tmp_dir, wasmparser, rustc};
 use std::collections::HashMap;
 use std::path::Path;

--- a/tests/run-make/wasm-import-module/rmake.rs
+++ b/tests/run-make/wasm-import-module/rmake.rs
@@ -1,7 +1,5 @@
 //@ only-wasm32-wasip1
 
-extern crate run_make_support;
-
 use run_make_support::{tmp_dir, wasmparser, rustc};
 use std::collections::HashMap;
 use wasmparser::TypeRef::Func;

--- a/tests/run-make/wasm-panic-small/rmake.rs
+++ b/tests/run-make/wasm-panic-small/rmake.rs
@@ -1,8 +1,6 @@
 //@ only-wasm32-wasip1
 #![deny(warnings)]
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/wasm-spurious-import/rmake.rs
+++ b/tests/run-make/wasm-spurious-import/rmake.rs
@@ -1,7 +1,5 @@
 //@ only-wasm32-wasip1
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::collections::HashMap;
 

--- a/tests/run-make/wasm-stringify-ints-small/rmake.rs
+++ b/tests/run-make/wasm-stringify-ints-small/rmake.rs
@@ -1,8 +1,6 @@
 //@ only-wasm32-wasip1
 #![deny(warnings)]
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/wasm-symbols-different-module/rmake.rs
+++ b/tests/run-make/wasm-symbols-different-module/rmake.rs
@@ -1,5 +1,4 @@
 //@ only-wasm32-wasip1
-extern crate run_make_support;
 
 use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::collections::{HashMap, HashSet};

--- a/tests/run-make/wasm-symbols-not-exported/rmake.rs
+++ b/tests/run-make/wasm-symbols-not-exported/rmake.rs
@@ -1,5 +1,4 @@
 //@ only-wasm32-wasip1
-extern crate run_make_support;
 
 use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::path::Path;

--- a/tests/run-make/wasm-symbols-not-imported/rmake.rs
+++ b/tests/run-make/wasm-symbols-not-imported/rmake.rs
@@ -1,5 +1,4 @@
 //@ only-wasm32-wasip1
-extern crate run_make_support;
 
 use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::path::Path;


### PR DESCRIPTION
`run_make_support` is part of the *extern prelude* of `rmake` test runners & we're using Rust 2021 for them since #124280 rendering `extern crate run_make_support` redundant:

https://github.com/rust-lang/rust/blob/80451a485b006bd32732c003a54ee7de457d8266/src/tools/compiletest/src/runtest.rs#L3826-L3827

~~Contains some fmt'ing changes because I've enabled format-on-save in my editor and because we don't run `x fmt` for `rmake` test runners yet (this gets addressed by #124613). I can revert those if you'd like me to.~~ (reverted)

r? jieyouxu or testing-devex(?) or boostrap(?)