### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -743,8 +743,18 @@ impl Align {
     }
 
     #[inline]
+    pub fn bytes_usize(self) -> usize {
+        self.bytes().try_into().unwrap()
+    }
+
+    #[inline]
     pub fn bits(self) -> u64 {
         self.bytes() * 8
+    }
+
+    #[inline]
+    pub fn bits_usize(self) -> usize {
+        self.bits().try_into().unwrap()
     }
 
     /// Computes the best alignment possible for the given offset

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -1223,7 +1223,7 @@ fn get_rust_try_fn<'a, 'gcc, 'tcx>(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig(
             iter::once(i8p),
-            Ty::new_unit(tcx),
+            tcx.types.unit,
             false,
             rustc_hir::Unsafety::Unsafe,
             Abi::Rust,
@@ -1234,7 +1234,7 @@ fn get_rust_try_fn<'a, 'gcc, 'tcx>(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig(
             [i8p, i8p].iter().cloned(),
-            Ty::new_unit(tcx),
+            tcx.types.unit,
             false,
             rustc_hir::Unsafety::Unsafe,
             Abi::Rust,

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -984,7 +984,7 @@ fn get_rust_try_fn<'ll, 'tcx>(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig(
             [i8p],
-            Ty::new_unit(tcx),
+            tcx.types.unit,
             false,
             hir::Unsafety::Unsafe,
             Abi::Rust,
@@ -995,7 +995,7 @@ fn get_rust_try_fn<'ll, 'tcx>(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig(
             [i8p, i8p],
-            Ty::new_unit(tcx),
+            tcx.types.unit,
             false,
             hir::Unsafety::Unsafe,
             Abi::Rust,

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -431,7 +431,6 @@ pub struct ProcessingDymutilFailed {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unable_to_run_dsymutil)]
-#[note]
 pub struct UnableToRunDsymutil {
     pub error: Error,
 }

--- a/compiler/rustc_const_eval/src/interpret/mod.rs
+++ b/compiler/rustc_const_eval/src/interpret/mod.rs
@@ -18,6 +18,7 @@ mod util;
 mod validity;
 mod visitor;
 
+#[doc(no_inline)]
 pub use rustc_middle::mir::interpret::*; // have all the `interpret` symbols in one place: here
 
 pub use self::eval_context::{format_interp_error, Frame, FrameInfo, InterpCx, StackPopCleanup};

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -208,11 +208,11 @@ pub fn check_intrinsic_type(
                 Ty::new_tup(tcx, &[param(0), tcx.types.bool]),
             ),
             "load" => (1, vec![Ty::new_imm_ptr(tcx, param(0))], param(0)),
-            "store" => (1, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], Ty::new_unit(tcx)),
+            "store" => (1, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit),
 
             "xchg" | "xadd" | "xsub" | "and" | "nand" | "or" | "xor" | "max" | "min" | "umax"
             | "umin" => (1, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], param(0)),
-            "fence" | "singlethreadfence" => (0, Vec::new(), Ty::new_unit(tcx)),
+            "fence" | "singlethreadfence" => (0, Vec::new(), tcx.types.unit),
             op => {
                 tcx.dcx().emit_err(UnrecognizedAtomicOperation { span, op });
                 return;
@@ -224,7 +224,7 @@ pub fn check_intrinsic_type(
         let (n_tps, n_cts, inputs, output) = match intrinsic_name {
             sym::abort => (0, 0, vec![], tcx.types.never),
             sym::unreachable => (0, 0, vec![], tcx.types.never),
-            sym::breakpoint => (0, 0, vec![], Ty::new_unit(tcx)),
+            sym::breakpoint => (0, 0, vec![], tcx.types.unit),
             sym::size_of | sym::pref_align_of | sym::min_align_of | sym::variant_count => {
                 (1, 0, vec![], tcx.types.usize)
             }
@@ -235,14 +235,14 @@ pub fn check_intrinsic_type(
             sym::caller_location => (0, 0, vec![], tcx.caller_location_ty()),
             sym::assert_inhabited
             | sym::assert_zero_valid
-            | sym::assert_mem_uninitialized_valid => (1, 0, vec![], Ty::new_unit(tcx)),
-            sym::forget => (1, 0, vec![param(0)], Ty::new_unit(tcx)),
+            | sym::assert_mem_uninitialized_valid => (1, 0, vec![], tcx.types.unit),
+            sym::forget => (1, 0, vec![param(0)], tcx.types.unit),
             sym::transmute | sym::transmute_unchecked => (2, 0, vec![param(0)], param(1)),
             sym::prefetch_read_data
             | sym::prefetch_write_data
             | sym::prefetch_read_instruction
             | sym::prefetch_write_instruction => {
-                (1, 0, vec![Ty::new_imm_ptr(tcx, param(0)), tcx.types.i32], Ty::new_unit(tcx))
+                (1, 0, vec![Ty::new_imm_ptr(tcx, param(0)), tcx.types.i32], tcx.types.unit)
             }
             sym::needs_drop => (1, 0, vec![], tcx.types.bool),
 
@@ -270,7 +270,7 @@ pub fn check_intrinsic_type(
                     Ty::new_mut_ptr(tcx, param(0)),
                     tcx.types.usize,
                 ],
-                Ty::new_unit(tcx),
+                tcx.types.unit,
             ),
             sym::volatile_copy_memory | sym::volatile_copy_nonoverlapping_memory => (
                 1,
@@ -280,7 +280,7 @@ pub fn check_intrinsic_type(
                     Ty::new_imm_ptr(tcx, param(0)),
                     tcx.types.usize,
                 ],
-                Ty::new_unit(tcx),
+                tcx.types.unit,
             ),
             sym::compare_bytes => {
                 let byte_ptr = Ty::new_imm_ptr(tcx, tcx.types.u8);
@@ -290,7 +290,7 @@ pub fn check_intrinsic_type(
                 1,
                 0,
                 vec![Ty::new_mut_ptr(tcx, param(0)), tcx.types.u8, tcx.types.usize],
-                Ty::new_unit(tcx),
+                tcx.types.unit,
             ),
 
             sym::sqrtf16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
@@ -409,7 +409,7 @@ pub fn check_intrinsic_type(
                 (1, 0, vec![Ty::new_imm_ptr(tcx, param(0))], param(0))
             }
             sym::volatile_store | sym::unaligned_volatile_store => {
-                (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], Ty::new_unit(tcx))
+                (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit)
             }
 
             sym::ctpop | sym::ctlz | sym::ctlz_nonzero | sym::cttz | sym::cttz_nonzero => {
@@ -440,7 +440,7 @@ pub fn check_intrinsic_type(
                 0,
                 1,
                 vec![Ty::new_mut_ptr(tcx, tcx.types.u8), tcx.types.usize, tcx.types.usize],
-                Ty::new_unit(tcx),
+                tcx.types.unit,
             ),
 
             sym::ptr_offset_from => (
@@ -477,16 +477,16 @@ pub fn check_intrinsic_type(
             | sym::frem_algebraic => (1, 0, vec![param(0), param(0)], param(0)),
             sym::float_to_int_unchecked => (2, 0, vec![param(0)], param(1)),
 
-            sym::assume => (0, 1, vec![tcx.types.bool], Ty::new_unit(tcx)),
+            sym::assume => (0, 1, vec![tcx.types.bool], tcx.types.unit),
             sym::likely => (0, 1, vec![tcx.types.bool], tcx.types.bool),
             sym::unlikely => (0, 1, vec![tcx.types.bool], tcx.types.bool),
 
             sym::read_via_copy => (1, 0, vec![Ty::new_imm_ptr(tcx, param(0))], param(0)),
             sym::write_via_move => {
-                (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], Ty::new_unit(tcx))
+                (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit)
             }
 
-            sym::typed_swap => (1, 1, vec![Ty::new_mut_ptr(tcx, param(0)); 2], Ty::new_unit(tcx)),
+            sym::typed_swap => (1, 1, vec![Ty::new_mut_ptr(tcx, param(0)); 2], tcx.types.unit),
 
             sym::discriminant_value => {
                 let assoc_items = tcx.associated_item_def_ids(
@@ -511,14 +511,14 @@ pub fn check_intrinsic_type(
                 let mut_u8 = Ty::new_mut_ptr(tcx, tcx.types.u8);
                 let try_fn_ty = ty::Binder::dummy(tcx.mk_fn_sig(
                     [mut_u8],
-                    Ty::new_unit(tcx),
+                    tcx.types.unit,
                     false,
                     hir::Unsafety::Normal,
                     Abi::Rust,
                 ));
                 let catch_fn_ty = ty::Binder::dummy(tcx.mk_fn_sig(
                     [mut_u8, mut_u8],
-                    Ty::new_unit(tcx),
+                    tcx.types.unit,
                     false,
                     hir::Unsafety::Normal,
                     Abi::Rust,
@@ -532,14 +532,14 @@ pub fn check_intrinsic_type(
             }
 
             sym::va_start | sym::va_end => match mk_va_list_ty(hir::Mutability::Mut) {
-                Some((va_list_ref_ty, _)) => (0, 0, vec![va_list_ref_ty], Ty::new_unit(tcx)),
+                Some((va_list_ref_ty, _)) => (0, 0, vec![va_list_ref_ty], tcx.types.unit),
                 None => bug!("`va_list` lang item needed for C-variadic intrinsics"),
             },
 
             sym::va_copy => match mk_va_list_ty(hir::Mutability::Not) {
                 Some((va_list_ref_ty, va_list_ty)) => {
                     let va_list_ptr_ty = Ty::new_mut_ptr(tcx, va_list_ty);
-                    (0, 0, vec![va_list_ptr_ty, va_list_ref_ty], Ty::new_unit(tcx))
+                    (0, 0, vec![va_list_ptr_ty, va_list_ref_ty], tcx.types.unit)
                 }
                 None => bug!("`va_list` lang item needed for C-variadic intrinsics"),
             },
@@ -550,7 +550,7 @@ pub fn check_intrinsic_type(
             },
 
             sym::nontemporal_store => {
-                (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], Ty::new_unit(tcx))
+                (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit)
             }
 
             sym::raw_eq => {
@@ -570,7 +570,7 @@ pub fn check_intrinsic_type(
             sym::const_eval_select => (4, 1, vec![param(0), param(1), param(2)], param(3)),
 
             sym::vtable_size | sym::vtable_align => {
-                (0, 0, vec![Ty::new_imm_ptr(tcx, Ty::new_unit(tcx))], tcx.types.usize)
+                (0, 0, vec![Ty::new_imm_ptr(tcx, tcx.types.unit)], tcx.types.usize)
             }
 
             // This type check is not particularly useful, but the `where` bounds
@@ -623,8 +623,8 @@ pub fn check_intrinsic_type(
             sym::simd_fma => (1, 0, vec![param(0), param(0), param(0)], param(0)),
             sym::simd_gather => (3, 0, vec![param(0), param(1), param(2)], param(0)),
             sym::simd_masked_load => (3, 0, vec![param(0), param(1), param(2)], param(2)),
-            sym::simd_masked_store => (3, 0, vec![param(0), param(1), param(2)], Ty::new_unit(tcx)),
-            sym::simd_scatter => (3, 0, vec![param(0), param(1), param(2)], Ty::new_unit(tcx)),
+            sym::simd_masked_store => (3, 0, vec![param(0), param(1), param(2)], tcx.types.unit),
+            sym::simd_scatter => (3, 0, vec![param(0), param(1), param(2)], tcx.types.unit),
             sym::simd_insert => (2, 0, vec![param(0), tcx.types.u32, param(1)], param(0)),
             sym::simd_extract => (2, 0, vec![param(0), tcx.types.u32], param(1)),
             sym::simd_cast

--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -330,6 +330,7 @@ fn orphan_check<'tcx>(
     };
 
     let Ok(result) = traits::orphan_check_trait_ref::<!>(
+        &infcx,
         trait_ref,
         traits::InCrate::Local { mode },
         lazily_normalize_ty,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2370,7 +2370,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     self.lower_ty(output)
                 }
             }
-            hir::FnRetTy::DefaultReturn(..) => Ty::new_unit(tcx),
+            hir::FnRetTy::DefaultReturn(..) => tcx.types.unit,
         };
 
         debug!(?output_ty);

--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -66,7 +66,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // us to give better error messages (pointing to a usually better
                 // arm for inconsistent arms or to the whole match when a `()` type
                 // is required).
-                Expectation::ExpectHasType(ety) if ety != Ty::new_unit(self.tcx) => ety,
+                Expectation::ExpectHasType(ety) if ety != tcx.types.unit => ety,
                 _ => self.next_ty_var(TypeVariableOrigin { param_def_id: None, span: expr.span }),
             };
             CoerceMany::with_coercion_sites(coerce_first, arms)

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1462,7 +1462,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
             fcx,
             cause,
             None,
-            Ty::new_unit(fcx.tcx),
+            fcx.tcx.types.unit,
             augment_error,
             label_unit_as_expected,
         )

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -654,7 +654,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             } else {
                 // Otherwise, this is a break *without* a value. That's
                 // always legal, and is equivalent to `break ()`.
-                e_ty = Ty::new_unit(tcx);
+                e_ty = tcx.types.unit;
                 cause = self.misc(expr.span);
             }
 
@@ -1133,7 +1133,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // The expected type is `bool` but this will result in `()` so we can reasonably
             // say that the user intended to write `lhs == rhs` instead of `lhs = rhs`.
             // The likely cause of this is `if foo = bar { .. }`.
-            let actual_ty = Ty::new_unit(self.tcx);
+            let actual_ty = self.tcx.types.unit;
             let mut err = self.demand_suptype_diag(expr.span, expected_ty, actual_ty).unwrap();
             let lhs_ty = self.check_expr(lhs);
             let rhs_ty = self.check_expr(rhs);
@@ -1256,7 +1256,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if let Err(guar) = (lhs_ty, rhs_ty).error_reported() {
             Ty::new_error(self.tcx, guar)
         } else {
-            Ty::new_unit(self.tcx)
+            self.tcx.types.unit
         }
     }
 
@@ -1319,7 +1319,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if ctxt.coerce.is_none() && !ctxt.may_break {
             self.dcx().span_bug(body.span, "no coercion, but loop may not break");
         }
-        ctxt.coerce.map(|c| c.complete(self)).unwrap_or_else(|| Ty::new_unit(self.tcx))
+        ctxt.coerce.map(|c| c.complete(self)).unwrap_or_else(|| self.tcx.types.unit)
     }
 
     /// Checks a method call.
@@ -3174,7 +3174,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.dcx().emit_err(YieldExprOutsideOfCoroutine { span: expr.span });
                 // Avoid expressions without types during writeback (#78653).
                 self.check_expr(value);
-                Ty::new_unit(self.tcx)
+                self.tcx.types.unit
             }
         }
     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1660,7 +1660,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             hir::StmtKind::Item(_) => {}
             hir::StmtKind::Expr(ref expr) => {
                 // Check with expected type of `()`.
-                self.check_expr_has_type_or_error(expr, Ty::new_unit(self.tcx), |err| {
+                self.check_expr_has_type_or_error(expr, self.tcx.types.unit, |err| {
                     if expr.can_have_side_effects() {
                         self.suggest_semicolon_at_end(expr.span, err);
                     }
@@ -1676,7 +1676,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     pub fn check_block_no_value(&self, blk: &'tcx hir::Block<'tcx>) {
-        let unit = Ty::new_unit(self.tcx);
+        let unit = self.tcx.types.unit;
         let ty = self.check_block_with_expected(blk, ExpectHasType(unit));
 
         // if the block produces a `!` value, that can always be
@@ -1794,7 +1794,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                         blk.span,
                                         blk.hir_id,
                                         expected_ty,
-                                        Ty::new_unit(self.tcx),
+                                        self.tcx.types.unit,
                                     );
                                 }
                                 if !self.err_ctxt().consider_removing_semicolon(

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -39,7 +39,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let ty =
             if !lhs_ty.is_ty_var() && !rhs_ty.is_ty_var() && is_builtin_binop(lhs_ty, rhs_ty, op) {
                 self.enforce_builtin_binop_types(lhs.span, lhs_ty, rhs.span, rhs_ty, op);
-                Ty::new_unit(self.tcx)
+                self.tcx.types.unit
             } else {
                 return_ty
             };

--- a/compiler/rustc_lint/src/unit_bindings.rs
+++ b/compiler/rustc_lint/src/unit_bindings.rs
@@ -1,7 +1,6 @@
 use crate::lints::UnitBindingsDiag;
 use crate::{LateLintPass, LintContext};
 use rustc_hir as hir;
-use rustc_middle::ty::Ty;
 use rustc_session::{declare_lint, declare_lint_pass};
 
 declare_lint! {
@@ -57,8 +56,8 @@ impl<'tcx> LateLintPass<'tcx> for UnitBindings {
             && let Some(init) = local.init
             && let init_ty = tyck_results.expr_ty(init)
             && let local_ty = tyck_results.node_type(local.hir_id)
-            && init_ty == Ty::new_unit(cx.tcx)
-            && local_ty == Ty::new_unit(cx.tcx)
+            && init_ty == cx.tcx.types.unit
+            && local_ty == cx.tcx.types.unit
             && local.ty.is_none()
             && !matches!(init.kind, hir::ExprKind::Tup([]))
             && !matches!(local.pat.kind, hir::PatKind::Tuple([], ..))

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -125,7 +125,7 @@ impl Primitive {
             F64 => tcx.types.f64,
             F128 => tcx.types.f128,
             // FIXME(erikdesjardins): handle non-default addrspace ptr sizes
-            Pointer(_) => Ty::new_mut_ptr(tcx, Ty::new_unit(tcx)),
+            Pointer(_) => Ty::new_mut_ptr(tcx, tcx.types.unit),
         }
     }
 
@@ -775,7 +775,7 @@ where
                     // (which may have no non-DST form), and will work as long
                     // as the `Abi` or `FieldsShape` is checked by users.
                     if i == 0 {
-                        let nil = Ty::new_unit(tcx);
+                        let nil = tcx.types.unit;
                         let unit_ptr_ty = if this.ty.is_unsafe_ptr() {
                             Ty::new_mut_ptr(tcx, nil)
                         } else {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1751,11 +1751,6 @@ impl<'tcx> Ty<'tcx> {
     // misc
 
     #[inline]
-    pub fn new_unit(tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
-        tcx.types.unit
-    }
-
-    #[inline]
     pub fn new_static_str(tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
         Ty::new_imm_ref(tcx, tcx.lifetimes.re_static, tcx.types.str_)
     }

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -997,7 +997,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         match self.unit_temp {
             Some(tmp) => tmp,
             None => {
-                let ty = Ty::new_unit(self.tcx);
+                let ty = self.tcx.types.unit;
                 let fn_span = self.fn_span;
                 let tmp = self.temp(ty, fn_span);
                 self.unit_temp = Some(tmp);

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -15,7 +15,7 @@ use rustc_hir::HirId;
 use rustc_hir::Node;
 use rustc_middle::middle::region;
 use rustc_middle::thir::*;
-use rustc_middle::ty::{self, RvalueScopes, Ty, TyCtxt};
+use rustc_middle::ty::{self, RvalueScopes, TyCtxt};
 
 pub(crate) fn thir_body(
     tcx: TyCtxt<'_>,
@@ -39,7 +39,7 @@ pub(crate) fn thir_body(
         // It will always be `()` in this case.
         if tcx.is_coroutine(owner_def.to_def_id()) && body.params.is_empty() {
             cx.thir.params.push(Param {
-                ty: Ty::new_unit(tcx),
+                ty: tcx.types.unit,
                 pat: None,
                 ty_span: None,
                 self_kind: None,

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -631,7 +631,7 @@ where
 
         let ref_ty = Ty::new_mut_ref(tcx, tcx.lifetimes.re_erased, ty);
         let ref_place = self.new_temp(ref_ty);
-        let unit_temp = Place::from(self.new_temp(Ty::new_unit(tcx)));
+        let unit_temp = Place::from(self.new_temp(tcx.types.unit));
 
         let result = BasicBlockData {
             statements: vec![self.assign(

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -1260,7 +1260,7 @@ fn create_coroutine_drop_shim<'tcx>(
     }
 
     // Replace the return variable
-    body.local_decls[RETURN_PLACE] = LocalDecl::with_source_info(Ty::new_unit(tcx), source_info);
+    body.local_decls[RETURN_PLACE] = LocalDecl::with_source_info(tcx.types.unit, source_info);
 
     make_coroutine_state_argument_indirect(tcx, &mut body);
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -781,7 +781,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             && self.fallback_has_occurred
                         {
                             let predicate = trait_predicate.map_bound(|trait_pred| {
-                                trait_pred.with_self_ty(self.tcx, Ty::new_unit(self.tcx))
+                                trait_pred.with_self_ty(self.tcx, tcx.types.unit)
                             });
                             let unit_obligation = obligation.with(tcx, predicate);
                             if self.predicate_may_hold(&unit_obligation) {

--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -519,7 +519,7 @@ fn virtual_call_violations_for_method<'tcx>(
 
             // e.g., `Rc<()>`
             let unit_receiver_ty =
-                receiver_for_self_ty(tcx, receiver_ty, Ty::new_unit(tcx), method.def_id);
+                receiver_for_self_ty(tcx, receiver_ty, tcx.types.unit, method.def_id);
 
             match abi_of_ty(unit_receiver_ty) {
                 Some(Abi::Scalar(..)) => (),

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1497,7 +1497,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // bound regions.
         let trait_ref = predicate.skip_binder().trait_ref;
 
-        coherence::trait_ref_is_knowable::<!>(self.tcx(), trait_ref, |ty| Ok(ty)).unwrap()
+        coherence::trait_ref_is_knowable::<!>(self.infcx, trait_ref, |ty| Ok(ty)).unwrap()
     }
 
     /// Returns `true` if the global caches can be used.

--- a/compiler/rustc_transmute/src/layout/tree.rs
+++ b/compiler/rustc_transmute/src/layout/tree.rs
@@ -266,7 +266,7 @@ pub(crate) mod rustc {
 
                 ty::Ref(lifetime, ty, mutability) => {
                     let ty_and_layout = cx.layout_of(*ty)?;
-                    let align = ty_and_layout.align.abi.bytes() as usize;
+                    let align = ty_and_layout.align.abi.bytes_usize();
                     let size = ty_and_layout.size.bytes_usize();
                     Ok(Tree::Ref(Ref {
                         lifetime: *lifetime,

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -854,7 +854,7 @@ fn make_thin_self_ptr<'tcx>(
     // we now have a type like `*mut RcBox<dyn Trait>`
     // change its layout to that of `*mut ()`, a thin pointer, but keep the same type
     // this is understood as a special case elsewhere in the compiler
-    let unit_ptr_ty = Ty::new_mut_ptr(tcx, Ty::new_unit(tcx));
+    let unit_ptr_ty = Ty::new_mut_ptr(tcx, tcx.types.unit);
 
     TyAndLayout {
         ty: fat_pointer_ty,

--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -120,16 +120,6 @@ pub(super) fn handle_needs(
             ignore_reason: "ignored on targets without Rust's LLDB",
         },
         Need {
-            name: "needs-i686-dlltool",
-            condition: cache.i686_dlltool,
-            ignore_reason: "ignored when dlltool for i686 is not present",
-        },
-        Need {
-            name: "needs-x86_64-dlltool",
-            condition: cache.x86_64_dlltool,
-            ignore_reason: "ignored when dlltool for x86_64 is not present",
-        },
-        Need {
             name: "needs-dlltool",
             condition: cache.dlltool,
             ignore_reason: "ignored when dlltool for the current architecture is not present",
@@ -218,27 +208,11 @@ pub(super) struct CachedNeedsConditions {
     profiler_support: bool,
     xray: bool,
     rust_lld: bool,
-    i686_dlltool: bool,
-    x86_64_dlltool: bool,
     dlltool: bool,
 }
 
 impl CachedNeedsConditions {
     pub(super) fn load(config: &Config) -> Self {
-        let path = std::env::var_os("PATH").expect("missing PATH environment variable");
-        let path = std::env::split_paths(&path).collect::<Vec<_>>();
-
-        // On Windows, dlltool.exe is used for all architectures.
-        #[cfg(windows)]
-        let dlltool = path.iter().any(|dir| dir.join("dlltool.exe").is_file());
-
-        // For non-Windows, there are architecture specific dlltool binaries.
-        #[cfg(not(windows))]
-        let i686_dlltool = path.iter().any(|dir| dir.join("i686-w64-mingw32-dlltool").is_file());
-        #[cfg(not(windows))]
-        let x86_64_dlltool =
-            path.iter().any(|dir| dir.join("x86_64-w64-mingw32-dlltool").is_file());
-
         let target = &&*config.target;
         let sanitizers = &config.target_cfg().sanitizers;
         Self {
@@ -278,26 +252,25 @@ impl CachedNeedsConditions {
                 .join(if config.host.contains("windows") { "rust-lld.exe" } else { "rust-lld" })
                 .exists(),
 
-            #[cfg(windows)]
-            i686_dlltool: dlltool,
-            #[cfg(windows)]
-            x86_64_dlltool: dlltool,
-            #[cfg(windows)]
-            dlltool,
-
-            // For non-Windows, there are architecture specific dlltool binaries.
-            #[cfg(not(windows))]
-            i686_dlltool,
-            #[cfg(not(windows))]
-            x86_64_dlltool,
-            #[cfg(not(windows))]
-            dlltool: if config.matches_arch("x86") {
-                i686_dlltool
-            } else if config.matches_arch("x86_64") {
-                x86_64_dlltool
-            } else {
-                false
-            },
+            dlltool: find_dlltool(&config),
         }
     }
+}
+
+fn find_dlltool(config: &Config) -> bool {
+    let path = std::env::var_os("PATH").expect("missing PATH environment variable");
+    let path = std::env::split_paths(&path).collect::<Vec<_>>();
+
+    // On Windows, dlltool.exe is used for all architectures.
+    // For non-Windows, there are architecture specific dlltool binaries.
+    let dlltool_found = if cfg!(windows) {
+        path.iter().any(|dir| dir.join("dlltool.exe").is_file())
+    } else if config.matches_arch("i686") {
+        path.iter().any(|dir| dir.join("i686-w64-mingw32-dlltool").is_file())
+    } else if config.matches_arch("x86_64") {
+        path.iter().any(|dir| dir.join("x86_64-w64-mingw32-dlltool").is_file())
+    } else {
+        false
+    };
+    dlltool_found
 }

--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -261,6 +261,11 @@ fn find_dlltool(config: &Config) -> bool {
     let path = std::env::var_os("PATH").expect("missing PATH environment variable");
     let path = std::env::split_paths(&path).collect::<Vec<_>>();
 
+    // dlltool is used ony by GNU based `*-*-windows-gnu`
+    if !(config.matches_os("windows") && config.matches_env("gnu") && config.matches_abi("")) {
+        return false;
+    }
+
     // On Windows, dlltool.exe is used for all architectures.
     // For non-Windows, there are architecture specific dlltool binaries.
     let dlltool_found = if cfg!(windows) {

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -89,8 +89,10 @@ mod shims;
 // Establish a "crate-wide prelude": we often import `crate::*`.
 
 // Make all those symbols available in the same place as our own.
+#[doc(no_inline)]
 pub use rustc_const_eval::interpret::*;
 // Resolve ambiguity.
+#[doc(no_inline)]
 pub use rustc_const_eval::interpret::{self, AllocMap, PlaceTy, Provenance as _};
 
 pub use crate::shims::env::{EnvVars, EvalContextExt as _};

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -380,7 +380,7 @@ impl<'mir, 'tcx: 'mir> PrimitiveLayouts<'tcx> {
         let mut_raw_ptr = Ty::new_mut_ptr(tcx, tcx.types.unit);
         let const_raw_ptr = Ty::new_imm_ptr(tcx, tcx.types.unit);
         Ok(Self {
-            unit: layout_cx.layout_of(Ty::new_unit(tcx))?,
+            unit: layout_cx.layout_of(tcx.types.unit)?,
             i8: layout_cx.layout_of(tcx.types.i8)?,
             i16: layout_cx.layout_of(tcx.types.i16)?,
             i32: layout_cx.layout_of(tcx.types.i32)?,

--- a/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
+++ b/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
@@ -3,8 +3,6 @@
 // Check that the `CURRENT_RUSTC_VERSION` placeholder is correctly replaced by the current
 // `rustc` version and the `since` property in feature stability gating is properly respected.
 
-extern crate run_make_support;
-
 use std::path::PathBuf;
 
 use run_make_support::{rustc, aux_build};

--- a/tests/run-make/a-b-a-linker-guard/rmake.rs
+++ b/tests/run-make/a-b-a-linker-guard/rmake.rs
@@ -3,8 +3,6 @@
 // Test that if we build `b` against a version of `a` that has one set of types, it will not run
 // with a dylib that has a different set of types.
 
-extern crate run_make_support;
-
 use run_make_support::{run, run_fail, rustc};
 
 fn main() {

--- a/tests/run-make/arguments-non-c-like-enum/rmake.rs
+++ b/tests/run-make/arguments-non-c-like-enum/rmake.rs
@@ -1,8 +1,6 @@
 //! Check that non-trivial `repr(C)` enum in Rust has valid C layout.
 //@ ignore-cross-compile
 
-extern crate run_make_support;
-
 use run_make_support::{cc, extra_c_flags, extra_cxx_flags, run, rustc, static_lib};
 
 pub fn main() {

--- a/tests/run-make/artifact-incr-cache-no-obj/rmake.rs
+++ b/tests/run-make/artifact-incr-cache-no-obj/rmake.rs
@@ -5,8 +5,6 @@
 //
 // Fixes: rust-lang/rust#123234
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/artifact-incr-cache/rmake.rs
+++ b/tests/run-make/artifact-incr-cache/rmake.rs
@@ -7,8 +7,6 @@
 // Also see discussion at
 // <https://internals.rust-lang.org/t/interaction-between-incremental-compilation-and-emit/20551>
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/compiler-builtins/rmake.rs
+++ b/tests/run-make/compiler-builtins/rmake.rs
@@ -14,8 +14,6 @@
 
 #![deny(warnings)]
 
-extern crate run_make_support;
-
 use run_make_support::object;
 use run_make_support::object::read::archive::ArchiveFile;
 use run_make_support::object::read::Object;

--- a/tests/run-make/core-no-fp-fmt-parse/rmake.rs
+++ b/tests/run-make/core-no-fp-fmt-parse/rmake.rs
@@ -1,8 +1,6 @@
 // This test checks that the core library of Rust can be compiled without enabling
 // support for formatting and parsing floating-point numbers.
 
-extern crate run_make_support;
-
 use run_make_support::rustc;
 use std::path::PathBuf;
 

--- a/tests/run-make/cross-lang-lto-riscv-abi/rmake.rs
+++ b/tests/run-make/cross-lang-lto-riscv-abi/rmake.rs
@@ -2,7 +2,6 @@
 //! which requires extra `target-abi` metadata to be emitted.
 //@ needs-matching-clang
 //@ needs-llvm-components riscv
-extern crate run_make_support;
 
 use run_make_support::{bin_name, clang, llvm_readobj, rustc, tmp_dir};
 use std::{

--- a/tests/run-make/exit-code/rmake.rs
+++ b/tests/run-make/exit-code/rmake.rs
@@ -1,7 +1,5 @@
 // Test that we exit with the correct exit code for successful / unsuccessful / ICE compilations
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, rustdoc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/issue-107495-archive-permissions/rmake.rs
+++ b/tests/run-make/issue-107495-archive-permissions/rmake.rs
@@ -2,7 +2,6 @@
 
 #[cfg(unix)]
 extern crate libc;
-extern crate run_make_support;
 
 use run_make_support::{aux_build, tmp_dir};
 use std::fs;

--- a/tests/run-make/no-input-file/rmake.rs
+++ b/tests/run-make/no-input-file/rmake.rs
@@ -1,5 +1,3 @@
-extern crate run_make_support;
-
 use run_make_support::{diff, rustc};
 
 fn main() {

--- a/tests/run-make/non-unicode-env/rmake.rs
+++ b/tests/run-make/non-unicode-env/rmake.rs
@@ -1,5 +1,3 @@
-extern crate run_make_support;
-
 use run_make_support::rustc;
 
 fn main() {

--- a/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
+++ b/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
@@ -1,5 +1,3 @@
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/print-cfg/rmake.rs
+++ b/tests/run-make/print-cfg/rmake.rs
@@ -5,8 +5,6 @@
 //!
 //! It also checks that some targets have the correct set cfgs.
 
-extern crate run_make_support;
-
 use std::collections::HashSet;
 use std::ffi::OsString;
 use std::io::BufRead;

--- a/tests/run-make/print-native-static-libs/rmake.rs
+++ b/tests/run-make/print-native-static-libs/rmake.rs
@@ -12,8 +12,6 @@
 //@ ignore-cross-compile
 //@ ignore-wasm
 
-extern crate run_make_support;
-
 use std::io::BufRead;
 
 use run_make_support::{rustc, is_msvc};

--- a/tests/run-make/print-to-output/rmake.rs
+++ b/tests/run-make/print-to-output/rmake.rs
@@ -1,8 +1,6 @@
 //! This checks the output of some `--print` options when
 //! output to a file (instead of stdout)
 
-extern crate run_make_support;
-
 use std::ffi::OsString;
 
 use run_make_support::{rustc, target, tmp_dir};

--- a/tests/run-make/raw-dylib-cross-compilation/Makefile
+++ b/tests/run-make/raw-dylib-cross-compilation/Makefile
@@ -1,8 +1,6 @@
 # Tests that raw-dylib cross compilation works correctly
 
-# only-gnu
-# needs-i686-dlltool
-# needs-x86_64-dlltool
+# needs-dlltool
 
 # i686 dlltool.exe can't product x64 binaries.
 # ignore-i686-pc-windows-gnu

--- a/tests/run-make/repr128-dwarf/rmake.rs
+++ b/tests/run-make/repr128-dwarf/rmake.rs
@@ -1,8 +1,6 @@
 //@ ignore-windows
 // This test should be replaced with one in tests/debuginfo once GDB or LLDB support 128-bit enums.
 
-extern crate run_make_support;
-
 use gimli::{AttributeValue, Dwarf, EndianRcSlice, Reader, RunTimeEndian};
 use object::{Object, ObjectSection};
 use run_make_support::{gimli, object, rustc, tmp_dir};

--- a/tests/run-make/rust-lld-custom-target/rmake.rs
+++ b/tests/run-make/rust-lld-custom-target/rmake.rs
@@ -8,8 +8,6 @@
 //@ needs-rust-lld
 //@ only-x86_64-unknown-linux-gnu
 
-extern crate run_make_support;
-
 use run_make_support::regex::Regex;
 use run_make_support::rustc;
 use std::process::Output;

--- a/tests/run-make/rust-lld/rmake.rs
+++ b/tests/run-make/rust-lld/rmake.rs
@@ -5,8 +5,6 @@
 //@ ignore-msvc
 //@ ignore-s390x lld does not yet support s390x as target
 
-extern crate run_make_support;
-
 use run_make_support::regex::Regex;
 use run_make_support::rustc;
 use std::process::Output;

--- a/tests/run-make/rustdoc-test-args/rmake.rs
+++ b/tests/run-make/rustdoc-test-args/rmake.rs
@@ -1,5 +1,3 @@
-extern crate run_make_support;
-
 use run_make_support::{rustdoc, tmp_dir};
 use std::path::Path;
 use std::{fs, iter};

--- a/tests/run-make/wasm-abi/rmake.rs
+++ b/tests/run-make/wasm-abi/rmake.rs
@@ -1,8 +1,6 @@
 //@ only-wasm32-wasip1
 //@ needs-wasmtime
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 use std::path::Path;
 use std::process::Command;

--- a/tests/run-make/wasm-custom-section/rmake.rs
+++ b/tests/run-make/wasm-custom-section/rmake.rs
@@ -1,5 +1,4 @@
 //@ only-wasm32-wasip1
-extern crate run_make_support;
 
 use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::collections::HashMap;

--- a/tests/run-make/wasm-custom-sections-opt/rmake.rs
+++ b/tests/run-make/wasm-custom-sections-opt/rmake.rs
@@ -1,5 +1,4 @@
 //@ only-wasm32-wasip1
-extern crate run_make_support;
 
 use run_make_support::{tmp_dir, wasmparser, rustc};
 use std::collections::HashMap;

--- a/tests/run-make/wasm-export-all-symbols/rmake.rs
+++ b/tests/run-make/wasm-export-all-symbols/rmake.rs
@@ -1,7 +1,5 @@
 //@ only-wasm32-wasip1
 
-extern crate run_make_support;
-
 use run_make_support::{tmp_dir, wasmparser, rustc};
 use std::collections::HashMap;
 use std::path::Path;

--- a/tests/run-make/wasm-import-module/rmake.rs
+++ b/tests/run-make/wasm-import-module/rmake.rs
@@ -1,7 +1,5 @@
 //@ only-wasm32-wasip1
 
-extern crate run_make_support;
-
 use run_make_support::{tmp_dir, wasmparser, rustc};
 use std::collections::HashMap;
 use wasmparser::TypeRef::Func;

--- a/tests/run-make/wasm-panic-small/rmake.rs
+++ b/tests/run-make/wasm-panic-small/rmake.rs
@@ -1,8 +1,6 @@
 //@ only-wasm32-wasip1
 #![deny(warnings)]
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/wasm-spurious-import/rmake.rs
+++ b/tests/run-make/wasm-spurious-import/rmake.rs
@@ -1,7 +1,5 @@
 //@ only-wasm32-wasip1
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::collections::HashMap;
 

--- a/tests/run-make/wasm-stringify-ints-small/rmake.rs
+++ b/tests/run-make/wasm-stringify-ints-small/rmake.rs
@@ -1,8 +1,6 @@
 //@ only-wasm32-wasip1
 #![deny(warnings)]
 
-extern crate run_make_support;
-
 use run_make_support::{rustc, tmp_dir};
 
 fn main() {

--- a/tests/run-make/wasm-symbols-different-module/rmake.rs
+++ b/tests/run-make/wasm-symbols-different-module/rmake.rs
@@ -1,5 +1,4 @@
 //@ only-wasm32-wasip1
-extern crate run_make_support;
 
 use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::collections::{HashMap, HashSet};

--- a/tests/run-make/wasm-symbols-not-exported/rmake.rs
+++ b/tests/run-make/wasm-symbols-not-exported/rmake.rs
@@ -1,5 +1,4 @@
 //@ only-wasm32-wasip1
-extern crate run_make_support;
 
 use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::path::Path;

--- a/tests/run-make/wasm-symbols-not-imported/rmake.rs
+++ b/tests/run-make/wasm-symbols-not-imported/rmake.rs
@@ -1,5 +1,4 @@
 //@ only-wasm32-wasip1
-extern crate run_make_support;
 
 use run_make_support::{rustc, tmp_dir, wasmparser};
 use std::path::Path;

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/dlltool-failed.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/dlltool-failed.rs
@@ -1,7 +1,5 @@
 // Tests that dlltool failing to generate an import library will raise an error.
 
-//@ only-gnu
-//@ only-windows
 //@ needs-dlltool
 //@ compile-flags: --crate-type lib --emit link
 //@ normalize-stderr-test: "[^ ']*/dlltool.exe" -> "$$DLLTOOL"

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/invalid-dlltool.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/invalid-dlltool.rs
@@ -1,7 +1,6 @@
 // Tests that failing to run dlltool will raise an error.
 
-//@ only-gnu
-//@ only-windows
+//@ needs-dlltool
 //@ compile-flags: --crate-type lib --emit link -Cdlltool=does_not_exit.exe
 #[link(name = "foo", kind = "raw-dylib")]
 extern "C" {


### PR DESCRIPTION
Successful merges:

 - #124138 (Ignore LLVM ABI in dlltool tests since those targets don't use dlltool)
 - #124414 (remove extraneous note on `UnableToRunDsymutil` diagnostic)
 - #124579 (Align: add bytes_usize and bits_usize)
 - #124622 (Cleanup: Rid the `rmake` test runners of `extern crate run_make_support;`)
 - #124623 (shallow resolve in orphan check)
 - #124624 (Use `tcx.types.unit` instead of `Ty::new_unit(tcx)`)
 - #124627 (interpret: hide some reexports in rustdoc)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=124138,124414,124579,124622,124623,124624,124627)
<!-- homu-ignore:end -->