### PR TITLE
CI: enable arbitrary try builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Checkout the source code
         uses: actions/checkout@v4
       - name: Calculate the CI job matrix
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: python3 src/ci/github-actions/calculate-job-matrix.py >> $GITHUB_OUTPUT
         id: jobs
   job:

--- a/src/ci/github-actions/calculate-job-matrix.py
+++ b/src/ci/github-actions/calculate-job-matrix.py
@@ -80,7 +80,7 @@ def get_custom_jobs(ctx: GitHubCtx) -> List[str]:
     if ctx.commit_message is None:
         return []
 
-    regex = re.compile(r"ci-job: (.*)")
+    regex = re.compile(r"^ci-job: (.*)", re.MULTILINE)
     jobs = []
     for match in regex.finditer(ctx.commit_message):
         jobs.append(match.group(1))


### PR DESCRIPTION
This PR should enable running arbitrary try builds with `@bors try`. So far there is no support for this in bors! You would need to manually add a special line (see below) to the PR description (this will later be automated with new bors).

try-job: aarch64-gnu
try-job: arm-android

r? @ghost