### PR TITLE
Fix #124275: Implemented Default for `Arc<str>`

### DIFF
--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -912,19 +912,6 @@ impl From<&CStr> for Rc<CStr> {
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
-impl Default for Arc<CStr> {
-    /// Creates an empty CStr inside an Arc
-    ///
-    /// This may or may not share an allocation with other Arcs.
-    #[inline]
-    fn default() -> Self {
-        let c_str: &CStr = Default::default();
-        Arc::from(c_str)
-    }
-}
-
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
 impl Default for Rc<CStr> {
     /// Creates an empty CStr inside an Rc
     ///

--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -914,6 +914,8 @@ impl From<&CStr> for Rc<CStr> {
 #[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
 impl Default for Arc<CStr> {
     /// Creates an empty CStr inside an Arc
+    ///
+    /// This may or may not share an allocation with other Arcs.
     #[inline]
     fn default() -> Self {
         let c_str: &CStr = Default::default();
@@ -925,6 +927,8 @@ impl Default for Arc<CStr> {
 #[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
 impl Default for Rc<CStr> {
     /// Creates an empty CStr inside an Rc
+    ///
+    /// This may or may not share an allocation with other Rcs on the same thread.
     #[inline]
     fn default() -> Self {
         let c_str: &CStr = Default::default();

--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -910,6 +910,28 @@ impl From<&CStr> for Rc<CStr> {
     }
 }
 
+#[cfg(not(no_global_oom_handling))]
+#[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
+impl Default for Arc<CStr> {
+    /// Creates an empty CStr inside an Arc
+    #[inline]
+    fn default() -> Self {
+        let c_str: &CStr = Default::default();
+        Arc::from(c_str)
+    }
+}
+
+#[cfg(not(no_global_oom_handling))]
+#[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
+impl Default for Rc<CStr> {
+    /// Creates an empty CStr inside an Rc
+    #[inline]
+    fn default() -> Self {
+        let c_str: &CStr = Default::default();
+        Rc::from(c_str)
+    }
+}
+
 #[cfg(not(test))]
 #[stable(feature = "default_box_extra", since = "1.17.0")]
 impl Default for Box<CStr> {

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2224,6 +2224,27 @@ impl<T: Default> Default for Rc<T> {
     }
 }
 
+#[cfg(not(no_global_oom_handling))]
+#[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
+impl Default for Rc<str> {
+    /// Creates an empty str inside an Rc
+    #[inline]
+    fn default() -> Self {
+        Rc::from("")
+    }
+}
+
+#[cfg(not(no_global_oom_handling))]
+#[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T> Default for Rc<[T]> {
+    /// Creates an empty `[T]` inside an Rc
+    #[inline]
+    fn default() -> Self {
+        let arr: [T; 0] = [];
+        Rc::from(arr)
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 trait RcEqIdent<T: ?Sized + PartialEq, A: Allocator> {
     fn eq(&self, other: &Rc<T, A>) -> bool;

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2228,6 +2228,8 @@ impl<T: Default> Default for Rc<T> {
 #[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
 impl Default for Rc<str> {
     /// Creates an empty str inside an Rc
+    ///
+    /// This may or may not share an allocation with other Rcs on the same thread.
     #[inline]
     fn default() -> Self {
         Rc::from("")
@@ -2238,6 +2240,8 @@ impl Default for Rc<str> {
 #[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
 impl<T> Default for Rc<[T]> {
     /// Creates an empty `[T]` inside an Rc
+    ///
+    /// This may or may not share an allocation with other Rcs on the same thread.
     #[inline]
     fn default() -> Self {
         let arr: [T; 0] = [];

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -3304,6 +3304,8 @@ impl<T: Default> Default for Arc<T> {
 #[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
 impl Default for Arc<str> {
     /// Creates an empty str inside an Arc
+    ///
+    /// This may or may not share an allocation with other Arcs.
     #[inline]
     fn default() -> Self {
         Arc::from("")
@@ -3314,6 +3316,8 @@ impl Default for Arc<str> {
 #[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
 impl<T> Default for Arc<[T]> {
     /// Creates an empty `[T]` inside an Arc
+    ///
+    /// This may or may not share an allocation with other Arcs.
     #[inline]
     fn default() -> Self {
         let arr: [T; 0] = [];

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -3300,6 +3300,27 @@ impl<T: Default> Default for Arc<T> {
     }
 }
 
+#[cfg(not(no_global_oom_handling))]
+#[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
+impl Default for Arc<str> {
+    /// Creates an empty str inside an Arc
+    #[inline]
+    fn default() -> Self {
+        Arc::from("")
+    }
+}
+
+#[cfg(not(no_global_oom_handling))]
+#[stable(feature = "more_rc_default_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T> Default for Arc<[T]> {
+    /// Creates an empty `[T]` inside an Arc
+    #[inline]
+    fn default() -> Self {
+        let arr: [T; 0] = [];
+        Arc::from(arr)
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized + Hash, A: Allocator> Hash for Arc<T, A> {
     fn hash<H: Hasher>(&self, state: &mut H) {


### PR DESCRIPTION
With added implementations.

```
GOOD    Arc<CStr> 
BROKEN  Arc<OsStr> // removed
GOOD    Rc<str>
GOOD    Rc<CStr>
BROKEN  Rc<OsStr> // removed

GOOD    Rc<[T]> 
GOOD    Arc<[T]>
```

For discussion of https://github.com/rust-lang/rust/pull/124367#issuecomment-2091940137.

Key pain points currently:
> I've had a guess at the best locations/feature attrs for them but they might not be correct.

> However I'm unclear how to get the OsStr impl to compile, which file should they go in to avoid the error below? Is it possible, perhaps with some special std rust lib magic?