### PR TITLE
Fix HorizonOS build broken by #124210

### DIFF
--- a/library/std/src/sys/pal/unix/fs.rs
+++ b/library/std/src/sys/pal/unix/fs.rs
@@ -860,6 +860,7 @@ impl Drop for Dir {
             target_os = "hurd",
             target_os = "espidf",
             target_os = "fuchsia",
+            target_os = "horizon",
         )))]
         {
             let fd = unsafe { libc::dirfd(self.0) };


### PR DESCRIPTION
HorizonOS (for the Tier-3 target `armv6k-nintendo-3ds`) does not support `dirfd()`, as many other similar targets.