### PR TITLE
MCDC Coverage: instrument last boolean RHS operands from condition coverage

### DIFF
--- a/compiler/rustc_mir_build/src/build/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/build/coverageinfo.rs
@@ -117,17 +117,37 @@ impl BranchInfoBuilder {
         }
     }
 
-    fn add_two_way_branch<'tcx>(
+    fn register_two_way_branch<'tcx>(
         &mut self,
+        tcx: TyCtxt<'tcx>,
         cfg: &mut CFG<'tcx>,
         source_info: SourceInfo,
         true_block: BasicBlock,
         false_block: BasicBlock,
     ) {
-        let true_marker = self.markers.inject_block_marker(cfg, source_info, true_block);
-        let false_marker = self.markers.inject_block_marker(cfg, source_info, false_block);
+        let this = self;
 
-        self.branch_spans.push(BranchSpan { span: source_info.span, true_marker, false_marker });
+        // Separate path for handling branches when MC/DC is enabled.
+        if let Some(mcdc_info) = this.mcdc_info.as_mut() {
+            let inject_block_marker =
+                |source_info, block| this.markers.inject_block_marker(cfg, source_info, block);
+            mcdc_info.visit_evaluated_condition(
+                tcx,
+                source_info,
+                true_block,
+                false_block,
+                inject_block_marker,
+            );
+        } else {
+            let true_marker = this.markers.inject_block_marker(cfg, source_info, true_block);
+            let false_marker = this.markers.inject_block_marker(cfg, source_info, false_block);
+
+            this.branch_spans.push(BranchSpan {
+                span: source_info.span,
+                true_marker,
+                false_marker,
+            });
+        }
     }
 
     pub(crate) fn into_done(self) -> Option<Box<mir::coverage::BranchInfo>> {
@@ -204,7 +224,14 @@ impl<'tcx> Builder<'_, 'tcx> {
             mir::TerminatorKind::if_(mir::Operand::Copy(place), true_block, false_block),
         );
 
-        branch_info.add_two_way_branch(&mut self.cfg, source_info, true_block, false_block);
+        // Separate path for handling branches when MC/DC is enabled.
+        branch_info.register_two_way_branch(
+            self.tcx,
+            &mut self.cfg,
+            source_info,
+            true_block,
+            false_block,
+        );
 
         let join_block = self.cfg.start_new_block();
         self.cfg.goto(true_block, source_info, join_block);
@@ -235,21 +262,12 @@ impl<'tcx> Builder<'_, 'tcx> {
 
         let source_info = SourceInfo { span: self.thir[expr_id].span, scope: self.source_scope };
 
-        // Separate path for handling branches when MC/DC is enabled.
-        if let Some(mcdc_info) = branch_info.mcdc_info.as_mut() {
-            let inject_block_marker = |source_info, block| {
-                branch_info.markers.inject_block_marker(&mut self.cfg, source_info, block)
-            };
-            mcdc_info.visit_evaluated_condition(
-                self.tcx,
-                source_info,
-                then_block,
-                else_block,
-                inject_block_marker,
-            );
-            return;
-        }
-
-        branch_info.add_two_way_branch(&mut self.cfg, source_info, then_block, else_block);
+        branch_info.register_two_way_branch(
+            self.tcx,
+            &mut self.cfg,
+            source_info,
+            then_block,
+            else_block,
+        );
     }
 }

--- a/compiler/rustc_mir_build/src/build/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/build/coverageinfo.rs
@@ -155,7 +155,64 @@ impl BranchInfoBuilder {
     }
 }
 
-impl Builder<'_, '_> {
+impl<'tcx> Builder<'_, 'tcx> {
+    /// If condition coverage is enabled, inject extra blocks and marker statements
+    /// that will let us track the value of the condition in `place`.
+    pub(crate) fn visit_coverage_standalone_condition(
+        &mut self,
+        mut expr_id: ExprId,     // Expression giving the span of the condition
+        place: mir::Place<'tcx>, // Already holds the boolean condition value
+        block: &mut BasicBlock,
+    ) {
+        // Bail out if condition coverage is not enabled for this function.
+        let Some(branch_info) = self.coverage_branch_info.as_mut() else { return };
+        if !self.tcx.sess.instrument_coverage_condition() {
+            return;
+        };
+
+        // Remove any wrappers, so that we can inspect the real underlying expression.
+        while let ExprKind::Use { source: inner } | ExprKind::Scope { value: inner, .. } =
+            self.thir[expr_id].kind
+        {
+            expr_id = inner;
+        }
+        // If the expression is a lazy logical op, it will naturally get branch
+        // coverage as part of its normal lowering, so we can disregard it here.
+        if let ExprKind::LogicalOp { .. } = self.thir[expr_id].kind {
+            return;
+        }
+
+        let source_info = SourceInfo { span: self.thir[expr_id].span, scope: self.source_scope };
+
+        // Using the boolean value that has already been stored in `place`, set up
+        // control flow in the shape of a diamond, so that we can place separate
+        // marker statements in the true and false blocks. The coverage MIR pass
+        // will use those markers to inject coverage counters as appropriate.
+        //
+        //          block
+        //         /     \
+        // true_block   false_block
+        //  (marker)     (marker)
+        //         \     /
+        //        join_block
+
+        let true_block = self.cfg.start_new_block();
+        let false_block = self.cfg.start_new_block();
+        self.cfg.terminate(
+            *block,
+            source_info,
+            mir::TerminatorKind::if_(mir::Operand::Copy(place), true_block, false_block),
+        );
+
+        branch_info.add_two_way_branch(&mut self.cfg, source_info, true_block, false_block);
+
+        let join_block = self.cfg.start_new_block();
+        self.cfg.goto(true_block, source_info, join_block);
+        self.cfg.goto(false_block, source_info, join_block);
+        // Any subsequent codegen in the caller should use the new join block.
+        *block = join_block;
+    }
+
     /// If branch coverage is enabled, inject marker statements into `then_block`
     /// and `else_block`, and record their IDs in the table of branch spans.
     pub(crate) fn visit_coverage_branch_condition(

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -181,9 +181,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         const_: Const::from_bool(this.tcx, constant),
                     },
                 );
-                let rhs = unpack!(this.expr_into_dest(destination, continuation, rhs));
+                let mut rhs_block = unpack!(this.expr_into_dest(destination, continuation, rhs));
+                // Instrument the lowered RHS's value for condition coverage.
+                // (Does nothing if condition coverage is not enabled.)
+                this.visit_coverage_standalone_condition(rhs, destination, &mut rhs_block);
+
                 let target = this.cfg.start_new_block();
-                this.cfg.goto(rhs, source_info, target);
+                this.cfg.goto(rhs_block, source_info, target);
                 this.cfg.goto(short_circuit, source_info, target);
                 target.unit()
             }

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -147,7 +147,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
             ExprKind::LogicalOp { op, lhs, rhs } => {
                 let condition_scope = this.local_scope();
-                let source_info = this.source_info(expr.span);
+                let expr_span = expr.span;
+                let source_info = this.source_info(expr_span);
+
+                this.visit_coverage_branch_operation(op, expr_span);
+
                 // We first evaluate the left-hand side of the predicate ...
                 let (then_block, else_block) =
                     this.in_if_then_scope(condition_scope, expr.span, |this| {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -159,8 +159,24 @@ pub enum CoverageLevel {
     Block,
     /// Also instrument branch points (includes block coverage).
     Branch,
-    /// Instrument for MC/DC. Mostly a superset of branch coverage, but might
-    /// differ in some corner cases.
+    /// Same as branch condition, with a single different case:
+    /// In boolean expressions that are not inside a control-flow decision,
+    /// it will intentionally insert an instrumented branch for the last operand.
+    ///
+    /// Example:
+    /// ```
+    /// # let (a, b) = (false, true);
+    /// let x = a && b;
+    /// //           ^ last operand
+    /// ```
+    /// Condition coverage does track true/false coverage for `b`,
+    /// but branch coverage doesn't.
+    ///
+    /// The main purpose of this coverage level is to be reused by MCDC.
+    Condition,
+    /// Instrument for MC/DC. Enables condition coverage under the hood.
+    /// Mostly a superset of branch coverage, but might differ in some
+    /// corner cases.
     Mcdc,
 }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -948,6 +948,7 @@ mod parse {
             match option {
                 "block" => slot.level = CoverageLevel::Block,
                 "branch" => slot.level = CoverageLevel::Branch,
+                "condition" => slot.level = CoverageLevel::Condition,
                 "mcdc" => slot.level = CoverageLevel::Mcdc,
                 _ => return false,
             }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -353,6 +353,11 @@ impl Session {
             && self.opts.unstable_opts.coverage_options.level >= CoverageLevel::Branch
     }
 
+    pub fn instrument_coverage_condition(&self) -> bool {
+        self.instrument_coverage()
+            && self.opts.unstable_opts.coverage_options.level >= CoverageLevel::Condition
+    }
+
     pub fn instrument_coverage_mcdc(&self) -> bool {
         self.instrument_coverage()
             && self.opts.unstable_opts.coverage_options.level >= CoverageLevel::Mcdc

--- a/tests/coverage/branch/conditions.cov-map
+++ b/tests/coverage/branch/conditions.cov-map
@@ -1,11 +1,11 @@
 Function name: conditions::assign_3
-Raw bytes (73): 0x[01, 01, 09, 07, 0b, 05, 09, 0d, 11, 01, 05, 01, 05, 22, 11, 01, 05, 22, 11, 01, 05, 09, 01, 17, 01, 00, 28, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 22, 00, 0d, 00, 0e, 22, 00, 12, 00, 13, 20, 1e, 11, 00, 12, 00, 13, 1e, 00, 17, 00, 18, 20, 09, 0d, 00, 17, 00, 18, 03, 01, 05, 01, 02]
+Raw bytes (73): 0x[01, 01, 09, 05, 07, 0b, 11, 09, 0d, 01, 05, 01, 05, 22, 11, 01, 05, 22, 11, 01, 05, 09, 01, 17, 01, 00, 28, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 22, 00, 0d, 00, 0e, 22, 00, 12, 00, 13, 20, 1e, 11, 00, 12, 00, 13, 1e, 00, 17, 00, 18, 20, 09, 0d, 00, 17, 00, 18, 03, 01, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 9
-- expression 0 operands: lhs = Expression(1, Add), rhs = Expression(2, Add)
-- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
-- expression 2 operands: lhs = Counter(3), rhs = Counter(4)
+- expression 0 operands: lhs = Counter(1), rhs = Expression(1, Add)
+- expression 1 operands: lhs = Expression(2, Add), rhs = Counter(4)
+- expression 2 operands: lhs = Counter(2), rhs = Counter(3)
 - expression 3 operands: lhs = Counter(0), rhs = Counter(1)
 - expression 4 operands: lhs = Counter(0), rhs = Counter(1)
 - expression 5 operands: lhs = Expression(8, Sub), rhs = Counter(4)
@@ -15,7 +15,7 @@ Number of expressions: 9
 Number of file 0 mappings: 9
 - Code(Counter(0)) at (prev + 23, 1) to (start + 0, 40)
 - Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
-    = ((c1 + c2) + (c3 + c4))
+    = (c1 + ((c2 + c3) + c4))
 - Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
 - Branch { true: Counter(1), false: Expression(8, Sub) } at (prev + 0, 13) to (start + 0, 14)
     true  = c1
@@ -31,7 +31,7 @@ Number of file 0 mappings: 9
     true  = c2
     false = c3
 - Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
-    = ((c1 + c2) + (c3 + c4))
+    = (c1 + ((c2 + c3) + c4))
 
 Function name: conditions::assign_3_bis
 Raw bytes (69): 0x[01, 01, 07, 07, 11, 09, 0d, 01, 05, 05, 09, 16, 1a, 05, 09, 01, 05, 09, 01, 1c, 01, 00, 2c, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 1a, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 20, 09, 16, 00, 12, 00, 13, 13, 00, 17, 00, 18, 20, 0d, 11, 00, 17, 00, 18, 03, 01, 05, 01, 02]
@@ -66,18 +66,18 @@ Number of file 0 mappings: 9
     = ((c2 + c3) + c4)
 
 Function name: conditions::assign_and
-Raw bytes (51): 0x[01, 01, 04, 09, 07, 0d, 0e, 01, 05, 01, 05, 07, 01, 0d, 01, 00, 21, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 20, 09, 0d, 00, 12, 00, 13, 03, 01, 05, 01, 02]
+Raw bytes (51): 0x[01, 01, 04, 07, 0e, 09, 0d, 01, 05, 01, 05, 07, 01, 0d, 01, 00, 21, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 20, 09, 0d, 00, 12, 00, 13, 03, 01, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 4
-- expression 0 operands: lhs = Counter(2), rhs = Expression(1, Add)
-- expression 1 operands: lhs = Counter(3), rhs = Expression(3, Sub)
+- expression 0 operands: lhs = Expression(1, Add), rhs = Expression(3, Sub)
+- expression 1 operands: lhs = Counter(2), rhs = Counter(3)
 - expression 2 operands: lhs = Counter(0), rhs = Counter(1)
 - expression 3 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 7
 - Code(Counter(0)) at (prev + 13, 1) to (start + 0, 33)
 - Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
-    = (c2 + (c3 + (c0 - c1)))
+    = ((c2 + c3) + (c0 - c1))
 - Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
 - Branch { true: Counter(1), false: Expression(3, Sub) } at (prev + 0, 13) to (start + 0, 14)
     true  = c1
@@ -87,7 +87,7 @@ Number of file 0 mappings: 7
     true  = c2
     false = c3
 - Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
-    = (c2 + (c3 + (c0 - c1)))
+    = ((c2 + c3) + (c0 - c1))
 
 Function name: conditions::assign_or
 Raw bytes (51): 0x[01, 01, 04, 07, 0d, 05, 09, 01, 05, 01, 05, 07, 01, 12, 01, 00, 20, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 0e, 00, 12, 00, 13, 20, 09, 0d, 00, 12, 00, 13, 03, 01, 05, 01, 02]
@@ -123,13 +123,13 @@ Number of file 0 mappings: 1
 - Code(Counter(0)) at (prev + 33, 1) to (start + 2, 2)
 
 Function name: conditions::func_call
-Raw bytes (39): 0x[01, 01, 03, 01, 05, 09, 0b, 0d, 02, 05, 01, 25, 01, 01, 0a, 20, 05, 02, 01, 09, 00, 0a, 05, 00, 0e, 00, 0f, 20, 09, 0d, 00, 0e, 00, 0f, 07, 01, 01, 00, 02]
+Raw bytes (39): 0x[01, 01, 03, 01, 05, 0b, 02, 09, 0d, 05, 01, 25, 01, 01, 0a, 20, 05, 02, 01, 09, 00, 0a, 05, 00, 0e, 00, 0f, 20, 09, 0d, 00, 0e, 00, 0f, 07, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 3
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
-- expression 1 operands: lhs = Counter(2), rhs = Expression(2, Add)
-- expression 2 operands: lhs = Counter(3), rhs = Expression(0, Sub)
+- expression 1 operands: lhs = Expression(2, Add), rhs = Expression(0, Sub)
+- expression 2 operands: lhs = Counter(2), rhs = Counter(3)
 Number of file 0 mappings: 5
 - Code(Counter(0)) at (prev + 37, 1) to (start + 1, 10)
 - Branch { true: Counter(1), false: Expression(0, Sub) } at (prev + 1, 9) to (start + 0, 10)
@@ -140,7 +140,7 @@ Number of file 0 mappings: 5
     true  = c2
     false = c3
 - Code(Expression(1, Add)) at (prev + 1, 1) to (start + 0, 2)
-    = (c2 + (c3 + (c0 - c1)))
+    = ((c2 + c3) + (c0 - c1))
 
 Function name: conditions::simple_assign
 Raw bytes (9): 0x[01, 01, 00, 01, 01, 08, 01, 03, 02]

--- a/tests/coverage/branch/conditions.cov-map
+++ b/tests/coverage/branch/conditions.cov-map
@@ -1,0 +1,128 @@
+Function name: conditions::assign_3
+Raw bytes (56): 0x[01, 01, 04, 05, 07, 09, 0d, 01, 05, 01, 05, 08, 01, 17, 01, 00, 28, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 0e, 00, 12, 00, 13, 20, 09, 0d, 00, 12, 00, 13, 09, 00, 17, 00, 18, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 4
+- expression 0 operands: lhs = Counter(1), rhs = Expression(1, Add)
+- expression 1 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 3 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 8
+- Code(Counter(0)) at (prev + 23, 1) to (start + 0, 40)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = (c1 + (c2 + c3))
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Branch { true: Counter(1), false: Expression(3, Sub) } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Expression(3, Sub)) at (prev + 0, 18) to (start + 0, 19)
+    = (c0 - c1)
+- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 18) to (start + 0, 19)
+    true  = c2
+    false = c3
+- Code(Counter(2)) at (prev + 0, 23) to (start + 0, 24)
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = (c1 + (c2 + c3))
+
+Function name: conditions::assign_3_bis
+Raw bytes (60): 0x[01, 01, 06, 0d, 13, 09, 16, 01, 05, 01, 05, 09, 16, 01, 05, 08, 01, 1c, 01, 00, 2c, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 16, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 20, 0d, 09, 00, 12, 00, 13, 13, 00, 17, 00, 18, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 6
+- expression 0 operands: lhs = Counter(3), rhs = Expression(4, Add)
+- expression 1 operands: lhs = Counter(2), rhs = Expression(5, Sub)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 3 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 4 operands: lhs = Counter(2), rhs = Expression(5, Sub)
+- expression 5 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 8
+- Code(Counter(0)) at (prev + 28, 1) to (start + 0, 44)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = (c3 + (c2 + (c0 - c1)))
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Branch { true: Counter(1), false: Expression(5, Sub) } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
+- Branch { true: Counter(3), false: Counter(2) } at (prev + 0, 18) to (start + 0, 19)
+    true  = c3
+    false = c2
+- Code(Expression(4, Add)) at (prev + 0, 23) to (start + 0, 24)
+    = (c2 + (c0 - c1))
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = (c3 + (c2 + (c0 - c1)))
+
+Function name: conditions::assign_and
+Raw bytes (42): 0x[01, 01, 03, 05, 0a, 01, 05, 01, 05, 06, 01, 0d, 01, 00, 21, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0a, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 3
+- expression 0 operands: lhs = Counter(1), rhs = Expression(2, Sub)
+- expression 1 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 6
+- Code(Counter(0)) at (prev + 13, 1) to (start + 0, 33)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = (c1 + (c0 - c1))
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Branch { true: Counter(1), false: Expression(2, Sub) } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = (c1 + (c0 - c1))
+
+Function name: conditions::assign_or
+Raw bytes (44): 0x[01, 01, 04, 05, 0e, 01, 05, 01, 05, 01, 05, 06, 01, 12, 01, 00, 20, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 0e, 00, 12, 00, 13, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 4
+- expression 0 operands: lhs = Counter(1), rhs = Expression(3, Sub)
+- expression 1 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 3 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 6
+- Code(Counter(0)) at (prev + 18, 1) to (start + 0, 32)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = (c1 + (c0 - c1))
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Branch { true: Counter(1), false: Expression(3, Sub) } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Expression(3, Sub)) at (prev + 0, 18) to (start + 0, 19)
+    = (c0 - c1)
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = (c1 + (c0 - c1))
+
+Function name: conditions::foo
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 21, 01, 02, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Counter(0)) at (prev + 33, 1) to (start + 2, 2)
+
+Function name: conditions::func_call
+Raw bytes (30): 0x[01, 01, 02, 01, 05, 05, 02, 04, 01, 25, 01, 01, 0a, 20, 05, 02, 01, 09, 00, 0a, 05, 00, 0e, 00, 0f, 07, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 2
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Expression(0, Sub)
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 37, 1) to (start + 1, 10)
+- Branch { true: Counter(1), false: Expression(0, Sub) } at (prev + 1, 9) to (start + 0, 10)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 14) to (start + 0, 15)
+- Code(Expression(1, Add)) at (prev + 1, 1) to (start + 0, 2)
+    = (c1 + (c0 - c1))
+
+Function name: conditions::simple_assign
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 08, 01, 03, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Counter(0)) at (prev + 8, 1) to (start + 3, 2)
+

--- a/tests/coverage/branch/conditions.cov-map
+++ b/tests/coverage/branch/conditions.cov-map
@@ -1,16 +1,107 @@
 Function name: conditions::assign_3
-Raw bytes (56): 0x[01, 01, 04, 05, 07, 09, 0d, 01, 05, 01, 05, 08, 01, 17, 01, 00, 28, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 0e, 00, 12, 00, 13, 20, 09, 0d, 00, 12, 00, 13, 09, 00, 17, 00, 18, 03, 01, 05, 01, 02]
+Raw bytes (73): 0x[01, 01, 09, 07, 0b, 05, 09, 0d, 11, 01, 05, 01, 05, 22, 11, 01, 05, 22, 11, 01, 05, 09, 01, 17, 01, 00, 28, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 22, 00, 0d, 00, 0e, 22, 00, 12, 00, 13, 20, 1e, 11, 00, 12, 00, 13, 1e, 00, 17, 00, 18, 20, 09, 0d, 00, 17, 00, 18, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 9
+- expression 0 operands: lhs = Expression(1, Add), rhs = Expression(2, Add)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 2 operands: lhs = Counter(3), rhs = Counter(4)
+- expression 3 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 4 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 5 operands: lhs = Expression(8, Sub), rhs = Counter(4)
+- expression 6 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 7 operands: lhs = Expression(8, Sub), rhs = Counter(4)
+- expression 8 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 23, 1) to (start + 0, 40)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = ((c1 + c2) + (c3 + c4))
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Branch { true: Counter(1), false: Expression(8, Sub) } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Expression(8, Sub)) at (prev + 0, 18) to (start + 0, 19)
+    = (c0 - c1)
+- Branch { true: Expression(7, Sub), false: Counter(4) } at (prev + 0, 18) to (start + 0, 19)
+    true  = ((c0 - c1) - c4)
+    false = c4
+- Code(Expression(7, Sub)) at (prev + 0, 23) to (start + 0, 24)
+    = ((c0 - c1) - c4)
+- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 23) to (start + 0, 24)
+    true  = c2
+    false = c3
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = ((c1 + c2) + (c3 + c4))
+
+Function name: conditions::assign_3_bis
+Raw bytes (69): 0x[01, 01, 07, 07, 11, 09, 0d, 01, 05, 05, 09, 16, 1a, 05, 09, 01, 05, 09, 01, 1c, 01, 00, 2c, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 1a, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 20, 09, 16, 00, 12, 00, 13, 13, 00, 17, 00, 18, 20, 0d, 11, 00, 17, 00, 18, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 7
+- expression 0 operands: lhs = Expression(1, Add), rhs = Counter(4)
+- expression 1 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 3 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 4 operands: lhs = Expression(5, Sub), rhs = Expression(6, Sub)
+- expression 5 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 6 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 28, 1) to (start + 0, 44)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = ((c2 + c3) + c4)
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Branch { true: Counter(1), false: Expression(6, Sub) } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
+- Branch { true: Counter(2), false: Expression(5, Sub) } at (prev + 0, 18) to (start + 0, 19)
+    true  = c2
+    false = (c1 - c2)
+- Code(Expression(4, Add)) at (prev + 0, 23) to (start + 0, 24)
+    = ((c1 - c2) + (c0 - c1))
+- Branch { true: Counter(3), false: Counter(4) } at (prev + 0, 23) to (start + 0, 24)
+    true  = c3
+    false = c4
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = ((c2 + c3) + c4)
+
+Function name: conditions::assign_and
+Raw bytes (51): 0x[01, 01, 04, 09, 07, 0d, 0e, 01, 05, 01, 05, 07, 01, 0d, 01, 00, 21, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 20, 09, 0d, 00, 12, 00, 13, 03, 01, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 4
-- expression 0 operands: lhs = Counter(1), rhs = Expression(1, Add)
-- expression 1 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 0 operands: lhs = Counter(2), rhs = Expression(1, Add)
+- expression 1 operands: lhs = Counter(3), rhs = Expression(3, Sub)
 - expression 2 operands: lhs = Counter(0), rhs = Counter(1)
 - expression 3 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 8
-- Code(Counter(0)) at (prev + 23, 1) to (start + 0, 40)
+Number of file 0 mappings: 7
+- Code(Counter(0)) at (prev + 13, 1) to (start + 0, 33)
 - Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
-    = (c1 + (c2 + c3))
+    = (c2 + (c3 + (c0 - c1)))
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Branch { true: Counter(1), false: Expression(3, Sub) } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
+- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 18) to (start + 0, 19)
+    true  = c2
+    false = c3
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = (c2 + (c3 + (c0 - c1)))
+
+Function name: conditions::assign_or
+Raw bytes (51): 0x[01, 01, 04, 07, 0d, 05, 09, 01, 05, 01, 05, 07, 01, 12, 01, 00, 20, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 0e, 00, 12, 00, 13, 20, 09, 0d, 00, 12, 00, 13, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 4
+- expression 0 operands: lhs = Expression(1, Add), rhs = Counter(3)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 3 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 7
+- Code(Counter(0)) at (prev + 18, 1) to (start + 0, 32)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = ((c1 + c2) + c3)
 - Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
 - Branch { true: Counter(1), false: Expression(3, Sub) } at (prev + 0, 13) to (start + 0, 14)
     true  = c1
@@ -20,79 +111,8 @@ Number of file 0 mappings: 8
 - Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 18) to (start + 0, 19)
     true  = c2
     false = c3
-- Code(Counter(2)) at (prev + 0, 23) to (start + 0, 24)
 - Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
-    = (c1 + (c2 + c3))
-
-Function name: conditions::assign_3_bis
-Raw bytes (60): 0x[01, 01, 06, 0d, 13, 09, 16, 01, 05, 01, 05, 09, 16, 01, 05, 08, 01, 1c, 01, 00, 2c, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 16, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 20, 0d, 09, 00, 12, 00, 13, 13, 00, 17, 00, 18, 03, 01, 05, 01, 02]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 6
-- expression 0 operands: lhs = Counter(3), rhs = Expression(4, Add)
-- expression 1 operands: lhs = Counter(2), rhs = Expression(5, Sub)
-- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
-- expression 3 operands: lhs = Counter(0), rhs = Counter(1)
-- expression 4 operands: lhs = Counter(2), rhs = Expression(5, Sub)
-- expression 5 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 8
-- Code(Counter(0)) at (prev + 28, 1) to (start + 0, 44)
-- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
-    = (c3 + (c2 + (c0 - c1)))
-- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
-- Branch { true: Counter(1), false: Expression(5, Sub) } at (prev + 0, 13) to (start + 0, 14)
-    true  = c1
-    false = (c0 - c1)
-- Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
-- Branch { true: Counter(3), false: Counter(2) } at (prev + 0, 18) to (start + 0, 19)
-    true  = c3
-    false = c2
-- Code(Expression(4, Add)) at (prev + 0, 23) to (start + 0, 24)
-    = (c2 + (c0 - c1))
-- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
-    = (c3 + (c2 + (c0 - c1)))
-
-Function name: conditions::assign_and
-Raw bytes (42): 0x[01, 01, 03, 05, 0a, 01, 05, 01, 05, 06, 01, 0d, 01, 00, 21, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0a, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 03, 01, 05, 01, 02]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 3
-- expression 0 operands: lhs = Counter(1), rhs = Expression(2, Sub)
-- expression 1 operands: lhs = Counter(0), rhs = Counter(1)
-- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 6
-- Code(Counter(0)) at (prev + 13, 1) to (start + 0, 33)
-- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
-    = (c1 + (c0 - c1))
-- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
-- Branch { true: Counter(1), false: Expression(2, Sub) } at (prev + 0, 13) to (start + 0, 14)
-    true  = c1
-    false = (c0 - c1)
-- Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
-- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
-    = (c1 + (c0 - c1))
-
-Function name: conditions::assign_or
-Raw bytes (44): 0x[01, 01, 04, 05, 0e, 01, 05, 01, 05, 01, 05, 06, 01, 12, 01, 00, 20, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 0e, 00, 12, 00, 13, 03, 01, 05, 01, 02]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 4
-- expression 0 operands: lhs = Counter(1), rhs = Expression(3, Sub)
-- expression 1 operands: lhs = Counter(0), rhs = Counter(1)
-- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
-- expression 3 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 6
-- Code(Counter(0)) at (prev + 18, 1) to (start + 0, 32)
-- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
-    = (c1 + (c0 - c1))
-- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
-- Branch { true: Counter(1), false: Expression(3, Sub) } at (prev + 0, 13) to (start + 0, 14)
-    true  = c1
-    false = (c0 - c1)
-- Code(Expression(3, Sub)) at (prev + 0, 18) to (start + 0, 19)
-    = (c0 - c1)
-- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
-    = (c1 + (c0 - c1))
+    = ((c1 + c2) + c3)
 
 Function name: conditions::foo
 Raw bytes (9): 0x[01, 01, 00, 01, 01, 21, 01, 02, 02]
@@ -103,20 +123,24 @@ Number of file 0 mappings: 1
 - Code(Counter(0)) at (prev + 33, 1) to (start + 2, 2)
 
 Function name: conditions::func_call
-Raw bytes (30): 0x[01, 01, 02, 01, 05, 05, 02, 04, 01, 25, 01, 01, 0a, 20, 05, 02, 01, 09, 00, 0a, 05, 00, 0e, 00, 0f, 07, 01, 01, 00, 02]
+Raw bytes (39): 0x[01, 01, 03, 01, 05, 09, 0b, 0d, 02, 05, 01, 25, 01, 01, 0a, 20, 05, 02, 01, 09, 00, 0a, 05, 00, 0e, 00, 0f, 20, 09, 0d, 00, 0e, 00, 0f, 07, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
-Number of expressions: 2
+Number of expressions: 3
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
-- expression 1 operands: lhs = Counter(1), rhs = Expression(0, Sub)
-Number of file 0 mappings: 4
+- expression 1 operands: lhs = Counter(2), rhs = Expression(2, Add)
+- expression 2 operands: lhs = Counter(3), rhs = Expression(0, Sub)
+Number of file 0 mappings: 5
 - Code(Counter(0)) at (prev + 37, 1) to (start + 1, 10)
 - Branch { true: Counter(1), false: Expression(0, Sub) } at (prev + 1, 9) to (start + 0, 10)
     true  = c1
     false = (c0 - c1)
 - Code(Counter(1)) at (prev + 0, 14) to (start + 0, 15)
+- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 14) to (start + 0, 15)
+    true  = c2
+    false = c3
 - Code(Expression(1, Add)) at (prev + 1, 1) to (start + 0, 2)
-    = (c1 + (c0 - c1))
+    = (c2 + (c3 + (c0 - c1)))
 
 Function name: conditions::simple_assign
 Raw bytes (9): 0x[01, 01, 00, 01, 01, 08, 01, 03, 02]

--- a/tests/coverage/branch/conditions.coverage
+++ b/tests/coverage/branch/conditions.coverage
@@ -15,6 +15,7 @@
                                ^2
   ------------------
   |  Branch (LL:13): [True: 2, False: 1]
+  |  Branch (LL:18): [True: 1, False: 1]
   ------------------
    LL|      3|    black_box(x);
    LL|      3|}
@@ -24,6 +25,7 @@
                                ^1
   ------------------
   |  Branch (LL:13): [True: 2, False: 1]
+  |  Branch (LL:18): [True: 0, False: 1]
   ------------------
    LL|      3|    black_box(x);
    LL|      3|}
@@ -34,6 +36,7 @@
   ------------------
   |  Branch (LL:13): [True: 2, False: 2]
   |  Branch (LL:18): [True: 1, False: 1]
+  |  Branch (LL:23): [True: 1, False: 0]
   ------------------
    LL|      4|    black_box(x);
    LL|      4|}
@@ -44,6 +47,7 @@
   ------------------
   |  Branch (LL:13): [True: 2, False: 2]
   |  Branch (LL:18): [True: 1, False: 1]
+  |  Branch (LL:23): [True: 2, False: 1]
   ------------------
    LL|      4|    black_box(x);
    LL|      4|}
@@ -57,6 +61,7 @@
                            ^2
   ------------------
   |  Branch (LL:9): [True: 2, False: 1]
+  |  Branch (LL:14): [True: 1, False: 1]
   ------------------
    LL|      3|}
    LL|       |

--- a/tests/coverage/branch/conditions.coverage
+++ b/tests/coverage/branch/conditions.coverage
@@ -1,0 +1,92 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2021
+   LL|       |//@ compile-flags: -Zcoverage-options=condition
+   LL|       |//@ llvm-cov-flags: --show-branches=count
+   LL|       |
+   LL|       |use core::hint::black_box;
+   LL|       |
+   LL|      2|fn simple_assign(a: bool) {
+   LL|      2|    let x = a;
+   LL|      2|    black_box(x);
+   LL|      2|}
+   LL|       |
+   LL|      3|fn assign_and(a: bool, b: bool) {
+   LL|      3|    let x = a && b;
+                               ^2
+  ------------------
+  |  Branch (LL:13): [True: 2, False: 1]
+  ------------------
+   LL|      3|    black_box(x);
+   LL|      3|}
+   LL|       |
+   LL|      3|fn assign_or(a: bool, b: bool) {
+   LL|      3|    let x = a || b;
+                               ^1
+  ------------------
+  |  Branch (LL:13): [True: 2, False: 1]
+  ------------------
+   LL|      3|    black_box(x);
+   LL|      3|}
+   LL|       |
+   LL|      4|fn assign_3(a: bool, b: bool, c: bool) {
+   LL|      4|    let x = a || b && c;
+                               ^2   ^1
+  ------------------
+  |  Branch (LL:13): [True: 2, False: 2]
+  |  Branch (LL:18): [True: 1, False: 1]
+  ------------------
+   LL|      4|    black_box(x);
+   LL|      4|}
+   LL|       |
+   LL|      4|fn assign_3_bis(a: bool, b: bool, c: bool) {
+   LL|      4|    let x = a && b || c;
+                               ^2   ^3
+  ------------------
+  |  Branch (LL:13): [True: 2, False: 2]
+  |  Branch (LL:18): [True: 1, False: 1]
+  ------------------
+   LL|      4|    black_box(x);
+   LL|      4|}
+   LL|       |
+   LL|      3|fn foo(a: bool) -> bool {
+   LL|      3|    black_box(a)
+   LL|      3|}
+   LL|       |
+   LL|      3|fn func_call(a: bool, b: bool) {
+   LL|      3|    foo(a && b);
+                           ^2
+  ------------------
+  |  Branch (LL:9): [True: 2, False: 1]
+  ------------------
+   LL|      3|}
+   LL|       |
+   LL|       |
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    simple_assign(true);
+   LL|       |    simple_assign(false);
+   LL|       |
+   LL|       |    assign_and(true, false);
+   LL|       |    assign_and(true, true);
+   LL|       |    assign_and(false, false);
+   LL|       |
+   LL|       |    assign_or(true, false);
+   LL|       |    assign_or(true, true);
+   LL|       |    assign_or(false, false);
+   LL|       |
+   LL|       |    assign_3(true, false, false);
+   LL|       |    assign_3(true, true, false);
+   LL|       |    assign_3(false, false, true);
+   LL|       |    assign_3(false, true, true);
+   LL|       |
+   LL|       |    assign_3_bis(true, false, false);
+   LL|       |    assign_3_bis(true, true, false);
+   LL|       |    assign_3_bis(false, false, true);
+   LL|       |    assign_3_bis(false, true, true);
+   LL|       |
+   LL|       |    func_call(true, false);
+   LL|       |    func_call(true, true);
+   LL|       |    func_call(false, false);
+   LL|       |}
+

--- a/tests/coverage/branch/conditions.rs
+++ b/tests/coverage/branch/conditions.rs
@@ -1,0 +1,69 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+//@ compile-flags: -Zcoverage-options=condition
+//@ llvm-cov-flags: --show-branches=count
+
+use core::hint::black_box;
+
+fn simple_assign(a: bool) {
+    let x = a;
+    black_box(x);
+}
+
+fn assign_and(a: bool, b: bool) {
+    let x = a && b;
+    black_box(x);
+}
+
+fn assign_or(a: bool, b: bool) {
+    let x = a || b;
+    black_box(x);
+}
+
+fn assign_3(a: bool, b: bool, c: bool) {
+    let x = a || b && c;
+    black_box(x);
+}
+
+fn assign_3_bis(a: bool, b: bool, c: bool) {
+    let x = a && b || c;
+    black_box(x);
+}
+
+fn foo(a: bool) -> bool {
+    black_box(a)
+}
+
+fn func_call(a: bool, b: bool) {
+    foo(a && b);
+}
+
+
+
+#[coverage(off)]
+fn main() {
+    simple_assign(true);
+    simple_assign(false);
+
+    assign_and(true, false);
+    assign_and(true, true);
+    assign_and(false, false);
+
+    assign_or(true, false);
+    assign_or(true, true);
+    assign_or(false, false);
+
+    assign_3(true, false, false);
+    assign_3(true, true, false);
+    assign_3(false, false, true);
+    assign_3(false, true, true);
+
+    assign_3_bis(true, false, false);
+    assign_3_bis(true, true, false);
+    assign_3_bis(false, false, true);
+    assign_3_bis(false, true, true);
+
+    func_call(true, false);
+    func_call(true, true);
+    func_call(false, false);
+}

--- a/tests/coverage/mcdc_non_control_flow.cov-map
+++ b/tests/coverage/mcdc_non_control_flow.cov-map
@@ -1,0 +1,199 @@
+Function name: mcdc_non_control_flow::assign_3
+Raw bytes (73): 0x[01, 01, 09, 05, 07, 0b, 11, 09, 0d, 01, 05, 01, 05, 22, 11, 01, 05, 22, 11, 01, 05, 09, 01, 13, 01, 00, 28, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 22, 00, 0d, 00, 0e, 22, 00, 12, 00, 13, 20, 1e, 11, 00, 12, 00, 13, 1e, 00, 17, 00, 18, 20, 09, 0d, 00, 17, 00, 18, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 9
+- expression 0 operands: lhs = Counter(1), rhs = Expression(1, Add)
+- expression 1 operands: lhs = Expression(2, Add), rhs = Counter(4)
+- expression 2 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 3 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 4 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 5 operands: lhs = Expression(8, Sub), rhs = Counter(4)
+- expression 6 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 7 operands: lhs = Expression(8, Sub), rhs = Counter(4)
+- expression 8 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 19, 1) to (start + 0, 40)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = (c1 + ((c2 + c3) + c4))
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Branch { true: Counter(1), false: Expression(8, Sub) } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Expression(8, Sub)) at (prev + 0, 18) to (start + 0, 19)
+    = (c0 - c1)
+- Branch { true: Expression(7, Sub), false: Counter(4) } at (prev + 0, 18) to (start + 0, 19)
+    true  = ((c0 - c1) - c4)
+    false = c4
+- Code(Expression(7, Sub)) at (prev + 0, 23) to (start + 0, 24)
+    = ((c0 - c1) - c4)
+- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 23) to (start + 0, 24)
+    true  = c2
+    false = c3
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = (c1 + ((c2 + c3) + c4))
+
+Function name: mcdc_non_control_flow::assign_3_bis
+Raw bytes (82): 0x[01, 01, 07, 07, 11, 09, 0d, 01, 05, 05, 09, 16, 1a, 05, 09, 01, 05, 0a, 01, 18, 01, 00, 2c, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 00, 02, 00, 0d, 00, 13, 30, 05, 1a, 01, 02, 00, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 30, 09, 16, 02, 00, 00, 00, 12, 00, 13, 13, 00, 17, 00, 18, 20, 0d, 11, 00, 17, 00, 18, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 7
+- expression 0 operands: lhs = Expression(1, Add), rhs = Counter(4)
+- expression 1 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 3 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 4 operands: lhs = Expression(5, Sub), rhs = Expression(6, Sub)
+- expression 5 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 6 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 10
+- Code(Counter(0)) at (prev + 24, 1) to (start + 0, 44)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = ((c2 + c3) + c4)
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- MCDCDecision { bitmap_idx: 0, conditions_num: 2 } at (prev + 0, 13) to (start + 0, 19)
+- MCDCBranch { true: Counter(1), false: Expression(6, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
+- MCDCBranch { true: Counter(2), false: Expression(5, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 18) to (start + 0, 19)
+    true  = c2
+    false = (c1 - c2)
+- Code(Expression(4, Add)) at (prev + 0, 23) to (start + 0, 24)
+    = ((c1 - c2) + (c0 - c1))
+- Branch { true: Counter(3), false: Counter(4) } at (prev + 0, 23) to (start + 0, 24)
+    true  = c3
+    false = c4
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = ((c2 + c3) + c4)
+
+Function name: mcdc_non_control_flow::assign_and
+Raw bytes (51): 0x[01, 01, 04, 07, 0e, 09, 0d, 01, 05, 01, 05, 07, 01, 09, 01, 00, 21, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 20, 09, 0d, 00, 12, 00, 13, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 4
+- expression 0 operands: lhs = Expression(1, Add), rhs = Expression(3, Sub)
+- expression 1 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 3 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 7
+- Code(Counter(0)) at (prev + 9, 1) to (start + 0, 33)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = ((c2 + c3) + (c0 - c1))
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Branch { true: Counter(1), false: Expression(3, Sub) } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
+- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 18) to (start + 0, 19)
+    true  = c2
+    false = c3
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = ((c2 + c3) + (c0 - c1))
+
+Function name: mcdc_non_control_flow::assign_or
+Raw bytes (51): 0x[01, 01, 04, 07, 0d, 05, 09, 01, 05, 01, 05, 07, 01, 0e, 01, 00, 20, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 0e, 00, 12, 00, 13, 20, 09, 0d, 00, 12, 00, 13, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 4
+- expression 0 operands: lhs = Expression(1, Add), rhs = Counter(3)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 3 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 7
+- Code(Counter(0)) at (prev + 14, 1) to (start + 0, 32)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = ((c1 + c2) + c3)
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Branch { true: Counter(1), false: Expression(3, Sub) } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Expression(3, Sub)) at (prev + 0, 18) to (start + 0, 19)
+    = (c0 - c1)
+- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 18) to (start + 0, 19)
+    true  = c2
+    false = c3
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = ((c1 + c2) + c3)
+
+Function name: mcdc_non_control_flow::foo
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 22, 01, 02, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Counter(0)) at (prev + 34, 1) to (start + 2, 2)
+
+Function name: mcdc_non_control_flow::func_call
+Raw bytes (39): 0x[01, 01, 03, 01, 05, 0b, 02, 09, 0d, 05, 01, 26, 01, 01, 0a, 20, 05, 02, 01, 09, 00, 0a, 05, 00, 0e, 00, 0f, 20, 09, 0d, 00, 0e, 00, 0f, 07, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 3
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Expression(2, Add), rhs = Expression(0, Sub)
+- expression 2 operands: lhs = Counter(2), rhs = Counter(3)
+Number of file 0 mappings: 5
+- Code(Counter(0)) at (prev + 38, 1) to (start + 1, 10)
+- Branch { true: Counter(1), false: Expression(0, Sub) } at (prev + 1, 9) to (start + 0, 10)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 14) to (start + 0, 15)
+- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 14) to (start + 0, 15)
+    true  = c2
+    false = c3
+- Code(Expression(1, Add)) at (prev + 1, 1) to (start + 0, 2)
+    = ((c2 + c3) + (c0 - c1))
+
+Function name: mcdc_non_control_flow::right_comb_tree
+Raw bytes (117): 0x[01, 01, 13, 07, 1a, 0b, 19, 0f, 15, 13, 11, 09, 0d, 01, 05, 01, 05, 05, 19, 05, 19, 4a, 15, 05, 19, 4a, 15, 05, 19, 46, 11, 4a, 15, 05, 19, 46, 11, 4a, 15, 05, 19, 0d, 01, 1d, 01, 00, 41, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 1a, 00, 0d, 00, 0e, 05, 00, 13, 00, 14, 20, 4a, 19, 00, 13, 00, 14, 4a, 00, 19, 00, 1a, 20, 46, 15, 00, 19, 00, 1a, 46, 00, 1f, 00, 20, 20, 42, 11, 00, 1f, 00, 20, 42, 00, 24, 00, 27, 20, 09, 0d, 00, 24, 00, 27, 03, 01, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 19
+- expression 0 operands: lhs = Expression(1, Add), rhs = Expression(6, Sub)
+- expression 1 operands: lhs = Expression(2, Add), rhs = Counter(6)
+- expression 2 operands: lhs = Expression(3, Add), rhs = Counter(5)
+- expression 3 operands: lhs = Expression(4, Add), rhs = Counter(4)
+- expression 4 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 5 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 6 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 7 operands: lhs = Counter(1), rhs = Counter(6)
+- expression 8 operands: lhs = Counter(1), rhs = Counter(6)
+- expression 9 operands: lhs = Expression(18, Sub), rhs = Counter(5)
+- expression 10 operands: lhs = Counter(1), rhs = Counter(6)
+- expression 11 operands: lhs = Expression(18, Sub), rhs = Counter(5)
+- expression 12 operands: lhs = Counter(1), rhs = Counter(6)
+- expression 13 operands: lhs = Expression(17, Sub), rhs = Counter(4)
+- expression 14 operands: lhs = Expression(18, Sub), rhs = Counter(5)
+- expression 15 operands: lhs = Counter(1), rhs = Counter(6)
+- expression 16 operands: lhs = Expression(17, Sub), rhs = Counter(4)
+- expression 17 operands: lhs = Expression(18, Sub), rhs = Counter(5)
+- expression 18 operands: lhs = Counter(1), rhs = Counter(6)
+Number of file 0 mappings: 13
+- Code(Counter(0)) at (prev + 29, 1) to (start + 0, 65)
+- Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
+    = (((((c2 + c3) + c4) + c5) + c6) + (c0 - c1))
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Branch { true: Counter(1), false: Expression(6, Sub) } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 19) to (start + 0, 20)
+- Branch { true: Expression(18, Sub), false: Counter(6) } at (prev + 0, 19) to (start + 0, 20)
+    true  = (c1 - c6)
+    false = c6
+- Code(Expression(18, Sub)) at (prev + 0, 25) to (start + 0, 26)
+    = (c1 - c6)
+- Branch { true: Expression(17, Sub), false: Counter(5) } at (prev + 0, 25) to (start + 0, 26)
+    true  = ((c1 - c6) - c5)
+    false = c5
+- Code(Expression(17, Sub)) at (prev + 0, 31) to (start + 0, 32)
+    = ((c1 - c6) - c5)
+- Branch { true: Expression(16, Sub), false: Counter(4) } at (prev + 0, 31) to (start + 0, 32)
+    true  = (((c1 - c6) - c5) - c4)
+    false = c4
+- Code(Expression(16, Sub)) at (prev + 0, 36) to (start + 0, 39)
+    = (((c1 - c6) - c5) - c4)
+- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 36) to (start + 0, 39)
+    true  = c2
+    false = c3
+- Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
+    = (((((c2 + c3) + c4) + c5) + c6) + (c0 - c1))
+

--- a/tests/coverage/mcdc_non_control_flow.cov-map
+++ b/tests/coverage/mcdc_non_control_flow.cov-map
@@ -1,5 +1,5 @@
 Function name: mcdc_non_control_flow::assign_3
-Raw bytes (73): 0x[01, 01, 09, 05, 07, 0b, 11, 09, 0d, 01, 05, 01, 05, 22, 11, 01, 05, 22, 11, 01, 05, 09, 01, 13, 01, 00, 28, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 22, 00, 0d, 00, 0e, 22, 00, 12, 00, 13, 20, 1e, 11, 00, 12, 00, 13, 1e, 00, 17, 00, 18, 20, 09, 0d, 00, 17, 00, 18, 03, 01, 05, 01, 02]
+Raw bytes (89): 0x[01, 01, 09, 05, 07, 0b, 11, 09, 0d, 01, 05, 01, 05, 22, 11, 01, 05, 22, 11, 01, 05, 0a, 01, 13, 01, 00, 28, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 00, 03, 00, 0d, 00, 18, 30, 05, 22, 01, 00, 02, 00, 0d, 00, 0e, 22, 00, 12, 00, 13, 30, 1e, 11, 02, 03, 00, 00, 12, 00, 13, 1e, 00, 17, 00, 18, 30, 09, 0d, 03, 00, 00, 00, 17, 00, 18, 03, 01, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 9
@@ -12,29 +12,30 @@ Number of expressions: 9
 - expression 6 operands: lhs = Counter(0), rhs = Counter(1)
 - expression 7 operands: lhs = Expression(8, Sub), rhs = Counter(4)
 - expression 8 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 9
+Number of file 0 mappings: 10
 - Code(Counter(0)) at (prev + 19, 1) to (start + 0, 40)
 - Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
     = (c1 + ((c2 + c3) + c4))
 - Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
-- Branch { true: Counter(1), false: Expression(8, Sub) } at (prev + 0, 13) to (start + 0, 14)
+- MCDCDecision { bitmap_idx: 0, conditions_num: 3 } at (prev + 0, 13) to (start + 0, 24)
+- MCDCBranch { true: Counter(1), false: Expression(8, Sub), condition_id: 1, true_next_id: 0, false_next_id: 2 } at (prev + 0, 13) to (start + 0, 14)
     true  = c1
     false = (c0 - c1)
 - Code(Expression(8, Sub)) at (prev + 0, 18) to (start + 0, 19)
     = (c0 - c1)
-- Branch { true: Expression(7, Sub), false: Counter(4) } at (prev + 0, 18) to (start + 0, 19)
+- MCDCBranch { true: Expression(7, Sub), false: Counter(4), condition_id: 2, true_next_id: 3, false_next_id: 0 } at (prev + 0, 18) to (start + 0, 19)
     true  = ((c0 - c1) - c4)
     false = c4
 - Code(Expression(7, Sub)) at (prev + 0, 23) to (start + 0, 24)
     = ((c0 - c1) - c4)
-- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 23) to (start + 0, 24)
+- MCDCBranch { true: Counter(2), false: Counter(3), condition_id: 3, true_next_id: 0, false_next_id: 0 } at (prev + 0, 23) to (start + 0, 24)
     true  = c2
     false = c3
 - Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
     = (c1 + ((c2 + c3) + c4))
 
 Function name: mcdc_non_control_flow::assign_3_bis
-Raw bytes (82): 0x[01, 01, 07, 07, 11, 09, 0d, 01, 05, 05, 09, 16, 1a, 05, 09, 01, 05, 0a, 01, 18, 01, 00, 2c, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 00, 02, 00, 0d, 00, 13, 30, 05, 1a, 01, 02, 00, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 30, 09, 16, 02, 00, 00, 00, 12, 00, 13, 13, 00, 17, 00, 18, 20, 0d, 11, 00, 17, 00, 18, 03, 01, 05, 01, 02]
+Raw bytes (85): 0x[01, 01, 07, 07, 11, 09, 0d, 01, 05, 05, 09, 16, 1a, 05, 09, 01, 05, 0a, 01, 18, 01, 00, 2c, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 00, 03, 00, 0d, 00, 18, 30, 05, 1a, 01, 03, 02, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 30, 09, 16, 03, 00, 02, 00, 12, 00, 13, 13, 00, 17, 00, 18, 30, 0d, 11, 02, 00, 00, 00, 17, 00, 18, 03, 01, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 7
@@ -50,24 +51,24 @@ Number of file 0 mappings: 10
 - Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
     = ((c2 + c3) + c4)
 - Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
-- MCDCDecision { bitmap_idx: 0, conditions_num: 2 } at (prev + 0, 13) to (start + 0, 19)
-- MCDCBranch { true: Counter(1), false: Expression(6, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
+- MCDCDecision { bitmap_idx: 0, conditions_num: 3 } at (prev + 0, 13) to (start + 0, 24)
+- MCDCBranch { true: Counter(1), false: Expression(6, Sub), condition_id: 1, true_next_id: 3, false_next_id: 2 } at (prev + 0, 13) to (start + 0, 14)
     true  = c1
     false = (c0 - c1)
 - Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
-- MCDCBranch { true: Counter(2), false: Expression(5, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 18) to (start + 0, 19)
+- MCDCBranch { true: Counter(2), false: Expression(5, Sub), condition_id: 3, true_next_id: 0, false_next_id: 2 } at (prev + 0, 18) to (start + 0, 19)
     true  = c2
     false = (c1 - c2)
 - Code(Expression(4, Add)) at (prev + 0, 23) to (start + 0, 24)
     = ((c1 - c2) + (c0 - c1))
-- Branch { true: Counter(3), false: Counter(4) } at (prev + 0, 23) to (start + 0, 24)
+- MCDCBranch { true: Counter(3), false: Counter(4), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 23) to (start + 0, 24)
     true  = c3
     false = c4
 - Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
     = ((c2 + c3) + c4)
 
 Function name: mcdc_non_control_flow::assign_and
-Raw bytes (51): 0x[01, 01, 04, 07, 0e, 09, 0d, 01, 05, 01, 05, 07, 01, 09, 01, 00, 21, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 20, 09, 0d, 00, 12, 00, 13, 03, 01, 05, 01, 02]
+Raw bytes (64): 0x[01, 01, 04, 07, 0e, 09, 0d, 01, 05, 01, 05, 08, 01, 09, 01, 00, 21, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 00, 02, 00, 0d, 00, 13, 30, 05, 0e, 01, 02, 00, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 30, 09, 0d, 02, 00, 00, 00, 12, 00, 13, 03, 01, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 4
@@ -75,23 +76,24 @@ Number of expressions: 4
 - expression 1 operands: lhs = Counter(2), rhs = Counter(3)
 - expression 2 operands: lhs = Counter(0), rhs = Counter(1)
 - expression 3 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 7
+Number of file 0 mappings: 8
 - Code(Counter(0)) at (prev + 9, 1) to (start + 0, 33)
 - Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
     = ((c2 + c3) + (c0 - c1))
 - Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
-- Branch { true: Counter(1), false: Expression(3, Sub) } at (prev + 0, 13) to (start + 0, 14)
+- MCDCDecision { bitmap_idx: 0, conditions_num: 2 } at (prev + 0, 13) to (start + 0, 19)
+- MCDCBranch { true: Counter(1), false: Expression(3, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
     true  = c1
     false = (c0 - c1)
 - Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
-- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 18) to (start + 0, 19)
+- MCDCBranch { true: Counter(2), false: Counter(3), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 18) to (start + 0, 19)
     true  = c2
     false = c3
 - Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
     = ((c2 + c3) + (c0 - c1))
 
 Function name: mcdc_non_control_flow::assign_or
-Raw bytes (51): 0x[01, 01, 04, 07, 0d, 05, 09, 01, 05, 01, 05, 07, 01, 0e, 01, 00, 20, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 0e, 00, 0d, 00, 0e, 0e, 00, 12, 00, 13, 20, 09, 0d, 00, 12, 00, 13, 03, 01, 05, 01, 02]
+Raw bytes (64): 0x[01, 01, 04, 07, 0d, 05, 09, 01, 05, 01, 05, 08, 01, 0e, 01, 00, 20, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 00, 02, 00, 0d, 00, 13, 30, 05, 0e, 01, 00, 02, 00, 0d, 00, 0e, 0e, 00, 12, 00, 13, 30, 09, 0d, 02, 00, 00, 00, 12, 00, 13, 03, 01, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 4
@@ -99,17 +101,18 @@ Number of expressions: 4
 - expression 1 operands: lhs = Counter(1), rhs = Counter(2)
 - expression 2 operands: lhs = Counter(0), rhs = Counter(1)
 - expression 3 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 7
+Number of file 0 mappings: 8
 - Code(Counter(0)) at (prev + 14, 1) to (start + 0, 32)
 - Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
     = ((c1 + c2) + c3)
 - Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
-- Branch { true: Counter(1), false: Expression(3, Sub) } at (prev + 0, 13) to (start + 0, 14)
+- MCDCDecision { bitmap_idx: 0, conditions_num: 2 } at (prev + 0, 13) to (start + 0, 19)
+- MCDCBranch { true: Counter(1), false: Expression(3, Sub), condition_id: 1, true_next_id: 0, false_next_id: 2 } at (prev + 0, 13) to (start + 0, 14)
     true  = c1
     false = (c0 - c1)
 - Code(Expression(3, Sub)) at (prev + 0, 18) to (start + 0, 19)
     = (c0 - c1)
-- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 18) to (start + 0, 19)
+- MCDCBranch { true: Counter(2), false: Counter(3), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 18) to (start + 0, 19)
     true  = c2
     false = c3
 - Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)
@@ -124,27 +127,28 @@ Number of file 0 mappings: 1
 - Code(Counter(0)) at (prev + 34, 1) to (start + 2, 2)
 
 Function name: mcdc_non_control_flow::func_call
-Raw bytes (39): 0x[01, 01, 03, 01, 05, 0b, 02, 09, 0d, 05, 01, 26, 01, 01, 0a, 20, 05, 02, 01, 09, 00, 0a, 05, 00, 0e, 00, 0f, 20, 09, 0d, 00, 0e, 00, 0f, 07, 01, 01, 00, 02]
+Raw bytes (52): 0x[01, 01, 03, 01, 05, 0b, 02, 09, 0d, 06, 01, 26, 01, 01, 0a, 28, 00, 02, 01, 09, 00, 0f, 30, 05, 02, 01, 02, 00, 00, 09, 00, 0a, 05, 00, 0e, 00, 0f, 30, 09, 0d, 02, 00, 00, 00, 0e, 00, 0f, 07, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 3
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 - expression 1 operands: lhs = Expression(2, Add), rhs = Expression(0, Sub)
 - expression 2 operands: lhs = Counter(2), rhs = Counter(3)
-Number of file 0 mappings: 5
+Number of file 0 mappings: 6
 - Code(Counter(0)) at (prev + 38, 1) to (start + 1, 10)
-- Branch { true: Counter(1), false: Expression(0, Sub) } at (prev + 1, 9) to (start + 0, 10)
+- MCDCDecision { bitmap_idx: 0, conditions_num: 2 } at (prev + 1, 9) to (start + 0, 15)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 9) to (start + 0, 10)
     true  = c1
     false = (c0 - c1)
 - Code(Counter(1)) at (prev + 0, 14) to (start + 0, 15)
-- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 14) to (start + 0, 15)
+- MCDCBranch { true: Counter(2), false: Counter(3), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 14) to (start + 0, 15)
     true  = c2
     false = c3
 - Code(Expression(1, Add)) at (prev + 1, 1) to (start + 0, 2)
     = ((c2 + c3) + (c0 - c1))
 
 Function name: mcdc_non_control_flow::right_comb_tree
-Raw bytes (117): 0x[01, 01, 13, 07, 1a, 0b, 19, 0f, 15, 13, 11, 09, 0d, 01, 05, 01, 05, 05, 19, 05, 19, 4a, 15, 05, 19, 4a, 15, 05, 19, 46, 11, 4a, 15, 05, 19, 46, 11, 4a, 15, 05, 19, 0d, 01, 1d, 01, 00, 41, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 20, 05, 1a, 00, 0d, 00, 0e, 05, 00, 13, 00, 14, 20, 4a, 19, 00, 13, 00, 14, 4a, 00, 19, 00, 1a, 20, 46, 15, 00, 19, 00, 1a, 46, 00, 1f, 00, 20, 20, 42, 11, 00, 1f, 00, 20, 42, 00, 24, 00, 27, 20, 09, 0d, 00, 24, 00, 27, 03, 01, 05, 01, 02]
+Raw bytes (139): 0x[01, 01, 13, 07, 1a, 0b, 19, 0f, 15, 13, 11, 09, 0d, 01, 05, 01, 05, 05, 19, 05, 19, 4a, 15, 05, 19, 4a, 15, 05, 19, 46, 11, 4a, 15, 05, 19, 46, 11, 4a, 15, 05, 19, 0e, 01, 1d, 01, 00, 41, 03, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 00, 05, 00, 0d, 00, 2a, 30, 05, 1a, 01, 02, 00, 00, 0d, 00, 0e, 05, 00, 13, 00, 14, 30, 4a, 19, 02, 03, 00, 00, 13, 00, 14, 4a, 00, 19, 00, 1a, 30, 46, 15, 03, 04, 00, 00, 19, 00, 1a, 46, 00, 1f, 00, 20, 30, 42, 11, 04, 05, 00, 00, 1f, 00, 20, 42, 00, 24, 00, 27, 30, 09, 0d, 05, 00, 00, 00, 24, 00, 27, 03, 01, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 19
@@ -167,31 +171,32 @@ Number of expressions: 19
 - expression 16 operands: lhs = Expression(17, Sub), rhs = Counter(4)
 - expression 17 operands: lhs = Expression(18, Sub), rhs = Counter(5)
 - expression 18 operands: lhs = Counter(1), rhs = Counter(6)
-Number of file 0 mappings: 13
+Number of file 0 mappings: 14
 - Code(Counter(0)) at (prev + 29, 1) to (start + 0, 65)
 - Code(Expression(0, Add)) at (prev + 1, 9) to (start + 0, 10)
     = (((((c2 + c3) + c4) + c5) + c6) + (c0 - c1))
 - Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
-- Branch { true: Counter(1), false: Expression(6, Sub) } at (prev + 0, 13) to (start + 0, 14)
+- MCDCDecision { bitmap_idx: 0, conditions_num: 5 } at (prev + 0, 13) to (start + 0, 42)
+- MCDCBranch { true: Counter(1), false: Expression(6, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
     true  = c1
     false = (c0 - c1)
 - Code(Counter(1)) at (prev + 0, 19) to (start + 0, 20)
-- Branch { true: Expression(18, Sub), false: Counter(6) } at (prev + 0, 19) to (start + 0, 20)
+- MCDCBranch { true: Expression(18, Sub), false: Counter(6), condition_id: 2, true_next_id: 3, false_next_id: 0 } at (prev + 0, 19) to (start + 0, 20)
     true  = (c1 - c6)
     false = c6
 - Code(Expression(18, Sub)) at (prev + 0, 25) to (start + 0, 26)
     = (c1 - c6)
-- Branch { true: Expression(17, Sub), false: Counter(5) } at (prev + 0, 25) to (start + 0, 26)
+- MCDCBranch { true: Expression(17, Sub), false: Counter(5), condition_id: 3, true_next_id: 4, false_next_id: 0 } at (prev + 0, 25) to (start + 0, 26)
     true  = ((c1 - c6) - c5)
     false = c5
 - Code(Expression(17, Sub)) at (prev + 0, 31) to (start + 0, 32)
     = ((c1 - c6) - c5)
-- Branch { true: Expression(16, Sub), false: Counter(4) } at (prev + 0, 31) to (start + 0, 32)
+- MCDCBranch { true: Expression(16, Sub), false: Counter(4), condition_id: 4, true_next_id: 5, false_next_id: 0 } at (prev + 0, 31) to (start + 0, 32)
     true  = (((c1 - c6) - c5) - c4)
     false = c4
 - Code(Expression(16, Sub)) at (prev + 0, 36) to (start + 0, 39)
     = (((c1 - c6) - c5) - c4)
-- Branch { true: Counter(2), false: Counter(3) } at (prev + 0, 36) to (start + 0, 39)
+- MCDCBranch { true: Counter(2), false: Counter(3), condition_id: 5, true_next_id: 0, false_next_id: 0 } at (prev + 0, 36) to (start + 0, 39)
     true  = c2
     false = c3
 - Code(Expression(0, Add)) at (prev + 1, 5) to (start + 1, 2)

--- a/tests/coverage/mcdc_non_control_flow.coverage
+++ b/tests/coverage/mcdc_non_control_flow.coverage
@@ -9,24 +9,6 @@
    LL|      3|fn assign_and(a: bool, b: bool) {
    LL|      3|    let x = a && b;
                                ^2
-   LL|      3|    black_box(x);
-   LL|      3|}
-   LL|       |
-   LL|      3|fn assign_or(a: bool, b: bool) {
-   LL|      3|    let x = a || b;
-                               ^1
-   LL|      3|    black_box(x);
-   LL|      3|}
-   LL|       |
-   LL|      4|fn assign_3(a: bool, b: bool, c: bool) {
-   LL|      4|    let x = a || b && c;
-                               ^2   ^1
-   LL|      4|    black_box(x);
-   LL|      4|}
-   LL|       |
-   LL|      4|fn assign_3_bis(a: bool, b: bool, c: bool) {
-   LL|      4|    let x = a && b || c;
-                               ^2   ^3
   ------------------
   |---> MC/DC Decision Region (LL:13) to (LL:19)
   |
@@ -46,12 +28,115 @@
   |  MC/DC Coverage for Decision: 100.00%
   |
   ------------------
+   LL|      3|    black_box(x);
+   LL|      3|}
+   LL|       |
+   LL|      3|fn assign_or(a: bool, b: bool) {
+   LL|      3|    let x = a || b;
+                               ^1
+  ------------------
+  |---> MC/DC Decision Region (LL:13) to (LL:19)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:13)
+  |     Condition C2 --> (LL:18)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  F  = F      }
+  |  2 { T,  -  = T      }
+  |
+  |  C1-Pair: covered: (1,2)
+  |  C2-Pair: not covered
+  |  MC/DC Coverage for Decision: 50.00%
+  |
+  ------------------
+   LL|      3|    black_box(x);
+   LL|      3|}
+   LL|       |
+   LL|      4|fn assign_3(a: bool, b: bool, c: bool) {
+   LL|      4|    let x = a || b && c;
+                               ^2   ^1
+  ------------------
+  |---> MC/DC Decision Region (LL:13) to (LL:24)
+  |
+  |  Number of Conditions: 3
+  |     Condition C1 --> (LL:13)
+  |     Condition C2 --> (LL:18)
+  |     Condition C3 --> (LL:23)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2, C3    Result
+  |  1 { F,  F,  -  = F      }
+  |  2 { T,  -,  -  = T      }
+  |  3 { F,  T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,2)
+  |  C2-Pair: covered: (1,3)
+  |  C3-Pair: not covered
+  |  MC/DC Coverage for Decision: 66.67%
+  |
+  ------------------
+   LL|      4|    black_box(x);
+   LL|      4|}
+   LL|       |
+   LL|      4|fn assign_3_bis(a: bool, b: bool, c: bool) {
+   LL|      4|    let x = a && b || c;
+                               ^2   ^3
+  ------------------
+  |---> MC/DC Decision Region (LL:13) to (LL:24)
+  |
+  |  Number of Conditions: 3
+  |     Condition C1 --> (LL:13)
+  |     Condition C2 --> (LL:18)
+  |     Condition C3 --> (LL:23)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2, C3    Result
+  |  1 { T,  F,  F  = F      }
+  |  2 { F,  -,  T  = T      }
+  |  3 { T,  T,  -  = T      }
+  |
+  |  C1-Pair: not covered
+  |  C2-Pair: covered: (1,3)
+  |  C3-Pair: not covered
+  |  MC/DC Coverage for Decision: 33.33%
+  |
+  ------------------
    LL|      4|    black_box(x);
    LL|      4|}
    LL|       |
    LL|      3|fn right_comb_tree(a: bool, b: bool, c: bool, d: bool, e: bool) {
    LL|      3|    let x = a && (b && (c && (d && (e))));
                                 ^2    ^1    ^1   ^1
+  ------------------
+  |---> MC/DC Decision Region (LL:13) to (LL:42)
+  |
+  |  Number of Conditions: 5
+  |     Condition C1 --> (LL:13)
+  |     Condition C2 --> (LL:19)
+  |     Condition C3 --> (LL:25)
+  |     Condition C4 --> (LL:31)
+  |     Condition C5 --> (LL:36)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2, C3, C4, C5    Result
+  |  1 { F,  -,  -,  -,  -  = F      }
+  |  2 { T,  F,  -,  -,  -  = F      }
+  |  3 { T,  T,  T,  T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  C3-Pair: not covered
+  |  C4-Pair: not covered
+  |  C5-Pair: not covered
+  |  MC/DC Coverage for Decision: 40.00%
+  |
+  ------------------
    LL|      3|    black_box(x);
    LL|      3|}
    LL|       |
@@ -62,6 +147,25 @@
    LL|      3|fn func_call(a: bool, b: bool) {
    LL|      3|    foo(a && b);
                            ^2
+  ------------------
+  |---> MC/DC Decision Region (LL:9) to (LL:15)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:9)
+  |     Condition C2 --> (LL:14)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  ------------------
    LL|      3|}
    LL|       |
    LL|       |

--- a/tests/coverage/mcdc_non_control_flow.coverage
+++ b/tests/coverage/mcdc_non_control_flow.coverage
@@ -1,0 +1,97 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2021
+   LL|       |//@ min-llvm-version: 18
+   LL|       |//@ compile-flags: -Zcoverage-options=mcdc
+   LL|       |//@ llvm-cov-flags: --show-mcdc
+   LL|       |
+   LL|       |use core::hint::black_box;
+   LL|       |
+   LL|      3|fn assign_and(a: bool, b: bool) {
+   LL|      3|    let x = a && b;
+                               ^2
+   LL|      3|    black_box(x);
+   LL|      3|}
+   LL|       |
+   LL|      3|fn assign_or(a: bool, b: bool) {
+   LL|      3|    let x = a || b;
+                               ^1
+   LL|      3|    black_box(x);
+   LL|      3|}
+   LL|       |
+   LL|      4|fn assign_3(a: bool, b: bool, c: bool) {
+   LL|      4|    let x = a || b && c;
+                               ^2   ^1
+   LL|      4|    black_box(x);
+   LL|      4|}
+   LL|       |
+   LL|      4|fn assign_3_bis(a: bool, b: bool, c: bool) {
+   LL|      4|    let x = a && b || c;
+                               ^2   ^3
+  ------------------
+  |---> MC/DC Decision Region (LL:13) to (LL:19)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:13)
+  |     Condition C2 --> (LL:18)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  ------------------
+   LL|      4|    black_box(x);
+   LL|      4|}
+   LL|       |
+   LL|      3|fn right_comb_tree(a: bool, b: bool, c: bool, d: bool, e: bool) {
+   LL|      3|    let x = a && (b && (c && (d && (e))));
+                                ^2    ^1    ^1   ^1
+   LL|      3|    black_box(x);
+   LL|      3|}
+   LL|       |
+   LL|      3|fn foo(a: bool) -> bool {
+   LL|      3|    black_box(a)
+   LL|      3|}
+   LL|       |
+   LL|      3|fn func_call(a: bool, b: bool) {
+   LL|      3|    foo(a && b);
+                           ^2
+   LL|      3|}
+   LL|       |
+   LL|       |
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    assign_and(true, false);
+   LL|       |    assign_and(true, true);
+   LL|       |    assign_and(false, false);
+   LL|       |
+   LL|       |    assign_or(true, false);
+   LL|       |    assign_or(true, true);
+   LL|       |    assign_or(false, false);
+   LL|       |
+   LL|       |    assign_3(true, false, false);
+   LL|       |    assign_3(true, true, false);
+   LL|       |    assign_3(false, false, true);
+   LL|       |    assign_3(false, true, true);
+   LL|       |
+   LL|       |    assign_3_bis(true, false, false);
+   LL|       |    assign_3_bis(true, true, false);
+   LL|       |    assign_3_bis(false, false, true);
+   LL|       |    assign_3_bis(false, true, true);
+   LL|       |
+   LL|       |    right_comb_tree(false, false, false, true, true);
+   LL|       |    right_comb_tree(true, false, false, true, true);
+   LL|       |    right_comb_tree(true, true, true, true, true);
+   LL|       |
+   LL|       |    func_call(true, false);
+   LL|       |    func_call(true, true);
+   LL|       |    func_call(false, false);
+   LL|       |}
+

--- a/tests/coverage/mcdc_non_control_flow.rs
+++ b/tests/coverage/mcdc_non_control_flow.rs
@@ -1,0 +1,71 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+//@ min-llvm-version: 18
+//@ compile-flags: -Zcoverage-options=mcdc
+//@ llvm-cov-flags: --show-mcdc
+
+use core::hint::black_box;
+
+fn assign_and(a: bool, b: bool) {
+    let x = a && b;
+    black_box(x);
+}
+
+fn assign_or(a: bool, b: bool) {
+    let x = a || b;
+    black_box(x);
+}
+
+fn assign_3(a: bool, b: bool, c: bool) {
+    let x = a || b && c;
+    black_box(x);
+}
+
+fn assign_3_bis(a: bool, b: bool, c: bool) {
+    let x = a && b || c;
+    black_box(x);
+}
+
+fn right_comb_tree(a: bool, b: bool, c: bool, d: bool, e: bool) {
+    let x = a && (b && (c && (d && (e))));
+    black_box(x);
+}
+
+fn foo(a: bool) -> bool {
+    black_box(a)
+}
+
+fn func_call(a: bool, b: bool) {
+    foo(a && b);
+}
+
+
+
+#[coverage(off)]
+fn main() {
+    assign_and(true, false);
+    assign_and(true, true);
+    assign_and(false, false);
+
+    assign_or(true, false);
+    assign_or(true, true);
+    assign_or(false, false);
+
+    assign_3(true, false, false);
+    assign_3(true, true, false);
+    assign_3(false, false, true);
+    assign_3(false, true, true);
+
+    assign_3_bis(true, false, false);
+    assign_3_bis(true, true, false);
+    assign_3_bis(false, false, true);
+    assign_3_bis(false, true, true);
+
+    right_comb_tree(false, false, false, true, true);
+    right_comb_tree(true, false, false, true, true);
+    right_comb_tree(true, true, true, true, true);
+
+    func_call(true, false);
+    func_call(true, true);
+    func_call(false, false);
+}


### PR DESCRIPTION
This PR ensures that the top-level boolean expressions that are not part of the control flow are correctly instrumented thanks to condition coverage.

See discussion on #124120.
Depends on @Zalathar 's condition coverage implementation #124644.