### PR TITLE
Set non-leaf frame pointers on Fuchsia targets

### DIFF
--- a/compiler/rustc_target/src/spec/base/fuchsia.rs
+++ b/compiler/rustc_target/src/spec/base/fuchsia.rs
@@ -1,4 +1,6 @@
-use crate::spec::{crt_objects, cvs, Cc, LinkOutputKind, LinkerFlavor, Lld, TargetOptions};
+use crate::spec::{
+    crt_objects, cvs, Cc, FramePointer, LinkOutputKind, LinkerFlavor, Lld, TargetOptions,
+};
 
 pub fn opts() -> TargetOptions {
     // This mirrors the linker options provided by clang. We presume lld for
@@ -38,6 +40,7 @@ pub fn opts() -> TargetOptions {
         ]),
         position_independent_executables: true,
         has_thread_local: true,
+        frame_pointer: FramePointer::NonLeaf,
         ..Default::default()
     }
 }


### PR DESCRIPTION
This is part of our work to enable shadow call stack sanitization on Fuchsia, see [this Fuchsia issue](https://g-issues.fuchsia.dev/issues/327643884).

r? @tmandry 