### PR TITLE
Improve check-cfg CLI errors with more structured diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4162,6 +4162,7 @@ dependencies = [
  "rustc_ast",
  "rustc_ast_lowering",
  "rustc_ast_passes",
+ "rustc_ast_pretty",
  "rustc_attr",
  "rustc_borrowck",
  "rustc_builtin_macros",

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -167,7 +167,7 @@ impl LitKind {
 
     pub fn descr(self) -> &'static str {
         match self {
-            Bool => panic!("literal token contains `Lit::Bool`"),
+            Bool => "boolean",
             Byte => "byte",
             Char => "char",
             Integer => "integer",

--- a/compiler/rustc_interface/Cargo.toml
+++ b/compiler/rustc_interface/Cargo.toml
@@ -10,6 +10,7 @@ rustc-rayon-core = { version = "0.5.0", optional = true }
 rustc_ast = { path = "../rustc_ast" }
 rustc_ast_lowering = { path = "../rustc_ast_lowering" }
 rustc_ast_passes = { path = "../rustc_ast_passes" }
+rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_attr = { path = "../rustc_attr" }
 rustc_borrowck = { path = "../rustc_borrowck" }
 rustc_builtin_macros = { path = "../rustc_builtin_macros" }

--- a/tests/ui/check-cfg/invalid-arguments.any_values.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.any_values.stderr
@@ -1,2 +1,5 @@
-error: invalid `--check-cfg` argument: `cfg(any(),values())` (`values()` cannot be specified before the names)
+error: invalid `--check-cfg` argument: `cfg(any(),values())`
+   |
+   = note: `values()` cannot be specified before the names
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.anything_else.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.anything_else.stderr
@@ -1,2 +1,5 @@
-error: invalid `--check-cfg` argument: `anything_else(...)` (expected `cfg(name, values("value1", "value2", ... "valueN"))`)
+error: invalid `--check-cfg` argument: `anything_else(...)`
+   |
+   = note: expected `cfg(name, values("value1", "value2", ... "valueN"))`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.boolean.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.boolean.stderr
@@ -1,6 +1,6 @@
-error: invalid `--check-cfg` argument: `cfg("NOT_IDENT")`
+error: invalid `--check-cfg` argument: `cfg(true)`
    |
-   = note: `"NOT_IDENT"` is a string literal
+   = note: `true` is a boolean literal
    = note: `cfg()` arguments must be simple identifiers, `any()` or `values(...)`
    = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.cfg_none.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.cfg_none.stderr
@@ -1,2 +1,6 @@
-error: invalid `--check-cfg` argument: `cfg(none())` (`cfg()` arguments must be simple identifiers, `any()` or `values(...)`)
+error: invalid `--check-cfg` argument: `cfg(none())`
+   |
+   = note: `none()` is invalid
+   = note: `cfg()` arguments must be simple identifiers, `any()` or `values(...)`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.giberich.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.giberich.stderr
@@ -1,2 +1,5 @@
-error: invalid `--check-cfg` argument: `cfg(...)` (expected `cfg(name, values("value1", "value2", ... "valueN"))`)
+error: invalid `--check-cfg` argument: `cfg(...)`
+   |
+   = note: expected `cfg(name, values("value1", "value2", ... "valueN"))`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.ident_in_values_1.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.ident_in_values_1.stderr
@@ -1,2 +1,6 @@
-error: invalid `--check-cfg` argument: `cfg(foo,values(bar))` (`values()` arguments must be string literals, `none()` or `any()`)
+error: invalid `--check-cfg` argument: `cfg(foo,values(bar))`
+   |
+   = note: `bar` is invalid
+   = note: `values()` arguments must be string literals, `none()` or `any()`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.ident_in_values_2.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.ident_in_values_2.stderr
@@ -1,2 +1,6 @@
-error: invalid `--check-cfg` argument: `cfg(foo,values("bar",bar,"bar"))` (`values()` arguments must be string literals, `none()` or `any()`)
+error: invalid `--check-cfg` argument: `cfg(foo,values("bar",bar,"bar"))`
+   |
+   = note: `bar` is invalid
+   = note: `values()` arguments must be string literals, `none()` or `any()`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.mixed_any.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.mixed_any.stderr
@@ -1,2 +1,5 @@
-error: invalid `--check-cfg` argument: `cfg(any(),values(any()))` (`values()` cannot be specified before the names)
+error: invalid `--check-cfg` argument: `cfg(any(),values(any()))`
+   |
+   = note: `values()` cannot be specified before the names
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.mixed_values_any.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.mixed_values_any.stderr
@@ -1,2 +1,5 @@
-error: invalid `--check-cfg` argument: `cfg(foo,values("bar",any()))` (`values()` arguments cannot specify string literals and `any()` at the same time)
+error: invalid `--check-cfg` argument: `cfg(foo,values("bar",any()))`
+   |
+   = note: `values()` arguments cannot specify string literals and `any()` at the same time
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.multiple_any.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.multiple_any.stderr
@@ -1,2 +1,5 @@
-error: invalid `--check-cfg` argument: `cfg(any(),any())` (`any()` cannot be specified multiple times)
+error: invalid `--check-cfg` argument: `cfg(any(),any())`
+   |
+   = note: `any()` cannot be specified multiple times
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.multiple_values.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.multiple_values.stderr
@@ -1,2 +1,5 @@
-error: invalid `--check-cfg` argument: `cfg(foo,values(),values())` (`values()` cannot be specified multiple times)
+error: invalid `--check-cfg` argument: `cfg(foo,values(),values())`
+   |
+   = note: `values()` cannot be specified multiple times
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.multiple_values_any.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.multiple_values_any.stderr
@@ -1,2 +1,6 @@
-error: invalid `--check-cfg` argument: `cfg(foo,values(any(),any()))` (`any()` in `values()` cannot be specified multiple times)
+error: invalid `--check-cfg` argument: `cfg(foo,values(any(),any()))`
+   |
+   = note: `any()` is invalid
+   = note: `any()` in `values()` cannot be specified multiple times
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.none_not_empty.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.none_not_empty.stderr
@@ -1,2 +1,6 @@
-error: invalid `--check-cfg` argument: `cfg(foo,values(none("test")))` (`none()` must be empty)
+error: invalid `--check-cfg` argument: `cfg(foo,values(none("test")))`
+   |
+   = note: `none("test")` is invalid
+   = note: `none()` in `values()` takes no argument
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.not_empty_any.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.not_empty_any.stderr
@@ -1,2 +1,6 @@
-error: invalid `--check-cfg` argument: `cfg(any(foo))` (`any()` must be empty)
+error: invalid `--check-cfg` argument: `cfg(any(foo))`
+   |
+   = note: `any(foo)` is invalid
+   = note: `any()` takes no argument
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.not_empty_values_any.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.not_empty_values_any.stderr
@@ -1,2 +1,6 @@
-error: invalid `--check-cfg` argument: `cfg(foo,values(any(bar)))` (`any()` must be empty)
+error: invalid `--check-cfg` argument: `cfg(foo,values(any(bar)))`
+   |
+   = note: `any(bar)` is invalid
+   = note: `any()` in `values()` takes no argument
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.rs
+++ b/tests/ui/check-cfg/invalid-arguments.rs
@@ -2,7 +2,7 @@
 //
 //@ check-fail
 //@ no-auto-check-cfg
-//@ revisions: anything_else
+//@ revisions: anything_else boolean
 //@ revisions: string_for_name_1 string_for_name_2 multiple_any multiple_values
 //@ revisions: multiple_values_any not_empty_any not_empty_values_any
 //@ revisions: values_any_missing_values values_any_before_ident ident_in_values_1
@@ -11,6 +11,7 @@
 //@ revisions: none_not_empty cfg_none
 //
 //@ [anything_else]compile-flags: --check-cfg=anything_else(...)
+//@ [boolean]compile-flags: --check-cfg=cfg(true)
 //@ [string_for_name_1]compile-flags: --check-cfg=cfg("NOT_IDENT")
 //@ [string_for_name_2]compile-flags: --check-cfg=cfg(foo,"NOT_IDENT",bar)
 //@ [multiple_any]compile-flags: --check-cfg=cfg(any(),any())

--- a/tests/ui/check-cfg/invalid-arguments.string_for_name_2.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.string_for_name_2.stderr
@@ -1,2 +1,6 @@
-error: invalid `--check-cfg` argument: `cfg(foo,"NOT_IDENT",bar)` (`cfg()` arguments must be simple identifiers, `any()` or `values(...)`)
+error: invalid `--check-cfg` argument: `cfg(foo,"NOT_IDENT",bar)`
+   |
+   = note: `"NOT_IDENT"` is a string literal
+   = note: `cfg()` arguments must be simple identifiers, `any()` or `values(...)`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.unknown_meta_item_1.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.unknown_meta_item_1.stderr
@@ -1,2 +1,5 @@
-error: invalid `--check-cfg` argument: `abc()` (expected `cfg(name, values("value1", "value2", ... "valueN"))`)
+error: invalid `--check-cfg` argument: `abc()`
+   |
+   = note: expected `cfg(name, values("value1", "value2", ... "valueN"))`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.unknown_meta_item_2.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.unknown_meta_item_2.stderr
@@ -1,2 +1,6 @@
-error: invalid `--check-cfg` argument: `cfg(foo,test())` (`cfg()` arguments must be simple identifiers, `any()` or `values(...)`)
+error: invalid `--check-cfg` argument: `cfg(foo,test())`
+   |
+   = note: `test()` is invalid
+   = note: `cfg()` arguments must be simple identifiers, `any()` or `values(...)`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.unknown_meta_item_3.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.unknown_meta_item_3.stderr
@@ -1,2 +1,6 @@
-error: invalid `--check-cfg` argument: `cfg(foo,values(test()))` (`values()` arguments must be string literals, `none()` or `any()`)
+error: invalid `--check-cfg` argument: `cfg(foo,values(test()))`
+   |
+   = note: `test()` is invalid
+   = note: `values()` arguments must be string literals, `none()` or `any()`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.unterminated.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.unterminated.stderr
@@ -1,2 +1,5 @@
-error: invalid `--check-cfg` argument: `cfg(` (expected `cfg(name, values("value1", "value2", ... "valueN"))`)
+error: invalid `--check-cfg` argument: `cfg(`
+   |
+   = note: expected `cfg(name, values("value1", "value2", ... "valueN"))`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.values_any_before_ident.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.values_any_before_ident.stderr
@@ -1,2 +1,5 @@
-error: invalid `--check-cfg` argument: `cfg(values(any()),foo)` (`values()` cannot be specified before the names)
+error: invalid `--check-cfg` argument: `cfg(values(any()),foo)`
+   |
+   = note: `values()` cannot be specified before the names
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 

--- a/tests/ui/check-cfg/invalid-arguments.values_any_missing_values.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.values_any_missing_values.stderr
@@ -1,2 +1,5 @@
-error: invalid `--check-cfg` argument: `cfg(foo,any())` (`cfg(any())` can only be provided in isolation)
+error: invalid `--check-cfg` argument: `cfg(foo,any())`
+   |
+   = note: `cfg(any())` can only be provided in isolation
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
 


### PR DESCRIPTION
This PR improve check-cfg CLI errors with more structured diagnostics.

In particular it now shows the statement where the error occurred, what kind lit it is, as well as pointing users to the doc for more details.

@rustbot label +F-check-cfg