### PR TITLE
Add `std::io::IoSlice::as_slice` method

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1385,6 +1385,34 @@ impl<'a> IoSlice<'a> {
         IoSlice(sys::io::IoSlice::new(buf))
     }
 
+    /// Returns a copy of the wrapped slice.
+    ///
+    /// The lifetime of the slice is not bound to the `IoSlice` itself, instead it references the
+    /// wrapped slice itself. This is unlike the slice which can be obtained from the [`Deref`]
+    /// implementation, its lifetime is tied to the specific `IoSlice`. This makes `as_slice`
+    /// suitable for changing the length of the slice in-place.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(io_slice_as_slice)]
+    ///
+    /// use std::io::IoSlice;
+    ///
+    /// let data = [0, 1, 2, 3, 4];
+    /// let mut buf = IoSlice::new(&data);
+    ///
+    /// // Discard the first and last bytes
+    /// buf = IoSlice::new(buf.as_slice()[1..4]);
+    /// assert_eq!(buf.as_slice(), [1, 2, 3].as_ref());
+    /// ```
+    #[unstable(feature = "io_slice_as_slice", issue = "124659")]
+    #[must_use]
+    #[inline]
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.0.as_slice()
+    }
+
     /// Advance the internal cursor of the slice.
     ///
     /// Also see [`IoSlice::advance_slices`] to advance the cursors of multiple

--- a/library/std/src/sys/pal/solid/io.rs
+++ b/library/std/src/sys/pal/solid/io.rs
@@ -33,7 +33,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 }

--- a/library/std/src/sys/pal/unix/io.rs
+++ b/library/std/src/sys/pal/unix/io.rs
@@ -33,7 +33,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 }

--- a/library/std/src/sys/pal/unsupported/io.rs
+++ b/library/std/src/sys/pal/unsupported/io.rs
@@ -15,7 +15,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &'a [u8] {
         self.0
     }
 }

--- a/library/std/src/sys/pal/wasi/io.rs
+++ b/library/std/src/sys/pal/wasi/io.rs
@@ -30,7 +30,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.vec.buf as *const u8, self.vec.buf_len) }
     }
 }

--- a/library/std/src/sys/pal/windows/io.rs
+++ b/library/std/src/sys/pal/windows/io.rs
@@ -35,7 +35,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.vec.buf, self.vec.len as usize) }
     }
 }


### PR DESCRIPTION
Fixes #124659.

This allows getting a slice with the same lifetime as the wrapped bytes.

```rust
impl<'a> IoSlice<'a> {
    pub fn as_slice(&self) -> &'a [u8] {
        // ...
    }
}
```

This works as the `IoSlice` is essentially just a transparent wrapper around `&'a [u8]`, but with a different layout. Since `&[u8]` implements `Copy`, this is essentially the same as just copying that `&[u8]` out of the `IoSlice`.