### PR TITLE
Suggest setting lifetime in borrowck error involving types with elided lifetimes

### DIFF
--- a/compiler/rustc_infer/messages.ftl
+++ b/compiler/rustc_infer/messages.ftl
@@ -164,7 +164,10 @@ infer_label_bad = {$bad_kind ->
 infer_lf_bound_not_satisfied = lifetime bound not satisfied
 infer_lifetime_mismatch = lifetime mismatch
 
-infer_lifetime_param_suggestion = consider introducing a named lifetime parameter{$is_impl ->
+infer_lifetime_param_suggestion = consider {$is_reuse ->
+    [true] reusing
+    *[false] introducing
+} a named lifetime parameter{$is_impl ->
     [true] {" "}and update trait if needed
     *[false] {""}
 }

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -450,6 +450,11 @@ impl Subdiagnostic for AddLifetimeParamsSuggestion<'_> {
             };
             visitor.visit_ty(self.ty_sub);
             visitor.visit_ty(self.ty_sup);
+            if let Some(fn_decl) = node.fn_decl()
+                && let hir::FnRetTy::Return(ty) = fn_decl.output
+            {
+                visitor.visit_ty(ty);
+            }
             if visitor.suggestions.is_empty() {
                 return false;
             }

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -517,6 +517,7 @@ impl Subdiagnostic for AddLifetimeParamsSuggestion<'_> {
                 Applicability::MaybeIncorrect,
             );
             diag.arg("is_impl", is_impl);
+            diag.arg("is_reuse", !introduce_new);
 
             true
         };

--- a/tests/ui/lifetimes/issue-17728.stderr
+++ b/tests/ui/lifetimes/issue-17728.stderr
@@ -29,8 +29,8 @@ LL |             Some(entry) => Ok(entry),
    |
 help: consider introducing a named lifetime parameter
    |
-LL |     fn attemptTraverse<'a>(&'a self, room: &'a Room, directionStr: &str) -> Result<&'a Room, &'a str> {
-   |                       ++++  ++              ++                                      ++        ++
+LL |     fn attemptTraverse<'a>(&self, room: &'a Room, directionStr: &str) -> Result<&'a Room, &'a str> {
+   |                       ++++               ++                                      ++        ++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/issue-17728.stderr
+++ b/tests/ui/lifetimes/issue-17728.stderr
@@ -29,8 +29,8 @@ LL |             Some(entry) => Ok(entry),
    |
 help: consider introducing a named lifetime parameter
    |
-LL |     fn attemptTraverse<'a>(&'a self, room: &'a Room, directionStr: &str) -> Result<&Room, &str> {
-   |                       ++++  ++              ++
+LL |     fn attemptTraverse<'a>(&'a self, room: &'a Room, directionStr: &str) -> Result<&'a Room, &'a str> {
+   |                       ++++  ++              ++                                      ++        ++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/issue-90170-elision-mismatch.stderr
+++ b/tests/ui/lifetimes/issue-90170-elision-mismatch.stderr
@@ -35,7 +35,7 @@ LL | pub fn foo3<'a>(_other: &'a [u8], x: &mut Vec<&u8>, y: &u8) { x.push(y); }
    |                                               |        let's call the lifetime of this reference `'1`
    |                                               let's call the lifetime of this reference `'2`
    |
-help: consider introducing a named lifetime parameter
+help: consider reusing a named lifetime parameter
    |
 LL | pub fn foo3<'a>(_other: &'a [u8], x: &mut Vec<&'a u8>, y: &'a u8) { x.push(y); }
    |                                                ++          ++

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.stderr
@@ -9,7 +9,7 @@ LL |
 LL |         if x > y { x } else { y }
    |                    ^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
    |
-help: consider introducing a named lifetime parameter and update trait if needed
+help: consider reusing a named lifetime parameter and update trait if needed
    |
 LL |     fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
    |                    ++

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.stderr
@@ -8,6 +8,11 @@ LL |     fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
 LL |
 LL |         if x > y { x } else { y }
    |                    ^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
+   |                    ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.fixed
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.fixed
@@ -5,7 +5,7 @@ struct Foo {
 }
 
 impl Foo {
-  fn foo<'a>(&self, x: &'a i32) -> &i32 {
+  fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
 
     x
     //~^ ERROR lifetime may not live long enough

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.fixed
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.fixed
@@ -5,7 +5,7 @@ struct Foo {
 }
 
 impl Foo {
-    fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
+    fn foo<'a>(&self, x: &'a i32) -> &'a i32 {
         x
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.fixed
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.fixed
@@ -5,13 +5,10 @@ struct Foo {
 }
 
 impl Foo {
-  fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
-
-    x
-    //~^ ERROR lifetime may not live long enough
-
-  }
-
+    fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
+        x
+        //~^ ERROR lifetime may not live long enough
+    }
 }
 
 fn main() {}

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.rs
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.rs
@@ -5,13 +5,10 @@ struct Foo {
 }
 
 impl Foo {
-  fn foo<'a>(&self, x: &'a i32) -> &i32 {
-
-    x
-    //~^ ERROR lifetime may not live long enough
-
-  }
-
+    fn foo<'a>(&self, x: &'a i32) -> &i32 {
+        x
+        //~^ ERROR lifetime may not live long enough
+    }
 }
 
 fn main() {}

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
@@ -11,8 +11,8 @@ LL |     x
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |   fn foo<'a>(&'a self, x: &'a i32) -> &i32 {
-   |               ++
+LL |   fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
+   |               ++                       ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
@@ -1,18 +1,17 @@
 error: lifetime may not live long enough
-  --> $DIR/ex1-return-one-existing-name-return-type-is-anon.rs:10:5
+  --> $DIR/ex1-return-one-existing-name-return-type-is-anon.rs:9:9
    |
-LL |   fn foo<'a>(&self, x: &'a i32) -> &i32 {
-   |          --  - let's call the lifetime of this reference `'1`
-   |          |
-   |          lifetime `'a` defined here
-LL |
-LL |     x
-   |     ^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
+LL |     fn foo<'a>(&self, x: &'a i32) -> &i32 {
+   |            --  - let's call the lifetime of this reference `'1`
+   |            |
+   |            lifetime `'a` defined here
+LL |         x
+   |         ^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |   fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
-   |               ++                       ++
+LL |     fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
+   |                 ++                       ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
@@ -8,7 +8,7 @@ LL |     fn foo<'a>(&self, x: &'a i32) -> &i32 {
 LL |         x
    |         ^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
    |
-help: consider introducing a named lifetime parameter and update trait if needed
+help: consider reusing a named lifetime parameter and update trait if needed
    |
 LL |     fn foo<'a>(&self, x: &'a i32) -> &'a i32 {
    |                                       ++

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
@@ -8,6 +8,11 @@ LL |   fn foo<'a>(&self, x: &'a i32) -> &i32 {
 LL |
 LL |     x
    |     ^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |   fn foo<'a>(&'a self, x: &'a i32) -> &i32 {
+   |               ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ex1-return-one-existing-name-return-type-is-anon.rs:8:5
+  --> $DIR/ex1-return-one-existing-name-return-type-is-anon.rs:10:5
    |
 LL |   fn foo<'a>(&self, x: &'a i32) -> &i32 {
    |          --  - let's call the lifetime of this reference `'1`

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
@@ -10,8 +10,8 @@ LL |         x
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
-   |                 ++                       ++
+LL |     fn foo<'a>(&self, x: &'a i32) -> &'a i32 {
+   |                                       ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
@@ -9,7 +9,7 @@ LL |
 LL |         if true { x } else { self }
    |                              ^^^^ method was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
    |
-help: consider introducing a named lifetime parameter and update trait if needed
+help: consider reusing a named lifetime parameter and update trait if needed
    |
 LL |     fn foo<'a>(&'a self, x: &'a Foo) -> &'a Foo {
    |                 ++

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
@@ -8,6 +8,11 @@ LL |     fn foo<'a>(&self, x: &'a Foo) -> &'a Foo {
 LL |
 LL |         if true { x } else { self }
    |                              ^^^^ method was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     fn foo<'a>(&'a self, x: &'a Foo) -> &'a Foo {
+   |                 ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex2b-push-no-existing-names.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex2b-push-no-existing-names.stderr
@@ -7,6 +7,11 @@ LL | fn foo(x: &mut Vec<Ref<i32>>, y: Ref<i32>) {
    |        has type `&mut Vec<Ref<'2, i32>>`
 LL |     x.push(y);
    |     ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | fn foo<'a>(x: &mut Vec<Ref<'a, i32>>, y: Ref<'a, i32>) {
+   |       ++++                 +++               +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-2.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-2.stderr
@@ -7,6 +7,11 @@ LL | fn foo(mut x: Ref, y: Ref) {
    |        has type `Ref<'_, '2>`
 LL |     x.b = y.b;
    |     ^^^^^^^^^ assignment requires that `'1` must outlive `'2`
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | fn foo<'a>(mut x: Ref<'a, 'a>, y: Ref<'a, 'a>) {
+   |       ++++           ++++++++        ++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-3.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-3.stderr
@@ -8,6 +8,11 @@ LL | fn foo(mut x: Ref) {
    |        has type `Ref<'2, '_>`
 LL |     x.a = x.b;
    |     ^^^^^^^^^ assignment requires that `'1` must outlive `'2`
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | fn foo<'a>(mut x: Ref<'a, 'a>) {
+   |       ++++           ++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs.stderr
@@ -7,6 +7,11 @@ LL | fn foo(mut x: Vec<Ref>, y: Ref) {
    |        has type `Vec<Ref<'2>>`
 LL |     x.push(y);
    |     ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | fn foo<'a>(mut x: Vec<Ref<'a>>, y: Ref<'a>) {
+   |       ++++               ++++         ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.stderr
@@ -7,6 +7,11 @@ LL | fn foo(mut x: Ref, y: &u32) {
    |        has type `Ref<'_, '1>`
 LL |     y = x.b;
    |     ^^^^^^^ assignment requires that `'1` must outlive `'2`
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | fn foo<'a>(mut x: Ref<'a, 'a>, y: &'a u32) {
+   |       ++++           ++++++++      ++
 
 error[E0384]: cannot assign to immutable argument `y`
   --> $DIR/ex3-both-anon-regions-one-is-struct-2.rs:4:5

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-3.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-3.stderr
@@ -7,6 +7,11 @@ LL | fn foo(mut y: Ref, x: &u32) {
    |        has type `Ref<'_, '2>`
 LL |     y.b = x;
    |     ^^^^^^^ assignment requires that `'1` must outlive `'2`
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | fn foo<'a>(mut y: Ref<'a, 'a>, x: &'a u32) {
+   |       ++++           ++++++++      ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-4.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-4.stderr
@@ -7,6 +7,11 @@ LL | fn foo(mut y: Ref, x: &u32) {
    |        has type `Ref<'_, '2>`
 LL |     y.b = x;
    |     ^^^^^^^ assignment requires that `'1` must outlive `'2`
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | fn foo<'a>(mut y: Ref<'a, 'a>, x: &'a u32) {
+   |       ++++           ++++++++      ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct.stderr
@@ -7,6 +7,11 @@ LL | fn foo(mut x: Ref, y: &u32) {
    |        has type `Ref<'_, '2>`
 LL |     x.b = y;
    |     ^^^^^^^ assignment requires that `'1` must outlive `'2`
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | fn foo<'a>(mut x: Ref<'a, 'a>, y: &'a u32) {
+   |       ++++           ++++++++      ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.fixed
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.fixed
@@ -1,17 +1,14 @@
 //@ run-rustfix
 #![allow(dead_code)]
 struct Foo {
-    field: i32,
+  field: i32,
 }
 
 impl Foo {
-  fn foo<'a>(&self, x: &'a i32) -> &i32 {
-
+  fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
     x
     //~^ ERROR lifetime may not live long enough
-
   }
-
 }
 
-fn main() {}
+fn main() { }

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.fixed
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.fixed
@@ -1,14 +1,14 @@
 //@ run-rustfix
 #![allow(dead_code)]
 struct Foo {
-  field: i32,
+    field: i32,
 }
 
 impl Foo {
-  fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
-    x
-    //~^ ERROR lifetime may not live long enough
-  }
+    fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
+        x
+        //~^ ERROR lifetime may not live long enough
+    }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.fixed
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.fixed
@@ -5,7 +5,7 @@ struct Foo {
 }
 
 impl Foo {
-    fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
+    fn foo<'a>(&self, x: &'a i32) -> &'a i32 {
         x
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.rs
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.rs
@@ -1,5 +1,7 @@
+//@ run-rustfix
+#![allow(dead_code)]
 struct Foo {
-  field: i32
+  field: i32,
 }
 
 impl Foo {

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.rs
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.rs
@@ -1,14 +1,14 @@
 //@ run-rustfix
 #![allow(dead_code)]
 struct Foo {
-  field: i32,
+    field: i32,
 }
 
 impl Foo {
-  fn foo<'a>(&self, x: &i32) -> &i32 {
-    x
-    //~^ ERROR lifetime may not live long enough
-  }
+    fn foo<'a>(&self, x: &i32) -> &i32 {
+        x
+        //~^ ERROR lifetime may not live long enough
+    }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ex3-both-anon-regions-return-type-is-anon.rs:7:5
+  --> $DIR/ex3-both-anon-regions-return-type-is-anon.rs:9:5
    |
 LL |   fn foo<'a>(&self, x: &i32) -> &i32 {
    |              -         - let's call the lifetime of this reference `'1`

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
@@ -10,8 +10,8 @@ LL |     x
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |   fn foo<'a>(&'a self, x: &'a i32) -> &i32 {
-   |               ++           ++
+LL |   fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
+   |               ++           ++          ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
@@ -1,17 +1,17 @@
 error: lifetime may not live long enough
-  --> $DIR/ex3-both-anon-regions-return-type-is-anon.rs:9:5
+  --> $DIR/ex3-both-anon-regions-return-type-is-anon.rs:9:9
    |
-LL |   fn foo<'a>(&self, x: &i32) -> &i32 {
-   |              -         - let's call the lifetime of this reference `'1`
-   |              |
-   |              let's call the lifetime of this reference `'2`
-LL |     x
-   |     ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+LL |     fn foo<'a>(&self, x: &i32) -> &i32 {
+   |                -         - let's call the lifetime of this reference `'1`
+   |                |
+   |                let's call the lifetime of this reference `'2`
+LL |         x
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |   fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
-   |               ++           ++          ++
+LL |     fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
+   |                 ++           ++          ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
@@ -10,8 +10,8 @@ LL |         x
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn foo<'a>(&'a self, x: &'a i32) -> &'a i32 {
-   |                 ++           ++          ++
+LL |     fn foo<'a>(&self, x: &'a i32) -> &'a i32 {
+   |                           ++          ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.stderr
@@ -8,7 +8,7 @@ LL |     fn foo<'a>(&self, x: &i32) -> &i32 {
 LL |         x
    |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
-help: consider introducing a named lifetime parameter and update trait if needed
+help: consider reusing a named lifetime parameter and update trait if needed
    |
 LL |     fn foo<'a>(&self, x: &'a i32) -> &'a i32 {
    |                           ++          ++

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.stderr
@@ -10,8 +10,8 @@ LL |         if true { x } else { self }
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn foo<'a>(&'a self, x: &'a Foo) -> &'a Foo {
-   |                 ++           ++          ++
+LL |     fn foo<'a>(&self, x: &'a Foo) -> &'a Foo {
+   |                           ++          ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.stderr
@@ -8,7 +8,7 @@ LL |     fn foo<'a>(&self, x: &Foo) -> &Foo {
 LL |         if true { x } else { self }
    |                   ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
-help: consider introducing a named lifetime parameter and update trait if needed
+help: consider reusing a named lifetime parameter and update trait if needed
    |
 LL |     fn foo<'a>(&self, x: &'a Foo) -> &'a Foo {
    |                           ++          ++

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.stderr
@@ -10,8 +10,8 @@ LL |         if true { x } else { self }
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn foo<'a>(&'a self, x: &'a Foo) -> &Foo {
-   |                 ++           ++
+LL |     fn foo<'a>(&'a self, x: &'a Foo) -> &'a Foo {
+   |                 ++           ++          ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
@@ -35,7 +35,7 @@ LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
    |                  |               let's call the lifetime of this reference `'1`
    |                  lifetime `'a` defined here
    |
-help: consider introducing a named lifetime parameter and update trait if needed
+help: consider reusing a named lifetime parameter and update trait if needed
    |
 LL |     async fn bar<'a>(self: Alias<&'a Self>, arg: &'a ()) -> &() { arg }
    |                                   ++

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
@@ -34,6 +34,11 @@ LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
    |                  |               |
    |                  |               let's call the lifetime of this reference `'1`
    |                  lifetime `'a` defined here
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     async fn bar<'a>(self: Alias<&'a Self>, arg: &'a ()) -> &() { arg }
+   |                                   ++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.rs
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.rs
@@ -6,6 +6,9 @@ impl Foo {
     fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
     //~^ lifetime may not live long enough
 
+    // For this suggestion to be right, we'd need to also suggest `self: Pin<&'a Self>`, which we
+    // don't, but we provide a follow up suggestion to do so, so I condider that good at least for
+    // now.
     fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
     //~^ lifetime may not live long enough
 }

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.rs
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.rs
@@ -3,20 +3,23 @@ use std::pin::Pin;
 struct Foo;
 
 impl Foo {
-    fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-    //~^ lifetime may not live long enough
+    fn a(self: Pin<&Foo>, f: &Foo) -> &Foo {
+        f //~ ERROR lifetime may not live long enough
+    }
 
     // For this suggestion to be right, we'd need to also suggest `self: Pin<&'a Self>`, which we
     // don't, but we provide a follow up suggestion to do so, so I condider that good at least for
     // now.
-    fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-    //~^ lifetime may not live long enough
+    fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) {
+        (self, f) //~ ERROR lifetime may not live long enough
+    }
 }
 
 type Alias<T> = Pin<T>;
 impl Foo {
-    fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
-    //~^ lifetime may not live long enough
+    fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() {
+        arg //~ ERROR lifetime may not live long enough
+    }
 }
 
 fn main() {}

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
@@ -9,8 +9,8 @@ LL |     fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn a<'a>(self: Pin<&'a Foo>, f: &'a Foo) -> &Foo { f }
-   |         ++++            ++           ++
+LL |     fn a<'a>(self: Pin<&'a Foo>, f: &'a Foo) -> &'a Foo { f }
+   |         ++++            ++           ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:9:69
@@ -23,8 +23,8 @@ LL |     fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, 
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn c<'a>(self: Pin<&'a Self>, f: &'a Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-   |         ++++            ++            ++
+LL |     fn c<'a>(self: Pin<&'a Self>, f: &'a Foo, g: &Foo) -> (Pin<&'a Foo>, &'a Foo) { (self, f) }
+   |         ++++            ++            ++                        ++        ++
 
 error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:15:58
@@ -36,8 +36,8 @@ LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn bar<'a>(self: Alias<&'a Self>, arg: &'a ()) -> &() { arg }
-   |                             ++
+LL |     fn bar<'a>(self: Alias<&'a Self>, arg: &'a ()) -> &'a () { arg }
+   |                             ++                         ++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
@@ -10,8 +10,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn a<'a>(self: Pin<&'a Foo>, f: &'a Foo) -> &'a Foo {
-   |         ++++            ++           ++          ++
+LL |     fn a<'a>(self: Pin<&Foo>, f: &'a Foo) -> &'a Foo {
+   |         ++++                      ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:14:9
@@ -25,8 +25,8 @@ LL |         (self, f)
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn c<'a>(self: Pin<&'a Self>, f: &'a Foo, g: &Foo) -> (Pin<&'a Foo>, &'a Foo) {
-   |         ++++            ++            ++                        ++        ++
+LL |     fn c<'a>(self: Pin<&Self>, f: &'a Foo, g: &Foo) -> (Pin<&'a Foo>, &'a Foo) {
+   |         ++++                       ++                        ++        ++
 
 error: lifetime may not live long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:21:9
@@ -40,8 +40,8 @@ LL |         arg
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn bar<'a>(self: Alias<&'a Self>, arg: &'a ()) -> &'a () {
-   |                             ++                         ++
+LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &'a () {
+   |                                                     ++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
@@ -1,42 +1,46 @@
 error: lifetime may not live long enough
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:6:46
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:7:9
    |
-LL |     fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-   |                    -         -               ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
-   |                    |         |
-   |                    |         let's call the lifetime of this reference `'1`
+LL |     fn a(self: Pin<&Foo>, f: &Foo) -> &Foo {
+   |                    -         - let's call the lifetime of this reference `'1`
+   |                    |
    |                    let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn a<'a>(self: Pin<&'a Foo>, f: &'a Foo) -> &'a Foo { f }
+LL |     fn a<'a>(self: Pin<&'a Foo>, f: &'a Foo) -> &'a Foo {
    |         ++++            ++           ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:12:69
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:14:9
    |
-LL |     fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-   |                    -          -                                     ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
-   |                    |          |
-   |                    |          let's call the lifetime of this reference `'1`
+LL |     fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) {
+   |                    -          - let's call the lifetime of this reference `'1`
+   |                    |
    |                    let's call the lifetime of this reference `'2`
+LL |         (self, f)
+   |         ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn c<'a>(self: Pin<&'a Self>, f: &'a Foo, g: &Foo) -> (Pin<&'a Foo>, &'a Foo) { (self, f) }
+LL |     fn c<'a>(self: Pin<&'a Self>, f: &'a Foo, g: &Foo) -> (Pin<&'a Foo>, &'a Foo) {
    |         ++++            ++            ++                        ++        ++
 
 error: lifetime may not live long enough
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:18:58
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:21:9
    |
-LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
-   |            --  ---- has type `Pin<&'1 Foo>`              ^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
+LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() {
+   |            --  ---- has type `Pin<&'1 Foo>`
    |            |
    |            lifetime `'a` defined here
+LL |         arg
+   |         ^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn bar<'a>(self: Alias<&'a Self>, arg: &'a ()) -> &'a () { arg }
+LL |     fn bar<'a>(self: Alias<&'a Self>, arg: &'a ()) -> &'a () {
    |                             ++                         ++
 
 error: aborting due to 3 previous errors

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
@@ -33,6 +33,11 @@ LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
    |            --  ---- has type `Pin<&'1 Foo>`              ^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
    |            |
    |            lifetime `'a` defined here
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     fn bar<'a>(self: Alias<&'a Self>, arg: &'a ()) -> &() { arg }
+   |                             ++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
@@ -13,7 +13,7 @@ LL |     fn a<'a>(self: Pin<&'a Foo>, f: &'a Foo) -> &'a Foo { f }
    |         ++++            ++           ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:9:69
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:12:69
    |
 LL |     fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
    |                    -          -                                     ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -27,7 +27,7 @@ LL |     fn c<'a>(self: Pin<&'a Self>, f: &'a Foo, g: &Foo) -> (Pin<&'a Foo>, &'
    |         ++++            ++            ++                        ++        ++
 
 error: lifetime may not live long enough
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:15:58
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:18:58
    |
 LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
    |            --  ---- has type `Pin<&'1 Foo>`              ^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
@@ -38,7 +38,7 @@ LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() {
 LL |         arg
    |         ^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
    |
-help: consider introducing a named lifetime parameter and update trait if needed
+help: consider reusing a named lifetime parameter and update trait if needed
    |
 LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &'a () {
    |                                                     ++

--- a/tests/ui/self/elision/lt-ref-self-async.fixed
+++ b/tests/ui/self/elision/lt-ref-self-async.fixed
@@ -4,7 +4,9 @@
 
 use std::pin::Pin;
 
-struct Struct<'a> { data: &'a u32 }
+struct Struct<'a> {
+    data: &'a u32,
+}
 
 impl<'a> Struct<'a> {
     // Test using `&self` sugar:
@@ -42,4 +44,4 @@ impl<'a> Struct<'a> {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/lt-ref-self-async.fixed
+++ b/tests/ui/self/elision/lt-ref-self-async.fixed
@@ -9,34 +9,34 @@ struct Struct<'a> { data: &'a u32 }
 impl<'a> Struct<'a> {
     // Test using `&self` sugar:
 
-    async fn ref_self(&self, f: &u32) -> &u32 {
+    async fn ref_self<'b>(&'b self, f: &'b u32) -> &u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
     // Test using `&Self` explicitly:
 
-    async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+    async fn ref_Self<'b>(self: &'b Self, f: &'b u32) -> &u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+    async fn box_ref_Self<'b>(self: Box<&'b Self>, f: &'b u32) -> &u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+    async fn pin_ref_Self<'b>(self: Pin<&'b Self>, f: &'b u32) -> &u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+    async fn box_box_ref_Self<'b>(self: Box<Box<&'b Self>>, f: &'b u32) -> &u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+    async fn box_pin_Self<'b>(self: Box<Pin<&'b Self>>, f: &'b u32) -> &u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/lt-ref-self-async.rs
+++ b/tests/ui/self/elision/lt-ref-self-async.rs
@@ -4,7 +4,9 @@
 
 use std::pin::Pin;
 
-struct Struct<'a> { data: &'a u32 }
+struct Struct<'a> {
+    data: &'a u32,
+}
 
 impl<'a> Struct<'a> {
     // Test using `&self` sugar:
@@ -42,4 +44,4 @@ impl<'a> Struct<'a> {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/lt-ref-self-async.stderr
+++ b/tests/ui/self/elision/lt-ref-self-async.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self-async.rs:13:9
+  --> $DIR/lt-ref-self-async.rs:15:9
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       -         - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     async fn ref_self<'b>(&'b self, f: &'b u32) -> &u32 {
    |                      ++++  ++           ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self-async.rs:20:9
+  --> $DIR/lt-ref-self-async.rs:22:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             -         - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     async fn ref_Self<'b>(self: &'b Self, f: &'b u32) -> &u32 {
    |                      ++++        ++           ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self-async.rs:25:9
+  --> $DIR/lt-ref-self-async.rs:27:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     -          - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     async fn box_ref_Self<'b>(self: Box<&'b Self>, f: &'b u32) -> &u32 {
    |                          ++++            ++            ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self-async.rs:30:9
+  --> $DIR/lt-ref-self-async.rs:32:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     -          - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     async fn pin_ref_Self<'b>(self: Pin<&'b Self>, f: &'b u32) -> &u32 {
    |                          ++++            ++            ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self-async.rs:35:9
+  --> $DIR/lt-ref-self-async.rs:37:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             -           - let's call the lifetime of this reference `'1`
@@ -74,7 +74,7 @@ LL |     async fn box_box_ref_Self<'b>(self: Box<Box<&'b Self>>, f: &'b u32) -> 
    |                              ++++                ++             ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self-async.rs:40:9
+  --> $DIR/lt-ref-self-async.rs:42:9
    |
 LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                         -           - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/lt-ref-self-async.stderr
+++ b/tests/ui/self/elision/lt-ref-self-async.stderr
@@ -10,7 +10,7 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     async fn ref_self<'a>(&'a self, f: &'a u32) -> &u32 {
+LL |     async fn ref_self<'b>(&'b self, f: &'b u32) -> &u32 {
    |                      ++++  ++           ++
 
 error: lifetime may not live long enough
@@ -25,7 +25,7 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     async fn ref_Self<'a>(self: &'a Self, f: &'a u32) -> &u32 {
+LL |     async fn ref_Self<'b>(self: &'b Self, f: &'b u32) -> &u32 {
    |                      ++++        ++           ++
 
 error: lifetime may not live long enough
@@ -40,7 +40,7 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     async fn box_ref_Self<'a>(self: Box<&'a Self>, f: &'a u32) -> &u32 {
+LL |     async fn box_ref_Self<'b>(self: Box<&'b Self>, f: &'b u32) -> &u32 {
    |                          ++++            ++            ++
 
 error: lifetime may not live long enough
@@ -55,7 +55,7 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     async fn pin_ref_Self<'a>(self: Pin<&'a Self>, f: &'a u32) -> &u32 {
+LL |     async fn pin_ref_Self<'b>(self: Pin<&'b Self>, f: &'b u32) -> &u32 {
    |                          ++++            ++            ++
 
 error: lifetime may not live long enough
@@ -70,7 +70,7 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     async fn box_box_ref_Self<'a>(self: Box<Box<&'a Self>>, f: &'a u32) -> &u32 {
+LL |     async fn box_box_ref_Self<'b>(self: Box<Box<&'b Self>>, f: &'b u32) -> &u32 {
    |                              ++++                ++             ++
 
 error: lifetime may not live long enough
@@ -85,7 +85,7 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     async fn box_pin_Self<'a>(self: Box<Pin<&'a Self>>, f: &'a u32) -> &u32 {
+LL |     async fn box_pin_Self<'b>(self: Box<Pin<&'b Self>>, f: &'b u32) -> &u32 {
    |                          ++++                ++             ++
 
 error: aborting due to 6 previous errors

--- a/tests/ui/self/elision/lt-ref-self.fixed
+++ b/tests/ui/self/elision/lt-ref-self.fixed
@@ -10,34 +10,34 @@ struct Struct<'a> {
 impl<'a> Struct<'a> {
     // Test using `&self` sugar:
 
-    fn ref_self<'b>(&'b self, f: &'b u32) -> &'b u32 {
+    fn ref_self<'b>(&self, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
     // Test using `&Self` explicitly:
 
-    fn ref_Self<'b>(self: &'b Self, f: &'b u32) -> &'b u32 {
+    fn ref_Self<'b>(self: &Self, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_ref_Self<'b>(self: Box<&'b Self>, f: &'b u32) -> &'b u32 {
+    fn box_ref_Self<'b>(self: Box<&Self>, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn pin_ref_Self<'b>(self: Pin<&'b Self>, f: &'b u32) -> &'b u32 {
+    fn pin_ref_Self<'b>(self: Pin<&Self>, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_box_ref_Self<'b>(self: Box<Box<&'b Self>>, f: &'b u32) -> &'b u32 {
+    fn box_box_ref_Self<'b>(self: Box<Box<&Self>>, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_pin_Self<'b>(self: Box<Pin<&'b Self>>, f: &'b u32) -> &'b u32 {
+    fn box_pin_Self<'b>(self: Box<Pin<&Self>>, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/lt-ref-self.fixed
+++ b/tests/ui/self/elision/lt-ref-self.fixed
@@ -1,4 +1,3 @@
-//@ edition:2018
 //@ run-rustfix
 #![allow(non_snake_case, dead_code)]
 
@@ -9,34 +8,34 @@ struct Struct<'a> { data: &'a u32 }
 impl<'a> Struct<'a> {
     // Test using `&self` sugar:
 
-    async fn ref_self(&self, f: &u32) -> &u32 {
+    fn ref_self<'b>(&'b self, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
     // Test using `&Self` explicitly:
 
-    async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+    fn ref_Self<'b>(self: &'b Self, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+    fn box_ref_Self<'b>(self: Box<&'b Self>, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+    fn pin_ref_Self<'b>(self: Pin<&'b Self>, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+    fn box_box_ref_Self<'b>(self: Box<Box<&'b Self>>, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+    fn box_pin_Self<'b>(self: Box<Pin<&'b Self>>, f: &'b u32) -> &'b u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/lt-ref-self.fixed
+++ b/tests/ui/self/elision/lt-ref-self.fixed
@@ -3,7 +3,9 @@
 
 use std::pin::Pin;
 
-struct Struct<'a> { data: &'a u32 }
+struct Struct<'a> {
+    data: &'a u32,
+}
 
 impl<'a> Struct<'a> {
     // Test using `&self` sugar:
@@ -41,4 +43,4 @@ impl<'a> Struct<'a> {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/lt-ref-self.rs
+++ b/tests/ui/self/elision/lt-ref-self.rs
@@ -1,4 +1,5 @@
-#![allow(non_snake_case)]
+//@ run-rustfix
+#![allow(non_snake_case, dead_code)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/lt-ref-self.rs
+++ b/tests/ui/self/elision/lt-ref-self.rs
@@ -3,7 +3,9 @@
 
 use std::pin::Pin;
 
-struct Struct<'a> { data: &'a u32 }
+struct Struct<'a> {
+    data: &'a u32,
+}
 
 impl<'a> Struct<'a> {
     // Test using `&self` sugar:
@@ -41,4 +43,4 @@ impl<'a> Struct<'a> {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/lt-ref-self.stderr
+++ b/tests/ui/self/elision/lt-ref-self.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:11:9
+  --> $DIR/lt-ref-self.rs:12:9
    |
 LL |     fn ref_self(&self, f: &u32) -> &u32 {
    |                 -         - let's call the lifetime of this reference `'1`
@@ -10,11 +10,11 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_self<'a>(&'a self, f: &'a u32) -> &'a u32 {
+LL |     fn ref_self<'b>(&'b self, f: &'b u32) -> &'b u32 {
    |                ++++  ++           ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:18:9
+  --> $DIR/lt-ref-self.rs:19:9
    |
 LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                       -         - let's call the lifetime of this reference `'1`
@@ -25,11 +25,11 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_Self<'a>(self: &'a Self, f: &'a u32) -> &'a u32 {
+LL |     fn ref_Self<'b>(self: &'b Self, f: &'b u32) -> &'b u32 {
    |                ++++        ++           ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:23:9
+  --> $DIR/lt-ref-self.rs:24:9
    |
 LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -40,11 +40,11 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_ref_Self<'a>(self: Box<&'a Self>, f: &'a u32) -> &'a u32 {
+LL |     fn box_ref_Self<'b>(self: Box<&'b Self>, f: &'b u32) -> &'b u32 {
    |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:28:9
+  --> $DIR/lt-ref-self.rs:29:9
    |
 LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -55,11 +55,11 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn pin_ref_Self<'a>(self: Pin<&'a Self>, f: &'a u32) -> &'a u32 {
+LL |     fn pin_ref_Self<'b>(self: Pin<&'b Self>, f: &'b u32) -> &'b u32 {
    |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:33:9
+  --> $DIR/lt-ref-self.rs:34:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                       -           - let's call the lifetime of this reference `'1`
@@ -70,11 +70,11 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a Self>>, f: &'a u32) -> &'a u32 {
+LL |     fn box_box_ref_Self<'b>(self: Box<Box<&'b Self>>, f: &'b u32) -> &'b u32 {
    |                        ++++                ++             ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:38:9
+  --> $DIR/lt-ref-self.rs:39:9
    |
 LL |     fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                   -           - let's call the lifetime of this reference `'1`
@@ -85,7 +85,7 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_pin_Self<'a>(self: Box<Pin<&'a Self>>, f: &'a u32) -> &'a u32 {
+LL |     fn box_pin_Self<'b>(self: Box<Pin<&'b Self>>, f: &'b u32) -> &'b u32 {
    |                    ++++                ++             ++          ++
 
 error: aborting due to 6 previous errors

--- a/tests/ui/self/elision/lt-ref-self.stderr
+++ b/tests/ui/self/elision/lt-ref-self.stderr
@@ -10,8 +10,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_self<'b>(&'b self, f: &'b u32) -> &'b u32 {
-   |                ++++  ++           ++          ++
+LL |     fn ref_self<'b>(&self, f: &'b u32) -> &'b u32 {
+   |                ++++            ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:21:9
@@ -25,8 +25,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_Self<'b>(self: &'b Self, f: &'b u32) -> &'b u32 {
-   |                ++++        ++           ++          ++
+LL |     fn ref_Self<'b>(self: &Self, f: &'b u32) -> &'b u32 {
+   |                ++++                  ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:26:9
@@ -40,8 +40,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_ref_Self<'b>(self: Box<&'b Self>, f: &'b u32) -> &'b u32 {
-   |                    ++++            ++            ++          ++
+LL |     fn box_ref_Self<'b>(self: Box<&Self>, f: &'b u32) -> &'b u32 {
+   |                    ++++                       ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:31:9
@@ -55,8 +55,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn pin_ref_Self<'b>(self: Pin<&'b Self>, f: &'b u32) -> &'b u32 {
-   |                    ++++            ++            ++          ++
+LL |     fn pin_ref_Self<'b>(self: Pin<&Self>, f: &'b u32) -> &'b u32 {
+   |                    ++++                       ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:36:9
@@ -70,8 +70,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_box_ref_Self<'b>(self: Box<Box<&'b Self>>, f: &'b u32) -> &'b u32 {
-   |                        ++++                ++             ++          ++
+LL |     fn box_box_ref_Self<'b>(self: Box<Box<&Self>>, f: &'b u32) -> &'b u32 {
+   |                        ++++                            ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:41:9
@@ -85,8 +85,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_pin_Self<'b>(self: Box<Pin<&'b Self>>, f: &'b u32) -> &'b u32 {
-   |                    ++++                ++             ++          ++
+LL |     fn box_pin_Self<'b>(self: Box<Pin<&Self>>, f: &'b u32) -> &'b u32 {
+   |                    ++++                            ++          ++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/self/elision/lt-ref-self.stderr
+++ b/tests/ui/self/elision/lt-ref-self.stderr
@@ -10,8 +10,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_self<'a>(&'a self, f: &'a u32) -> &u32 {
-   |                ++++  ++           ++
+LL |     fn ref_self<'a>(&'a self, f: &'a u32) -> &'a u32 {
+   |                ++++  ++           ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:18:9
@@ -25,8 +25,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_Self<'a>(self: &'a Self, f: &'a u32) -> &u32 {
-   |                ++++        ++           ++
+LL |     fn ref_Self<'a>(self: &'a Self, f: &'a u32) -> &'a u32 {
+   |                ++++        ++           ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:23:9
@@ -40,8 +40,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_ref_Self<'a>(self: Box<&'a Self>, f: &'a u32) -> &u32 {
-   |                    ++++            ++            ++
+LL |     fn box_ref_Self<'a>(self: Box<&'a Self>, f: &'a u32) -> &'a u32 {
+   |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:28:9
@@ -55,8 +55,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn pin_ref_Self<'a>(self: Pin<&'a Self>, f: &'a u32) -> &u32 {
-   |                    ++++            ++            ++
+LL |     fn pin_ref_Self<'a>(self: Pin<&'a Self>, f: &'a u32) -> &'a u32 {
+   |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:33:9
@@ -70,8 +70,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a Self>>, f: &'a u32) -> &u32 {
-   |                        ++++                ++             ++
+LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a Self>>, f: &'a u32) -> &'a u32 {
+   |                        ++++                ++             ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/lt-ref-self.rs:38:9
@@ -85,8 +85,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_pin_Self<'a>(self: Box<Pin<&'a Self>>, f: &'a u32) -> &u32 {
-   |                    ++++                ++             ++
+LL |     fn box_pin_Self<'a>(self: Box<Pin<&'a Self>>, f: &'a u32) -> &'a u32 {
+   |                    ++++                ++             ++          ++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/self/elision/lt-ref-self.stderr
+++ b/tests/ui/self/elision/lt-ref-self.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:12:9
+  --> $DIR/lt-ref-self.rs:14:9
    |
 LL |     fn ref_self(&self, f: &u32) -> &u32 {
    |                 -         - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn ref_self<'b>(&'b self, f: &'b u32) -> &'b u32 {
    |                ++++  ++           ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:19:9
+  --> $DIR/lt-ref-self.rs:21:9
    |
 LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                       -         - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn ref_Self<'b>(self: &'b Self, f: &'b u32) -> &'b u32 {
    |                ++++        ++           ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:24:9
+  --> $DIR/lt-ref-self.rs:26:9
    |
 LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     fn box_ref_Self<'b>(self: Box<&'b Self>, f: &'b u32) -> &'b u32 {
    |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:29:9
+  --> $DIR/lt-ref-self.rs:31:9
    |
 LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     fn pin_ref_Self<'b>(self: Pin<&'b Self>, f: &'b u32) -> &'b u32 {
    |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:34:9
+  --> $DIR/lt-ref-self.rs:36:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                       -           - let's call the lifetime of this reference `'1`
@@ -74,7 +74,7 @@ LL |     fn box_box_ref_Self<'b>(self: Box<Box<&'b Self>>, f: &'b u32) -> &'b u3
    |                        ++++                ++             ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/lt-ref-self.rs:39:9
+  --> $DIR/lt-ref-self.rs:41:9
    |
 LL |     fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                   -           - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-mut-self.fixed
+++ b/tests/ui/self/elision/ref-mut-self.fixed
@@ -3,7 +3,7 @@
 
 use std::pin::Pin;
 
-struct Struct { }
+struct Struct {}
 
 impl Struct {
     // Test using `&mut self` sugar:
@@ -41,4 +41,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/ref-mut-self.fixed
+++ b/tests/ui/self/elision/ref-mut-self.fixed
@@ -8,34 +8,34 @@ struct Struct {}
 impl Struct {
     // Test using `&mut self` sugar:
 
-    fn ref_self<'a>(&'a mut self, f: &'a u32) -> &'a u32 {
+    fn ref_self<'a>(&mut self, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
     // Test using `&mut Self` explicitly:
 
-    fn ref_Self<'a>(self: &'a mut Self, f: &'a u32) -> &'a u32 {
+    fn ref_Self<'a>(self: &mut Self, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_ref_Self<'a>(self: Box<&'a mut Self>, f: &'a u32) -> &'a u32 {
+    fn box_ref_Self<'a>(self: Box<&mut Self>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn pin_ref_Self<'a>(self: Pin<&'a mut Self>, f: &'a u32) -> &'a u32 {
+    fn pin_ref_Self<'a>(self: Pin<&mut Self>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_box_ref_Self<'a>(self: Box<Box<&'a mut Self>>, f: &'a u32) -> &'a u32 {
+    fn box_box_ref_Self<'a>(self: Box<Box<&mut Self>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_pin_ref_Self<'a>(self: Box<Pin<&'a mut Self>>, f: &'a u32) -> &'a u32 {
+    fn box_pin_ref_Self<'a>(self: Box<Pin<&mut Self>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/ref-mut-self.fixed
+++ b/tests/ui/self/elision/ref-mut-self.fixed
@@ -8,34 +8,34 @@ struct Struct { }
 impl Struct {
     // Test using `&mut self` sugar:
 
-    fn ref_self(&mut self, f: &u32) -> &u32 {
+    fn ref_self<'a>(&'a mut self, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
     // Test using `&mut Self` explicitly:
 
-    fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
+    fn ref_Self<'a>(self: &'a mut Self, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
+    fn box_ref_Self<'a>(self: Box<&'a mut Self>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
+    fn pin_ref_Self<'a>(self: Pin<&'a mut Self>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
+    fn box_box_ref_Self<'a>(self: Box<Box<&'a mut Self>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
+    fn box_pin_ref_Self<'a>(self: Box<Pin<&'a mut Self>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/ref-mut-self.rs
+++ b/tests/ui/self/elision/ref-mut-self.rs
@@ -3,7 +3,7 @@
 
 use std::pin::Pin;
 
-struct Struct { }
+struct Struct {}
 
 impl Struct {
     // Test using `&mut self` sugar:
@@ -41,4 +41,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/ref-mut-self.stderr
+++ b/tests/ui/self/elision/ref-mut-self.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-self.rs:11:9
+  --> $DIR/ref-mut-self.rs:12:9
    |
 LL |     fn ref_self(&mut self, f: &u32) -> &u32 {
    |                 -             - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn ref_self<'a>(&'a mut self, f: &'a u32) -> &'a u32 {
    |                ++++  ++               ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-self.rs:18:9
+  --> $DIR/ref-mut-self.rs:19:9
    |
 LL |     fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
    |                       -             - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn ref_Self<'a>(self: &'a mut Self, f: &'a u32) -> &'a u32 {
    |                ++++        ++               ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-self.rs:23:9
+  --> $DIR/ref-mut-self.rs:24:9
    |
 LL |     fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
    |                               -              - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     fn box_ref_Self<'a>(self: Box<&'a mut Self>, f: &'a u32) -> &'a u32 {
    |                    ++++            ++                ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-self.rs:28:9
+  --> $DIR/ref-mut-self.rs:29:9
    |
 LL |     fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
    |                               -              - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     fn pin_ref_Self<'a>(self: Pin<&'a mut Self>, f: &'a u32) -> &'a u32 {
    |                    ++++            ++                ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-self.rs:33:9
+  --> $DIR/ref-mut-self.rs:34:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
    |                                       -               - let's call the lifetime of this reference `'1`
@@ -74,7 +74,7 @@ LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a mut Self>>, f: &'a u32) -> &'
    |                        ++++                ++                 ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-self.rs:38:9
+  --> $DIR/ref-mut-self.rs:39:9
    |
 LL |     fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
    |                                       -               - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-mut-self.stderr
+++ b/tests/ui/self/elision/ref-mut-self.stderr
@@ -10,8 +10,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_self<'a>(&'a mut self, f: &'a u32) -> &'a u32 {
-   |                ++++  ++               ++          ++
+LL |     fn ref_self<'a>(&mut self, f: &'a u32) -> &'a u32 {
+   |                ++++                ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:19:9
@@ -25,8 +25,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_Self<'a>(self: &'a mut Self, f: &'a u32) -> &'a u32 {
-   |                ++++        ++               ++          ++
+LL |     fn ref_Self<'a>(self: &mut Self, f: &'a u32) -> &'a u32 {
+   |                ++++                      ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:24:9
@@ -40,8 +40,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_ref_Self<'a>(self: Box<&'a mut Self>, f: &'a u32) -> &'a u32 {
-   |                    ++++            ++                ++          ++
+LL |     fn box_ref_Self<'a>(self: Box<&mut Self>, f: &'a u32) -> &'a u32 {
+   |                    ++++                           ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:29:9
@@ -55,8 +55,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn pin_ref_Self<'a>(self: Pin<&'a mut Self>, f: &'a u32) -> &'a u32 {
-   |                    ++++            ++                ++          ++
+LL |     fn pin_ref_Self<'a>(self: Pin<&mut Self>, f: &'a u32) -> &'a u32 {
+   |                    ++++                           ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:34:9
@@ -70,8 +70,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a mut Self>>, f: &'a u32) -> &'a u32 {
-   |                        ++++                ++                 ++          ++
+LL |     fn box_box_ref_Self<'a>(self: Box<Box<&mut Self>>, f: &'a u32) -> &'a u32 {
+   |                        ++++                                ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:39:9
@@ -85,8 +85,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&'a mut Self>>, f: &'a u32) -> &'a u32 {
-   |                        ++++                ++                 ++          ++
+LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&mut Self>>, f: &'a u32) -> &'a u32 {
+   |                        ++++                                ++          ++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/self/elision/ref-mut-self.stderr
+++ b/tests/ui/self/elision/ref-mut-self.stderr
@@ -10,8 +10,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_self<'a>(&'a mut self, f: &'a u32) -> &u32 {
-   |                ++++  ++               ++
+LL |     fn ref_self<'a>(&'a mut self, f: &'a u32) -> &'a u32 {
+   |                ++++  ++               ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:18:9
@@ -25,8 +25,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_Self<'a>(self: &'a mut Self, f: &'a u32) -> &u32 {
-   |                ++++        ++               ++
+LL |     fn ref_Self<'a>(self: &'a mut Self, f: &'a u32) -> &'a u32 {
+   |                ++++        ++               ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:23:9
@@ -40,8 +40,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_ref_Self<'a>(self: Box<&'a mut Self>, f: &'a u32) -> &u32 {
-   |                    ++++            ++                ++
+LL |     fn box_ref_Self<'a>(self: Box<&'a mut Self>, f: &'a u32) -> &'a u32 {
+   |                    ++++            ++                ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:28:9
@@ -55,8 +55,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn pin_ref_Self<'a>(self: Pin<&'a mut Self>, f: &'a u32) -> &u32 {
-   |                    ++++            ++                ++
+LL |     fn pin_ref_Self<'a>(self: Pin<&'a mut Self>, f: &'a u32) -> &'a u32 {
+   |                    ++++            ++                ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:33:9
@@ -70,8 +70,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a mut Self>>, f: &'a u32) -> &u32 {
-   |                        ++++                ++                 ++
+LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a mut Self>>, f: &'a u32) -> &'a u32 {
+   |                        ++++                ++                 ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-self.rs:38:9
@@ -85,8 +85,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&'a mut Self>>, f: &'a u32) -> &u32 {
-   |                        ++++                ++                 ++
+LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&'a mut Self>>, f: &'a u32) -> &'a u32 {
+   |                        ++++                ++                 ++          ++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/self/elision/ref-mut-struct.fixed
+++ b/tests/ui/self/elision/ref-mut-struct.fixed
@@ -8,27 +8,27 @@ struct Struct { }
 impl Struct {
     // Test using `&mut Struct` explicitly:
 
-    fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
+    fn ref_Struct<'a>(self: &'a mut Struct, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
+    fn box_ref_Struct<'a>(self: Box<&'a mut Struct>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
+    fn pin_ref_Struct<'a>(self: Pin<&'a mut Struct>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
+    fn box_box_ref_Struct<'a>(self: Box<Box<&'a mut Struct>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
+    fn box_pin_ref_Struct<'a>(self: Box<Pin<&'a mut Struct>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/ref-mut-struct.fixed
+++ b/tests/ui/self/elision/ref-mut-struct.fixed
@@ -3,7 +3,7 @@
 
 use std::pin::Pin;
 
-struct Struct { }
+struct Struct {}
 
 impl Struct {
     // Test using `&mut Struct` explicitly:
@@ -34,4 +34,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/ref-mut-struct.fixed
+++ b/tests/ui/self/elision/ref-mut-struct.fixed
@@ -8,27 +8,27 @@ struct Struct {}
 impl Struct {
     // Test using `&mut Struct` explicitly:
 
-    fn ref_Struct<'a>(self: &'a mut Struct, f: &'a u32) -> &'a u32 {
+    fn ref_Struct<'a>(self: &mut Struct, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_ref_Struct<'a>(self: Box<&'a mut Struct>, f: &'a u32) -> &'a u32 {
+    fn box_ref_Struct<'a>(self: Box<&mut Struct>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn pin_ref_Struct<'a>(self: Pin<&'a mut Struct>, f: &'a u32) -> &'a u32 {
+    fn pin_ref_Struct<'a>(self: Pin<&mut Struct>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_box_ref_Struct<'a>(self: Box<Box<&'a mut Struct>>, f: &'a u32) -> &'a u32 {
+    fn box_box_ref_Struct<'a>(self: Box<Box<&mut Struct>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_pin_ref_Struct<'a>(self: Box<Pin<&'a mut Struct>>, f: &'a u32) -> &'a u32 {
+    fn box_pin_ref_Struct<'a>(self: Box<Pin<&mut Struct>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/ref-mut-struct.rs
+++ b/tests/ui/self/elision/ref-mut-struct.rs
@@ -3,7 +3,7 @@
 
 use std::pin::Pin;
 
-struct Struct { }
+struct Struct {}
 
 impl Struct {
     // Test using `&mut Struct` explicitly:
@@ -34,4 +34,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/ref-mut-struct.stderr
+++ b/tests/ui/self/elision/ref-mut-struct.stderr
@@ -10,8 +10,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_Struct<'a>(self: &'a mut Struct, f: &'a u32) -> &'a u32 {
-   |                  ++++        ++                 ++          ++
+LL |     fn ref_Struct<'a>(self: &mut Struct, f: &'a u32) -> &'a u32 {
+   |                  ++++                        ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:17:9
@@ -25,8 +25,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_ref_Struct<'a>(self: Box<&'a mut Struct>, f: &'a u32) -> &'a u32 {
-   |                      ++++            ++                  ++          ++
+LL |     fn box_ref_Struct<'a>(self: Box<&mut Struct>, f: &'a u32) -> &'a u32 {
+   |                      ++++                             ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:22:9
@@ -40,8 +40,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn pin_ref_Struct<'a>(self: Pin<&'a mut Struct>, f: &'a u32) -> &'a u32 {
-   |                      ++++            ++                  ++          ++
+LL |     fn pin_ref_Struct<'a>(self: Pin<&mut Struct>, f: &'a u32) -> &'a u32 {
+   |                      ++++                             ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:27:9
@@ -55,8 +55,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&'a mut Struct>>, f: &'a u32) -> &'a u32 {
-   |                          ++++                ++                   ++          ++
+LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&mut Struct>>, f: &'a u32) -> &'a u32 {
+   |                          ++++                                  ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:32:9
@@ -70,8 +70,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_pin_ref_Struct<'a>(self: Box<Pin<&'a mut Struct>>, f: &'a u32) -> &'a u32 {
-   |                          ++++                ++                   ++          ++
+LL |     fn box_pin_ref_Struct<'a>(self: Box<Pin<&mut Struct>>, f: &'a u32) -> &'a u32 {
+   |                          ++++                                  ++          ++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/self/elision/ref-mut-struct.stderr
+++ b/tests/ui/self/elision/ref-mut-struct.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct.rs:11:9
+  --> $DIR/ref-mut-struct.rs:12:9
    |
 LL |     fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                         -               - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn ref_Struct<'a>(self: &'a mut Struct, f: &'a u32) -> &'a u32 {
    |                  ++++        ++                 ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct.rs:16:9
+  --> $DIR/ref-mut-struct.rs:17:9
    |
 LL |     fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                 -                - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn box_ref_Struct<'a>(self: Box<&'a mut Struct>, f: &'a u32) -> &'a u32
    |                      ++++            ++                  ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct.rs:21:9
+  --> $DIR/ref-mut-struct.rs:22:9
    |
 LL |     fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                 -                - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     fn pin_ref_Struct<'a>(self: Pin<&'a mut Struct>, f: &'a u32) -> &'a u32
    |                      ++++            ++                  ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct.rs:26:9
+  --> $DIR/ref-mut-struct.rs:27:9
    |
 LL |     fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
    |                                         -                 - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&'a mut Struct>>, f: &'a u32) -
    |                          ++++                ++                   ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct.rs:31:9
+  --> $DIR/ref-mut-struct.rs:32:9
    |
 LL |     fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
    |                                         -                 - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-mut-struct.stderr
+++ b/tests/ui/self/elision/ref-mut-struct.stderr
@@ -10,8 +10,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_Struct<'a>(self: &'a mut Struct, f: &'a u32) -> &u32 {
-   |                  ++++        ++                 ++
+LL |     fn ref_Struct<'a>(self: &'a mut Struct, f: &'a u32) -> &'a u32 {
+   |                  ++++        ++                 ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:16:9
@@ -25,8 +25,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_ref_Struct<'a>(self: Box<&'a mut Struct>, f: &'a u32) -> &u32 {
-   |                      ++++            ++                  ++
+LL |     fn box_ref_Struct<'a>(self: Box<&'a mut Struct>, f: &'a u32) -> &'a u32 {
+   |                      ++++            ++                  ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:21:9
@@ -40,8 +40,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn pin_ref_Struct<'a>(self: Pin<&'a mut Struct>, f: &'a u32) -> &u32 {
-   |                      ++++            ++                  ++
+LL |     fn pin_ref_Struct<'a>(self: Pin<&'a mut Struct>, f: &'a u32) -> &'a u32 {
+   |                      ++++            ++                  ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:26:9
@@ -55,8 +55,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&'a mut Struct>>, f: &'a u32) -> &u32 {
-   |                          ++++                ++                   ++
+LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&'a mut Struct>>, f: &'a u32) -> &'a u32 {
+   |                          ++++                ++                   ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-mut-struct.rs:31:9
@@ -70,8 +70,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_pin_ref_Struct<'a>(self: Box<Pin<&'a mut Struct>>, f: &'a u32) -> &u32 {
-   |                          ++++                ++                   ++
+LL |     fn box_pin_ref_Struct<'a>(self: Box<Pin<&'a mut Struct>>, f: &'a u32) -> &'a u32 {
+   |                          ++++                ++                   ++          ++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/self/elision/ref-self.fixed
+++ b/tests/ui/self/elision/ref-self.fixed
@@ -12,7 +12,9 @@ struct Wrap<T, P>(T, PhantomData<P>);
 
 impl<T, P> Deref for Wrap<T, P> {
     type Target = T;
-    fn deref(&self) -> &T { &self.0 }
+    fn deref(&self) -> &T {
+        &self.0
+    }
 }
 
 impl Struct {
@@ -56,4 +58,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/ref-self.fixed
+++ b/tests/ui/self/elision/ref-self.fixed
@@ -20,39 +20,39 @@ impl<T, P> Deref for Wrap<T, P> {
 impl Struct {
     // Test using `&self` sugar:
 
-    fn ref_self<'a>(&'a self, f: &'a u32) -> &'a u32 {
+    fn ref_self<'a>(&self, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
     // Test using `&Self` explicitly:
 
-    fn ref_Self<'a>(self: &'a Self, f: &'a u32) -> &'a u32 {
+    fn ref_Self<'a>(self: &Self, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_ref_Self<'a>(self: Box<&'a Self>, f: &'a u32) -> &'a u32 {
+    fn box_ref_Self<'a>(self: Box<&Self>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn pin_ref_Self<'a>(self: Pin<&'a Self>, f: &'a u32) -> &'a u32 {
+    fn pin_ref_Self<'a>(self: Pin<&Self>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_box_ref_Self<'a>(self: Box<Box<&'a Self>>, f: &'a u32) -> &'a u32 {
+    fn box_box_ref_Self<'a>(self: Box<Box<&Self>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_pin_ref_Self<'a>(self: Box<Pin<&'a Self>>, f: &'a u32) -> &'a u32 {
+    fn box_pin_ref_Self<'a>(self: Box<Pin<&Self>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn wrap_ref_Self_Self<'a>(self: Wrap<&'a Self, Self>, f: &'a u8) -> &'a u8 {
+    fn wrap_ref_Self_Self<'a>(self: Wrap<&Self, Self>, f: &'a u8) -> &'a u8 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/ref-self.fixed
+++ b/tests/ui/self/elision/ref-self.fixed
@@ -18,39 +18,39 @@ impl<T, P> Deref for Wrap<T, P> {
 impl Struct {
     // Test using `&self` sugar:
 
-    fn ref_self(&self, f: &u32) -> &u32 {
+    fn ref_self<'a>(&'a self, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
     // Test using `&Self` explicitly:
 
-    fn ref_Self(self: &Self, f: &u32) -> &u32 {
+    fn ref_Self<'a>(self: &'a Self, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+    fn box_ref_Self<'a>(self: Box<&'a Self>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+    fn pin_ref_Self<'a>(self: Pin<&'a Self>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+    fn box_box_ref_Self<'a>(self: Box<Box<&'a Self>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+    fn box_pin_ref_Self<'a>(self: Box<Pin<&'a Self>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
+    fn wrap_ref_Self_Self<'a>(self: Wrap<&'a Self, Self>, f: &'a u8) -> &'a u8 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/ref-self.rs
+++ b/tests/ui/self/elision/ref-self.rs
@@ -12,7 +12,9 @@ struct Wrap<T, P>(T, PhantomData<P>);
 
 impl<T, P> Deref for Wrap<T, P> {
     type Target = T;
-    fn deref(&self) -> &T { &self.0 }
+    fn deref(&self) -> &T {
+        &self.0
+    }
 }
 
 impl Struct {
@@ -56,4 +58,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/ref-self.stderr
+++ b/tests/ui/self/elision/ref-self.stderr
@@ -10,8 +10,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_self<'a>(&'a self, f: &'a u32) -> &'a u32 {
-   |                ++++  ++           ++          ++
+LL |     fn ref_self<'a>(&self, f: &'a u32) -> &'a u32 {
+   |                ++++            ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:31:9
@@ -25,8 +25,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_Self<'a>(self: &'a Self, f: &'a u32) -> &'a u32 {
-   |                ++++        ++           ++          ++
+LL |     fn ref_Self<'a>(self: &Self, f: &'a u32) -> &'a u32 {
+   |                ++++                  ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:36:9
@@ -40,8 +40,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_ref_Self<'a>(self: Box<&'a Self>, f: &'a u32) -> &'a u32 {
-   |                    ++++            ++            ++          ++
+LL |     fn box_ref_Self<'a>(self: Box<&Self>, f: &'a u32) -> &'a u32 {
+   |                    ++++                       ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:41:9
@@ -55,8 +55,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn pin_ref_Self<'a>(self: Pin<&'a Self>, f: &'a u32) -> &'a u32 {
-   |                    ++++            ++            ++          ++
+LL |     fn pin_ref_Self<'a>(self: Pin<&Self>, f: &'a u32) -> &'a u32 {
+   |                    ++++                       ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:46:9
@@ -70,8 +70,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a Self>>, f: &'a u32) -> &'a u32 {
-   |                        ++++                ++             ++          ++
+LL |     fn box_box_ref_Self<'a>(self: Box<Box<&Self>>, f: &'a u32) -> &'a u32 {
+   |                        ++++                            ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:51:9
@@ -85,8 +85,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&'a Self>>, f: &'a u32) -> &'a u32 {
-   |                        ++++                ++             ++          ++
+LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&Self>>, f: &'a u32) -> &'a u32 {
+   |                        ++++                            ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:56:9
@@ -100,8 +100,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn wrap_ref_Self_Self<'a>(self: Wrap<&'a Self, Self>, f: &'a u8) -> &'a u8 {
-   |                          ++++             ++                  ++         ++
+LL |     fn wrap_ref_Self_Self<'a>(self: Wrap<&Self, Self>, f: &'a u8) -> &'a u8 {
+   |                          ++++                              ++         ++
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/self/elision/ref-self.stderr
+++ b/tests/ui/self/elision/ref-self.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:22:9
+  --> $DIR/ref-self.rs:24:9
    |
 LL |     fn ref_self(&self, f: &u32) -> &u32 {
    |                 -         - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn ref_self<'a>(&'a self, f: &'a u32) -> &'a u32 {
    |                ++++  ++           ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:29:9
+  --> $DIR/ref-self.rs:31:9
    |
 LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                       -         - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn ref_Self<'a>(self: &'a Self, f: &'a u32) -> &'a u32 {
    |                ++++        ++           ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:34:9
+  --> $DIR/ref-self.rs:36:9
    |
 LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     fn box_ref_Self<'a>(self: Box<&'a Self>, f: &'a u32) -> &'a u32 {
    |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:39:9
+  --> $DIR/ref-self.rs:41:9
    |
 LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     fn pin_ref_Self<'a>(self: Pin<&'a Self>, f: &'a u32) -> &'a u32 {
    |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:44:9
+  --> $DIR/ref-self.rs:46:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                       -           - let's call the lifetime of this reference `'1`
@@ -74,7 +74,7 @@ LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a Self>>, f: &'a u32) -> &'a u3
    |                        ++++                ++             ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:49:9
+  --> $DIR/ref-self.rs:51:9
    |
 LL |     fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                       -           - let's call the lifetime of this reference `'1`
@@ -89,7 +89,7 @@ LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&'a Self>>, f: &'a u32) -> &'a u3
    |                        ++++                ++             ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:54:9
+  --> $DIR/ref-self.rs:56:9
    |
 LL |     fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                      -                - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-self.stderr
+++ b/tests/ui/self/elision/ref-self.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:21:9
+  --> $DIR/ref-self.rs:22:9
    |
 LL |     fn ref_self(&self, f: &u32) -> &u32 {
    |                 -         - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn ref_self<'a>(&'a self, f: &'a u32) -> &'a u32 {
    |                ++++  ++           ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:28:9
+  --> $DIR/ref-self.rs:29:9
    |
 LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                       -         - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn ref_Self<'a>(self: &'a Self, f: &'a u32) -> &'a u32 {
    |                ++++        ++           ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:33:9
+  --> $DIR/ref-self.rs:34:9
    |
 LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     fn box_ref_Self<'a>(self: Box<&'a Self>, f: &'a u32) -> &'a u32 {
    |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:38:9
+  --> $DIR/ref-self.rs:39:9
    |
 LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     fn pin_ref_Self<'a>(self: Pin<&'a Self>, f: &'a u32) -> &'a u32 {
    |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:43:9
+  --> $DIR/ref-self.rs:44:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                       -           - let's call the lifetime of this reference `'1`
@@ -74,7 +74,7 @@ LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a Self>>, f: &'a u32) -> &'a u3
    |                        ++++                ++             ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:48:9
+  --> $DIR/ref-self.rs:49:9
    |
 LL |     fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                       -           - let's call the lifetime of this reference `'1`
@@ -89,7 +89,7 @@ LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&'a Self>>, f: &'a u32) -> &'a u3
    |                        ++++                ++             ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:53:9
+  --> $DIR/ref-self.rs:54:9
    |
 LL |     fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                      -                - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-self.stderr
+++ b/tests/ui/self/elision/ref-self.stderr
@@ -10,8 +10,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_self<'a>(&'a self, f: &'a u32) -> &u32 {
-   |                ++++  ++           ++
+LL |     fn ref_self<'a>(&'a self, f: &'a u32) -> &'a u32 {
+   |                ++++  ++           ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:28:9
@@ -25,8 +25,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_Self<'a>(self: &'a Self, f: &'a u32) -> &u32 {
-   |                ++++        ++           ++
+LL |     fn ref_Self<'a>(self: &'a Self, f: &'a u32) -> &'a u32 {
+   |                ++++        ++           ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:33:9
@@ -40,8 +40,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_ref_Self<'a>(self: Box<&'a Self>, f: &'a u32) -> &u32 {
-   |                    ++++            ++            ++
+LL |     fn box_ref_Self<'a>(self: Box<&'a Self>, f: &'a u32) -> &'a u32 {
+   |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:38:9
@@ -55,8 +55,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn pin_ref_Self<'a>(self: Pin<&'a Self>, f: &'a u32) -> &u32 {
-   |                    ++++            ++            ++
+LL |     fn pin_ref_Self<'a>(self: Pin<&'a Self>, f: &'a u32) -> &'a u32 {
+   |                    ++++            ++            ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:43:9
@@ -70,8 +70,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a Self>>, f: &'a u32) -> &u32 {
-   |                        ++++                ++             ++
+LL |     fn box_box_ref_Self<'a>(self: Box<Box<&'a Self>>, f: &'a u32) -> &'a u32 {
+   |                        ++++                ++             ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:48:9
@@ -85,8 +85,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&'a Self>>, f: &'a u32) -> &u32 {
-   |                        ++++                ++             ++
+LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&'a Self>>, f: &'a u32) -> &'a u32 {
+   |                        ++++                ++             ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-self.rs:53:9
@@ -100,8 +100,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn wrap_ref_Self_Self<'a>(self: Wrap<&'a Self, Self>, f: &'a u8) -> &u8 {
-   |                          ++++             ++                  ++
+LL |     fn wrap_ref_Self_Self<'a>(self: Wrap<&'a Self, Self>, f: &'a u8) -> &'a u8 {
+   |                          ++++             ++                  ++         ++
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/self/elision/ref-struct.fixed
+++ b/tests/ui/self/elision/ref-struct.fixed
@@ -8,27 +8,27 @@ struct Struct {}
 impl Struct {
     // Test using `&Struct` explicitly:
 
-    fn ref_Struct<'a>(self: &'a Struct, f: &'a u32) -> &'a u32 {
+    fn ref_Struct<'a>(self: &Struct, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_ref_Struct<'a>(self: Box<&'a Struct>, f: &'a u32) -> &'a u32 {
+    fn box_ref_Struct<'a>(self: Box<&Struct>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn pin_ref_Struct<'a>(self: Pin<&'a Struct>, f: &'a u32) -> &'a u32 {
+    fn pin_ref_Struct<'a>(self: Pin<&Struct>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_box_ref_Struct<'a>(self: Box<Box<&'a Struct>>, f: &'a u32) -> &'a u32 {
+    fn box_box_ref_Struct<'a>(self: Box<Box<&Struct>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_pin_Struct<'a>(self: Box<Pin<&'a Struct>>, f: &'a u32) -> &'a u32 {
+    fn box_pin_Struct<'a>(self: Box<Pin<&Struct>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/ref-struct.fixed
+++ b/tests/ui/self/elision/ref-struct.fixed
@@ -6,29 +6,29 @@ use std::pin::Pin;
 struct Struct { }
 
 impl Struct {
-    // Test using `&mut Struct` explicitly:
+    // Test using `&Struct` explicitly:
 
-    fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
+    fn ref_Struct<'a>(self: &'a Struct, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
+    fn box_ref_Struct<'a>(self: Box<&'a Struct>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
+    fn pin_ref_Struct<'a>(self: Pin<&'a Struct>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
+    fn box_box_ref_Struct<'a>(self: Box<Box<&'a Struct>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }
 
-    fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
+    fn box_pin_Struct<'a>(self: Box<Pin<&'a Struct>>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/ref-struct.fixed
+++ b/tests/ui/self/elision/ref-struct.fixed
@@ -3,7 +3,7 @@
 
 use std::pin::Pin;
 
-struct Struct { }
+struct Struct {}
 
 impl Struct {
     // Test using `&Struct` explicitly:
@@ -34,4 +34,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/ref-struct.rs
+++ b/tests/ui/self/elision/ref-struct.rs
@@ -3,7 +3,7 @@
 
 use std::pin::Pin;
 
-struct Struct { }
+struct Struct {}
 
 impl Struct {
     // Test using `&Struct` explicitly:
@@ -34,4 +34,4 @@ impl Struct {
     }
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/self/elision/ref-struct.rs
+++ b/tests/ui/self/elision/ref-struct.rs
@@ -1,4 +1,5 @@
-#![allow(non_snake_case)]
+//@ run-rustfix
+#![allow(non_snake_case, dead_code)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-struct.stderr
+++ b/tests/ui/self/elision/ref-struct.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-struct.rs:11:9
+  --> $DIR/ref-struct.rs:12:9
    |
 LL |     fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                         -           - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn ref_Struct<'a>(self: &'a Struct, f: &'a u32) -> &'a u32 {
    |                  ++++        ++             ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct.rs:16:9
+  --> $DIR/ref-struct.rs:17:9
    |
 LL |     fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                 -            - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn box_ref_Struct<'a>(self: Box<&'a Struct>, f: &'a u32) -> &'a u32 {
    |                      ++++            ++              ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct.rs:21:9
+  --> $DIR/ref-struct.rs:22:9
    |
 LL |     fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                 -            - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     fn pin_ref_Struct<'a>(self: Pin<&'a Struct>, f: &'a u32) -> &'a u32 {
    |                      ++++            ++              ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct.rs:26:9
+  --> $DIR/ref-struct.rs:27:9
    |
 LL |     fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                         -             - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&'a Struct>>, f: &'a u32) -> &'
    |                          ++++                ++               ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct.rs:31:9
+  --> $DIR/ref-struct.rs:32:9
    |
 LL |     fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                     -             - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-struct.stderr
+++ b/tests/ui/self/elision/ref-struct.stderr
@@ -10,8 +10,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_Struct<'a>(self: &'a Struct, f: &'a u32) -> &u32 {
-   |                  ++++        ++             ++
+LL |     fn ref_Struct<'a>(self: &'a Struct, f: &'a u32) -> &'a u32 {
+   |                  ++++        ++             ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:16:9
@@ -25,8 +25,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_ref_Struct<'a>(self: Box<&'a Struct>, f: &'a u32) -> &u32 {
-   |                      ++++            ++              ++
+LL |     fn box_ref_Struct<'a>(self: Box<&'a Struct>, f: &'a u32) -> &'a u32 {
+   |                      ++++            ++              ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:21:9
@@ -40,8 +40,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn pin_ref_Struct<'a>(self: Pin<&'a Struct>, f: &'a u32) -> &u32 {
-   |                      ++++            ++              ++
+LL |     fn pin_ref_Struct<'a>(self: Pin<&'a Struct>, f: &'a u32) -> &'a u32 {
+   |                      ++++            ++              ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:26:9
@@ -55,8 +55,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&'a Struct>>, f: &'a u32) -> &u32 {
-   |                          ++++                ++               ++
+LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&'a Struct>>, f: &'a u32) -> &'a u32 {
+   |                          ++++                ++               ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:31:9
@@ -70,8 +70,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_pin_Struct<'a>(self: Box<Pin<&'a Struct>>, f: &'a u32) -> &u32 {
-   |                      ++++                ++               ++
+LL |     fn box_pin_Struct<'a>(self: Box<Pin<&'a Struct>>, f: &'a u32) -> &'a u32 {
+   |                      ++++                ++               ++          ++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/self/elision/ref-struct.stderr
+++ b/tests/ui/self/elision/ref-struct.stderr
@@ -10,8 +10,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn ref_Struct<'a>(self: &'a Struct, f: &'a u32) -> &'a u32 {
-   |                  ++++        ++             ++          ++
+LL |     fn ref_Struct<'a>(self: &Struct, f: &'a u32) -> &'a u32 {
+   |                  ++++                    ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:17:9
@@ -25,8 +25,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_ref_Struct<'a>(self: Box<&'a Struct>, f: &'a u32) -> &'a u32 {
-   |                      ++++            ++              ++          ++
+LL |     fn box_ref_Struct<'a>(self: Box<&Struct>, f: &'a u32) -> &'a u32 {
+   |                      ++++                         ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:22:9
@@ -40,8 +40,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn pin_ref_Struct<'a>(self: Pin<&'a Struct>, f: &'a u32) -> &'a u32 {
-   |                      ++++            ++              ++          ++
+LL |     fn pin_ref_Struct<'a>(self: Pin<&Struct>, f: &'a u32) -> &'a u32 {
+   |                      ++++                         ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:27:9
@@ -55,8 +55,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&'a Struct>>, f: &'a u32) -> &'a u32 {
-   |                          ++++                ++               ++          ++
+LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&Struct>>, f: &'a u32) -> &'a u32 {
+   |                          ++++                              ++          ++
 
 error: lifetime may not live long enough
   --> $DIR/ref-struct.rs:32:9
@@ -70,8 +70,8 @@ LL |         f
    |
 help: consider introducing a named lifetime parameter and update trait if needed
    |
-LL |     fn box_pin_Struct<'a>(self: Box<Pin<&'a Struct>>, f: &'a u32) -> &'a u32 {
-   |                      ++++                ++               ++          ++
+LL |     fn box_pin_Struct<'a>(self: Box<Pin<&Struct>>, f: &'a u32) -> &'a u32 {
+   |                      ++++                              ++          ++
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
```
error: lifetime may not live long enough
  --> $DIR/ex3-both-anon-regions-both-are-structs-2.rs:7:5
   |
LL | fn foo(mut x: Ref, y: Ref) {
   |        -----       - has type `Ref<'_, '1>`
   |        |
   |        has type `Ref<'_, '2>`
LL |     x.b = y.b;
   |     ^^^^^^^^^ assignment requires that `'1` must outlive `'2`
   |
help: consider introducing a named lifetime parameter
   |
LL | fn foo<'a>(mut x: Ref<'a, 'a>, y: Ref<'a, 'a>) {
   |       ++++           ++++++++        ++++++++
```

As can be seen above, it currently doesn't try to compare the `ty::Ty` lifetimes that diverged vs the `hir::Ty` to correctly suggest the following

```
help: consider introducing a named lifetime parameter
   |
LL | fn foo<'a>(mut x: Ref<'_, 'a>, y: Ref<'_, 'a>) {
   |       ++++           ++++++++        ++++++++
```

but I believe this to still be an improvement over the status quo.

Fix #40990.