### PR TITLE
Do not ICE on foreign malformed `diagnostic::on_unimplemented`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
@@ -499,12 +499,14 @@ impl<'tcx> OnUnimplementedDirective {
             }
 
             if is_diagnostic_namespace_variant {
-                tcx.emit_node_span_lint(
-                    UNKNOWN_OR_MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                    tcx.local_def_id_to_hir_id(item_def_id.expect_local()),
-                    vec![item.span()],
-                    MalformedOnUnimplementedAttrLint::new(item.span()),
-                );
+                if let Some(def_id) = item_def_id.as_local() {
+                    tcx.emit_node_span_lint(
+                        UNKNOWN_OR_MALFORMED_DIAGNOSTIC_ATTRIBUTES,
+                        tcx.local_def_id_to_hir_id(def_id),
+                        vec![item.span()],
+                        MalformedOnUnimplementedAttrLint::new(item.span()),
+                    );
+                }
             } else {
                 // nothing found
                 tcx.dcx().emit_err(NoValueInOnUnimplemented { span: item.span() });

--- a/tests/ui/diagnostic_namespace/auxiliary/bad_on_unimplemented.rs
+++ b/tests/ui/diagnostic_namespace/auxiliary/bad_on_unimplemented.rs
@@ -1,0 +1,2 @@
+#[diagnostic::on_unimplemented(aa = "broken")]
+pub trait Test {}

--- a/tests/ui/diagnostic_namespace/on_unimplemented_ice.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented_ice.rs
@@ -1,0 +1,17 @@
+//@ edition:2021
+//@ compile-flags:--test
+//@ aux-build:bad_on_unimplemented.rs
+
+// Do not ICE when encountering a malformed `#[diagnostic::on_unimplemented]` annotation in a
+// dependency when incorrectly used (#124651).
+
+extern crate bad_on_unimplemented;
+
+use bad_on_unimplemented::Test;
+
+fn breakage<T: Test>(_: T) {}
+
+#[test]
+fn test() {
+    breakage(1); //~ ERROR E0277
+}

--- a/tests/ui/diagnostic_namespace/on_unimplemented_ice.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented_ice.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `{integer}: Test` is not satisfied
+  --> $DIR/on_unimplemented_ice.rs:16:14
+   |
+LL |     breakage(1);
+   |     -------- ^ the trait `Test` is not implemented for `{integer}`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `breakage`
+  --> $DIR/on_unimplemented_ice.rs:12:16
+   |
+LL | fn breakage<T: Test>(_: T) {}
+   |                ^^^^ required by this bound in `breakage`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fix #124651.