### PR TITLE
Make `Bounds.clauses` private

### DIFF
--- a/compiler/rustc_hir_analysis/src/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/bounds.rs
@@ -23,7 +23,7 @@ use rustc_span::Span;
 /// include the self type (e.g., `trait_bounds`) but in others we do not
 #[derive(Default, PartialEq, Eq, Clone, Debug)]
 pub struct Bounds<'tcx> {
-    pub clauses: Vec<(ty::Clause<'tcx>, Span)>,
+    clauses: Vec<(ty::Clause<'tcx>, Span)>,
 }
 
 impl<'tcx> Bounds<'tcx> {


### PR DESCRIPTION
Construct it through `Bounds::default()`, then consume the clauses via the method `Bounds::clauses()`.

This helps with effects desugaring where `clauses()` is not only the clauses within the `clauses` field.