### PR TITLE
Canonicalize all nested goals together at once when making response

### DIFF
--- a/compiler/rustc_middle/src/traits/solve/inspect.rs
+++ b/compiler/rustc_middle/src/traits/solve/inspect.rs
@@ -116,7 +116,7 @@ impl Debug for Probe<'_> {
 pub enum ProbeStep<'tcx> {
     /// We added a goal to the `EvalCtxt` which will get proven
     /// the next time `EvalCtxt::try_evaluate_added_goals` is called.
-    AddGoal(GoalSource, CanonicalState<'tcx, Goal<'tcx, ty::Predicate<'tcx>>>),
+    AddGoal(GoalSource, Goal<'tcx, ty::Predicate<'tcx>>),
     /// The inside of a `EvalCtxt::try_evaluate_added_goals` call.
     EvaluateGoals(AddedGoalsEvaluation<'tcx>),
     /// A call to `probe` while proving the current goal. This is
@@ -128,7 +128,11 @@ pub enum ProbeStep<'tcx> {
     /// with the certainty of the `try_evaluate_added_goals` that is done within;
     /// if it's `Certainty::Yes`, then we can trust that the candidate is "finished"
     /// and we didn't force ambiguity for some reason.
-    MakeCanonicalResponse { shallow_certainty: Certainty },
+    MakeCanonicalResponse {
+        shallow_certainty: Certainty,
+        added_goals:
+            CanonicalState<'tcx, &'tcx ty::List<(GoalSource, Goal<'tcx, ty::Predicate<'tcx>>)>>,
+    },
 }
 
 /// What kind of probe we're in. In case the probe represents a candidate, or

--- a/compiler/rustc_middle/src/traits/solve/inspect/format.rs
+++ b/compiler/rustc_middle/src/traits/solve/inspect/format.rs
@@ -133,7 +133,7 @@ impl<'a, 'b> ProofTreeFormatter<'a, 'b> {
                     }
                     ProbeStep::EvaluateGoals(eval) => this.format_added_goals_evaluation(eval)?,
                     ProbeStep::NestedProbe(probe) => this.format_probe(probe)?,
-                    ProbeStep::MakeCanonicalResponse { shallow_certainty } => {
+                    ProbeStep::MakeCanonicalResponse { shallow_certainty, added_goals: _ } => {
                         writeln!(this.f, "EVALUATE GOALS AND MAKE RESPONSE: {shallow_certainty:?}")?
                     }
                 }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -4,6 +4,7 @@
 //! to help with the tedium.
 
 use crate::mir::interpret;
+use crate::traits::solve;
 use crate::ty::fold::{FallibleTypeFolder, TypeFoldable, TypeSuperFoldable};
 use crate::ty::print::{with_no_trimmed_paths, FmtPrinter, Printer};
 use crate::ty::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitor};
@@ -557,6 +558,17 @@ impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for &'tcx ty::List<ty::Const<'tcx>> {
         folder: &mut F,
     ) -> Result<Self, F::Error> {
         ty::util::fold_list(self, folder, |tcx, v| tcx.mk_const_list(v))
+    }
+}
+
+impl<'tcx> TypeFoldable<TyCtxt<'tcx>>
+    for &'tcx ty::List<(solve::GoalSource, solve::Goal<'tcx, ty::Predicate<'tcx>>)>
+{
+    fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
+        self,
+        folder: &mut F,
+    ) -> Result<Self, F::Error> {
+        ty::util::fold_list(self, folder, |tcx, v| tcx.mk_nested_goals(v))
     }
 }
 

--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -12,7 +12,6 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
-#![feature(rustdoc_internals)]
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
@@ -20,11 +19,14 @@
 #![feature(associated_type_defaults)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
+#![feature(coroutines)]
 #![feature(extract_if)]
 #![feature(if_let_guard)]
+#![feature(iter_from_coroutine)]
 #![feature(let_chains)]
-#![feature(option_take_if)]
 #![feature(never_type)]
+#![feature(option_take_if)]
+#![feature(rustdoc_internals)]
 #![feature(type_alias_impl_trait)]
 #![recursion_limit = "512"] // For rustdoc
 

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
@@ -90,7 +90,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         &mut self,
         certainty: Certainty,
     ) -> QueryResult<'tcx> {
-        self.inspect.make_canonical_response(certainty);
+        self.inspect.make_canonical_response(self.infcx, self.max_input_universe, certainty);
 
         let goals_certainty = self.try_evaluate_added_goals()?;
         assert_eq!(
@@ -444,5 +444,5 @@ pub(in crate::solve) fn instantiate_canonical_state<'tcx, T: TypeFoldable<TyCtxt
     let inspect::State { var_values, data } = state.instantiate(infcx.tcx, &instantiation);
 
     EvalCtxt::unify_query_var_values(infcx, param_env, orig_values, var_values);
-    data
+    infcx.resolve_vars_if_possible(data)
 }

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
@@ -462,13 +462,13 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
 
     #[instrument(level = "debug", skip(self))]
     pub(super) fn add_normalizes_to_goal(&mut self, goal: Goal<'tcx, ty::NormalizesTo<'tcx>>) {
-        self.inspect.add_normalizes_to_goal(self.infcx, self.max_input_universe, goal);
+        self.inspect.add_normalizes_to_goal(self.tcx(), goal);
         self.nested_goals.normalizes_to_goals.push(goal);
     }
 
     #[instrument(level = "debug", skip(self))]
     pub(super) fn add_goal(&mut self, source: GoalSource, goal: Goal<'tcx, ty::Predicate<'tcx>>) {
-        self.inspect.add_goal(self.infcx, self.max_input_universe, source, goal);
+        self.inspect.add_goal(source, goal);
         self.nested_goals.goals.push((source, goal));
     }
 


### PR DESCRIPTION
Since we canonicalize each added goal separately, any time we add two goals that should be linked by an inference variable *local* to our evaluation, they end up unlinked in the nested goals of a inspect candidate. For example,

```rust
impl<T, U> Foo for T
where
    T: Constrain<Output = U>,
    U: Bar,
{
}

impl Constrain for () {
    type Output = ();
}
```

when proving `(): Foo`, we expect two nested goals: `<() as Constrain>::Output = ?0` and `?0: Bar`. However, we end up actually instantiating the second goal as `?1: Bar`, leaving it totally unconstrained. This leads to anomalous states, such as a candidate with `Certainty::Yes` but with `Certainty::Maybe` in its nested goals❗

This PR aims to fix this problem by canonicalizing all of the nested goals all together at once, which means that we'll canonicalize any duplicated instances of a variable as a *single* variable.

r? lcnr