### PR TITLE
Fix ignored tests for formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -13,6 +13,12 @@ ignore = [
 
     # tests for now are not formatted, as they are sometimes pretty-printing constrained
     # (and generally rustfmt can move around comments in UI-testing incompatible ways)
+    "/tests/*",
+
+    # but we still want to format rmake.rs files in tests/run-make/ so we need to do this
+    # dance to avoid the parent directory from being excluded
+    "!/tests/run-make/",
+    "/tests/run-make/*/*.rs",
     "!/tests/run-make/*/rmake.rs",
 
     # do not format submodules


### PR DESCRIPTION
This PR fixes the ignored rules in `rustfmt.toml` that were changed in https://github.com/rust-lang/rust/pull/124613 to allow formatting `rmake.rs` but ended up allowing formatting every Rust files in `tests/`.

The fix is a bit involved since we need to workaround a [`.gitignore` pattern limitation](https://git-scm.com/docs/gitignore#_pattern_format):
> An optional prefix "!" which negates the pattern; any matching file excluded by a previous pattern will become included again. It is not possible to re-include a file if a parent directory of that file is excluded. Git doesn’t list excluded directories for performance reasons, so any patterns on contained files have no effect, no matter where they are defined.

Workaround using https://stackoverflow.com/a/5534865

I tested the fix by changing the formatting in an `rmake.rs` and UI test, and verifying that only the `rmake.rs` files were formatted.

Fixes https://github.com/rust-lang/rust/pull/124613#issuecomment-2094094670
cc @GuillaumeGomez
r? @onur-ozkan