### PR TITLE
Implement `do_not_recommend` in the new solver

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -518,7 +518,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // RFC 2397
     gated!(
         do_not_recommend, Normal, template!(Word), WarnFollowing,
-        EncodeCrossCrate::No, experimental!(do_not_recommend)
+        EncodeCrossCrate::Yes, experimental!(do_not_recommend)
     ),
 
     // `#[cfi_encoding = ""]`

--- a/tests/ui/diagnostic_namespace/do_not_recommend/simple.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/simple.current.stderr
@@ -1,0 +1,20 @@
+error[E0277]: the trait bound `*mut (): Foo` is not satisfied
+  --> $DIR/simple.rs:19:17
+   |
+LL |     needs_foo::<*mut ()>();
+   |                 ^^^^^^^ the trait `Send` is not implemented for `*mut ()`, which is required by `*mut (): Foo`
+   |
+note: required for `*mut ()` to implement `Foo`
+  --> $DIR/simple.rs:10:9
+   |
+LL | impl<T> Foo for T where T: Send {}
+   |         ^^^     ^          ---- unsatisfied trait bound introduced here
+note: required by a bound in `needs_foo`
+  --> $DIR/simple.rs:14:17
+   |
+LL | fn needs_foo<T: Foo>() {}
+   |                 ^^^ required by this bound in `needs_foo`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/diagnostic_namespace/do_not_recommend/simple.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/simple.next.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `*mut (): Foo` is not satisfied
+  --> $DIR/simple.rs:19:17
+   |
+LL |     needs_foo::<*mut ()>();
+   |                 ^^^^^^^ the trait `Foo` is not implemented for `*mut ()`
+   |
+note: required by a bound in `needs_foo`
+  --> $DIR/simple.rs:14:17
+   |
+LL | fn needs_foo<T: Foo>() {}
+   |                 ^^^ required by this bound in `needs_foo`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/diagnostic_namespace/do_not_recommend/simple.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/simple.rs
@@ -1,0 +1,23 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+#![feature(do_not_recommend)]
+
+trait Foo {}
+
+#[do_not_recommend]
+impl<T> Foo for T where T: Send {}
+//[current]~^ NOTE required for `*mut ()` to implement `Foo`
+//[current]~| NOTE unsatisfied trait bound introduced here
+
+fn needs_foo<T: Foo>() {}
+//~^ NOTE required by a bound in `needs_foo`
+//~| NOTE required by this bound in `needs_foo`
+
+fn main() {
+    needs_foo::<*mut ()>();
+    //~^ ERROR the trait bound `*mut (): Foo` is not satisfied
+    //[current]~| NOTE the trait `Send` is not implemented for `*mut ()`
+    //[next]~| NOTE the trait `Foo` is not implemented for `*mut ()`
+}


### PR DESCRIPTION
Put the test into `diagnostic_namespace` test folder even though it's not in the diagnostic namespace, because it should be soon.

r? lcnr
cc @weiznich 