### PR TITLE
Record impl args in the proof tree

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
@@ -888,8 +888,12 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         self.infcx.resolve_vars_if_possible(value)
     }
 
-    pub(super) fn fresh_args_for_item(&self, def_id: DefId) -> ty::GenericArgsRef<'tcx> {
-        self.infcx.fresh_args_for_item(DUMMY_SP, def_id)
+    pub(super) fn fresh_args_for_item(&mut self, def_id: DefId) -> ty::GenericArgsRef<'tcx> {
+        let args = self.infcx.fresh_args_for_item(DUMMY_SP, def_id);
+        for arg in args {
+            self.inspect.add_var_value(arg);
+        }
+        args
     }
 
     pub(super) fn translate_args(

--- a/tests/ui/traits/next-solver/diagnostics/point-at-failing-nested.rs
+++ b/tests/ui/traits/next-solver/diagnostics/point-at-failing-nested.rs
@@ -1,0 +1,24 @@
+//@ compile-flags: -Znext-solver
+
+trait Foo {}
+trait Bar {}
+trait Constrain {
+    type Output;
+}
+
+impl<T, U> Foo for T
+where
+    T: Constrain<Output = U>,
+    U: Bar,
+{
+}
+
+impl Constrain for () {
+    type Output = ();
+}
+
+fn needs_foo<T: Foo>() {}
+fn main() {
+    needs_foo::<()>();
+    //~^ the trait bound `(): Foo` is not satisfied
+}

--- a/tests/ui/traits/next-solver/diagnostics/point-at-failing-nested.stderr
+++ b/tests/ui/traits/next-solver/diagnostics/point-at-failing-nested.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `(): Foo` is not satisfied
+  --> $DIR/point-at-failing-nested.rs:22:17
+   |
+LL |     needs_foo::<()>();
+   |                 ^^ the trait `Bar` is not implemented for `()`, which is required by `(): Foo`
+   |
+note: required for `()` to implement `Foo`
+  --> $DIR/point-at-failing-nested.rs:9:12
+   |
+LL | impl<T, U> Foo for T
+   |            ^^^     ^
+...
+LL |     U: Bar,
+   |        --- unsatisfied trait bound introduced here
+note: required by a bound in `needs_foo`
+  --> $DIR/point-at-failing-nested.rs:20:17
+   |
+LL | fn needs_foo<T: Foo>() {}
+   |                 ^^^ required by this bound in `needs_foo`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Weren't recording these since they went through a different infcx method

r? lcnr