### PR TITLE
Prefer lower vtable candidates in select in new solver

### DIFF
--- a/tests/ui/traits/normalize-supertrait.rs
+++ b/tests/ui/traits/normalize-supertrait.rs
@@ -4,6 +4,9 @@
 // comparing the supertrait `Derived<()>` to the expected trait.
 
 //@ build-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
 
 trait Proj {
     type S;


### PR DESCRIPTION
Also, adjust the select visitor to only winnow when the *parent* goal is `Certainty::Yes`. This means that we won't winnow in cases when we have any ambiguous inference guidance from two candidates.

r? lcnr