### PR TITLE
Re-add `From<f16> for f64`

### DIFF
--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -165,8 +165,9 @@ impl_from!(u16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0"
 impl_from!(u32 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 
 // float -> float
-// FIXME(f16_f128): adding additional `From` impls for existing types breaks inference. See
-// <https://github.com/rust-lang/rust/issues/123824>
+// FIXME(f16_f128): adding additional `From<{float}>` impls to `f32` breaks inference. See
+// <https://github.com/rust-lang/rust/issues/123831>
+impl_from!(f16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(f16 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(f32 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(f32 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);


### PR DESCRIPTION
This impl was originally added in #122470 before being removed in #123830 due to #123831. However, the issue only affects `f32` (which currently only has one `From<{float}>` impl, `From<f32>`) as `f64` already has two `From<{float}>` impls (`From<f32>` and `From<f64>`) and is also the float literal fallback type anyway. Therefore it is safe to re-add `From<f16> for f64`.

This PR also updates the FIXME link to point to the open issue #123831 rather than the closed issue #123824.

Tracking issue: #116909

@rustbot label +F-f16_and_f128 +T-libs-api