### PR TITLE
[Experiment] Replace `unreachable_unchecked()` with `uninit().assume_init()` in `unwrap_unchecked()`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1037,7 +1037,7 @@ impl<T> Option<T> {
         match self {
             Some(val) => val,
             // SAFETY: the safety contract must be upheld by the caller.
-            None => unsafe { hint::unreachable_unchecked() },
+            None => unsafe { mem::MaybeUninit::uninit().assume_init() },
         }
     }
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -557,7 +557,7 @@ use crate::iter::{self, FusedIterator, TrustedLen};
 use crate::panicking::{panic, panic_display};
 use crate::pin::Pin;
 use crate::{
-    cmp, convert, hint, mem,
+    cmp, convert, mem,
     ops::{self, ControlFlow, Deref, DerefMut},
     slice,
 };
@@ -1037,7 +1037,7 @@ impl<T> Option<T> {
         match self {
             Some(val) => val,
             // SAFETY: the safety contract must be upheld by the caller.
-            None => unsafe { MaybeUninit::uninit().assume_init() },
+            None => unsafe { mem::MaybeUninit::uninit().assume_init() },
         }
     }
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1037,7 +1037,7 @@ impl<T> Option<T> {
         match self {
             Some(val) => val,
             // SAFETY: the safety contract must be upheld by the caller.
-            None => unsafe { mem::MaybeUninit::uninit().assume_init() },
+            None => unsafe { MaybeUninit::uninit().assume_init() },
         }
     }
 

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1460,7 +1460,7 @@ impl<T, E> Result<T, E> {
         match self {
             Ok(t) => t,
             // SAFETY: the safety contract must be upheld by the caller.
-            Err(_) => unsafe { hint::unreachable_unchecked() },
+            Err(_) => unsafe { mem::MaybeUninit::uninit().assume_init() },
         }
     }
 
@@ -1491,7 +1491,7 @@ impl<T, E> Result<T, E> {
         debug_assert!(self.is_err());
         match self {
             // SAFETY: the safety contract must be upheld by the caller.
-            Ok(_) => unsafe { hint::unreachable_unchecked() },
+            Ok(_) => unsafe { mem::MaybeUninit::uninit().assume_init() },
             Err(e) => e,
         }
     }

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -490,7 +490,7 @@
 
 use crate::iter::{self, FusedIterator, TrustedLen};
 use crate::ops::{self, ControlFlow, Deref, DerefMut};
-use crate::{convert, fmt, hint};
+use crate::{convert, fmt, hint, mem};
 
 /// `Result` is a type that represents either success ([`Ok`]) or failure ([`Err`]).
 ///

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -490,7 +490,7 @@
 
 use crate::iter::{self, FusedIterator, TrustedLen};
 use crate::ops::{self, ControlFlow, Deref, DerefMut};
-use crate::{convert, fmt, hint, mem};
+use crate::{convert, fmt, mem};
 
 /// `Result` is a type that represents either success ([`Ok`]) or failure ([`Err`]).
 ///


### PR DESCRIPTION
[Relevant ACP.](https://github.com/rust-lang/libs-team/issues/378) [Relevant godbolt.](https://godbolt.org/z/WqfcT7Ys9)

Attempt to clean up the LLVM IR we generate based on the assumption that we usually don't want to `assume` the value of the discriminant (because it sticks around in the IR and randomly inhibits optimizations).