### PR TITLE
`rustc --explain E0582` additional example

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0582.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0582.md
@@ -42,9 +42,9 @@ where
     f: F
 }
 ```
-The latter scenario encounters this error because `Foo::Assoc<'a>` could be implemented by a type that does not use
-the `'a` parameter, so there is no guarentee that `X::Assoc<'a>` actually uses
-`'a`.
+The latter scenario encounters this error because `Foo::Assoc<'a>` could be
+implemented by a type that does not use the `'a` parameter, so there is no
+guarentee that `X::Assoc<'a>` actually uses `'a`.
 
 To fix this we can pass a dummy parameter:
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0582.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0582.md
@@ -42,7 +42,7 @@ where
     f: F
 }
 ```
-This is as `Foo::Assoc<'a>` could be implemented by a type that does not use
+The latter scenario encounters this error because `Foo::Assoc<'a>` could be implemented by a type that does not use
 the `'a` parameter, so there is no guarentee that `X::Assoc<'a>` actually uses
 `'a`.
 

--- a/compiler/rustc_error_codes/src/error_codes/E0582.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0582.md
@@ -27,6 +27,40 @@ fn bar<F, G>(t: F, u: G)
 fn main() { }
 ```
 
+This error also includes the use of associated types with lifetime parameters.
+```compile_fail,E0582
+trait Foo {
+    type Assoc<'a>;
+}
+
+struct Bar<X, F>
+where
+    X: Foo,
+    F: for<'a> Fn(X::Assoc<'a>) -> &'a i32
+{
+    x: X,
+    f: F
+}
+```
+This is as `Foo::Assoc<'a>` could be implemented by a type that does not use 
+the `'a` parameter, so there is no guarentee that `X::Assoc<'a>` actually uses 
+`'a`.
+
+To fix this we can pass a dummy parameter:
+```
+# trait Foo {
+#     type Assoc<'a>;
+# }
+struct Bar<X, F>
+where
+    X: Foo,
+    F: for<'a> Fn(X::Assoc<'a>, /* dummy */ &'a ()) -> &'a i32
+{
+    x: X,
+    f: F
+}
+```
+
 Note: The examples above used to be (erroneously) accepted by the
 compiler, but this was since corrected. See [issue #33685] for more
 details.

--- a/compiler/rustc_error_codes/src/error_codes/E0582.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0582.md
@@ -42,8 +42,8 @@ where
     f: F
 }
 ```
-This is as `Foo::Assoc<'a>` could be implemented by a type that does not use 
-the `'a` parameter, so there is no guarentee that `X::Assoc<'a>` actually uses 
+This is as `Foo::Assoc<'a>` could be implemented by a type that does not use
+the `'a` parameter, so there is no guarentee that `X::Assoc<'a>` actually uses
 `'a`.
 
 To fix this we can pass a dummy parameter:


### PR DESCRIPTION
## Context
*From #124744*

Expands the example for E0582, an error ensuring that lifetime in a function's return type is sufficiently constrained (e.g. actually tied to some input type), to show an additional example where one sees the lifetime occurring syntactically among the relevant function input types, but is nonetheless rejected by rustc because a syntactic occurrence is not always sufficient.