### PR TITLE
[rustdoc] Fix bad color for setting cog in ayu theme

### DIFF
--- a/src/librustdoc/html/static/css/noscript.css
+++ b/src/librustdoc/html/static/css/noscript.css
@@ -85,6 +85,7 @@ nav.sub {
 	--search-tab-button-not-selected-background: #e6e6e6;
 	--search-tab-button-selected-border-top-color: #0089ff;
 	--search-tab-button-selected-background: #fff;
+	--settings-menu-filter: none;
 	--stab-background-color: #fff5d6;
 	--stab-code-color: #000;
 	--code-highlight-kw-color: #8959a8;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1625,6 +1625,7 @@ a.tooltip:hover::after {
 	,5.1715698,7.5,6  S6.8284302,7.5,6,7.5z" fill="black"/></svg>');
 	width: 22px;
 	height: 22px;
+	filter: var(--settings-menu-filter);
 }
 
 #sidebar-button > a:before {
@@ -2419,6 +2420,7 @@ by default.
 	--search-tab-button-not-selected-background: #e6e6e6;
 	--search-tab-button-selected-border-top-color: #0089ff;
 	--search-tab-button-selected-background: #fff;
+	--settings-menu-filter: none;
 	--stab-background-color: #fff5d6;
 	--stab-code-color: #000;
 	--code-highlight-kw-color: #8959a8;
@@ -2524,6 +2526,7 @@ by default.
 	--search-tab-button-not-selected-background: #252525;
 	--search-tab-button-selected-border-top-color: #0089ff;
 	--search-tab-button-selected-background: #353535;
+	--settings-menu-filter: none;
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 	--code-highlight-kw-color: #ab8ac1;
@@ -2636,6 +2639,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--search-tab-button-not-selected-background: transparent !important;
 	--search-tab-button-selected-border-top-color: none;
 	--search-tab-button-selected-background: #141920 !important;
+	--settings-menu-filter: invert(100%);
 	--stab-background-color: #314559;
 	--stab-code-color: #e6e1cf;
 	--code-highlight-kw-color: #ff7733;

--- a/tests/rustdoc-gui/settings-button.goml
+++ b/tests/rustdoc-gui/settings-button.goml
@@ -1,0 +1,31 @@
+// This test ensures that the icon of the settings button looks as expected on
+// all themes.
+include: "utils.goml"
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+show-text: true
+
+define-function: (
+    "check-image",
+    [theme, filter],
+    block {
+        call-function: ("switch-theme", {"theme": |theme|})
+        assert-css: ("#settings-menu > a::before", {
+            "filter": |filter|,
+            "width": "22px",
+            "height": "22px",
+        })
+    }
+)
+
+call-function: ("check-image", {
+    "theme": "ayu",
+    "filter": "invert(1)",
+})
+call-function: ("check-image", {
+    "theme": "dark",
+    "filter": "none",
+})
+call-function: ("check-image", {
+    "theme": "light",
+    "filter": "none",
+})

--- a/tests/rustdoc-gui/settings.goml
+++ b/tests/rustdoc-gui/settings.goml
@@ -1,6 +1,5 @@
 // This test ensures that the settings menu display is working as expected and that
 // the settings page is also rendered as expected.
-include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 show-text: true // needed when we check for colors below.
 // First, we check that the settings page doesn't exist.

--- a/tests/rustdoc-gui/src/theme_css/custom-theme.css
+++ b/tests/rustdoc-gui/src/theme_css/custom-theme.css
@@ -49,6 +49,7 @@
 	--search-tab-button-not-selected-background: #e6e6e6;
 	--search-tab-button-selected-border-top-color: #0089ff;
 	--search-tab-button-selected-background: #fff;
+	--settings-menu-filter: none;
 	--stab-background-color: #fff5d6;
 	--stab-code-color: #000;
 	--code-highlight-kw-color: #8959a8;


### PR DESCRIPTION
Before:

![Screenshot from 2024-05-05 19-29-36](https://github.com/rust-lang/rust/assets/3050060/e1f078e5-7fb3-472d-91e7-b4bde551d411)

After:

![image](https://github.com/rust-lang/rust/assets/3050060/0aa115ac-dd69-48e1-b93e-067a39cf25d2)

r? @notriddle