### PR TITLE
Avoid a cast in `ptr::slice_from_raw_parts(_mut)`

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -812,7 +812,7 @@ pub const fn from_mut<T: ?Sized>(r: &mut T) -> *mut T {
 #[rustc_allow_const_fn_unstable(ptr_metadata)]
 #[rustc_diagnostic_item = "ptr_slice_from_raw_parts"]
 pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
-    from_raw_parts(data.cast(), len)
+    intrinsics::aggregate_raw_ptr(data, len)
 }
 
 /// Forms a raw mutable slice from a pointer and a length.
@@ -858,7 +858,7 @@ pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
 #[rustc_const_unstable(feature = "const_slice_from_raw_parts_mut", issue = "67456")]
 #[rustc_diagnostic_item = "ptr_slice_from_raw_parts_mut"]
 pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
-    from_raw_parts_mut(data.cast(), len)
+    intrinsics::aggregate_raw_ptr(data, len)
 }
 
 /// Swaps the values at two mutable locations of the same type, without

--- a/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
@@ -11,10 +11,28 @@
 +     scope 1 (inlined std::ptr::drop_in_place::<Vec<A>> - shim(Some(Vec<A>))) {
 +         let mut _6: &mut std::vec::Vec<A>;
 +         let mut _7: ();
++         scope 2 (inlined <Vec<A> as Drop>::drop) {
++             let mut _8: *mut [A];
++             let mut _9: *mut A;
++             let mut _10: usize;
++             scope 3 (inlined Vec::<A>::as_mut_ptr) {
++                 let mut _11: &alloc::raw_vec::RawVec<A>;
++                 scope 4 (inlined alloc::raw_vec::RawVec::<A>::ptr) {
++                     let mut _13: std::ptr::NonNull<A>;
++                     scope 5 (inlined Unique::<A>::as_ptr) {
++                         scope 6 (inlined NonNull::<A>::as_ptr) {
++                             let mut _12: *const A;
++                         }
++                     }
++                 }
++             }
++             scope 7 (inlined slice_from_raw_parts_mut::<A>) {
++             }
++         }
 +     }
-+     scope 2 (inlined std::ptr::drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
-+         let mut _8: isize;
-+         let mut _9: isize;
++     scope 8 (inlined std::ptr::drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
++         let mut _14: isize;
++         let mut _15: isize;
 +     }
   
       bb0: {
@@ -25,7 +43,24 @@
 +         StorageLive(_6);
 +         StorageLive(_7);
 +         _6 = &mut (*_4);
-+         _7 = <Vec<A> as Drop>::drop(move _6) -> [return: bb2, unwind unreachable];
++         StorageLive(_8);
++         StorageLive(_9);
++         StorageLive(_11);
++         _11 = &((*_6).0: alloc::raw_vec::RawVec<A>);
++         StorageLive(_13);
++         _13 = ((((*_6).0: alloc::raw_vec::RawVec<A>).0: std::ptr::Unique<A>).0: std::ptr::NonNull<A>);
++         StorageLive(_12);
++         _12 = (_13.0: *const A);
++         _9 = move _12 as *mut A (PtrToPtr);
++         StorageDead(_12);
++         StorageDead(_13);
++         StorageDead(_11);
++         StorageLive(_10);
++         _10 = ((*_6).1: usize);
++         _8 = *mut [A] from (_9, _10);
++         StorageDead(_10);
++         StorageDead(_9);
++         _7 = std::ptr::drop_in_place::<[A]>(move _8) -> [return: bb2, unwind unreachable];
       }
   
       bb1: {
@@ -36,19 +71,20 @@
           StorageLive(_5);
           _5 = _2;
 -         _0 = std::ptr::drop_in_place::<Option<B>>(move _5) -> [return: bb2, unwind unreachable];
-+         StorageLive(_8);
-+         StorageLive(_9);
-+         _8 = discriminant((*_5));
-+         switchInt(move _8) -> [0: bb3, otherwise: bb4];
++         StorageLive(_14);
++         StorageLive(_15);
++         _14 = discriminant((*_5));
++         switchInt(move _14) -> [0: bb3, otherwise: bb4];
       }
   
       bb2: {
++         StorageDead(_8);
 +         drop(((*_4).0: alloc::raw_vec::RawVec<A>)) -> [return: bb1, unwind unreachable];
 +     }
 + 
 +     bb3: {
-+         StorageDead(_9);
-+         StorageDead(_8);
++         StorageDead(_15);
++         StorageDead(_14);
           StorageDead(_5);
           return;
 +     }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
@@ -4,20 +4,47 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     debug slice => _1;
     debug index => _2;
     let mut _0: &mut [u32];
+    let mut _3: usize;
+    let mut _4: usize;
     scope 1 (inlined core::slice::<impl [u32]>::get_unchecked_mut::<std::ops::Range<usize>>) {
-        let mut _3: *mut [u32];
-        let mut _4: *mut [u32];
+        let mut _5: *mut [u32];
+        let mut _9: *mut [u32];
+        scope 2 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) {
+            let _6: usize;
+            let mut _7: *mut u32;
+            let mut _8: *mut u32;
+            scope 3 {
+                scope 6 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) {
+                }
+                scope 7 (inlined std::ptr::mut_ptr::<impl *mut u32>::add) {
+                }
+                scope 8 (inlined slice_from_raw_parts_mut::<u32>) {
+                }
+            }
+            scope 4 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::len) {
+                scope 5 (inlined std::ptr::metadata::<[u32]>) {
+                }
+            }
+        }
     }
 
     bb0: {
-        StorageLive(_3);
-        _3 = &raw mut (*_1);
-        _4 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut(move _2, move _3) -> [return: bb1, unwind unreachable];
-    }
-
-    bb1: {
-        StorageDead(_3);
-        _0 = &mut (*_4);
+        _3 = move (_2.0: usize);
+        _4 = move (_2.1: usize);
+        StorageLive(_5);
+        _5 = &raw mut (*_1);
+        StorageLive(_6);
+        _6 = SubUnchecked(_4, _3);
+        StorageLive(_8);
+        StorageLive(_7);
+        _7 = _5 as *mut u32 (PtrToPtr);
+        _8 = Offset(_7, _3);
+        StorageDead(_7);
+        _9 = *mut [u32] from (_8, _6);
+        StorageDead(_8);
+        StorageDead(_6);
+        StorageDead(_5);
+        _0 = &mut (*_9);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
@@ -4,20 +4,47 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     debug slice => _1;
     debug index => _2;
     let mut _0: &mut [u32];
+    let mut _3: usize;
+    let mut _4: usize;
     scope 1 (inlined core::slice::<impl [u32]>::get_unchecked_mut::<std::ops::Range<usize>>) {
-        let mut _3: *mut [u32];
-        let mut _4: *mut [u32];
+        let mut _5: *mut [u32];
+        let mut _9: *mut [u32];
+        scope 2 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) {
+            let _6: usize;
+            let mut _7: *mut u32;
+            let mut _8: *mut u32;
+            scope 3 {
+                scope 6 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) {
+                }
+                scope 7 (inlined std::ptr::mut_ptr::<impl *mut u32>::add) {
+                }
+                scope 8 (inlined slice_from_raw_parts_mut::<u32>) {
+                }
+            }
+            scope 4 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::len) {
+                scope 5 (inlined std::ptr::metadata::<[u32]>) {
+                }
+            }
+        }
     }
 
     bb0: {
-        StorageLive(_3);
-        _3 = &raw mut (*_1);
-        _4 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut(move _2, move _3) -> [return: bb1, unwind continue];
-    }
-
-    bb1: {
-        StorageDead(_3);
-        _0 = &mut (*_4);
+        _3 = move (_2.0: usize);
+        _4 = move (_2.1: usize);
+        StorageLive(_5);
+        _5 = &raw mut (*_1);
+        StorageLive(_6);
+        _6 = SubUnchecked(_4, _3);
+        StorageLive(_8);
+        StorageLive(_7);
+        _7 = _5 as *mut u32 (PtrToPtr);
+        _8 = Offset(_7, _3);
+        StorageDead(_7);
+        _9 = *mut [u32] from (_8, _6);
+        StorageDead(_8);
+        StorageDead(_6);
+        StorageDead(_5);
+        _0 = &mut (*_9);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-abort.mir
@@ -17,11 +17,6 @@ fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -
                 scope 7 (inlined std::ptr::const_ptr::<impl *const u32>::add) {
                 }
                 scope 8 (inlined slice_from_raw_parts::<u32>) {
-                    let mut _8: *const ();
-                    scope 9 (inlined std::ptr::const_ptr::<impl *const u32>::cast::<()>) {
-                    }
-                    scope 10 (inlined std::ptr::from_raw_parts::<[u32]>) {
-                    }
                 }
             }
             scope 4 (inlined std::ptr::const_ptr::<impl *const [u32]>::len) {
@@ -41,10 +36,7 @@ fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -
         _6 = _1 as *const u32 (PtrToPtr);
         _7 = Offset(_6, _3);
         StorageDead(_6);
-        StorageLive(_8);
-        _8 = _7 as *const () (PtrToPtr);
-        _0 = *const [u32] from (_8, _5);
-        StorageDead(_8);
+        _0 = *const [u32] from (_7, _5);
         StorageDead(_7);
         StorageDead(_5);
         return;

--- a/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-unwind.mir
@@ -17,11 +17,6 @@ fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -
                 scope 7 (inlined std::ptr::const_ptr::<impl *const u32>::add) {
                 }
                 scope 8 (inlined slice_from_raw_parts::<u32>) {
-                    let mut _8: *const ();
-                    scope 9 (inlined std::ptr::const_ptr::<impl *const u32>::cast::<()>) {
-                    }
-                    scope 10 (inlined std::ptr::from_raw_parts::<[u32]>) {
-                    }
                 }
             }
             scope 4 (inlined std::ptr::const_ptr::<impl *const [u32]>::len) {
@@ -41,10 +36,7 @@ fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -
         _6 = _1 as *const u32 (PtrToPtr);
         _7 = Offset(_6, _3);
         StorageDead(_6);
-        StorageLive(_8);
-        _8 = _7 as *const () (PtrToPtr);
-        _0 = *const [u32] from (_8, _5);
-        StorageDead(_8);
+        _0 = *const [u32] from (_7, _5);
         StorageDead(_7);
         StorageDead(_5);
         return;

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
@@ -25,7 +25,7 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
         scope 6 (inlined std::slice::from_raw_parts::<'_, u8>) {
             debug data => _4;
             debug len => _5;
-            let _7: *const [u8];
+            let _6: *const [u8];
             scope 7 (inlined core::ub_checks::check_language_ub) {
                 scope 8 (inlined core::ub_checks::check_language_ub::runtime) {
                 }
@@ -37,14 +37,6 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
             scope 11 (inlined slice_from_raw_parts::<u8>) {
                 debug data => _4;
                 debug len => _5;
-                let mut _6: *const ();
-                scope 12 (inlined std::ptr::const_ptr::<impl *const u8>::cast::<()>) {
-                    debug self => _4;
-                }
-                scope 13 (inlined std::ptr::from_raw_parts::<[u8]>) {
-                    debug data_pointer => _6;
-                    debug metadata => _5;
-                }
             }
         }
     }
@@ -60,13 +52,10 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
         StorageDead(_2);
         StorageLive(_5);
         _5 = ((*_1).1: usize);
-        StorageLive(_6);
-        _6 = _4 as *const () (PtrToPtr);
-        _7 = *const [u8] from (_6, _5);
-        StorageDead(_6);
+        _6 = *const [u8] from (_4, _5);
         StorageDead(_5);
         StorageDead(_4);
-        _0 = &(*_7);
+        _0 = &(*_6);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
@@ -25,7 +25,7 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
         scope 6 (inlined std::slice::from_raw_parts::<'_, u8>) {
             debug data => _4;
             debug len => _5;
-            let _7: *const [u8];
+            let _6: *const [u8];
             scope 7 (inlined core::ub_checks::check_language_ub) {
                 scope 8 (inlined core::ub_checks::check_language_ub::runtime) {
                 }
@@ -37,14 +37,6 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
             scope 11 (inlined slice_from_raw_parts::<u8>) {
                 debug data => _4;
                 debug len => _5;
-                let mut _6: *const ();
-                scope 12 (inlined std::ptr::const_ptr::<impl *const u8>::cast::<()>) {
-                    debug self => _4;
-                }
-                scope 13 (inlined std::ptr::from_raw_parts::<[u8]>) {
-                    debug data_pointer => _6;
-                    debug metadata => _5;
-                }
             }
         }
     }
@@ -60,13 +52,10 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
         StorageDead(_2);
         StorageLive(_5);
         _5 = ((*_1).1: usize);
-        StorageLive(_6);
-        _6 = _4 as *const () (PtrToPtr);
-        _7 = *const [u8] from (_6, _5);
-        StorageDead(_6);
+        _6 = *const [u8] from (_4, _5);
         StorageDead(_5);
         StorageDead(_4);
-        _0 = &(*_7);
+        _0 = &(*_6);
         return;
     }
 }


### PR DESCRIPTION
Casting to `*const ()` or `*mut ()` is no longer needed after https://github.com/rust-lang/rust/pull/123840 so let's make the MIR smaller (and more inline-able, as seen in the tests).

If [ACP#362](https://github.com/rust-lang/libs-team/issues/362) goes through we can keep calling `ptr::from_raw_parts(_mut)` in these also without the cast, but that hasn't had any libs-api attention yet, so I'm not waiting on it.