### PR TITLE
std::alloc: use posix_memalign instead of memalign on solarish

### DIFF
--- a/library/std/src/sys/pal/unix/alloc.rs
+++ b/library/std/src/sys/pal/unix/alloc.rs
@@ -61,9 +61,7 @@ unsafe impl GlobalAlloc for System {
 cfg_if::cfg_if! {
     if #[cfg(any(
         target_os = "android",
-        target_os = "illumos",
         target_os = "redox",
-        target_os = "solaris",
         target_os = "espidf",
         target_os = "horizon",
         target_os = "vita",


### PR DESCRIPTION
`memalign` on Solarish requires the alignment to be at least the size of a pointer, which we did not honor. `posix_memalign` also requires that, but that code path already takes care of this requirement.

close GH-124787