### PR TITLE
Change `unexpected_cfg` to `allow` by default

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3345,7 +3345,7 @@ declare_lint! {
     /// The known condition include names or values passed in `--check-cfg`, and some
     /// well-knows names and values built into the compiler.
     pub UNEXPECTED_CFGS,
-    Warn,
+    Allow,
     "detects unexpected names and values in `#[cfg]` conditions",
 }
 

--- a/tests/ui/check-cfg/allow-macro-cfg.rs
+++ b/tests/ui/check-cfg/allow-macro-cfg.rs
@@ -4,6 +4,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
+#![warn(unexpected_cfgs)]
+
 #[allow(unexpected_cfgs)]
 fn foo() {
     if cfg!(FALSE) {}

--- a/tests/ui/check-cfg/allow-same-level.rs
+++ b/tests/ui/check-cfg/allow-same-level.rs
@@ -4,6 +4,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
+#![warn(unexpected_cfgs)]
+
 #[allow(unexpected_cfgs)]
 #[cfg(FALSE)]
 //~^ WARNING unexpected `cfg` condition name

--- a/tests/ui/check-cfg/allow-same-level.stderr
+++ b/tests/ui/check-cfg/allow-same-level.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `FALSE`
-  --> $DIR/allow-same-level.rs:8:7
+  --> $DIR/allow-same-level.rs:10:7
    |
 LL | #[cfg(FALSE)]
    |       ^^^^^
@@ -7,7 +7,11 @@ LL | #[cfg(FALSE)]
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `doctest`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
    = help: to expect this configuration use `--check-cfg=cfg(FALSE)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/allow-same-level.rs:7:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/check-cfg/allow-upper-level.rs
+++ b/tests/ui/check-cfg/allow-upper-level.rs
@@ -4,6 +4,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
+#![warn(unexpected_cfgs)]
+
 #[allow(unexpected_cfgs)]
 mod aa {
     #[cfg(FALSE)]

--- a/tests/ui/check-cfg/cargo-feature.none.stderr
+++ b/tests/ui/check-cfg/cargo-feature.none.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `serde`
-  --> $DIR/cargo-feature.rs:14:7
+  --> $DIR/cargo-feature.rs:16:7
    |
 LL | #[cfg(feature = "serde")]
    |       ^^^^^^^^^^^^^^^^^ help: remove the condition
@@ -7,10 +7,14 @@ LL | #[cfg(feature = "serde")]
    = note: no expected values for `feature`
    = help: consider adding `serde` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/cargo-feature.rs:14:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: (none)
-  --> $DIR/cargo-feature.rs:18:7
+  --> $DIR/cargo-feature.rs:20:7
    |
 LL | #[cfg(feature)]
    |       ^^^^^^^ help: remove the condition
@@ -20,7 +24,7 @@ LL | #[cfg(feature)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `tokio_unstable`
-  --> $DIR/cargo-feature.rs:22:7
+  --> $DIR/cargo-feature.rs:24:7
    |
 LL | #[cfg(tokio_unstable)]
    |       ^^^^^^^^^^^^^^
@@ -30,7 +34,7 @@ LL | #[cfg(tokio_unstable)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `CONFIG_NVME`
-  --> $DIR/cargo-feature.rs:26:7
+  --> $DIR/cargo-feature.rs:28:7
    |
 LL | #[cfg(CONFIG_NVME = "m")]
    |       ^^^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/cargo-feature.rs
+++ b/tests/ui/check-cfg/cargo-feature.rs
@@ -11,6 +11,8 @@
 //@ [some]compile-flags: --check-cfg=cfg(CONFIG_NVME,values("y"))
 //@ [none]error-pattern:Cargo.toml
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(feature = "serde")]
 //~^ WARNING unexpected `cfg` condition value
 fn ser() {}

--- a/tests/ui/check-cfg/cargo-feature.some.stderr
+++ b/tests/ui/check-cfg/cargo-feature.some.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `serde`
-  --> $DIR/cargo-feature.rs:14:7
+  --> $DIR/cargo-feature.rs:16:7
    |
 LL | #[cfg(feature = "serde")]
    |       ^^^^^^^^^^^^^^^^^
@@ -7,10 +7,14 @@ LL | #[cfg(feature = "serde")]
    = note: expected values for `feature` are: `bitcode`
    = help: consider adding `serde` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/cargo-feature.rs:14:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: (none)
-  --> $DIR/cargo-feature.rs:18:7
+  --> $DIR/cargo-feature.rs:20:7
    |
 LL | #[cfg(feature)]
    |       ^^^^^^^- help: specify a config value: `= "bitcode"`
@@ -20,7 +24,7 @@ LL | #[cfg(feature)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `tokio_unstable`
-  --> $DIR/cargo-feature.rs:22:7
+  --> $DIR/cargo-feature.rs:24:7
    |
 LL | #[cfg(tokio_unstable)]
    |       ^^^^^^^^^^^^^^
@@ -30,7 +34,7 @@ LL | #[cfg(tokio_unstable)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `m`
-  --> $DIR/cargo-feature.rs:26:7
+  --> $DIR/cargo-feature.rs:28:7
    |
 LL | #[cfg(CONFIG_NVME = "m")]
    |       ^^^^^^^^^^^^^^---

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.rs
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.rs
@@ -5,6 +5,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg(foo,values("value")) --check-cfg=cfg(bar,values("value")) --check-cfg=cfg(bee,values("value")) --check-cfg=cfg(cow,values("value"))
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(value)]
 //~^ WARNING unexpected `cfg` condition name: `value`
 fn x() {}

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.stderr
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `value`
-  --> $DIR/cfg-value-for-cfg-name-duplicate.rs:8:7
+  --> $DIR/cfg-value-for-cfg-name-duplicate.rs:10:7
    |
 LL | #[cfg(value)]
    |       ^^^^^
@@ -7,7 +7,11 @@ LL | #[cfg(value)]
    = help: expected names are: `bar`, `bee`, `clippy`, `cow`, `debug_assertions`, `doc`, `doctest`, `foo`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
    = help: to expect this configuration use `--check-cfg=cfg(value)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/cfg-value-for-cfg-name-duplicate.rs:8:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.rs
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.rs
@@ -5,6 +5,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg(foo,values("my_value")) --check-cfg=cfg(bar,values("my_value"))
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(my_value)]
 //~^ WARNING unexpected `cfg` condition name: `my_value`
 fn x() {}

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.stderr
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `my_value`
-  --> $DIR/cfg-value-for-cfg-name-multiple.rs:8:7
+  --> $DIR/cfg-value-for-cfg-name-multiple.rs:10:7
    |
 LL | #[cfg(my_value)]
    |       ^^^^^^^^
@@ -7,7 +7,11 @@ LL | #[cfg(my_value)]
    = help: expected names are: `bar`, `clippy`, `debug_assertions`, `doc`, `doctest`, `foo`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
    = help: to expect this configuration use `--check-cfg=cfg(my_value)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/cfg-value-for-cfg-name-multiple.rs:8:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 help: found config with similar value
    |
 LL | #[cfg(foo = "my_value")]

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name.rs
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name.rs
@@ -6,6 +6,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(linux)]
 //~^ WARNING unexpected `cfg` condition name: `linux`
 fn x() {}

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name.stderr
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `linux`
-  --> $DIR/cfg-value-for-cfg-name.rs:9:7
+  --> $DIR/cfg-value-for-cfg-name.rs:11:7
    |
 LL | #[cfg(linux)]
    |       ^^^^^ help: found config with similar value: `target_os = "linux"`
@@ -7,10 +7,14 @@ LL | #[cfg(linux)]
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `doctest`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
    = help: to expect this configuration use `--check-cfg=cfg(linux)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/cfg-value-for-cfg-name.rs:9:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition name: `linux`
-  --> $DIR/cfg-value-for-cfg-name.rs:14:7
+  --> $DIR/cfg-value-for-cfg-name.rs:16:7
    |
 LL | #[cfg(linux = "os-name")]
    |       ^^^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/compact-names.rs
+++ b/tests/ui/check-cfg/compact-names.rs
@@ -4,6 +4,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
+#![warn(unexpected_cfgs)]
+
 #![feature(cfg_target_compact)]
 
 #[cfg(target(os = "linux", arch = "arm"))]

--- a/tests/ui/check-cfg/compact-names.stderr
+++ b/tests/ui/check-cfg/compact-names.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `target_architecture`
-  --> $DIR/compact-names.rs:12:28
+  --> $DIR/compact-names.rs:14:28
    |
 LL | #[cfg(target(os = "linux", architecture = "arm"))]
    |                            ^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,11 @@ LL | #[cfg(target(os = "linux", architecture = "arm"))]
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `doctest`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
    = help: to expect this configuration use `--check-cfg=cfg(target_architecture, values("arm"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/compact-names.rs:7:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/check-cfg/compact-values.rs
+++ b/tests/ui/check-cfg/compact-values.rs
@@ -4,6 +4,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
+#![warn(unexpected_cfgs)]
+
 #![feature(cfg_target_compact)]
 
 #[cfg(target(os = "linux", arch = "arm"))]

--- a/tests/ui/check-cfg/compact-values.stderr
+++ b/tests/ui/check-cfg/compact-values.stderr
@@ -1,12 +1,16 @@
 warning: unexpected `cfg` condition value: `X`
-  --> $DIR/compact-values.rs:12:28
+  --> $DIR/compact-values.rs:14:28
    |
 LL | #[cfg(target(os = "linux", pointer_width = "X"))]
    |                            ^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `target_pointer_width` are: `16`, `32`, `64`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/compact-values.rs:7:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/check-cfg/concat-values.rs
+++ b/tests/ui/check-cfg/concat-values.rs
@@ -3,6 +3,8 @@
 //@ compile-flags: --check-cfg=cfg(my_cfg,values("foo")) --check-cfg=cfg(my_cfg,values("bar"))
 //@ compile-flags: --check-cfg=cfg(my_cfg,values())
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(my_cfg)]
 //~^ WARNING unexpected `cfg` condition value
 fn my_cfg() {}

--- a/tests/ui/check-cfg/concat-values.stderr
+++ b/tests/ui/check-cfg/concat-values.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: (none)
-  --> $DIR/concat-values.rs:6:7
+  --> $DIR/concat-values.rs:8:7
    |
 LL | #[cfg(my_cfg)]
    |       ^^^^^^
@@ -7,10 +7,14 @@ LL | #[cfg(my_cfg)]
    = note: expected values for `my_cfg` are: `bar`, `foo`
    = help: to expect this configuration use `--check-cfg=cfg(my_cfg)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/concat-values.rs:6:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: `unk`
-  --> $DIR/concat-values.rs:10:7
+  --> $DIR/concat-values.rs:12:7
    |
 LL | #[cfg(my_cfg = "unk")]
    |       ^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/diagnotics.cargo.stderr
+++ b/tests/ui/check-cfg/diagnotics.cargo.stderr
@@ -1,15 +1,19 @@
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:8:7
+  --> $DIR/diagnotics.rs:10:7
    |
 LL | #[cfg(featur)]
    |       ^^^^^^ help: there is a config with a similar name: `feature`
    |
    = help: expected values for `feature` are: `foo`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/diagnotics.rs:8:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:12:7
+  --> $DIR/diagnotics.rs:14:7
    |
 LL | #[cfg(featur = "foo")]
    |       ^^^^^^^^^^^^^^
@@ -21,7 +25,7 @@ LL | #[cfg(feature = "foo")]
    |       ~~~~~~~
 
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:16:7
+  --> $DIR/diagnotics.rs:18:7
    |
 LL | #[cfg(featur = "fo")]
    |       ^^^^^^^^^^^^^
@@ -34,7 +38,7 @@ LL | #[cfg(feature = "foo")]
    |       ~~~~~~~~~~~~~~~
 
 warning: unexpected `cfg` condition name: `no_value`
-  --> $DIR/diagnotics.rs:23:7
+  --> $DIR/diagnotics.rs:25:7
    |
 LL | #[cfg(no_value)]
    |       ^^^^^^^^ help: there is a config with a similar name: `no_values`
@@ -43,7 +47,7 @@ LL | #[cfg(no_value)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `no_value`
-  --> $DIR/diagnotics.rs:27:7
+  --> $DIR/diagnotics.rs:29:7
    |
 LL | #[cfg(no_value = "foo")]
    |       ^^^^^^^^^^^^^^^^
@@ -56,7 +60,7 @@ LL | #[cfg(no_values)]
    |       ~~~~~~~~~
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/diagnotics.rs:31:7
+  --> $DIR/diagnotics.rs:33:7
    |
 LL | #[cfg(no_values = "bar")]
    |       ^^^^^^^^^--------

--- a/tests/ui/check-cfg/diagnotics.rs
+++ b/tests/ui/check-cfg/diagnotics.rs
@@ -5,6 +5,8 @@
 //@ [cargo]rustc-env:CARGO_CRATE_NAME=foo
 //@ compile-flags: --check-cfg=cfg(feature,values("foo")) --check-cfg=cfg(no_values)
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(featur)]
 //~^ WARNING unexpected `cfg` condition name
 fn feature() {}

--- a/tests/ui/check-cfg/diagnotics.rustc.stderr
+++ b/tests/ui/check-cfg/diagnotics.rustc.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:8:7
+  --> $DIR/diagnotics.rs:10:7
    |
 LL | #[cfg(featur)]
    |       ^^^^^^ help: there is a config with a similar name: `feature`
@@ -7,10 +7,14 @@ LL | #[cfg(featur)]
    = help: expected values for `feature` are: `foo`
    = help: to expect this configuration use `--check-cfg=cfg(featur)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/diagnotics.rs:8:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:12:7
+  --> $DIR/diagnotics.rs:14:7
    |
 LL | #[cfg(featur = "foo")]
    |       ^^^^^^^^^^^^^^
@@ -23,7 +27,7 @@ LL | #[cfg(feature = "foo")]
    |       ~~~~~~~
 
 warning: unexpected `cfg` condition name: `featur`
-  --> $DIR/diagnotics.rs:16:7
+  --> $DIR/diagnotics.rs:18:7
    |
 LL | #[cfg(featur = "fo")]
    |       ^^^^^^^^^^^^^
@@ -37,7 +41,7 @@ LL | #[cfg(feature = "foo")]
    |       ~~~~~~~~~~~~~~~
 
 warning: unexpected `cfg` condition name: `no_value`
-  --> $DIR/diagnotics.rs:23:7
+  --> $DIR/diagnotics.rs:25:7
    |
 LL | #[cfg(no_value)]
    |       ^^^^^^^^ help: there is a config with a similar name: `no_values`
@@ -46,7 +50,7 @@ LL | #[cfg(no_value)]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `no_value`
-  --> $DIR/diagnotics.rs:27:7
+  --> $DIR/diagnotics.rs:29:7
    |
 LL | #[cfg(no_value = "foo")]
    |       ^^^^^^^^^^^^^^^^
@@ -59,7 +63,7 @@ LL | #[cfg(no_values)]
    |       ~~~~~~~~~
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/diagnotics.rs:31:7
+  --> $DIR/diagnotics.rs:33:7
    |
 LL | #[cfg(no_values = "bar")]
    |       ^^^^^^^^^--------

--- a/tests/ui/check-cfg/empty-values.rs
+++ b/tests/ui/check-cfg/empty-values.rs
@@ -4,6 +4,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg(foo,values())
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(foo = "foo")]
 //~^ WARNING unexpected `cfg` condition value
 fn do_foo() {}

--- a/tests/ui/check-cfg/empty-values.stderr
+++ b/tests/ui/check-cfg/empty-values.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/empty-values.rs:7:7
+  --> $DIR/empty-values.rs:9:7
    |
 LL | #[cfg(foo = "foo")]
    |       ^^^^^^^^^^^ help: remove the condition
@@ -7,10 +7,14 @@ LL | #[cfg(foo = "foo")]
    = note: no expected values for `foo`
    = help: to expect this configuration use `--check-cfg=cfg(foo, values("foo"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/empty-values.rs:7:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: (none)
-  --> $DIR/empty-values.rs:11:7
+  --> $DIR/empty-values.rs:13:7
    |
 LL | #[cfg(foo)]
    |       ^^^ help: remove the condition

--- a/tests/ui/check-cfg/exhaustive-names-values.empty_cfg.stderr
+++ b/tests/ui/check-cfg/exhaustive-names-values.empty_cfg.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `unknown_key`
-  --> $DIR/exhaustive-names-values.rs:10:7
+  --> $DIR/exhaustive-names-values.rs:12:7
    |
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -7,10 +7,14 @@ LL | #[cfg(unknown_key = "value")]
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `doctest`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
    = help: to expect this configuration use `--check-cfg=cfg(unknown_key, values("value"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive-names-values.rs:10:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: `value`
-  --> $DIR/exhaustive-names-values.rs:14:7
+  --> $DIR/exhaustive-names-values.rs:16:7
    |
 LL | #[cfg(test = "value")]
    |       ^^^^----------
@@ -21,7 +25,7 @@ LL | #[cfg(test = "value")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `feature`
-  --> $DIR/exhaustive-names-values.rs:18:7
+  --> $DIR/exhaustive-names-values.rs:20:7
    |
 LL | #[cfg(feature = "unk")]
    |       ^^^^^^^^^^^^^^^
@@ -30,7 +34,7 @@ LL | #[cfg(feature = "unk")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `feature`
-  --> $DIR/exhaustive-names-values.rs:25:7
+  --> $DIR/exhaustive-names-values.rs:27:7
    |
 LL | #[cfg(feature = "std")]
    |       ^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/exhaustive-names-values.feature.stderr
+++ b/tests/ui/check-cfg/exhaustive-names-values.feature.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `unknown_key`
-  --> $DIR/exhaustive-names-values.rs:10:7
+  --> $DIR/exhaustive-names-values.rs:12:7
    |
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -7,10 +7,14 @@ LL | #[cfg(unknown_key = "value")]
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
    = help: to expect this configuration use `--check-cfg=cfg(unknown_key, values("value"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive-names-values.rs:10:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: `value`
-  --> $DIR/exhaustive-names-values.rs:14:7
+  --> $DIR/exhaustive-names-values.rs:16:7
    |
 LL | #[cfg(test = "value")]
    |       ^^^^----------
@@ -21,7 +25,7 @@ LL | #[cfg(test = "value")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `unk`
-  --> $DIR/exhaustive-names-values.rs:18:7
+  --> $DIR/exhaustive-names-values.rs:20:7
    |
 LL | #[cfg(feature = "unk")]
    |       ^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/exhaustive-names-values.full.stderr
+++ b/tests/ui/check-cfg/exhaustive-names-values.full.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `unknown_key`
-  --> $DIR/exhaustive-names-values.rs:10:7
+  --> $DIR/exhaustive-names-values.rs:12:7
    |
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -7,10 +7,14 @@ LL | #[cfg(unknown_key = "value")]
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
    = help: to expect this configuration use `--check-cfg=cfg(unknown_key, values("value"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive-names-values.rs:10:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: `value`
-  --> $DIR/exhaustive-names-values.rs:14:7
+  --> $DIR/exhaustive-names-values.rs:16:7
    |
 LL | #[cfg(test = "value")]
    |       ^^^^----------
@@ -21,7 +25,7 @@ LL | #[cfg(test = "value")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `unk`
-  --> $DIR/exhaustive-names-values.rs:18:7
+  --> $DIR/exhaustive-names-values.rs:20:7
    |
 LL | #[cfg(feature = "unk")]
    |       ^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/exhaustive-names-values.rs
+++ b/tests/ui/check-cfg/exhaustive-names-values.rs
@@ -7,6 +7,8 @@
 //@ [feature]compile-flags: --check-cfg=cfg(feature,values("std"))
 //@ [full]compile-flags: --check-cfg=cfg(feature,values("std")) --check-cfg=cfg()
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(unknown_key = "value")]
 //~^ WARNING unexpected `cfg` condition name
 pub fn f() {}

--- a/tests/ui/check-cfg/exhaustive-names.rs
+++ b/tests/ui/check-cfg/exhaustive-names.rs
@@ -4,6 +4,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(unknown_key = "value")]
 //~^ WARNING unexpected `cfg` condition name
 pub fn f() {}

--- a/tests/ui/check-cfg/exhaustive-names.stderr
+++ b/tests/ui/check-cfg/exhaustive-names.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `unknown_key`
-  --> $DIR/exhaustive-names.rs:7:7
+  --> $DIR/exhaustive-names.rs:9:7
    |
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,11 @@ LL | #[cfg(unknown_key = "value")]
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `doctest`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
    = help: to expect this configuration use `--check-cfg=cfg(unknown_key, values("value"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive-names.rs:7:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/check-cfg/exhaustive-values.empty_cfg.stderr
+++ b/tests/ui/check-cfg/exhaustive-values.empty_cfg.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `value`
-  --> $DIR/exhaustive-values.rs:9:7
+  --> $DIR/exhaustive-values.rs:11:7
    |
 LL | #[cfg(test = "value")]
    |       ^^^^----------
@@ -8,7 +8,11 @@ LL | #[cfg(test = "value")]
    |
    = note: no expected value for `test`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive-values.rs:9:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/check-cfg/exhaustive-values.rs
+++ b/tests/ui/check-cfg/exhaustive-values.rs
@@ -6,6 +6,8 @@
 //@ [empty_cfg]compile-flags: --check-cfg=cfg()
 //@ [without_names]compile-flags: --check-cfg=cfg(any())
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(test = "value")]
 //~^ WARNING unexpected `cfg` condition value
 pub fn f() {}

--- a/tests/ui/check-cfg/exhaustive-values.without_names.stderr
+++ b/tests/ui/check-cfg/exhaustive-values.without_names.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `value`
-  --> $DIR/exhaustive-values.rs:9:7
+  --> $DIR/exhaustive-values.rs:11:7
    |
 LL | #[cfg(test = "value")]
    |       ^^^^----------
@@ -8,7 +8,11 @@ LL | #[cfg(test = "value")]
    |
    = note: no expected value for `test`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive-values.rs:9:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/check-cfg/invalid-arguments.rs
+++ b/tests/ui/check-cfg/invalid-arguments.rs
@@ -34,4 +34,6 @@
 //@ [giberich]compile-flags: --check-cfg=cfg(...)
 //@ [unterminated]compile-flags: --check-cfg=cfg(
 
+#![warn(unexpected_cfgs)]
+
 fn main() {}

--- a/tests/ui/check-cfg/mix.rs
+++ b/tests/ui/check-cfg/mix.rs
@@ -7,6 +7,8 @@
 //@ compile-flags: --cfg feature="bar" --cfg unknown_name
 //@ compile-flags: --check-cfg=cfg(feature,values("foo"))
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(windows)]
 fn do_windows_stuff() {}
 

--- a/tests/ui/check-cfg/mix.stderr
+++ b/tests/ui/check-cfg/mix.stderr
@@ -1,15 +1,19 @@
 warning: unexpected `cfg` condition name: `widnows`
-  --> $DIR/mix.rs:13:7
+  --> $DIR/mix.rs:15:7
    |
 LL | #[cfg(widnows)]
    |       ^^^^^^^ help: there is a config with a similar name: `windows`
    |
    = help: to expect this configuration use `--check-cfg=cfg(widnows)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/mix.rs:10:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: (none)
-  --> $DIR/mix.rs:17:7
+  --> $DIR/mix.rs:19:7
    |
 LL | #[cfg(feature)]
    |       ^^^^^^^- help: specify a config value: `= "foo"`
@@ -19,7 +23,7 @@ LL | #[cfg(feature)]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/mix.rs:24:7
+  --> $DIR/mix.rs:26:7
    |
 LL | #[cfg(feature = "bar")]
    |       ^^^^^^^^^^^^^^^
@@ -29,7 +33,7 @@ LL | #[cfg(feature = "bar")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:28:7
+  --> $DIR/mix.rs:30:7
    |
 LL | #[cfg(feature = "zebra")]
    |       ^^^^^^^^^^^^^^^^^
@@ -39,7 +43,7 @@ LL | #[cfg(feature = "zebra")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `uu`
-  --> $DIR/mix.rs:32:12
+  --> $DIR/mix.rs:34:12
    |
 LL | #[cfg_attr(uu, test)]
    |            ^^
@@ -49,7 +53,7 @@ LL | #[cfg_attr(uu, test)]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `widnows`
-  --> $DIR/mix.rs:41:10
+  --> $DIR/mix.rs:43:10
    |
 LL |     cfg!(widnows);
    |          ^^^^^^^ help: there is a config with a similar name: `windows`
@@ -58,7 +62,7 @@ LL |     cfg!(widnows);
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/mix.rs:44:10
+  --> $DIR/mix.rs:46:10
    |
 LL |     cfg!(feature = "bar");
    |          ^^^^^^^^^^^^^^^
@@ -68,7 +72,7 @@ LL |     cfg!(feature = "bar");
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:46:10
+  --> $DIR/mix.rs:48:10
    |
 LL |     cfg!(feature = "zebra");
    |          ^^^^^^^^^^^^^^^^^
@@ -78,7 +82,7 @@ LL |     cfg!(feature = "zebra");
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:48:10
+  --> $DIR/mix.rs:50:10
    |
 LL |     cfg!(xxx = "foo");
    |          ^^^^^^^^^^^
@@ -87,7 +91,7 @@ LL |     cfg!(xxx = "foo");
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:50:10
+  --> $DIR/mix.rs:52:10
    |
 LL |     cfg!(xxx);
    |          ^^^
@@ -96,7 +100,7 @@ LL |     cfg!(xxx);
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:52:14
+  --> $DIR/mix.rs:54:14
    |
 LL |     cfg!(any(xxx, windows));
    |              ^^^
@@ -105,7 +109,7 @@ LL |     cfg!(any(xxx, windows));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `bad`
-  --> $DIR/mix.rs:54:14
+  --> $DIR/mix.rs:56:14
    |
 LL |     cfg!(any(feature = "bad", windows));
    |              ^^^^^^^^^^^^^^^
@@ -115,7 +119,7 @@ LL |     cfg!(any(feature = "bad", windows));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:56:23
+  --> $DIR/mix.rs:58:23
    |
 LL |     cfg!(any(windows, xxx));
    |                       ^^^
@@ -124,7 +128,7 @@ LL |     cfg!(any(windows, xxx));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:58:20
+  --> $DIR/mix.rs:60:20
    |
 LL |     cfg!(all(unix, xxx));
    |                    ^^^
@@ -133,7 +137,7 @@ LL |     cfg!(all(unix, xxx));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `aa`
-  --> $DIR/mix.rs:60:14
+  --> $DIR/mix.rs:62:14
    |
 LL |     cfg!(all(aa, bb));
    |              ^^
@@ -142,7 +146,7 @@ LL |     cfg!(all(aa, bb));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `bb`
-  --> $DIR/mix.rs:60:18
+  --> $DIR/mix.rs:62:18
    |
 LL |     cfg!(all(aa, bb));
    |                  ^^
@@ -151,7 +155,7 @@ LL |     cfg!(all(aa, bb));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `aa`
-  --> $DIR/mix.rs:63:14
+  --> $DIR/mix.rs:65:14
    |
 LL |     cfg!(any(aa, bb));
    |              ^^
@@ -160,7 +164,7 @@ LL |     cfg!(any(aa, bb));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `bb`
-  --> $DIR/mix.rs:63:18
+  --> $DIR/mix.rs:65:18
    |
 LL |     cfg!(any(aa, bb));
    |                  ^^
@@ -169,7 +173,7 @@ LL |     cfg!(any(aa, bb));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:66:20
+  --> $DIR/mix.rs:68:20
    |
 LL |     cfg!(any(unix, feature = "zebra"));
    |                    ^^^^^^^^^^^^^^^^^
@@ -179,7 +183,7 @@ LL |     cfg!(any(unix, feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:68:14
+  --> $DIR/mix.rs:70:14
    |
 LL |     cfg!(any(xxx, feature = "zebra"));
    |              ^^^
@@ -188,7 +192,7 @@ LL |     cfg!(any(xxx, feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:68:19
+  --> $DIR/mix.rs:70:19
    |
 LL |     cfg!(any(xxx, feature = "zebra"));
    |                   ^^^^^^^^^^^^^^^^^
@@ -198,7 +202,7 @@ LL |     cfg!(any(xxx, feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:71:14
+  --> $DIR/mix.rs:73:14
    |
 LL |     cfg!(any(xxx, unix, xxx));
    |              ^^^
@@ -207,7 +211,7 @@ LL |     cfg!(any(xxx, unix, xxx));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `xxx`
-  --> $DIR/mix.rs:71:25
+  --> $DIR/mix.rs:73:25
    |
 LL |     cfg!(any(xxx, unix, xxx));
    |                         ^^^
@@ -216,7 +220,7 @@ LL |     cfg!(any(xxx, unix, xxx));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:74:14
+  --> $DIR/mix.rs:76:14
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    |              ^^^^^^^^^^^^^^^^^
@@ -226,7 +230,7 @@ LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:74:33
+  --> $DIR/mix.rs:76:33
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    |                                 ^^^^^^^^^^^^^^^^^
@@ -236,7 +240,7 @@ LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:74:52
+  --> $DIR/mix.rs:76:52
    |
 LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    |                                                    ^^^^^^^^^^^^^^^^^
@@ -246,7 +250,7 @@ LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `zebra`
-  --> $DIR/mix.rs:78:10
+  --> $DIR/mix.rs:80:10
    |
 LL |     cfg!(target_feature = "zebra");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/no-expected-values.empty.stderr
+++ b/tests/ui/check-cfg/no-expected-values.empty.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:11:7
+  --> $DIR/no-expected-values.rs:13:7
    |
 LL | #[cfg(feature = "foo")]
    |       ^^^^^^^--------
@@ -9,10 +9,14 @@ LL | #[cfg(feature = "foo")]
    = note: no expected value for `feature`
    = help: to expect this configuration use `--check-cfg=cfg(feature, values("foo"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/no-expected-values.rs:11:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:15:7
+  --> $DIR/no-expected-values.rs:17:7
    |
 LL | #[cfg(test = "foo")]
    |       ^^^^--------

--- a/tests/ui/check-cfg/no-expected-values.mixed.stderr
+++ b/tests/ui/check-cfg/no-expected-values.mixed.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:11:7
+  --> $DIR/no-expected-values.rs:13:7
    |
 LL | #[cfg(feature = "foo")]
    |       ^^^^^^^--------
@@ -9,10 +9,14 @@ LL | #[cfg(feature = "foo")]
    = note: no expected value for `feature`
    = help: to expect this configuration use `--check-cfg=cfg(feature, values("foo"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/no-expected-values.rs:11:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:15:7
+  --> $DIR/no-expected-values.rs:17:7
    |
 LL | #[cfg(test = "foo")]
    |       ^^^^--------

--- a/tests/ui/check-cfg/no-expected-values.rs
+++ b/tests/ui/check-cfg/no-expected-values.rs
@@ -8,6 +8,8 @@
 //@ [mixed]compile-flags: --check-cfg=cfg(test,feature)
 //@ [empty]compile-flags: --check-cfg=cfg(test,feature,values(none()))
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(feature = "foo")]
 //~^ WARNING unexpected `cfg` condition value
 fn do_foo() {}

--- a/tests/ui/check-cfg/no-expected-values.simple.stderr
+++ b/tests/ui/check-cfg/no-expected-values.simple.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:11:7
+  --> $DIR/no-expected-values.rs:13:7
    |
 LL | #[cfg(feature = "foo")]
    |       ^^^^^^^--------
@@ -9,10 +9,14 @@ LL | #[cfg(feature = "foo")]
    = note: no expected value for `feature`
    = help: to expect this configuration use `--check-cfg=cfg(feature, values("foo"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/no-expected-values.rs:11:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: `foo`
-  --> $DIR/no-expected-values.rs:15:7
+  --> $DIR/no-expected-values.rs:17:7
    |
 LL | #[cfg(test = "foo")]
    |       ^^^^--------

--- a/tests/ui/check-cfg/order-independant.rs
+++ b/tests/ui/check-cfg/order-independant.rs
@@ -6,6 +6,8 @@
 //@ [values_before]compile-flags: --check-cfg=cfg(a,values("b")) --check-cfg=cfg(a)
 //@ [values_after]compile-flags: --check-cfg=cfg(a) --check-cfg=cfg(a,values("b"))
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(a)]
 fn my_cfg() {}
 

--- a/tests/ui/check-cfg/order-independant.values_after.stderr
+++ b/tests/ui/check-cfg/order-independant.values_after.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `unk`
-  --> $DIR/order-independant.rs:12:7
+  --> $DIR/order-independant.rs:14:7
    |
 LL | #[cfg(a = "unk")]
    |       ^^^^^^^^^
@@ -7,7 +7,11 @@ LL | #[cfg(a = "unk")]
    = note: expected values for `a` are: (none), `b`
    = help: to expect this configuration use `--check-cfg=cfg(a, values("unk"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/order-independant.rs:9:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/check-cfg/order-independant.values_before.stderr
+++ b/tests/ui/check-cfg/order-independant.values_before.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `unk`
-  --> $DIR/order-independant.rs:12:7
+  --> $DIR/order-independant.rs:14:7
    |
 LL | #[cfg(a = "unk")]
    |       ^^^^^^^^^
@@ -7,7 +7,11 @@ LL | #[cfg(a = "unk")]
    = note: expected values for `a` are: (none), `b`
    = help: to expect this configuration use `--check-cfg=cfg(a, values("unk"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/order-independant.rs:9:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/check-cfg/stmt-no-ice.rs
+++ b/tests/ui/check-cfg/stmt-no-ice.rs
@@ -4,6 +4,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags:--check-cfg=cfg()
 
+#![warn(unexpected_cfgs)]
+
 fn main() {
     #[cfg(crossbeam_loom)]
     //~^ WARNING unexpected `cfg` condition name

--- a/tests/ui/check-cfg/stmt-no-ice.stderr
+++ b/tests/ui/check-cfg/stmt-no-ice.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `crossbeam_loom`
-  --> $DIR/stmt-no-ice.rs:8:11
+  --> $DIR/stmt-no-ice.rs:10:11
    |
 LL |     #[cfg(crossbeam_loom)]
    |           ^^^^^^^^^^^^^^
@@ -7,7 +7,11 @@ LL |     #[cfg(crossbeam_loom)]
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `doctest`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
    = help: to expect this configuration use `--check-cfg=cfg(crossbeam_loom)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/stmt-no-ice.rs:7:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/check-cfg/unexpected-cfg-name.rs
+++ b/tests/ui/check-cfg/unexpected-cfg-name.rs
@@ -4,6 +4,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(widnows)]
 //~^ WARNING unexpected `cfg` condition name
 pub fn f() {}

--- a/tests/ui/check-cfg/unexpected-cfg-name.stderr
+++ b/tests/ui/check-cfg/unexpected-cfg-name.stderr
@@ -1,12 +1,16 @@
 warning: unexpected `cfg` condition name: `widnows`
-  --> $DIR/unexpected-cfg-name.rs:7:7
+  --> $DIR/unexpected-cfg-name.rs:9:7
    |
 LL | #[cfg(widnows)]
    |       ^^^^^^^ help: there is a config with a similar name: `windows`
    |
    = help: to expect this configuration use `--check-cfg=cfg(widnows)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/unexpected-cfg-name.rs:7:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/check-cfg/unexpected-cfg-value.rs
+++ b/tests/ui/check-cfg/unexpected-cfg-value.rs
@@ -5,6 +5,8 @@
 //@ compile-flags: --cfg=feature="rand"
 //@ compile-flags: --check-cfg=cfg(feature,values("serde","full"))
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(feature = "sedre")]
 //~^ WARNING unexpected `cfg` condition value
 pub fn f() {}

--- a/tests/ui/check-cfg/unexpected-cfg-value.stderr
+++ b/tests/ui/check-cfg/unexpected-cfg-value.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `sedre`
-  --> $DIR/unexpected-cfg-value.rs:8:7
+  --> $DIR/unexpected-cfg-value.rs:10:7
    |
 LL | #[cfg(feature = "sedre")]
    |       ^^^^^^^^^^-------
@@ -9,10 +9,14 @@ LL | #[cfg(feature = "sedre")]
    = note: expected values for `feature` are: `full`, `serde`
    = help: to expect this configuration use `--check-cfg=cfg(feature, values("sedre"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/unexpected-cfg-value.rs:8:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: `rand`
-  --> $DIR/unexpected-cfg-value.rs:15:7
+  --> $DIR/unexpected-cfg-value.rs:17:7
    |
 LL | #[cfg(feature = "rand")]
    |       ^^^^^^^^^^^^^^^^

--- a/tests/ui/check-cfg/unknown-values.rs
+++ b/tests/ui/check-cfg/unknown-values.rs
@@ -8,6 +8,8 @@
 //@ [mixed]compile-flags: --check-cfg=cfg(foo) --check-cfg=cfg(foo,values(any()))
 //@ [with_values]compile-flags:--check-cfg=cfg(foo,values(any())) --check-cfg=cfg(foo,values("aa"))
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(foo = "value")]
 pub fn f() {}
 

--- a/tests/ui/check-cfg/values-none.explicit.stderr
+++ b/tests/ui/check-cfg/values-none.explicit.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `too`
-  --> $DIR/values-none.rs:11:7
+  --> $DIR/values-none.rs:13:7
    |
 LL | #[cfg(foo = "too")]
    |       ^^^--------
@@ -9,10 +9,14 @@ LL | #[cfg(foo = "too")]
    = note: no expected value for `foo`
    = help: to expect this configuration use `--check-cfg=cfg(foo, values("too"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/values-none.rs:11:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/values-none.rs:16:7
+  --> $DIR/values-none.rs:18:7
    |
 LL | #[cfg(foo = "bar")]
    |       ^^^--------

--- a/tests/ui/check-cfg/values-none.implicit.stderr
+++ b/tests/ui/check-cfg/values-none.implicit.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `too`
-  --> $DIR/values-none.rs:11:7
+  --> $DIR/values-none.rs:13:7
    |
 LL | #[cfg(foo = "too")]
    |       ^^^--------
@@ -9,10 +9,14 @@ LL | #[cfg(foo = "too")]
    = note: no expected value for `foo`
    = help: to expect this configuration use `--check-cfg=cfg(foo, values("too"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/values-none.rs:11:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: `bar`
-  --> $DIR/values-none.rs:16:7
+  --> $DIR/values-none.rs:18:7
    |
 LL | #[cfg(foo = "bar")]
    |       ^^^--------

--- a/tests/ui/check-cfg/values-none.rs
+++ b/tests/ui/check-cfg/values-none.rs
@@ -8,6 +8,8 @@
 //@ [concat_1]compile-flags: --check-cfg=cfg(foo) --check-cfg=cfg(foo,values("too"))
 //@ [concat_2]compile-flags: --check-cfg=cfg(foo,values("too")) --check-cfg=cfg(foo)
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(foo = "too")]
 //[explicit]~^ WARNING unexpected `cfg` condition value
 //[implicit]~^^ WARNING unexpected `cfg` condition value

--- a/tests/ui/check-cfg/values-target-json.rs
+++ b/tests/ui/check-cfg/values-target-json.rs
@@ -5,6 +5,8 @@
 //@ needs-llvm-components: x86
 //@ compile-flags: --crate-type=lib --check-cfg=cfg() --target={{src-base}}/check-cfg/my-awesome-platform.json
 
+#![warn(unexpected_cfgs)]
+
 #![feature(lang_items, no_core, auto_traits)]
 #![no_core]
 

--- a/tests/ui/check-cfg/well-known-names.rs
+++ b/tests/ui/check-cfg/well-known-names.rs
@@ -4,6 +4,8 @@
 //@ no-auto-check-cfg
 //@ compile-flags: --check-cfg=cfg()
 
+#![warn(unexpected_cfgs)]
+
 #[cfg(target_oz = "linux")]
 //~^ WARNING unexpected `cfg` condition name
 fn target_os_misspell() {}

--- a/tests/ui/check-cfg/well-known-names.stderr
+++ b/tests/ui/check-cfg/well-known-names.stderr
@@ -1,19 +1,23 @@
 warning: unexpected `cfg` condition name: `target_oz`
-  --> $DIR/well-known-names.rs:7:7
+  --> $DIR/well-known-names.rs:9:7
    |
 LL | #[cfg(target_oz = "linux")]
    |       ^^^^^^^^^^^^^^^^^^^
    |
    = help: to expect this configuration use `--check-cfg=cfg(target_oz, values("linux"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/well-known-names.rs:7:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 help: there is a config with a similar name and value
    |
 LL | #[cfg(target_os = "linux")]
    |       ~~~~~~~~~
 
 warning: unexpected `cfg` condition name: `features`
-  --> $DIR/well-known-names.rs:14:7
+  --> $DIR/well-known-names.rs:16:7
    |
 LL | #[cfg(features = "foo")]
    |       ^^^^^^^^^^^^^^^^
@@ -23,7 +27,7 @@ LL | #[cfg(features = "foo")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `feature`
-  --> $DIR/well-known-names.rs:18:7
+  --> $DIR/well-known-names.rs:20:7
    |
 LL | #[cfg(feature = "foo")]
    |       ^^^^^^^^^^^^^^^
@@ -32,7 +36,7 @@ LL | #[cfg(feature = "foo")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `uniw`
-  --> $DIR/well-known-names.rs:22:7
+  --> $DIR/well-known-names.rs:24:7
    |
 LL | #[cfg(uniw)]
    |       ^^^^ help: there is a config with a similar name: `unix`

--- a/tests/ui/check-cfg/well-known-values.rs
+++ b/tests/ui/check-cfg/well-known-values.rs
@@ -9,6 +9,8 @@
 //@ compile-flags: --check-cfg=cfg()
 //@ compile-flags: -Zcheck-cfg-all-expected
 
+#![warn(unexpected_cfgs)]
+
 #![feature(cfg_overflow_checks)]
 #![feature(cfg_relocation_model)]
 #![feature(cfg_sanitize)]

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:28:5
+  --> $DIR/well-known-values.rs:30:5
    |
 LL |     clippy = "_UNEXPECTED_VALUE",
    |     ^^^^^^----------------------
@@ -8,10 +8,14 @@ LL |     clippy = "_UNEXPECTED_VALUE",
    |
    = note: no expected value for `clippy`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
+note: the lint level is defined here
+  --> $DIR/well-known-values.rs:12:9
+   |
+LL | #![warn(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:30:5
+  --> $DIR/well-known-values.rs:32:5
    |
 LL |     debug_assertions = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^----------------------
@@ -22,7 +26,7 @@ LL |     debug_assertions = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:32:5
+  --> $DIR/well-known-values.rs:34:5
    |
 LL |     doc = "_UNEXPECTED_VALUE",
    |     ^^^----------------------
@@ -33,7 +37,7 @@ LL |     doc = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:34:5
+  --> $DIR/well-known-values.rs:36:5
    |
 LL |     doctest = "_UNEXPECTED_VALUE",
    |     ^^^^^^^----------------------
@@ -44,7 +48,7 @@ LL |     doctest = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:36:5
+  --> $DIR/well-known-values.rs:38:5
    |
 LL |     miri = "_UNEXPECTED_VALUE",
    |     ^^^^----------------------
@@ -55,7 +59,7 @@ LL |     miri = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:38:5
+  --> $DIR/well-known-values.rs:40:5
    |
 LL |     overflow_checks = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^----------------------
@@ -66,7 +70,7 @@ LL |     overflow_checks = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:40:5
+  --> $DIR/well-known-values.rs:42:5
    |
 LL |     panic = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -75,7 +79,7 @@ LL |     panic = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:42:5
+  --> $DIR/well-known-values.rs:44:5
    |
 LL |     proc_macro = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^----------------------
@@ -86,7 +90,7 @@ LL |     proc_macro = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:44:5
+  --> $DIR/well-known-values.rs:46:5
    |
 LL |     relocation_model = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +99,7 @@ LL |     relocation_model = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:46:5
+  --> $DIR/well-known-values.rs:48:5
    |
 LL |     rustfmt = "_UNEXPECTED_VALUE",
    |     ^^^^^^^----------------------
@@ -106,7 +110,7 @@ LL |     rustfmt = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:48:5
+  --> $DIR/well-known-values.rs:50:5
    |
 LL |     sanitize = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -115,7 +119,7 @@ LL |     sanitize = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:50:5
+  --> $DIR/well-known-values.rs:52:5
    |
 LL |     target_abi = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -124,7 +128,7 @@ LL |     target_abi = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:52:5
+  --> $DIR/well-known-values.rs:54:5
    |
 LL |     target_arch = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -133,7 +137,7 @@ LL |     target_arch = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:54:5
+  --> $DIR/well-known-values.rs:56:5
    |
 LL |     target_endian = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -142,7 +146,7 @@ LL |     target_endian = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:56:5
+  --> $DIR/well-known-values.rs:58:5
    |
 LL |     target_env = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -151,7 +155,7 @@ LL |     target_env = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:58:5
+  --> $DIR/well-known-values.rs:60:5
    |
 LL |     target_family = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -160,7 +164,7 @@ LL |     target_family = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:60:5
+  --> $DIR/well-known-values.rs:62:5
    |
 LL |     target_feature = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,7 +173,7 @@ LL |     target_feature = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:62:5
+  --> $DIR/well-known-values.rs:64:5
    |
 LL |     target_has_atomic = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -178,7 +182,7 @@ LL |     target_has_atomic = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:64:5
+  --> $DIR/well-known-values.rs:66:5
    |
 LL |     target_has_atomic_equal_alignment = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -187,7 +191,7 @@ LL |     target_has_atomic_equal_alignment = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:66:5
+  --> $DIR/well-known-values.rs:68:5
    |
 LL |     target_has_atomic_load_store = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -196,7 +200,7 @@ LL |     target_has_atomic_load_store = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:68:5
+  --> $DIR/well-known-values.rs:70:5
    |
 LL |     target_os = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -205,7 +209,7 @@ LL |     target_os = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:70:5
+  --> $DIR/well-known-values.rs:72:5
    |
 LL |     target_pointer_width = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -214,7 +218,7 @@ LL |     target_pointer_width = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:72:5
+  --> $DIR/well-known-values.rs:74:5
    |
 LL |     target_thread_local = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^----------------------
@@ -225,7 +229,7 @@ LL |     target_thread_local = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:74:5
+  --> $DIR/well-known-values.rs:76:5
    |
 LL |     target_vendor = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -234,7 +238,7 @@ LL |     target_vendor = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:76:5
+  --> $DIR/well-known-values.rs:78:5
    |
 LL |     test = "_UNEXPECTED_VALUE",
    |     ^^^^----------------------
@@ -245,7 +249,7 @@ LL |     test = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:78:5
+  --> $DIR/well-known-values.rs:80:5
    |
 LL |     ub_checks = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^----------------------
@@ -256,7 +260,7 @@ LL |     ub_checks = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:80:5
+  --> $DIR/well-known-values.rs:82:5
    |
 LL |     unix = "_UNEXPECTED_VALUE",
    |     ^^^^----------------------
@@ -267,7 +271,7 @@ LL |     unix = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
-  --> $DIR/well-known-values.rs:82:5
+  --> $DIR/well-known-values.rs:84:5
    |
 LL |     windows = "_UNEXPECTED_VALUE",
    |     ^^^^^^^----------------------
@@ -278,7 +282,7 @@ LL |     windows = "_UNEXPECTED_VALUE",
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `linuz`
-  --> $DIR/well-known-values.rs:88:7
+  --> $DIR/well-known-values.rs:90:7
    |
 LL | #[cfg(target_os = "linuz")] // testing that we suggest `linux`
    |       ^^^^^^^^^^^^-------


### PR DESCRIPTION
This allows to find solutions to the false positives that were found in the ecosystem before turning it to `warn` by default again.

Most projects hit by this seem to just disable the warning, which indicates that it isn't working as expected.

CC #124800
CC #124804
CC #124821
CC https://github.com/hyperium/hyper/pull/3660
CC https://github.com/microsoft/windows-rs/pull/3022
CC https://github.com/rust-bitcoin/rust-bitcoin/pull/2748
CC https://github.com/tokio-rs/tokio/pull/6538