### PR TITLE
Don't ICE when we cannot eval a const to a valtree in the new solver

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
@@ -1052,12 +1052,12 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         ty: Ty<'tcx>,
     ) -> Option<ty::Const<'tcx>> {
         use rustc_middle::mir::interpret::ErrorHandled;
-        match self.infcx.try_const_eval_resolve(param_env, unevaluated, ty, DUMMY_SP) {
-            Ok(ct) => Some(ct),
+        match self.infcx.const_eval_resolve(param_env, unevaluated, DUMMY_SP) {
+            Ok(Some(val)) => Some(ty::Const::new_value(self.tcx(), val, ty)),
+            Ok(None) | Err(ErrorHandled::TooGeneric(_)) => None,
             Err(ErrorHandled::Reported(e, _)) => {
                 Some(ty::Const::new_error(self.tcx(), e.into(), ty))
             }
-            Err(ErrorHandled::TooGeneric(_)) => None,
         }
     }
 

--- a/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.rs
+++ b/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.rs
@@ -1,8 +1,9 @@
-//@ compile-flags: -Znext-solver=coherence
+//@ compile-flags: -Znext-solver
 
 #[derive(Debug)]
 struct X<const FN: fn() = { || {} }>;
 //~^ ERROR using function pointers as const generic parameters is forbidden
 //~| ERROR using function pointers as const generic parameters is forbidden
+//~| ERROR type annotations needed
 
 fn main() {}

--- a/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.stderr
+++ b/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.stderr
@@ -1,3 +1,9 @@
+error[E0282]: type annotations needed
+  --> $DIR/const-region-infer-to-static-in-binder.rs:4:10
+   |
+LL | struct X<const FN: fn() = { || {} }>;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the constant `{ || {} }`
+
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/const-region-infer-to-static-in-binder.rs:4:20
    |
@@ -15,5 +21,6 @@ LL | struct X<const FN: fn() = { || {} }>;
    = note: the only supported types are integers, `bool` and `char`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
Use `const_eval_resolve` instead of `try_const_eval_resolve` because naming aside, the former doesn't ICE when a value can't be evaluated to a valtree.

r? lcnr