### PR TITLE
alias-relate: add fast reject optimization

### DIFF
--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -266,6 +266,14 @@ pub trait GenericArg<I: Interner<GenericArg = Self>>:
     + From<I::Region>
     + From<I::Const>
 {
+    fn as_term(&self) -> Option<I::Term> {
+        match self.kind() {
+            ty::GenericArgKind::Lifetime(_) => None,
+            ty::GenericArgKind::Type(ty) => Some(ty.into()),
+            ty::GenericArgKind::Const(ct) => Some(ct.into()),
+        }
+    }
+
     fn as_type(&self) -> Option<I::Ty> {
         if let ty::GenericArgKind::Type(ty) = self.kind() { Some(ty) } else { None }
     }

--- a/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.next.stderr
+++ b/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.next.stderr
@@ -4,6 +4,20 @@ error[E0308]: mismatched types
 LL |     fn func<const N: u32>() -> [(); { () }] {
    |                                       ^^ expected `usize`, found `()`
 
+error[E0271]: type mismatch resolving `N == { () }`
+  --> $DIR/const-in-impl-fn-return-type.rs:20:5
+   |
+LL |     fn func<const N: u32>() -> [(); { () }] {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ
+   |
+note: the requirement `N == { () }` appears on the `impl`'s method `func` but not on the corresponding trait's method
+  --> $DIR/const-in-impl-fn-return-type.rs:12:8
+   |
+LL | trait Trait {
+   |       ----- in this trait
+LL |     fn func<const N: u32>() -> [(); N];
+   |        ^^^^ this trait's method doesn't have the requirement `N == { () }`
+
 error: the constant `N` is not of type `usize`
   --> $DIR/const-in-impl-fn-return-type.rs:12:32
    |
@@ -12,6 +26,7 @@ LL |     fn func<const N: u32>() -> [(); N];
    |
    = note: the length of array `[(); N]` must be type `usize`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0271, E0308.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.rs
+++ b/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.rs
@@ -19,6 +19,7 @@ struct S {}
 impl Trait for S {
     fn func<const N: u32>() -> [(); { () }] {
         //~^ ERROR mismatched types
+        //[next]~| ERROR type mismatch resolving `N == { () }`
         N
     }
 }


### PR DESCRIPTION
may be necessary to compile rayon https://github.com/rust-lang/trait-system-refactor-initiative/issues/109

I don't like this PR too much and ideally we'd find a more principled way to avoid the exponential blowup(s) in rayon. Keeping this open for now but don't intend to merge this until we're more certain that it is required.

r? @compiler-errors