### PR TITLE
Fix `MemCategorization` and `ExprUse` visitors for new solver

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -555,7 +555,7 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
 
         // Select just those fields of the `with`
         // expression that will actually be used
-        match with_place.place.ty().kind() {
+        match self.mc.try_structurally_resolve_type(with_expr.span, with_place.place.ty()).kind() {
             ty::Adt(adt, args) if adt.is_struct() => {
                 // Consume those fields of the with expression that are needed.
                 for (f_index, with_field) in adt.non_enum_variant().fields.iter_enumerated() {

--- a/compiler/rustc_hir_typeck/src/mem_categorization.rs
+++ b/compiler/rustc_hir_typeck/src/mem_categorization.rs
@@ -131,8 +131,14 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
         match ty {
             Some(ty) => {
                 let ty = self.resolve_vars_if_possible(ty);
-                if ty.references_error() || ty.is_ty_var() {
+                if ty.references_error() {
                     debug!("resolve_type_vars_or_error: error from {:?}", ty);
+                    Err(())
+                } else if ty.is_ty_var() {
+                    debug!("resolve_type_vars_or_error: infer var from {:?}", ty);
+                    self.tcx()
+                        .dcx()
+                        .span_delayed_bug(self.tcx().hir().span(id), "encountered type variable");
                     Err(())
                 } else {
                     Ok(ty)
@@ -210,6 +216,9 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
                         Some(t) => Ok(t.ty),
                         None => {
                             debug!("By-ref binding of non-derefable type");
+                            self.tcx()
+                                .dcx()
+                                .span_delayed_bug(pat.span, "by-ref binding of non-derefable type");
                             Err(())
                         }
                     }
@@ -488,6 +497,10 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
             Some(mt) => mt.ty,
             None => {
                 debug!("explicit deref of non-derefable type: {:?}", base_curr_ty);
+                self.tcx().dcx().span_delayed_bug(
+                    self.tcx().hir().span(node.hir_id()),
+                    "explicit deref of non-derefable type",
+                );
                 return Err(());
             }
         };
@@ -732,6 +745,9 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
             PatKind::Slice(before, ref slice, after) => {
                 let Some(element_ty) = place_with_id.place.ty().builtin_index() else {
                     debug!("explicit index of non-indexable type {:?}", place_with_id);
+                    self.tcx()
+                        .dcx()
+                        .span_delayed_bug(pat.span, "explicit index of non-indexable type");
                     return Err(());
                 };
                 let elt_place = self.cat_projection(

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -252,14 +252,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
 
-        euv::ExprUseVisitor::new(
-            &mut delegate,
-            &self.infcx,
-            closure_def_id,
-            self.param_env,
-            &self.typeck_results.borrow(),
-        )
-        .consume_body(body);
+        euv::ExprUseVisitor::new(&mut delegate, self, closure_def_id).consume_body(body);
 
         // If a coroutine is comes from a coroutine-closure that is `move`, but
         // the coroutine-closure was inferred to be `FnOnce` during signature

--- a/tests/ui/traits/next-solver/typeck/normalize-in-upvar-collection.rs
+++ b/tests/ui/traits/next-solver/typeck/normalize-in-upvar-collection.rs
@@ -1,0 +1,15 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+struct Struct {
+    field: i32,
+}
+
+fn hello(f: impl Fn() -> &'static Box<[i32]>, f2: impl Fn() -> &'static Struct) {
+    let cl = || {
+        let x = &f()[0];
+        let y = &f2().field;
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
Best reviewed per-commit.

1. First, we add delayed span bugs for the cases where we previously silently quit in `MemCategorization`.
2. Second, we just inline `FnCtxt` into these visitors. Shouldn't change any behavior.
3. Actually change behavior (in the new solver) to structurally resolve aliases before calling `Ty::kind` and `Ty::builtin_deref`.

This fixes an ICE in icu4x when building it in the new trait solver. 

r? lcnr