### PR TITLE
rustdoc: use stability, instead of features, to decide what to show

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -285,8 +285,6 @@ pub(crate) struct RenderOptions {
     pub(crate) no_emit_shared: bool,
     /// If `true`, HTML source code pages won't be generated.
     pub(crate) html_no_source: bool,
-    /// Whether `-Zforce-unstable-if-unmarked` unstable option is set
-    pub(crate) force_unstable_if_unmarked: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -353,7 +351,6 @@ impl Options {
 
         let codegen_options = CodegenOptions::build(early_dcx, matches);
         let unstable_opts = UnstableOptions::build(early_dcx, matches);
-        let force_unstable_if_unmarked = unstable_opts.force_unstable_if_unmarked;
 
         let dcx = new_dcx(error_format, None, diagnostic_width, &unstable_opts);
 
@@ -790,7 +787,6 @@ impl Options {
             call_locations,
             no_emit_shared: false,
             html_no_source,
-            force_unstable_if_unmarked,
         };
         Some((options, render_options))
     }

--- a/tests/rustdoc/inline_cross/issue-76736-4.rs
+++ b/tests/rustdoc/inline_cross/issue-76736-4.rs
@@ -4,15 +4,16 @@
 // https://github.com/rust-lang/rust/issues/124635
 
 #![crate_name = "foo"]
-#![feature(rustc_private)]
+#![feature(rustc_private, staged_api)]
+#![unstable(feature = "rustc_private", issue = "none")]
 
 extern crate issue_76736_1;
 extern crate issue_76736_2;
 
 // @has foo/struct.Foo.html
-// @!has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
+// @has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
 pub struct Foo;
 
 // @has foo/struct.Bar.html
-// @!has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
+// @has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
 pub use issue_76736_2::Bar;


### PR DESCRIPTION
Fixes #124635

To decide if internal items should be inlined in a doc page, check if the crate is itself internal, rather than if it has the rustc_private feature flag. The standard library uses internal items, but is not itself internal and should not show internal items on its docs pages.