### PR TITLE
Migrate `run-make/rustdoc-output-path` to rmake

### DIFF
--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -245,7 +245,6 @@ run-make/rlib-format-packed-bundled-libs/Makefile
 run-make/rmeta-preferred/Makefile
 run-make/rustc-macro-dep-files/Makefile
 run-make/rustdoc-io-error/Makefile
-run-make/rustdoc-output-path/Makefile
 run-make/rustdoc-scrape-examples-invalid-expr/Makefile
 run-make/rustdoc-scrape-examples-macros/Makefile
 run-make/rustdoc-scrape-examples-multiple/Makefile

--- a/tests/run-make/rustdoc-output-path/Makefile
+++ b/tests/run-make/rustdoc-output-path/Makefile
@@ -1,4 +1,0 @@
-include ../tools.mk
-
-all:
-	$(RUSTDOC) -o "$(TMPDIR)/foo/bar/doc" foo.rs

--- a/tests/run-make/rustdoc-output-path/rmake.rs
+++ b/tests/run-make/rustdoc-output-path/rmake.rs
@@ -1,0 +1,9 @@
+// Checks that if the output folder doesn't exist, rustdoc will create it.
+
+use run_make_support::{rustdoc, tmp_dir};
+
+fn main() {
+    let out_dir = tmp_dir().join("foo/bar/doc");
+    rustdoc().input("foo.rs").output(&out_dir).run();
+    assert!(out_dir.exists());
+}


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/121876.

r? @jieyouxu