### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_lint/src/reference_casting.rs
+++ b/compiler/rustc_lint/src/reference_casting.rs
@@ -199,6 +199,13 @@ fn is_cast_to_bigger_memory_layout<'tcx>(
     let e_alloc = cx.expr_or_init(e);
     let e_alloc =
         if let ExprKind::AddrOf(_, _, inner_expr) = e_alloc.kind { inner_expr } else { e_alloc };
+
+    // if the current expr looks like this `&mut expr[index]` then just looking
+    // at `expr[index]` won't give us the underlying allocation, so we just skip it
+    if let ExprKind::Index(..) = e_alloc.kind {
+        return None;
+    }
+
     let alloc_ty = cx.typeck_results().node_type(e_alloc.hir_id);
 
     // if we do not find it we bail out, as this may not be UB

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -332,7 +332,22 @@ impl<'tcx> SizeSkeleton<'tcx> {
         match *ty.kind() {
             ty::Ref(_, pointee, _) | ty::RawPtr(pointee, _) => {
                 let non_zero = !ty.is_unsafe_ptr();
-                let tail = tcx.struct_tail_erasing_lifetimes(pointee, param_env);
+
+                let tail = tcx.struct_tail_with_normalize(
+                    pointee,
+                    |ty| match tcx.try_normalize_erasing_regions(param_env, ty) {
+                        Ok(ty) => ty,
+                        Err(_e) => {
+                            if let Some(guar) = tcx.dcx().has_errors() {
+                                Ty::new_error(tcx, guar)
+                            } else {
+                                bug!("normalization failed, but no errors reported");
+                            }
+                        }
+                    },
+                    || {},
+                );
+
                 match tail.kind() {
                     ty::Param(_) | ty::Alias(ty::Projection | ty::Inherent, _) => {
                         debug_assert!(tail.has_non_region_param());

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -285,8 +285,6 @@ pub(crate) struct RenderOptions {
     pub(crate) no_emit_shared: bool,
     /// If `true`, HTML source code pages won't be generated.
     pub(crate) html_no_source: bool,
-    /// Whether `-Zforce-unstable-if-unmarked` unstable option is set
-    pub(crate) force_unstable_if_unmarked: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -353,7 +351,6 @@ impl Options {
 
         let codegen_options = CodegenOptions::build(early_dcx, matches);
         let unstable_opts = UnstableOptions::build(early_dcx, matches);
-        let force_unstable_if_unmarked = unstable_opts.force_unstable_if_unmarked;
 
         let dcx = new_dcx(error_format, None, diagnostic_width, &unstable_opts);
 
@@ -790,7 +787,6 @@ impl Options {
             call_locations,
             no_emit_shared: false,
             html_no_source,
-            force_unstable_if_unmarked,
         };
         Some((options, render_options))
     }

--- a/tests/rustdoc/inline_cross/issue-76736-4.rs
+++ b/tests/rustdoc/inline_cross/issue-76736-4.rs
@@ -4,15 +4,16 @@
 // https://github.com/rust-lang/rust/issues/124635
 
 #![crate_name = "foo"]
-#![feature(rustc_private)]
+#![feature(rustc_private, staged_api)]
+#![unstable(feature = "rustc_private", issue = "none")]
 
 extern crate issue_76736_1;
 extern crate issue_76736_2;
 
 // @has foo/struct.Foo.html
-// @!has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
+// @has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
 pub struct Foo;
 
 // @has foo/struct.Bar.html
-// @!has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
+// @has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
 pub use issue_76736_2::Bar;

--- a/tests/ui/lint/reference_casting.rs
+++ b/tests/ui/lint/reference_casting.rs
@@ -247,6 +247,14 @@ unsafe fn bigger_layout() {
     unsafe fn from_ref(this: &i32) -> &i64 {
         &*(this as *const i32 as *const i64)
     }
+
+    // https://github.com/rust-lang/rust/issues/124685
+    unsafe fn slice_index(array: &mut [u8], offset: usize) {
+        let a1 = &mut array[offset];
+        let a2 = a1 as *mut u8;
+        let a3 = a2 as *mut u64;
+        unsafe { *a3 = 3 };
+    }
 }
 
 const RAW_PTR: *mut u8 = 1 as *mut u8;

--- a/tests/ui/structs/ice-struct-tail-normalization-113272.rs
+++ b/tests/ui/structs/ice-struct-tail-normalization-113272.rs
@@ -1,9 +1,10 @@
-//@ known-bug: #113272
 trait Trait {
     type RefTarget;
 }
 
 impl Trait for () where Missing: Trait {}
+//~^ ERROR cannot find type `Missing` in this scope
+//~| ERROR not all trait items implemented, missing: `RefTarget`
 
 struct Other {
     data: <() as Trait>::RefTarget,

--- a/tests/ui/structs/ice-struct-tail-normalization-113272.stderr
+++ b/tests/ui/structs/ice-struct-tail-normalization-113272.stderr
@@ -1,0 +1,19 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/ice-struct-tail-normalization-113272.rs:5:25
+   |
+LL | impl Trait for () where Missing: Trait {}
+   |                         ^^^^^^^ not found in this scope
+
+error[E0046]: not all trait items implemented, missing: `RefTarget`
+  --> $DIR/ice-struct-tail-normalization-113272.rs:5:1
+   |
+LL |     type RefTarget;
+   |     -------------- `RefTarget` from trait
+...
+LL | impl Trait for () where Missing: Trait {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `RefTarget` in implementation
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0046, E0412.
+For more information about an error, try `rustc --explain E0046`.


### PR DESCRIPTION
Successful merges:

 - #124548 (Handle normalization failure in `struct_tail_erasing_lifetimes`)
 - #124761 (Fix insufficient logic when searching for the underlying allocation)
 - #124864 (rustdoc: use stability, instead of features, to decide what to show)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=124548,124761,124864)
<!-- homu-ignore:end -->