### PR TITLE
Handle field projections like slice indexing in invalid_reference_casting

### DIFF
--- a/compiler/rustc_lint/src/reference_casting.rs
+++ b/compiler/rustc_lint/src/reference_casting.rs
@@ -202,7 +202,8 @@ fn is_cast_to_bigger_memory_layout<'tcx>(
 
     // if the current expr looks like this `&mut expr[index]` then just looking
     // at `expr[index]` won't give us the underlying allocation, so we just skip it
-    if let ExprKind::Index(..) = e_alloc.kind {
+    // the same logic applies field access like `&mut expr.field`
+    if let ExprKind::Index(..) | ExprKind::Field(..) = e_alloc.kind {
         return None;
     }
 

--- a/tests/ui/lint/reference_casting.rs
+++ b/tests/ui/lint/reference_casting.rs
@@ -255,6 +255,12 @@ unsafe fn bigger_layout() {
         let a3 = a2 as *mut u64;
         unsafe { *a3 = 3 };
     }
+
+    unsafe fn field_access(v: &mut Vec3<i32>) {
+        let r = &mut v.0;
+        let ptr = r as *mut i32 as *mut Vec3<i32>;
+        unsafe { *ptr = Vec3(0, 0, 0) }
+    }
 }
 
 const RAW_PTR: *mut u8 = 1 as *mut u8;


### PR DESCRIPTION
r? @Urgau 

I saw the implementation in https://github.com/rust-lang/rust/pull/124761, and I was wondering if we also need to handle field access. We do. Without this PR, we get this errant diagnostic:
```
error: casting references to a bigger memory layout than the backing allocation is undefined behavior, even if the reference is unused                                                                                
  --> /home/ben/rust/tests/ui/lint/reference_casting.rs:262:18                                                                                                                                                        
   |                                                                                                       
LL |         let r = &mut v.0;
   |                      --- backing allocation comes from here                                        
LL |         let ptr = r as *mut i32 as *mut Vec3<i32>;            
   |                   ------------------------------- casting happend here                                
LL |         unsafe { *ptr = Vec3(0, 0, 0) }                                                               
   |                  ^^^^^^^^^^^^^^^^^^^^                                                                 
   |                                                                                                       
   = note: casting from `i32` (4 bytes) to `Vec3<i32>` (12 bytes)     
```