### PR TITLE
Check whether the next_node is else-less if in get_return_block

### DIFF
--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -549,6 +549,7 @@ impl<'hir> Map<'hir> {
                     Node::Block(Block { expr: None, .. }) => return None,
                     // The current node is not the tail expression of its parent.
                     Node::Block(Block { expr: Some(e), .. }) if hir_id != e.hir_id => return None,
+                    Node::Block(Block { expr: Some(e), ..}) if matches!(e.kind, ExprKind::If(_, _, None)) => return None,
                     _ => {}
                 }
             }
@@ -563,9 +564,6 @@ impl<'hir> Map<'hir> {
                     // We verify that indirectly by checking that the previous node is the
                     // current node's body
                     if node.body_id().map(|b| b.hir_id) == prev_hir_id =>  {
-                        if let Node::Expr(Expr { kind: ExprKind::Block(_, _), ..}) = self.tcx.hir_node(prev_hir_id.unwrap()) {
-                            return None;
-                        }
                         return Some(hir_id)
                 }
                 // Ignore `return`s on the first iteration

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -563,6 +563,9 @@ impl<'hir> Map<'hir> {
                     // We verify that indirectly by checking that the previous node is the
                     // current node's body
                     if node.body_id().map(|b| b.hir_id) == prev_hir_id =>  {
+                        if let Node::Expr(Expr { kind: ExprKind::Block(_, _), ..}) = self.tcx.hir_node(prev_hir_id.unwrap()) {
+                            return None;
+                        }
                         return Some(hir_id)
                 }
                 // Ignore `return`s on the first iteration

--- a/tests/ui/return/tail-expr-if-as-return.rs
+++ b/tests/ui/return/tail-expr-if-as-return.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if true {
+        "" //~ ERROR mismatched types [E0308]
+    }
+}

--- a/tests/ui/return/tail-expr-if-as-return.stderr
+++ b/tests/ui/return/tail-expr-if-as-return.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/tail-expr-if-as-return.rs:3:9
+   |
+LL | /     if true {
+LL | |         ""
+   | |         ^^ expected `()`, found `&str`
+LL | |     }
+   | |_____- expected this to be `()`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fix #124819 
