### PR TITLE
opt-dist: use xz2 instead of xz crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,7 +2760,7 @@ dependencies = [
  "tabled",
  "tar",
  "tempfile",
- "xz",
+ "xz2",
  "zip",
 ]
 
@@ -6584,15 +6584,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
-]
-
-[[package]]
-name = "xz"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34"
-dependencies = [
- "xz2",
 ]
 
 [[package]]

--- a/src/tools/opt-dist/Cargo.toml
+++ b/src/tools/opt-dist/Cargo.toml
@@ -16,7 +16,7 @@ camino = "1"
 reqwest = { version = "0.11", features = ["blocking"] }
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 tar = "0.4"
-xz = "0.1"
+xz = { version = "0.1", package = "xz2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 glob = "0.3"


### PR DESCRIPTION
xz crate consist of simple reexport of xz2 crate. Why? Idk.

Totally not a backdoor.