### PR TITLE
Make sure we consume a generic arg when checking mistyped turbofish

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1224,7 +1224,11 @@ impl<'a> Parser<'a> {
             let x = self.parse_seq_to_before_end(
                 &token::Gt,
                 SeqSep::trailing_allowed(token::Comma),
-                |p| p.parse_generic_arg(None),
+                |p| match p.parse_generic_arg(None)? {
+                    Some(arg) => Ok(arg),
+                    // If we didn't eat a generic arg, then we should error.
+                    None => p.unexpected_any(),
+                },
             );
             match x {
                 Ok((_, _, Recovered::No)) => {

--- a/tests/ui/parser/recover/turbofish-arg-with-stray-colon.rs
+++ b/tests/ui/parser/recover/turbofish-arg-with-stray-colon.rs
@@ -1,0 +1,6 @@
+fn foo() {
+    let x = Tr<A, A:>;
+    //~^ ERROR expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, found `,`
+}
+
+fn main() {}

--- a/tests/ui/parser/recover/turbofish-arg-with-stray-colon.stderr
+++ b/tests/ui/parser/recover/turbofish-arg-with-stray-colon.stderr
@@ -1,0 +1,14 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, found `,`
+  --> $DIR/turbofish-arg-with-stray-colon.rs:2:17
+   |
+LL |     let x = Tr<A, A:>;
+   |                 ^ expected one of 8 possible tokens
+   |
+   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: maybe write a path separator here
+   |
+LL |     let x = Tr<A, A::>;
+   |                    ~~
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
When recovering un-turbofish-ed args in expr position (e.g. `let x = a<T, U>();` in `check_mistyped_turbofish_with_multiple_type_params`, we used `parse_seq_to_before_end` to parse the fake generic args; however, it used `parse_generic_arg` which *optionally* parses a generic arg. If it doesn't end up parsing an arg, it returns `Ok(None)` and consumes no tokens. If we don't find a delimiter after this (`,`), we try parsing *another* element. In this case, we just infinitely loop looking for a subsequent element.

We can fix this by making sure that we either parse a generic arg or error in `parse_seq_to_before_end`'s callback.

Fixes #124897