### PR TITLE
Always hide private fields in aliased type

### DIFF
--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -8,6 +8,9 @@ use crate::core::DocContext;
 mod stripper;
 pub(crate) use stripper::*;
 
+mod strip_aliased_non_local;
+pub(crate) use self::strip_aliased_non_local::STRIP_ALIASED_NON_LOCAL;
+
 mod strip_hidden;
 pub(crate) use self::strip_hidden::STRIP_HIDDEN;
 
@@ -71,6 +74,7 @@ pub(crate) enum Condition {
 pub(crate) const PASSES: &[Pass] = &[
     CHECK_CUSTOM_CODE_CLASSES,
     CHECK_DOC_TEST_VISIBILITY,
+    STRIP_ALIASED_NON_LOCAL,
     STRIP_HIDDEN,
     STRIP_PRIVATE,
     STRIP_PRIV_IMPORTS,
@@ -86,6 +90,7 @@ pub(crate) const DEFAULT_PASSES: &[ConditionalPass] = &[
     ConditionalPass::always(CHECK_CUSTOM_CODE_CLASSES),
     ConditionalPass::always(COLLECT_TRAIT_IMPLS),
     ConditionalPass::always(CHECK_DOC_TEST_VISIBILITY),
+    ConditionalPass::always(STRIP_ALIASED_NON_LOCAL),
     ConditionalPass::new(STRIP_HIDDEN, WhenNotDocumentHidden),
     ConditionalPass::new(STRIP_PRIVATE, WhenNotDocumentPrivate),
     ConditionalPass::new(STRIP_PRIV_IMPORTS, WhenDocumentPrivate),

--- a/src/librustdoc/passes/strip_aliased_non_local.rs
+++ b/src/librustdoc/passes/strip_aliased_non_local.rs
@@ -1,0 +1,57 @@
+use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::Visibility;
+
+use crate::clean;
+use crate::clean::Item;
+use crate::core::DocContext;
+use crate::fold::{strip_item, DocFolder};
+use crate::passes::Pass;
+
+pub(crate) const STRIP_ALIASED_NON_LOCAL: Pass = Pass {
+    name: "strip-aliased-non-local",
+    run: strip_aliased_non_local,
+    description: "strips all non-local private aliased items from the output",
+};
+
+fn strip_aliased_non_local(krate: clean::Crate, cx: &mut DocContext<'_>) -> clean::Crate {
+    let mut stripper = AliasedNonLocalStripper { tcx: cx.tcx };
+    stripper.fold_crate(krate)
+}
+
+struct AliasedNonLocalStripper<'tcx> {
+    tcx: TyCtxt<'tcx>,
+}
+
+impl<'tcx> DocFolder for AliasedNonLocalStripper<'tcx> {
+    fn fold_item(&mut self, i: Item) -> Option<Item> {
+        Some(match *i.kind {
+            clean::TypeAliasItem(..) => {
+                let mut stripper = NonLocalStripper { tcx: self.tcx };
+                // don't call `fold_item` as that could strip the type-alias it-self
+                // which we don't want to strip out
+                stripper.fold_item_recur(i)
+            }
+            _ => self.fold_item_recur(i),
+        })
+    }
+}
+
+struct NonLocalStripper<'tcx> {
+    tcx: TyCtxt<'tcx>,
+}
+
+impl<'tcx> DocFolder for NonLocalStripper<'tcx> {
+    fn fold_item(&mut self, i: Item) -> Option<Item> {
+        // If not local, we want to respect the original visibility of
+        // the field and not the one given by the user for the currrent crate.
+        //
+        // FIXME(#125009): Not-local should probably consider same Cargo workspace
+        if !i.def_id().map_or(true, |did| did.is_local()) {
+            if i.visibility(self.tcx) != Some(Visibility::Public) || i.is_doc_hidden() {
+                return Some(strip_item(i));
+            }
+        }
+
+        Some(self.fold_item_recur(i))
+    }
+}

--- a/tests/rustdoc-ui/issues/issue-91713.stdout
+++ b/tests/rustdoc-ui/issues/issue-91713.stdout
@@ -1,6 +1,7 @@
 Available passes for running rustdoc:
 check-custom-code-classes - check for custom code classes without the feature-gate enabled
 check_doc_test_visibility - run various visibility-related lints on doctests
+strip-aliased-non-local - strips all non-local private aliased items from the output
         strip-hidden - strips all `#[doc(hidden)]` items from the output
        strip-private - strips all private items from a crate which cannot be seen externally, implies strip-priv-imports
   strip-priv-imports - strips all private import statements (`use`, `extern crate`) from a crate
@@ -14,6 +15,7 @@ Default passes for rustdoc:
 check-custom-code-classes
  collect-trait-impls
 check_doc_test_visibility
+strip-aliased-non-local
         strip-hidden  (when not --document-hidden-items)
        strip-private  (when not --document-private-items)
   strip-priv-imports  (when --document-private-items)

--- a/tests/rustdoc/private-non-local-fields-2.rs
+++ b/tests/rustdoc/private-non-local-fields-2.rs
@@ -1,0 +1,11 @@
+//! This test makes sure that with never show the inner fields in the
+//! aliased type view of type alias.
+
+//@ compile-flags: -Z unstable-options --document-private-items
+
+#![crate_name = "foo"]
+
+use std::collections::BTreeMap;
+
+// @has 'foo/type.FooBar.html' '//*[@class="rust item-decl"]/code' 'struct FooBar { /* private fields */ }'
+pub type FooBar = BTreeMap<u32, String>;

--- a/tests/rustdoc/private-non-local-fields.rs
+++ b/tests/rustdoc/private-non-local-fields.rs
@@ -1,0 +1,9 @@
+//! This test makes sure that with never show the inner fields in the
+//! aliased type view of type alias.
+
+#![crate_name = "foo"]
+
+use std::collections::BTreeMap;
+
+// @has 'foo/type.FooBar.html' '//*[@class="rust item-decl"]/code' 'struct FooBar { /* private fields */ }'
+pub type FooBar = BTreeMap<u32, String>;


### PR DESCRIPTION
This PR adds a new rustdoc pass that unconditionally always strips all private fields in aliased type, since showing them, even with `--document-private-items`, is confusing, unhelpful, and run backwards to the "Aliased type" feature, which is to show the type as it would be seen by the user.

r? @GuillaumeGomez
Fixes #124938
Fixes #123860