### PR TITLE
[DO NOT MERGE] perf: test prototype mum-add-hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/orlp/rustc-hash/?branch=mum-hash-perf-run#0bb327e2f6df4fd59b2b973da0d0182ee8fecd2d"
+source = "git+https://github.com/orlp/rustc-hash/?branch=mum-hash-perf-run#a43a6c7140ba914cab0ea40c3870322abd687517"
 
 [[package]]
 name = "rustc-main"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/orlp/rustc-hash/?branch=mum-hash-perf-run#a43a6c7140ba914cab0ea40c3870322abd687517"
+source = "git+https://github.com/orlp/rustc-hash/?branch=mum-hash-perf-run#223c31462e3b1376abb1a7ccbd2863153fd10a2a"
 
 [[package]]
 name = "rustc-main"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/orlp/rustc-hash/?branch=mum-hash-perf-run#576bcaf44a3dd1820b0e28166a0244e1f68e0875"
+source = "git+https://github.com/orlp/rustc-hash/?branch=mum-hash-perf-run#148207f464dbfd22e9345ae59f8907df9fbb84fa"
 
 [[package]]
 name = "rustc-main"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,8 +3447,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+source = "git+https://github.com/orlp/rustc-hash/?branch=mum-hash-perf-run#576bcaf44a3dd1820b0e28166a0244e1f68e0875"
 
 [[package]]
 name = "rustc-main"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/orlp/rustc-hash/?branch=mum-hash-perf-run#148207f464dbfd22e9345ae59f8907df9fbb84fa"
+source = "git+https://github.com/orlp/rustc-hash/?branch=mum-hash-perf-run#0bb327e2f6df4fd59b2b973da0d0182ee8fecd2d"
 
 [[package]]
 name = "rustc-main"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,3 +111,4 @@ strip = true
 rustc-std-workspace-core = { path = 'library/rustc-std-workspace-core' }
 rustc-std-workspace-alloc = { path = 'library/rustc-std-workspace-alloc' }
 rustc-std-workspace-std = { path = 'library/rustc-std-workspace-std' }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash/", branch = "mum-hash-perf-run" }


### PR DESCRIPTION
This PR solely exists to do a perf run of a prototype hash I created to see if it would be a worthwhile replacement for FxHash.

The hash function being tested: https://github.com/orlp/rustc-hash/blob/576bcaf44a3dd1820b0e28166a0244e1f68e0875/src/mum_add_hasher.rs.

?r @thomcc 