### PR TITLE
Make `non-local-def` lint Allow by default

### DIFF
--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -47,7 +47,7 @@ declare_lint! {
     /// All nested bodies (functions, enum discriminant, array length, consts) (expect for
     /// `const _: Ty = { ... }` in top-level module, which is still undecided) are checked.
     pub NON_LOCAL_DEFINITIONS,
-    Warn,
+    Allow,
     "checks for non-local definitions",
     report_in_external_macro
 }

--- a/tests/rustdoc-ui/doctest/non_local_defs.rs
+++ b/tests/rustdoc-ui/doctest/non_local_defs.rs
@@ -5,6 +5,7 @@
 //@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 //! ```
+//! #![warn(non_local_definitions)]
 //! #[macro_export]
 //! macro_rules! a_macro { () => {} }
 //! ```

--- a/tests/rustdoc-ui/doctest/non_local_defs.stderr
+++ b/tests/rustdoc-ui/doctest/non_local_defs.stderr
@@ -1,5 +1,5 @@
 warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
-  --> $DIR/non_local_defs.rs:9:1
+  --> $DIR/non_local_defs.rs:10:1
    |
 LL | macro_rules! a_macro { () => {} }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,11 @@ LL | macro_rules! a_macro { () => {} }
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/non_local_defs.rs:7:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/non-local-defs/cargo-update.rs
+++ b/tests/ui/lint/non-local-defs/cargo-update.rs
@@ -10,6 +10,8 @@
 // of the `cargo update` suggestion we assert it here.
 //@ error-pattern: `cargo update -p non_local_macro`
 
+#![warn(non_local_definitions)]
+
 extern crate non_local_macro;
 
 struct LocalStruct;

--- a/tests/ui/lint/non-local-defs/cargo-update.stderr
+++ b/tests/ui/lint/non-local-defs/cargo-update.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/cargo-update.rs:17:1
+  --> $DIR/cargo-update.rs:19:1
    |
 LL | non_local_macro::non_local_impl!(LocalStruct);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,11 @@ LL | non_local_macro::non_local_impl!(LocalStruct);
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: the macro `non_local_macro::non_local_impl` may come from an old version of the `non_local_macro` crate, try updating your dependency with `cargo update -p non_local_macro`
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/cargo-update.rs:13:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
    = note: this warning originates in the macro `non_local_macro::non_local_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted

--- a/tests/ui/lint/non-local-defs/consts.rs
+++ b/tests/ui/lint/non-local-defs/consts.rs
@@ -2,6 +2,8 @@
 //@ edition:2021
 //@ rustc-env:CARGO_CRATE_NAME=non_local_def
 
+#![warn(non_local_definitions)]
+
 struct Test;
 
 trait Uto {}

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/consts.rs:13:5
+  --> $DIR/consts.rs:15:5
    |
 LL | const Z: () = {
    |       - help: use a const-anon item to suppress this lint: `_`
@@ -11,10 +11,14 @@ LL |     impl Uto for &Test {}
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/consts.rs:5:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/consts.rs:24:5
+  --> $DIR/consts.rs:26:5
    |
 LL |     impl Uto2 for Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +29,7 @@ LL |     impl Uto2 for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/consts.rs:32:5
+  --> $DIR/consts.rs:34:5
    |
 LL |     impl Uto3 for Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -36,7 +40,7 @@ LL |     impl Uto3 for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/consts.rs:43:5
+  --> $DIR/consts.rs:45:5
    |
 LL | /     impl Test {
 LL | |
@@ -50,7 +54,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/consts.rs:50:9
+  --> $DIR/consts.rs:52:9
    |
 LL | /         impl Test {
 LL | |
@@ -64,7 +68,7 @@ LL | |         }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/consts.rs:59:9
+  --> $DIR/consts.rs:61:9
    |
 LL | /         impl Test {
 LL | |
@@ -78,7 +82,7 @@ LL | |         }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/consts.rs:72:9
+  --> $DIR/consts.rs:74:9
    |
 LL |         impl Uto9 for Test {}
    |         ^^^^^^^^^^^^^^^^^^^^^
@@ -89,7 +93,7 @@ LL |         impl Uto9 for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/consts.rs:79:9
+  --> $DIR/consts.rs:81:9
    |
 LL |         impl Uto10 for Test {}
    |         ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.rs
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 struct Dog;
 
 fn main() {

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive-trait.rs:7:5
+  --> $DIR/exhaustive-trait.rs:9:5
    |
 LL | /     impl PartialEq<()> for Dog {
 LL | |
@@ -13,10 +13,14 @@ LL | |     }
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive-trait.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive-trait.rs:14:5
+  --> $DIR/exhaustive-trait.rs:16:5
    |
 LL | /     impl PartialEq<()> for &Dog {
 LL | |
@@ -32,7 +36,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive-trait.rs:21:5
+  --> $DIR/exhaustive-trait.rs:23:5
    |
 LL | /     impl PartialEq<Dog> for () {
 LL | |
@@ -48,7 +52,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive-trait.rs:28:5
+  --> $DIR/exhaustive-trait.rs:30:5
    |
 LL | /     impl PartialEq<&Dog> for () {
 LL | |
@@ -64,7 +68,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive-trait.rs:35:5
+  --> $DIR/exhaustive-trait.rs:37:5
    |
 LL | /     impl PartialEq<Dog> for &Dog {
 LL | |
@@ -80,7 +84,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive-trait.rs:42:5
+  --> $DIR/exhaustive-trait.rs:44:5
    |
 LL | /     impl PartialEq<&Dog> for &Dog {
 LL | |

--- a/tests/ui/lint/non-local-defs/exhaustive.rs
+++ b/tests/ui/lint/non-local-defs/exhaustive.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 use std::fmt::Display;
 
 trait Trait {}

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:10:5
+  --> $DIR/exhaustive.rs:12:5
    |
 LL | /     impl Test {
 LL | |
@@ -11,10 +11,14 @@ LL | |     }
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:15:5
+  --> $DIR/exhaustive.rs:17:5
    |
 LL | /     impl Display for Test {
 LL | |
@@ -30,7 +34,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:22:5
+  --> $DIR/exhaustive.rs:24:5
    |
 LL |     impl dyn Trait {}
    |     ^^^^^^^^^^^^^^^^^
@@ -41,7 +45,7 @@ LL |     impl dyn Trait {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:25:5
+  --> $DIR/exhaustive.rs:27:5
    |
 LL |     impl<T: Trait> Trait for Vec<T> { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +56,7 @@ LL |     impl<T: Trait> Trait for Vec<T> { }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:28:5
+  --> $DIR/exhaustive.rs:30:5
    |
 LL |     impl Trait for &dyn Trait {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +67,7 @@ LL |     impl Trait for &dyn Trait {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:31:5
+  --> $DIR/exhaustive.rs:33:5
    |
 LL |     impl Trait for *mut Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,7 +78,7 @@ LL |     impl Trait for *mut Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:34:5
+  --> $DIR/exhaustive.rs:36:5
    |
 LL |     impl Trait for *mut [Test] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -85,7 +89,7 @@ LL |     impl Trait for *mut [Test] {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:37:5
+  --> $DIR/exhaustive.rs:39:5
    |
 LL |     impl Trait for [Test; 8] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -96,7 +100,7 @@ LL |     impl Trait for [Test; 8] {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:40:5
+  --> $DIR/exhaustive.rs:42:5
    |
 LL |     impl Trait for (Test,) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,7 +111,7 @@ LL |     impl Trait for (Test,) {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:43:5
+  --> $DIR/exhaustive.rs:45:5
    |
 LL |     impl Trait for fn(Test) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,7 +122,7 @@ LL |     impl Trait for fn(Test) -> () {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:46:5
+  --> $DIR/exhaustive.rs:48:5
    |
 LL |     impl Trait for fn() -> Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,7 +133,7 @@ LL |     impl Trait for fn() -> Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:50:9
+  --> $DIR/exhaustive.rs:52:9
    |
 LL |         impl Trait for Test {}
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -140,7 +144,7 @@ LL |         impl Trait for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:58:5
+  --> $DIR/exhaustive.rs:60:5
    |
 LL |     impl Trait for *mut InsideMain {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -151,7 +155,7 @@ LL |     impl Trait for *mut InsideMain {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:60:5
+  --> $DIR/exhaustive.rs:62:5
    |
 LL |     impl Trait for *mut [InsideMain] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,7 +166,7 @@ LL |     impl Trait for *mut [InsideMain] {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:62:5
+  --> $DIR/exhaustive.rs:64:5
    |
 LL |     impl Trait for [InsideMain; 8] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -173,7 +177,7 @@ LL |     impl Trait for [InsideMain; 8] {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:64:5
+  --> $DIR/exhaustive.rs:66:5
    |
 LL |     impl Trait for (InsideMain,) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -184,7 +188,7 @@ LL |     impl Trait for (InsideMain,) {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:66:5
+  --> $DIR/exhaustive.rs:68:5
    |
 LL |     impl Trait for fn(InsideMain) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -195,7 +199,7 @@ LL |     impl Trait for fn(InsideMain) -> () {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:68:5
+  --> $DIR/exhaustive.rs:70:5
    |
 LL |     impl Trait for fn() -> InsideMain {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -206,7 +210,7 @@ LL |     impl Trait for fn() -> InsideMain {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:72:9
+  --> $DIR/exhaustive.rs:74:9
    |
 LL | /         impl Display for InsideMain {
 LL | |
@@ -222,7 +226,7 @@ LL | |         }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/exhaustive.rs:79:9
+  --> $DIR/exhaustive.rs:81:9
    |
 LL | /         impl InsideMain {
 LL | |

--- a/tests/ui/lint/non-local-defs/from-local-for-global.rs
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 struct Cat;
 struct Wrap<T>(T);
 

--- a/tests/ui/lint/non-local-defs/from-local-for-global.stderr
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/from-local-for-global.rs:8:5
+  --> $DIR/from-local-for-global.rs:10:5
    |
 LL | /     impl From<Cat> for () {
 LL | |
@@ -13,10 +13,14 @@ LL | |     }
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/from-local-for-global.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/from-local-for-global.rs:18:5
+  --> $DIR/from-local-for-global.rs:20:5
    |
 LL | /     impl From<Wrap<Wrap<Elephant>>> for () {
 LL | |
@@ -32,7 +36,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/from-local-for-global.rs:32:5
+  --> $DIR/from-local-for-global.rs:34:5
    |
 LL |     impl StillNonLocal for &Foo {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -43,7 +47,7 @@ LL |     impl StillNonLocal for &Foo {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/from-local-for-global.rs:40:5
+  --> $DIR/from-local-for-global.rs:42:5
    |
 LL | /     impl From<Local1> for GlobalSameFunction {
 LL | |
@@ -59,7 +63,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/from-local-for-global.rs:48:5
+  --> $DIR/from-local-for-global.rs:50:5
    |
 LL | /     impl From<Local2> for GlobalSameFunction {
 LL | |

--- a/tests/ui/lint/non-local-defs/generics.rs
+++ b/tests/ui/lint/non-local-defs/generics.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 trait Global {}
 
 fn main() {

--- a/tests/ui/lint/non-local-defs/generics.stderr
+++ b/tests/ui/lint/non-local-defs/generics.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/generics.rs:9:5
+  --> $DIR/generics.rs:11:5
    |
 LL |     impl<T: Local> Global for Vec<T> { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,10 +8,14 @@ LL |     impl<T: Local> Global for Vec<T> { }
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/generics.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/generics.rs:20:5
+  --> $DIR/generics.rs:22:5
    |
 LL |     impl Uto7 for Test where Local: std::any::Any {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +26,7 @@ LL |     impl Uto7 for Test where Local: std::any::Any {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/generics.rs:23:5
+  --> $DIR/generics.rs:25:5
    |
 LL |     impl<T> Uto8 for T {}
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +37,7 @@ LL |     impl<T> Uto8 for T {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/generics.rs:32:5
+  --> $DIR/generics.rs:34:5
    |
 LL | /     impl Default for UwU<OwO> {
 LL | |
@@ -49,7 +53,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/generics.rs:43:5
+  --> $DIR/generics.rs:45:5
    |
 LL | /     impl AsRef<Cat> for () {
 LL | |
@@ -63,7 +67,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/generics.rs:54:5
+  --> $DIR/generics.rs:56:5
    |
 LL | /     impl PartialEq<B> for G {
 LL | |
@@ -79,7 +83,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/generics.rs:69:5
+  --> $DIR/generics.rs:71:5
    |
 LL | /     impl From<Wrap<Wrap<Lion>>> for () {
 LL | |
@@ -95,7 +99,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/generics.rs:76:5
+  --> $DIR/generics.rs:78:5
    |
 LL | /     impl From<()> for Wrap<Lion> {
 LL | |

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.rs
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 macro_rules! m {
     () => {
         trait MacroTrait {}

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/inside-macro_rules.rs:9:13
+  --> $DIR/inside-macro_rules.rs:11:13
    |
 LL |             impl MacroTrait for OutsideStruct {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,11 @@ LL | m!();
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/inside-macro_rules.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
    = note: this warning originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted

--- a/tests/ui/lint/non-local-defs/macro_rules.rs
+++ b/tests/ui/lint/non-local-defs/macro_rules.rs
@@ -3,6 +3,8 @@
 //@ aux-build:non_local_macro.rs
 //@ rustc-env:CARGO_CRATE_NAME=non_local_def
 
+#![warn(non_local_definitions)]
+
 extern crate non_local_macro;
 
 const B: u32 = {

--- a/tests/ui/lint/non-local-defs/macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/macro_rules.stderr
@@ -1,5 +1,5 @@
 warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
-  --> $DIR/macro_rules.rs:10:5
+  --> $DIR/macro_rules.rs:12:5
    |
 LL |     macro_rules! m0 { () => { } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,10 +8,14 @@ LL |     macro_rules! m0 { () => { } };
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/macro_rules.rs:6:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
-  --> $DIR/macro_rules.rs:16:1
+  --> $DIR/macro_rules.rs:18:1
    |
 LL | non_local_macro::non_local_macro_rules!(my_macro);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +28,7 @@ LL | non_local_macro::non_local_macro_rules!(my_macro);
    = note: this warning originates in the macro `non_local_macro::non_local_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
-  --> $DIR/macro_rules.rs:21:5
+  --> $DIR/macro_rules.rs:23:5
    |
 LL |     macro_rules! m { () => { } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +39,7 @@ LL |     macro_rules! m { () => { } };
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
-  --> $DIR/macro_rules.rs:29:13
+  --> $DIR/macro_rules.rs:31:13
    |
 LL |             macro_rules! m2 { () => { } };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.rs
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 // https://github.com/rust-lang/rust/issues/123573#issue-2229428739
 
 pub trait Test {}

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/trait-solver-overflow-123573.rs:12:5
+  --> $DIR/trait-solver-overflow-123573.rs:14:5
    |
 LL |     impl Test for &Local {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,11 @@ LL |     impl Test for &Local {}
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/trait-solver-overflow-123573.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/non-local-defs/weird-exprs.rs
+++ b/tests/ui/lint/non-local-defs/weird-exprs.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 trait Uto {}
 struct Test;
 

--- a/tests/ui/lint/non-local-defs/weird-exprs.stderr
+++ b/tests/ui/lint/non-local-defs/weird-exprs.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/weird-exprs.rs:8:5
+  --> $DIR/weird-exprs.rs:10:5
    |
 LL |     impl Uto for *mut Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,10 +8,14 @@ LL |     impl Uto for *mut Test {}
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/weird-exprs.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/weird-exprs.rs:16:9
+  --> $DIR/weird-exprs.rs:18:9
    |
 LL |         impl Uto for Test {}
    |         ^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +26,7 @@ LL |         impl Uto for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/weird-exprs.rs:25:9
+  --> $DIR/weird-exprs.rs:27:9
    |
 LL | /         impl Test {
 LL | |
@@ -36,7 +40,7 @@ LL | |         }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/weird-exprs.rs:34:9
+  --> $DIR/weird-exprs.rs:36:9
    |
 LL |         impl Uto for &Test {}
    |         ^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +51,7 @@ LL |         impl Uto for &Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/weird-exprs.rs:41:9
+  --> $DIR/weird-exprs.rs:43:9
    |
 LL |         impl Uto for &(Test,) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,7 +62,7 @@ LL |         impl Uto for &(Test,) {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, they should be avoided as they go against expectation
-  --> $DIR/weird-exprs.rs:48:9
+  --> $DIR/weird-exprs.rs:50:9
    |
 LL |         impl Uto for &(Test,Test) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Updates the `non-local-def` lint to be Allow by default. The lint currently triggers undesirably in a few places and we'd like to see that updated (or at least fully investigated) before this ships to stable Rust.

cc #124396
cc #124557
cc #124534
cc #120363

cc @Urgau as discussed in the T-compiler triage meeting today 🙂 