### PR TITLE
Handle Deref expressions in invalid_reference_casting

### DIFF
--- a/compiler/rustc_lint/src/reference_casting.rs
+++ b/compiler/rustc_lint/src/reference_casting.rs
@@ -202,8 +202,10 @@ fn is_cast_to_bigger_memory_layout<'tcx>(
 
     // if the current expr looks like this `&mut expr[index]` then just looking
     // at `expr[index]` won't give us the underlying allocation, so we just skip it
-    // the same logic applies field access like `&mut expr.field`
-    if let ExprKind::Index(..) | ExprKind::Field(..) = e_alloc.kind {
+    // the same logic applies field access `&mut expr.field` and reborrows `&mut *expr`.
+    if let ExprKind::Index(..) | ExprKind::Field(..) | ExprKind::Unary(UnOp::Deref, ..) =
+        e_alloc.kind
+    {
         return None;
     }
 

--- a/tests/ui/lint/reference_casting.rs
+++ b/tests/ui/lint/reference_casting.rs
@@ -261,6 +261,13 @@ unsafe fn bigger_layout() {
         let ptr = r as *mut i32 as *mut Vec3<i32>;
         unsafe { *ptr = Vec3(0, 0, 0) }
     }
+
+    unsafe fn deref(v: &mut Vec3<i32>) {
+        let r = &mut v.0;
+        let r = &mut *r;
+        let ptr = &mut *(r as *mut i32 as *mut Vec3<i32>);
+        unsafe { *ptr = Vec3(0, 0, 0) }
+    }
 }
 
 const RAW_PTR: *mut u8 = 1 as *mut u8;


### PR DESCRIPTION
Similar to https://github.com/rust-lang/rust/pull/124908

See https://github.com/rust-lang/rust/issues/124951 for context; this PR fixes the last of the known false postiive cases with this lint that we encounter in Crater.