### PR TITLE
Rename `${length()}` to `${len()}`

### DIFF
--- a/compiler/rustc_expand/src/mbe/metavar_expr.rs
+++ b/compiler/rustc_expand/src/mbe/metavar_expr.rs
@@ -23,7 +23,7 @@ pub(crate) enum MetaVarExpr {
 
     /// The length of the repetition at a particular depth, where 0 is the inner-most
     /// repetition. The `usize` is the depth.
-    Length(usize),
+    Len(usize),
 }
 
 impl MetaVarExpr {
@@ -48,13 +48,13 @@ impl MetaVarExpr {
                 MetaVarExpr::Ignore(parse_ident(&mut iter, psess, ident.span)?)
             }
             "index" => MetaVarExpr::Index(parse_depth(&mut iter, psess, ident.span)?),
-            "length" => MetaVarExpr::Length(parse_depth(&mut iter, psess, ident.span)?),
+            "len" => MetaVarExpr::Len(parse_depth(&mut iter, psess, ident.span)?),
             _ => {
                 let err_msg = "unrecognized meta-variable expression";
                 let mut err = psess.dcx.struct_span_err(ident.span, err_msg);
                 err.span_suggestion(
                     ident.span,
-                    "supported expressions are count, ignore, index and length",
+                    "supported expressions are count, ignore, index and len",
                     "",
                     Applicability::MachineApplicable,
                 );
@@ -68,7 +68,7 @@ impl MetaVarExpr {
     pub(crate) fn ident(&self) -> Option<Ident> {
         match *self {
             MetaVarExpr::Count(ident, _) | MetaVarExpr::Ignore(ident) => Some(ident),
-            MetaVarExpr::Index(..) | MetaVarExpr::Length(..) => None,
+            MetaVarExpr::Index(..) | MetaVarExpr::Len(..) => None,
         }
     }
 }
@@ -111,7 +111,7 @@ fn parse_count<'psess>(
     Ok(MetaVarExpr::Count(ident, depth))
 }
 
-/// Parses the depth used by index(depth) and length(depth).
+/// Parses the depth used by index(depth) and len(depth).
 fn parse_depth<'psess>(
     iter: &mut RefTokenTreeCursor<'_>,
     psess: &'psess ParseSess,

--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -357,7 +357,7 @@ fn parse_sep_and_kleene_op<'a>(
 
 // `$$` or a meta-variable is the lhs of a macro but shouldn't.
 //
-// For example, `macro_rules! foo { ( ${length()} ) => {} }`
+// For example, `macro_rules! foo { ( ${len()} ) => {} }`
 fn span_dollar_dollar_or_metavar_in_the_lhs_err(sess: &Session, token: &Token) {
     sess.dcx()
         .span_err(token.span, format!("unexpected token: {}", pprust::token_to_string(token)));

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -675,14 +675,14 @@ fn transcribe_metavar_expr<'a>(
             }
             None => return Err(out_of_bounds_err(cx, repeats.len(), sp.entire(), "index")),
         },
-        MetaVarExpr::Length(depth) => match repeats.iter().nth_back(depth) {
+        MetaVarExpr::Len(depth) => match repeats.iter().nth_back(depth) {
             Some((_, length)) => {
                 result.push(TokenTree::token_alone(
                     TokenKind::lit(token::Integer, sym::integer(*length), None),
                     visited_span(),
                 ));
             }
-            None => return Err(out_of_bounds_err(cx, repeats.len(), sp.entire(), "length")),
+            None => return Err(out_of_bounds_err(cx, repeats.len(), sp.entire(), "len")),
         },
     }
     Ok(())

--- a/tests/ui/macros/meta-variable-depth-outside-repeat.rs
+++ b/tests/ui/macros/meta-variable-depth-outside-repeat.rs
@@ -2,8 +2,8 @@
 
 macro_rules! metavar {
     ( $i:expr ) => {
-        ${length(0)}
-        //~^ ERROR meta-variable expression `length` with depth parameter must be called inside of a macro repetition
+        ${len(0)}
+        //~^ ERROR meta-variable expression `len` with depth parameter must be called inside of a macro repetition
     };
 }
 

--- a/tests/ui/macros/meta-variable-depth-outside-repeat.stderr
+++ b/tests/ui/macros/meta-variable-depth-outside-repeat.stderr
@@ -1,8 +1,8 @@
-error: meta-variable expression `length` with depth parameter must be called inside of a macro repetition
+error: meta-variable expression `len` with depth parameter must be called inside of a macro repetition
   --> $DIR/meta-variable-depth-outside-repeat.rs:5:10
    |
-LL |         ${length(0)}
-   |          ^^^^^^^^^^^
+LL |         ${len(0)}
+   |          ^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/rfc-3086-metavar-expr/count-and-length-are-distinct.rs
+++ b/tests/ui/macros/rfc-3086-metavar-expr/count-and-length-are-distinct.rs
@@ -3,60 +3,55 @@
 #![feature(macro_metavar_expr)]
 
 fn main() {
-    macro_rules! one_nested_count_and_length {
+    macro_rules! one_nested_count_and_len {
         ( $( [ $( $l:literal ),* ] ),* ) => {
             [
                 // outer-most repetition
                 $(
                     // inner-most repetition
                     $(
-                        ${ignore($l)} ${index()}, ${length()},
+                        ${ignore($l)} ${index()}, ${len()},
                     )*
-                    ${count($l)}, ${index()}, ${length()},
+                    ${count($l)}, ${index()}, ${len()},
                 )*
                 ${count($l)},
             ]
         };
     }
     assert_eq!(
-        one_nested_count_and_length!(["foo"], ["bar", "baz"]),
+        one_nested_count_and_len!(["foo"], ["bar", "baz"]),
         [
             // # ["foo"]
 
             // ## inner-most repetition (first iteration)
             //
             // `index` is 0 because this is the first inner-most iteration.
-            // `length` is 1 because there is only one inner-most repetition, "foo".
+            // `len` is 1 because there is only one inner-most repetition, "foo".
             0, 1,
-
             // ## outer-most repetition (first iteration)
             //
             // `count` is 1 because of "foo", i,e, `$l` has only one repetition,
             // `index` is 0 because this is the first outer-most iteration.
-            // `length` is 2 because there are 2 outer-most repetitions, ["foo"] and ["bar", "baz"]
+            // `len` is 2 because there are 2 outer-most repetitions, ["foo"] and ["bar", "baz"]
             1, 0, 2,
-
             // # ["bar", "baz"]
 
             // ## inner-most repetition (first iteration)
             //
             // `index` is 0 because this is the first inner-most iteration
-            // `length` is 2 because there are repetitions, "bar" and "baz"
+            // `len` is 2 because there are repetitions, "bar" and "baz"
             0, 2,
-
             // ## inner-most repetition (second iteration)
             //
             // `index` is 1 because this is the second inner-most iteration
-            // `length` is 2 because there are repetitions, "bar" and "baz"
+            // `len` is 2 because there are repetitions, "bar" and "baz"
             1, 2,
-
             // ## outer-most repetition (second iteration)
             //
             // `count` is 2 because of "bar" and "baz", i,e, `$l` has two repetitions,
             // `index` is 1 because this is the second outer-most iteration
-            // `length` is 2 because there are 2 outer-most repetitions, ["foo"] and ["bar", "baz"]
+            // `len` is 2 because there are 2 outer-most repetitions, ["foo"] and ["bar", "baz"]
             2, 1, 2,
-
             // # last count
 
             // Because there are a total of 3 repetitions of `$l`, "foo", "bar" and "baz"
@@ -131,7 +126,6 @@ fn main() {
             &[2][..],
             // t u v w x y z
             &[7][..],
-
             // (a b c) (d e f)
             &[6, 2][..],
             // (g h) (i j k l m)
@@ -142,7 +136,6 @@ fn main() {
             &[5, 3][..],
             // (t u v w x y z)
             &[7, 1][..],
-
             // [ (a b c) (d e f) ]
             // [ (g h) (i j k l m) ]
             // [ (n) ]
@@ -150,7 +143,6 @@ fn main() {
             // [ (o) (p q) (r s) ]
             // [ (t u v w x y z) ]
             &[12, 4, 2][..],
-
             // {
             //     [ (a b c) (d e f) ]
             //     [ (g h) (i j k l m) ]
@@ -165,43 +157,43 @@ fn main() {
     );
 
     // Grouped from the outer-most to the inner-most
-    macro_rules! three_nested_length {
+    macro_rules! three_nested_len {
         ( $( { $( [ $( ( $( $i:ident )* ) )* ] )* } )* ) => {
             &[
                 $( $( $( $(
                     &[
-                        ${ignore($i)} ${length(3)},
-                        ${ignore($i)} ${length(2)},
-                        ${ignore($i)} ${length(1)},
-                        ${ignore($i)} ${length(0)},
+                        ${ignore($i)} ${len(3)},
+                        ${ignore($i)} ${len(2)},
+                        ${ignore($i)} ${len(1)},
+                        ${ignore($i)} ${len(0)},
                     ][..],
                 )* )* )* )*
 
                 $( $( $(
                     &[
-                        ${ignore($i)} ${length(2)},
-                        ${ignore($i)} ${length(1)},
-                        ${ignore($i)} ${length(0)},
+                        ${ignore($i)} ${len(2)},
+                        ${ignore($i)} ${len(1)},
+                        ${ignore($i)} ${len(0)},
                     ][..],
                 )* )* )*
 
                 $( $(
                     &[
-                        ${ignore($i)} ${length(1)},
-                        ${ignore($i)} ${length(0)},
+                        ${ignore($i)} ${len(1)},
+                        ${ignore($i)} ${len(0)},
                     ][..],
                 )* )*
 
                 $(
                     &[
-                        ${ignore($i)} ${length(0)},
+                        ${ignore($i)} ${len(0)},
                     ][..],
                 )*
             ][..]
         }
     }
     assert_eq!(
-        three_nested_length!(
+        three_nested_len!(
             {
                 [ (a b c) (d e f) ]
                 [ (g h) (i j k l m) ]
@@ -214,45 +206,64 @@ fn main() {
         ),
         &[
             // a b c
-            &[2, 3, 2, 3][..], &[2, 3, 2, 3][..], &[2, 3, 2, 3][..],
+            &[2, 3, 2, 3][..],
+            &[2, 3, 2, 3][..],
+            &[2, 3, 2, 3][..],
             // d e f
-            &[2, 3, 2, 3][..], &[2, 3, 2, 3][..], &[2, 3, 2, 3][..],
+            &[2, 3, 2, 3][..],
+            &[2, 3, 2, 3][..],
+            &[2, 3, 2, 3][..],
             // g h
-            &[2, 3, 2, 2][..], &[2, 3, 2, 2][..],
+            &[2, 3, 2, 2][..],
+            &[2, 3, 2, 2][..],
             // i j k l m
-            &[2, 3, 2, 5][..], &[2, 3, 2, 5][..], &[2, 3, 2, 5][..], &[2, 3, 2, 5][..],
+            &[2, 3, 2, 5][..],
+            &[2, 3, 2, 5][..],
+            &[2, 3, 2, 5][..],
+            &[2, 3, 2, 5][..],
             &[2, 3, 2, 5][..],
             // n
             &[2, 3, 1, 1][..],
             // o
             &[2, 2, 3, 1][..],
             // p q
-            &[2, 2, 3, 2][..], &[2, 2, 3, 2][..],
+            &[2, 2, 3, 2][..],
+            &[2, 2, 3, 2][..],
             // r s
-            &[2, 2, 3, 2][..], &[2, 2, 3, 2][..],
+            &[2, 2, 3, 2][..],
+            &[2, 2, 3, 2][..],
             // t u v w x y z
-            &[2, 2, 1, 7][..], &[2, 2, 1, 7][..], &[2, 2, 1, 7][..], &[2, 2, 1, 7][..],
-            &[2, 2, 1, 7][..], &[2, 2, 1, 7][..], &[2, 2, 1, 7][..],
-
+            &[2, 2, 1, 7][..],
+            &[2, 2, 1, 7][..],
+            &[2, 2, 1, 7][..],
+            &[2, 2, 1, 7][..],
+            &[2, 2, 1, 7][..],
+            &[2, 2, 1, 7][..],
+            &[2, 2, 1, 7][..],
             // (a b c) (d e f)
-            &[2, 3, 2][..], &[2, 3, 2][..],
+            &[2, 3, 2][..],
+            &[2, 3, 2][..],
             // (g h) (i j k l m)
-            &[2, 3, 2][..], &[2, 3, 2][..],
+            &[2, 3, 2][..],
+            &[2, 3, 2][..],
             // (n)
             &[2, 3, 1][..],
             // (o) (p q) (r s)
-            &[2, 2, 3][..], &[2, 2, 3][..], &[2, 2, 3][..],
+            &[2, 2, 3][..],
+            &[2, 2, 3][..],
+            &[2, 2, 3][..],
             // (t u v w x y z)
             &[2, 2, 1][..],
-
             // [ (a b c) (d e f) ]
             // [ (g h) (i j k l m) ]
             // [ (n) ]
-            &[2, 3][..], &[2, 3][..],  &[2, 3,][..],
+            &[2, 3][..],
+            &[2, 3][..],
+            &[2, 3,][..],
             // [ (o) (p q) (r s) ]
             // [ (t u v w x y z) ]
-            &[2, 2][..], &[2, 2][..],
-
+            &[2, 2][..],
+            &[2, 2][..],
             // {
             //     [ (a b c) (d e f) ]
             //     [ (g h) (i j k l m) ]
@@ -262,10 +273,11 @@ fn main() {
             //     [ (o) (p q) (r s) ]
             //     [ (t u v w x y z) ]
             // }
-            &[2][..], &[2][..]
+            &[2][..],
+            &[2][..]
         ][..]
     );
 
-    // It is possible to say, to some degree, that count is an "amalgamation" of length (see
-    // each length line result and compare them with the count results)
+    // It is possible to say, to some degree, that count is an "amalgamation" of len (see
+    // each len line result and compare them with the count results)
 }

--- a/tests/ui/macros/rfc-3086-metavar-expr/feature-gate-macro_metavar_expr.rs
+++ b/tests/ui/macros/rfc-3086-metavar-expr/feature-gate-macro_metavar_expr.rs
@@ -37,17 +37,17 @@ macro_rules! count_depth_limits {
     };
 }
 
-/// Produce (index, length) pairs for literals in a macro repetition.
+/// Produce (index, len) pairs for literals in a macro repetition.
 /// The literal is not included in the output, so this macro uses the
 /// `ignore` meta-variable expression to create a non-expanding
 /// repetition binding.
 macro_rules! enumerate_literals {
     ( $( ($l:stmt) ),* ) => {
-        [$( ${ignore($l)} (${index()}, ${length()}) ),*]
+        [$( ${ignore($l)} (${index()}, ${len()}) ),*]
     };
 }
 
-/// Produce index and length tuples for literals in a 2-dimensional
+/// Produce index and len tuples for literals in a 2-dimensional
 /// macro repetition.
 macro_rules! enumerate_literals_2 {
     ( $( [ $( ($l:literal) ),* ] ),* ) => {
@@ -56,9 +56,9 @@ macro_rules! enumerate_literals_2 {
                 $(
                     (
                         ${index(1)},
-                        ${length(1)},
+                        ${len(1)},
                         ${index(0)},
-                        ${length(0)},
+                        ${len(0)},
                         $l
                     ),
                 )*
@@ -134,7 +134,6 @@ fn main() {
             (0, 2, 0, 3, "foo"),
             (0, 2, 1, 3, "bar"),
             (0, 2, 2, 3, "baz"),
-
             (1, 2, 0, 4, "qux"),
             (1, 2, 1, 4, "quux"),
             (1, 2, 2, 4, "quuz"),

--- a/tests/ui/macros/rfc-3086-metavar-expr/macro-expansion.rs
+++ b/tests/ui/macros/rfc-3086-metavar-expr/macro-expansion.rs
@@ -17,20 +17,20 @@ macro_rules! example {
             _nested: vec![
             $(
                 Example {
-                    _indexes: &[(${index()}, ${length()})],
+                    _indexes: &[(${index()}, ${len()})],
                     _counts: &[${count($x, 0)}, ${count($x, 1)}],
                     _nested: vec![
                     $(
                         Example {
-                            _indexes: &[(${index(1)}, ${length(1)}), (${index()}, ${length()})],
+                            _indexes: &[(${index(1)}, ${len(1)}), (${index()}, ${len()})],
                             _counts: &[${count($x)}],
                             _nested: vec![
                             $(
                                 Example {
                                     _indexes: &[
-                                        (${index(2)}, ${length(2)}),
-                                        (${index(1)}, ${length(1)}),
-                                        (${index()}, ${length()})
+                                        (${index(2)}, ${len(2)}),
+                                        (${index(1)}, ${len(1)}),
+                                        (${index()}, ${len()})
                                     ],
                                     _counts: &[],
                                     _nested: vec![],

--- a/tests/ui/macros/rfc-3086-metavar-expr/out-of-bounds-arguments.rs
+++ b/tests/ui/macros/rfc-3086-metavar-expr/out-of-bounds-arguments.rs
@@ -28,9 +28,9 @@ macro_rules! c {
         (
             $( $(
                 ${ignore($foo)}
-                ${length(0)}
-                ${length(10)}
-                //~^ ERROR depth parameter of meta-variable expression `length` must be less than 2
+                ${len(0)}
+                ${len(10)}
+                //~^ ERROR depth parameter of meta-variable expression `len` must be less than 2
             )* )*
         )
     };

--- a/tests/ui/macros/rfc-3086-metavar-expr/out-of-bounds-arguments.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/out-of-bounds-arguments.stderr
@@ -10,11 +10,11 @@ error: depth parameter of meta-variable expression `index` must be less than 3
 LL |                 ${index(10)},
    |                  ^^^^^^^^^^^
 
-error: depth parameter of meta-variable expression `length` must be less than 2
+error: depth parameter of meta-variable expression `len` must be less than 2
   --> $DIR/out-of-bounds-arguments.rs:32:18
    |
-LL |                 ${length(10)}
-   |                  ^^^^^^^^^^^^
+LL |                 ${len(10)}
+   |                  ^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/macros/rfc-3086-metavar-expr/required-feature.rs
+++ b/tests/ui/macros/rfc-3086-metavar-expr/required-feature.rs
@@ -32,13 +32,12 @@ macro_rules! ignore {
     }};
 }
 
-macro_rules! length {
+macro_rules! len {
     ( $( $e:stmt ),* ) => {
-        $( ${ignore($e)} ${length()} )*
+        $( ${ignore($e)} ${len()} )*
         //~^ ERROR meta-variable expressions are unstable
         //~| ERROR meta-variable expressions are unstable
     };
 }
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/macros/rfc-3086-metavar-expr/required-feature.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/required-feature.stderr
@@ -81,7 +81,7 @@ LL |         0 $( + 1 ${ignore($i)} )*
 error[E0658]: meta-variable expressions are unstable
   --> $DIR/required-feature.rs:37:13
    |
-LL |         $( ${ignore($e)} ${length()} )*
+LL |         $( ${ignore($e)} ${len()} )*
    |             ^^^^^^^^^^^^
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
@@ -91,8 +91,8 @@ LL |         $( ${ignore($e)} ${length()} )*
 error[E0658]: meta-variable expressions are unstable
   --> $DIR/required-feature.rs:37:27
    |
-LL |         $( ${ignore($e)} ${length()} )*
-   |                           ^^^^^^^^^^
+LL |         $( ${ignore($e)} ${len()} )*
+   |                           ^^^^^^^
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable

--- a/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.rs
+++ b/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.rs
@@ -18,23 +18,27 @@ macro_rules! curly__rhs_dollar__no_round {
     //~^ ERROR `count` can not be placed inside the inner-most repetition
 }
 
+#[rustfmt::skip] // autoformatters can break a few of the error traces
 macro_rules! no_curly__no_rhs_dollar__round {
     ( $( $i:ident ),* ) => { count(i) };
     //~^ ERROR cannot find function `count` in this scope
     //~| ERROR cannot find value `i` in this scope
 }
 
+#[rustfmt::skip] // autoformatters can break a few of the error traces
 macro_rules! no_curly__no_rhs_dollar__no_round {
     ( $i:ident ) => { count(i) };
     //~^ ERROR cannot find function `count` in this scope
     //~| ERROR cannot find value `i` in this scope
 }
 
+#[rustfmt::skip] // autoformatters can break a few of the error traces
 macro_rules! no_curly__rhs_dollar__round {
     ( $( $i:ident ),* ) => { count($i) };
     //~^ ERROR variable 'i' is still repeating at this depth
 }
 
+#[rustfmt::skip] // autoformatters can break a few of the error traces
 macro_rules! no_curly__rhs_dollar__no_round {
     ( $i:ident ) => { count($i) };
     //~^ ERROR cannot find function `count` in this scope
@@ -44,7 +48,7 @@ macro_rules! no_curly__rhs_dollar__no_round {
 
 macro_rules! dollar_dollar_in_the_lhs {
     ( $$ $a:ident ) => {
-    //~^ ERROR unexpected token: $
+        //~^ ERROR unexpected token: $
     };
 }
 
@@ -85,7 +89,7 @@ macro_rules! metavar_depth_is_not_literal {
 }
 
 macro_rules! metavar_in_the_lhs {
-    ( ${ length() } ) => {
+    ( ${ len() } ) => {
         //~^ ERROR unexpected token: {
         //~| ERROR expected one of: `*`, `+`, or `?`
     };
@@ -109,6 +113,7 @@ macro_rules! metavar_without_parens {
     //~| ERROR expected expression, found `$`
 }
 
+#[rustfmt::skip]
 macro_rules! open_brackets_without_tokens {
     ( $( $i:ident ),* ) => { ${ {} } };
     //~^ ERROR expected expression, found `$`

--- a/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
@@ -1,200 +1,200 @@
 error: unexpected token: $
-  --> $DIR/syntax-errors.rs:46:8
+  --> $DIR/syntax-errors.rs:50:8
    |
 LL |     ( $$ $a:ident ) => {
    |        ^
 
 note: `$$` and meta-variable expressions are not allowed inside macro parameter definitions
-  --> $DIR/syntax-errors.rs:46:8
+  --> $DIR/syntax-errors.rs:50:8
    |
 LL |     ( $$ $a:ident ) => {
    |        ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:53:19
+  --> $DIR/syntax-errors.rs:57:19
    |
 LL |         ${count() a b c}
    |                   ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:53:19
+  --> $DIR/syntax-errors.rs:57:19
    |
 LL |         ${count() a b c}
    |                   ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:56:20
+  --> $DIR/syntax-errors.rs:60:20
    |
 LL |         ${count($i a b c)}
    |                    ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:56:20
+  --> $DIR/syntax-errors.rs:60:20
    |
 LL |         ${count($i a b c)}
    |                    ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:58:23
+  --> $DIR/syntax-errors.rs:62:23
    |
 LL |         ${count($i, 1 a b c)}
    |                       ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:58:23
+  --> $DIR/syntax-errors.rs:62:23
    |
 LL |         ${count($i, 1 a b c)}
    |                       ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:60:21
+  --> $DIR/syntax-errors.rs:64:21
    |
 LL |         ${count($i) a b c}
    |                     ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:60:21
+  --> $DIR/syntax-errors.rs:64:21
    |
 LL |         ${count($i) a b c}
    |                     ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:63:22
+  --> $DIR/syntax-errors.rs:67:22
    |
 LL |         ${ignore($i) a b c}
    |                      ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:63:22
+  --> $DIR/syntax-errors.rs:67:22
    |
 LL |         ${ignore($i) a b c}
    |                      ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:65:21
+  --> $DIR/syntax-errors.rs:69:21
    |
 LL |         ${ignore($i a b c)}
    |                     ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:65:21
+  --> $DIR/syntax-errors.rs:69:21
    |
 LL |         ${ignore($i a b c)}
    |                     ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:68:19
+  --> $DIR/syntax-errors.rs:72:19
    |
 LL |         ${index() a b c}
    |                   ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:68:19
-   |
-LL |         ${index() a b c}
-   |                   ^
-
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:70:19
-   |
-LL |         ${index(1 a b c)}
-   |                   ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:70:19
-   |
-LL |         ${index(1 a b c)}
-   |                   ^
-
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:73:19
-   |
-LL |         ${index() a b c}
-   |                   ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:73:19
+  --> $DIR/syntax-errors.rs:72:19
    |
 LL |         ${index() a b c}
    |                   ^
 
 error: unexpected token: a
-  --> $DIR/syntax-errors.rs:75:19
+  --> $DIR/syntax-errors.rs:74:19
    |
 LL |         ${index(1 a b c)}
    |                   ^
    |
 note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:75:19
+  --> $DIR/syntax-errors.rs:74:19
+   |
+LL |         ${index(1 a b c)}
+   |                   ^
+
+error: unexpected token: a
+  --> $DIR/syntax-errors.rs:77:19
+   |
+LL |         ${index() a b c}
+   |                   ^
+   |
+note: meta-variable expression must not have trailing tokens
+  --> $DIR/syntax-errors.rs:77:19
+   |
+LL |         ${index() a b c}
+   |                   ^
+
+error: unexpected token: a
+  --> $DIR/syntax-errors.rs:79:19
+   |
+LL |         ${index(1 a b c)}
+   |                   ^
+   |
+note: meta-variable expression must not have trailing tokens
+  --> $DIR/syntax-errors.rs:79:19
    |
 LL |         ${index(1 a b c)}
    |                   ^
 
 error: meta-variable expression depth must be a literal
-  --> $DIR/syntax-errors.rs:82:33
+  --> $DIR/syntax-errors.rs:86:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(IDX) } };
    |                                 ^^^^^
 
 error: unexpected token: {
-  --> $DIR/syntax-errors.rs:88:8
+  --> $DIR/syntax-errors.rs:92:8
    |
-LL |     ( ${ length() } ) => {
-   |        ^^^^^^^^^^^^
+LL |     ( ${ len() } ) => {
+   |        ^^^^^^^^^
 
 note: `$$` and meta-variable expressions are not allowed inside macro parameter definitions
-  --> $DIR/syntax-errors.rs:88:8
+  --> $DIR/syntax-errors.rs:92:8
    |
-LL |     ( ${ length() } ) => {
-   |        ^^^^^^^^^^^^
+LL |     ( ${ len() } ) => {
+   |        ^^^^^^^^^
 
 error: expected one of: `*`, `+`, or `?`
-  --> $DIR/syntax-errors.rs:88:8
+  --> $DIR/syntax-errors.rs:92:8
    |
-LL |     ( ${ length() } ) => {
-   |        ^^^^^^^^^^^^
+LL |     ( ${ len() } ) => {
+   |        ^^^^^^^^^
 
 error: meta-variables within meta-variable expressions must be referenced using a dollar sign
-  --> $DIR/syntax-errors.rs:95:33
+  --> $DIR/syntax-errors.rs:99:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ ignore() } };
    |                                 ^^^^^^
 
 error: only unsuffixes integer literals are supported in meta-variable expressions
-  --> $DIR/syntax-errors.rs:101:33
+  --> $DIR/syntax-errors.rs:105:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(1u32) } };
    |                                 ^^^^^
 
 error: meta-variable expression parameter must be wrapped in parentheses
-  --> $DIR/syntax-errors.rs:107:33
+  --> $DIR/syntax-errors.rs:111:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ count{i} } };
    |                                 ^^^^^
 
-error: expected identifier
-  --> $DIR/syntax-errors.rs:113:31
-   |
-LL |     ( $( $i:ident ),* ) => { ${ {} } };
-   |                               ^^^^^^
-
 error: meta-variables within meta-variable expressions must be referenced using a dollar sign
-  --> $DIR/syntax-errors.rs:120:11
+  --> $DIR/syntax-errors.rs:125:11
    |
 LL |         ${count(foo)}
    |           ^^^^^
 
 error: meta-variables within meta-variable expressions must be referenced using a dollar sign
-  --> $DIR/syntax-errors.rs:128:11
+  --> $DIR/syntax-errors.rs:133:11
    |
 LL |         ${ignore(bar)}
    |           ^^^^^^
 
 error: unrecognized meta-variable expression
-  --> $DIR/syntax-errors.rs:135:33
+  --> $DIR/syntax-errors.rs:140:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
-   |                                 ^^^^^^^^^^^^^^ help: supported expressions are count, ignore, index and length
+   |                                 ^^^^^^^^^^^^^^ help: supported expressions are count, ignore, index and len
+
+error: expected identifier
+  --> $DIR/syntax-errors.rs:118:31
+   |
+LL |     ( $( $i:ident ),* ) => { ${ {} } };
+   |                               ^^^^^^
 
 error: `count` can not be placed inside the inner-most repetition
   --> $DIR/syntax-errors.rs:12:24
@@ -209,13 +209,13 @@ LL |     ( $i:ident ) => { ${ count($i) } };
    |                        ^^^^^^^^^^^^^
 
 error: variable 'i' is still repeating at this depth
-  --> $DIR/syntax-errors.rs:34:36
+  --> $DIR/syntax-errors.rs:37:36
    |
 LL |     ( $( $i:ident ),* ) => { count($i) };
    |                                    ^^
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:53:9
+  --> $DIR/syntax-errors.rs:57:9
    |
 LL |         ${count() a b c}
    |         ^ expected expression
@@ -226,7 +226,7 @@ LL |     extra_garbage_after_metavar!(a);
    = note: this error originates in the macro `extra_garbage_after_metavar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:82:30
+  --> $DIR/syntax-errors.rs:86:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(IDX) } };
    |                              ^ expected expression
@@ -237,7 +237,7 @@ LL |     metavar_depth_is_not_literal!(a);
    = note: this error originates in the macro `metavar_depth_is_not_literal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:95:30
+  --> $DIR/syntax-errors.rs:99:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ ignore() } };
    |                              ^ expected expression
@@ -248,7 +248,7 @@ LL |     metavar_token_without_ident!(a);
    = note: this error originates in the macro `metavar_token_without_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:101:30
+  --> $DIR/syntax-errors.rs:105:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(1u32) } };
    |                              ^ expected expression
@@ -259,7 +259,7 @@ LL |     metavar_with_literal_suffix!(a);
    = note: this error originates in the macro `metavar_with_literal_suffix` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:107:30
+  --> $DIR/syntax-errors.rs:111:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ count{i} } };
    |                              ^ expected expression
@@ -270,7 +270,7 @@ LL |     metavar_without_parens!(a);
    = note: this error originates in the macro `metavar_without_parens` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:113:30
+  --> $DIR/syntax-errors.rs:118:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ {} } };
    |                              ^ expected expression
@@ -281,7 +281,7 @@ LL |     open_brackets_without_tokens!(a);
    = note: this error originates in the macro `open_brackets_without_tokens` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:120:9
+  --> $DIR/syntax-errors.rs:125:9
    |
 LL |         ${count(foo)}
    |         ^ expected expression
@@ -292,7 +292,7 @@ LL |     unknown_count_ident!(a);
    = note: this error originates in the macro `unknown_count_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:128:9
+  --> $DIR/syntax-errors.rs:133:9
    |
 LL |         ${ignore(bar)}
    |         ^ expected expression
@@ -303,7 +303,7 @@ LL |     unknown_ignore_ident!(a);
    = note: this error originates in the macro `unknown_ignore_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
-  --> $DIR/syntax-errors.rs:135:30
+  --> $DIR/syntax-errors.rs:140:30
    |
 LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
    |                              ^ expected expression
@@ -314,7 +314,7 @@ LL |     unknown_metavar!(a);
    = note: this error originates in the macro `unknown_metavar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `i` in this scope
-  --> $DIR/syntax-errors.rs:22:36
+  --> $DIR/syntax-errors.rs:23:36
    |
 LL |     ( $( $i:ident ),* ) => { count(i) };
    |                                    ^ not found in this scope
@@ -325,7 +325,7 @@ LL |     no_curly__no_rhs_dollar__round!(a, b, c);
    = note: this error originates in the macro `no_curly__no_rhs_dollar__round` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `i` in this scope
-  --> $DIR/syntax-errors.rs:28:29
+  --> $DIR/syntax-errors.rs:30:29
    |
 LL |     ( $i:ident ) => { count(i) };
    |                             ^ not found in this scope
@@ -336,13 +336,13 @@ LL |     no_curly__no_rhs_dollar__no_round!(a);
    = note: this error originates in the macro `no_curly__no_rhs_dollar__no_round` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `a` in this scope
-  --> $DIR/syntax-errors.rs:147:37
+  --> $DIR/syntax-errors.rs:152:37
    |
 LL |     no_curly__rhs_dollar__no_round!(a);
    |                                     ^ not found in this scope
 
 error[E0425]: cannot find function `count` in this scope
-  --> $DIR/syntax-errors.rs:22:30
+  --> $DIR/syntax-errors.rs:23:30
    |
 LL |     ( $( $i:ident ),* ) => { count(i) };
    |                              ^^^^^ not found in this scope
@@ -353,7 +353,7 @@ LL |     no_curly__no_rhs_dollar__round!(a, b, c);
    = note: this error originates in the macro `no_curly__no_rhs_dollar__round` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find function `count` in this scope
-  --> $DIR/syntax-errors.rs:28:23
+  --> $DIR/syntax-errors.rs:30:23
    |
 LL |     ( $i:ident ) => { count(i) };
    |                       ^^^^^ not found in this scope
@@ -364,7 +364,7 @@ LL |     no_curly__no_rhs_dollar__no_round!(a);
    = note: this error originates in the macro `no_curly__no_rhs_dollar__no_round` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find function `count` in this scope
-  --> $DIR/syntax-errors.rs:39:23
+  --> $DIR/syntax-errors.rs:43:23
    |
 LL |     ( $i:ident ) => { count($i) };
    |                       ^^^^^ not found in this scope


### PR DESCRIPTION
Implements the rename suggested in https://github.com/rust-lang/rust/pull/122808#issuecomment-2047722187
> I brought this up in the doc PR but it belongs here – `length` should probably be renamed `len` before stabilization. The latter is de facto standard in the standard library, whereas the former is only used in a single unstable API. These metafunctions aren’t library items of course, but should presumably still be consistent with established names.

r? @c410-f3r