### PR TITLE
Also expand weak alias tys inside consts inside `expand_weak_alias_tys`

### DIFF
--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1130,7 +1130,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for WeakAliasTypeExpander<'tcx> {
     }
 
     fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {
-        if !ct.ty().has_type_flags(ty::TypeFlags::HAS_TY_WEAK) {
+        if !ct.has_type_flags(ty::TypeFlags::HAS_TY_WEAK) {
             return ct;
         }
         ct.super_fold_with(self)


### PR DESCRIPTION
Ever since #121344 has been merged, I couldn't let go of the fear that I might've slipped a tiny bug into rustc (:P). 

Checking the type flags of the `Const` is strictly more correct than only checking the ones of the `Const`'s `Ty`. I don't think it's possible to trigger an ICE rn (i.e., one of the two `bug!("unexpected weak alias type")` I added in branches where `expand_weak_alias_tys` should've expanded *all* weak alias tys) because presently const exprs aren't allowed to capture late-bound vars. To be future-proof however, we should iron this out.

A possible reproducer would be the following if I'm not mistaken (currently fails to compile due to the aforementioned restriction):

```rs
#![feature(lazy_type_alias, adt_const_params, generic_const_exprs)]

type F = for<'a> fn(A<{ S::<Weak<'a>>(loop {}) }>) -> &'a ();

type A<const N: S<Weak<'static>>> = ();

#[derive(PartialEq, Eq, std::marker::ConstParamTy)]
struct S<T>(T);

type Weak<'a> = &'a ();
```

Whether a late-bound region should actually be considered constrained by a const expr is a separate question — one which we don't need to answer until / unless we actually allow them in such contexts (probable answer: only inside the return exprs of a block but not inside the stmts).

r? oli-obk (he's not available rn but that's fine) or types or compiler