### PR TITLE
Fix println! ICE when parsing percent prefix number

### DIFF
--- a/compiler/rustc_builtin_macros/src/format_foreign.rs
+++ b/compiler/rustc_builtin_macros/src/format_foreign.rs
@@ -263,13 +263,13 @@ pub(crate) mod printf {
     }
 
     impl Num {
-        fn from_str(s: &str, arg: Option<&str>) -> Self {
+        fn from_str(s: &str, arg: Option<&str>) -> Option<Self> {
             if let Some(arg) = arg {
-                Num::Arg(arg.parse().unwrap_or_else(|_| panic!("invalid format arg `{arg:?}`")))
+                arg.parse().ok().map(|arg| Num::Arg(arg))
             } else if s == "*" {
-                Num::Next
+                Some(Num::Next)
             } else {
-                Num::Num(s.parse().unwrap_or_else(|_| panic!("invalid format num `{s:?}`")))
+                s.parse().ok().map(|num| Num::Num(num))
             }
         }
 
@@ -421,7 +421,10 @@ pub(crate) mod printf {
                             state = Prec;
                             parameter = None;
                             flags = "";
-                            width = Some(Num::from_str(at.slice_between(end).unwrap(), None));
+                            width = at.slice_between(end).and_then(|num| Num::from_str(num, None));
+                            if width.is_none() {
+                                return fallback();
+                            }
                             move_to!(end);
                         }
                         // It's invalid, is what it is.
@@ -452,7 +455,10 @@ pub(crate) mod printf {
                 '1'..='9' => {
                     let end = at_next_cp_while(next, char::is_ascii_digit);
                     state = Prec;
-                    width = Some(Num::from_str(at.slice_between(end).unwrap(), None));
+                    width = at.slice_between(end).and_then(|num| Num::from_str(num, None));
+                    if width.is_none() {
+                        return fallback();
+                    }
                     move_to!(end);
                 }
                 _ => {
@@ -468,7 +474,7 @@ pub(crate) mod printf {
             match end.next_cp() {
                 Some(('$', end2)) => {
                     state = Prec;
-                    width = Some(Num::from_str("", Some(at.slice_between(end).unwrap())));
+                    width = Num::from_str("", at.slice_between(end));
                     move_to!(end2);
                 }
                 _ => {
@@ -500,7 +506,7 @@ pub(crate) mod printf {
                     match end.next_cp() {
                         Some(('$', end2)) => {
                             state = Length;
-                            precision = Some(Num::from_str("*", next.slice_between(end)));
+                            precision = Num::from_str("*", next.slice_between(end));
                             move_to!(end2);
                         }
                         _ => {
@@ -513,7 +519,7 @@ pub(crate) mod printf {
                 '0'..='9' => {
                     let end = at_next_cp_while(next, char::is_ascii_digit);
                     state = Length;
-                    precision = Some(Num::from_str(at.slice_between(end).unwrap(), None));
+                    precision = at.slice_between(end).and_then(|num| Num::from_str(num, None));
                     move_to!(end);
                 }
                 _ => return fallback(),

--- a/tests/ui/macros/println-percent-prefix-num-issue-125002.rs
+++ b/tests/ui/macros/println-percent-prefix-num-issue-125002.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!("%100000", 1);
+    //~^ ERROR argument never used
+    println!("%     65536", 1);
+    //~^ ERROR argument never used
+}

--- a/tests/ui/macros/println-percent-prefix-num-issue-125002.stderr
+++ b/tests/ui/macros/println-percent-prefix-num-issue-125002.stderr
@@ -1,0 +1,28 @@
+error: argument never used
+  --> $DIR/println-percent-prefix-num-issue-125002.rs:2:25
+   |
+LL |     println!("%100000", 1);
+   |                         ^ argument never used
+   |
+note: format specifiers use curly braces, and the conversion specifier `1` is unknown or unsupported
+  --> $DIR/println-percent-prefix-num-issue-125002.rs:2:15
+   |
+LL |     println!("%100000", 1);
+   |               ^^
+   = note: printf formatting is not supported; see the documentation for `std::fmt`
+
+error: argument never used
+  --> $DIR/println-percent-prefix-num-issue-125002.rs:4:29
+   |
+LL |     println!("%     65536", 1);
+   |                             ^ argument never used
+   |
+note: format specifiers use curly braces, and the conversion specifier ` ` is unknown or unsupported
+  --> $DIR/println-percent-prefix-num-issue-125002.rs:4:15
+   |
+LL |     println!("%     65536", 1);
+   |               ^^
+   = note: printf formatting is not supported; see the documentation for `std::fmt`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This PR fixes #125002 ICE occurring, for example, with `println!("%100000", 1)` or `println!("%    100000", 1)`.

## Test Case/Change Explanation

The return type of `Num::from_str` has been changed to `Option<Self>` to handle errors when parsing large integers fails.

1. The first `println!` in the test case covers the change of the first `Num::from_str` usage in `format_foreign.rs:426`.
2. The second `println!` in the test case covers the change of the second `Num::from_str` usage in line 460.
3. The 3rd to 5th `Num::from_str` usages behave the same as before.

The 3rd usage would cause an ICE when `num > u16::MAX` in the previous version, but this commit does not include a fix for the ICE in `println!("{:100000$}")`. I think we need to emit an error in the compiler and have more discussion in another issue/PR.