### PR TITLE
io::Write::write_fmt: panic if the formatter fails when the stream does not fail

### DIFF
--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -630,7 +630,9 @@ pub fn format(args: Arguments<'_>) -> string::String {
     fn format_inner(args: Arguments<'_>) -> string::String {
         let capacity = args.estimated_capacity();
         let mut output = string::String::with_capacity(capacity);
-        output.write_fmt(args).expect("a formatting trait implementation returned an error");
+        output
+            .write_fmt(args)
+            .expect("a formatting trait implementation returned an error when the underlying stream did not");
         output
     }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1839,7 +1839,11 @@ pub trait Write {
                 if output.error.is_err() {
                     output.error
                 } else {
-                    Err(error::const_io_error!(ErrorKind::Uncategorized, "formatter error"))
+                    // This shouldn't happen: the underlying stream did not error, but somehow
+                    // the formatter still errored?
+                    panic!(
+                        "a formatting trait implementation returned an error when the underlying stream did not"
+                    );
                 }
             }
         }


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/124954