### PR TITLE
Rewrite 3 very similar `run-make` alloc tests to rmake

### DIFF
--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -1,6 +1,3 @@
-run-make/alloc-no-oom-handling/Makefile
-run-make/alloc-no-rc/Makefile
-run-make/alloc-no-sync/Makefile
 run-make/allocator-shim-circular-deps/Makefile
 run-make/allow-non-lint-warnings-cmdline/Makefile
 run-make/allow-warnings-cmdline-stability/Makefile

--- a/tests/run-make/alloc-no-oom-handling/Makefile
+++ b/tests/run-make/alloc-no-oom-handling/Makefile
@@ -1,7 +1,0 @@
-# This test checks that alloc can still compile correctly when the unstable no_global_oom_handling feature is turned on.
-# See https://github.com/rust-lang/rust/pull/84266
-
-include ../tools.mk
-
-all:
-	$(RUSTC) --edition=2021 -Dwarnings --crate-type=rlib ../../../library/alloc/src/lib.rs --cfg no_global_oom_handling

--- a/tests/run-make/alloc-no-oom-handling/rmake.rs
+++ b/tests/run-make/alloc-no-oom-handling/rmake.rs
@@ -1,0 +1,14 @@
+// This test checks that alloc can still compile correctly when the unstable no_global_oom_handling feature is turned on.
+// See https://github.com/rust-lang/rust/pull/84266
+
+use run_make_support::rustc;
+
+fn main() {
+    rustc()
+        .edition("2021")
+        .arg("-Dwarnings")
+        .crate_type("rlib")
+        .input("../../../library/alloc/src/lib.rs")
+        .cfg("no_global_oom_handling")
+        .run();
+}

--- a/tests/run-make/alloc-no-oom-handling/rmake.rs
+++ b/tests/run-make/alloc-no-oom-handling/rmake.rs
@@ -1,4 +1,5 @@
-// This test checks that alloc can still compile correctly when the unstable no_global_oom_handling feature is turned on.
+// This test checks that alloc can still compile correctly
+// when the unstable no_global_oom_handling feature is turned on.
 // See https://github.com/rust-lang/rust/pull/84266
 
 use run_make_support::rustc;

--- a/tests/run-make/alloc-no-rc/Makefile
+++ b/tests/run-make/alloc-no-rc/Makefile
@@ -1,7 +1,0 @@
-# This test checks that alloc can still compile correctly when the unstable no_rc feature is turned on.
-# See https://github.com/rust-lang/rust/pull/89891
-
-include ../tools.mk
-
-all:
-	$(RUSTC) --edition=2021 -Dwarnings --crate-type=rlib ../../../library/alloc/src/lib.rs --cfg no_rc

--- a/tests/run-make/alloc-no-rc/rmake.rs
+++ b/tests/run-make/alloc-no-rc/rmake.rs
@@ -1,0 +1,14 @@
+// This test checks that alloc can still compile correctly when the unstable no_rc feature is turned on.
+// See https://github.com/rust-lang/rust/pull/84266
+
+use run_make_support::rustc;
+
+fn main() {
+    rustc()
+        .edition("2021")
+        .arg("-Dwarnings")
+        .crate_type("rlib")
+        .input("../../../library/alloc/src/lib.rs")
+        .cfg("no_rc")
+        .run();
+}

--- a/tests/run-make/alloc-no-rc/rmake.rs
+++ b/tests/run-make/alloc-no-rc/rmake.rs
@@ -1,4 +1,5 @@
-// This test checks that alloc can still compile correctly when the unstable no_rc feature is turned on.
+// This test checks that alloc can still compile correctly
+// when the unstable no_rc feature is turned on.
 // See https://github.com/rust-lang/rust/pull/84266
 
 use run_make_support::rustc;

--- a/tests/run-make/alloc-no-sync/Makefile
+++ b/tests/run-make/alloc-no-sync/Makefile
@@ -1,7 +1,0 @@
-# This test checks that alloc can still compile correctly when the unstable no_sync feature is turned on.
-# See https://github.com/rust-lang/rust/pull/89891
-
-include ../tools.mk
-
-all:
-	$(RUSTC) --edition=2021 -Dwarnings --crate-type=rlib ../../../library/alloc/src/lib.rs --cfg no_sync

--- a/tests/run-make/alloc-no-sync/rmake.rs
+++ b/tests/run-make/alloc-no-sync/rmake.rs
@@ -1,0 +1,14 @@
+// This test checks that alloc can still compile correctly when the unstable no_sync feature is turned on.
+// See https://github.com/rust-lang/rust/pull/84266
+
+use run_make_support::rustc;
+
+fn main() {
+    rustc()
+        .edition("2021")
+        .arg("-Dwarnings")
+        .crate_type("rlib")
+        .input("../../../library/alloc/src/lib.rs")
+        .cfg("no_sync")
+        .run();
+}

--- a/tests/run-make/alloc-no-sync/rmake.rs
+++ b/tests/run-make/alloc-no-sync/rmake.rs
@@ -1,4 +1,5 @@
-// This test checks that alloc can still compile correctly when the unstable no_sync feature is turned on.
+// This test checks that alloc can still compile correctly
+// when the unstable no_sync feature is turned on.
 // See https://github.com/rust-lang/rust/pull/84266
 
 use run_make_support::rustc;

--- a/tests/run-make/core-no-fp-fmt-parse/rmake.rs
+++ b/tests/run-make/core-no-fp-fmt-parse/rmake.rs
@@ -2,7 +2,6 @@
 // support for formatting and parsing floating-point numbers.
 
 use run_make_support::rustc;
-use std::path::PathBuf;
 
 fn main() {
     rustc()


### PR DESCRIPTION
Part of #121876

#121918 attempted to port these 3 tests 2 months ago. However, since then, the structure of `run-make-support` has changed a bit and new helper functions were added. Since there has been no activity on the PR, they are good low-hanging fruit to knock down, using the new functions of the current library.

There is also the removal of a useless import on a very similar test.