### PR TITLE
Migrate `run-make/c-link-to-rust-va-list-fn` to `rmake`

### DIFF
--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -12,7 +12,6 @@ run-make/c-dynamic-dylib/Makefile
 run-make/c-dynamic-rlib/Makefile
 run-make/c-link-to-rust-dylib/Makefile
 run-make/c-link-to-rust-staticlib/Makefile
-run-make/c-link-to-rust-va-list-fn/Makefile
 run-make/c-static-dylib/Makefile
 run-make/c-static-rlib/Makefile
 run-make/c-unwind-abi-catch-lib-panic/Makefile

--- a/tests/run-make/c-link-to-rust-va-list-fn/Makefile
+++ b/tests/run-make/c-link-to-rust-va-list-fn/Makefile
@@ -1,7 +1,0 @@
-# ignore-cross-compile
-include ../tools.mk
-
-all:
-	$(RUSTC) checkrust.rs
-	$(CC) test.c $(call STATICLIB,checkrust) $(call OUT_EXE,test) $(EXTRACFLAGS)
-	$(call RUN,test)

--- a/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
+++ b/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
@@ -8,8 +8,7 @@
 use run_make_support::{cc, extra_c_flags, run, rustc, static_lib};
 
 fn main() {
-    rustc().input("checkrust.rs")
-        .run();
+    rustc().input("checkrust.rs").run();
     cc().input("test.c")
         .input(static_lib("checkrust"))
         .out_exe("test")

--- a/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
+++ b/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
@@ -8,11 +8,9 @@
 use run_make_support::{cc, extra_c_flags, run, rustc, static_lib};
 
 fn main() {
-    rustc()
-        .input("checkrust.rs")
+    rustc().input("checkrust.rs")
         .run();
-    cc()
-        .input("test.c")
+    cc().input("test.c")
         .input(static_lib("checkrust"))
         .out_exe("test")
         .args(&extra_c_flags())

--- a/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
+++ b/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
@@ -1,5 +1,5 @@
 // test.c and its static library checkrust.rs make use of variadic functions (VaList).
-// This test checks that the use of this feature does not 
+// This test checks that the use of this feature does not
 // prevent the creation of a functional binary.
 // See https://github.com/rust-lang/rust/pull/49878
 

--- a/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
+++ b/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
@@ -1,0 +1,21 @@
+// test.c and its static library checkrust.rs make use of variadic functions (VaList).
+// This test checks that the use of this feature does not 
+// prevent the creation of a functional binary.
+// See https://github.com/rust-lang/rust/pull/49878
+
+//@ ignore-cross-compile
+
+use run_make_support::{cc, extra_c_flags, run, rustc, static_lib};
+
+fn main() {
+    rustc()
+        .input("checkrust.rs")
+        .run();
+    cc()
+        .input("test.c")
+        .input(static_lib("checkrust"))
+        .out_exe("test")
+        .args(&extra_c_flags())
+        .run();
+    run("test");
+}


### PR DESCRIPTION
Part of #121876.

r? @jieyouxu