### PR TITLE
Fix hidden title in rustdoc book

### DIFF
--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -273,7 +273,7 @@ will be added.
 
 When rendering Rust files, this flag is ignored.
 
-## `--html-in-header`: include more HTML in <head>
+## `--html-in-header`: include more HTML in `<head>`
 
 Using this flag looks like this:
 


### PR DESCRIPTION
raw html is treated as actual html by markdown, so this title needs to use some form of escaping in order to display correctly