### PR TITLE
Use ordinal number in argument error

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1094,7 +1094,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     } else {
                         "".to_string()
                     };
-                    labels.push((provided_span, format!("unexpected argument{provided_ty_name}")));
+                    let idx = if provided_arg_tys.len() == 1 {
+                        "".to_string()
+                    } else {
+                        format!(" #{}", arg_idx.as_usize() + 1)
+                    };
+                    labels.push((
+                        provided_span,
+                        format!("unexpected argument{idx}{provided_ty_name}"),
+                    ));
                     let mut span = provided_span;
                     if span.can_be_used_for_suggestions()
                         && error_span.can_be_used_for_suggestions()
@@ -1175,7 +1183,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             } else {
                                 "".to_string()
                             };
-                            labels.push((span, format!("an argument{rendered} is missing")));
+                            labels.push((
+                                span,
+                                format!(
+                                    "argument #{}{rendered} is missing",
+                                    expected_idx.as_usize() + 1
+                                ),
+                            ));
+
                             suggestion_text = match suggestion_text {
                                 SuggestionText::None => SuggestionText::Provide(false),
                                 SuggestionText::Provide(_) => SuggestionText::Provide(true),

--- a/tests/ui/argument-suggestions/basic.stderr
+++ b/tests/ui/argument-suggestions/basic.stderr
@@ -33,7 +33,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/basic.rs:22:5
    |
 LL |     missing();
-   |     ^^^^^^^-- an argument of type `u32` is missing
+   |     ^^^^^^^-- argument #1 of type `u32` is missing
    |
 note: function defined here
   --> $DIR/basic.rs:15:4
@@ -86,7 +86,7 @@ error[E0057]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/basic.rs:27:5
    |
 LL |     closure();
-   |     ^^^^^^^-- an argument is missing
+   |     ^^^^^^^-- argument #1 is missing
    |
 note: closure defined here
   --> $DIR/basic.rs:26:19

--- a/tests/ui/argument-suggestions/display-is-suggestable.stderr
+++ b/tests/ui/argument-suggestions/display-is-suggestable.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/display-is-suggestable.rs:6:5
    |
 LL |     foo();
-   |     ^^^-- an argument of type `&dyn std::fmt::Display + Send` is missing
+   |     ^^^-- argument #1 of type `&dyn std::fmt::Display + Send` is missing
    |
 note: function defined here
   --> $DIR/display-is-suggestable.rs:3:4

--- a/tests/ui/argument-suggestions/extern-fn-arg-names.stderr
+++ b/tests/ui/argument-suggestions/extern-fn-arg-names.stderr
@@ -8,7 +8,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/extern-fn-arg-names.rs:7:5
    |
 LL |     dstfn(1);
-   |     ^^^^^--- an argument is missing
+   |     ^^^^^--- argument #2 is missing
    |
 note: function defined here
   --> $DIR/extern-fn-arg-names.rs:2:8

--- a/tests/ui/argument-suggestions/extra_arguments.stderr
+++ b/tests/ui/argument-suggestions/extra_arguments.stderr
@@ -19,9 +19,9 @@ error[E0061]: this function takes 0 arguments but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:20:3
    |
 LL |   empty(1, 1);
-   |   ^^^^^ -  - unexpected argument of type `{integer}`
+   |   ^^^^^ -  - unexpected argument #2 of type `{integer}`
    |         |
-   |         unexpected argument of type `{integer}`
+   |         unexpected argument #1 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:1:4
@@ -38,7 +38,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:22:3
    |
 LL |   one_arg(1, 1);
-   |   ^^^^^^^    - unexpected argument of type `{integer}`
+   |   ^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -55,7 +55,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:23:3
    |
 LL |   one_arg(1, "");
-   |   ^^^^^^^    -- unexpected argument of type `&'static str`
+   |   ^^^^^^^    -- unexpected argument #2 of type `&'static str`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -72,9 +72,9 @@ error[E0061]: this function takes 1 argument but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:24:3
    |
 LL |   one_arg(1, "", 1.0);
-   |   ^^^^^^^    --  --- unexpected argument of type `{float}`
+   |   ^^^^^^^    --  --- unexpected argument #3 of type `{float}`
    |              |
-   |              unexpected argument of type `&'static str`
+   |              unexpected argument #2 of type `&'static str`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -91,7 +91,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:26:3
    |
 LL |   two_arg_same(1, 1, 1);
-   |   ^^^^^^^^^^^^       - unexpected argument of type `{integer}`
+   |   ^^^^^^^^^^^^       - unexpected argument #3 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:3:4
@@ -108,7 +108,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:27:3
    |
 LL |   two_arg_same(1, 1, 1.0);
-   |   ^^^^^^^^^^^^       --- unexpected argument of type `{float}`
+   |   ^^^^^^^^^^^^       --- unexpected argument #3 of type `{float}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:3:4
@@ -125,7 +125,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:29:3
    |
 LL |   two_arg_diff(1, 1, "");
-   |   ^^^^^^^^^^^^    - unexpected argument of type `{integer}`
+   |   ^^^^^^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -142,7 +142,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:30:3
    |
 LL |   two_arg_diff(1, "", "");
-   |   ^^^^^^^^^^^^        -- unexpected argument of type `&'static str`
+   |   ^^^^^^^^^^^^        -- unexpected argument #3 of type `&'static str`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -159,9 +159,9 @@ error[E0061]: this function takes 2 arguments but 4 arguments were supplied
   --> $DIR/extra_arguments.rs:31:3
    |
 LL |   two_arg_diff(1, 1, "", "");
-   |   ^^^^^^^^^^^^    -      -- unexpected argument of type `&'static str`
+   |   ^^^^^^^^^^^^    -      -- unexpected argument #4 of type `&'static str`
    |                   |
-   |                   unexpected argument of type `{integer}`
+   |                   unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -178,9 +178,9 @@ error[E0061]: this function takes 2 arguments but 4 arguments were supplied
   --> $DIR/extra_arguments.rs:32:3
    |
 LL |   two_arg_diff(1, "", 1, "");
-   |   ^^^^^^^^^^^^        -  -- unexpected argument of type `&'static str`
+   |   ^^^^^^^^^^^^        -  -- unexpected argument #4 of type `&'static str`
    |                       |
-   |                       unexpected argument of type `{integer}`
+   |                       unexpected argument #3 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -197,7 +197,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:35:3
    |
 LL |   two_arg_same(1, 1,     "");
-   |   ^^^^^^^^^^^^           -- unexpected argument of type `&'static str`
+   |   ^^^^^^^^^^^^           -- unexpected argument #3 of type `&'static str`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:3:4
@@ -214,7 +214,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:36:3
    |
 LL |   two_arg_diff(1, 1,     "");
-   |   ^^^^^^^^^^^^    - unexpected argument of type `{integer}`
+   |   ^^^^^^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -234,7 +234,7 @@ LL |   two_arg_same(
    |   ^^^^^^^^^^^^
 ...
 LL |     ""
-   |     -- unexpected argument of type `&'static str`
+   |     -- unexpected argument #3 of type `&'static str`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:3:4
@@ -255,7 +255,7 @@ LL |   two_arg_diff(
    |   ^^^^^^^^^^^^
 LL |     1,
 LL |     1,
-   |     - unexpected argument of type `{integer}`
+   |     - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -271,12 +271,12 @@ error[E0061]: this function takes 0 arguments but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:8:9
    |
 LL |         empty($x, 1);
-   |         ^^^^^     - unexpected argument of type `{integer}`
+   |         ^^^^^     - unexpected argument #2 of type `{integer}`
 ...
 LL |   foo!(1, ~);
    |   ----------
    |   |    |
-   |   |    unexpected argument of type `{integer}`
+   |   |    unexpected argument #1 of type `{integer}`
    |   in this macro invocation
    |
 note: function defined here
@@ -290,12 +290,12 @@ error[E0061]: this function takes 0 arguments but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:14:9
    |
 LL |         empty(1, $y);
-   |         ^^^^^ - unexpected argument of type `{integer}`
+   |         ^^^^^ - unexpected argument #1 of type `{integer}`
 ...
 LL |   foo!(~, 1);
    |   ----------
    |   |       |
-   |   |       unexpected argument of type `{integer}`
+   |   |       unexpected argument #2 of type `{integer}`
    |   in this macro invocation
    |
 note: function defined here
@@ -314,8 +314,8 @@ LL |         empty($x, $y);
 LL |   foo!(1, 1);
    |   ----------
    |   |    |  |
-   |   |    |  unexpected argument of type `{integer}`
-   |   |    unexpected argument of type `{integer}`
+   |   |    |  unexpected argument #2 of type `{integer}`
+   |   |    unexpected argument #1 of type `{integer}`
    |   in this macro invocation
    |
 note: function defined here
@@ -329,7 +329,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:53:3
    |
 LL |   one_arg(1, panic!());
-   |   ^^^^^^^    -------- unexpected argument
+   |   ^^^^^^^    -------- unexpected argument #2
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -346,7 +346,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:54:3
    |
 LL |   one_arg(panic!(), 1);
-   |   ^^^^^^^           - unexpected argument of type `{integer}`
+   |   ^^^^^^^           - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -363,7 +363,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:55:3
    |
 LL |   one_arg(stringify!($e), 1);
-   |   ^^^^^^^                 - unexpected argument of type `{integer}`
+   |   ^^^^^^^                 - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -380,7 +380,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:60:3
    |
 LL |   one_arg(for _ in 1.. {}, 1);
-   |   ^^^^^^^                  - unexpected argument of type `{integer}`
+   |   ^^^^^^^                  - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4

--- a/tests/ui/argument-suggestions/issue-100478.stderr
+++ b/tests/ui/argument-suggestions/issue-100478.stderr
@@ -4,8 +4,8 @@ error[E0061]: this function takes 3 arguments but 1 argument was supplied
 LL |     three_diff(T2::new(0));
    |     ^^^^^^^^^^------------
    |               ||
-   |               |an argument of type `T1` is missing
-   |               an argument of type `T3` is missing
+   |               |argument #1 of type `T1` is missing
+   |               argument #3 of type `T3` is missing
    |
 note: function defined here
   --> $DIR/issue-100478.rs:30:4
@@ -63,7 +63,7 @@ LL |     foo(
    |     ^^^
 ...
 LL |         p3, p4, p5, p6, p7, p8,
-   |         -- an argument of type `Arc<T2>` is missing
+   |         -- argument #2 of type `Arc<T2>` is missing
    |
 note: function defined here
   --> $DIR/issue-100478.rs:29:4

--- a/tests/ui/argument-suggestions/issue-101097.stderr
+++ b/tests/ui/argument-suggestions/issue-101097.stderr
@@ -4,7 +4,7 @@ error[E0061]: this function takes 6 arguments but 7 arguments were supplied
 LL |     f(C, A, A, A, B, B, C);
    |     ^ -     -  -  - expected `C`, found `B`
    |       |     |  |
-   |       |     |  unexpected argument of type `A`
+   |       |     |  unexpected argument #4 of type `A`
    |       |     expected `B`, found `A`
    |       expected `A`, found `C`
    |
@@ -64,8 +64,8 @@ error[E0308]: arguments to this function are incorrect
 LL |     f(A, A, D, D, B, B);
    |     ^       -  -  ---- two arguments of type `C` and `C` are missing
    |             |  |
-   |             |  unexpected argument of type `D`
-   |             unexpected argument of type `D`
+   |             |  unexpected argument #4 of type `D`
+   |             unexpected argument #3 of type `D`
    |
 note: function defined here
   --> $DIR/issue-101097.rs:6:4

--- a/tests/ui/argument-suggestions/issue-109425.stderr
+++ b/tests/ui/argument-suggestions/issue-109425.stderr
@@ -2,9 +2,9 @@ error[E0061]: this function takes 0 arguments but 2 arguments were supplied
   --> $DIR/issue-109425.rs:10:5
    |
 LL |     f(0, 1,);        // f()
-   |     ^ -  - unexpected argument of type `{integer}`
+   |     ^ -  - unexpected argument #2 of type `{integer}`
    |       |
-   |       unexpected argument of type `{integer}`
+   |       unexpected argument #1 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-109425.rs:3:4
@@ -21,9 +21,9 @@ error[E0061]: this function takes 1 argument but 3 arguments were supplied
   --> $DIR/issue-109425.rs:12:5
    |
 LL |     i(0, 1, 2,);     // i(0,)
-   |     ^    -  - unexpected argument of type `{integer}`
+   |     ^    -  - unexpected argument #3 of type `{integer}`
    |          |
-   |          unexpected argument of type `{integer}`
+   |          unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-109425.rs:4:4
@@ -40,9 +40,9 @@ error[E0061]: this function takes 1 argument but 3 arguments were supplied
   --> $DIR/issue-109425.rs:14:5
    |
 LL |     i(0, 1, 2);      // i(0)
-   |     ^    -  - unexpected argument of type `{integer}`
+   |     ^    -  - unexpected argument #3 of type `{integer}`
    |          |
-   |          unexpected argument of type `{integer}`
+   |          unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-109425.rs:4:4
@@ -59,9 +59,9 @@ error[E0061]: this function takes 2 arguments but 4 arguments were supplied
   --> $DIR/issue-109425.rs:16:5
    |
 LL |     is(0, 1, 2, ""); // is(0, "")
-   |     ^^    -  - unexpected argument of type `{integer}`
+   |     ^^    -  - unexpected argument #3 of type `{integer}`
    |           |
-   |           unexpected argument of type `{integer}`
+   |           unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-109425.rs:5:4
@@ -78,9 +78,9 @@ error[E0061]: this function takes 1 argument but 3 arguments were supplied
   --> $DIR/issue-109425.rs:18:5
    |
 LL |     s(0, 1, "");     // s("")
-   |     ^ -  - unexpected argument of type `{integer}`
+   |     ^ -  - unexpected argument #2 of type `{integer}`
    |       |
-   |       unexpected argument of type `{integer}`
+   |       unexpected argument #1 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-109425.rs:6:4

--- a/tests/ui/argument-suggestions/issue-109831.stderr
+++ b/tests/ui/argument-suggestions/issue-109831.stderr
@@ -29,7 +29,7 @@ error[E0061]: this function takes 3 arguments but 4 arguments were supplied
   --> $DIR/issue-109831.rs:7:5
    |
 LL |     f(A, A, B, C);
-   |     ^ -  -     - unexpected argument
+   |     ^ -  -     - unexpected argument #4
    |       |  |
    |       |  expected `B`, found `A`
    |       expected `B`, found `A`

--- a/tests/ui/argument-suggestions/issue-112507.stderr
+++ b/tests/ui/argument-suggestions/issue-112507.stderr
@@ -4,12 +4,12 @@ error[E0061]: this enum variant takes 1 argument but 4 arguments were supplied
 LL |     let _a = Value::Float(
    |              ^^^^^^^^^^^^
 LL |         0,
-   |         - unexpected argument of type `{integer}`
+   |         - unexpected argument #1 of type `{integer}`
 LL |         None,
 LL |         None,
-   |         ---- unexpected argument of type `Option<_>`
+   |         ---- unexpected argument #3 of type `Option<_>`
 LL |         0,
-   |         - unexpected argument of type `{integer}`
+   |         - unexpected argument #4 of type `{integer}`
    |
 note: tuple variant defined here
   --> $DIR/issue-112507.rs:2:5

--- a/tests/ui/argument-suggestions/issue-96638.stderr
+++ b/tests/ui/argument-suggestions/issue-96638.stderr
@@ -4,7 +4,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
 LL |     f(&x, "");
    |     ^ --  -- expected `usize`, found `&str`
    |       |
-   |       an argument of type `usize` is missing
+   |       argument #1 of type `usize` is missing
    |
 note: function defined here
   --> $DIR/issue-96638.rs:1:4

--- a/tests/ui/argument-suggestions/issue-97484.stderr
+++ b/tests/ui/argument-suggestions/issue-97484.stderr
@@ -2,11 +2,11 @@ error[E0061]: this function takes 4 arguments but 7 arguments were supplied
   --> $DIR/issue-97484.rs:12:5
    |
 LL |     foo(&&A, B, C, D, E, F, G);
-   |     ^^^      -  -     -  - unexpected argument of type `F`
+   |     ^^^      -  -     -  - unexpected argument #6 of type `F`
    |              |  |     |
    |              |  |     expected `&E`, found `E`
-   |              |  unexpected argument of type `C`
-   |              unexpected argument of type `B`
+   |              |  unexpected argument #3 of type `C`
+   |              unexpected argument #2 of type `B`
    |
 note: function defined here
   --> $DIR/issue-97484.rs:9:4

--- a/tests/ui/argument-suggestions/issue-98894.stderr
+++ b/tests/ui/argument-suggestions/issue-98894.stderr
@@ -2,7 +2,7 @@ error[E0057]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/issue-98894.rs:2:5
    |
 LL |     (|_, ()| ())(if true {} else {return;});
-   |     ^^^^^^^^^^^^--------------------------- an argument of type `()` is missing
+   |     ^^^^^^^^^^^^--------------------------- argument #2 of type `()` is missing
    |
 note: closure defined here
   --> $DIR/issue-98894.rs:2:6

--- a/tests/ui/argument-suggestions/issue-98897.stderr
+++ b/tests/ui/argument-suggestions/issue-98897.stderr
@@ -2,7 +2,7 @@ error[E0057]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/issue-98897.rs:2:5
    |
 LL |     (|_, ()| ())([return, ()]);
-   |     ^^^^^^^^^^^^-------------- an argument of type `()` is missing
+   |     ^^^^^^^^^^^^-------------- argument #2 of type `()` is missing
    |
 note: closure defined here
   --> $DIR/issue-98897.rs:2:6

--- a/tests/ui/argument-suggestions/issue-99482.stderr
+++ b/tests/ui/argument-suggestions/issue-99482.stderr
@@ -2,7 +2,7 @@ error[E0057]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/issue-99482.rs:3:14
    |
 LL |     let _f = f(main);
-   |              ^ ---- an argument of type `()` is missing
+   |              ^ ---- argument #1 of type `()` is missing
    |
 note: closure defined here
   --> $DIR/issue-99482.rs:2:13

--- a/tests/ui/argument-suggestions/missing_arguments.stderr
+++ b/tests/ui/argument-suggestions/missing_arguments.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/missing_arguments.rs:10:3
    |
 LL |   one_arg();
-   |   ^^^^^^^-- an argument of type `i32` is missing
+   |   ^^^^^^^-- argument #1 of type `i32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:1:4
@@ -34,7 +34,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:15:3
    |
 LL |   two_same(   1           );
-   |   ^^^^^^^^----------------- an argument of type `i32` is missing
+   |   ^^^^^^^^----------------- argument #2 of type `i32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:2:4
@@ -66,7 +66,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:17:3
    |
 LL |   two_diff(   1           );
-   |   ^^^^^^^^----------------- an argument of type `f32` is missing
+   |   ^^^^^^^^----------------- argument #2 of type `f32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:3:4
@@ -82,7 +82,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:18:3
    |
 LL |   two_diff(          1.0  );
-   |   ^^^^^^^^           --- an argument of type `i32` is missing
+   |   ^^^^^^^^           --- argument #1 of type `i32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:3:4
@@ -130,7 +130,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:23:3
    |
 LL |   three_same(   1,      1           );
-   |   ^^^^^^^^^^------------------------- an argument of type `i32` is missing
+   |   ^^^^^^^^^^------------------------- argument #3 of type `i32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:4:4
@@ -146,7 +146,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:26:3
    |
 LL |   three_diff(          1.0,     ""  );
-   |   ^^^^^^^^^^           --- an argument of type `i32` is missing
+   |   ^^^^^^^^^^           --- argument #1 of type `i32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:5:4
@@ -162,7 +162,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:27:3
    |
 LL |   three_diff(   1,              ""  );
-   |   ^^^^^^^^^^                    -- an argument of type `f32` is missing
+   |   ^^^^^^^^^^                    -- argument #2 of type `f32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:5:4
@@ -178,7 +178,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:28:3
    |
 LL |   three_diff(   1,     1.0          );
-   |   ^^^^^^^^^^------------------------- an argument of type `&str` is missing
+   |   ^^^^^^^^^^------------------------- argument #3 of type `&str` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:5:4
@@ -212,8 +212,8 @@ error[E0061]: this function takes 3 arguments but 1 argument was supplied
 LL |   three_diff(          1.0          );
    |   ^^^^^^^^^^-------------------------
    |             |          |
-   |             |          an argument of type `i32` is missing
-   |             an argument of type `&str` is missing
+   |             |          argument #1 of type `i32` is missing
+   |             argument #3 of type `&str` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:5:4

--- a/tests/ui/argument-suggestions/mixed_cases.stderr
+++ b/tests/ui/argument-suggestions/mixed_cases.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/mixed_cases.rs:10:3
    |
 LL |   two_args(1, "", X {});
-   |   ^^^^^^^^    --  ---- unexpected argument of type `X`
+   |   ^^^^^^^^    --  ---- unexpected argument #3 of type `X`
    |               |
    |               expected `f32`, found `&str`
    |
@@ -21,10 +21,10 @@ error[E0061]: this function takes 3 arguments but 4 arguments were supplied
   --> $DIR/mixed_cases.rs:11:3
    |
 LL |   three_args(1, "", X {}, "");
-   |   ^^^^^^^^^^    --  ----  -- unexpected argument of type `&'static str`
+   |   ^^^^^^^^^^    --  ----  -- unexpected argument #4 of type `&'static str`
    |                 |   |
-   |                 |   unexpected argument of type `X`
-   |                 an argument of type `f32` is missing
+   |                 |   unexpected argument #3 of type `X`
+   |                 argument #2 of type `f32` is missing
    |
 note: function defined here
   --> $DIR/mixed_cases.rs:6:4
@@ -43,7 +43,7 @@ LL |   three_args(1, X {});
    |   ^^^^^^^^^^---------
    |             |   |
    |             |   expected `f32`, found `X`
-   |             an argument of type `&str` is missing
+   |             argument #3 of type `&str` is missing
    |
 note: function defined here
   --> $DIR/mixed_cases.rs:6:4
@@ -59,9 +59,9 @@ error[E0308]: arguments to this function are incorrect
   --> $DIR/mixed_cases.rs:17:3
    |
 LL |   three_args(1, "", X {});
-   |   ^^^^^^^^^^    --  ---- unexpected argument of type `X`
+   |   ^^^^^^^^^^    --  ---- unexpected argument #3 of type `X`
    |                 |
-   |                 an argument of type `f32` is missing
+   |                 argument #2 of type `f32` is missing
    |
 note: function defined here
   --> $DIR/mixed_cases.rs:6:4
@@ -98,7 +98,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
 LL |   three_args("", 1);
    |   ^^^^^^^^^^ --  -
    |              |   |
-   |              |   an argument of type `f32` is missing
+   |              |   argument #2 of type `f32` is missing
    |              |   expected `&str`, found `{integer}`
    |              expected `i32`, found `&'static str`
    |

--- a/tests/ui/argument-suggestions/suggest-better-removing-issue-126246.stderr
+++ b/tests/ui/argument-suggestions/suggest-better-removing-issue-126246.stderr
@@ -32,7 +32,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:10:5
    |
 LL |     add_one(2, 2);
-   |     ^^^^^^^    - unexpected argument of type `{integer}`
+   |     ^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:1:4
@@ -49,7 +49,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:11:5
    |
 LL |     add_one(no_such_local, 10);
-   |     ^^^^^^^ ------------- unexpected argument
+   |     ^^^^^^^ ------------- unexpected argument #1
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:1:4
@@ -66,7 +66,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:13:5
    |
 LL |     add_one(10, no_such_local);
-   |     ^^^^^^^     ------------- unexpected argument
+   |     ^^^^^^^     ------------- unexpected argument #2
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:1:4
@@ -83,7 +83,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:15:5
    |
 LL |     add_two(10, no_such_local, 10);
-   |     ^^^^^^^     ------------- unexpected argument
+   |     ^^^^^^^     ------------- unexpected argument #2
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:5:4
@@ -100,7 +100,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:17:5
    |
 LL |     add_two(no_such_local, 10, 10);
-   |     ^^^^^^^ ------------- unexpected argument
+   |     ^^^^^^^ ------------- unexpected argument #1
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:5:4
@@ -117,7 +117,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:19:5
    |
 LL |     add_two(10, 10, no_such_local);
-   |     ^^^^^^^         ------------- unexpected argument
+   |     ^^^^^^^         ------------- unexpected argument #3
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:5:4

--- a/tests/ui/associated-inherent-types/issue-109768.stderr
+++ b/tests/ui/associated-inherent-types/issue-109768.stderr
@@ -34,7 +34,7 @@ error[E0061]: this struct takes 1 argument but 0 arguments were supplied
   --> $DIR/issue-109768.rs:10:56
    |
 LL |     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper();
-   |                                                        ^^^^^^^-- an argument is missing
+   |                                                        ^^^^^^^-- argument #1 is missing
    |
 note: tuple struct defined here
   --> $DIR/issue-109768.rs:3:8

--- a/tests/ui/c-variadic/variadic-ffi-1.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-1.stderr
@@ -24,7 +24,7 @@ error[E0060]: this function takes at least 2 arguments but 1 argument was suppli
   --> $DIR/variadic-ffi-1.rs:23:9
    |
 LL |         foo(1);
-   |         ^^^--- an argument of type `u8` is missing
+   |         ^^^--- argument #2 of type `u8` is missing
    |
 note: function defined here
   --> $DIR/variadic-ffi-1.rs:15:8

--- a/tests/ui/cast/ice-cast-type-with-error-124848.stderr
+++ b/tests/ui/cast/ice-cast-type-with-error-124848.stderr
@@ -39,7 +39,7 @@ error[E0061]: this struct takes 2 arguments but 1 argument was supplied
   --> $DIR/ice-cast-type-with-error-124848.rs:12:24
    |
 LL |     let mut unpinned = MyType(Cell::new(None));
-   |                        ^^^^^^----------------- an argument is missing
+   |                        ^^^^^^----------------- argument #2 is missing
    |
 note: tuple struct defined here
   --> $DIR/ice-cast-type-with-error-124848.rs:7:8

--- a/tests/ui/coroutine/issue-102645.stderr
+++ b/tests/ui/coroutine/issue-102645.stderr
@@ -2,7 +2,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> $DIR/issue-102645.rs:15:22
    |
 LL |     Pin::new(&mut b).resume();
-   |                      ^^^^^^-- an argument of type `()` is missing
+   |                      ^^^^^^-- argument #1 of type `()` is missing
    |
 note: method defined here
   --> $SRC_DIR/core/src/ops/coroutine.rs:LL:COL

--- a/tests/ui/error-codes/E0057.stderr
+++ b/tests/ui/error-codes/E0057.stderr
@@ -2,7 +2,7 @@ error[E0057]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/E0057.rs:3:13
    |
 LL |     let a = f();
-   |             ^-- an argument is missing
+   |             ^-- argument #1 is missing
    |
 note: closure defined here
   --> $DIR/E0057.rs:2:13
@@ -18,7 +18,7 @@ error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/E0057.rs:5:13
    |
 LL |     let c = f(2, 3);
-   |             ^    - unexpected argument of type `{integer}`
+   |             ^    - unexpected argument #2 of type `{integer}`
    |
 note: closure defined here
   --> $DIR/E0057.rs:2:13

--- a/tests/ui/error-codes/E0060.stderr
+++ b/tests/ui/error-codes/E0060.stderr
@@ -2,7 +2,7 @@ error[E0060]: this function takes at least 1 argument but 0 arguments were suppl
   --> $DIR/E0060.rs:6:14
    |
 LL |     unsafe { printf(); }
-   |              ^^^^^^-- an argument of type `*const u8` is missing
+   |              ^^^^^^-- argument #1 of type `*const u8` is missing
    |
 note: function defined here
   --> $DIR/E0060.rs:2:8

--- a/tests/ui/error-codes/E0061.stderr
+++ b/tests/ui/error-codes/E0061.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/E0061.rs:6:5
    |
 LL |     f(0);
-   |     ^--- an argument of type `&str` is missing
+   |     ^--- argument #2 of type `&str` is missing
    |
 note: function defined here
   --> $DIR/E0061.rs:1:4
@@ -18,7 +18,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/E0061.rs:9:5
    |
 LL |     f2();
-   |     ^^-- an argument of type `u16` is missing
+   |     ^^-- argument #1 of type `u16` is missing
    |
 note: function defined here
   --> $DIR/E0061.rs:3:4

--- a/tests/ui/extern/issue-18819.stderr
+++ b/tests/ui/extern/issue-18819.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/issue-18819.rs:16:5
    |
 LL |     print_x(X);
-   |     ^^^^^^^--- an argument of type `&str` is missing
+   |     ^^^^^^^--- argument #2 of type `&str` is missing
    |
 note: expected `&dyn Foo<Item = bool>`, found `X`
   --> $DIR/issue-18819.rs:16:13

--- a/tests/ui/fn/issue-3044.stderr
+++ b/tests/ui/fn/issue-3044.stderr
@@ -5,7 +5,7 @@ LL |       needlesArr.iter().fold(|x, y| {
    |  _______________________^^^^-
 LL | |
 LL | |     });
-   | |______- an argument is missing
+   | |______- argument #2 is missing
    |
 note: method defined here
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL

--- a/tests/ui/generic-associated-types/issue-91139.migrate.stderr
+++ b/tests/ui/generic-associated-types/issue-91139.migrate.stderr
@@ -1,7 +1,6 @@
 error: expected identifier, found `<<`
   --> $DIR/issue-91139.rs:1:1
    |
-LL | <<<<<<< HEAD
    | ^^ expected identifier
 
 error: aborting due to 1 previous error

--- a/tests/ui/higher-ranked/trait-bounds/issue-58451.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/issue-58451.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/issue-58451.rs:12:9
    |
 LL |     f(&[f()]);
-   |         ^-- an argument is missing
+   |         ^-- argument #1 is missing
    |
 note: function defined here
   --> $DIR/issue-58451.rs:5:4

--- a/tests/ui/issues/issue-4935.stderr
+++ b/tests/ui/issues/issue-4935.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/issue-4935.rs:5:13
    |
 LL | fn main() { foo(5, 6) }
-   |             ^^^    - unexpected argument of type `{integer}`
+   |             ^^^    - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-4935.rs:3:4

--- a/tests/ui/lifetimes/issue-26638.stderr
+++ b/tests/ui/lifetimes/issue-26638.stderr
@@ -50,7 +50,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/issue-26638.rs:4:47
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
-   |                                               ^^^^-- an argument of type `&u8` is missing
+   |                                               ^^^^-- argument #1 of type `&u8` is missing
    |
 help: provide the argument
    |

--- a/tests/ui/methods/method-call-err-msg.stderr
+++ b/tests/ui/methods/method-call-err-msg.stderr
@@ -19,7 +19,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> $DIR/method-call-err-msg.rs:14:7
    |
 LL |      .one()
-   |       ^^^-- an argument of type `isize` is missing
+   |       ^^^-- argument #1 of type `isize` is missing
    |
 note: method defined here
   --> $DIR/method-call-err-msg.rs:6:8
@@ -35,7 +35,7 @@ error[E0061]: this method takes 2 arguments but 1 argument was supplied
   --> $DIR/method-call-err-msg.rs:15:7
    |
 LL |      .two(0);
-   |       ^^^--- an argument of type `isize` is missing
+   |       ^^^--- argument #2 of type `isize` is missing
    |
 note: method defined here
   --> $DIR/method-call-err-msg.rs:7:8

--- a/tests/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/tests/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -16,7 +16,7 @@ error[E0057]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:35:15
    |
 LL |     let ans = s();
-   |               ^-- an argument of type `isize` is missing
+   |               ^-- argument #1 of type `isize` is missing
    |
 note: implementation defined here
   --> $DIR/overloaded-calls-bad.rs:10:1
@@ -32,7 +32,7 @@ error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:37:15
    |
 LL |     let ans = s("burma", "shave");
-   |               ^ -------  ------- unexpected argument of type `&'static str`
+   |               ^ -------  ------- unexpected argument #2 of type `&'static str`
    |                 |
    |                 expected `isize`, found `&str`
    |

--- a/tests/ui/not-enough-arguments.stderr
+++ b/tests/ui/not-enough-arguments.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 4 arguments but 3 arguments were supplied
   --> $DIR/not-enough-arguments.rs:27:3
    |
 LL |   foo(1, 2, 3);
-   |   ^^^--------- an argument of type `isize` is missing
+   |   ^^^--------- argument #4 of type `isize` is missing
    |
 note: function defined here
   --> $DIR/not-enough-arguments.rs:5:4

--- a/tests/ui/span/issue-34264.stderr
+++ b/tests/ui/span/issue-34264.stderr
@@ -54,7 +54,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/issue-34264.rs:7:5
    |
 LL |     foo(Some(42), 2, "");
-   |     ^^^              -- unexpected argument of type `&'static str`
+   |     ^^^              -- unexpected argument #3 of type `&'static str`
    |
 note: function defined here
   --> $DIR/issue-34264.rs:1:4
@@ -85,7 +85,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/issue-34264.rs:10:5
    |
 LL |     bar(1, 2, 3);
-   |     ^^^       - unexpected argument of type `{integer}`
+   |     ^^^       - unexpected argument #3 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-34264.rs:3:4

--- a/tests/ui/span/missing-unit-argument.stderr
+++ b/tests/ui/span/missing-unit-argument.stderr
@@ -2,7 +2,7 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:11:33
    |
 LL |     let _: Result<(), String> = Ok();
-   |                                 ^^-- an argument of type `()` is missing
+   |                                 ^^-- argument #1 of type `()` is missing
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -31,7 +31,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing-unit-argument.rs:13:5
    |
 LL |     foo(());
-   |     ^^^---- an argument of type `()` is missing
+   |     ^^^---- argument #2 of type `()` is missing
    |
 note: function defined here
   --> $DIR/missing-unit-argument.rs:1:4
@@ -47,7 +47,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:14:5
    |
 LL |     bar();
-   |     ^^^-- an argument of type `()` is missing
+   |     ^^^-- argument #1 of type `()` is missing
    |
 note: function defined here
   --> $DIR/missing-unit-argument.rs:2:4
@@ -63,7 +63,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:15:7
    |
 LL |     S.baz();
-   |       ^^^-- an argument of type `()` is missing
+   |       ^^^-- argument #1 of type `()` is missing
    |
 note: method defined here
   --> $DIR/missing-unit-argument.rs:6:8
@@ -79,7 +79,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:16:7
    |
 LL |     S.generic::<()>();
-   |       ^^^^^^^^^^^^^-- an argument of type `()` is missing
+   |       ^^^^^^^^^^^^^-- argument #1 of type `()` is missing
    |
 note: method defined here
   --> $DIR/missing-unit-argument.rs:7:8

--- a/tests/ui/suggestions/args-instead-of-tuple-errors.stderr
+++ b/tests/ui/suggestions/args-instead-of-tuple-errors.stderr
@@ -2,7 +2,7 @@ error[E0061]: this enum variant takes 1 argument but 2 arguments were supplied
   --> $DIR/args-instead-of-tuple-errors.rs:6:34
    |
 LL |     let _: Option<(i32, bool)> = Some(1, 2);
-   |                                  ^^^^    - unexpected argument of type `{integer}`
+   |                                  ^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: expected `(i32, bool)`, found integer
   --> $DIR/args-instead-of-tuple-errors.rs:6:39
@@ -30,7 +30,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/args-instead-of-tuple-errors.rs:8:5
    |
 LL |     int_bool(1, 2);
-   |     ^^^^^^^^    - unexpected argument of type `{integer}`
+   |     ^^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: expected `(i32, bool)`, found integer
   --> $DIR/args-instead-of-tuple-errors.rs:8:14
@@ -54,7 +54,7 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/args-instead-of-tuple-errors.rs:11:28
    |
 LL |     let _: Option<(i8,)> = Some();
-   |                            ^^^^-- an argument of type `(i8,)` is missing
+   |                            ^^^^-- argument #1 of type `(i8,)` is missing
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/ui/suggestions/args-instead-of-tuple.stderr
+++ b/tests/ui/suggestions/args-instead-of-tuple.stderr
@@ -28,7 +28,7 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/args-instead-of-tuple.rs:11:25
    |
 LL |     let _: Option<()> = Some();
-   |                         ^^^^-- an argument of type `()` is missing
+   |                         ^^^^-- argument #1 of type `()` is missing
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/ui/suggestions/issue-109396.stderr
+++ b/tests/ui/suggestions/issue-109396.stderr
@@ -11,14 +11,14 @@ LL |         let mut mutex = std::mem::zeroed(
    |                         ^^^^^^^^^^^^^^^^
 LL |
 LL |             file.as_raw_fd(),
-   |             ---------------- unexpected argument
+   |             ---------------- unexpected argument #1
 LL |
 LL |             0,
-   |             - unexpected argument of type `{integer}`
+   |             - unexpected argument #2 of type `{integer}`
 LL |             0,
-   |             - unexpected argument of type `{integer}`
+   |             - unexpected argument #3 of type `{integer}`
 LL |             0,
-   |             - unexpected argument of type `{integer}`
+   |             - unexpected argument #4 of type `{integer}`
    |
 note: function defined here
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL

--- a/tests/ui/suggestions/issue-109854.stderr
+++ b/tests/ui/suggestions/issue-109854.stderr
@@ -7,9 +7,9 @@ LL |       String::with_capacity(
 LL | /     r#"
 LL | | pub(crate) struct Person<T: Clone> {}
 LL | | "#,
-   | |__- unexpected argument of type `&'static str`
+   | |__- unexpected argument #2 of type `&'static str`
 LL |        r#""#,
-   |        ----- unexpected argument of type `&'static str`
+   |        ----- unexpected argument #3 of type `&'static str`
    |
 note: expected `usize`, found fn item
   --> $DIR/issue-109854.rs:4:5

--- a/tests/ui/tuple/wrong_argument_ice-3.stderr
+++ b/tests/ui/tuple/wrong_argument_ice-3.stderr
@@ -2,7 +2,7 @@ error[E0061]: this method takes 1 argument but 2 arguments were supplied
   --> $DIR/wrong_argument_ice-3.rs:9:16
    |
 LL |         groups.push(new_group, vec![process]);
-   |                ^^^^            ------------- unexpected argument of type `Vec<&Process>`
+   |                ^^^^            ------------- unexpected argument #2 of type `Vec<&Process>`
    |
 note: expected `(Vec<String>, Vec<Process>)`, found `Vec<String>`
   --> $DIR/wrong_argument_ice-3.rs:9:21

--- a/tests/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
+++ b/tests/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
@@ -2,7 +2,7 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/enum-variant-priority-higher-than-other-inherent.rs:21:5
    |
 LL |     <E>::V();
-   |     ^^^^^^-- an argument of type `u8` is missing
+   |     ^^^^^^-- argument #1 of type `u8` is missing
    |
 note: tuple variant defined here
   --> $DIR/enum-variant-priority-higher-than-other-inherent.rs:5:5

--- a/tests/ui/type/type-ascription-instead-of-initializer.stderr
+++ b/tests/ui/type/type-ascription-instead-of-initializer.stderr
@@ -11,7 +11,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/type-ascription-instead-of-initializer.rs:2:12
    |
 LL |     let x: Vec::with_capacity(10, 20);
-   |            ^^^^^^^^^^^^^^^^^^     -- unexpected argument of type `{integer}`
+   |            ^^^^^^^^^^^^^^^^^^     -- unexpected argument #2 of type `{integer}`
    |
 note: associated function defined here
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL

--- a/tests/ui/type/type-check/point-at-inference-4.rs
+++ b/tests/ui/type/type-check/point-at-inference-4.rs
@@ -13,7 +13,7 @@ fn main() {
     //~^ ERROR this method takes 2 arguments but 1 argument was supplied
     //~| NOTE this argument has type `i32`...
     //~| NOTE ... which causes `s` to have type `S<i32, _>`
-    //~| NOTE an argument is missing
+    //~| NOTE argument #2 is missing
     //~| HELP provide the argument
     //~| HELP change the type of the numeric literal from `i32` to `u32`
     let t: S<u32, _> = s;

--- a/tests/ui/type/type-check/point-at-inference-4.stderr
+++ b/tests/ui/type/type-check/point-at-inference-4.stderr
@@ -2,7 +2,7 @@ error[E0061]: this method takes 2 arguments but 1 argument was supplied
   --> $DIR/point-at-inference-4.rs:12:7
    |
 LL |     s.infer(0i32);
-   |       ^^^^^------ an argument is missing
+   |       ^^^^^------ argument #2 is missing
    |
 note: method defined here
   --> $DIR/point-at-inference-4.rs:4:8

--- a/tests/ui/typeck/cyclic_type_ice.stderr
+++ b/tests/ui/typeck/cyclic_type_ice.stderr
@@ -13,7 +13,7 @@ error[E0057]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/cyclic_type_ice.rs:3:5
    |
 LL |     f(f);
-   |     ^--- an argument is missing
+   |     ^--- argument #2 is missing
    |
 note: closure defined here
   --> $DIR/cyclic_type_ice.rs:2:13

--- a/tests/ui/typeck/remove-extra-argument.stderr
+++ b/tests/ui/typeck/remove-extra-argument.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/remove-extra-argument.rs:6:5
    |
 LL |     l(vec![], vec![])
-   |     ^         ------ unexpected argument of type `Vec<_>`
+   |     ^         ------ unexpected argument #2 of type `Vec<_>`
    |
 note: function defined here
   --> $DIR/remove-extra-argument.rs:3:4

--- a/tests/ui/typeck/struct-enum-wrong-args.stderr
+++ b/tests/ui/typeck/struct-enum-wrong-args.stderr
@@ -2,7 +2,7 @@ error[E0061]: this enum variant takes 1 argument but 2 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:6:13
    |
 LL |     let _ = Some(3, 2);
-   |             ^^^^    - unexpected argument of type `{integer}`
+   |             ^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -16,9 +16,9 @@ error[E0061]: this enum variant takes 1 argument but 3 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:7:13
    |
 LL |     let _ = Ok(3, 6, 2);
-   |             ^^    -  - unexpected argument of type `{integer}`
+   |             ^^    -  - unexpected argument #3 of type `{integer}`
    |                   |
-   |                   unexpected argument of type `{integer}`
+   |                   unexpected argument #2 of type `{integer}`
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -32,7 +32,7 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:8:13
    |
 LL |     let _ = Ok();
-   |             ^^-- an argument is missing
+   |             ^^-- argument #1 is missing
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -45,7 +45,7 @@ error[E0061]: this struct takes 1 argument but 0 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:9:13
    |
 LL |     let _ = Wrapper();
-   |             ^^^^^^^-- an argument of type `i32` is missing
+   |             ^^^^^^^-- argument #1 of type `i32` is missing
    |
 note: tuple struct defined here
   --> $DIR/struct-enum-wrong-args.rs:2:8
@@ -61,7 +61,7 @@ error[E0061]: this struct takes 1 argument but 2 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:10:13
    |
 LL |     let _ = Wrapper(5, 2);
-   |             ^^^^^^^    - unexpected argument of type `{integer}`
+   |             ^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: tuple struct defined here
   --> $DIR/struct-enum-wrong-args.rs:2:8
@@ -94,7 +94,7 @@ error[E0061]: this struct takes 2 arguments but 1 argument was supplied
   --> $DIR/struct-enum-wrong-args.rs:12:13
    |
 LL |     let _ = DoubleWrapper(5);
-   |             ^^^^^^^^^^^^^--- an argument of type `i32` is missing
+   |             ^^^^^^^^^^^^^--- argument #2 of type `i32` is missing
    |
 note: tuple struct defined here
   --> $DIR/struct-enum-wrong-args.rs:3:8
@@ -110,7 +110,7 @@ error[E0061]: this struct takes 2 arguments but 3 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:13:13
    |
 LL |     let _ = DoubleWrapper(5, 2, 7);
-   |             ^^^^^^^^^^^^^       - unexpected argument of type `{integer}`
+   |             ^^^^^^^^^^^^^       - unexpected argument #3 of type `{integer}`
    |
 note: tuple struct defined here
   --> $DIR/struct-enum-wrong-args.rs:3:8


### PR DESCRIPTION
Add an ordinal number to two argument errors ("unexpected" and "missing") for ease of understanding error.

```
error[E0061]: this function takes 3 arguments but 2 arguments were supplied
  --> test.rs:11:5
   |
11 |     f(42, 'a');
   |     ^     --- 2nd argument of type `f32` is missing
   |
(snip)

error[E0061]: this function takes 3 arguments but 4 arguments were supplied
  --> test.rs:12:5
   |
12 |     f(42, 42, 1.0, 'a');
   |     ^   ----
   |         | |
   |         | unexpected 2nd argument of type `{integer}`
   |         help: remove the extra argument
```

To get an ordinal number, I copied `ordinalize` from other crate `rustc_resolve` because I think it is too much to link `rustc_resolve` for this small function. Please let me know if there is a better way.