### PR TITLE
Add test for dynamic dispatch + Pin::new soundness

### DIFF
--- a/tests/ui/coercion/pin-dyn-dispatch-sound.rs
+++ b/tests/ui/coercion/pin-dyn-dispatch-sound.rs
@@ -1,0 +1,19 @@
+use std::marker::PhantomPinned;
+use std::pin::Pin;
+
+trait MyUnpinTrait {
+    fn into_pinned_type(self: Pin<&mut Self>) -> Pin<&mut PhantomPinned>;
+}
+impl MyUnpinTrait for PhantomPinned {
+    fn into_pinned_type(self: Pin<&mut Self>) -> Pin<&mut PhantomPinned> {
+        self
+    }
+}
+impl Unpin for dyn MyUnpinTrait {} //~ ERROR E0321
+
+// It would be unsound for this function to compile.
+fn pin_it(not_yet_pinned: &mut PhantomPinned) -> Pin<&mut PhantomPinned> {
+    Pin::new(not_yet_pinned as &mut dyn MyUnpinTrait).into_pinned_type()
+}
+
+fn main() {}

--- a/tests/ui/coercion/pin-dyn-dispatch-sound.stderr
+++ b/tests/ui/coercion/pin-dyn-dispatch-sound.stderr
@@ -1,0 +1,9 @@
+error[E0321]: cross-crate traits with a default impl, like `Unpin`, can only be implemented for a struct/enum type, not `(dyn MyUnpinTrait + 'static)`
+  --> $DIR/pin-dyn-dispatch-sound.rs:12:1
+   |
+LL | impl Unpin for dyn MyUnpinTrait {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't implement cross-crate trait with a default impl for non-struct/enum type
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0321`.


### PR DESCRIPTION
While working on [the `#[derive(SmartPointer)]` RFC][1], I realized that the soundness of <code>impl [DispatchFromDyn](https://doc.rust-lang.org/stable/std/ops/trait.DispatchFromDyn.html) for [Pin](https://doc.rust-lang.org/stable/std/pin/struct.Pin.html)</code> relies on the restriction that you can't implement [`Unpin`](https://doc.rust-lang.org/stable/std/marker/trait.Unpin.html) for trait objects.

As far as I can tell, the relevant error exists to solve some unrelated issues with coherence. To avoid cases where `Pin` is made unsound due to changes in the coherence-related errors, add a test that verifies that unsound use of `Pin` and `DispatchFromDyn` does not become allowed in the future.

[1]: https://github.com/rust-lang/rfcs/pull/3621