### PR TITLE
fix: break inside async closure has incorrect span for enclosing closure

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1311,6 +1311,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
             CoroutineKind::AsyncGen { .. } => hir::CoroutineDesugaring::AsyncGen,
         };
         let closure_id = coroutine_kind.closure_id();
+
+        let span = if let FnRetTy::Default(span) = decl.output
+            && matches!(coroutine_source, rustc_hir::CoroutineSource::Closure)
+        {
+            body_span.with_lo(span.lo())
+        } else {
+            body_span
+        };
         let coroutine_expr = self.make_desugared_coroutine_expr(
             // The default capture mode here is by-ref. Later on during upvar analysis,
             // we will force the captured arguments to by-move, but for async closures,
@@ -1319,7 +1327,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             CaptureBy::Ref,
             closure_id,
             None,
-            body_span,
+            span,
             desugaring_kind,
             coroutine_source,
             mkbody,

--- a/tests/ui/async-await/async-closures/wrong-fn-kind.stderr
+++ b/tests/ui/async-await/async-closures/wrong-fn-kind.stderr
@@ -20,15 +20,16 @@ LL | fn needs_async_fn(_: impl async Fn()) {}
    |                           ^^^^^^^^^^ required by this bound in `needs_async_fn`
 
 error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
-  --> $DIR/wrong-fn-kind.rs:9:29
+  --> $DIR/wrong-fn-kind.rs:9:20
    |
 LL |   fn needs_async_fn(_: impl async Fn()) {}
    |                        --------------- change this to accept `FnMut` instead of `Fn`
 ...
 LL |       needs_async_fn(async || {
-   |  _____--------------_--------_^
-   | |     |              |
-   | |     |              in this closure
+   |       -------------- ^-------
+   |       |              |
+   |  _____|______________in this closure
+   | |     |
    | |     expects `Fn` instead of `FnMut`
 LL | |
 LL | |         x += 1;

--- a/tests/ui/coroutine/break-inside-coroutine-issue-124495.rs
+++ b/tests/ui/coroutine/break-inside-coroutine-issue-124495.rs
@@ -18,6 +18,7 @@ async gen fn async_gen_fn() {
 
 fn main() {
     let _ = async { break; }; //~ ERROR `break` inside `async` block
+
     let _ = async || { break; }; //~ ERROR `break` inside `async` closure
 
     let _ = gen { break; }; //~ ERROR `break` inside `gen` block

--- a/tests/ui/coroutine/break-inside-coroutine-issue-124495.stderr
+++ b/tests/ui/coroutine/break-inside-coroutine-issue-124495.stderr
@@ -38,16 +38,16 @@ LL |     let _ = async { break; };
    |             enclosing `async` block
 
 error[E0267]: `break` inside `async` closure
-  --> $DIR/break-inside-coroutine-issue-124495.rs:21:24
+  --> $DIR/break-inside-coroutine-issue-124495.rs:22:24
    |
 LL |     let _ = async || { break; };
-   |                      --^^^^^---
-   |                      | |
-   |                      | cannot `break` inside `async` closure
-   |                      enclosing `async` closure
+   |             -----------^^^^^---
+   |             |          |
+   |             |          cannot `break` inside `async` closure
+   |             enclosing `async` closure
 
 error[E0267]: `break` inside `gen` block
-  --> $DIR/break-inside-coroutine-issue-124495.rs:23:19
+  --> $DIR/break-inside-coroutine-issue-124495.rs:24:19
    |
 LL |     let _ = gen { break; };
    |             ------^^^^^---
@@ -56,7 +56,7 @@ LL |     let _ = gen { break; };
    |             enclosing `gen` block
 
 error[E0267]: `break` inside `async gen` block
-  --> $DIR/break-inside-coroutine-issue-124495.rs:25:25
+  --> $DIR/break-inside-coroutine-issue-124495.rs:26:25
    |
 LL |     let _ = async gen { break; };
    |             ------------^^^^^---


### PR DESCRIPTION
Fixes #124496

