### PR TITLE
`rustc_hir_typeck`: Account for `skipped_ref_pats` in `expr_use_visitor`

### DIFF
--- a/tests/ui/pattern/skipped-ref-pats-issue-125058.rs
+++ b/tests/ui/pattern/skipped-ref-pats-issue-125058.rs
@@ -1,0 +1,18 @@
+//@ run-pass
+//@ edition: 2024
+//@ compile-flags: -Zunstable-options
+
+#![allow(incomplete_features)]
+#![feature(ref_pat_eat_one_layer_2024)]
+
+struct Foo;
+//~^ WARN struct `Foo` is never constructed
+
+fn main() {
+    || {
+        //~^ WARN unused closure that must be used
+        if let Some(Some(&mut x)) = &mut Some(&mut Some(0)) {
+            let _: u32 = x;
+        }
+    };
+}

--- a/tests/ui/pattern/skipped-ref-pats-issue-125058.stderr
+++ b/tests/ui/pattern/skipped-ref-pats-issue-125058.stderr
@@ -1,0 +1,24 @@
+warning: struct `Foo` is never constructed
+  --> $DIR/skipped-ref-pats-issue-125058.rs:8:8
+   |
+LL | struct Foo;
+   |        ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: unused closure that must be used
+  --> $DIR/skipped-ref-pats-issue-125058.rs:12:5
+   |
+LL | /     || {
+LL | |
+LL | |         if let Some(Some(&mut x)) = &mut Some(&mut Some(0)) {
+LL | |             let _: u32 = x;
+LL | |         }
+LL | |     };
+   | |_____^
+   |
+   = note: closures are lazy and do nothing unless called
+   = note: `#[warn(unused_must_use)]` on by default
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Fixes #125058

r? @Nadrieril

cc https://github.com/rust-lang/rust/issues/123076

@rustbot label A-edition-2024 A-patterns