### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(internal_features)]
 #![feature(decl_macro)]
 #![feature(let_chains)]
+#![feature(panic_backtrace_config)]
 #![feature(panic_update_hook)]
 #![feature(result_flattening)]
 
@@ -1317,8 +1318,8 @@ pub fn install_ice_hook(
     // by the user. Compiler developers and other rustc users can
     // opt in to less-verbose backtraces by manually setting "RUST_BACKTRACE"
     // (e.g. `RUST_BACKTRACE=1`)
-    if std::env::var_os("RUST_BACKTRACE").is_none() {
-        std::env::set_var("RUST_BACKTRACE", "full");
+    if env::var_os("RUST_BACKTRACE").is_none() {
+        panic::set_backtrace_style(panic::BacktraceStyle::Full);
     }
 
     let using_internal_features = Arc::new(std::sync::atomic::AtomicBool::default());

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2055,7 +2055,6 @@ pub trait Seek {
     /// # Example
     ///
     /// ```no_run
-    /// #![feature(seek_seek_relative)]
     /// use std::{
     ///     io::{self, Seek},
     ///     fs::File,
@@ -2070,7 +2069,7 @@ pub trait Seek {
     /// ```
     ///
     /// [`BufReader`]: crate::io::BufReader
-    #[unstable(feature = "seek_seek_relative", issue = "117374")]
+    #[stable(feature = "seek_seek_relative", since = "CURRENT_RUSTC_VERSION")]
     fn seek_relative(&mut self, offset: i64) -> Result<()> {
         self.seek(SeekFrom::Current(offset))?;
         Ok(())

--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -43,6 +43,7 @@ include:
 - Miscellaneous `rustfmt` bugfixes.
 - Use version-sort (sort `x8`, `x16`, `x32`, `x64`, `x128` in that order).
 - Change "ASCIIbetical" sort to Unicode-aware "non-lowercase before lowercase".
+- Format single associated type `where` clauses on the same line if they fit.
 
 ## Rust 2015/2018/2021 style edition
 

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -296,7 +296,7 @@ Prefer to use single-letter names for generic parameters.
 These rules apply for `where` clauses on any item.
 
 If a where clause is short, and appears on a short one-line function
-declaration with no body or a short associated type with no `=`, format it on
+declaration with no body or on a short type with no `=`, format it on
 the same line as the declaration:
 
 ```rust

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -347,7 +347,7 @@ where
 ```
 
 If a `where` clause is very short, prefer using an inline bound on the type
-parameter.
+parameter if possible.
 
 If a component of a `where` clause does not fit and contains `+`, break it
 before each `+` and block-indent the continuation lines. Put each bound on its

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -421,8 +421,19 @@ Format associated types like type aliases. Where an associated type has a
 bound, put a space after the colon but not before:
 
 ```rust
-pub type Foo: Bar;
+type Foo: Bar;
 ```
+
+If an associated type has no `=`, and has a `where` clause with only one entry,
+format the entire type declaration including the `where` clause on the same
+line if it fits:
+
+```rust
+type Item<'a> where Self: 'a;
+```
+
+If the associated type has a `=`, or if the `where` clause contains multiple
+entries, format it across multiple lines as with a type alias.
 
 ## extern items
 

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -295,8 +295,18 @@ Prefer to use single-letter names for generic parameters.
 
 These rules apply for `where` clauses on any item.
 
-If immediately following a closing bracket of any kind, write the keyword
-`where` on the same line, with a space before it.
+If a where clause is short, and appears on a short one-line function
+declaration with no body or a short associated type with no `=`, format it on
+the same line as the declaration:
+
+```rust
+fn new(&self) -> Self where Self: Sized;
+
+type Item<'a>: SomeTrait where Self: 'a;
+```
+
+Otherwise, if immediately following a closing bracket of any kind, write the
+keyword `where` on the same line, with a space before it.
 
 Otherwise, put `where` on a new line at the same indentation level. Put each
 component of a `where` clause on its own line, block-indented. Use a trailing
@@ -424,9 +434,9 @@ bound, put a space after the colon but not before:
 type Foo: Bar;
 ```
 
-If an associated type has no `=`, and has a `where` clause with only one entry,
-format the entire type declaration including the `where` clause on the same
-line if it fits:
+If an associated type is short, has no `=`, and has a `where` clause with only
+one entry, format the entire type declaration including the `where` clause on
+the same line if it fits:
 
 ```rust
 type Item<'a> where Self: 'a;

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -430,6 +430,7 @@ line if it fits:
 
 ```rust
 type Item<'a> where Self: 'a;
+type Item<'a>: PartialEq + Send where Self: 'a;
 ```
 
 If the associated type has a `=`, or if the `where` clause contains multiple

--- a/src/tools/run-make-support/src/rustdoc.rs
+++ b/src/tools/run-make-support/src/rustdoc.rs
@@ -143,6 +143,14 @@ impl Rustdoc {
         self
     }
 
+    /// Add a directory to the library search path. It corresponds to the `-L`
+    /// rustdoc option.
+    pub fn library_search_path<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+        self.cmd.arg("-L");
+        self.cmd.arg(path.as_ref());
+        self
+    }
+
     #[track_caller]
     pub fn run_fail_assert_exit_code(&mut self, code: i32) -> Output {
         let caller_location = std::panic::Location::caller();

--- a/src/tools/run-make-support/src/rustdoc.rs
+++ b/src/tools/run-make-support/src/rustdoc.rs
@@ -123,6 +123,12 @@ impl Rustdoc {
         self
     }
 
+    /// Specify the target triple, or a path to a custom target json spec file.
+    pub fn target(&mut self, target: &str) -> &mut Self {
+        self.cmd.arg(format!("--target={target}"));
+        self
+    }
+
     /// Specify the crate type.
     pub fn crate_type(&mut self, crate_type: &str) -> &mut Self {
         self.cmd.arg("--crate-type");

--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -251,7 +251,6 @@ run-make/rustdoc-scrape-examples-multiple/Makefile
 run-make/rustdoc-scrape-examples-remap/Makefile
 run-make/rustdoc-scrape-examples-test/Makefile
 run-make/rustdoc-scrape-examples-whitespace/Makefile
-run-make/rustdoc-target-spec-json-path/Makefile
 run-make/rustdoc-themes/Makefile
 run-make/rustdoc-verify-output-files/Makefile
 run-make/rustdoc-with-out-dir-option/Makefile

--- a/tests/run-make/rustdoc-target-spec-json-path/Makefile
+++ b/tests/run-make/rustdoc-target-spec-json-path/Makefile
@@ -1,9 +1,0 @@
-include ../tools.mk
-
-# Test that rustdoc will properly canonicalize the target spec json path just like rustc
-
-OUTPUT_DIR := "$(TMPDIR)/rustdoc-target-spec-json-path"
-
-all:
-	$(RUSTC) --crate-type lib dummy_core.rs --target target.json
-	$(RUSTDOC) -o $(OUTPUT_DIR) -L $(TMPDIR) my_crate.rs --target target.json

--- a/tests/run-make/rustdoc-target-spec-json-path/rmake.rs
+++ b/tests/run-make/rustdoc-target-spec-json-path/rmake.rs
@@ -1,0 +1,14 @@
+// Test that rustdoc will properly canonicalize the target spec json path just like rustc.
+
+use run_make_support::{rustc, rustdoc, tmp_dir};
+
+fn main() {
+    let out_dir = tmp_dir().join("rustdoc-target-spec-json-path");
+    rustc().crate_type("lib").input("dummy_core.rs").target("target.json").run();
+    rustdoc()
+        .input("my_crate.rs")
+        .output(out_dir)
+        .library_search_path(tmp_dir())
+        .target("target.json")
+        .run();
+}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -383,7 +383,7 @@ message_on_add = """\
 - Priority?
 - Regression?
 - Notify people/groups?
-- Needs `I-nominated`?
+- Needs `I-{team}-nominated`?
 """
 message_on_remove = "Issue #{number}'s prioritization request has been removed."
 message_on_close = "Issue #{number} has been closed while requested for prioritization."


### PR DESCRIPTION
Successful merges:

 - #119515 (style-guide: Format single associated type `where` clauses on the same line)
 - #119959 ([meta] Clarify prioritization alert)
 - #123817 (Stabilize `seek_seek_relative`)
 - #125063 (Don't call `env::set_var` in `rustc_driver::install_ice_hook`)
 - #125071 (Migrate rustdoc target spec json path)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=119515,119959,123817,125063,125071)
<!-- homu-ignore:end -->