### PR TITLE
Convert some macros from `LegacyBang` to `Bang`.

### DIFF
--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -59,21 +59,32 @@ rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
 pub fn register_builtin_macros(resolver: &mut dyn ResolverExpand) {
     let mut register = |name, kind| resolver.register_builtin_macro(name, kind);
     macro register_bang($($name:ident: $f:expr,)*) {
+        $(register(sym::$name, SyntaxExtensionKind::Bang(Box::new($f)));)*
+    }
+    macro register_legacy_bang($($name:ident: $f:expr,)*) {
         $(register(sym::$name, SyntaxExtensionKind::LegacyBang(Box::new($f as MacroExpanderFn)));)*
     }
-    macro register_attr($($name:ident: $f:expr,)*) {
+    macro register_legacy_attr($($name:ident: $f:expr,)*) {
         $(register(sym::$name, SyntaxExtensionKind::LegacyAttr(Box::new($f)));)*
     }
-    macro register_derive($($name:ident: $f:expr,)*) {
+    macro register_legacy_derive($($name:ident: $f:expr,)*) {
         $(register(sym::$name, SyntaxExtensionKind::LegacyDerive(Box::new(BuiltinDerive($f))));)*
     }
 
     register_bang! {
         // tidy-alphabetical-start
-        asm: asm::expand_asm,
-        assert: assert::expand_assert,
         cfg: cfg::expand_cfg,
         column: source_util::expand_column,
+        file: source_util::expand_file,
+        line: source_util::expand_line,
+        module_path: source_util::expand_module_path,
+        // tidy-alphabetical-end
+    }
+
+    register_legacy_bang! {
+        // tidy-alphabetical-start
+        asm: asm::expand_asm,
+        assert: assert::expand_assert,
         compile_error: compile_error::expand_compile_error,
         concat: concat::expand_concat,
         concat_bytes: concat_bytes::expand_concat_bytes,
@@ -81,16 +92,13 @@ pub fn register_builtin_macros(resolver: &mut dyn ResolverExpand) {
         const_format_args: format::expand_format_args,
         core_panic: edition_panic::expand_panic,
         env: env::expand_env,
-        file: source_util::expand_file,
         format_args: format::expand_format_args,
         format_args_nl: format::expand_format_args_nl,
         global_asm: asm::expand_global_asm,
         include: source_util::expand_include,
         include_bytes: source_util::expand_include_bytes,
         include_str: source_util::expand_include_str,
-        line: source_util::expand_line,
         log_syntax: log_syntax::expand_log_syntax,
-        module_path: source_util::expand_mod,
         option_env: env::expand_option_env,
         pattern_type: pattern_type::expand,
         std_panic: edition_panic::expand_panic,
@@ -100,7 +108,7 @@ pub fn register_builtin_macros(resolver: &mut dyn ResolverExpand) {
         // tidy-alphabetical-end
     }
 
-    register_attr! {
+    register_legacy_attr! {
         alloc_error_handler: alloc_error_handler::expand,
         bench: test::expand_bench,
         cfg_accessible: cfg_accessible::Expander,
@@ -112,7 +120,7 @@ pub fn register_builtin_macros(resolver: &mut dyn ResolverExpand) {
         test_case: test::expand_test_case,
     }
 
-    register_derive! {
+    register_legacy_derive! {
         Clone: clone::expand_deriving_clone,
         Copy: bounds::expand_deriving_copy,
         ConstParamTy: bounds::expand_deriving_const_param_ty,

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -290,16 +290,15 @@ pub trait BangProcMacro {
 
 impl<F> BangProcMacro for F
 where
-    F: Fn(TokenStream) -> TokenStream,
+    F: Fn(&mut ExtCtxt<'_>, Span, TokenStream) -> TokenStream,
 {
     fn expand<'cx>(
         &self,
-        _ecx: &'cx mut ExtCtxt<'_>,
-        _span: Span,
+        ecx: &'cx mut ExtCtxt<'_>,
+        span: Span,
         ts: TokenStream,
     ) -> Result<TokenStream, ErrorGuaranteed> {
-        // FIXME setup implicit context in TLS before calling self.
-        Ok(self(ts))
+        Ok(self(ecx, span, ts))
     }
 }
 

--- a/tests/ui/macros/macro-error.rs
+++ b/tests/ui/macros/macro-error.rs
@@ -5,5 +5,5 @@ macro_rules! foo {
 fn main() {
     foo!(0); // Check that we report errors at macro definition, not expansion.
 
-    let _: cfg!(FALSE) = (); //~ ERROR non-type macro in type position
+    let _: cfg!(FALSE) = (); //~ ERROR expected type, found keyword `false`
 }

--- a/tests/ui/macros/macro-error.stderr
+++ b/tests/ui/macros/macro-error.stderr
@@ -4,11 +4,16 @@ error: macro rhs must be delimited
 LL |     ($a:expr) => a;
    |                  ^
 
-error: non-type macro in type position: cfg
+error: expected type, found keyword `false`
   --> $DIR/macro-error.rs:8:12
    |
 LL |     let _: cfg!(FALSE) = ();
    |            ^^^^^^^^^^^
+   |            |
+   |            expected type
+   |            this macro call doesn't expand to a type
+   |
+   = note: this error originates in the macro `cfg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Specifically: `cfg!`, `column!`, `file!`, `line!`, `module_path!`.

This requires changing `BangProcMacro for F` to use the `ecx` and `span` arguments, instead of ignoring them.

r? @petrochenkov 