### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -140,7 +140,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             | ty::Never
             | ty::Dynamic(_, _, ty::DynStar)
             | ty::Error(_) => {
-                self.dcx().span_bug(span, format!("`{t:?}` should be sized but is not?"));
+                let guar = self
+                    .dcx()
+                    .span_delayed_bug(span, format!("`{t:?}` should be sized but is not?"));
+                return Err(guar);
             }
         })
     }

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -59,11 +59,39 @@
 //!
 //! ## Allocated object
 //!
-//! For several operations, such as [`offset`] or field projections (`expr.field`), the notion of an
-//! "allocated object" becomes relevant. An allocated object is a contiguous region of memory.
-//! Common examples of allocated objects include stack-allocated variables (each variable is a
-//! separate allocated object), heap allocations (each allocation created by the global allocator is
-//! a separate allocated object), and `static` variables.
+//! An *allocated object* is a subset of program memory which is addressable
+//! from Rust, and within which pointer arithmetic is possible. Examples of
+//! allocated objects include heap allocations, stack-allocated variables,
+//! statics, and consts. The safety preconditions of some Rust operations -
+//! such as `offset` and field projections (`expr.field`) - are defined in
+//! terms of the allocated objects on which they operate.
+//!
+//! An allocated object has a base address, a size, and a set of memory
+//! addresses. It is possible for an allocated object to have zero size, but
+//! such an allocated object will still have a base address. The base address
+//! of an allocated object is not necessarily unique. While it is currently the
+//! case that an allocated object always has a set of memory addresses which is
+//! fully contiguous (i.e., has no "holes"), there is no guarantee that this
+//! will not change in the future.
+//!
+//! For any allocated object with `base` address, `size`, and a set of
+//! `addresses`, the following are guaranteed:
+//! - For all addresses `a` in `addresses`, `a` is in the range `base .. (base +
+//!   size)` (note that this requires `a < base + size`, not `a <= base + size`)
+//! - `base` is not equal to [`null()`] (i.e., the address with the numerical
+//!   value 0)
+//! - `base + size <= usize::MAX`
+//! - `size <= isize::MAX`
+//!
+//! As a consequence of these guarantees, given any address `a` within the set
+//! of addresses of an allocated object:
+//! - It is guaranteed that `a - base` does not overflow `isize`
+//! - It is guaranteed that `a - base` is non-negative
+//! - It is guaranteed that, given `o = a - base` (i.e., the offset of `a` within
+//!   the allocated object), `base + o` will not wrap around the address space (in
+//!   other words, will not overflow `usize`)
+//!
+//! [`null()`]: null
 //!
 //! # Strict Provenance
 //!

--- a/src/doc/rustc/src/platform-support/fuchsia.md
+++ b/src/doc/rustc/src/platform-support/fuchsia.md
@@ -387,7 +387,7 @@ meta/hello_fuchsia.cm=pkg/meta/hello_fuchsia.cm
 ```
 
 *Note: Relative manifest paths are resolved starting from the working directory
-of `pm`. Make sure to fill out `<SDK_PATH>` with the path to the downloaded
+of `ffx`. Make sure to fill out `<SDK_PATH>` with the path to the downloaded
 SDK.*
 
 The `.manifest` file will be used to describe the contents of the package by
@@ -459,12 +459,10 @@ hello_fuchsia/
 Next, we'll build a package manifest as defined by our manifest:
 
 ```sh
-${SDK_PATH}/tools/${ARCH}/pm \
-    -api-level $(${SDK_PATH}/tools/${ARCH}/ffx version -v | grep "api-level" | head -1 |  awk -F ' ' '{print $2}') \
-    -o pkg/hello_fuchsia_manifest \
-    -m pkg/hello_fuchsia.manifest \
-    build \
-    -output-package-manifest pkg/hello_fuchsia_package_manifest
+${SDK_PATH}/tools/${ARCH}/ffx package build \
+    --api-level $(${SDK_PATH}/tools/${ARCH}/ffx --machine json version | jq .tool_version.api_level) \
+    --out pkg/hello_fuchsia_manifest \
+    pkg/hello_fuchsia.manifest
 ```
 
 This will produce `pkg/hello_fuchsia_manifest/` which is a package manifest we can
@@ -498,8 +496,7 @@ to.
 We can set up our repository with:
 
 ```sh
-${SDK_PATH}/tools/${ARCH}/pm newrepo \
-    -repo pkg/repo
+${SDK_PATH}/tools/${ARCH}/ffx repository create pkg/repo
 ```
 
 **Current directory structure**
@@ -523,17 +520,17 @@ hello_fuchsia/
 We can publish our new package to that repository with:
 
 ```sh
-${SDK_PATH}/tools/${ARCH}/pm publish \
-    -repo pkg/repo \
-    -lp -f <(echo "pkg/hello_fuchsia_package_manifest")
+${SDK_PATH}/tools/${ARCH}/ffx repository publish \
+    --package pkg/hello_fuchsia_package_manifest \
+    pkg/repo
 ```
 
 Then we can add the repository to `ffx`'s package server as `hello-fuchsia` using:
 
 ```sh
 ${SDK_PATH}/tools/${ARCH}/ffx repository add-from-pm \
-    pkg/repo \
-    -r hello-fuchsia
+    --repository hello-fuchsia \
+    pkg/repo
 ```
 
 ## Running a Fuchsia component on an emulator

--- a/tests/ui/cast/ice-cast-type-with-error-124848.rs
+++ b/tests/ui/cast/ice-cast-type-with-error-124848.rs
@@ -1,0 +1,18 @@
+// Regression test for ICE #124848
+// Tests that there is no ICE when a cast
+// involves a type with error
+
+use std::cell::Cell;
+
+struct MyType<'a>(Cell<Option<&'unpinned mut MyType<'a>>>, Pin);
+//~^ ERROR use of undeclared lifetime name `'unpinned`
+//~| ERROR cannot find type `Pin` in this scope
+
+fn main() {
+    let mut unpinned = MyType(Cell::new(None));
+    //~^ ERROR his struct takes 2 arguments but 1 argument was supplied
+    let bad_addr = &unpinned as *const Cell<Option<&'a mut MyType<'a>>> as usize;
+    //~^ ERROR use of undeclared lifetime name `'a`
+    //~| ERROR use of undeclared lifetime name `'a`
+    //~| ERROR casting `&MyType<'_>` as `*const Cell<Option<&mut MyType<'_>>>` is invalid
+}

--- a/tests/ui/cast/ice-cast-type-with-error-124848.stderr
+++ b/tests/ui/cast/ice-cast-type-with-error-124848.stderr
@@ -1,0 +1,63 @@
+error[E0261]: use of undeclared lifetime name `'unpinned`
+  --> $DIR/ice-cast-type-with-error-124848.rs:7:32
+   |
+LL | struct MyType<'a>(Cell<Option<&'unpinned mut MyType<'a>>>, Pin);
+   |               -                ^^^^^^^^^ undeclared lifetime
+   |               |
+   |               help: consider introducing lifetime `'unpinned` here: `'unpinned,`
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/ice-cast-type-with-error-124848.rs:14:53
+   |
+LL | fn main() {
+   |        - help: consider introducing lifetime `'a` here: `<'a>`
+...
+LL |     let bad_addr = &unpinned as *const Cell<Option<&'a mut MyType<'a>>> as usize;
+   |                                                     ^^ undeclared lifetime
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/ice-cast-type-with-error-124848.rs:14:67
+   |
+LL | fn main() {
+   |        - help: consider introducing lifetime `'a` here: `<'a>`
+...
+LL |     let bad_addr = &unpinned as *const Cell<Option<&'a mut MyType<'a>>> as usize;
+   |                                                                   ^^ undeclared lifetime
+
+error[E0412]: cannot find type `Pin` in this scope
+  --> $DIR/ice-cast-type-with-error-124848.rs:7:60
+   |
+LL | struct MyType<'a>(Cell<Option<&'unpinned mut MyType<'a>>>, Pin);
+   |                                                            ^^^ not found in this scope
+   |
+help: consider importing this struct
+   |
+LL + use std::pin::Pin;
+   |
+
+error[E0061]: this struct takes 2 arguments but 1 argument was supplied
+  --> $DIR/ice-cast-type-with-error-124848.rs:12:24
+   |
+LL |     let mut unpinned = MyType(Cell::new(None));
+   |                        ^^^^^^----------------- an argument is missing
+   |
+note: tuple struct defined here
+  --> $DIR/ice-cast-type-with-error-124848.rs:7:8
+   |
+LL | struct MyType<'a>(Cell<Option<&'unpinned mut MyType<'a>>>, Pin);
+   |        ^^^^^^
+help: provide the argument
+   |
+LL |     let mut unpinned = MyType(Cell::new(None), /* value */);
+   |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error[E0606]: casting `&MyType<'_>` as `*const Cell<Option<&mut MyType<'_>>>` is invalid
+  --> $DIR/ice-cast-type-with-error-124848.rs:14:20
+   |
+LL |     let bad_addr = &unpinned as *const Cell<Option<&'a mut MyType<'a>>> as usize;
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0061, E0261, E0412, E0606.
+For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/coercion/pin-dyn-dispatch-sound.rs
+++ b/tests/ui/coercion/pin-dyn-dispatch-sound.rs
@@ -1,0 +1,19 @@
+use std::marker::PhantomPinned;
+use std::pin::Pin;
+
+trait MyUnpinTrait {
+    fn into_pinned_type(self: Pin<&mut Self>) -> Pin<&mut PhantomPinned>;
+}
+impl MyUnpinTrait for PhantomPinned {
+    fn into_pinned_type(self: Pin<&mut Self>) -> Pin<&mut PhantomPinned> {
+        self
+    }
+}
+impl Unpin for dyn MyUnpinTrait {} //~ ERROR E0321
+
+// It would be unsound for this function to compile.
+fn pin_it(not_yet_pinned: &mut PhantomPinned) -> Pin<&mut PhantomPinned> {
+    Pin::new(not_yet_pinned as &mut dyn MyUnpinTrait).into_pinned_type()
+}
+
+fn main() {}

--- a/tests/ui/coercion/pin-dyn-dispatch-sound.stderr
+++ b/tests/ui/coercion/pin-dyn-dispatch-sound.stderr
@@ -1,0 +1,9 @@
+error[E0321]: cross-crate traits with a default impl, like `Unpin`, can only be implemented for a struct/enum type, not `(dyn MyUnpinTrait + 'static)`
+  --> $DIR/pin-dyn-dispatch-sound.rs:12:1
+   |
+LL | impl Unpin for dyn MyUnpinTrait {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't implement cross-crate trait with a default impl for non-struct/enum type
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0321`.


### PR DESCRIPTION
Successful merges:

 - #116675 ([ptr] Document maximum allocation size)
 - #124997 (Fix ICE while casting a type with error)
 - #125072 (Add test for dynamic dispatch + Pin::new soundness)
 - #125090 (Migrate fuchsia docs from `pm` to `ffx`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=116675,124997,125072,125090)
<!-- homu-ignore:end -->