### PR TITLE
[DO NOT MERGE] Expand core's prelude with more types

### DIFF
--- a/library/core/src/prelude/common.rs
+++ b/library/core/src/prelude/common.rs
@@ -41,6 +41,67 @@ pub use crate::option::Option::{self, None, Some};
 #[doc(no_inline)]
 pub use crate::result::Result::{self, Err, Ok};
 
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::cell::{Cell, LazyCell, OnceCell, RefCell, SyncUnsafeCell, UnsafeCell};
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::ffi::{
+    c_char, c_double, c_float, c_int, c_long, c_longlong, c_ptrdiff_t, c_schar, c_short, c_size_t,
+    c_ssize_t, c_str, c_uchar, c_uint, c_ulong, c_ulonglong, c_ushort, c_void, CStr,
+};
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::io::{BorrowedBuf, BorrowedCursor};
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::marker::{PhantomData, PhantomPinned};
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::mem::{ManuallyDrop, MaybeUninit};
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::num::{
+    NonZero, NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
+    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+};
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::panic::PanicInfo;
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::pin::Pin;
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::ptr::NonNull;
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::sync::atomic::{
+    AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16,
+    AtomicU32, AtomicU64, AtomicU8, AtomicUsize,
+};
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::time::Duration;
+
+#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::ops::ControlFlow;
+
 // Re-exported built-in macros
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[doc(no_inline)]

--- a/library/core/src/prelude/common.rs
+++ b/library/core/src/prelude/common.rs
@@ -43,13 +43,13 @@ pub use crate::result::Result::{self, Err, Ok};
 
 #[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
 #[doc(no_inline)]
-pub use crate::cell::{Cell, LazyCell, OnceCell, RefCell, SyncUnsafeCell, UnsafeCell};
+pub use crate::cell::{LazyCell, OnceCell, RefCell, SyncUnsafeCell, UnsafeCell};
 
 #[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
 #[doc(no_inline)]
 pub use crate::ffi::{
     c_char, c_double, c_float, c_int, c_long, c_longlong, c_ptrdiff_t, c_schar, c_short, c_size_t,
-    c_ssize_t, c_str, c_uchar, c_uint, c_ulong, c_ulonglong, c_ushort, c_void, CStr,
+    c_ssize_t, c_uchar, c_uint, c_ulong, c_ulonglong, c_ushort, c_void, CStr,
 };
 
 #[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
@@ -93,10 +93,6 @@ pub use crate::sync::atomic::{
     AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16,
     AtomicU32, AtomicU64, AtomicU8, AtomicUsize,
 };
-
-#[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
-#[doc(no_inline)]
-pub use crate::time::Duration;
 
 #[stable(feature = "core_prelude_extra", since = "CURRENT_RUSTC_VERSION")]
 #[doc(no_inline)]

--- a/src/tools/clippy/clippy_lints/src/lifetimes.rs
+++ b/src/tools/clippy/clippy_lints/src/lifetimes.rs
@@ -599,7 +599,7 @@ fn has_where_lifetimes<'tcx>(cx: &LateContext<'tcx>, generics: &'tcx Generics<'_
 struct LifetimeChecker<'cx, 'tcx, F> {
     cx: &'cx LateContext<'tcx>,
     map: FxHashMap<Symbol, Span>,
-    phantom: std::marker::PhantomData<F>,
+    phantom: PhantomData<F>,
 }
 
 impl<'cx, 'tcx, F> LifetimeChecker<'cx, 'tcx, F> {
@@ -607,7 +607,7 @@ impl<'cx, 'tcx, F> LifetimeChecker<'cx, 'tcx, F> {
         Self {
             cx,
             map,
-            phantom: std::marker::PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/src/tools/clippy/clippy_lints/src/zero_repeat_side_effects.rs
+++ b/src/tools/clippy/clippy_lints/src/zero_repeat_side_effects.rs
@@ -68,9 +68,9 @@ fn inner_check(cx: &LateContext<'_>, expr: &'_ rustc_hir::Expr<'_>, inner_expr: 
     // check if expr is a call or has a call inside it
     if for_each_expr(inner_expr, |x| {
         if let ExprKind::Call(_, _) | ExprKind::MethodCall(_, _, _, _) = x.kind {
-            std::ops::ControlFlow::Break(())
+            ControlFlow::Break(())
         } else {
-            std::ops::ControlFlow::Continue(())
+            ControlFlow::Continue(())
         }
     })
     .is_some()

--- a/src/tools/clippy/tests/ui-toml/toml_disallowed_types/conf_disallowed_types.stderr
+++ b/src/tools/clippy/tests/ui-toml/toml_disallowed_types/conf_disallowed_types.stderr
@@ -1,4 +1,4 @@
-error: `std::sync::atomic::AtomicU32` is not allowed according to config
+error: `std::prelude::rust_2021::AtomicU32` is not allowed according to config
   --> tests/ui-toml/toml_disallowed_types/conf_disallowed_types.rs:7:1
    |
 LL | use std::sync::atomic::AtomicU32;
@@ -25,7 +25,7 @@ error: `std::time::Instant` is not allowed according to config
 LL | fn bad_arg_type(_: impl Fn(Sneaky) -> foo::atomic::AtomicU32) {}
    |                            ^^^^^^
 
-error: `std::sync::atomic::AtomicU32` is not allowed according to config
+error: `std::prelude::rust_2021::AtomicU32` is not allowed according to config
   --> tests/ui-toml/toml_disallowed_types/conf_disallowed_types.rs:16:39
    |
 LL | fn bad_arg_type(_: impl Fn(Sneaky) -> foo::atomic::AtomicU32) {}
@@ -93,19 +93,19 @@ error: `std::time::Instant` is not allowed according to config
 LL |     let _ = Sneaky::now();
    |             ^^^^^^
 
-error: `std::sync::atomic::AtomicU32` is not allowed according to config
+error: `std::prelude::rust_2021::AtomicU32` is not allowed according to config
   --> tests/ui-toml/toml_disallowed_types/conf_disallowed_types.rs:36:13
    |
 LL |     let _ = foo::atomic::AtomicU32::new(0);
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
-error: `std::sync::atomic::AtomicU32` is not allowed according to config
+error: `std::prelude::rust_2021::AtomicU32` is not allowed according to config
   --> tests/ui-toml/toml_disallowed_types/conf_disallowed_types.rs:37:17
    |
 LL |     static FOO: std::sync::atomic::AtomicU32 = foo::atomic::AtomicU32::new(1);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `std::sync::atomic::AtomicU32` is not allowed according to config
+error: `std::prelude::rust_2021::AtomicU32` is not allowed according to config
   --> tests/ui-toml/toml_disallowed_types/conf_disallowed_types.rs:37:48
    |
 LL |     static FOO: std::sync::atomic::AtomicU32 = foo::atomic::AtomicU32::new(1);

--- a/src/tools/clippy/tests/ui/crashes/ice-6252.rs
+++ b/src/tools/clippy/tests/ui/crashes/ice-6252.rs
@@ -1,6 +1,7 @@
 // originally from glacier fixed/77919.rs
 // encountered errors resolving bounds after type-checking
 //@no-rustfix
+#![no_implicit_prelude]
 trait TypeVal<T> {
     const VAL: T;
 }

--- a/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
@@ -1,5 +1,5 @@
 error[E0412]: cannot find type `PhantomData` in this scope
-  --> tests/ui/crashes/ice-6252.rs:9:9
+  --> tests/ui/crashes/ice-6252.rs:10:9
    |
 LL |     _n: PhantomData,
    |         ^^^^^^^^^^^ not found in this scope
@@ -12,7 +12,7 @@ LL + use std::marker::PhantomData;
    |
 
 error[E0412]: cannot find type `VAL` in this scope
-  --> tests/ui/crashes/ice-6252.rs:11:63
+  --> tests/ui/crashes/ice-6252.rs:12:63
    |
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    |                                                               ^^^ not found in this scope
@@ -23,7 +23,7 @@ LL | impl<N, M, VAL> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    |          +++++
 
 error[E0046]: not all trait items implemented, missing: `VAL`
-  --> tests/ui/crashes/ice-6252.rs:11:1
+  --> tests/ui/crashes/ice-6252.rs:12:1
    |
 LL |     const VAL: T;
    |     ------------ `VAL` from trait

--- a/tests/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/tests/ui/proc-macro/meta-macro-hygiene.stdout
@@ -55,6 +55,9 @@ crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctx
 crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "diagnostic::on_unimplemented")
 crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
 crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
+crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
+crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
+crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
 crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Bang, "include")
 
 SyntaxContexts:

--- a/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
+++ b/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
@@ -77,6 +77,9 @@ crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctx
 crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "diagnostic::on_unimplemented")
 crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
 crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
+crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
+crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
+crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Attr, "derive")
 crate1::{{expnNNN}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Bang, "include")
 
 SyntaxContexts:

--- a/tests/ui/std-uncopyable-atomics.stderr
+++ b/tests/ui/std-uncopyable-atomics.stderr
@@ -2,7 +2,7 @@ error[E0507]: cannot move out of a shared reference
   --> $DIR/std-uncopyable-atomics.rs:9:13
    |
 LL |     let x = *&x;
-   |             ^^^ move occurs because value has type `std::sync::atomic::AtomicBool`, which does not implement the `Copy` trait
+   |             ^^^ move occurs because value has type `std::prelude::rust_2021::AtomicBool`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -14,7 +14,7 @@ error[E0507]: cannot move out of a shared reference
   --> $DIR/std-uncopyable-atomics.rs:11:13
    |
 LL |     let x = *&x;
-   |             ^^^ move occurs because value has type `std::sync::atomic::AtomicIsize`, which does not implement the `Copy` trait
+   |             ^^^ move occurs because value has type `std::prelude::rust_2021::AtomicIsize`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -26,7 +26,7 @@ error[E0507]: cannot move out of a shared reference
   --> $DIR/std-uncopyable-atomics.rs:13:13
    |
 LL |     let x = *&x;
-   |             ^^^ move occurs because value has type `std::sync::atomic::AtomicUsize`, which does not implement the `Copy` trait
+   |             ^^^ move occurs because value has type `std::prelude::rust_2021::AtomicUsize`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -38,7 +38,7 @@ error[E0507]: cannot move out of a shared reference
   --> $DIR/std-uncopyable-atomics.rs:15:13
    |
 LL |     let x = *&x;
-   |             ^^^ move occurs because value has type `std::sync::atomic::AtomicPtr<usize>`, which does not implement the `Copy` trait
+   |             ^^^ move occurs because value has type `std::prelude::rust_2021::AtomicPtr<usize>`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.stderr
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.stderr
@@ -6,7 +6,7 @@ LL |     let _x = NonZero::new(5u32).unwrap();
    |
 help: consider importing one of these items
    |
-LL + use core::num::NonZero;
+LL + use core::prelude::rust_2024::NonZero;
    |
 LL + use std::num::NonZero;
    |


### PR DESCRIPTION
This adds some more types to the core prelude, to explore the [proposed prelude policy](https://github.com/rust-lang/std-dev-guide/pull/66).

Without any further context, types in the standard library are strongly associated with the standard library so they are good candidates for the prelude, assuming their name doesn't require a module to make sense of. As a bonus this avoids some of the repetition required for `cell::Cell`, `pin::Pin`, `atomic::Atomic*`, etc.

Currently this includes some nightly types. These should be removed before this is merged.

In summary, this PR currently exports the following from the prelude:
```rust
pub use core::cell::{Cell, LazyCell, OnceCell, RefCell, SyncUnsafeCell, UnsafeCell};
pub use core::ffi::{
    c_char, c_double, c_float, c_int, c_long, c_longlong, c_ptrdiff_t, c_schar, c_short, c_size_t,
    c_ssize_t, c_str, c_uchar, c_uint, c_ulong, c_ulonglong, c_ushort, c_void, CStr,
};
pub use core::io::{BorrowedBuf, BorrowedCursor};
pub use core::marker::{PhantomData, PhantomPinned};
pub use core::mem::{ManuallyDrop, MaybeUninit};
pub use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
pub use core::num::{
    NonZero, NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
};
pub use core::panic::PanicInfo;
pub use core::pin::Pin;
pub use core::ptr::NonNull;
pub use core::sync::atomic::{
    AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16,
    AtomicU32, AtomicU64, AtomicU8, AtomicUsize,
};
pub use core::time::Duration;
pub use core::ops::ControlFlow;
```

UPDATE:

There have so far been concerns raised about the following types:

- `Cell` is maybe too generic a word to be in a prelude type
- It is common for time libs to make their own `Duration` type so having it in the prelude may be confusing. This perhaps also suggests the design of std's `Duration` is not ideal but in any case that can't be changed at this point.
