### PR TITLE
Use new utility functions/methods in run-make tests

### DIFF
--- a/tests/run-make/doctests-keep-binaries/rmake.rs
+++ b/tests/run-make/doctests-keep-binaries/rmake.rs
@@ -26,8 +26,7 @@ fn main() {
             .arg("--test")
             .arg("--persist-doctests")
             .arg(out_dir)
-            .arg("--extern")
-            .arg(format!("t={}", extern_path.display()))
+            .extern_("t", extern_path)
             .run();
         check_generated_binaries();
     });
@@ -38,8 +37,7 @@ fn main() {
             .arg("--test")
             .arg("--persist-doctests")
             .arg(out_dir)
-            .arg("--extern")
-            .arg(format!("t={}", extern_path.display()))
+            .extern_("t", extern_path)
             .arg("--no-run")
             .run();
         check_generated_binaries();
@@ -59,8 +57,7 @@ fn main() {
             .arg("doctests")
             .arg("--test-run-directory")
             .arg(run_dir)
-            .arg("--extern")
-            .arg("t=libt.rlib")
+            .extern_("t", "libt.rlib")
             .run();
 
         remove_dir_all(run_dir_path);

--- a/tests/run-make/doctests-runtool/rmake.rs
+++ b/tests/run-make/doctests-runtool/rmake.rs
@@ -29,8 +29,7 @@ fn main() {
         .arg(run_dir_name)
         .arg("--runtool")
         .arg(&run_tool_binary)
-        .arg("--extern")
-        .arg("t=libt.rlib")
+        .extern_("t", "libt.rlib")
         .current_dir(tmp_dir())
         .run();
 

--- a/tests/run-make/rustdoc-map-file/rmake.rs
+++ b/tests/run-make/rustdoc-map-file/rmake.rs
@@ -1,5 +1,4 @@
-use run_make_support::{rustdoc, tmp_dir};
-use std::process::Command;
+use run_make_support::{python_command, rustdoc, tmp_dir};
 
 fn main() {
     let out_dir = tmp_dir().join("out");
@@ -10,6 +9,5 @@ fn main() {
         .output(&out_dir)
         .run();
     // FIXME (GuillaumeGomez): Port the python script to Rust as well.
-    let python = std::env::var("PYTHON").unwrap_or("python".into());
-    assert!(Command::new(python).arg("validate_json.py").arg(&out_dir).status().unwrap().success());
+    assert!(python_command().arg("validate_json.py").arg(&out_dir).status().unwrap().success());
 }


### PR DESCRIPTION
Little cleanup using new functions/methods I added into the `run-make-support` library.

r? @jieyouxu 