### PR TITLE
Add support for -Cforce-frame-poiners=non-leaf

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -45,6 +45,7 @@ use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_session::config::OutputFilenames;
 use rustc_session::Session;
 use rustc_span::{sym, Symbol};
+use rustc_target::spec::FramePointer;
 
 pub use crate::config::*;
 use crate::prelude::*;
@@ -270,7 +271,10 @@ fn build_isa(sess: &Session, backend_config: &BackendConfig) -> Arc<dyn TargetIs
 
     let preserve_frame_pointer = sess.target.options.frame_pointer
         != rustc_target::spec::FramePointer::MayOmit
-        || matches!(sess.opts.cg.force_frame_pointers, Some(true));
+        || matches!(
+            sess.opts.cg.force_frame_pointers,
+            Some(FramePointer::Always | FramePointer::NonLeaf)
+        );
     flags_builder
         .set("preserve_frame_pointers", if preserve_frame_pointer { "true" } else { "false" })
         .unwrap();

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -108,8 +108,10 @@ pub fn frame_pointer_type_attr<'ll>(cx: &CodegenCx<'ll, '_>) -> Option<&'ll Attr
     let opts = &cx.sess().opts;
     // "mcount" function relies on stack pointer.
     // See <https://sourceware.org/binutils/docs/gprof/Implementation.html>.
-    if opts.unstable_opts.instrument_mcount || matches!(opts.cg.force_frame_pointers, Some(true)) {
-        fp = FramePointer::Always;
+    match (opts.unstable_opts.instrument_mcount, opts.cg.force_frame_pointers) {
+        (true, _) => fp = FramePointer::Always,
+        (_, Some(fp_opt)) => fp = fp_opt,
+        (_, None) => {}
     }
     let attr_value = match fp {
         FramePointer::Always => "all",

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -20,7 +20,8 @@ use rustc_span::source_map::{RealFileLoader, SourceMapInputs};
 use rustc_span::symbol::sym;
 use rustc_span::{FileName, SourceFileHashAlgorithm};
 use rustc_target::spec::{
-    CodeModel, LinkerFlavorCli, MergeFunctions, OnBrokenPipe, PanicStrategy, RelocModel, WasmCAbi,
+    CodeModel, FramePointer, LinkerFlavorCli, MergeFunctions, OnBrokenPipe, PanicStrategy,
+    RelocModel, WasmCAbi,
 };
 use rustc_target::spec::{RelroLevel, SanitizerSet, SplitDebuginfo, StackProtector, TlsModel};
 use std::collections::{BTreeMap, BTreeSet};
@@ -605,7 +606,7 @@ fn test_codegen_options_tracking_hash() {
     tracked!(debug_assertions, Some(true));
     tracked!(debuginfo, DebugInfo::Limited);
     tracked!(embed_bitcode, false);
-    tracked!(force_frame_pointers, Some(false));
+    tracked!(force_frame_pointers, Some(FramePointer::MayOmit));
     tracked!(force_unwind_tables, Some(true));
     tracked!(inline_threshold, Some(0xf007ba11));
     tracked!(instrument_coverage, InstrumentCoverage::Yes);

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2913,7 +2913,8 @@ pub(crate) mod dep_tracking {
         CodeModel, MergeFunctions, OnBrokenPipe, PanicStrategy, RelocModel, WasmCAbi,
     };
     use rustc_target::spec::{
-        RelroLevel, SanitizerSet, SplitDebuginfo, StackProtector, TargetTriple, TlsModel,
+        FramePointer, RelroLevel, SanitizerSet, SplitDebuginfo, StackProtector, TargetTriple,
+        TlsModel,
     };
     use std::collections::BTreeMap;
     use std::hash::{DefaultHasher, Hash};
@@ -2970,6 +2971,7 @@ pub(crate) mod dep_tracking {
         RelocModel,
         CodeModel,
         TlsModel,
+        FramePointer,
         InstrumentCoverage,
         CoverageOptions,
         InstrumentXRay,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1421,11 +1421,13 @@ mod parse {
         slot: &mut Option<FramePointer>,
         v: Option<&str>,
     ) -> bool {
+        let mut always = false;
         match v {
-            Some("always" | "yes" | "y" | "on" | "true") | None => {
-                *slot = Some(FramePointer::Always)
+            Some(v) if parse_bool(&mut always, Some(v)) => {
+                *slot = Some(if always { FramePointer::Always } else { FramePointer::MayOmit })
             }
-            Some("never" | "false" | "no" | "n" | "off") => *slot = Some(FramePointer::MayOmit),
+            Some("always") | None => *slot = Some(FramePointer::Always),
+            Some("never") => *slot = Some(FramePointer::MayOmit),
             Some("non-leaf") => *slot = Some(FramePointer::NonLeaf),
             Some(_) => return false,
         }


### PR DESCRIPTION
This brings the command-line option up to parity with the frame-pointers field in the json target specs. It's still backwards compatible with before but now also accepts `always`, `never` and `non-leaf`.