### PR TITLE
Remove the branches from `len_utf8`

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1739,15 +1739,9 @@ impl EscapeDebugExtArgs {
 
 #[inline]
 const fn len_utf8(code: u32) -> usize {
-    if code < MAX_ONE_B {
-        1
-    } else if code < MAX_TWO_B {
-        2
-    } else if code < MAX_THREE_B {
-        3
-    } else {
-        4
-    }
+    1 + ((code >= MAX_ONE_B) as usize)
+        + ((code >= MAX_TWO_B) as usize)
+        + ((code >= MAX_THREE_B) as usize)
 }
 
 /// Encodes a raw u32 value as UTF-8 into the provided byte buffer,

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1739,9 +1739,11 @@ impl EscapeDebugExtArgs {
 
 #[inline]
 const fn len_utf8(code: u32) -> usize {
-    1 + ((code >= MAX_ONE_B) as usize)
-        + ((code >= MAX_TWO_B) as usize)
-        + ((code >= MAX_THREE_B) as usize)
+    if code < MAX_ONE_B {
+        1
+    } else {
+        2 + ((code >= MAX_TWO_B) as usize) + ((code >= MAX_THREE_B) as usize)
+    }
 }
 
 /// Encodes a raw u32 value as UTF-8 into the provided byte buffer,


### PR DESCRIPTION
This changes `len_utf8` to add all of the range comparisons together,
rather than branching on each one. We should definitely test performance
though, because it's possible that this will pessimize mostly-ascii
inputs that would have had a short branch-predicted path before.
