### PR TITLE
Fix the dedup error because of spans from suggestion

### DIFF
--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -896,7 +896,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         style: SuggestionStyle,
     ) -> &mut Self {
         suggestion.sort_unstable();
-        suggestion.dedup();
+        suggestion.dedup_by(|(s1, m1), (s2, m2)| s1.source_equal(*s2) && m1 == m2);
 
         let parts = suggestion
             .into_iter()

--- a/tests/ui/macros/macro-span-issue-116502.rs
+++ b/tests/ui/macros/macro-span-issue-116502.rs
@@ -1,0 +1,16 @@
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+fn bug() {
+    macro_rules! m {
+        () => {
+            _ //~ ERROR the placeholder `_` is not allowed within types on item signatures for structs
+        };
+    }
+    struct S<T = m!()>(m!(), T)
+    where
+        T: Trait<m!()>;
+}
+trait Trait<T> {}
+
+fn main() {}

--- a/tests/ui/macros/macro-span-issue-116502.stderr
+++ b/tests/ui/macros/macro-span-issue-116502.stderr
@@ -1,0 +1,30 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/macro-span-issue-116502.rs:7:13
+   |
+LL |             _
+   |             ^
+   |             |
+   |             not allowed in type signatures
+   |             not allowed in type signatures
+   |             not allowed in type signatures
+...
+LL |     struct S<T = m!()>(m!(), T)
+   |                  ----  ---- in this macro invocation
+   |                  |
+   |                  in this macro invocation
+LL |     where
+LL |         T: Trait<m!()>;
+   |                  ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use type parameters instead
+   |
+LL ~             U
+LL |         };
+LL |     }
+LL ~     struct S<U>(m!(), T)
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
Fixes #116502

I believe this kind of issue is supposed resolved by #118057, but the `==` in `span` respect syntax context, here we should only care that they point to the same bytes of source text, so should use `source_equal`.
