### PR TITLE
Migrate `run-make/panic-impl-transitive` to `rmake`

### DIFF
--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -192,7 +192,6 @@ run-make/output-with-hyphens/Makefile
 run-make/override-aliased-flags/Makefile
 run-make/overwrite-input/Makefile
 run-make/panic-abort-eh_frame/Makefile
-run-make/panic-impl-transitive/Makefile
 run-make/pass-linker-flags-flavor/Makefile
 run-make/pass-linker-flags-from-dep/Makefile
 run-make/pass-linker-flags/Makefile

--- a/tests/run-make/panic-impl-transitive/Makefile
+++ b/tests/run-make/panic-impl-transitive/Makefile
@@ -1,7 +1,0 @@
-include ../tools.mk
-
-# NOTE we use --emit=llvm-ir to avoid running the linker (linking will fail because there's no main
-# in this crate)
-all:
-	$(RUSTC) panic-impl-provider.rs
-	$(RUSTC) panic-impl-consumer.rs -C panic=abort --emit=llvm-ir -L $(TMPDIR)

--- a/tests/run-make/panic-impl-transitive/rmake.rs
+++ b/tests/run-make/panic-impl-transitive/rmake.rs
@@ -10,5 +10,10 @@ use run_make_support::{rustc, tmp_dir};
 
 fn main() {
     rustc().input("panic-impl-provider.rs").run();
-    rustc().input("panic-impl-consumer.rs").panic("abort").emit("llvm-ir").library_search_path(tmp_dir()).run();
+    rustc()
+        .input("panic-impl-consumer.rs")
+        .panic("abort")
+        .emit("llvm-ir")
+        .library_search_path(tmp_dir())
+        .run();
 }

--- a/tests/run-make/panic-impl-transitive/rmake.rs
+++ b/tests/run-make/panic-impl-transitive/rmake.rs
@@ -1,0 +1,14 @@
+// In Rust programs where the standard library is unavailable (#![no_std]), we may be interested
+// in customizing how panics are handled. Here, the provider specifies that panics should be handled
+// by entering an infinite loop. This test checks that this panic implementation can be transitively
+// provided by an external crate.
+// --emit=llvm-ir is used to avoid running the linker, as linking will fail due to the lack of main
+// function in the crate.
+// See https://github.com/rust-lang/rust/pull/50338
+
+use run_make_support::{rustc, tmp_dir};
+
+fn main() {
+    rustc().input("panic-impl-provider.rs").run();
+    rustc().input("panic-impl-consumer.rs").panic("abort").emit("llvm-ir").library_search_path(tmp_dir()).run();
+}


### PR DESCRIPTION
Part of #121876 and the associated [Google Summer of Code project](https://blog.rust-lang.org/2024/05/01/gsoc-2024-selected-projects.html).

The test itself is quite simple, but the "handle panics by entering infinite loop" part is strange.