### PR TITLE
hir pretty: fix block indent

### DIFF
--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1454,7 +1454,7 @@ impl<'a> State<'a> {
                     self.word_space(":");
                 }
                 // containing cbox, will be closed by print-block at `}`
-                self.cbox(INDENT_UNIT);
+                self.cbox(0);
                 // head-box, will be closed by print-block after `{`
                 self.ibox(0);
                 self.print_block(blk);

--- a/tests/pretty/issue-4264.pp
+++ b/tests/pretty/issue-4264.pp
@@ -11,17 +11,15 @@ extern crate std;
 fn foo(_: [i32; (3 as usize)]) ({ } as ())
 
 fn bar() ({
-        const FOO: usize = ((5 as usize) - (4 as usize) as usize);
-        let _: [(); (FOO as usize)] = ([(() as ())] as [(); 1]);
+    const FOO: usize = ((5 as usize) - (4 as usize) as usize);
+    let _: [(); (FOO as usize)] = ([(() as ())] as [(); 1]);
 
-        let _: [(); (1 as usize)] = ([(() as ())] as [(); 1]);
+    let _: [(); (1 as usize)] = ([(() as ())] as [(); 1]);
 
-        let _ =
-            (((&([(1 as i32), (2 as i32), (3 as i32)] as [i32; 3]) as
-                        &[i32; 3]) as *const _ as *const [i32; 3]) as
-                *const [i32; (3 as usize)] as *const [i32; 3]);
-
-
+    let _ =
+        (((&([(1 as i32), (2 as i32), (3 as i32)] as [i32; 3]) as &[i32; 3])
+                as *const _ as *const [i32; 3]) as *const [i32; (3 as usize)]
+            as *const [i32; 3]);
 
 
 
@@ -29,17 +27,19 @@ fn bar() ({
 
 
 
-        ({
-                let res =
-                    ((::alloc::fmt::format as
-                            for<'a> fn(Arguments<'a>) -> String {format})(((format_arguments::new_const
-                                as
-                                fn(&[&'static str]) -> Arguments<'_> {Arguments::<'_>::new_const})((&([("test"
-                                            as &str)] as [&str; 1]) as &[&str; 1])) as Arguments<'_>))
-                        as String);
-                (res as String)
-            } as String);
-    } as ())
+
+
+    ({
+        let res =
+            ((::alloc::fmt::format as
+                    for<'a> fn(Arguments<'a>) -> String {format})(((format_arguments::new_const
+                        as
+                        fn(&[&'static str]) -> Arguments<'_> {Arguments::<'_>::new_const})((&([("test"
+                                    as &str)] as [&str; 1]) as &[&str; 1])) as Arguments<'_>))
+                as String);
+        (res as String)
+    } as String);
+} as ())
 type Foo = [i32; (3 as usize)];
 struct Bar {
     x: [i32; (3 as usize)],
@@ -48,9 +48,9 @@ struct TupleBar([i32; (4 as usize)]);
 enum Baz { BazVariant([i32; (5 as usize)]), }
 fn id<T>(x: T) -> T ({ (x as T) } as T)
 fn use_id() ({
-        let _ =
-            ((id::<[i32; (3 as usize)]> as
-                    fn([i32; 3]) -> [i32; 3] {id::<[i32; 3]>})(([(1 as i32),
-                        (2 as i32), (3 as i32)] as [i32; 3])) as [i32; 3]);
-    } as ())
+    let _ =
+        ((id::<[i32; (3 as usize)]> as
+                fn([i32; 3]) -> [i32; 3] {id::<[i32; 3]>})(([(1 as i32),
+                    (2 as i32), (3 as i32)] as [i32; 3])) as [i32; 3]);
+} as ())
 fn main() ({ } as ())

--- a/tests/ui/match/issue-82392.stdout
+++ b/tests/ui/match/issue-82392.stdout
@@ -7,10 +7,10 @@ extern crate std;
 //@ check-pass
 
 fn main() ({
-        (if (true as bool)
-                ({ } as
-                    ()) else if (let Some(a) =
-                       ((Some as
-                               fn(i32) -> Option<i32> {Option::<i32>::Some})((3 as i32)) as
-                           Option<i32>) as bool) ({ } as ()) as ())
-               } as ())
+    (if (true as bool)
+            ({ } as
+                ()) else if (let Some(a) =
+                   ((Some as
+                           fn(i32) -> Option<i32> {Option::<i32>::Some})((3 as i32)) as
+                       Option<i32>) as bool) ({ } as ()) as ())
+           } as ())

--- a/tests/ui/sized/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.stderr
+++ b/tests/ui/sized/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.stderr
@@ -25,8 +25,8 @@ LL +     let str::as_bytes;
    |
 
 error[E0533]: expected unit struct, unit variant or constant, found associated function `str<{
-                      fn str() { let (/*ERROR*/); }
-                  }, T>::as_bytes`
+                  fn str() { let (/*ERROR*/); }
+              }, T>::as_bytes`
   --> $DIR/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.rs:2:9
    |
 LL |     let str::<{fn str() { let str::T>>::as_bytes; }}, T>::as_bytes;

--- a/tests/ui/type-alias-impl-trait/issue-60662.stdout
+++ b/tests/ui/type-alias-impl-trait/issue-60662.stdout
@@ -10,5 +10,5 @@ extern crate std;
 trait Animal { }
 
 fn main() {
-        type ServeFut = /*impl Trait*/;
-    }
+    type ServeFut = /*impl Trait*/;
+}

--- a/tests/ui/unpretty/bad-literal.stdout
+++ b/tests/ui/unpretty/bad-literal.stdout
@@ -7,5 +7,5 @@ extern crate std;
 
 // In #100948 this caused an ICE with -Zunpretty=hir.
 fn main() {
-        <bad-literal>;
-    }
+    <bad-literal>;
+}

--- a/tests/ui/unpretty/box.stdout
+++ b/tests/ui/unpretty/box.stdout
@@ -8,7 +8,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 
 fn main() {
-        let _ =
-            #[rustc_box]
-            Box::new(1);
-    }
+    let _ =
+        #[rustc_box]
+        Box::new(1);
+}

--- a/tests/ui/unpretty/flattened-format-args.stdout
+++ b/tests/ui/unpretty/flattened-format-args.stdout
@@ -6,10 +6,10 @@ extern crate std;
 //@ check-pass
 
 fn main() {
-        let x = 1;
-        // Should flatten to println!("a 123 b {x} xyz\n"):
-        {
-                ::std::io::_print(format_arguments::new_v1(&["a 123 b ",
-                                    " xyz\n"], &[format_argument::new_display(&x)]));
-            };
-    }
+    let x = 1;
+    // Should flatten to println!("a 123 b {x} xyz\n"):
+    {
+        ::std::io::_print(format_arguments::new_v1(&["a 123 b ", " xyz\n"],
+                &[format_argument::new_display(&x)]));
+    };
+}

--- a/tests/ui/unpretty/let-else-hir.stdout
+++ b/tests/ui/unpretty/let-else-hir.stdout
@@ -9,10 +9,10 @@ extern crate std;
 
 fn foo(x:
         Option<u32>) {
-        let Some(_) = x else
-            {
+    let Some(_) = x else
+        {
 
-            { ::std::rt::begin_panic("explicit panic") }
-        };
-    }
+        { ::std::rt::begin_panic("explicit panic") }
+    };
+}
 fn main() { }


### PR DESCRIPTION
before:
```rust
fn main() {
        {
                {
                        ::std::io::_print(format_arguments::new_const(&["Hello, world!\n"]));
                    };
            }
    }
```
after:
```rust
fn main() {
    {
        {
            ::std::io::_print(format_arguments::new_const(&["Hello, world!\n"]));
        };
    }
}
```

AST pretty does the same.