### PR TITLE
Print `token::Interpolated` with token stream pretty printing.

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -870,18 +870,11 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
     }
 
     fn nonterminal_to_string(&self, nt: &Nonterminal) -> String {
-        match nt {
-            token::NtExpr(e) => self.expr_to_string(e),
-            token::NtMeta(e) => self.attr_item_to_string(e),
-            token::NtTy(e) => self.ty_to_string(e),
-            token::NtPath(e) => self.path_to_string(e),
-            token::NtItem(e) => self.item_to_string(e),
-            token::NtBlock(e) => self.block_to_string(e),
-            token::NtStmt(e) => self.stmt_to_string(e),
-            token::NtPat(e) => self.pat_to_string(e),
-            token::NtLiteral(e) => self.expr_to_string(e),
-            token::NtVis(e) => self.vis_to_string(e),
-        }
+        // We extract the token stream from the AST fragment and pretty print
+        // it, rather than using AST pretty printing, because `Nonterminal` is
+        // slated for removal in #124141. (This method will also then be
+        // removed.)
+        self.tts_to_string(&TokenStream::from_nonterminal_ast(nt))
     }
 
     /// Print the token kind precisely, without converting `$crate` into its respective crate name.
@@ -1013,6 +1006,10 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
 
     fn attr_item_to_string(&self, ai: &ast::AttrItem) -> String {
         Self::to_string(|s| s.print_attr_item(ai, ai.path.span))
+    }
+
+    fn tts_to_string(&self, tokens: &TokenStream) -> String {
+        Self::to_string(|s| s.print_tts(tokens, false))
     }
 
     fn to_string(f: impl FnOnce(&mut State<'_>)) -> String {
@@ -2058,10 +2055,6 @@ impl<'a> State<'a> {
         Self::to_string(|s| {
             s.print_tt(tt, false);
         })
-    }
-
-    pub(crate) fn tts_to_string(&self, tokens: &TokenStream) -> String {
-        Self::to_string(|s| s.print_tts(tokens, false))
     }
 
     pub(crate) fn path_segment_to_string(&self, p: &ast::PathSegment) -> String {

--- a/tests/ui/macros/trace_faulty_macros.rs
+++ b/tests/ui/macros/trace_faulty_macros.rs
@@ -46,7 +46,7 @@ macro_rules! test {
     (let $p:pat = $e:expr) => {test!(($p,$e))};
     // this should be expr
     //           vvv
-    (($p:pat, $e:pat)) => {let $p = $e;}; //~ ERROR expected expression, found pattern `1 + 1`
+    (($p:pat, $e:pat)) => {let $p = $e;}; //~ ERROR expected expression, found pattern `1+1`
 }
 
 fn foo() {

--- a/tests/ui/macros/trace_faulty_macros.stderr
+++ b/tests/ui/macros/trace_faulty_macros.stderr
@@ -50,7 +50,7 @@ LL |     my_recursive_macro!();
    = note: expanding `my_recursive_macro! {  }`
    = note: to `my_recursive_macro! ();`
 
-error: expected expression, found pattern `A { a: a, b: 0, c: _, .. }`
+error: expected expression, found pattern `A { a : a, b : 0, c : _, .. }`
   --> $DIR/trace_faulty_macros.rs:16:9
    |
 LL |         $a
@@ -69,7 +69,7 @@ LL | #[derive(Debug)]
 LL | fn use_derive_macro_as_attr() {}
    | -------------------------------- not a `struct`, `enum` or `union`
 
-error: expected expression, found pattern `1 + 1`
+error: expected expression, found pattern `1+1`
   --> $DIR/trace_faulty_macros.rs:49:37
    |
 LL |     (let $p:pat = $e:expr) => {test!(($p,$e))};
@@ -96,7 +96,7 @@ LL |     let a = pat_macro!();
    = note: expanding `pat_macro! {  }`
    = note: to `pat_macro! (A { a : a, b : 0, c : _, .. });`
    = note: expanding `pat_macro! { A { a : a, b : 0, c : _, .. } }`
-   = note: to `A { a: a, b: 0, c: _, .. }`
+   = note: to `A { a : a, b : 0, c : _, .. }`
 
 note: trace_macro
   --> $DIR/trace_faulty_macros.rs:53:5
@@ -105,9 +105,9 @@ LL |     test!(let x = 1+1);
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `test! { let x = 1+1 }`
-   = note: to `test! ((x, 1 + 1))`
-   = note: expanding `test! { (x, 1 + 1) }`
-   = note: to `let x = 1 + 1;`
+   = note: to `test! ((x, 1+1))`
+   = note: expanding `test! { (x, 1+1) }`
+   = note: to `let x = 1+1;`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/proc-macro/capture-macro-rules-invoke.stdout
+++ b/tests/ui/proc-macro/capture-macro-rules-invoke.stdout
@@ -11,9 +11,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
         span: $DIR/capture-macro-rules-invoke.rs:21:21: 21:26 (#3),
     },
 ]
-PRINT-BANG INPUT (DISPLAY): 1 + 1, { "a" }, let a = 1;, String, my_name, 'a, my_val = 30,
-std::option::Option, pub(in some::path) , [a b c], -30
-PRINT-BANG RE-COLLECTED (DISPLAY): 1 + 1, { "a" }, let a = 1, String, my_name, 'a, my_val = 30,
+PRINT-BANG INPUT (DISPLAY): 1 + 1, { "a" }, let a = 1, String, my_name, 'a, my_val = 30,
 std::option::Option, pub(in some::path), [a b c], -30
 PRINT-BANG DEEP-RE-COLLECTED (DISPLAY): 1 + 1, { "a" }, let a = 1, String, my_name, 'a, my_val = 30,
 std :: option :: Option, pub(in some :: path), [a b c], - 30

--- a/tests/ui/proc-macro/expr-stmt-nonterminal-tokens.stdout
+++ b/tests/ui/proc-macro/expr-stmt-nonterminal-tokens.stdout
@@ -1,5 +1,4 @@
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = #[allow(warnings)] 0; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = #[allow(warnings)] #[allow(warnings)] 0; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = #[allow(warnings)] #[allow(warnings)] 0; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -122,8 +121,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #3 bytes(308..357),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0; }; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { 0 }; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0 }; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -280,8 +278,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #11 bytes(432..485),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH; }; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { PATH }; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH }; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -358,8 +355,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #15 bytes(432..485),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0 + 1; }; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { 0 + 1 }; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { 0 + 1 }; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",
@@ -449,8 +445,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #19 bytes(432..485),
     },
 ]
-PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH + 1; }; 0 }, }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): enum E { V = { let _ = { PATH + 1 }; 0 }, }
+PRINT-DERIVE INPUT (DISPLAY): enum E { V = { let _ = { PATH + 1 }; 0 }, }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "enum",

--- a/tests/ui/proc-macro/issue-78675-captured-inner-attrs.stdout
+++ b/tests/ui/proc-macro/issue-78675-captured-inner-attrs.stdout
@@ -1,6 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): foo! { #[fake_attr] mod bar {
-    #![doc = r" Foo"]
-} }
+PRINT-BANG INPUT (DISPLAY): foo! { #[fake_attr] mod bar { #![doc = r" Foo"] } }
 PRINT-BANG DEEP-RE-COLLECTED (DISPLAY): foo! { #[fake_attr] mod bar { #! [doc = r" Foo"] } }
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {


### PR DESCRIPTION
This is a step towards removing `token::Interpolated` (#124141). It unavoidably changes the output of the `stringify!` macro, generally for the better.

r? @petrochenkov