### PR TITLE
remove `git-commit-hash` file from the source tarballs

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -996,7 +996,6 @@ impl Step for PlainSourceTarball {
         let write_git_info = |info: Option<&Info>, path: &Path| {
             if let Some(info) = info {
                 t!(std::fs::create_dir_all(path));
-                channel::write_commit_hash_file(path, &info.sha);
                 channel::write_commit_info_file(path, info);
             }
         };

--- a/src/bootstrap/src/utils/channel.rs
+++ b/src/bootstrap/src/utils/channel.rs
@@ -152,8 +152,3 @@ pub fn write_commit_info_file(root: &Path, info: &Info) {
     let commit_info = format!("{}\n{}\n{}\n", info.sha, info.short_sha, info.commit_date);
     t!(fs::write(root.join("git-commit-info"), commit_info));
 }
-
-/// Write the commit hash to the `git-commit-hash` file given the project root.
-pub fn write_commit_hash_file(root: &Path, sha: &str) {
-    t!(fs::write(root.join("git-commit-hash"), sha));
-}

--- a/src/bootstrap/src/utils/tarball.rs
+++ b/src/bootstrap/src/utils/tarball.rs
@@ -321,7 +321,6 @@ impl<'a> Tarball<'a> {
         t!(std::fs::create_dir_all(&self.overlay_dir));
         self.builder.create(&self.overlay_dir.join("version"), &self.overlay.version(self.builder));
         if let Some(info) = self.builder.rust_info().info() {
-            channel::write_commit_hash_file(&self.overlay_dir, &info.sha);
             channel::write_commit_info_file(&self.overlay_dir, info);
         }
         for file in self.overlay.legal_and_readme() {


### PR DESCRIPTION
We put 2 files in source tarballs that contains git related informations.

1: git-commit-info:

```txt
9b00956e56009bab2aa15d7bff10916599e3d6d6
9b00956e5
2024-04-29
```

2: git-commit-hash:

```txt
9b00956e56009bab2aa15d7bff10916599e3d6d6
```

As the commit hash already covered in the `git-commit-info` file, this change removes the use of git-commit-hash and uses git-commit-info file instead.