### PR TITLE
Migrate `run-make/rustdoc-with-out-dir-option` to new `rmake.rs`

### DIFF
--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -66,7 +66,7 @@ pub fn python_command() -> Command {
 
 pub fn htmldocck() -> Command {
     let mut python = python_command();
-    python.arg(source_path().join("/src/etc/htmldocck.py"));
+    python.arg(source_path().join("src/etc/htmldocck.py"));
     python
 }
 

--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -243,7 +243,6 @@ run-make/rustdoc-scrape-examples-remap/Makefile
 run-make/rustdoc-scrape-examples-test/Makefile
 run-make/rustdoc-scrape-examples-whitespace/Makefile
 run-make/rustdoc-verify-output-files/Makefile
-run-make/rustdoc-with-out-dir-option/Makefile
 run-make/rustdoc-with-output-option/Makefile
 run-make/rustdoc-with-short-out-dir-option/Makefile
 run-make/sanitizer-cdylib-link/Makefile

--- a/tests/run-make/rustdoc-scrape-examples-ordering/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-ordering/rmake.rs
@@ -45,5 +45,5 @@ fn main() {
     }
     rustdoc.run();
 
-    htmldocck().arg(out_dir).arg("src/lib.rs").status().unwrap().success();
+    assert!(htmldocck().arg(out_dir).arg("src/lib.rs").status().unwrap().success());
 }

--- a/tests/run-make/rustdoc-themes/rmake.rs
+++ b/tests/run-make/rustdoc-themes/rmake.rs
@@ -27,5 +27,5 @@ fn main() {
     std::fs::write(&test_css, test_content).unwrap();
 
     rustdoc().output(&out_dir).input("foo.rs").arg("--theme").arg(&test_css).run();
-    htmldocck().arg(out_dir).arg("foo.rs").status().unwrap().success();
+    assert!(htmldocck().arg(out_dir).arg("foo.rs").status().unwrap().success());
 }

--- a/tests/run-make/rustdoc-with-out-dir-option/Makefile
+++ b/tests/run-make/rustdoc-with-out-dir-option/Makefile
@@ -1,8 +1,0 @@
-include ../tools.mk
-
-OUTPUT_DIR := "$(TMPDIR)/rustdoc"
-
-all:
-	$(RUSTDOC) src/lib.rs --crate-name foobar --crate-type lib --out-dir $(OUTPUT_DIR)
-
-	$(HTMLDOCCK) $(OUTPUT_DIR) src/lib.rs

--- a/tests/run-make/rustdoc-with-out-dir-option/rmake.rs
+++ b/tests/run-make/rustdoc-with-out-dir-option/rmake.rs
@@ -1,0 +1,7 @@
+use run_make_support::{htmldocck, rustdoc, tmp_dir};
+
+fn main() {
+    let out_dir = tmp_dir().join("rustdoc");
+    rustdoc().input("src/lib.rs").crate_name("foobar").crate_type("lib").output(&out_dir).run();
+    assert!(htmldocck().arg(out_dir).arg("src/lib.rs").status().unwrap().success());
+}


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/121876.

r? @jieyouxu