### PR TITLE
std: make ExitCode Eq

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1954,7 +1954,7 @@ impl crate::error::Error for ExitStatusError {}
 ///     ExitCode::SUCCESS
 /// }
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[stable(feature = "process_exitcode", since = "1.61.0")]
 pub struct ExitCode(imp::ExitCode);
 


### PR DESCRIPTION
rustup currently has its own utility `ExitCode` type, which is sometimes converted from `std::process::ExitStatus` and it would be nice to be able to check whether it represents success.

Not sure if this kind of thing needs to be unstable for a while?