### PR TITLE
Fix ICE in non-operand `aggregate_raw_ptr` intrinsic codegen

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -121,7 +121,11 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 bx.write_operand_repeatedly(cg_elem, count, dest);
             }
 
-            mir::Rvalue::Aggregate(ref kind, ref operands) => {
+            // This implementation does field projection, so never use it for `RawPtr`,
+            // which will always be fine with the `codegen_rvalue_operand` path below.
+            mir::Rvalue::Aggregate(ref kind, ref operands)
+                if !matches!(**kind, mir::AggregateKind::RawPtr(..)) =>
+            {
                 let (variant_index, variant_dest, active_field_index) = match **kind {
                     mir::AggregateKind::Adt(_, variant_index, _, _, active_field_index) => {
                         let variant_dest = dest.project_downcast(bx, variant_index);

--- a/tests/codegen/intrinsics/aggregate-thin-pointer.rs
+++ b/tests/codegen/intrinsics/aggregate-thin-pointer.rs
@@ -1,0 +1,23 @@
+//@ compile-flags: -O -C no-prepopulate-passes -Z mir-enable-passes=-InstSimplify
+//@ only-64bit (so I don't need to worry about usize)
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics)]
+
+use std::intrinsics::aggregate_raw_ptr;
+
+// InstSimplify replaces these with casts if it can, which means they're almost
+// never seen in codegen, but PR#121571 found a way, so add a test for it.
+
+#[inline(never)]
+pub fn opaque(_p: &*const i32) {}
+
+// CHECK-LABEL: @thin_ptr_via_aggregate(
+#[no_mangle]
+pub unsafe fn thin_ptr_via_aggregate(p: *const ()) {
+    // CHECK: %mem = alloca
+    // CHECK: store ptr %p, ptr %mem
+    // CHECK: call {{.+}}aggregate_thin_pointer{{.+}} %mem)
+    let mem = aggregate_raw_ptr(p, ());
+    opaque(&mem);
+}


### PR DESCRIPTION
Introduced in #123840
Found in #121571, cc @clarfonthey