### PR TITLE
 Fallback to Parking in `std::sync::mpsc` Channels

### DIFF
--- a/library/std/src/sync/mpmc/waker.rs
+++ b/library/std/src/sync/mpmc/waker.rs
@@ -4,7 +4,7 @@ use super::context::Context;
 use super::select::{Operation, Selected};
 
 use crate::ptr;
-use crate::sync::atomic::{AtomicBool, Ordering};
+use crate::sync::atomic::{AtomicU64, Ordering};
 use crate::sync::Mutex;
 
 /// Represents a thread blocked on a specific channel operation.
@@ -94,6 +94,18 @@ impl Waker {
         }
     }
 
+    /// Registers an operation waiting to be ready.
+    #[inline]
+    pub(crate) fn watch(&mut self, oper: Operation, cx: &Context) {
+        self.observers.push(Entry { oper, packet: ptr::null_mut(), cx: cx.clone() });
+    }
+
+    /// Unregisters an operation waiting to be ready.
+    #[inline]
+    pub(crate) fn unwatch(&mut self, oper: Operation) {
+        self.observers.retain(|e| e.oper != oper);
+    }
+
     /// Notifies all operations waiting to be ready.
     #[inline]
     pub(crate) fn notify(&mut self) {
@@ -137,50 +149,66 @@ pub(crate) struct SyncWaker {
     /// The inner `Waker`.
     inner: Mutex<Waker>,
 
-    /// `true` if the waker is empty.
-    is_empty: AtomicBool,
+    /// Atomic state for this waker.
+    state: WakerState,
 }
 
 impl SyncWaker {
     /// Creates a new `SyncWaker`.
     #[inline]
     pub(crate) fn new() -> Self {
-        SyncWaker { inner: Mutex::new(Waker::new()), is_empty: AtomicBool::new(true) }
+        SyncWaker { inner: Mutex::new(Waker::new()), state: WakerState::new() }
+    }
+
+    /// Returns a token that can be used to manage the state of a blocking operation.
+    pub(crate) fn start(&self) -> BlockingState<'_> {
+        BlockingState { is_waker: false, waker: self }
     }
 
     /// Registers the current thread with an operation.
     #[inline]
-    pub(crate) fn register(&self, oper: Operation, cx: &Context) {
-        let mut inner = self.inner.lock().unwrap();
-        inner.register(oper, cx);
-        self.is_empty
-            .store(inner.selectors.is_empty() && inner.observers.is_empty(), Ordering::SeqCst);
+    pub(crate) fn register(&self, oper: Operation, cx: &Context, state: &BlockingState<'_>) {
+        self.inner.lock().unwrap().register(oper, cx);
+        self.state.park(state.is_waker);
     }
 
     /// Unregisters an operation previously registered by the current thread.
     #[inline]
     pub(crate) fn unregister(&self, oper: Operation) -> Option<Entry> {
-        let mut inner = self.inner.lock().unwrap();
-        let entry = inner.unregister(oper);
-        self.is_empty
-            .store(inner.selectors.is_empty() && inner.observers.is_empty(), Ordering::SeqCst);
-        entry
+        self.inner.lock().unwrap().unregister(oper)
     }
 
     /// Attempts to find one thread (not the current one), select its operation, and wake it up.
     #[inline]
     pub(crate) fn notify(&self) {
-        if !self.is_empty.load(Ordering::SeqCst) {
-            let mut inner = self.inner.lock().unwrap();
-            if !self.is_empty.load(Ordering::SeqCst) {
-                inner.try_select();
-                inner.notify();
-                self.is_empty.store(
-                    inner.selectors.is_empty() && inner.observers.is_empty(),
-                    Ordering::SeqCst,
-                );
-            }
+        if self.state.try_notify() {
+            self.notify_one()
         }
+    }
+
+    // Finds a thread (not the current one), select its operation, and wake it up.
+    #[inline]
+    pub(crate) fn notify_one(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.try_select();
+        inner.notify();
+    }
+
+    /// Registers an operation waiting to be ready.
+    ///
+    /// All watching threads are notified when a relevant operation completes, instead of being
+    /// put in the registration queue.
+    #[inline]
+    pub(crate) fn watch(&self, oper: Operation, cx: &Context, state: &BlockingState<'_>) {
+        self.inner.lock().unwrap().watch(oper, cx);
+        self.state.park(state.is_waker);
+    }
+
+    /// Unregisters an operation waiting to be ready.
+    #[inline]
+    pub(crate) fn unwatch(&self, oper: Operation) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.unwatch(oper);
     }
 
     /// Notifies all threads that the channel is disconnected.
@@ -188,15 +216,138 @@ impl SyncWaker {
     pub(crate) fn disconnect(&self) {
         let mut inner = self.inner.lock().unwrap();
         inner.disconnect();
-        self.is_empty
-            .store(inner.selectors.is_empty() && inner.observers.is_empty(), Ordering::SeqCst);
     }
 }
 
 impl Drop for SyncWaker {
     #[inline]
     fn drop(&mut self) {
-        debug_assert!(self.is_empty.load(Ordering::SeqCst));
+        debug_assert!(!self.state.has_waiters());
+    }
+}
+
+/// A guard that manages the state of a blocking operation.
+pub(crate) struct BlockingState<'a> {
+    /// True if this thread is the waker thread, meaning it must
+    /// try to notify waiters after it completes.
+    is_waker: bool,
+
+    waker: &'a SyncWaker,
+}
+
+impl BlockingState<'_> {
+    /// Reset the state after waking up from parking.
+    #[inline]
+    pub(crate) fn unpark(&mut self) {
+        self.is_waker = self.waker.state.unpark();
+    }
+}
+
+impl Drop for BlockingState<'_> {
+    fn drop(&mut self) {
+        if self.is_waker && self.waker.state.drop_waker() {
+            self.waker.notify_one();
+        }
+    }
+}
+
+const NOTIFIED: u64 = 0b01;
+const WAKER: u64 = 0b10;
+
+/// The state of a `SyncWaker`.
+///
+/// A waker manages a count of waiting threads, as well as a "waker thread".
+/// The waker thread has the task of waking up another thread after it succeeds,
+/// transferring ownership of notifications. If there is an active waker thread,
+/// additional threads are not notified. This throttles wakeups, reducing contention
+/// on the channel, as well as creates a chain that makes up for lost wakeups,
+/// allowing threads to park even if the channel is in an inconsistent state.
+struct WakerState {
+    state: AtomicU64,
+}
+
+impl WakerState {
+    /// Initialize the waker state.
+    fn new() -> WakerState {
+        WakerState { state: AtomicU64::new(0) }
+    }
+
+    /// Returns whether or not a waiter needs to be notified.
+    ///
+    /// Note that the preceding write to the channel must use `SeqCst` ordering.
+    fn try_notify(&self) -> bool {
+        // Because writes to the channel are also sequentially consistent,
+        // this creates a total order between storing a value and registering a waiter.
+        let state = self.state.load(Ordering::SeqCst);
+
+        // If a notification is already set, the waker thread will take care
+        // of further notifications. Otherwise we have to notify if there are waiters.
+        if (state >> WAKER) > 0 && (state & NOTIFIED == 0) {
+            return self
+                .state
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |state| {
+                    // Set the notification if there are waiters and it is not already set.
+                    if (state >> WAKER) > 0 && (state & NOTIFIED == 0) {
+                        Some(state | (WAKER | NOTIFIED))
+                    } else {
+                        None
+                    }
+                })
+                .is_ok();
+        }
+
+        false
+    }
+
+    /// Get ready for this waker to park.
+    ///
+    /// Note that the following read before parking must use `SeqCst` ordering to synchronize
+    /// with notifications.
+    fn park(&self, waker: bool) {
+        // Increment the waiter count. If we are the waker thread, we also have to remove the
+        // notification to allow other waiters to be notified after we park.
+        let update = (1_u64 << WAKER).wrapping_sub(u64::from(waker));
+        self.state.fetch_add(update, Ordering::SeqCst);
+    }
+
+    /// Remove this waiter from the waker state after it was unparked.
+    ///
+    /// Returns `true` if this thread became the waking thread and must call `drop_waker`
+    /// after it completes it's operation.
+    fn unpark(&self) -> bool {
+        self.state
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |state| {
+                // Decrement the waiter count and consume the waker token.
+                Some((state - (1 << WAKER)) & !WAKER)
+            })
+            // Did we consume the token and become the waker thread?
+            .map(|state| state & WAKER != 0)
+            .unwrap()
+    }
+
+    /// Called by the waking thread after completing it's operation.
+    ///
+    /// Returns `true` if a waiter should be notified.
+    fn drop_waker(&self) -> bool {
+        self.state
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |state| {
+                // If there are waiters, set the waker token and wake someone, transferring the
+                // waker thread. Otherwise unset the notification so new waiters can synchronize
+                // with new notifications.
+                Some(if (state >> WAKER) > 0 {
+                    state | WAKER
+                } else {
+                    state.wrapping_sub(NOTIFIED)
+                })
+            })
+            // Were there waiters?
+            .map(|state| (state >> WAKER) > 0)
+            .unwrap()
+    }
+
+    /// Returns `true` if there are active waiters.
+    fn has_waiters(&self) -> bool {
+        (self.state.load(Ordering::Relaxed) >> WAKER) > 0
     }
 }
 


### PR DESCRIPTION
Currently, the queues used by the `mpsc` channel flavors are not lock-free. The linearization point of a send or receive is moving the tail or head index respectively, meaning that senders and receivers must spin if they see an updated head/tail despite the corresponding value not being written yet. Blocking in such a case is not possible as sends might notify a receiver even though they are not yet visible due to a lagging sender holding up the channel, or vice versa, leading to missed wakeups.

The current solution of unbounded spinning can lead to issues, especially on platforms with a single core or custom thread priorities. One way to allow falling back to blocking is if waiters that see more values in the channel after being woken up notify any other waiters, making up for any missed notifications. However, this ends up being quite expensive and can lead to many unnecessary wakeups. The solution implemented by this PR is wakeup throttling, as used [by tokio](https://tokio.rs/blog/2019-10-scheduler#reducing-cross-thread-synchronization) and other userspace schedulers. The new algorithm is in `sync/mpmc/waker.rs`.

Should resolve https://github.com/rust-lang/rust/issues/114851 and https://github.com/rust-lang/rust/issues/112723. An alternative solution is to introduce a non-linearizable version of `try_recv`, but fixing the unbounded spinning is important regardless. This PR leaves a couple cases of unbounded spinning when discarding the messages in the unbounded channel that can be addressed in a later PR, those should not be a large concern.

There are a couple other cosmetic changes included in this PR that were not previously ported from crossbeam. Hopefully they shouldn't distract from the primary changes. Downstream patch: https://github.com/crossbeam-rs/crossbeam/pull/1105.

r? @Amanieu