### PR TITLE
Fixup Windows verbatim paths when used with the `include!` macro

### DIFF
--- a/tests/run-make/import-macro-verbatim/include/include.txt
+++ b/tests/run-make/import-macro-verbatim/include/include.txt
@@ -1,0 +1,1 @@
+static TEST: &str = "Hello World!";

--- a/tests/run-make/import-macro-verbatim/rmake.rs
+++ b/tests/run-make/import-macro-verbatim/rmake.rs
@@ -1,0 +1,8 @@
+//@ only-windows other platforms do not have Windows verbatim paths
+use run_make_support::rustc;
+fn main() {
+    // Canonicalizing the path ensures that it's verbatim (i.e. starts with `\\?\`)
+    let mut path = std::fs::canonicalize(file!()).unwrap();
+    path.pop();
+    rustc().input("verbatim.rs").env("VERBATIM_DIR", path).run();
+}

--- a/tests/run-make/import-macro-verbatim/verbatim.rs
+++ b/tests/run-make/import-macro-verbatim/verbatim.rs
@@ -1,0 +1,12 @@
+//! Include a file by concating the verbatim path using `/` instead of `\`
+
+include!(concat!(env!("VERBATIM_DIR"), "/include/include.txt"));
+fn main() {
+    assert_eq!(TEST, "Hello World!");
+
+    let s = include_str!(concat!(env!("VERBATIM_DIR"), "/include/include.txt"));
+    assert_eq!(s, "static TEST: &str = \"Hello World!\";\n");
+
+    let b = include_bytes!(concat!(env!("VERBATIM_DIR"), "/include/include.txt"));
+    assert_eq!(b, b"static TEST: &str = \"Hello World!\";\n");
+}


### PR DESCRIPTION
On Windows, the following code can fail if the `OUT_DIR` environment variable is a [verbatim path](https://doc.rust-lang.org/std/path/enum.Prefix.html) (i.e. begins with `\\?\`):

```rust
include!(concat!(env!("OUT_DIR"), "/src/repro.rs"));
```

This is because verbatim paths treat `/` literally, as if it were just another character in the file name.

The good news is that the standard library already has code to fix this. We can simply use `components` to normalize the path so it works as intended.