### PR TITLE
Stablize `const_binary_heap_constructor`

### DIFF
--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -440,7 +440,10 @@ impl<T: Ord> BinaryHeap<T> {
     /// heap.push(4);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_binary_heap_constructor", issue = "112353")]
+    #[rustc_const_stable(
+        feature = "const_binary_heap_constructor",
+        since = "CURRENT_RUSTC_VERSION"
+    )]
     #[must_use]
     pub const fn new() -> BinaryHeap<T> {
         BinaryHeap { data: vec![] }
@@ -484,7 +487,7 @@ impl<T: Ord, A: Allocator> BinaryHeap<T, A> {
     /// heap.push(4);
     /// ```
     #[unstable(feature = "allocator_api", issue = "32838")]
-    #[rustc_const_unstable(feature = "const_binary_heap_constructor", issue = "112353")]
+    #[rustc_const_unstable(feature = "const_binary_heap_new_in", issue = "112353")]
     #[must_use]
     pub const fn new_in(alloc: A) -> BinaryHeap<T, A> {
         BinaryHeap { data: Vec::new_in(alloc) }


### PR DESCRIPTION
This pr aims to stablize `const_binary_heap_constructor`.

`BinaryHeap::new` is able to be stablized, but `BinaryHeap::new_in` is not. Because the latter depends on `Vec::new_in` which is unstable.

The `const_binary_heap_constructor` feature contains the two functions, and I want to split this feature now. This pr creates `const_binary_heap_new_in` feature for `BinaryHeap::new_in` and stablizes `const_binary_heap_constructor` (now this original feature only contains one function).