### PR TITLE
Migrate `run-make/static-unwinding` to `rmake`

### DIFF
--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -264,7 +264,6 @@ run-make/stable-symbol-names/Makefile
 run-make/static-dylib-by-default/Makefile
 run-make/static-extern-type/Makefile
 run-make/static-pie/Makefile
-run-make/static-unwinding/Makefile
 run-make/staticlib-blank-lib/Makefile
 run-make/staticlib-dylib-linkage/Makefile
 run-make/std-core-cycle/Makefile

--- a/tests/run-make/static-unwinding/Makefile
+++ b/tests/run-make/static-unwinding/Makefile
@@ -1,8 +1,0 @@
-# ignore-cross-compile
-# needs-unwind
-include ../tools.mk
-
-all:
-	$(RUSTC) lib.rs
-	$(RUSTC) main.rs
-	$(call RUN,main)

--- a/tests/run-make/static-unwinding/rmake.rs
+++ b/tests/run-make/static-unwinding/rmake.rs
@@ -1,0 +1,15 @@
+// During unwinding, an implementation of Drop is possible to clean up resources.
+// This test implements drop in both a main function and its static library.
+// If the test succeeds, a Rust program being a static library does not affect Drop implementations.
+// See https://github.com/rust-lang/rust/issues/10434
+
+//@ ignore-cross-compile
+//@ needs-unwind
+
+use run_make_support::{run, rustc};
+
+fn main() {
+    rustc().input("lib.rs").run();
+    rustc().input("main.rs").run();
+    run("main");
+}


### PR DESCRIPTION
Part of #121876 and the associated [Google Summer of Code project](https://blog.rust-lang.org/2024/05/01/gsoc-2024-selected-projects.html).

An easy one after the last one, though the explanatory comment could use some clarification.