### PR TITLE
Only make GAT ambiguous in `match_projection_projections` considering shallow resolvability

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1778,9 +1778,19 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // If this type is a GAT, and of the GAT args resolve to something new,
             // that means that we must have newly inferred something about the GAT.
             // We should give up in that case.
+            // FIXME(generic-associated-types): This only detects one layer of inference,
+            // which is probably not what we actually want, but fixing it causes some ambiguity:
+            // <https://github.com/rust-lang/rust/issues/125196>.
             if !generics.own_params.is_empty()
                 && obligation.predicate.args[generics.parent_count..].iter().any(|&p| {
-                    p.has_non_region_infer() && self.infcx.resolve_vars_if_possible(p) != p
+                    p.has_non_region_infer()
+                        && match p.unpack() {
+                            ty::GenericArgKind::Const(ct) => {
+                                self.infcx.shallow_resolve_const(ct) != ct
+                            }
+                            ty::GenericArgKind::Type(ty) => self.infcx.shallow_resolve(ty) != ty,
+                            ty::GenericArgKind::Lifetime(_) => false,
+                        }
                 })
             {
                 ProjectionMatchesProjection::Ambiguous

--- a/tests/ui/generic-associated-types/guide-inference-in-gat-arg-deeper.rs
+++ b/tests/ui/generic-associated-types/guide-inference-in-gat-arg-deeper.rs
@@ -1,0 +1,19 @@
+// Fix for <https://github.com/rust-lang/rust/issues/125196>.
+//@ check-pass
+
+trait Tr {
+    type Gat<T>;
+}
+
+struct W<T>(T);
+
+fn foo<T: Tr>() where for<'a> &'a T: Tr<Gat<W<i32>> = i32> {
+    let x: <&T as Tr>::Gat<W<_>> = 1i32;
+    // Previously, `match_projection_projections` only checked that
+    // `shallow_resolve(W<?0>) = W<?0>`. This won't prevent *all* inference guidance
+    // from projection predicates in the environment, just ones that guide the
+    // outermost type of each GAT constructor. This is definitely wrong, but there is
+    // code that relies on it in the wild :/
+}
+
+fn main() {}


### PR DESCRIPTION
In #123537, I tweaked the hack from #93892 to use `resolve_vars_if_possible` instead of `shallow_resolve`. This considers more inference guidance ambiguous. This resulted in crater regressions in #125196.

I've effectively reverted the change to the old behavior. That being said, I don't *like* this behavior, but I'd rather keep it for now since #123537 was not meant to make any behavioral changes. See the attached example.

This also affects the new solver, for the record, which doesn't have any rules about not guiding inference from param-env candidates which may constrain GAT args as a side-effect.

r? @lcnr or @jackh726 