### PR TITLE
Repair several `riscv64gc-unknown-linux-gnu` codegen tests

### DIFF
--- a/tests/codegen/riscv-abi/call-llvm-intrinsics.rs
+++ b/tests/codegen/riscv-abi/call-llvm-intrinsics.rs
@@ -23,7 +23,7 @@ pub fn do_call() {
 
     unsafe {
         // Ensure that we `call` LLVM intrinsics instead of trying to `invoke` them
-        // CHECK: store float 4.000000e+00, float* %{{.}}, align 4
+        // CHECK: store float 4.000000e+00, ptr %{{.}}, align 4
         // CHECK: call float @llvm.sqrt.f32(float %{{.}}
         sqrt(4.0);
     }

--- a/tests/codegen/riscv-abi/riscv64-lp64d-abi.rs
+++ b/tests/codegen/riscv-abi/riscv64-lp64d-abi.rs
@@ -1,10 +1,19 @@
-//
-//@ compile-flags: -C no-prepopulate-passes
-//@ only-riscv64
-//@ only-linux
-#![crate_type = "lib"]
+//@ compile-flags: -O -C no-prepopulate-passes --target riscv64gc-unknown-linux-gnu
+//@ needs-llvm-components: riscv
 
-// CHECK: define void @f_fpr_tracking(double %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, i8 zeroext %i)
+#![feature(no_core, lang_items)]
+#![crate_type = "lib"]
+#![no_std]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "freeze"]
+trait Freeze {}
+#[lang = "copy"]
+trait Copy {}
+
+// CHECK: define void @f_fpr_tracking(double %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, i8 noundef zeroext %i)
 #[no_mangle]
 pub extern "C" fn f_fpr_tracking(
     a: f64,
@@ -144,7 +153,7 @@ pub extern "C" fn f_ret_double_int64_s() -> DoubleInt64 {
     DoubleInt64 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_double_int8_s_arg_insufficient_gprs(i32 signext %a, i32 signext %b, i32 signext %c, i32 signext %d, i32 signext %e, i32 signext %f, i32 signext %g, i32 signext %h, [2 x i64] %0)
+// CHECK: define void @f_double_int8_s_arg_insufficient_gprs(i32 noundef signext %a, i32 noundef signext %b, i32 noundef signext %c, i32 noundef signext %d, i32 noundef signext %e, i32 noundef signext %f, i32 noundef signext %g, i32 noundef signext %h, [2 x i64] %0)
 #[no_mangle]
 pub extern "C" fn f_double_int8_s_arg_insufficient_gprs(
     a: i32,
@@ -250,11 +259,11 @@ pub struct IntDoubleInt {
     c: i32,
 }
 
-// CHECK: define void @f_int_double_int_s_arg(%IntDoubleInt* {{.*}}%a)
+// CHECK: define void @f_int_double_int_s_arg(ptr {{.*}} %a)
 #[no_mangle]
 pub extern "C" fn f_int_double_int_s_arg(a: IntDoubleInt) {}
 
-// CHECK: define void @f_ret_int_double_int_s(%IntDoubleInt* {{.*}}sret
+// CHECK: define void @f_ret_int_double_int_s(ptr {{.*}} sret([24 x i8]) align 8 dereferenceable(24) %_0)
 #[no_mangle]
 pub extern "C" fn f_ret_int_double_int_s() -> IntDoubleInt {
     IntDoubleInt { a: 1, b: 2., c: 3 }

--- a/tests/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs
+++ b/tests/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs
@@ -1,10 +1,19 @@
-//
-//@ compile-flags: -C no-prepopulate-passes
-//@ only-riscv64
-//@ only-linux
-#![crate_type = "lib"]
+//@ compile-flags: -O -C no-prepopulate-passes --target riscv64gc-unknown-linux-gnu
+//@ needs-llvm-components: riscv
 
-// CHECK: define void @f_fpr_tracking(float %0, float %1, float %2, float %3, float %4, float %5, float %6, float %7, i8 zeroext %i)
+#![feature(no_core, lang_items)]
+#![crate_type = "lib"]
+#![no_std]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "freeze"]
+trait Freeze {}
+#[lang = "copy"]
+trait Copy {}
+
+// CHECK: define void @f_fpr_tracking(float %0, float %1, float %2, float %3, float %4, float %5, float %6, float %7, i8 noundef zeroext %i)
 #[no_mangle]
 pub extern "C" fn f_fpr_tracking(
     a: f32,
@@ -128,7 +137,7 @@ pub extern "C" fn f_ret_float_int64_s() -> FloatInt64 {
     FloatInt64 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_float_int8_s_arg_insufficient_gprs(i32 signext %a, i32 signext %b, i32 signext %c, i32 signext %d, i32 signext %e, i32 signext %f, i32 signext %g, i32 signext %h, i64 %0)
+// CHECK: define void @f_float_int8_s_arg_insufficient_gprs(i32 noundef signext %a, i32 noundef signext %b, i32 noundef signext %c, i32 noundef signext %d, i32 noundef signext %e, i32 noundef signext %f, i32 noundef signext %g, i32 noundef signext %h, i64 %0)
 #[no_mangle]
 pub extern "C" fn f_float_int8_s_arg_insufficient_gprs(
     a: i32,

--- a/tests/ui/debuginfo/debuginfo-emit-llvm-ir-and-split-debuginfo.rs
+++ b/tests/ui/debuginfo/debuginfo-emit-llvm-ir-and-split-debuginfo.rs
@@ -1,5 +1,6 @@
 //@ build-pass
 //@ only-linux
+//@ ignore-riscv64 On this platform `-Csplit-debuginfo=unpacked` is unstable, see #120518
 //
 //@ compile-flags: -g --emit=llvm-ir -Csplit-debuginfo=unpacked
 //


### PR DESCRIPTION
Together with joshua.zivkovic@codethink.co.uk, we've been starting to explore improving the state of the `riscv64gc-unknown-linux-gnu` target. Additionally, I'm looking to add support for this platform in [Ferrocene](https://github.com/ferrocene/ferrocene) ([Related PR](https://github.com/ferrocene/ferrocene/pull/618)).

While running the test suite, we noted several tests were failing.

It appears that several of the riscv64gc-unknown-linux-gnu codegen tests have not been updated in some time and seem to have experienced a small amount of bitrot.

After speaking with @workingjubilee (as I have little expertise in LLVM codegen) I believe these changes to be correct.

### `tests/codegen/riscv-abi/call-llvm-intrinsics.rs`

I believe this change does not alter what the test is testing and is harmless.

### `tests/codegen/riscv-abi/riscv64-lp64d-abi.rs`

The changes largely mirrors those from loongarch64:

https://github.com/rust-lang/rust/blob/550d1b4fb6de23990f4108815c3b1a9d1659e5c4/tests/codegen/loongarch-abi/loongarch64-lp64d-abi.rs#L13-L15

https://github.com/rust-lang/rust/blob/550d1b4fb6de23990f4108815c3b1a9d1659e5c4/tests/codegen/loongarch-abi/loongarch64-lp64d-abi.rs#L153-L155

https://github.com/rust-lang/rust/blob/550d1b4fb6de23990f4108815c3b1a9d1659e5c4/tests/codegen/loongarch-abi/loongarch64-lp64d-abi.rs#L259-L261

https://github.com/rust-lang/rust/blob/550d1b4fb6de23990f4108815c3b1a9d1659e5c4/tests/codegen/loongarch-abi/loongarch64-lp64d-abi.rs#L263-L267

### `tests/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs` 

The changes largely mirror that from loongarch64 or llvm:

https://github.com/rust-lang/rust/blob/550d1b4fb6de23990f4108815c3b1a9d1659e5c4/tests/codegen/loongarch-abi/loongarch64-lp64d-abi.rs#L13-L26

https://github.com/rust-lang/llvm-project/blob/5399a24c66cb6164cf32280e7d300488c90d5765/clang/test/CodeGen/RISCV/riscv64-abi.c#L612-L617

### `tests/ui/debuginfo/debuginfo-emit-llvm-ir-and-split-debuginfo.rs`

The test is ignored since `-Csplit-debuginfo=unpacked` is not supported on this platform. Context can be found in #120518.

## Reproducing the failures

Using a `config.toml` with the following:

```toml
# ...

target = [
   # ...
   "riscv64gc-unknown-linux-gnu",
]
```

> [!NOTE]  
> You may need to install a RICV-V toolchain! We get ours from [here](https://www.embecosm.com/resources/tool-chain-downloads/#riscv-linux).
>
> If you are using an old (20.04) Ubuntu container the compiler in the repositories (`gcc-riscv64-linux-gnu`) won't work!

Run the following test suite:

```bash
./x.py test tests/codegen
```

<details>

<summary>Expected output</summary>

```
ana@Autonoma:~/git/rust-lang/rust$ ./x.py test tests/codegen
Building bootstrap
    Finished `dev` profile [unoptimized] target(s) in 0.03s
WARNING: The `change-id` is missing in the `config.toml`. This means that you will not be able to track the major changes made to the bootstrap configurations.
NOTE: to silence this warning, add `change-id = 124501` at the top of `config.toml`
Building stage0 library artifacts (x86_64-unknown-linux-gnu)
    Finished `release` profile [optimized] target(s) in 0.11s
Building compiler artifacts (stage0 -> stage1, x86_64-unknown-linux-gnu)
    Finished `release` profile [optimized] target(s) in 0.18s
Creating a sysroot for stage1 compiler (use `rustup toolchain link 'name' build/host/stage1`)
Building stage1 library artifacts (x86_64-unknown-linux-gnu)
    Finished `release` profile [optimized] target(s) in 0.11s
Building stage0 tool compiletest (x86_64-unknown-linux-gnu)
    Finished `release` profile [optimized] target(s) in 0.11s
Testing stage1 compiletest suite=codegen mode=codegen (x86_64-unknown-linux-gnu)

running 652 tests
iii......ii...iiiiiii...........ii..iii....i......i......i......iii...iiiii..i..i...i...  88/652
.............i............iii..iiii.....................i............................... 176/652
iiiiiii.............iiiiiiiii.iii....i.................i....................i...ii....i. 264/652
..i........i.........i..i........iii.........i............ii................ii..i....... 352/652
...............i...i....ii.i.....i......................ii.ii...iiiiiiiiiiiiiiiiiiiiiiii 440/652
iii....................iiiiiiiiiiiiiiii.........................iii.i..........i........ 528/652
...i...ii...........i...ii.i..i..........i..............................ii.....ii.i..ii. 616/652
.ii.................................

test result: ok. 498 passed; 0 failed; 154 ignored; 0 measured; 0 filtered out; finished in 4.76s

Building stage1 library artifacts (x86_64-unknown-linux-gnu -> riscv64gc-unknown-linux-gnu)
    Finished `release` profile [optimized] target(s) in 0.10s
Testing stage1 compiletest suite=codegen mode=codegen (x86_64-unknown-linux-gnu -> riscv64gc-unknown-linux-gnu)

running 652 tests
iii......ii..iiiiiii.....i..i..i.i...i........i..i.......i......iii...iiiii..i.i....i...  88/652
.............i............iii..iiii....................i...............................i 176/652
iiiiii..............iiiiiiiii.iii.....i................i..................i.....ii....i. 264/652
..i........i..........i.i........iii..........i...........ii................ii..i....... 352/652
...............i...i....ii.i.....i......................i.......iii.iiiiiiiiiiiiiiiiiiii 440/652
iiii...................iiiiiiiiiiiiiiii................
[codegen] tests/codegen/riscv-abi/call-llvm-intrinsics.rs ... F
.....
[codegen] tests/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs ... F
..iii.i.
[codegen] tests/codegen/riscv-abi/riscv64-lp64d-abi.rs ... F
........i........ 528/652
...i...ii...........i...ii..i.i..........i..............................ii.....ii.i..ii. 616/652
.ii.................................

failures:

---- [codegen] tests/codegen/riscv-abi/call-llvm-intrinsics.rs stdout ----

error: verification with 'FileCheck' failed
status: exit status: 1
command: "/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/llvm/build/bin/FileCheck" "--input-file" "/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/call-llvm-intrinsics/call-llvm-intrinsics.ll" "/home/ana/git/rust-lang/rust/tests/codegen/riscv-abi/call-llvm-intrinsics.rs" "--check-prefix=CHECK" "--check-prefix" "NONMSVC" "--allow-unused-prefixes" "--dump-input-context" "100"
stdout: none
--- stderr -------------------------------
/home/ana/git/rust-lang/rust/tests/codegen/riscv-abi/call-llvm-intrinsics.rs:26:12: error: CHECK: expected string not found in input
 // CHECK: store float 4.000000e+00, float* %{{.}}, align 4
           ^
/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/call-llvm-intrinsics/call-llvm-intrinsics.ll:1:1: note: scanning from here
; ModuleID = 'call_llvm_intrinsics.b4a95fd5831b1bb7-cgu.0'
^
/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/call-llvm-intrinsics/call-llvm-intrinsics.ll:53:2: note: possible intended match here
 store float 4.000000e+00, ptr %3, align 4
 ^

Input file: /home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/call-llvm-intrinsics/call-llvm-intrinsics.ll
Check file: /home/ana/git/rust-lang/rust/tests/codegen/riscv-abi/call-llvm-intrinsics.rs

-dump-input=help explains the following input dump.

Input was:
<<<<<<
            1: ; ModuleID = 'call_llvm_intrinsics.b4a95fd5831b1bb7-cgu.0' 
check:26'0     X~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ error: no match found
            2: source_filename = "call_llvm_intrinsics.b4a95fd5831b1bb7-cgu.0" 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            3: target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128" 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            4: target triple = "riscv64-unknown-linux-gnu" 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            5:  
check:26'0     ~
            6: @alloc_cebd5a1664be1c73eee4a1aab7937c96 = private unnamed_addr constant <{ [2 x i8] }> <{ [2 x i8] c"A\0A" }>, align 1 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            7: @alloc_bddb4fe6d67b5a5a93d73a63d68b4b9e = private unnamed_addr constant <{ ptr, [8 x i8] }> <{ ptr @alloc_cebd5a1664be1c73eee4a1aab7937c96, [8 x i8] c"\02\00\00\00\00\00\00\00" }>, align 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            8: @0 = private unnamed_addr constant <{ [8 x i8], [8 x i8] }> <{ [8 x i8] zeroinitializer, [8 x i8] undef }>, align 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            9:  
check:26'0     ~
           10: ; core::ptr::drop_in_place<call_llvm_intrinsics::A> 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           11: ; Function Attrs: uwtable 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
           12: define internal void @"_ZN4core3ptr44drop_in_place$LT$call_llvm_intrinsics..A$GT$17hf11b50bd9b9c5359E"(ptr noalias noundef nonnull align 1 %_1) unnamed_addr #0 { 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           13: start: 
check:26'0     ~~~~~~~
           14: ; call <call_llvm_intrinsics::A as core::ops::drop::Drop>::drop 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           15:  call void @"_ZN65_$LT$call_llvm_intrinsics..A$u20$as$u20$core..ops..drop..Drop$GT$4drop17hc84a7f61b5f719bdE"(ptr noalias noundef nonnull align 1 %_1) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           16:  ret void 
check:26'0     ~~~~~~~~~~
           17: } 
check:26'0     ~~
           18:  
check:26'0     ~
           19: ; <call_llvm_intrinsics::A as core::ops::drop::Drop>::drop 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           20: ; Function Attrs: uwtable 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
           21: define void @"_ZN65_$LT$call_llvm_intrinsics..A$u20$as$u20$core..ops..drop..Drop$GT$4drop17hc84a7f61b5f719bdE"(ptr noalias noundef nonnull align 1 %self) unnamed_addr #0 { 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           22: start: 
check:26'0     ~~~~~~~
           23:  %_3 = alloca [48 x i8], align 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           24:  call void @llvm.lifetime.start.p0(i64 48, ptr %_3) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           25:  store ptr @alloc_bddb4fe6d67b5a5a93d73a63d68b4b9e, ptr %_3, align 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           26:  %0 = getelementptr inbounds i8, ptr %_3, i64 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           27:  store i64 1, ptr %0, align 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           28:  %1 = load ptr, ptr @0, align 8, !align !4, !noundef !5 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           29:  %2 = load i64, ptr getelementptr inbounds (i8, ptr @0, i64 8), align 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           30:  %3 = getelementptr inbounds i8, ptr %_3, i64 32 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           31:  store ptr %1, ptr %3, align 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           32:  %4 = getelementptr inbounds i8, ptr %3, i64 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           33:  store i64 %2, ptr %4, align 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           34:  %5 = getelementptr inbounds i8, ptr %_3, i64 16 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           35:  store ptr inttoptr (i64 8 to ptr), ptr %5, align 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           36:  %6 = getelementptr inbounds i8, ptr %5, i64 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           37:  store i64 0, ptr %6, align 8 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           38: ; call std::io::stdio::_print 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           39:  call void @_ZN3std2io5stdio6_print17h38b16d890daf9d05E(ptr noalias nocapture noundef align 8 dereferenceable(48) %_3) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           40:  call void @llvm.lifetime.end.p0(i64 48, ptr %_3) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           41:  ret void 
check:26'0     ~~~~~~~~~~
           42: } 
check:26'0     ~~
           43:  
check:26'0     ~
           44: ; call_llvm_intrinsics::do_call 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           45: ; Function Attrs: uwtable 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
           46: define void @_ZN20call_llvm_intrinsics7do_call17h1d78694c55381316E() unnamed_addr #0 { 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           47: start: 
check:26'0     ~~~~~~~
           48:  %0 = alloca [4 x i8], align 4 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           49:  %1 = alloca [4 x i8], align 4 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           50:  %2 = alloca [4 x i8], align 4 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           51:  %3 = alloca [4 x i8], align 4 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           52:  %_1 = alloca [0 x i8], align 1 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           53:  store float 4.000000e+00, ptr %3, align 4 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
check:26'1      ?                                          possible intended match
           54:  call void @llvm.lifetime.start.p0(i64 4, ptr %2) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           55:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %2, ptr align 4 %3, i64 4, i1 false) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           56:  %4 = load float, ptr %2, align 4 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           57:  call void @llvm.lifetime.end.p0(i64 4, ptr %2) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           58:  %5 = call float @llvm.sqrt.f32(float %4) #4 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           59:  call void @llvm.lifetime.start.p0(i64 4, ptr %1) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           60:  call void @llvm.lifetime.start.p0(i64 4, ptr %0) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           61:  store float %5, ptr %0, align 4 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           62:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %1, ptr align 4 %0, i64 4, i1 false) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           63:  call void @llvm.lifetime.end.p0(i64 4, ptr %0) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           64:  %_2 = load float, ptr %1, align 4, !noundef !5 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           65:  call void @llvm.lifetime.end.p0(i64 4, ptr %1) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           66: ; call core::ptr::drop_in_place<call_llvm_intrinsics::A> 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           67:  call void @"_ZN4core3ptr44drop_in_place$LT$call_llvm_intrinsics..A$GT$17hf11b50bd9b9c5359E"(ptr noalias noundef nonnull align 1 %_1) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           68:  ret void 
check:26'0     ~~~~~~~~~~
           69: } 
check:26'0     ~~
           70:  
check:26'0     ~
           71: ; std::io::stdio::_print 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~
           72: ; Function Attrs: uwtable 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
           73: declare void @_ZN3std2io5stdio6_print17h38b16d890daf9d05E(ptr noalias nocapture noundef align 8 dereferenceable(48)) unnamed_addr #0 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           74:  
check:26'0     ~
           75: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           76: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #1 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           77:  
check:26'0     ~
           78: ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           79: declare float @llvm.sqrt.f32(float) unnamed_addr #2 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           80:  
check:26'0     ~
           81: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           82: declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #3 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           83:  
check:26'0     ~
           84: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           85: declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #3 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           86:  
check:26'0     ~
           87: attributes #0 = { uwtable "target-cpu"="generic-rv64" "target-features"="+m,+a,+f,+d,+c" } 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           88: attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) } 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           89: attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) } 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           90: attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) } 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           91: attributes #4 = { nounwind } 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           92:  
check:26'0     ~
           93: !llvm.module.flags = !{!0, !1, !2} 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           94: !llvm.ident = !{!3} 
check:26'0     ~~~~~~~~~~~~~~~~~~~~
           95:  
check:26'0     ~
           96: !0 = !{i32 8, !"PIC Level", i32 2} 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           97: !1 = !{i32 1, !"Code Model", i32 3} 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           98: !2 = !{i32 1, !"target-abi", !"lp64d"} 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           99: !3 = !{!"rustc version 1.80.0-dev"} 
check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          100: !4 = !{i64 8} 
check:26'0     ~~~~~~~~~~~~~~
          101: !5 = !{} 
check:26'0     ~~~~~~~~~
>>>>>>
------------------------------------------


---- [codegen] tests/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs stdout ----

error: verification with 'FileCheck' failed
status: exit status: 1
command: "/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/llvm/build/bin/FileCheck" "--input-file" "/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/riscv64-lp64f-lp64d-abi/riscv64-lp64f-lp64d-abi.ll" "/home/ana/git/rust-lang/rust/tests/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs" "--check-prefix=CHECK" "--check-prefix" "NONMSVC" "--allow-unused-prefixes" "--dump-input-context" "100"
stdout: none
--- stderr -------------------------------
/home/ana/git/rust-lang/rust/tests/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs:7:11: error: CHECK: expected string not found in input
// CHECK: define void @f_fpr_tracking(float %0, float %1, float %2, float %3, float %4, float %5, float %6, float %7, i8 zeroext %i)
          ^
/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/riscv64-lp64f-lp64d-abi/riscv64-lp64f-lp64d-abi.ll:1:1: note: scanning from here
; ModuleID = 'riscv64_lp64f_lp64d_abi.ae8fa95bac1a0604-cgu.0'
^
/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/riscv64-lp64f-lp64d-abi/riscv64-lp64f-lp64d-abi.ll:9:1: note: possible intended match here
define void @f_fpr_tracking(float %0, float %1, float %2, float %3, float %4, float %5, float %6, float %7, i8 noundef zeroext %i) unnamed_addr #0 {
^

Input file: /home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/riscv64-lp64f-lp64d-abi/riscv64-lp64f-lp64d-abi.ll
Check file: /home/ana/git/rust-lang/rust/tests/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs

-dump-input=help explains the following input dump.

Input was:
<<<<<<
           1: ; ModuleID = 'riscv64_lp64f_lp64d_abi.ae8fa95bac1a0604-cgu.0' 
check:7'0     X~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ error: no match found
           2: source_filename = "riscv64_lp64f_lp64d_abi.ae8fa95bac1a0604-cgu.0" 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           3: target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128" 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           4: target triple = "riscv64-unknown-linux-gnu" 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           5:  
check:7'0     ~
           6: %Tricky1 = type { [1 x float] } 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           7:  
check:7'0     ~
           8: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
           9: define void @f_fpr_tracking(float %0, float %1, float %2, float %3, float %4, float %5, float %6, float %7, i8 noundef zeroext %i) unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
check:7'1     ?                                                                                                                                                     possible intended match
          10: start: 
check:7'0     ~~~~~~~
          11:  %8 = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          12:  %h = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          13:  %9 = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          14:  %g = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          15:  %10 = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          16:  %f = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          17:  %11 = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          18:  %e = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          19:  %12 = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          20:  %d = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          21:  %13 = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          22:  %c = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          23:  %14 = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          24:  %b = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          25:  %15 = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          26:  %a = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          27:  call void @llvm.lifetime.start.p0(i64 4, ptr %15) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          28:  store float %0, ptr %15, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          29:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a, ptr align 4 %15, i64 4, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          30:  call void @llvm.lifetime.end.p0(i64 4, ptr %15) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          31:  call void @llvm.lifetime.start.p0(i64 4, ptr %14) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          32:  store float %1, ptr %14, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          33:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b, ptr align 4 %14, i64 4, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          34:  call void @llvm.lifetime.end.p0(i64 4, ptr %14) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          35:  call void @llvm.lifetime.start.p0(i64 4, ptr %13) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          36:  store float %2, ptr %13, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          37:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %c, ptr align 4 %13, i64 4, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          38:  call void @llvm.lifetime.end.p0(i64 4, ptr %13) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          39:  call void @llvm.lifetime.start.p0(i64 4, ptr %12) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          40:  store float %3, ptr %12, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          41:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %d, ptr align 4 %12, i64 4, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          42:  call void @llvm.lifetime.end.p0(i64 4, ptr %12) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          43:  call void @llvm.lifetime.start.p0(i64 4, ptr %11) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          44:  store float %4, ptr %11, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          45:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %e, ptr align 4 %11, i64 4, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          46:  call void @llvm.lifetime.end.p0(i64 4, ptr %11) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          47:  call void @llvm.lifetime.start.p0(i64 4, ptr %10) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          48:  store float %5, ptr %10, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          49:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %f, ptr align 4 %10, i64 4, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          50:  call void @llvm.lifetime.end.p0(i64 4, ptr %10) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          51:  call void @llvm.lifetime.start.p0(i64 4, ptr %9) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          52:  store float %6, ptr %9, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          53:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %g, ptr align 4 %9, i64 4, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          54:  call void @llvm.lifetime.end.p0(i64 4, ptr %9) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          55:  call void @llvm.lifetime.start.p0(i64 4, ptr %8) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          56:  store float %7, ptr %8, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          57:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %h, ptr align 4 %8, i64 4, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          58:  call void @llvm.lifetime.end.p0(i64 4, ptr %8) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          59:  ret void 
check:7'0     ~~~~~~~~~~
          60: } 
check:7'0     ~~
          61:  
check:7'0     ~
          62: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
          63: define void @f_float_s_arg(float %0) unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          64: start: 
check:7'0     ~~~~~~~
          65:  %1 = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          66:  %a = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          67:  call void @llvm.lifetime.start.p0(i64 4, ptr %1) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          68:  store float %0, ptr %1, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          69:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a, ptr align 4 %1, i64 4, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          70:  call void @llvm.lifetime.end.p0(i64 4, ptr %1) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          71:  ret void 
check:7'0     ~~~~~~~~~~
          72: } 
check:7'0     ~~
          73:  
check:7'0     ~
          74: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
          75: define float @f_ret_float_s() unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          76: start: 
check:7'0     ~~~~~~~
          77:  %_0 = alloca [4 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          78:  store float 1.000000e+00, ptr %_0, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          79:  %0 = load float, ptr %_0, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          80:  ret float %0 
check:7'0     ~~~~~~~~~~~~~~
          81: } 
check:7'0     ~~
          82:  
check:7'0     ~
          83: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
          84: define void @f_float_float_s_arg({ float, float } %0) unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          85: start: 
check:7'0     ~~~~~~~
          86:  %1 = alloca [8 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          87:  %a = alloca [8 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          88:  call void @llvm.lifetime.start.p0(i64 8, ptr %1) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          89:  store { float, float } %0, ptr %1, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          90:  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a, ptr align 4 %1, i64 8, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          91:  call void @llvm.lifetime.end.p0(i64 8, ptr %1) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          92:  ret void 
check:7'0     ~~~~~~~~~~
          93: } 
check:7'0     ~~
          94:  
check:7'0     ~
          95: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
          96: define { float, float } @f_ret_float_float_s() unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          97: start: 
check:7'0     ~~~~~~~
          98:  %0 = alloca [8 x i8], align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          99:  store float 1.000000e+00, ptr %0, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         100:  %1 = getelementptr inbounds i8, ptr %0, i64 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         101:  store float 2.000000e+00, ptr %1, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         102:  %2 = load { float, float }, ptr %0, align 4 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         103:  ret { float, float } %2 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~
         104: } 
check:7'0     ~~
         105:  
check:7'0     ~
         106: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
         107: define void @f_float_float_s_arg_insufficient_fprs(float %0, float %1, float %2, float %3, float %4, float %5, float %6, i64 %7) unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         108: start: 
check:7'0     ~~~~~~~
         109:  %8 = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           .
           .
           .
>>>>>>
------------------------------------------


---- [codegen] tests/codegen/riscv-abi/riscv64-lp64d-abi.rs stdout ----

error: verification with 'FileCheck' failed
status: exit status: 1
command: "/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/llvm/build/bin/FileCheck" "--input-file" "/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/riscv64-lp64d-abi/riscv64-lp64d-abi.ll" "/home/ana/git/rust-lang/rust/tests/codegen/riscv-abi/riscv64-lp64d-abi.rs" "--check-prefix=CHECK" "--check-prefix" "NONMSVC" "--allow-unused-prefixes" "--dump-input-context" "100"
stdout: none
--- stderr -------------------------------
/home/ana/git/rust-lang/rust/tests/codegen/riscv-abi/riscv64-lp64d-abi.rs:7:11: error: CHECK: expected string not found in input
// CHECK: define void @f_fpr_tracking(double %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, i8 zeroext %i)
          ^
/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/riscv64-lp64d-abi/riscv64-lp64d-abi.ll:1:1: note: scanning from here
; ModuleID = 'riscv64_lp64d_abi.bed282cd9c73cc17-cgu.0'
^
/home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/riscv64-lp64d-abi/riscv64-lp64d-abi.ll:9:1: note: possible intended match here
define void @f_fpr_tracking(double %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, i8 noundef zeroext %i) unnamed_addr #0 {
^

Input file: /home/ana/git/rust-lang/rust/build/x86_64-unknown-linux-gnu/test/codegen/riscv-abi/riscv64-lp64d-abi/riscv64-lp64d-abi.ll
Check file: /home/ana/git/rust-lang/rust/tests/codegen/riscv-abi/riscv64-lp64d-abi.rs

-dump-input=help explains the following input dump.

Input was:
<<<<<<
           1: ; ModuleID = 'riscv64_lp64d_abi.bed282cd9c73cc17-cgu.0' 
check:7'0     X~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ error: no match found
           2: source_filename = "riscv64_lp64d_abi.bed282cd9c73cc17-cgu.0" 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           3: target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128" 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           4: target triple = "riscv64-unknown-linux-gnu" 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           5:  
check:7'0     ~
           6: %Tricky1 = type { [1 x double] } 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           7:  
check:7'0     ~
           8: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
           9: define void @f_fpr_tracking(double %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, i8 noundef zeroext %i) unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
check:7'1     ?                                                                                                                                                             possible intended match
          10: start: 
check:7'0     ~~~~~~~
          11:  %8 = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          12:  %h = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          13:  %9 = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          14:  %g = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          15:  %10 = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          16:  %f = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          17:  %11 = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          18:  %e = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          19:  %12 = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          20:  %d = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          21:  %13 = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          22:  %c = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          23:  %14 = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          24:  %b = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          25:  %15 = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          26:  %a = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          27:  call void @llvm.lifetime.start.p0(i64 8, ptr %15) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          28:  store double %0, ptr %15, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          29:  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %a, ptr align 8 %15, i64 8, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          30:  call void @llvm.lifetime.end.p0(i64 8, ptr %15) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          31:  call void @llvm.lifetime.start.p0(i64 8, ptr %14) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          32:  store double %1, ptr %14, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          33:  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %b, ptr align 8 %14, i64 8, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          34:  call void @llvm.lifetime.end.p0(i64 8, ptr %14) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          35:  call void @llvm.lifetime.start.p0(i64 8, ptr %13) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          36:  store double %2, ptr %13, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          37:  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %c, ptr align 8 %13, i64 8, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          38:  call void @llvm.lifetime.end.p0(i64 8, ptr %13) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          39:  call void @llvm.lifetime.start.p0(i64 8, ptr %12) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          40:  store double %3, ptr %12, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          41:  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %d, ptr align 8 %12, i64 8, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          42:  call void @llvm.lifetime.end.p0(i64 8, ptr %12) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          43:  call void @llvm.lifetime.start.p0(i64 8, ptr %11) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          44:  store double %4, ptr %11, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          45:  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %e, ptr align 8 %11, i64 8, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          46:  call void @llvm.lifetime.end.p0(i64 8, ptr %11) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          47:  call void @llvm.lifetime.start.p0(i64 8, ptr %10) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          48:  store double %5, ptr %10, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          49:  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %f, ptr align 8 %10, i64 8, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          50:  call void @llvm.lifetime.end.p0(i64 8, ptr %10) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          51:  call void @llvm.lifetime.start.p0(i64 8, ptr %9) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          52:  store double %6, ptr %9, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          53:  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %g, ptr align 8 %9, i64 8, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          54:  call void @llvm.lifetime.end.p0(i64 8, ptr %9) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          55:  call void @llvm.lifetime.start.p0(i64 8, ptr %8) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          56:  store double %7, ptr %8, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          57:  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %h, ptr align 8 %8, i64 8, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          58:  call void @llvm.lifetime.end.p0(i64 8, ptr %8) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          59:  ret void 
check:7'0     ~~~~~~~~~~
          60: } 
check:7'0     ~~
          61:  
check:7'0     ~
          62: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
          63: define void @f_double_s_arg(double %0) unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          64: start: 
check:7'0     ~~~~~~~
          65:  %1 = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          66:  %a = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          67:  call void @llvm.lifetime.start.p0(i64 8, ptr %1) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          68:  store double %0, ptr %1, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          69:  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %a, ptr align 8 %1, i64 8, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          70:  call void @llvm.lifetime.end.p0(i64 8, ptr %1) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          71:  ret void 
check:7'0     ~~~~~~~~~~
          72: } 
check:7'0     ~~
          73:  
check:7'0     ~
          74: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
          75: define double @f_ret_double_s() unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          76: start: 
check:7'0     ~~~~~~~
          77:  %_0 = alloca [8 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          78:  store double 1.000000e+00, ptr %_0, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          79:  %0 = load double, ptr %_0, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          80:  ret double %0 
check:7'0     ~~~~~~~~~~~~~~~
          81: } 
check:7'0     ~~
          82:  
check:7'0     ~
          83: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
          84: define void @f_double_double_s_arg({ double, double } %0) unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          85: start: 
check:7'0     ~~~~~~~
          86:  %1 = alloca [16 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          87:  %a = alloca [16 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          88:  call void @llvm.lifetime.start.p0(i64 16, ptr %1) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          89:  store { double, double } %0, ptr %1, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          90:  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %a, ptr align 8 %1, i64 16, i1 false) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          91:  call void @llvm.lifetime.end.p0(i64 16, ptr %1) 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          92:  ret void 
check:7'0     ~~~~~~~~~~
          93: } 
check:7'0     ~~
          94:  
check:7'0     ~
          95: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
          96: define { double, double } @f_ret_double_double_s() unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          97: start: 
check:7'0     ~~~~~~~
          98:  %0 = alloca [16 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          99:  store double 1.000000e+00, ptr %0, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         100:  %1 = getelementptr inbounds i8, ptr %0, i64 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         101:  store double 2.000000e+00, ptr %1, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         102:  %2 = load { double, double }, ptr %0, align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         103:  ret { double, double } %2 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         104: } 
check:7'0     ~~
         105:  
check:7'0     ~
         106: ; Function Attrs: uwtable 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
         107: define void @f_double_float_s_arg({ double, float } %0) unnamed_addr #0 { 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         108: start: 
check:7'0     ~~~~~~~
         109:  %1 = alloca [12 x i8], align 8 
check:7'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           .
           .
           .
>>>>>>
------------------------------------------



failures:
    [codegen] tests/codegen/riscv-abi/call-llvm-intrinsics.rs
    [codegen] tests/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs
    [codegen] tests/codegen/riscv-abi/riscv64-lp64d-abi.rs

test result: FAILED. 498 passed; 3 failed; 151 ignored; 0 measured; 0 filtered out; finished in 4.70s

Some tests failed in compiletest suite=codegen mode=codegen host=x86_64-unknown-linux-gnu target=riscv64gc-unknown-linux-gnu
Build completed unsuccessfully in 0:00:15
```

</details>