### PR TITLE
Migrate `run-make/issue-46239` to `rmake`

### DIFF
--- a/src/tools/run-make-support/src/rustc.rs
+++ b/src/tools/run-make-support/src/rustc.rs
@@ -64,6 +64,12 @@ impl Rustc {
         self
     }
 
+    /// Specify a specific optimization level.
+    pub fn opt_level(&mut self, option: &str) -> &mut Self {
+        self.cmd.arg(format!("-Copt-level={option}"));
+        self
+    }
+
     /// Specify type(s) of output files to generate.
     pub fn emit(&mut self, kinds: &str) -> &mut Self {
         self.cmd.arg(format!("--emit={kinds}"));

--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -112,7 +112,6 @@ run-make/issue-37839/Makefile
 run-make/issue-37893/Makefile
 run-make/issue-38237/Makefile
 run-make/issue-40535/Makefile
-run-make/issue-46239/Makefile
 run-make/issue-47384/Makefile
 run-make/issue-47551/Makefile
 run-make/issue-51671/Makefile

--- a/tests/codegen/noalias-freeze.rs
+++ b/tests/codegen/noalias-freeze.rs
@@ -1,0 +1,21 @@
+//@ compile-flags: -Copt-level=1
+
+// References returned by a Frozen pointer type
+// could be marked as "noalias", which caused miscompilation errors.
+// This test runs the most minimal possible code that can reproduce this bug,
+// and checks that noalias does not appear.
+// See https://github.com/rust-lang/rust/issues/46239
+
+#![crate_type = "lib"]
+
+fn project<T>(x: &(T,)) -> &T { &x.0 }
+
+fn dummy() {}
+
+// CHECK-LABEL: @foo(
+// CHECK-NOT: noalias
+#[no_mangle]
+pub fn foo() {
+    let f = (dummy as fn(),);
+    (*project(&f))();
+}

--- a/tests/run-make/issue-46239/Makefile
+++ b/tests/run-make/issue-46239/Makefile
@@ -1,6 +1,0 @@
-# ignore-cross-compile
-include ../tools.mk
-
-all:
-	$(RUSTC) main.rs -C opt-level=1
-	$(call RUN,main)

--- a/tests/run-make/issue-46239/main.rs
+++ b/tests/run-make/issue-46239/main.rs
@@ -1,8 +1,0 @@
-fn project<T>(x: &(T,)) -> &T { &x.0 }
-
-fn dummy() {}
-
-fn main() {
-    let f = (dummy as fn(),);
-    (*project(&f))();
-}


### PR DESCRIPTION
Part of #121876 and the associated [Google Summer of Code project](https://blog.rust-lang.org/2024/05/01/gsoc-2024-selected-projects.html).