### PR TITLE
android: use posix_memalign for aligned allocations

### DIFF
--- a/library/std/src/sys/pal/unix/alloc.rs
+++ b/library/std/src/sys/pal/unix/alloc.rs
@@ -59,8 +59,8 @@ unsafe impl GlobalAlloc for System {
 }
 
 cfg_if::cfg_if! {
+    // We use posix_memalign wherever possible, but not all targets have that function.
     if #[cfg(any(
-        target_os = "android",
         target_os = "redox",
         target_os = "espidf",
         target_os = "horizon",
@@ -68,23 +68,6 @@ cfg_if::cfg_if! {
     ))] {
         #[inline]
         unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
-            // On android we currently target API level 9 which unfortunately
-            // doesn't have the `posix_memalign` API used below. Instead we use
-            // `memalign`, but this unfortunately has the property on some systems
-            // where the memory returned cannot be deallocated by `free`!
-            //
-            // Upon closer inspection, however, this appears to work just fine with
-            // Android, so for this platform we should be fine to call `memalign`
-            // (which is present in API level 9). Some helpful references could
-            // possibly be chromium using memalign [1], attempts at documenting that
-            // memalign + free is ok [2] [3], or the current source of chromium
-            // which still uses memalign on android [4].
-            //
-            // [1]: https://codereview.chromium.org/10796020/
-            // [2]: https://code.google.com/p/android/issues/detail?id=35391
-            // [3]: https://bugs.chromium.org/p/chromium/issues/detail?id=138579
-            // [4]: https://chromium.googlesource.com/chromium/src/base/+/master/
-            //                                       /memory/aligned_memory.cc
             libc::memalign(layout.align(), layout.size()) as *mut u8
         }
     } else {


### PR DESCRIPTION
Our target page says
> Rust will support the most recent Long Term Support (LTS) Android Native Development Kit (NDK). By default Rust will support all API levels supported by the NDK, but a higher minimum API level may be required if deemed necessary.

According to [this](https://github.com/android/ndk/wiki/Changelog-r26), the minimum API level of the current LTS NDK is 21. According to [this](https://stackoverflow.com/questions/44852378/android-ndk-r15b-posix-memalign-undeclared-identifier), posix_memalign exists since API level 16. So I think we should be able to use it here?