### PR TITLE
Fix parsing of erroneously placed semicolons

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -58,9 +58,16 @@ impl<'a> Parser<'a> {
 
         let post_attr_lo = self.token.span;
         let mut items = ThinVec::new();
-        while let Some(item) = self.parse_item(ForceCollect::No)? {
-            items.push(item);
-            self.maybe_consume_incorrect_semicolon(&items);
+
+        loop {
+            // Consume all incorrect semicolons before trying
+            // to parse an item
+            while self.maybe_consume_incorrect_semicolon(&items) {}
+
+            match self.parse_item(ForceCollect::No)? {
+                Some(item) => items.push(item),
+                None => break,
+            }
         }
 
         if !self.eat(term) {

--- a/tests/ui/parser/issues/incorrect-semicolon-missing-main-err-124935.rs
+++ b/tests/ui/parser/issues/incorrect-semicolon-missing-main-err-124935.rs
@@ -1,0 +1,6 @@
+// Regression test for issue #124935
+// Tests that we do not erroneously emit an error about
+// missing main function when the mod starts with a `;`
+
+; //~ ERROR expected item, found `;`
+fn main() { }

--- a/tests/ui/parser/issues/incorrect-semicolon-missing-main-err-124935.stderr
+++ b/tests/ui/parser/issues/incorrect-semicolon-missing-main-err-124935.stderr
@@ -1,0 +1,8 @@
+error: expected item, found `;`
+  --> $DIR/incorrect-semicolon-missing-main-err-124935.rs:5:1
+   |
+LL | ;
+   | ^ help: remove this semicolon
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/issues/issue-49040.rs
+++ b/tests/ui/parser/issues/issue-49040.rs
@@ -1,3 +1,3 @@
 #![allow(unused_variables)]; //~ ERROR expected item, found `;`
-//~^ ERROR `main` function
 fn foo() {}
+//~^ ERROR `main` function

--- a/tests/ui/parser/issues/issue-49040.stderr
+++ b/tests/ui/parser/issues/issue-49040.stderr
@@ -5,10 +5,10 @@ LL | #![allow(unused_variables)];
    |                            ^ help: remove this semicolon
 
 error[E0601]: `main` function not found in crate `issue_49040`
-  --> $DIR/issue-49040.rs:1:29
+  --> $DIR/issue-49040.rs:2:12
    |
-LL | #![allow(unused_variables)];
-   |                             ^ consider adding a `main` function to `$DIR/issue-49040.rs`
+LL | fn foo() {}
+   |            ^ consider adding a `main` function to `$DIR/issue-49040.rs`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes #124935 

The  issue occurred with code like this where a semicolon occurs at the start before any items:
```rust
;
fn main() { }
```

The root cause lay in the parser wherein we weren't consuming the semicolon and getting it out of the way before trying to parse the item (i.e. `main` in this case). This meant we attempted to parse the semicolon as an item which failed and we stopped parsing further because of that failure. The end result was that no `main` was recorded in the AST which lead to the `no main` error later on in one of the lints.

This PR ensures that we consume all consecutive semicolons (as there could be more than one) before trying to parse an item. 