### PR TITLE
Migrate `run-make/rustdoc-scrape-examples-invalid-expr` to `rmake.rs`

### DIFF
--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -234,7 +234,6 @@ run-make/rlib-format-packed-bundled-libs/Makefile
 run-make/rmeta-preferred/Makefile
 run-make/rustc-macro-dep-files/Makefile
 run-make/rustdoc-io-error/Makefile
-run-make/rustdoc-scrape-examples-invalid-expr/Makefile
 run-make/rustdoc-scrape-examples-macros/Makefile
 run-make/rustdoc-scrape-examples-multiple/Makefile
 run-make/rustdoc-scrape-examples-test/Makefile

--- a/tests/run-make/rustdoc-scrape-examples-invalid-expr/Makefile
+++ b/tests/run-make/rustdoc-scrape-examples-invalid-expr/Makefile
@@ -1,5 +1,0 @@
-deps := ex
-
-include ../rustdoc-scrape-examples-multiple/scrape.mk
-
-all: scrape

--- a/tests/run-make/rustdoc-scrape-examples-invalid-expr/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-invalid-expr/rmake.rs
@@ -1,0 +1,6 @@
+#[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
+mod scrape;
+
+fn main() {
+    scrape::scrape();
+}


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/121876.

r? @jieyouxu