### PR TITLE
Add `#[inline]` to float `Debug` fallback used by `cfg(no_fp_fmt_parse)`

### DIFF
--- a/library/core/src/fmt/nofloat.rs
+++ b/library/core/src/fmt/nofloat.rs
@@ -4,6 +4,7 @@ macro_rules! floating {
     ($ty:ident) => {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Debug for $ty {
+            #[inline]
             fn fmt(&self, _fmt: &mut Formatter<'_>) -> Result {
                 panic!("floating point support is turned off");
             }


### PR DESCRIPTION
Fixes #125229.