### PR TITLE
Add `FRAC_1_SQRT_2PI` constant to f16/f32/f64/f128

### DIFF
--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -68,6 +68,12 @@ pub mod consts {
     pub const FRAC_1_SQRT_PI: f128 =
         0.564189583547756286948079451560772585844050629328998856844086_f128;
 
+    /// 1/sqrt(2π)
+    #[unstable(feature = "f128", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const FRAC_1_SQRT_2PI: f128 =
+        0.398942280401432677939946059934381868475858631164934657665926_f128;
+
     /// 2/π
     #[unstable(feature = "f128", issue = "116909")]
     pub const FRAC_2_PI: f128 = 0.636619772367581343075535053490057448137838582961825794990669_f128;

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -69,6 +69,7 @@ pub mod consts {
         0.564189583547756286948079451560772585844050629328998856844086_f128;
 
     /// 1/sqrt(2π)
+    #[doc(alias = "FRAC_1_SQRT_TAU")]
     #[unstable(feature = "f128", issue = "116909")]
     // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
     pub const FRAC_1_SQRT_2PI: f128 =

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -68,6 +68,7 @@ pub mod consts {
     pub const FRAC_1_SQRT_PI: f16 = 0.564189583547756286948079451560772586_f16;
 
     /// 1/sqrt(2π)
+    #[doc(alias = "FRAC_1_SQRT_TAU")]
     #[unstable(feature = "f16", issue = "116909")]
     // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
     pub const FRAC_1_SQRT_2PI: f16 = 0.398942280401432677939946059934381868_f16;

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -67,6 +67,11 @@ pub mod consts {
     // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
     pub const FRAC_1_SQRT_PI: f16 = 0.564189583547756286948079451560772586_f16;
 
+    /// 1/sqrt(2π)
+    #[unstable(feature = "f16", issue = "116909")]
+    // Also, #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const FRAC_1_SQRT_2PI: f16 = 0.398942280401432677939946059934381868_f16;
+
     /// 2/π
     #[unstable(feature = "f16", issue = "116909")]
     pub const FRAC_2_PI: f16 = 0.636619772367581343075535053490057448_f16;

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -328,6 +328,7 @@ pub mod consts {
     pub const FRAC_1_SQRT_PI: f32 = 0.564189583547756286948079451560772586_f32;
 
     /// 1/sqrt(2π)
+    #[doc(alias = "FRAC_1_SQRT_TAU")]
     #[unstable(feature = "more_float_constants", issue = "103883")]
     pub const FRAC_1_SQRT_2PI: f32 = 0.398942280401432677939946059934381868_f32;
 

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -327,6 +327,10 @@ pub mod consts {
     #[unstable(feature = "more_float_constants", issue = "103883")]
     pub const FRAC_1_SQRT_PI: f32 = 0.564189583547756286948079451560772586_f32;
 
+    /// 1/sqrt(2π)
+    #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const FRAC_1_SQRT_2PI: f32 = 0.398942280401432677939946059934381868_f32;
+
     /// 2/π
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_2_PI: f32 = 0.636619772367581343075535053490057448_f32;

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -328,6 +328,7 @@ pub mod consts {
     pub const FRAC_1_SQRT_PI: f64 = 0.564189583547756286948079451560772586_f64;
 
     /// 1/sqrt(2π)
+    #[doc(alias = "FRAC_1_SQRT_TAU")]
     #[unstable(feature = "more_float_constants", issue = "103883")]
     pub const FRAC_1_SQRT_2PI: f64 = 0.398942280401432677939946059934381868_f64;
 

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -327,6 +327,10 @@ pub mod consts {
     #[unstable(feature = "more_float_constants", issue = "103883")]
     pub const FRAC_1_SQRT_PI: f64 = 0.564189583547756286948079451560772586_f64;
 
+    /// 1/sqrt(2π)
+    #[unstable(feature = "more_float_constants", issue = "103883")]
+    pub const FRAC_1_SQRT_2PI: f64 = 0.398942280401432677939946059934381868_f64;
+
     /// 2/π
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_2_PI: f64 = 0.636619772367581343075535053490057448_f64;


### PR DESCRIPTION
This adds the `FRAC_1_SQRT_2PI` to the `f16`, `f32`, `f64` and `f128` as [`1/√(2π)`](https://www.wolframalpha.com/input?i=1%2Fsqrt%282*pi%29). The rationale is that while `FRAC_1_SQRT_PI` already exists, [Gaussian calculations](https://en.wikipedia.org/wiki/Gaussian_function) for random normal distributions require a `1/(σ√(2π))` term, which could then be directly expressed e.g. as `f32::FRAC_1_SQRT_2PI / sigma`.

The actual value is approximately `1/√(2π) = 0.3989422804014326779399460599343818684758586311649346576659258296…`. Truncated/rounded forms were used for the individual types. 

---

~~I did not any of the `#[unstable]` attributes since I am not aware of their implications.~~

**Edit:** I applied the stability attributes from the surrounding types according to what seemed most likely correct. I believe the `more_float_constants` feature marker is incorrectly applied, but I wasn't sure how to proceed.