### PR TITLE
Allow printing `TraitRef` and `TraitPredicate` with `Infcx` information

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -4,7 +4,6 @@
 
 pub mod tls;
 
-use hir::def::Namespace;
 pub use rustc_type_ir::lift::Lift;
 
 use crate::arena::Arena;
@@ -54,7 +53,7 @@ use rustc_errors::{
     Applicability, Diag, DiagCtxt, DiagMessage, ErrorGuaranteed, LintDiagnostic, MultiSpan,
 };
 use rustc_hir as hir;
-use rustc_hir::def::DefKind;
+use rustc_hir::def::{DefKind, Namespace};
 use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use rustc_hir::definitions::Definitions;
 use rustc_hir::intravisit::Visitor;

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -180,15 +180,18 @@ impl<I: Interner> DebugWithInfcx<I> for InferConst {
         this: WithInfcx<'_, Infcx, &Self>,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
-        match *this.data {
-            InferConst::Var(vid) => match this.infcx.universe_of_ct(vid) {
-                None => write!(f, "{:?}", this.data),
-                Some(universe) => write!(f, "?{}_{}c", vid.index(), universe.index()),
+        match this.infcx {
+            None => write!(f, "{:?}", this.data),
+            Some(infcx) => match *this.data {
+                InferConst::Var(vid) => match infcx.universe_of_ct(vid) {
+                    None => write!(f, "?{}_..c", vid.index()),
+                    Some(universe) => write!(f, "?{}_{}c", vid.index(), universe.index()),
+                },
+                InferConst::EffectVar(vid) => write!(f, "?{}e", vid.index()),
+                InferConst::Fresh(_) => {
+                    unreachable!()
+                }
             },
-            InferConst::EffectVar(vid) => write!(f, "?{}e", vid.index()),
-            InferConst::Fresh(_) => {
-                unreachable!()
-            }
         }
     }
 }

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -29,6 +29,8 @@ pub trait Interner:
     + IrPrint<FnSig<Self>>
 {
     type DefId: Copy + Debug + Hash + Eq;
+    fn print_def_path(defid: Self::DefId, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
+
     type AdtDef: Copy + Debug + Hash + Eq;
 
     type GenericArgs: GenericArgs<Self>;

--- a/compiler/rustc_type_ir/src/ir_print.rs
+++ b/compiler/rustc_type_ir/src/ir_print.rs
@@ -48,4 +48,4 @@ define_display_via_print!(
     FnSig,
 );
 
-define_debug_via_print!(TraitRef, ExistentialTraitRef, ExistentialProjection);
+define_debug_via_print!(ExistentialTraitRef, ExistentialProjection);

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -415,7 +415,6 @@ impl<I: Interner> DebugWithInfcx<I> for TyKind<I> {
     }
 }
 
-// This is manually implemented because a derive would require `I: Debug`
 impl<I: Interner> fmt::Debug for TyKind<I> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         WithInfcx::with_no_infcx(self).fmt(f)
@@ -924,15 +923,18 @@ impl<I: Interner> DebugWithInfcx<I> for InferTy {
         this: WithInfcx<'_, Infcx, &Self>,
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
-        match this.data {
-            InferTy::TyVar(vid) => {
-                if let Some(universe) = this.infcx.universe_of_ty(*vid) {
-                    write!(f, "?{}_{}t", vid.index(), universe.index())
-                } else {
-                    write!(f, "{:?}", this.data)
+        match this.infcx {
+            None => write!(f, "{:?}", this.data),
+            Some(infcx) => match this.data {
+                InferTy::TyVar(vid) => {
+                    if let Some(universe) = infcx.universe_of_ty(*vid) {
+                        write!(f, "?{}_{}t", vid.index(), universe.index())
+                    } else {
+                        write!(f, "{}_..t", vid.index())
+                    }
                 }
-            }
-            _ => write!(f, "{:?}", this.data),
+                _ => write!(f, "{:?}", this.data),
+            },
         }
     }
 }

--- a/tests/ui/traits/cache-reached-depth-ice.rs
+++ b/tests/ui/traits/cache-reached-depth-ice.rs
@@ -41,5 +41,5 @@ fn test<X: ?Sized + Send>() {}
 
 fn main() {
     test::<A>();
-    //~^ ERROR evaluate(Binder { value: TraitPredicate(<A as std::marker::Send>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
+    //~^ ERROR evaluate(Binder { value: (A: std::marker::Send), bound_vars: [] }) = Ok(EvaluatedToOk)
 }

--- a/tests/ui/traits/cache-reached-depth-ice.stderr
+++ b/tests/ui/traits/cache-reached-depth-ice.stderr
@@ -1,4 +1,4 @@
-error: evaluate(Binder { value: TraitPredicate(<A as std::marker::Send>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
+error: evaluate(Binder { value: (A: std::marker::Send), bound_vars: [] }) = Ok(EvaluatedToOk)
   --> $DIR/cache-reached-depth-ice.rs:43:5
    |
 LL | fn test<X: ?Sized + Send>() {}

--- a/tests/ui/traits/issue-83538-tainted-cache-after-cycle.rs
+++ b/tests/ui/traits/issue-83538-tainted-cache-after-cycle.rs
@@ -57,10 +57,10 @@ fn main() {
     // Key is that Vec<First> is "ok" and Third<'_, Ty> is "ok modulo regions":
 
     forward();
-    //~^ ERROR evaluate(Binder { value: TraitPredicate(<std::vec::Vec<First> as std::marker::Unpin>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
-    //~| ERROR evaluate(Binder { value: TraitPredicate(<Third<'_, Ty> as std::marker::Unpin>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
+    //~^ ERROR evaluate(Binder { value: (std::vec::Vec<First, std::alloc::Global>: std::marker::Unpin), bound_vars: [] }) = Ok(EvaluatedToOk)
+    //~| ERROR evaluate(Binder { value: (Third<'?0, Ty>: std::marker::Unpin), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
 
     reverse();
-    //~^ ERROR evaluate(Binder { value: TraitPredicate(<std::vec::Vec<First> as std::marker::Unpin>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
-    //~| ERROR evaluate(Binder { value: TraitPredicate(<Third<'_, Ty> as std::marker::Unpin>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
+    //~^ ERROR evaluate(Binder { value: (std::vec::Vec<First, std::alloc::Global>: std::marker::Unpin), bound_vars: [] }) = Ok(EvaluatedToOk)
+    //~| ERROR evaluate(Binder { value: (Third<'?2, Ty>: std::marker::Unpin), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
 }

--- a/tests/ui/traits/issue-83538-tainted-cache-after-cycle.stderr
+++ b/tests/ui/traits/issue-83538-tainted-cache-after-cycle.stderr
@@ -1,4 +1,4 @@
-error: evaluate(Binder { value: TraitPredicate(<std::vec::Vec<First> as std::marker::Unpin>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
+error: evaluate(Binder { value: (std::vec::Vec<First, std::alloc::Global>: std::marker::Unpin), bound_vars: [] }) = Ok(EvaluatedToOk)
   --> $DIR/issue-83538-tainted-cache-after-cycle.rs:59:5
    |
 LL |     Vec<First>: Unpin,
@@ -7,7 +7,7 @@ LL |     Vec<First>: Unpin,
 LL |     forward();
    |     ^^^^^^^
 
-error: evaluate(Binder { value: TraitPredicate(<Third<'_, Ty> as std::marker::Unpin>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
+error: evaluate(Binder { value: (Third<'?0, Ty>: std::marker::Unpin), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
   --> $DIR/issue-83538-tainted-cache-after-cycle.rs:59:5
    |
 LL |     Third<'a, Ty>: Unpin,
@@ -16,7 +16,7 @@ LL |     Third<'a, Ty>: Unpin,
 LL |     forward();
    |     ^^^^^^^
 
-error: evaluate(Binder { value: TraitPredicate(<Third<'_, Ty> as std::marker::Unpin>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
+error: evaluate(Binder { value: (Third<'?2, Ty>: std::marker::Unpin), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
   --> $DIR/issue-83538-tainted-cache-after-cycle.rs:63:5
    |
 LL |     Third<'a, Ty>: Unpin,
@@ -25,7 +25,7 @@ LL |     Third<'a, Ty>: Unpin,
 LL |     reverse();
    |     ^^^^^^^
 
-error: evaluate(Binder { value: TraitPredicate(<std::vec::Vec<First> as std::marker::Unpin>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
+error: evaluate(Binder { value: (std::vec::Vec<First, std::alloc::Global>: std::marker::Unpin), bound_vars: [] }) = Ok(EvaluatedToOk)
   --> $DIR/issue-83538-tainted-cache-after-cycle.rs:63:5
    |
 LL |     Vec<First>: Unpin,

--- a/tests/ui/traits/issue-85360-eval-obligation-ice.rs
+++ b/tests/ui/traits/issue-85360-eval-obligation-ice.rs
@@ -7,10 +7,10 @@ use core::marker::PhantomData;
 
 fn main() {
     test::<MaskedStorage<GenericComp<Pos>>>(make());
-    //~^ ERROR evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
+    //~^ ERROR evaluate(Binder { value: (MaskedStorage<GenericComp<Pos>>: std::marker::Sized), bound_vars: [] }) = Ok(EvaluatedToOk)
 
     test::<MaskedStorage<GenericComp2<Pos>>>(make());
-    //~^ ERROR evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
+    //~^ ERROR evaluate(Binder { value: (MaskedStorage<GenericComp2<Pos>>: std::marker::Sized), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
 }
 
 #[rustc_evaluate_where_clauses]
@@ -59,7 +59,10 @@ struct GenericComp2<T> {
     _t: T,
 }
 
-impl<T: 'static> Component for GenericComp2<T> where for<'a> &'a bool: 'a {
+impl<T: 'static> Component for GenericComp2<T>
+where
+    for<'a> &'a bool: 'a,
+{
     type Storage = VecStorage;
 }
 

--- a/tests/ui/traits/issue-85360-eval-obligation-ice.stderr
+++ b/tests/ui/traits/issue-85360-eval-obligation-ice.stderr
@@ -1,4 +1,4 @@
-error: evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
+error: evaluate(Binder { value: (MaskedStorage<GenericComp<Pos>>: std::marker::Sized), bound_vars: [] }) = Ok(EvaluatedToOk)
   --> $DIR/issue-85360-eval-obligation-ice.rs:9:5
    |
 LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
@@ -7,7 +7,7 @@ LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
 LL | fn test<T: Sized>(_: T) {}
    |            ----- predicate
 
-error: evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
+error: evaluate(Binder { value: (MaskedStorage<GenericComp2<Pos>>: std::marker::Sized), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
   --> $DIR/issue-85360-eval-obligation-ice.rs:12:5
    |
 LL |     test::<MaskedStorage<GenericComp2<Pos>>>(make());

--- a/tests/ui/traits/project-modulo-regions.rs
+++ b/tests/ui/traits/project-modulo-regions.rs
@@ -21,7 +21,10 @@ struct Bar;
 // The `where` clause on this impl will cause us to produce `EvaluatedToOkModuloRegions`
 // when evaluating a projection involving this impl
 #[cfg(with_clause)]
-impl MyTrait for Bar where for<'b> &'b (): 'b {
+impl MyTrait for Bar
+where
+    for<'b> &'b (): 'b,
+{
     type Assoc = bool;
 }
 
@@ -42,14 +45,17 @@ impl HelperTrait for Helper where <MyStruct as MyTrait>::Assoc: Sized {}
 // Evaluating this 'where' clause will (recursively) end up evaluating
 // `for<'b> &'b (): 'b`, which will produce `EvaluatedToOkModuloRegions`
 #[rustc_evaluate_where_clauses]
-fn test(val: MyStruct) where Helper: HelperTrait  {
+fn test(val: MyStruct)
+where
+    Helper: HelperTrait,
+{
     panic!()
 }
 
 fn foo(val: MyStruct) {
     test(val);
-    //[with_clause]~^     ERROR evaluate(Binder { value: TraitPredicate(<Helper as HelperTrait>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
-    //[without_clause]~^^ ERROR evaluate(Binder { value: TraitPredicate(<Helper as HelperTrait>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
+    //[with_clause]~^     ERROR evaluate(Binder { value: (Helper: HelperTrait), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
+    //[without_clause]~^^ ERROR evaluate(Binder { value: (Helper: HelperTrait), bound_vars: [] }) = Ok(EvaluatedToOk)
 }
 
 fn main() {}

--- a/tests/ui/traits/project-modulo-regions.with_clause.stderr
+++ b/tests/ui/traits/project-modulo-regions.with_clause.stderr
@@ -1,8 +1,8 @@
-error: evaluate(Binder { value: TraitPredicate(<Helper as HelperTrait>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
-  --> $DIR/project-modulo-regions.rs:50:5
+error: evaluate(Binder { value: (Helper: HelperTrait), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
+  --> $DIR/project-modulo-regions.rs:56:5
    |
-LL | fn test(val: MyStruct) where Helper: HelperTrait  {
-   |                                      ----------- predicate
+LL |     Helper: HelperTrait,
+   |             ----------- predicate
 ...
 LL |     test(val);
    |     ^^^^

--- a/tests/ui/traits/project-modulo-regions.without_clause.stderr
+++ b/tests/ui/traits/project-modulo-regions.without_clause.stderr
@@ -1,8 +1,8 @@
-error: evaluate(Binder { value: TraitPredicate(<Helper as HelperTrait>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
-  --> $DIR/project-modulo-regions.rs:50:5
+error: evaluate(Binder { value: (Helper: HelperTrait), bound_vars: [] }) = Ok(EvaluatedToOk)
+  --> $DIR/project-modulo-regions.rs:56:5
    |
-LL | fn test(val: MyStruct) where Helper: HelperTrait  {
-   |                                      ----------- predicate
+LL |     Helper: HelperTrait,
+   |             ----------- predicate
 ...
 LL |     test(val);
    |     ^^^^

--- a/tests/ui/type-alias-impl-trait/in-where-clause.stderr
+++ b/tests/ui/type-alias-impl-trait/in-where-clause.stderr
@@ -16,7 +16,7 @@ LL | / fn foo() -> Bar
 LL | | where
 LL | |     Bar: Send,
    | |______________^
-   = note: ...which requires revealing opaque types in `[Binder { value: TraitPredicate(<Bar as core::marker::Send>, polarity:Positive), bound_vars: [] }]`...
+   = note: ...which requires revealing opaque types in `[Binder { value: (Alias(Opaque, AliasTy { args: [], def_id: DefId(0:7 ~ in_where_clause[cb1b]::Bar::{opaque#0}) }): core::marker::Send), bound_vars: [] }]`...
    = note: ...which again requires computing type of `Bar::{opaque#0}`, completing the cycle
 note: cycle used when checking that `Bar::{opaque#0}` is well-formed
   --> $DIR/in-where-clause.rs:5:12


### PR DESCRIPTION
This PR is a bit of a mess apologies. I've tried to split up into two commits.

The first commit makes the `Infcx` in `WithInfcx` be stored inside of an `Option` and makes `NoInfcx` into an uninhabited type so that we do not have a type that is not anything like an `Infcx` implement the `InferCtxtLike` trait and then get constructed and passed to places that expect an infcx. Generally the "leafs" of debug printing do not share codepaths for printing with or without an infcx and so need to be able to determine which to use.

While updating the leaves to match on the `Option` I changed the debug printing of inference variables to be `?0_..t` for when we cant probe the variable `?0` instead of "silently" downgrading to normal `Debug` printing. I'm not sure how valuable this is but it was easy to do and given how many places accidentally are not going through the `DebugWithInfcx` trait it seems valuable to be able to tell in logs if an inference variable is being printed through the wrong trait or just doesnt have a universe available. 

As an example of not going through the right trait, it seems like the `Ty: DebugWithInfcx` impl just.... did not actually pass through to `TyKind: DebugWithInfcx` and so would not ever print out the universes ^^' fixed that in this commit too.

The second commit actually introduces the `DebugWithInfcx` implementations for `TraitRef` and `TraitPredicate`. Previously `TraitPredicate` was formatted as: `TraitPredicate(<T as Trait<U>>, polarity::Positive)` and now it is `(T: Trait<U>)`. This should hopefully make reading debug logs involving lots of trait bounds easier (and it'll get a lot better with custom `Binder` `Debug` impls) `TraitRef`'s formatting has not really changed. Previously it was `<T as Trait<U>>` and now it is `(T as Trait<U>)`.

r? @compiler-errors 