### PR TITLE
Fix parsing of erroneously placed semicolons

### DIFF
--- a/tests/ui/parser/issues/fn-no-semicolon-issue-124935-semi-after-item.rs
+++ b/tests/ui/parser/issues/fn-no-semicolon-issue-124935-semi-after-item.rs
@@ -1,0 +1,6 @@
+// Regression test for issue #124935
+// Tests that we do not erroneously emit an error about
+// missing main function when the mod starts with a `;`
+
+; //~ ERROR expected item, found `;`
+fn main() { }

--- a/tests/ui/parser/issues/fn-no-semicolon-issue-124935-semi-after-item.stderr
+++ b/tests/ui/parser/issues/fn-no-semicolon-issue-124935-semi-after-item.stderr
@@ -1,0 +1,8 @@
+error: expected item, found `;`
+  --> $DIR/fn-no-semicolon-issue-124935-semi-after-item.rs:5:1
+   |
+LL | ;
+   | ^ help: remove this semicolon
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/issues/issue-49040.rs
+++ b/tests/ui/parser/issues/issue-49040.rs
@@ -1,3 +1,3 @@
 #![allow(unused_variables)]; //~ ERROR expected item, found `;`
-//~^ ERROR `main` function
 fn foo() {}
+//~^ ERROR `main` function

--- a/tests/ui/parser/issues/issue-49040.stderr
+++ b/tests/ui/parser/issues/issue-49040.stderr
@@ -5,10 +5,10 @@ LL | #![allow(unused_variables)];
    |                            ^ help: remove this semicolon
 
 error[E0601]: `main` function not found in crate `issue_49040`
-  --> $DIR/issue-49040.rs:1:29
+  --> $DIR/issue-49040.rs:2:12
    |
-LL | #![allow(unused_variables)];
-   |                             ^ consider adding a `main` function to `$DIR/issue-49040.rs`
+LL | fn foo() {}
+   |            ^ consider adding a `main` function to `$DIR/issue-49040.rs`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/issues/missing-main-issue-124935-semi-after-item.rs
+++ b/tests/ui/parser/issues/missing-main-issue-124935-semi-after-item.rs
@@ -1,0 +1,5 @@
+// Regression test for issue #124935
+// Tests that we still emit an error after an item.
+
+fn main() { }
+; //~ ERROR expected item, found `;`

--- a/tests/ui/parser/issues/missing-main-issue-124935-semi-after-item.stderr
+++ b/tests/ui/parser/issues/missing-main-issue-124935-semi-after-item.stderr
@@ -1,0 +1,10 @@
+error: expected item, found `;`
+  --> $DIR/missing-main-issue-124935-semi-after-item.rs:5:1
+   |
+LL | ;
+   | ^ help: remove this semicolon
+   |
+   = help: function declarations are not followed by a semicolon
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This closes https://github.com/rust-lang/rust/issues/124935, is a continuation of https://github.com/rust-lang/rust/pull/125245 after rebasing https://github.com/rust-lang/rust/pull/125117.

Thanks @gurry for your code and sorry for making it confusing :P

r? fmease