### PR TITLE
Add a new lint `unneeded_where_clauses`, suggests removing empty where clauses

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -615,6 +615,8 @@ lint_unknown_lint =
 lint_unknown_tool_in_scoped_lint = unknown tool name `{$tool_name}` found in scoped lint: `{$tool_name}::{$lint_name}`
     .help = add `#![register_tool({$tool_name})]` to the crate root
 
+lint_unneeded_where_clauses = this empty where clause is unneeded
+
 lint_unsupported_group = `{$lint_group}` lint group is not supported with ´--force-warn´
 
 lint_untranslatable_diag = diagnostics should be created using translatable messages

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -36,7 +36,7 @@ use crate::{
         BuiltinUngatedAsyncFnTrackCaller, BuiltinUnpermittedTypeInit,
         BuiltinUnpermittedTypeInitSub, BuiltinUnreachablePub, BuiltinUnsafe,
         BuiltinUnstableFeatures, BuiltinUnusedDocComment, BuiltinUnusedDocCommentSub,
-        BuiltinWhileTrue, SuggestChangingAssocTypes,
+        BuiltinWhileTrue, SuggestChangingAssocTypes, UnneededWhereClauseDiag,
     },
     EarlyContext, EarlyLintPass, LateContext, LateLintPass, Level, LintContext,
 };
@@ -1644,7 +1644,8 @@ declare_lint_pass!(
         UNSTABLE_FEATURES,
         UNREACHABLE_PUB,
         TYPE_ALIAS_BOUNDS,
-        TRIVIAL_BOUNDS
+        TRIVIAL_BOUNDS,
+        UNNEEDED_WHERE_CLAUSES,
     ]
 );
 
@@ -2971,6 +2972,26 @@ impl EarlyLintPass for SpecialModuleName {
                     _ => continue,
                 }
             }
+        }
+    }
+}
+
+declare_lint! {
+    pub UNNEEDED_WHERE_CLAUSES,
+    Warn,
+    "suggests removing empty where clauses"
+}
+
+declare_lint_pass! { UnneededWhereClauses => [UNNEEDED_WHERE_CLAUSES] }
+
+impl EarlyLintPass for UnneededWhereClauses {
+    fn check_generics(&mut self, cx: &EarlyContext<'_>, generics: &ast::Generics) {
+        if generics.where_clause.has_where_token && generics.where_clause.predicates.is_empty() {
+            cx.emit_span_lint(
+                UNNEEDED_WHERE_CLAUSES,
+                generics.where_clause.span,
+                UnneededWhereClauseDiag,
+            )
         }
     }
 }

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -171,6 +171,7 @@ early_lint_methods!(
             IncompleteInternalFeatures: IncompleteInternalFeatures,
             RedundantSemicolons: RedundantSemicolons,
             UnusedDocComment: UnusedDocComment,
+            UnneededWhereClauses: UnneededWhereClauses,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1946,3 +1946,7 @@ pub struct UnitBindingsDiag {
     #[label]
     pub label: Span,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(lint_unneeded_where_clauses)]
+pub struct UnneededWhereClauseDiag;

--- a/tests/ui/lint/unneeded_where_clauses.rs
+++ b/tests/ui/lint/unneeded_where_clauses.rs
@@ -1,0 +1,7 @@
+#[deny(unneeded_where_clauses)]
+
+fn foo() where {} //~ ERROR this empty where clause is unneeded
+
+fn main() {
+    foo();
+}

--- a/tests/ui/lint/unneeded_where_clauses.stderr
+++ b/tests/ui/lint/unneeded_where_clauses.stderr
@@ -1,0 +1,14 @@
+error: this empty where clause is unneeded
+  --> $DIR/unneeded_where_clauses.rs:3:10
+   |
+LL | fn foo() where {}
+   |          ^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unneeded_where_clauses.rs:1:8
+   |
+LL | #[deny(unneeded_where_clauses)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #125242