### PR TITLE
Never type unsafe lint improvements

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4263,8 +4263,7 @@ declare_lint! {
     ///
     /// // where absurd is a function with the following signature
     /// // (it's sound, because `!` always marks unreachable code):
-    /// fn absurd<T>(_: !) -> T { ... }
-    // FIXME: use `core::convert::absurd` here instead, once it's merged
+    /// fn absurd<T>(never: !) -> T { ... }
     /// ```
     ///
     /// While it's convenient to be able to use non-diverging code in one of the branches (like

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4320,7 +4320,12 @@ declare_lint! {
     /// [`()`]: https://doc.rust-lang.org/core/primitive.unit.html
     pub NEVER_TYPE_FALLBACK_FLOWING_INTO_UNSAFE,
     Warn,
-    "never type fallback affecting unsafe function calls"
+    "never type fallback affecting unsafe function calls",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::FutureReleaseSemanticsChange,
+        reference: "issue #123748 <https://github.com/rust-lang/rust/issues/123748>",
+    };
+    report_in_external_macro
 }
 
 declare_lint! {

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
@@ -7,6 +7,7 @@ fn _zero() {
     if false {
         unsafe { mem::zeroed() }
         //~^ warn: never type fallback affects this call to an `unsafe` function
+        //~| warn: this will change its meaning in a future release!
     } else {
         return;
     };
@@ -21,6 +22,7 @@ fn _trans() {
             struct Zst;
             core::mem::transmute(Zst)
             //~^ warn: never type fallback affects this call to an `unsafe` function
+            //~| warn: this will change its meaning in a future release!
         }
     } else {
         return;
@@ -36,6 +38,7 @@ fn _union() {
 
         unsafe { Union { a: () }.b }
         //~^ warn: never type fallback affects this union access
+        //~| warn: this will change its meaning in a future release!
     } else {
         return;
     };
@@ -45,6 +48,7 @@ fn _deref() {
     if false {
         unsafe { *ptr::from_ref(&()).cast() }
         //~^ warn: never type fallback affects this raw pointer dereference
+        //~| warn: this will change its meaning in a future release!
     } else {
         return;
     };
@@ -62,6 +66,7 @@ fn _only_generics() {
 
         unsafe { internally_create(x) }
         //~^ warn: never type fallback affects this call to an `unsafe` function
+        //~| warn: this will change its meaning in a future release!
 
         x.unwrap()
     } else {
@@ -73,9 +78,11 @@ fn _stored_function() {
     if false {
         let zeroed = mem::zeroed;
         //~^ warn: never type fallback affects this `unsafe` function
+        //~| warn: this will change its meaning in a future release!
 
         unsafe { zeroed() }
         //~^ warn: never type fallback affects this call to an `unsafe` function
+        //~| warn: this will change its meaning in a future release!
     } else {
         return;
     };
@@ -90,6 +97,7 @@ fn _only_generics_stored_function() {
         let x = None;
         let f = internally_create;
         //~^ warn: never type fallback affects this `unsafe` function
+        //~| warn: this will change its meaning in a future release!
 
         unsafe { f(x) }
 
@@ -113,6 +121,7 @@ fn _method() {
         unsafe {
             S(marker::PhantomData).create_out_of_thin_air()
             //~^ warn: never type fallback affects this call to an `unsafe` method
+            //~| warn: this will change its meaning in a future release!
         }
     } else {
         return;
@@ -129,6 +138,7 @@ fn _objc() {
         () => {
             match send_message::<_ /* ?0 */>() {
                 //~^ warn: never type fallback affects this call to an `unsafe` function
+                //~| warn: this will change its meaning in a future release!
                 Ok(x) => x,
                 Err(_) => loop {},
             }

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.stderr
@@ -4,75 +4,93 @@ warning: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 
 warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:22:13
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:23:13
    |
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
 warning: never type fallback affects this union access
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:37:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:39:18
    |
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
 warning: never type fallback affects this raw pointer dereference
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:46:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:49:18
    |
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
 warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:63:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:67:18
    |
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
 warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:77:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:83:18
    |
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
 warning: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:74:22
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:79:22
    |
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
 warning: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:91:17
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:98:17
    |
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
 warning: never type fallback affects this call to an `unsafe` method
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:114:13
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:122:13
    |
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
 warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:130:19
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:139:19
    |
 LL |             match send_message::<_ /* ?0 */>() {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,6 +98,8 @@ LL |             match send_message::<_ /* ?0 */>() {
 LL |         msg_send!();
    |         ----------- in this macro invocation
    |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
- Move linting code to a separate method
- Remove mentions of `core::convert::absurd` (#124311 was rejected)
- Make the lint into FCW

The last thing is a bit weird though. On one hand it should be `EditionSemanticsChange(2024)`, but on the other hand it shouldn't, because we also plan to break it on all editions some time later. _Also_, it's weird that we don't have `FutureReleaseSemanticsChangeReportInDeps`, IMO "this might cause UB in a future release" is important enough to be reported in deps...

IMO we ought to have three enums instead of [`FutureIncompatibilityReason`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint_defs/enum.FutureIncompatibilityReason.html#):

```rust
enum IncompatibilityWhen {
     FutureRelease,
     Edition(Edition),
}

enum IncompatibilyWhat {
    Error,
    SemanticChange,
}

enum IncompatibilityReportInDeps {
    No,
    Yes,
}
```

Tracking:
- https://github.com/rust-lang/rust/issues/123748