### PR TITLE
Update to LLVM 18.1.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/18.0-2024-02-13
+	branch = rustc/18.1-2024-05-19
 	shallow = true
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book


### PR DESCRIPTION
This rebases our LLVM fork on top of LLVM 18.1.6, which is planned to be the last release of the 18.x series.

Fixes #123695 (miscompile with wrapping pointer arithmetic).
Fixes #125053 (compiler crash on M1).
Also fixes https://bugzilla.redhat.com/show_bug.cgi?id=2226905 (crypto miscompile on s390x).

r? @cuviper 