### PR TITLE
Fix `unexpected_cfgs` lint on std

### DIFF
--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -40,3 +40,12 @@ compiler-builtins-weak-intrinsics = ["compiler_builtins/weak-intrinsics"]
 panic_immediate_abort = ["core/panic_immediate_abort"]
 # Choose algorithms that are optimized for binary size instead of runtime performance
 optimize_for_size = ["core/optimize_for_size"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(no_global_oom_handling)',
+    'cfg(bootstrap)',
+    'cfg(no_rc)',
+    'cfg(no_sync)',
+]

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -43,9 +43,12 @@ optimize_for_size = ["core/optimize_for_size"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
+# x.py uses beta cargo, so `check-cfg` entries do not yet take effect
+# for rust-lang/rust. But for users of `-Zbuild-std` it does.
+# The unused warning is waiting for rust-lang/cargo#13925 to reach beta.
 check-cfg = [
-    'cfg(no_global_oom_handling)',
     'cfg(bootstrap)',
+    'cfg(no_global_oom_handling)',
     'cfg(no_rc)',
     'cfg(no_sync)',
 ]

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -39,9 +39,13 @@ debug_refcell = []
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
+# x.py uses beta cargo, so `check-cfg` entries do not yet take effect
+# for rust-lang/rust. But for users of `-Zbuild-std` it does.
+# The unused warning is waiting for rust-lang/cargo#13925 to reach beta.
 check-cfg = [
     'cfg(no_fp_fmt_parse)',
     'cfg(bootstrap)',
     'cfg(stdarch_intel_sde)',
-    'cfg(feature, values("all_lane_counts"))',
+    # This matches `EXTRA_CHECK_CFGS` in `src/bootstrap/src/lib.rs`.
+    'cfg(feature, values(any()))',
 ]

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -36,3 +36,12 @@ optimize_for_size = []
 # Make `RefCell` store additional debugging information, which is printed out when
 # a borrow error occurs
 debug_refcell = []
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(no_fp_fmt_parse)',
+    'cfg(bootstrap)',
+    'cfg(stdarch_intel_sde)',
+    'cfg(feature, values("all_lane_counts"))',
+]

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -43,8 +43,8 @@ level = "warn"
 # for rust-lang/rust. But for users of `-Zbuild-std` it does.
 # The unused warning is waiting for rust-lang/cargo#13925 to reach beta.
 check-cfg = [
-    'cfg(no_fp_fmt_parse)',
     'cfg(bootstrap)',
+    'cfg(no_fp_fmt_parse)',
     'cfg(stdarch_intel_sde)',
     # This matches `EXTRA_CHECK_CFGS` in `src/bootstrap/src/lib.rs`.
     'cfg(feature, values(any()))',

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -97,3 +97,13 @@ heap_size = 0x8000000
 name = "stdbenches"
 path = "benches/lib.rs"
 test = true
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(bootstrap)',
+    'cfg(backtrace_in_libstd)',
+    'cfg(netbsd10)',
+    'cfg(target_arch, values("xtensa"))',
+    'cfg(feature, values("std", "as_crate"))',
+]

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -84,6 +84,7 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
     (Some(Mode::ToolRustc), "rust_analyzer", None),
     (Some(Mode::ToolStd), "rust_analyzer", None),
     (Some(Mode::Codegen), "parallel_compiler", None),
+    // NOTE: consider updating `check-cfg` entries in `std/Cargo.toml` too.
     (Some(Mode::Std), "stdarch_intel_sde", None),
     (Some(Mode::Std), "no_fp_fmt_parse", None),
     (Some(Mode::Std), "no_global_oom_handling", None),

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -85,6 +85,8 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
     (Some(Mode::ToolStd), "rust_analyzer", None),
     (Some(Mode::Codegen), "parallel_compiler", None),
     // NOTE: consider updating `check-cfg` entries in `std/Cargo.toml` too.
+    // cfg(bootstrap) remove these once the bootstrap compiler supports
+    // `lints.rust.unexpected_cfgs.check-cfg`
     (Some(Mode::Std), "stdarch_intel_sde", None),
     (Some(Mode::Std), "no_fp_fmt_parse", None),
     (Some(Mode::Std), "no_global_oom_handling", None),


### PR DESCRIPTION
closes #125291 

r? rust-lang/compiler
