### PR TITLE
rustdoc: Don't strip items with inherited visibility in `AliasedNonLocalStripper`

### DIFF
--- a/src/librustdoc/passes/strip_aliased_non_local.rs
+++ b/src/librustdoc/passes/strip_aliased_non_local.rs
@@ -46,8 +46,13 @@ impl<'tcx> DocFolder for NonLocalStripper<'tcx> {
         // the field and not the one given by the user for the currrent crate.
         //
         // FIXME(#125009): Not-local should probably consider same Cargo workspace
-        if !i.def_id().map_or(true, |did| did.is_local()) {
-            if i.visibility(self.tcx) != Some(Visibility::Public) || i.is_doc_hidden() {
+        if let Some(def_id) = i.def_id()
+            && !def_id.is_local()
+        {
+            if i.is_doc_hidden()
+                // Default to *not* stripping items with inherited visibility.
+                || i.visibility(self.tcx).map_or(false, |viz| viz != Visibility::Public)
+            {
                 return Some(strip_item(i));
             }
         }

--- a/tests/rustdoc/auxiliary/cross_crate_generic_typedef.rs
+++ b/tests/rustdoc/auxiliary/cross_crate_generic_typedef.rs
@@ -3,3 +3,8 @@ pub struct InlineOne<A> {
 }
 
 pub type InlineU64 = InlineOne<u64>;
+
+pub enum GenericEnum<T> {
+   Variant(T),
+   Variant2(T, T),
+}

--- a/tests/rustdoc/typedef-inner-variants.rs
+++ b/tests/rustdoc/typedef-inner-variants.rs
@@ -117,3 +117,10 @@ pub type HighlyGenericAABB<A, B> = HighlyGenericStruct<A, A, B, B>;
 // @count - '//*[@id="variants"]' 0
 // @count - '//*[@id="fields"]' 1
 pub use cross_crate_generic_typedef::InlineU64;
+
+// @has 'inner_variants/type.InlineEnum.html'
+// @count - '//*[@id="aliased-type"]' 1
+// @count - '//*[@id="variants"]' 1
+// @count - '//*[@id="fields"]' 0
+// @count - '//*[@class="variant"]' 2
+pub type InlineEnum = cross_crate_generic_typedef::GenericEnum<i32>;


### PR DESCRIPTION
Enum variants return `None` in `Item::visibility`, which fails the comparison to `Some(Visibility::Public)`. This means that all enums in type aliases are being stripped, leading to this in the `rustc_middle` docs:

<img width="474" alt="image" src="https://github.com/rust-lang/rust/assets/3674314/83704d94-a571-4c28-acbd-ca51c4efd46e">

This regressed in https://github.com/rust-lang/rust/pull/124939#discussion_r1606130566.

This switches the `AliasedNonLocalStripper` to not strip items with `None` as their visibility.