### PR TITLE
fix suggestion in E0373 for !Unpin coroutines

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -3343,6 +3343,10 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 } else if string.starts_with("gen") {
                     // `gen` is 3 chars long
                     Some(3)
+                } else if string.starts_with("static") {
+                    // `static` is 6 chars long
+                    // This is used for `!Unpin` coroutines
+                    Some(6)
                 } else {
                     None
                 };

--- a/tests/ui/coroutine/static-move-suggestion.fixed
+++ b/tests/ui/coroutine/static-move-suggestion.fixed
@@ -1,0 +1,19 @@
+//@ run-rustfix
+
+// check to make sure that we suggest adding `move` after `static`
+
+#![feature(coroutines)]
+
+fn check() -> impl Sized {
+    let x = 0;
+    #[coroutine]
+    static move || {
+        //~^ ERROR E0373
+        yield;
+        x
+    }
+}
+
+fn main() {
+    check();
+}

--- a/tests/ui/coroutine/static-move-suggestion.rs
+++ b/tests/ui/coroutine/static-move-suggestion.rs
@@ -1,0 +1,19 @@
+//@ run-rustfix
+
+// check to make sure that we suggest adding `move` after `static`
+
+#![feature(coroutines)]
+
+fn check() -> impl Sized {
+    let x = 0;
+    #[coroutine]
+    static || {
+        //~^ ERROR E0373
+        yield;
+        x
+    }
+}
+
+fn main() {
+    check();
+}

--- a/tests/ui/coroutine/static-move-suggestion.stderr
+++ b/tests/ui/coroutine/static-move-suggestion.stderr
@@ -1,0 +1,26 @@
+error[E0373]: coroutine may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/static-move-suggestion.rs:10:5
+   |
+LL |     static || {
+   |     ^^^^^^^^^ may outlive borrowed value `x`
+...
+LL |         x
+   |         - `x` is borrowed here
+   |
+note: coroutine is returned here
+  --> $DIR/static-move-suggestion.rs:10:5
+   |
+LL | /     static || {
+LL | |
+LL | |         yield;
+LL | |         x
+LL | |     }
+   | |_____^
+help: to force the coroutine to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |     static move || {
+   |            ++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0373`.


### PR DESCRIPTION
Coroutines can be prefixed with the `static` keyword to make them
`!Unpin`.
However, given the following function:

```rust

fn check() -> impl Sized {
    let x = 0;
    #[coroutine]
    static || {
        yield;
        x
    }
}
```

We currently suggest prefixing `move` before `static`, which is
syntactically incorrect:

```
error[E0373]: coroutine may outlive the current function, but it borrows
...
 --> src/main.rs:6:5
  |
6 |     static || {
  |     ^^^^^^^^^ may outlive borrowed value `x`
7 |         yield;
8 |         x
  |         - `x` is borrowed here
  |
note: coroutine is returned here
 --> src/main.rs:6:5
  |
6 | /     static || {
7 | |         yield;
8 | |         x
9 | |     }
  | |_____^
help: to force the coroutine to take ownership of `x` (and any other
referenced variables), use the `move` keyword
  |     // this is syntactically incorrect, it should be `static move ||`
6 |     move static || {
  |     ++++

```

This PR suggests adding `move` after `static` for these coroutines.

I also added a UI test for this case.