### PR TITLE
Migrate `run-make/rustdoc-scrape-examples-whitespace` to `rmake.rs`

### DIFF
--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -236,7 +236,6 @@ run-make/rustc-macro-dep-files/Makefile
 run-make/rustdoc-io-error/Makefile
 run-make/rustdoc-scrape-examples-macros/Makefile
 run-make/rustdoc-scrape-examples-multiple/Makefile
-run-make/rustdoc-scrape-examples-whitespace/Makefile
 run-make/rustdoc-verify-output-files/Makefile
 run-make/rustdoc-with-output-option/Makefile
 run-make/rustdoc-with-short-out-dir-option/Makefile

--- a/tests/run-make/rustdoc-scrape-examples-whitespace/Makefile
+++ b/tests/run-make/rustdoc-scrape-examples-whitespace/Makefile
@@ -1,5 +1,0 @@
-deps := ex
-
-include ../rustdoc-scrape-examples-multiple/scrape.mk
-
-all: scrape

--- a/tests/run-make/rustdoc-scrape-examples-whitespace/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-whitespace/rmake.rs
@@ -1,0 +1,6 @@
+#[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
+mod scrape;
+
+fn main() {
+    scrape::scrape(&[]);
+}


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/121876.

r? @jieyouxu