### PR TITLE
Optimize `escape_ascii`.

### DIFF
--- a/library/core/src/escape.rs
+++ b/library/core/src/escape.rs
@@ -29,6 +29,11 @@ const fn escape_ascii<const N: usize>(byte: u8) -> ([ascii::Char; N], Range<u8>)
     // NOTE: This `match` is roughly ordered by the frequency of ASCII
     //       characters for performance.
     match byte.as_ascii() {
+         Some(
+            c @ ascii::Char::QuotationMark
+            | c @ ascii::Char::Apostrophe
+            | c @ ascii::Char::ReverseSolidus,
+        ) => backslash(c),
         Some(c) if !byte.is_ascii_control() => {
             output[0] = c;
             (output, 0..1)
@@ -36,11 +41,6 @@ const fn escape_ascii<const N: usize>(byte: u8) -> ([ascii::Char; N], Range<u8>)
         Some(ascii::Char::LineFeed) => backslash(ascii::Char::SmallN),
         Some(ascii::Char::CarriageReturn) => backslash(ascii::Char::SmallR),
         Some(ascii::Char::CharacterTabulation) => backslash(ascii::Char::SmallT),
-        Some(
-            c @ ascii::Char::QuotationMark
-            | c @ ascii::Char::Apostrophe
-            | c @ ascii::Char::ReverseSolidus,
-        ) => backslash(c),
         _ => {
             let hi = HEX_DIGITS[(byte >> 4) as usize];
             let lo = HEX_DIGITS[(byte & 0xf) as usize];

--- a/library/core/src/escape.rs
+++ b/library/core/src/escape.rs
@@ -24,35 +24,40 @@ const fn backslash<const N: usize>(a: ascii::Char) -> ([ascii::Char; N], Range<u
 const fn escape_ascii<const N: usize>(byte: u8) -> ([ascii::Char; N], Range<u8>) {
     const { assert!(N >= 4) };
 
-    let mut output = [ascii::Char::Null; N];
+    let mut output = [ascii::Char::ReverseSolidus; N];
+    output[1] = ascii::Char::SmallX;
+    output[2] = HEX_DIGITS[(byte >> 4) as usize];
+    output[3] = HEX_DIGITS[(byte & 0b1111) as usize];
 
-    // NOTE: This `match` is roughly ordered by the frequency of ASCII
-    //       characters for performance.
-    match byte.as_ascii() {
-         Some(
-            c @ ascii::Char::QuotationMark
-            | c @ ascii::Char::Apostrophe
-            | c @ ascii::Char::ReverseSolidus,
-        ) => backslash(c),
-        Some(c) if !byte.is_ascii_control() => {
-            output[0] = c;
-            (output, 0..1)
+    let len = if byte < 127 {
+        match byte {
+            c @ b'\"' | c @ b'\'' | c @ b'\\' => {
+                output[1] = c.as_ascii().unwrap();
+                2
+            }
+            c @ 0x20..0x7f => {
+                output[0] = c.as_ascii().unwrap();
+                1
+            }
+            b'\n' => {
+                output[1] = ascii::Char::SmallN;
+                2
+            }
+            b'\r' => {
+                output[1] = ascii::Char::SmallR;
+                2
+            }
+            b'\t' => {
+                output[1] = ascii::Char::SmallT;
+                2
+            }
+            _ => 4,
         }
-        Some(ascii::Char::LineFeed) => backslash(ascii::Char::SmallN),
-        Some(ascii::Char::CarriageReturn) => backslash(ascii::Char::SmallR),
-        Some(ascii::Char::CharacterTabulation) => backslash(ascii::Char::SmallT),
-        _ => {
-            let hi = HEX_DIGITS[(byte >> 4) as usize];
-            let lo = HEX_DIGITS[(byte & 0xf) as usize];
+    } else {
+        4
+    };
 
-            output[0] = ascii::Char::ReverseSolidus;
-            output[1] = ascii::Char::SmallX;
-            output[2] = hi;
-            output[3] = lo;
-
-            (output, 0..4)
-        }
-    }
+    (output, 0..len)
 }
 
 /// Escapes a character `\u{NNNN}` representation.

--- a/library/core/src/escape.rs
+++ b/library/core/src/escape.rs
@@ -26,19 +26,21 @@ const fn escape_ascii<const N: usize>(byte: u8) -> ([ascii::Char; N], Range<u8>)
 
     let mut output = [ascii::Char::Null; N];
 
+    // NOTE: This `match` is roughly ordered by the frequency of ASCII
+    //       characters for performance.
     match byte.as_ascii() {
-        Some(ascii::Char::CharacterTabulation) => backslash(ascii::Char::SmallT),
-        Some(ascii::Char::CarriageReturn) => backslash(ascii::Char::SmallR),
-        Some(ascii::Char::LineFeed) => backslash(ascii::Char::SmallN),
-        Some(
-            c @ ascii::Char::ReverseSolidus
-            | c @ ascii::Char::Apostrophe
-            | c @ ascii::Char::QuotationMark,
-        ) => backslash(c),
         Some(c) if !byte.is_ascii_control() => {
             output[0] = c;
             (output, 0..1)
         }
+        Some(ascii::Char::LineFeed) => backslash(ascii::Char::SmallN),
+        Some(ascii::Char::CarriageReturn) => backslash(ascii::Char::SmallR),
+        Some(ascii::Char::CharacterTabulation) => backslash(ascii::Char::SmallT),
+        Some(
+            c @ ascii::Char::QuotationMark
+            | c @ ascii::Char::Apostrophe
+            | c @ ascii::Char::ReverseSolidus,
+        ) => backslash(c),
         _ => {
             let hi = HEX_DIGITS[(byte >> 4) as usize];
             let lo = HEX_DIGITS[(byte & 0xf) as usize];

--- a/library/core/src/escape.rs
+++ b/library/core/src/escape.rs
@@ -35,7 +35,7 @@ const fn escape_ascii<const N: usize>(byte: u8) -> ([ascii::Char; N], Range<u8>)
                 output[1] = c.as_ascii().unwrap();
                 2
             }
-            c @ 0x20..0x7f => {
+            c @ 0x20..=0x7e => {
                 output[0] = c.as_ascii().unwrap();
                 1
             }

--- a/library/core/src/escape.rs
+++ b/library/core/src/escape.rs
@@ -24,32 +24,31 @@ const fn backslash<const N: usize>(a: ascii::Char) -> ([ascii::Char; N], Range<u
 const fn escape_ascii<const N: usize>(byte: u8) -> ([ascii::Char; N], Range<u8>) {
     const { assert!(N >= 4) };
 
-    match byte {
-        b'\t' => backslash(ascii::Char::SmallT),
-        b'\r' => backslash(ascii::Char::SmallR),
-        b'\n' => backslash(ascii::Char::SmallN),
-        b'\\' => backslash(ascii::Char::ReverseSolidus),
-        b'\'' => backslash(ascii::Char::Apostrophe),
-        b'\"' => backslash(ascii::Char::QuotationMark),
-        byte => {
-            let mut output = [ascii::Char::Null; N];
+    let mut output = [ascii::Char::Null; N];
 
-            if let Some(c) = byte.as_ascii()
-                && !byte.is_ascii_control()
-            {
-                output[0] = c;
-                (output, 0..1)
-            } else {
-                let hi = HEX_DIGITS[(byte >> 4) as usize];
-                let lo = HEX_DIGITS[(byte & 0xf) as usize];
+    match byte.as_ascii() {
+        Some(ascii::Char::CharacterTabulation) => backslash(ascii::Char::SmallT),
+        Some(ascii::Char::CarriageReturn) => backslash(ascii::Char::SmallR),
+        Some(ascii::Char::LineFeed) => backslash(ascii::Char::SmallN),
+        Some(
+            c @ ascii::Char::ReverseSolidus
+            | c @ ascii::Char::Apostrophe
+            | c @ ascii::Char::QuotationMark,
+        ) => backslash(c),
+        Some(c) if !byte.is_ascii_control() => {
+            output[0] = c;
+            (output, 0..1)
+        }
+        _ => {
+            let hi = HEX_DIGITS[(byte >> 4) as usize];
+            let lo = HEX_DIGITS[(byte & 0xf) as usize];
 
-                output[0] = ascii::Char::ReverseSolidus;
-                output[1] = ascii::Char::SmallX;
-                output[2] = hi;
-                output[3] = lo;
+            output[0] = ascii::Char::ReverseSolidus;
+            output[1] = ascii::Char::SmallX;
+            output[2] = hi;
+            output[3] = lo;
 
-                (output, 0..4)
-            }
+            (output, 0..4)
         }
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/124307. CC @joboet

Alternative/addition to https://github.com/rust-lang/rust/pull/125317.

Based on https://github.com/rust-lang/rust/pull/124307#issuecomment-2120926515, it doesn't look like this function is the cause for the regression, but this change produces even fewer instructions (https://rust.godbolt.org/z/nebzqoveG).
