### PR TITLE
`-Znext-solver`: eagerly normalize when adding goals

### DIFF
--- a/compiler/rustc_middle/src/ty/predicate.rs
+++ b/compiler/rustc_middle/src/ty/predicate.rs
@@ -121,17 +121,14 @@ impl<'tcx> Predicate<'tcx> {
     #[inline]
     pub fn allow_normalization(self) -> bool {
         match self.kind().skip_binder() {
-            PredicateKind::Clause(ClauseKind::WellFormed(_)) => false,
-            // `NormalizesTo` is only used in the new solver, so this shouldn't
-            // matter. Normalizing `term` would be 'wrong' however, as it changes whether
-            // `normalizes-to(<T as Trait>::Assoc, <T as Trait>::Assoc)` holds.
-            PredicateKind::NormalizesTo(..) => false,
+            PredicateKind::Clause(ClauseKind::WellFormed(_))
+            | PredicateKind::AliasRelate(..)
+            | PredicateKind::NormalizesTo(..) => false,
             PredicateKind::Clause(ClauseKind::Trait(_))
             | PredicateKind::Clause(ClauseKind::RegionOutlives(_))
             | PredicateKind::Clause(ClauseKind::TypeOutlives(_))
             | PredicateKind::Clause(ClauseKind::Projection(_))
             | PredicateKind::Clause(ClauseKind::ConstArgHasType(..))
-            | PredicateKind::AliasRelate(..)
             | PredicateKind::ObjectSafe(_)
             | PredicateKind::Subtype(_)
             | PredicateKind::Coerce(_)

--- a/compiler/rustc_trait_selection/src/solve/alias_relate.rs
+++ b/compiler/rustc_trait_selection/src/solve/alias_relate.rs
@@ -28,6 +28,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
     ) -> QueryResult<'tcx> {
         let tcx = self.tcx();
         let Goal { param_env, predicate: (lhs, rhs, direction) } = goal;
+        debug_assert!(lhs.to_alias_term().is_some() || rhs.to_alias_term().is_some());
 
         // Structurally normalize the lhs.
         let lhs = if let Some(alias) = lhs.to_alias_term() {

--- a/tests/ui/coherence/coherence-overlap-unnormalizable-projection-1.next.stderr
+++ b/tests/ui/coherence/coherence-overlap-unnormalizable-projection-1.next.stderr
@@ -12,7 +12,7 @@ LL |   impl<T> Trait for Box<T> {}
    |   ^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Box<_>`
    |
    = note: downstream crates may implement trait `WithAssoc<'a>` for type `std::boxed::Box<_>`
-   = note: downstream crates may implement trait `WhereBound` for type `std::boxed::Box<<std::boxed::Box<_> as WithAssoc<'a>>::Assoc>`
+   = note: downstream crates may implement trait `WhereBound` for type `std::boxed::Box<_>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coherence/occurs-check/opaques.next.stderr
+++ b/tests/ui/coherence/occurs-check/opaques.next.stderr
@@ -11,7 +11,7 @@ error[E0282]: type annotations needed
   --> $DIR/opaques.rs:13:20
    |
 LL |     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
-   |                    ^ cannot infer type for associated type `<T as Trait<T>>::Assoc`
+   |                    ^ cannot infer type
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.next.stderr
@@ -16,6 +16,22 @@ LL |     where
 LL |         T: AsExpression<Self::SqlType>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Foo::check`
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `&str: AsExpression<Integer>` is not satisfied
+  --> $DIR/as_expression.rs:57:15
+   |
+LL |     SelectInt.check("bar");
+   |               ^^^^^ the trait `AsExpression<Integer>` is not implemented for `&str`
+   |
+   = help: the trait `AsExpression<Text>` is implemented for `&str`
+   = help: for that trait implementation, expected `Text`, found `Integer`
 
-For more information about this error, try `rustc --explain E0277`.
+error[E0271]: type mismatch resolving `<&str as AsExpression<<SelectInt as Expression>::SqlType>>::Expression == _`
+  --> $DIR/as_expression.rs:57:5
+   |
+LL |     SelectInt.check("bar");
+   |     ^^^^^^^^^^^^^^^^^^^^^^ types differ
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.rs
@@ -55,6 +55,7 @@ impl<T> Foo for T where T: Expression {}
 
 fn main() {
     SelectInt.check("bar");
-    //[next]~^ ERROR the trait bound `&str: AsExpression<<SelectInt as Expression>::SqlType>` is not satisfied
-    //[current]~^^ ERROR the trait bound `&str: AsExpression<Integer>` is not satisfied
+    //~^ ERROR the trait bound `&str: AsExpression<Integer>` is not satisfied
+    //[next]~| the trait bound `&str: AsExpression<<SelectInt as Expression>::SqlType>` is not satisfied
+    //[next]~| type mismatch
 }

--- a/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.stderr
+++ b/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.stderr
@@ -1,8 +1,8 @@
-error[E0284]: type annotations needed: cannot satisfy `the constant `{ || {} }` can be evaluated`
+error[E0284]: type annotations needed: cannot satisfy `{ || {} } == _`
   --> $DIR/const-region-infer-to-static-in-binder.rs:4:10
    |
 LL | struct X<const FN: fn() = { || {} }>;
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot satisfy `the constant `{ || {} }` can be evaluated`
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot satisfy `{ || {} } == _`
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/const-region-infer-to-static-in-binder.rs:4:20

--- a/tests/ui/traits/next-solver/cycles/cycle-modulo-ambig-aliases.rs
+++ b/tests/ui/traits/next-solver/cycles/cycle-modulo-ambig-aliases.rs
@@ -1,0 +1,89 @@
+//@ compile-flags: -Znext-solver
+
+// A regression test for #125269. We previously ended up
+// recursively proving `&<_ as SpeciesPackedElem>::Assoc: Typed`
+// for all aliases which ended up causing exponential blowup.
+//
+// This has been fixed by eagerly normalizing the associated
+// type before computing the nested goals, resulting in an
+// immediate inductive cycle.
+
+pub trait Typed {}
+
+pub struct SpeciesCases<E>(E);
+
+pub trait SpeciesPackedElim {
+    type Ogre;
+    type Cyclops;
+    type Wendigo;
+    type Cavetroll;
+    type Mountaintroll;
+    type Swamptroll;
+    type Dullahan;
+    type Werewolf;
+    type Occultsaurok;
+    type Mightysaurok;
+    type Slysaurok;
+    type Mindflayer;
+    type Minotaur;
+    type Tidalwarrior;
+    type Yeti;
+    type Harvester;
+    type Blueoni;
+    type Redoni;
+    type Cultistwarlord;
+    type Cultistwarlock;
+    type Huskbrute;
+    type Tursus;
+    type Gigasfrost;
+    type AdletElder;
+    type SeaBishop;
+    type HaniwaGeneral;
+    type TerracottaBesieger;
+    type TerracottaDemolisher;
+    type TerracottaPunisher;
+    type TerracottaPursuer;
+    type Cursekeeper;
+}
+
+impl<'b, E: SpeciesPackedElim> Typed for &'b SpeciesCases<E>
+where
+    &'b E::Ogre: Typed,
+    &'b E::Cyclops: Typed,
+    &'b E::Wendigo: Typed,
+    &'b E::Cavetroll: Typed,
+    &'b E::Mountaintroll: Typed,
+    &'b E::Swamptroll: Typed,
+    &'b E::Dullahan: Typed,
+    &'b E::Werewolf: Typed,
+    &'b E::Occultsaurok: Typed,
+    &'b E::Mightysaurok: Typed,
+    &'b E::Slysaurok: Typed,
+    &'b E::Mindflayer: Typed,
+    &'b E::Minotaur: Typed,
+    &'b E::Tidalwarrior: Typed,
+    &'b E::Yeti: Typed,
+    &'b E::Harvester: Typed,
+    &'b E::Blueoni: Typed,
+    &'b E::Redoni: Typed,
+    &'b E::Cultistwarlord: Typed,
+    &'b E::Cultistwarlock: Typed,
+    &'b E::Huskbrute: Typed,
+    &'b E::Tursus: Typed,
+    &'b E::Gigasfrost: Typed,
+    &'b E::AdletElder: Typed,
+    &'b E::SeaBishop: Typed,
+    &'b E::HaniwaGeneral: Typed,
+    &'b E::TerracottaBesieger: Typed,
+    &'b E::TerracottaDemolisher: Typed,
+    &'b E::TerracottaPunisher: Typed,
+    &'b E::TerracottaPursuer: Typed,
+    &'b E::Cursekeeper: Typed,
+{}
+
+fn foo<T: Typed>() {}
+
+fn main() {
+    foo::<&_>();
+    //~^ ERROR overflow evaluating the requirement `&_: Typed`
+}

--- a/tests/ui/traits/next-solver/cycles/cycle-modulo-ambig-aliases.stderr
+++ b/tests/ui/traits/next-solver/cycles/cycle-modulo-ambig-aliases.stderr
@@ -1,0 +1,15 @@
+error[E0275]: overflow evaluating the requirement `&_: Typed`
+  --> $DIR/cycle-modulo-ambig-aliases.rs:87:11
+   |
+LL |     foo::<&_>();
+   |           ^^
+   |
+note: required by a bound in `foo`
+  --> $DIR/cycle-modulo-ambig-aliases.rs:84:11
+   |
+LL | fn foo<T: Typed>() {}
+   |           ^^^^^ required by this bound in `foo`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/next-solver/dyn-any-dont-prefer-impl.rs
+++ b/tests/ui/traits/next-solver/dyn-any-dont-prefer-impl.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: -Znext-solver
-//@ check-pass
+//@ run-pass
 
 // Test that selection prefers the builtin trait object impl for `Any`
 // instead of the user defined impl. Both impls apply to the trait


### PR DESCRIPTION
fixes #125269. I am not totally with this fix and going to keep this open until we have a more general discussion about how to handle hangs caused by lazy norm in the new solver.