### PR TITLE
Use Backtrace::force_capture instead of Backtrace::capture in rustc_log

### DIFF
--- a/compiler/rustc_log/src/lib.rs
+++ b/compiler/rustc_log/src/lib.rs
@@ -159,7 +159,9 @@ where
         if !target.contains(&self.backtrace_target) {
             return Ok(());
         }
-        let backtrace = std::backtrace::Backtrace::capture();
+        // Use Backtrace::force_capture because we don't want to depend on the
+        // RUST_BACKTRACE environment variable being set.
+        let backtrace = std::backtrace::Backtrace::force_capture();
         writeln!(writer, "stack backtrace: \n{backtrace:?}")
     }
 }


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/125063, the compiler and custom drivers won't automatically set the RUST_BACKTRACE environment variable anymore, so we have to call `Backtrace::force_capture` instead of `Backtrace::capture` to unconditionally capture a backtrace.

rustc_log handles enabling backtraces via env vars itself, so we don't want RUST_BACKTRACE to make a difference.