### PR TITLE
make declarative macro expansion a part of query system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3809,6 +3809,7 @@ dependencies = [
  "rustc_lexer",
  "rustc_lint_defs",
  "rustc_macros",
+ "rustc_middle",
  "rustc_parse",
  "rustc_serialize",
  "rustc_session",

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2769,7 +2769,7 @@ impl UseTree {
 /// Distinguishes between `Attribute`s that decorate items and Attributes that
 /// are contained as statements within items. These two cases need to be
 /// distinguished for pretty-printing.
-#[derive(Clone, PartialEq, Encodable, Decodable, Debug, Copy, HashStable_Generic)]
+#[derive(Clone, PartialEq, Encodable, Decodable, Debug, Copy, HashStable_Generic, Hash)]
 pub enum AttrStyle {
     Outer,
     Inner,

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2769,7 +2769,7 @@ impl UseTree {
 /// Distinguishes between `Attribute`s that decorate items and Attributes that
 /// are contained as statements within items. These two cases need to be
 /// distinguished for pretty-printing.
-#[derive(Clone, PartialEq, Encodable, Decodable, Debug, Copy, HashStable_Generic, Hash)]
+#[derive(Clone, PartialEq, Encodable, Decodable, Debug, Copy, HashStable_Generic)]
 pub enum AttrStyle {
     Outer,
     Inner,

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -64,7 +64,7 @@ pub enum Delimiter {
 // type. This means that float literals like `1f32` are classified by this type
 // as `Int`. Only upon conversion to `ast::LitKind` will such a literal be
 // given the `Float` kind.
-#[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic, Hash)]
+#[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
 pub enum LitKind {
     Bool, // AST only, must never appear in a `Token`
     Byte,
@@ -81,7 +81,7 @@ pub enum LitKind {
 }
 
 /// A literal token.
-#[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic, Hash)]
+#[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
 pub struct Lit {
     pub kind: LitKind,
     pub symbol: Symbol,
@@ -225,7 +225,7 @@ fn ident_can_begin_type(name: Symbol, span: Span, is_raw: IdentIsRaw) -> bool {
             .contains(&name)
 }
 
-#[derive(PartialEq, Encodable, Decodable, Debug, Copy, Clone, HashStable_Generic, Hash)]
+#[derive(PartialEq, Encodable, Decodable, Debug, Copy, Clone, HashStable_Generic)]
 pub enum IdentIsRaw {
     No,
     Yes,
@@ -870,7 +870,7 @@ pub enum Nonterminal {
     NtVis(P<ast::Visibility>),
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Encodable, Decodable, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Encodable, Decodable)]
 pub enum NonterminalKind {
     Item,
     Block,

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -17,8 +17,9 @@ use rustc_span::symbol::{Ident, Symbol};
 use rustc_span::{edition::Edition, ErrorGuaranteed, Span, DUMMY_SP};
 use std::borrow::Cow;
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
-#[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
+#[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic, Hash)]
 pub enum CommentKind {
     Line,
     Block,
@@ -63,7 +64,7 @@ pub enum Delimiter {
 // type. This means that float literals like `1f32` are classified by this type
 // as `Int`. Only upon conversion to `ast::LitKind` will such a literal be
 // given the `Float` kind.
-#[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
+#[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic, Hash)]
 pub enum LitKind {
     Bool, // AST only, must never appear in a `Token`
     Byte,
@@ -80,7 +81,7 @@ pub enum LitKind {
 }
 
 /// A literal token.
-#[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
+#[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic, Hash)]
 pub struct Lit {
     pub kind: LitKind,
     pub symbol: Symbol,
@@ -224,7 +225,7 @@ fn ident_can_begin_type(name: Symbol, span: Span, is_raw: IdentIsRaw) -> bool {
             .contains(&name)
 }
 
-#[derive(PartialEq, Encodable, Decodable, Debug, Copy, Clone, HashStable_Generic)]
+#[derive(PartialEq, Encodable, Decodable, Debug, Copy, Clone, HashStable_Generic, Hash)]
 pub enum IdentIsRaw {
     No,
     Yes,
@@ -244,7 +245,7 @@ impl From<IdentIsRaw> for bool {
 
 // SAFETY: due to the `Clone` impl below, all fields of all variants other than
 // `Interpolated` must impl `Copy`.
-#[derive(PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
+#[derive(PartialEq, Encodable, Decodable, Debug, HashStable_Generic, Hash)]
 pub enum TokenKind {
     /* Expression-operator symbols. */
     /// `=`
@@ -370,7 +371,7 @@ impl Clone for TokenKind {
     }
 }
 
-#[derive(Clone, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
+#[derive(Clone, PartialEq, Encodable, Decodable, Debug, HashStable_Generic, Hash)]
 pub struct Token {
     pub kind: TokenKind,
     pub span: Span,
@@ -869,7 +870,7 @@ pub enum Nonterminal {
     NtVis(P<ast::Visibility>),
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Encodable, Decodable)]
+#[derive(Debug, Copy, Clone, PartialEq, Encodable, Decodable, Hash)]
 pub enum NonterminalKind {
     Item,
     Block,
@@ -1014,6 +1015,12 @@ where
     CTX: crate::HashStableContext,
 {
     fn hash_stable(&self, _hcx: &mut CTX, _hasher: &mut StableHasher) {
+        panic!("interpolated tokens should not be present in the HIR")
+    }
+}
+
+impl Hash for Nonterminal {
+    fn hash<H: Hasher>(&self, _state: &mut H) {
         panic!("interpolated tokens should not be present in the HIR")
     }
 }

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -17,7 +17,7 @@ use rustc_span::symbol::{Ident, Symbol};
 use rustc_span::{edition::Edition, ErrorGuaranteed, Span, DUMMY_SP};
 use std::borrow::Cow;
 use std::fmt;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 
 #[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic, Hash)]
 pub enum CommentKind {
@@ -245,7 +245,7 @@ impl From<IdentIsRaw> for bool {
 
 // SAFETY: due to the `Clone` impl below, all fields of all variants other than
 // `Interpolated` must impl `Copy`.
-#[derive(PartialEq, Encodable, Decodable, Debug, HashStable_Generic, Hash)]
+#[derive(PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
 pub enum TokenKind {
     /* Expression-operator symbols. */
     /// `=`
@@ -371,7 +371,7 @@ impl Clone for TokenKind {
     }
 }
 
-#[derive(Clone, PartialEq, Encodable, Decodable, Debug, HashStable_Generic, Hash)]
+#[derive(Clone, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
 pub struct Token {
     pub kind: TokenKind,
     pub span: Span,
@@ -1015,12 +1015,6 @@ where
     CTX: crate::HashStableContext,
 {
     fn hash_stable(&self, _hcx: &mut CTX, _hasher: &mut StableHasher) {
-        panic!("interpolated tokens should not be present in the HIR")
-    }
-}
-
-impl Hash for Nonterminal {
-    fn hash<H: Hasher>(&self, _state: &mut H) {
         panic!("interpolated tokens should not be present in the HIR")
     }
 }

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -26,11 +26,11 @@ use rustc_span::{sym, Span, SpanDecoder, SpanEncoder, Symbol, DUMMY_SP};
 use smallvec::{smallvec, SmallVec};
 
 use std::borrow::Cow;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::{cmp, fmt, iter};
 
 /// Part of a `TokenStream`.
-#[derive(Debug, Clone, PartialEq, Encodable, Decodable, HashStable_Generic, Hash)]
+#[derive(Debug, Clone, PartialEq, Encodable, Decodable, HashStable_Generic)]
 pub enum TokenTree {
     /// A single token. Should never be `OpenDelim` or `CloseDelim`, because
     /// delimiters are implicitly represented by `Delimited`.
@@ -108,13 +108,13 @@ where
     }
 }
 
-impl Hash for TokenStream {
+/*impl Hash for TokenStream {
     fn hash<H: Hasher>(&self, state: &mut H) {
         for sub_tt in self.trees() {
             sub_tt.hash(state);
         }
     }
-}
+}*/
 
 pub trait ToAttrTokenStream: sync::DynSend + sync::DynSync {
     fn to_attr_token_stream(&self) -> AttrTokenStream;

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -26,7 +26,6 @@ use rustc_span::{sym, Span, SpanDecoder, SpanEncoder, Symbol, DUMMY_SP};
 use smallvec::{smallvec, SmallVec};
 
 use std::borrow::Cow;
-use std::hash::Hash;
 use std::{cmp, fmt, iter};
 
 /// Part of a `TokenStream`.
@@ -107,15 +106,6 @@ where
         }
     }
 }
-
-/*impl Hash for TokenStream {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        for sub_tt in self.trees() {
-            sub_tt.hash(state);
-        }
-    }
-}*/
-
 pub trait ToAttrTokenStream: sync::DynSend + sync::DynSync {
     fn to_attr_token_stream(&self) -> AttrTokenStream;
 }
@@ -306,7 +296,7 @@ pub struct TokenStream(pub(crate) Lrc<Vec<TokenTree>>);
 /// compound token. Used for conversions to `proc_macro::Spacing`. Also used to
 /// guide pretty-printing, which is where the `JointHidden` value (which isn't
 /// part of `proc_macro::Spacing`) comes in useful.
-#[derive(Clone, Copy, Debug, PartialEq, Encodable, Decodable, HashStable_Generic, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Encodable, Decodable, HashStable_Generic)]
 pub enum Spacing {
     /// The token cannot join with the following token to form a compound
     /// token.
@@ -742,7 +732,7 @@ impl TokenTreeCursor {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Encodable, Decodable, HashStable_Generic, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Encodable, Decodable, HashStable_Generic)]
 pub struct DelimSpan {
     pub open: Span,
     pub close: Span,
@@ -766,7 +756,7 @@ impl DelimSpan {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Encodable, Decodable, HashStable_Generic, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Encodable, Decodable, HashStable_Generic)]
 pub struct DelimSpacing {
     pub open: Spacing,
     pub close: Spacing,

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -26,10 +26,11 @@ use rustc_span::{sym, Span, SpanDecoder, SpanEncoder, Symbol, DUMMY_SP};
 use smallvec::{smallvec, SmallVec};
 
 use std::borrow::Cow;
+use std::hash::{Hash, Hasher};
 use std::{cmp, fmt, iter};
 
 /// Part of a `TokenStream`.
-#[derive(Debug, Clone, PartialEq, Encodable, Decodable, HashStable_Generic)]
+#[derive(Debug, Clone, PartialEq, Encodable, Decodable, HashStable_Generic, Hash)]
 pub enum TokenTree {
     /// A single token. Should never be `OpenDelim` or `CloseDelim`, because
     /// delimiters are implicitly represented by `Delimited`.
@@ -103,6 +104,14 @@ where
     fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
         for sub_tt in self.trees() {
             sub_tt.hash_stable(hcx, hasher);
+        }
+    }
+}
+
+impl Hash for TokenStream {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for sub_tt in self.trees() {
+            sub_tt.hash(state);
         }
     }
 }
@@ -297,7 +306,7 @@ pub struct TokenStream(pub(crate) Lrc<Vec<TokenTree>>);
 /// compound token. Used for conversions to `proc_macro::Spacing`. Also used to
 /// guide pretty-printing, which is where the `JointHidden` value (which isn't
 /// part of `proc_macro::Spacing`) comes in useful.
-#[derive(Clone, Copy, Debug, PartialEq, Encodable, Decodable, HashStable_Generic)]
+#[derive(Clone, Copy, Debug, PartialEq, Encodable, Decodable, HashStable_Generic, Hash)]
 pub enum Spacing {
     /// The token cannot join with the following token to form a compound
     /// token.
@@ -733,7 +742,7 @@ impl TokenTreeCursor {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Encodable, Decodable, HashStable_Generic)]
+#[derive(Debug, Copy, Clone, PartialEq, Encodable, Decodable, HashStable_Generic, Hash)]
 pub struct DelimSpan {
     pub open: Span,
     pub close: Span,
@@ -757,7 +766,7 @@ impl DelimSpan {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Encodable, Decodable, HashStable_Generic)]
+#[derive(Copy, Clone, Debug, PartialEq, Encodable, Decodable, HashStable_Generic, Hash)]
 pub struct DelimSpacing {
     pub open: Spacing,
     pub close: Spacing,

--- a/compiler/rustc_expand/Cargo.toml
+++ b/compiler/rustc_expand/Cargo.toml
@@ -20,6 +20,7 @@ rustc_fluent_macro = { path = "../rustc_fluent_macro" }
 rustc_lexer = { path = "../rustc_lexer" }
 rustc_lint_defs = { path = "../rustc_lint_defs" }
 rustc_macros = { path = "../rustc_macros" }
+rustc_middle = { path = "../rustc_middle" }
 rustc_parse = { path = "../rustc_parse" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_session = { path = "../rustc_session" }

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1043,7 +1043,6 @@ pub trait ResolverExpand {
     fn expand_legacy_bang(
         &self,
         invoc_id: LocalExpnId,
-        span: Span,
         current_expansion: LocalExpnId,
     ) -> Result<(TokenStream, usize), CanRetry>;
 }

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -395,13 +395,13 @@ pub struct MacroExpander<'a, 'b> {
 
 pub fn expand_legacy_bang<'tcx>(
     tcx: TyCtxt<'tcx>,
-    key: (LocalExpnId, Span, LocalExpnId),
+    key: (LocalExpnId, LocalExpnId),
 ) -> Result<(&'tcx TokenStream, usize), CanRetry> {
-    let (invoc_id, span, current_expansion) = key;
+    let (invoc_id, current_expansion) = key;
     let map = tcx.macro_map.borrow();
-    let (arg, expander) = map.get(&invoc_id).as_ref().unwrap();
+    let (arg, span, expander) = map.get(&invoc_id).as_ref().unwrap();
     expander
-        .expand(&tcx.sess, span, arg.clone(), current_expansion)
+        .expand(&tcx.sess, *span, arg.clone(), current_expansion)
         .map(|(tts, i)| (tcx.arena.alloc(tts) as &TokenStream, i))
 }
 
@@ -704,11 +704,11 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
 
                     // Macros defined in the current crate have a real node id,
                     // whereas macros from an external crate have a dummy id.\
-                    let tok_result: Box<dyn MacResult> = match self.cx.resolver.expand_legacy_bang(
-                        invoc.expansion_data.id,
-                        span,
-                        self.cx.current_expansion.id,
-                    ) {
+                    let tok_result: Box<dyn MacResult> = match self
+                        .cx
+                        .resolver
+                        .expand_legacy_bang(invoc.expansion_data.id, self.cx.current_expansion.id)
+                    {
                         Ok((tts, i)) => {
                             if self.cx.trace_macros() {
                                 let msg = format!("to `{}`", pprust::tts_to_string(&tts));

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -26,7 +26,8 @@ mod placeholders;
 mod proc_macro_server;
 
 pub use mbe::macro_rules::compile_declarative_macro;
-use rustc_middle::query::Providers;pub mod base;
+use rustc_middle::query::Providers;
+pub mod base;
 pub mod config;
 pub mod expand;
 pub mod module;

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -26,12 +26,16 @@ mod placeholders;
 mod proc_macro_server;
 
 pub use mbe::macro_rules::compile_declarative_macro;
-pub mod base;
+use rustc_middle::query::Providers;pub mod base;
 pub mod config;
 pub mod expand;
 pub mod module;
 // FIXME(Nilstrieb) Translate proc_macro diagnostics
 #[allow(rustc::untranslatable_diagnostic)]
 pub mod proc_macro;
+
+pub fn provide(providers: &mut Providers) {
+    providers.expand_legacy_bang = expand::expand_legacy_bang;
+}
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -18,7 +18,7 @@ use tracing::debug;
 
 use super::macro_rules::{parser_from_cx, NoopTracker};
 
-pub(super) fn failed_to_match_macro<'cx>(
+pub(crate) fn failed_to_match_macro<'cx>(
     cx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     def_span: Span,

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -388,7 +388,8 @@ fn maybe_use_metavar_location(
         })
     );
     if undelimited_seq {
-        // Do not record metavar spans for tokens from undelimited sequences, for perf reasons.        return orig_tt.clone();
+        // Do not record metavar spans for tokens from undelimited sequences, for perf reasons.
+        return orig_tt.clone();
     }
 
     let insert = |mspans: &mut FxHashMap<_, _>, s, ms| match mspans.try_insert(s, ms) {

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -620,6 +620,7 @@ pub static DEFAULT_QUERY_PROVIDERS: LazyLock<Providers> = LazyLock::new(|| {
     rustc_monomorphize::provide(providers);
     rustc_privacy::provide(providers);
     rustc_resolve::provide(providers);
+    rustc_expand::provide(providers);
     rustc_hir_analysis::provide(providers);
     rustc_hir_typeck::provide(providers);
     ty::provide(providers);

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -116,6 +116,7 @@ macro_rules! arena_types {
             [decode] specialization_graph: rustc_middle::traits::specialization_graph::Graph,
             [] crate_inherent_impls: rustc_middle::ty::CrateInherentImpls,
             [] hir_owner_nodes: rustc_hir::OwnerNodes<'tcx>,
+            [] expand_lagacy_bang: rustc_ast::tokenstream::TokenStream,
         ]);
     )
 }

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -116,7 +116,7 @@ macro_rules! arena_types {
             [decode] specialization_graph: rustc_middle::traits::specialization_graph::Graph,
             [] crate_inherent_impls: rustc_middle::ty::CrateInherentImpls,
             [] hir_owner_nodes: rustc_hir::OwnerNodes<'tcx>,
-            [] expand_lagacy_bang: rustc_ast::tokenstream::TokenStream,
+            [] expand_legacy_bang: rustc_ast::tokenstream::TokenStream,
         ]);
     )
 }

--- a/compiler/rustc_middle/src/expand.rs
+++ b/compiler/rustc_middle/src/expand.rs
@@ -1,0 +1,29 @@
+use rustc_ast::tokenstream::TokenStream;
+use rustc_ast::NodeId;
+use rustc_macros::HashStable_Generic;
+use rustc_session::Session;
+use rustc_span::symbol::Ident;
+use rustc_span::{ErrorGuaranteed, LocalExpnId, Span};
+
+pub trait TcxMacroExpander {
+    fn expand(
+        &self,
+        _sess: &Session,
+        _span: Span,
+        _input: TokenStream,
+        _expand_id: LocalExpnId,
+    ) -> Result<(TokenStream, usize), CanRetry>;
+
+    fn name(&self) -> Ident;
+
+    fn arm_span(&self, rhs: usize) -> Span;
+
+    fn node_id(&self) -> NodeId;
+}
+
+#[derive(Copy, Clone, HashStable_Generic, Debug)]
+pub enum CanRetry {
+    Yes,
+    /// We are not allowed to retry macro expansion as a fatal error has been emitted already.
+    No(ErrorGuaranteed),
+}

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -75,6 +75,7 @@ mod macros;
 #[macro_use]
 pub mod arena;
 pub mod error;
+pub mod expand;
 pub mod hir;
 pub mod hooks;
 pub mod infer;
@@ -92,6 +93,8 @@ mod values;
 pub mod query;
 #[macro_use]
 pub mod dep_graph;
+
+use rustc_span::HashStableContext;
 
 // Allows macros to refer to this crate as `::rustc_middle`
 extern crate self as rustc_middle;

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -3,6 +3,8 @@ use crate::query::CyclePlaceholder;
 use crate::traits;
 use crate::ty::adjustment::CoerceUnsizedInfo;
 use crate::ty::{self, Ty};
+use rustc_ast::tokenstream::TokenStream;
+use rustc_middle::expand::CanRetry;
 use std::intrinsics::transmute_unchecked;
 use std::mem::{size_of, MaybeUninit};
 
@@ -167,6 +169,10 @@ impl EraseType for Result<&'_ ty::List<Ty<'_>>, ty::util::AlwaysRequiresDrop> {
 
 impl EraseType for Result<ty::EarlyBinder<Ty<'_>>, CyclePlaceholder> {
     type Result = [u8; size_of::<Result<ty::EarlyBinder<Ty<'_>>, CyclePlaceholder>>()];
+}
+
+impl EraseType for Result<(&'_ TokenStream, usize), CanRetry> {
+    type Result = [u8; size_of::<Result<(&'_ TokenStream, usize), CanRetry>>()];
 }
 
 impl<T> EraseType for Option<&'_ T> {

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -11,7 +11,7 @@ use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, LocalModDefId, ModDefId, LO
 use rustc_hir::hir_id::{HirId, OwnerId};
 use rustc_query_system::query::{DefIdCache, DefaultCache, SingleCache, VecCache};
 use rustc_span::symbol::{Ident, Symbol};
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{LocalExpnId, Span, DUMMY_SP};
 use rustc_target::abi;
 
 /// Placeholder for `CrateNum`'s "local" counterpart
@@ -582,5 +582,17 @@ impl<'tcx> Key for (ValidityRequirement, ty::ParamEnvAnd<'tcx, Ty<'tcx>>) {
             ty::Adt(adt, _) => Some(adt.did()),
             _ => None,
         }
+    }
+}
+
+impl Key for (LocalExpnId, Span, LocalExpnId) {
+    type Cache<V> = DefaultCache<Self, V>;
+
+    fn default_span(&self, _: TyCtxt<'_>) -> Span {
+        self.1
+    }
+
+    fn ty_def_id(&self) -> Option<DefId> {
+        None
     }
 }

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -585,11 +585,11 @@ impl<'tcx> Key for (ValidityRequirement, ty::ParamEnvAnd<'tcx, Ty<'tcx>>) {
     }
 }
 
-impl Key for (LocalExpnId, Span, LocalExpnId) {
+impl Key for (LocalExpnId, LocalExpnId) {
     type Cache<V> = DefaultCache<Self, V>;
 
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
-        self.1
+        DUMMY_SP
     }
 
     fn ty_def_id(&self) -> Option<DefId> {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -118,10 +118,10 @@ rustc_queries! {
         desc { "triggering a delayed bug for testing incremental" }
     }
 
-    query expand_legacy_bang(key: (LocalExpnId, Span, LocalExpnId)) -> Result<(&'tcx TokenStream, usize), CanRetry> {
+    query expand_legacy_bang(key: (LocalExpnId, LocalExpnId)) -> Result<(&'tcx TokenStream, usize), CanRetry> {
         eval_always
         no_hash
-        desc { "expand lagacy bang" }
+        desc { "expand legacy bang" }
     }
 
     /// Collects the list of all tools registered using `#![register_tool]`.

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -120,6 +120,7 @@ rustc_queries! {
 
     query expand_legacy_bang(key: (LocalExpnId, Span, LocalExpnId)) -> Result<(&'tcx TokenStream, usize), CanRetry> {
         eval_always
+        no_hash
         desc { "expand lagacy bang" }
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -52,10 +52,13 @@ use crate::ty::{
     self, print::describe_as_module, CrateInherentImpls, ParamEnvAnd, Ty, TyCtxt,
     UnusedGenericParams,
 };
+
+use crate::expand::CanRetry;
 use crate::ty::{GenericArg, GenericArgsRef};
 use rustc_arena::TypedArena;
 use rustc_ast as ast;
 use rustc_ast::expand::{allocator::AllocatorKind, StrippedCfgItem};
+use rustc_ast::tokenstream::TokenStream;
 use rustc_attr as attr;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
@@ -82,7 +85,7 @@ use rustc_session::lint::LintExpectationId;
 use rustc_session::Limits;
 use rustc_span::def_id::LOCAL_CRATE;
 use rustc_span::symbol::Symbol;
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{LocalExpnId, Span, DUMMY_SP};
 use rustc_target::abi;
 use rustc_target::spec::PanicStrategy;
 use std::mem;
@@ -113,6 +116,11 @@ rustc_queries! {
     /// This exists purely for testing the interactions between delayed bugs and incremental.
     query trigger_delayed_bug(key: DefId) {
         desc { "triggering a delayed bug for testing incremental" }
+    }
+
+    query expand_legacy_bang(key: (LocalExpnId, Span, LocalExpnId)) -> Result<(&'tcx TokenStream, usize), CanRetry> {
+        eval_always
+        desc { "expand lagacy bang" }
     }
 
     /// Collects the list of all tools registered using `#![register_tool]`.

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -76,9 +76,10 @@ use rustc_type_ir::TyKind::*;
 use rustc_type_ir::WithCachedTypeInfo;
 use rustc_type_ir::{CollectAndApply, Interner, TypeFlags};
 
-use std::assert_matches::assert_matches;
 use rustc_ast::tokenstream::TokenStream;
-use rustc_middle::expand::TcxMacroExpander;use std::borrow::Borrow;
+use rustc_middle::expand::TcxMacroExpander;
+use std::assert_matches::assert_matches;
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -860,9 +861,10 @@ pub struct GlobalCtxt<'tcx> {
     pub macro_map: RwLock<
         FxHashMap<
             LocalExpnId,
-            (TokenStream, Lrc<dyn TcxMacroExpander + sync::DynSync + sync::DynSend>),
+            (TokenStream, Span, Lrc<dyn TcxMacroExpander + sync::DynSync + sync::DynSend>),
         >,
-    >,}
+    >,
+}
 
 impl<'tcx> GlobalCtxt<'tcx> {
     /// Installs `self` in a `TyCtxt` and `ImplicitCtxt` for the duration of

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -303,11 +303,11 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
             self.create_stable_hashing_context(),
         );
         if let SyntaxExtensionKind::TcxLegacyBang(tcx_expander) = &ext.kind {
-            if let InvocationKind::Bang { ref mac, .. } = invoc.kind {
+            if let InvocationKind::Bang { ref mac, span } = invoc.kind {
                 self.tcx
                     .macro_map
                     .borrow_mut()
-                    .insert(invoc_id, (mac.args.tokens.clone(), tcx_expander.clone()));
+                    .insert(invoc_id, (mac.args.tokens.clone(), span, tcx_expander.clone()));
             }
         }
 
@@ -466,11 +466,10 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
     fn expand_legacy_bang(
         &self,
         invoc_id: LocalExpnId,
-        span: Span,
         current_expansion: LocalExpnId,
     ) -> Result<(TokenStream, usize), CanRetry> {
         self.tcx()
-            .expand_legacy_bang((invoc_id, span, current_expansion))
+            .expand_legacy_bang((invoc_id, current_expansion))
             .map(|(tts, i)| (tts.clone(), i))
     }
 }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -1550,3 +1550,9 @@ impl<CTX: HashStableContext> HashStable<CTX> for ExpnId {
         hash.hash_stable(ctx, hasher);
     }
 }
+
+impl<CTX: HashStableContext> HashStable<CTX> for LocalExpnId {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+        self.to_expn_id().hash_stable(ctx, hasher)
+    }
+}


### PR DESCRIPTION
This is an attempt to make the macro expansion a part of incremental compilation.

Processing of procedural macros is difficult since they may involve interactions with the external environment. Declaring macros is a good start.

**It is not yet possible to test the effect of this PR on incremental compilation since the new query is declared as `eval_always`.**