### PR TITLE
Don't do cc detection for synthetic targets

### DIFF
--- a/src/bootstrap/src/core/build_steps/synthetic_targets.rs
+++ b/src/bootstrap/src/core/build_steps/synthetic_targets.rs
@@ -80,8 +80,5 @@ fn create_synthetic_target(
     customize(spec_map);
 
     std::fs::write(&path, serde_json::to_vec_pretty(&spec).unwrap()).unwrap();
-    let target = TargetSelection::create_synthetic(&name, path.to_str().unwrap());
-    crate::utils::cc_detect::find_target(builder, target);
-
-    target
+    TargetSelection::create_synthetic(&name, path.to_str().unwrap())
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/125365

Synthetic targets only exist for mir-opt tests, and the mir-opt test suite is in general designed to avoid any use of a C compiler. We don't need to do CC detection. It's unclear to me how this code didn't cause issues before.