### PR TITLE
Create a triagebot ping group for Rust for Linux

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -122,6 +122,8 @@ issues).
 """
 label = "O-apple"
 
+# This ping group is meant for situations where a rustc/stdlib change breaks RfL.
+# In that case, we want to notify the RfL group.
 [ping.rust-for-linux]
 alias = ["rfl"]
 message = """\

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -122,6 +122,17 @@ issues).
 """
 label = "O-apple"
 
+[ping.rust-for-linux]
+alias = ["rfl"]
+message = """\
+Hey Rust for Linux group! It looks like something broke the Rust for Linux integration.
+Could you try to take a look?
+In case it's useful, here are some [instructions] for tackling these sorts of issues.
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/rust-for-linux.html
+"""
+label = "O-rfl"
+
 [prioritize]
 label = "I-prioritize"
 


### PR DESCRIPTION
Corresponding rustc-dev-guide PR [here](https://github.com/rust-lang/rustc-dev-guide/pull/1984). Discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Testing.20Rust.20for.20Linux.20in.20our.20CI).