### PR TITLE
Simplify logic for unindenting doc comments

### DIFF
--- a/tests/rustdoc-ui/unescaped_backticks.stderr
+++ b/tests/rustdoc-ui/unescaped_backticks.stderr
@@ -280,11 +280,11 @@ LL | |     /// level changes.
    | |______________________^
    |
    = help: the opening backtick of a previous inline code may be missing
-            change: The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
-           to this: The `Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
+            change:  The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
+           to this:  The `Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
    = help: if you meant to use a literal backtick, escape it
-            change: `None`. Otherwise, it will return `Some(Dispatch)`.
-           to this: `None`. Otherwise, it will return `Some(Dispatch)\`.
+            change:  `None`. Otherwise, it will return `Some(Dispatch)`.
+           to this:  `None`. Otherwise, it will return `Some(Dispatch)\`.
 
 error: unescaped backtick
   --> $DIR/unescaped_backticks.rs:323:5
@@ -300,8 +300,8 @@ LL | |     /// level changes.
    |
    = help: the opening or closing backtick of an inline code may be missing
    = help: if you meant to use a literal backtick, escape it
-            change: or `None` if it isn't.
-           to this: or `None\` if it isn't.
+            change:  or `None` if it isn't.
+           to this:  or `None\` if it isn't.
 
 error: unescaped backtick
   --> $DIR/unescaped_backticks.rs:323:5
@@ -316,11 +316,11 @@ LL | |     /// level changes.
    | |______________________^
    |
    = help: a previous inline code might be longer than expected
-            change: Called before the filtered [`Layer]'s [`on_event`], to determine if
-           to this: Called before the filtered [`Layer`]'s [`on_event`], to determine if
+            change:  Called before the filtered [`Layer]'s [`on_event`], to determine if
+           to this:  Called before the filtered [`Layer`]'s [`on_event`], to determine if
    = help: if you meant to use a literal backtick, escape it
-            change: `on_event` should be called.
-           to this: `on_event\` should be called.
+            change:  `on_event` should be called.
+           to this:  `on_event\` should be called.
 
 error: unescaped backtick
   --> $DIR/unescaped_backticks.rs:323:5
@@ -335,11 +335,11 @@ LL | |     /// level changes.
    | |______________________^
    |
    = help: a previous inline code might be longer than expected
-            change: Therefore, if the `Filter will change the value returned by this
-           to this: Therefore, if the `Filter` will change the value returned by this
+            change:  Therefore, if the `Filter will change the value returned by this
+           to this:  Therefore, if the `Filter` will change the value returned by this
    = help: if you meant to use a literal backtick, escape it
-            change: [`rebuild_interest_cache`][rebuild] is called after the value of the max
-           to this: [`rebuild_interest_cache\`][rebuild] is called after the value of the max
+            change:  [`rebuild_interest_cache`][rebuild] is called after the value of the max
+           to this:  [`rebuild_interest_cache\`][rebuild] is called after the value of the max
 
 error: unescaped backtick
   --> $DIR/unescaped_backticks.rs:349:56

--- a/tests/rustdoc/unindent.rs
+++ b/tests/rustdoc/unindent.rs
@@ -40,7 +40,7 @@ pub struct G;
 pub struct H;
 
 // @has foo/struct.I.html
-// @matches - '//pre[@class="rust rust-example-rendered"]' '(?m)4 whitespaces!\Z'
+// @has - '//div[@class="docblock"]/p' '4 whitespaces! something'
 ///     4 whitespaces!
 #[doc = "something"]
 pub struct I;


### PR DESCRIPTION
Related to #65802 (but does not resolve it).

This has almost the same behavior, except that it completely ignores raw
doc comments (i.e., `#[doc = "..."]`) for the purposes of computing
indentation.
