### PR TITLE
Use correct param-env in `MissingCopyImplementations`

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -674,11 +674,10 @@ impl<'tcx> LateLintPass<'tcx> for MissingCopyImplementations {
                 return;
             }
         }
-        let param_env = ty::ParamEnv::empty();
-        if ty.is_copy_modulo_regions(cx.tcx, param_env) {
+        if ty.is_copy_modulo_regions(cx.tcx, cx.param_env) {
             return;
         }
-        if type_implements_negative_copy_modulo_regions(cx.tcx, ty, param_env) {
+        if type_implements_negative_copy_modulo_regions(cx.tcx, ty, cx.param_env) {
             return;
         }
         if def.is_variant_list_non_exhaustive()
@@ -694,7 +693,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingCopyImplementations {
                 .tcx
                 .infer_ctxt()
                 .build()
-                .type_implements_trait(iter_trait, [ty], param_env)
+                .type_implements_trait(iter_trait, [ty], cx.param_env)
                 .must_apply_modulo_regions()
         {
             return;
@@ -711,7 +710,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingCopyImplementations {
 
         if type_allowed_to_implement_copy(
             cx.tcx,
-            param_env,
+            cx.param_env,
             ty,
             traits::ObligationCause::misc(item.span, item.owner_id.def_id),
         )

--- a/tests/ui/lint/missing_copy_impl_trivial_bounds.rs
+++ b/tests/ui/lint/missing_copy_impl_trivial_bounds.rs
@@ -1,0 +1,21 @@
+//@ check-pass
+
+#![feature(trivial_bounds)]
+#![allow(trivial_bounds)]
+
+// Make sure that we still use the where-clauses from the struct when checking
+// if it may implement `Copy` unconditionally.
+// Fix for <https://github.com/rust-lang/rust/issues/125394>.
+
+pub trait Foo {
+    type Assoc;
+}
+
+pub struct Bar;
+
+// This needs to be public
+pub struct Baz2(<Bar as Foo>::Assoc)
+where
+    Bar: Foo;
+
+fn main() {}


### PR DESCRIPTION
We shouldn't assume the param-env is empty for this lint, since although we check the struct has no parameters, there still may be trivial where-clauses.

fixes #125394