### PR TITLE
Update `compiler-builtins` test to not clear essential env vars

### DIFF
--- a/tests/run-make/compiler-builtins/rmake.rs
+++ b/tests/run-make/compiler-builtins/rmake.rs
@@ -56,7 +56,6 @@ fn main() {
         "--target",
         &target,
     ])
-    .env_clear()
     .env("PATH", path)
     .env("RUSTC", rustc)
     .env("RUSTFLAGS", "-Copt-level=0 -Cdebug-assertions=yes")


### PR DESCRIPTION
Noticed in https://github.com/rust-lang/rust/pull/122580#issuecomment-2125755689, the `compiler-builtins` test failed on Windows for a `cargo` invocation because necessary env vars `TMP` and `TEMP` were cleared by `Command::env_clear`, causing temp dir eventually used by codegen to fallback to the Windows directory, which will trigger permission errors.

This PR removes the `env_clear` on the cargo invocation.

r? @saethlin (feel free to reroll, since you authored the test)

try-job: x86_64-msvc
try-job: test-various