### PR TITLE
Cleanup check-cfg handling in core and std

### DIFF
--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -46,6 +46,8 @@ check-cfg = [
     'cfg(bootstrap)',
     'cfg(no_fp_fmt_parse)',
     'cfg(stdarch_intel_sde)',
-    # This matches `EXTRA_CHECK_CFGS` in `src/bootstrap/src/lib.rs`.
+    # core use #[path] imports to portable-simd `core_simd` crate
+    # and to stdarch `core_arch` crate which messes-up with Cargo list
+    # of declared features, we therefor expect any feature cfg
     'cfg(feature, values(any()))',
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -100,6 +100,9 @@ test = true
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
+# x.py uses beta cargo, so `check-cfg` entries do not yet take effect
+# for rust-lang/rust. But for users of `-Zbuild-std` it does.
+# The unused warning is waiting for rust-lang/cargo#13925 to reach beta.
 check-cfg = [
     'cfg(bootstrap)',
     'cfg(target_arch, values("xtensa"))',

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -105,5 +105,8 @@ check-cfg = [
     'cfg(backtrace_in_libstd)',
     'cfg(netbsd10)',
     'cfg(target_arch, values("xtensa"))',
-    'cfg(feature, values("std", "as_crate"))',
+    # std use #[path] imports to portable-simd `std_float` crate
+    # and to the `backtrace` crate which messes-up with Cargo list
+    # of declared features, we therefor expect any feature cfg
+    'cfg(feature, values(any()))',
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -102,8 +102,6 @@ test = true
 level = "warn"
 check-cfg = [
     'cfg(bootstrap)',
-    'cfg(backtrace_in_libstd)',
-    'cfg(netbsd10)',
     'cfg(target_arch, values("xtensa"))',
     # std use #[path] imports to portable-simd `std_float` crate
     # and to the `backtrace` crate which messes-up with Cargo list

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -7,9 +7,12 @@ fn main() {
     let target_vendor =
         env::var("CARGO_CFG_TARGET_VENDOR").expect("CARGO_CFG_TARGET_VENDOR was not set");
     let target_env = env::var("CARGO_CFG_TARGET_ENV").expect("CARGO_CFG_TARGET_ENV was not set");
+
+    println!("cargo:rustc-check-cfg=cfg(netbsd10)");
     if target_os == "netbsd" && env::var("RUSTC_STD_NETBSD10").is_ok() {
         println!("cargo:rustc-cfg=netbsd10");
     }
+
     println!("cargo:rustc-check-cfg=cfg(restricted_std)");
     if target_os == "linux"
         || target_os == "android"
@@ -62,6 +65,9 @@ fn main() {
         // - Any new targets that have not been explicitly added above.
         println!("cargo:rustc-cfg=restricted_std");
     }
-    println!("cargo:rustc-env=STD_ENV_ARCH={}", env::var("CARGO_CFG_TARGET_ARCH").unwrap());
+
+    println!("cargo:rustc-check-cfg=cfg(backtrace_in_libstd)");
     println!("cargo:rustc-cfg=backtrace_in_libstd");
+
+    println!("cargo:rustc-env=STD_ENV_ARCH={}", env::var("CARGO_CFG_TARGET_ARCH").unwrap());
 }

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -10,6 +10,7 @@ fn main() {
     if target_os == "netbsd" && env::var("RUSTC_STD_NETBSD10").is_ok() {
         println!("cargo:rustc-cfg=netbsd10");
     }
+    println!("cargo:rustc-check-cfg=cfg(restricted_std)");
     if target_os == "linux"
         || target_os == "android"
         || target_os == "netbsd"
@@ -59,7 +60,7 @@ fn main() {
         // - arch=avr
         // - JSON targets
         // - Any new targets that have not been explicitly added above.
-        println!("cargo:rustc-cfg=feature=\"restricted-std\"");
+        println!("cargo:rustc-cfg=restricted_std");
     }
     println!("cargo:rustc-env=STD_ENV_ARCH={}", env::var("CARGO_CFG_TARGET_ARCH").unwrap());
     println!("cargo:rustc-cfg=backtrace_in_libstd");

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -213,9 +213,9 @@
 //! [array]: prim@array
 //! [slice]: prim@slice
 
-#![cfg_attr(not(feature = "restricted-std"), stable(feature = "rust1", since = "1.0.0"))]
+#![cfg_attr(not(restricted_std), stable(feature = "rust1", since = "1.0.0"))]
 #![cfg_attr(
-    feature = "restricted-std",
+    restricted_std,
     unstable(
         feature = "restricted_std",
         issue = "none",

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -94,6 +94,7 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
     (Some(Mode::Std), "no_sync", None),
     (Some(Mode::Std), "netbsd10", None),
     (Some(Mode::Std), "backtrace_in_libstd", None),
+    (Some(Mode::Std), "restricted_std", None),
     /* Extra values not defined in the built-in targets yet, but used in std */
     (Some(Mode::Std), "target_env", Some(&["libnx", "p2"])),
     (Some(Mode::Std), "target_os", Some(&["visionos"])),

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -92,9 +92,6 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
     (Some(Mode::Std), "no_global_oom_handling", None),
     (Some(Mode::Std), "no_rc", None),
     (Some(Mode::Std), "no_sync", None),
-    (Some(Mode::Std), "netbsd10", None),
-    (Some(Mode::Std), "backtrace_in_libstd", None),
-    (Some(Mode::Std), "restricted_std", None),
     /* Extra values not defined in the built-in targets yet, but used in std */
     (Some(Mode::Std), "target_env", Some(&["libnx", "p2"])),
     (Some(Mode::Std), "target_os", Some(&["visionos"])),


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/125296 where we:
 - expect any feature cfg in std, due to `#[path]` imports
 - move some check-cfg args inside the `build.rs` as per Cargo recommendation
 - and replace the fake Cargo feature `"restricted-std"` by the custom cfg `restricted_std`
 
Fixes https://github.com/rust-lang/rust/pull/125296#issuecomment-2127009301
r? @bjorn3 (maybe, feel free to re-roll)