### PR TITLE
Remove the limitation of try_lock being a protected function.

### DIFF
--- a/library/std/src/sync/reentrant_lock.rs
+++ b/library/std/src/sync/reentrant_lock.rs
@@ -222,7 +222,7 @@ impl<T: ?Sized> ReentrantLock<T> {
     /// Otherwise, an RAII guard is returned.
     ///
     /// This function does not block.
-    pub(crate) fn try_lock(&self) -> Option<ReentrantLockGuard<'_, T>> {
+    pub fn try_lock(&self) -> Option<ReentrantLockGuard<'_, T>> {
         let this_thread = current_thread_unique_ptr();
         // Safety: We only touch lock_count when we own the lock.
         unsafe {


### PR DESCRIPTION
This honestly looks like it was completely arbitrary to be limited to `pub(crate)` even though it didnt need to be like this.