### PR TITLE
Explicitly disable debug-assertions when building std for mir-opt tests

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -279,7 +279,7 @@ impl Step for Std {
         // debug-assertions is the only offending setting currently known, so we just stomp any
         // previous setting here, setting it to the value used in the distributed standard library.
         if self.is_for_mir_opt_tests {
-            cargo.rustflags("-Cdebug-assertions=no");
+            cargo.rustflag("-Cdebug-assertions=no");
         }
 
         let _guard = builder.msg(

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -274,6 +274,14 @@ impl Step for Std {
             cargo.rustflag(rustflag);
         }
 
+        // We want the eventual MIR produced in mir-opt tests to be immune to config settings, so
+        // that contributors do not get CI failures even though they have blessed the tests.
+        // debug-assertions is the only offending setting currently known, so we just stomp any
+        // previous setting here, setting it to the value used in the distributed standard library.
+        if self.is_for_mir_opt_tests {
+            cargo.rustflags("-Cdebug-assertions=no");
+        }
+
         let _guard = builder.msg(
             Kind::Build,
             compiler.stage,


### PR DESCRIPTION
Most users have debug-assertions enabled in their `config.toml`, which means that when they run the mir-opt tests or attempt to bless them, they get very different output from CI.

Adding the extra flag in here should stabilize the build config, and I'm selecting `no` because that is what we distribute so that makes the most sense in a codegen test.