### PR TITLE
Don't continue probing for method if in suggestion and autoderef hits ambiguity

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -395,8 +395,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // ambiguous.
         if let Some(bad_ty) = &steps.opt_bad_ty {
             if is_suggestion.0 {
-                // Ambiguity was encountered during a suggestion. Just keep going.
-                debug!("ProbeContext: encountered ambiguity in suggestion");
+                // Ambiguity was encountered during a suggestion. There's really
+                // not much use in suggesting methods in this case.
+                return Err(MethodError::NoMatch(NoMatchData {
+                    static_candidates: Vec::new(),
+                    unsatisfied_predicates: Vec::new(),
+                    out_of_scope_traits: Vec::new(),
+                    similar_candidate: None,
+                    mode,
+                }));
             } else if bad_ty.reached_raw_pointer
                 && !self.tcx.features().arbitrary_self_types
                 && !self.tcx.sess.at_least_rust_2018()

--- a/tests/ui/methods/suggest-method-on-call-for-ambig-receiver.rs
+++ b/tests/ui/methods/suggest-method-on-call-for-ambig-receiver.rs
@@ -1,0 +1,16 @@
+// Fix for <https://github.com/rust-lang/rust/issues/125432>.
+
+fn separate_arms() {
+    let mut x = None;
+    match x {
+        None => {
+            x = Some(0);
+        }
+        Some(right) => {
+            consume(right);
+            //~^ ERROR cannot find function `consume` in this scope
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/methods/suggest-method-on-call-for-ambig-receiver.stderr
+++ b/tests/ui/methods/suggest-method-on-call-for-ambig-receiver.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find function `consume` in this scope
+  --> $DIR/suggest-method-on-call-for-ambig-receiver.rs:10:13
+   |
+LL |             consume(right);
+   |             ^^^^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
The title is somewhat self-explanatory. When we hit ambiguity in method autoderef steps, we previously would continue to probe for methods if we were giving a suggestion. This seems useless, and causes an ICE when we are not able to unify the receiver later on in confirmation.

Fixes #125432