### PR TITLE
Only suppress binop error in favor of semicolon suggestion if we're in an assignment statement

### DIFF
--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -381,10 +381,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let maybe_missing_semi = self.check_for_missing_semi(expr, &mut err);
 
                 // We defer to the later error produced by `check_lhs_assignable`.
-                // We only downgrade this if it's the LHS, though.
+                // We only downgrade this if it's the LHS, though, and if this is a
+                // valid assignment statement.
                 if maybe_missing_semi
                     && let hir::Node::Expr(parent) = self.tcx.parent_hir_node(expr.hir_id)
                     && let hir::ExprKind::Assign(lhs, _, _) = parent.kind
+                    && let hir::Node::Stmt(stmt) = self.tcx.parent_hir_node(parent.hir_id)
+                    && let hir::StmtKind::Expr(_) | hir::StmtKind::Semi(_) = stmt.kind
                     && lhs.hir_id == expr.hir_id
                 {
                     err.downgrade_to_delayed_bug();

--- a/tests/ui/binop/nested-assignment-may-be-deref.rs
+++ b/tests/ui/binop/nested-assignment-may-be-deref.rs
@@ -1,0 +1,14 @@
+pub fn bad(x: &mut bool) {
+    if true
+    *x = true {}
+    //~^ ERROR cannot multiply `bool` by `&mut bool`
+}
+
+pub fn bad2(x: &mut bool) {
+    let y: bool;
+    y = true
+    *x = true;
+    //~^ ERROR cannot multiply `bool` by `&mut bool`
+}
+
+fn main() {}

--- a/tests/ui/binop/nested-assignment-may-be-deref.stderr
+++ b/tests/ui/binop/nested-assignment-may-be-deref.stderr
@@ -1,0 +1,29 @@
+error[E0369]: cannot multiply `bool` by `&mut bool`
+  --> $DIR/nested-assignment-may-be-deref.rs:3:5
+   |
+LL |     if true
+   |        ---- bool
+LL |     *x = true {}
+   |     ^- &mut bool
+   |
+help: you might have meant to write a semicolon here
+   |
+LL |     if true;
+   |            +
+
+error[E0369]: cannot multiply `bool` by `&mut bool`
+  --> $DIR/nested-assignment-may-be-deref.rs:10:5
+   |
+LL |     y = true
+   |         ---- bool
+LL |     *x = true;
+   |     ^- &mut bool
+   |
+help: you might have meant to write a semicolon here
+   |
+LL |     y = true;
+   |             +
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0369`.


### PR DESCRIPTION
Similar to #123722, we are currently too aggressive when delaying a binop error with the expectation that we'll emit another error elsewhere. This adjusts that heuristic to be more accurate, at the cost of some possibly poorer suggestions.

Fixes #125458