### PR TITLE
Don't skip out of inner const when looking for body for suggestion

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1871,11 +1871,8 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
         // If this is due to a block, then maybe we forgot a `return`/`break`.
         if due_to_block
             && let Some(expr) = expression
-            && let Some((parent_fn_decl, parent_id)) = fcx
-                .tcx
-                .hir()
-                .parent_iter(block_or_return_id)
-                .find_map(|(_, node)| Some((node.fn_decl()?, node.associated_body()?.0)))
+            && let Some(parent_fn_decl) =
+                fcx.tcx.hir().fn_decl_by_hir_id(fcx.tcx.local_def_id_to_hir_id(fcx.body_id))
         {
             fcx.suggest_missing_break_or_return_expr(
                 &mut err,
@@ -1884,7 +1881,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                 expected,
                 found,
                 block_or_return_id,
-                parent_id,
+                fcx.body_id,
             );
         }
 

--- a/tests/ui/return/dont-suggest-through-inner-const.rs
+++ b/tests/ui/return/dont-suggest-through-inner-const.rs
@@ -1,0 +1,9 @@
+const fn f() -> usize {
+    //~^ ERROR mismatched types
+    const FIELD: usize = loop {
+        0
+        //~^ ERROR mismatched types
+    };
+}
+
+fn main() {}

--- a/tests/ui/return/dont-suggest-through-inner-const.stderr
+++ b/tests/ui/return/dont-suggest-through-inner-const.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-through-inner-const.rs:4:9
+   |
+LL |         0
+   |         ^ expected `()`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-through-inner-const.rs:1:17
+   |
+LL | const fn f() -> usize {
+   |          -      ^^^^^ expected `usize`, found `()`
+   |          |
+   |          implicitly returns `()` as its body has no tail or `return` expression
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Self-explanatory title, I'll point out the important logic in an inline comment.

Fixes #125370