### PR TITLE
Fix the dead link in the bootstrap README

### DIFF
--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -6,7 +6,7 @@ and some of the technical details of the build system.
 Note that this README only covers internal information, not how to use the tool.
 Please check [bootstrapping dev guide][bootstrapping-dev-guide] for further information.
 
-[bootstrapping-dev-guide]: https://rustc-dev-guide.rust-lang.org/building/bootstrapping.html
+[bootstrapping-dev-guide]: https://rustc-dev-guide.rust-lang.org/building/bootstrapping/intro.html
 
 ## Introduction
 


### PR DESCRIPTION
This link has been changed since https://github.com/rust-lang/rustc-dev-guide/pull/1939