### PR TITLE
Migrate `run-make/rustdoc-with-output-dir-option` to `rmake.rs`

### DIFF
--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -228,7 +228,6 @@ run-make/rmeta-preferred/Makefile
 run-make/rustc-macro-dep-files/Makefile
 run-make/rustdoc-io-error/Makefile
 run-make/rustdoc-verify-output-files/Makefile
-run-make/rustdoc-with-output-option/Makefile
 run-make/sanitizer-cdylib-link/Makefile
 run-make/sanitizer-dylib-link/Makefile
 run-make/sanitizer-staticlib-link/Makefile

--- a/tests/run-make/rustdoc-with-output-option/Makefile
+++ b/tests/run-make/rustdoc-with-output-option/Makefile
@@ -1,8 +1,0 @@
-include ../tools.mk
-
-OUTPUT_DIR := "$(TMPDIR)/rustdoc"
-
-all:
-	$(RUSTDOC) src/lib.rs --crate-name foobar --crate-type lib --output $(OUTPUT_DIR)
-
-	$(HTMLDOCCK) $(OUTPUT_DIR) src/lib.rs

--- a/tests/run-make/rustdoc-with-output-option/rmake.rs
+++ b/tests/run-make/rustdoc-with-output-option/rmake.rs
@@ -1,0 +1,16 @@
+use run_make_support::{htmldocck, rustdoc, tmp_dir};
+
+fn main() {
+    let out_dir = tmp_dir().join("rustdoc");
+
+    rustdoc()
+        .input("src/lib.rs")
+        .crate_name("foobar")
+        .crate_type("lib")
+        // This is intentionally using `--output` option flag and not the `output()` method.
+        .arg("--output")
+        .arg(&out_dir)
+        .run();
+
+    assert!(htmldocck().arg(out_dir).arg("src/lib.rs").status().unwrap().success());
+}


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/121876.

r? @jieyouxu