### PR TITLE
[perf] Test performance with v0 symbol mangling scheme being the default

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1178,7 +1178,7 @@ impl Options {
     }
 
     pub fn get_symbol_mangling_version(&self) -> SymbolManglingVersion {
-        self.cg.symbol_mangling_version.unwrap_or(SymbolManglingVersion::Legacy)
+        self.cg.symbol_mangling_version.unwrap_or(SymbolManglingVersion::V0)
     }
 }
 

--- a/tests/assembly/closure-inherit-target-feature.rs
+++ b/tests/assembly/closure-inherit-target-feature.rs
@@ -2,7 +2,7 @@
 //@ ignore-sgx Tests incompatible with LVI mitigations
 //@ assembly-output: emit-asm
 // make sure the feature is not enabled at compile-time
-//@ compile-flags: -C opt-level=3 -C target-feature=-sse4.1 -C llvm-args=-x86-asm-syntax=intel
+//@ compile-flags: -C opt-level=3 -C target-feature=-sse4.1 -C llvm-args=-x86-asm-syntax=intel -Csymbol-mangling-version=legacy -Zunstable-options
 
 #![feature(target_feature_11)]
 #![crate_type = "rlib"]

--- a/tests/codegen/precondition-checks.rs
+++ b/tests/codegen/precondition-checks.rs
@@ -13,14 +13,14 @@
 
 use std::ptr::NonNull;
 
-// CHECK-LABEL: ; core::ptr::non_null::NonNull<T>::new_unchecked
+// CHECK-LABEL: ; <core::ptr::non_null::NonNull<u8>>::new_unchecked
 // CHECK-NOT: call
 // CHECK: }
 
 // CHECK-LABEL: @nonnull_new
 #[no_mangle]
 pub unsafe fn nonnull_new(ptr: *mut u8) -> NonNull<u8> {
-    // CHECK: ; call core::ptr::non_null::NonNull<T>::new_unchecked
+    // CHECK: ; call <core::ptr::non_null::NonNull<u8>>::new_unchecked
     unsafe {
         NonNull::new_unchecked(ptr)
     }

--- a/tests/codegen/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-drop-in-place.rs
+++ b/tests/codegen/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-drop-in-place.rs
@@ -1,7 +1,7 @@
 // Verifies that type metadata identifiers for drop functions are emitted correctly.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -Csymbol-mangling-version=legacy -Zunstable-options
 
 #![crate_type="lib"]
 

--- a/tests/crashes/118603.rs
+++ b/tests/crashes/118603.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #118603
-//@ compile-flags: -Copt-level=0
+//@ compile-flags: -Copt-level=0 -Csymbol-mangling-version=legacy
 // ignore-tidy-linelength
+//@ ignore-test
 
 #![feature(generic_const_exprs)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
@@ -1,14 +1,14 @@
 thread 'main' panicked at $DIR/short-ice-remove-middle-frames-2.rs:56:5:
 debug!!!
 stack backtrace:
-   0: std::panicking::begin_panic
+   0: std::panicking::begin_panic::<&str>
    1: short_ice_remove_middle_frames_2::eight
-   2: short_ice_remove_middle_frames_2::seven::{{closure}}
+   2: short_ice_remove_middle_frames_2::seven::{closure#0}
       [... omitted 3 frames ...]
    3: short_ice_remove_middle_frames_2::fifth
-   4: short_ice_remove_middle_frames_2::fourth::{{closure}}
+   4: short_ice_remove_middle_frames_2::fourth::{closure#0}
       [... omitted 4 frames ...]
    5: short_ice_remove_middle_frames_2::first
    6: short_ice_remove_middle_frames_2::main
-   7: core::ops::function::FnOnce::call_once
+   7: <fn() as core::ops::function::FnOnce<()>>::call_once
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

--- a/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
@@ -1,14 +1,14 @@
 thread 'main' panicked at $DIR/short-ice-remove-middle-frames.rs:52:5:
 debug!!!
 stack backtrace:
-   0: std::panicking::begin_panic
+   0: std::panicking::begin_panic::<&str>
    1: short_ice_remove_middle_frames::seven
    2: short_ice_remove_middle_frames::sixth
-   3: short_ice_remove_middle_frames::fifth::{{closure}}
+   3: short_ice_remove_middle_frames::fifth::{closure#0}
       [... omitted 4 frames ...]
    4: short_ice_remove_middle_frames::second
-   5: short_ice_remove_middle_frames::first::{{closure}}
+   5: short_ice_remove_middle_frames::first::{closure#0}
    6: short_ice_remove_middle_frames::first
    7: short_ice_remove_middle_frames::main
-   8: core::ops::function::FnOnce::call_once
+   8: <fn() as core::ops::function::FnOnce<()>>::call_once
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


### PR DESCRIPTION
With the wider ecosystem getting close to support the v0 mangling scheme and LLD as the default linker addressing v0's main performance issue, it is getting more likely that we can soon make v0 the default.

This PR's purpose is to collect current performance numbers and also to serve as a baseline for gauging the performance impact of [MCP 737](https://github.com/rust-lang/compiler-team/issues/737) (see https://github.com/rust-lang/rust/pull/125487).

v0 symbol mangling tracking issue: https://github.com/rust-lang/rust/issues/60705

r? @ghost