### PR TITLE
[do not merge] Proof of concept implementation of forward compatible v0 symbols (MCP 737)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
  "libc",
  "miniz_oxide",
  "object 0.32.2",
- "rustc-demangle",
+ "rustc-demangle 0.1.24",
 ]
 
 [[package]]
@@ -840,7 +840,7 @@ dependencies = [
  "md-5",
  "miniz_oxide",
  "regex",
- "rustc-demangle",
+ "rustc-demangle 0.1.25",
 ]
 
 [[package]]
@@ -3246,7 +3246,7 @@ name = "rust-demangler"
 version = "0.0.1"
 dependencies = [
  "regex",
- "rustc-demangle",
+ "rustc-demangle 0.1.24",
 ]
 
 [[package]]
@@ -3279,6 +3279,11 @@ dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "git+https://github.com/michaelwoerister/rustc-demangle.git?branch=skip_unknown#7e674e483a7c61803edc8d59f2641a4ad52a1a30"
 
 [[package]]
 name = "rustc-hash"
@@ -3551,7 +3556,7 @@ dependencies = [
  "libc",
  "measureme",
  "object 0.32.2",
- "rustc-demangle",
+ "rustc-demangle 0.1.25",
  "rustc_ast",
  "rustc_attr",
  "rustc_codegen_ssa",
@@ -4553,7 +4558,7 @@ name = "rustc_symbol_mangling"
 version = "0.0.0"
 dependencies = [
  "punycode",
- "rustc-demangle",
+ "rustc-demangle 0.1.25",
  "rustc_data_structures",
  "rustc_errors",
  "rustc_hir",
@@ -5147,7 +5152,7 @@ dependencies = [
  "r-efi-alloc",
  "rand",
  "rand_xorshift",
- "rustc-demangle",
+ "rustc-demangle 0.1.24",
  "std_detect",
  "unwind",
  "wasi",

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -13,7 +13,7 @@ itertools = "0.12"
 libc = "0.2"
 measureme = "11"
 object = { version = "0.32.0", default-features = false, features = ["std", "read"] }
-rustc-demangle = "0.1.21"
+rustc-demangle = { git = "https://github.com/michaelwoerister/rustc-demangle.git", branch = "skip_unknown" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_attr = { path = "../rustc_attr" }
 rustc_codegen_ssa = { path = "../rustc_codegen_ssa" }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1178,7 +1178,7 @@ impl Options {
     }
 
     pub fn get_symbol_mangling_version(&self) -> SymbolManglingVersion {
-        self.cg.symbol_mangling_version.unwrap_or(SymbolManglingVersion::Legacy)
+        self.cg.symbol_mangling_version.unwrap_or(SymbolManglingVersion::V0)
     }
 }
 

--- a/compiler/rustc_symbol_mangling/Cargo.toml
+++ b/compiler/rustc_symbol_mangling/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 # tidy-alphabetical-start
 punycode = "0.4.0"
-rustc-demangle = "0.1.21"
+rustc-demangle = { git = "https://github.com/michaelwoerister/rustc-demangle.git", branch = "skip_unknown" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_hir = { path = "../rustc_hir" }

--- a/src/tools/coverage-dump/Cargo.toml
+++ b/src/tools/coverage-dump/Cargo.toml
@@ -11,4 +11,4 @@ leb128 = "0.2.5"
 md5 = { package = "md-5" , version = "0.10.5" }
 miniz_oxide = "0.7.1"
 regex = "1.8.4"
-rustc-demangle = "0.1.23"
+rustc-demangle = { git = "https://github.com/michaelwoerister/rustc-demangle.git", branch = "skip_unknown" }

--- a/tests/assembly/closure-inherit-target-feature.rs
+++ b/tests/assembly/closure-inherit-target-feature.rs
@@ -2,7 +2,7 @@
 //@ ignore-sgx Tests incompatible with LVI mitigations
 //@ assembly-output: emit-asm
 // make sure the feature is not enabled at compile-time
-//@ compile-flags: -C opt-level=3 -C target-feature=-sse4.1 -C llvm-args=-x86-asm-syntax=intel
+//@ compile-flags: -C opt-level=3 -C target-feature=-sse4.1 -C llvm-args=-x86-asm-syntax=intel -Csymbol-mangling-version=legacy -Zunstable-options
 
 #![feature(target_feature_11)]
 #![crate_type = "rlib"]

--- a/tests/codegen/precondition-checks.rs
+++ b/tests/codegen/precondition-checks.rs
@@ -13,14 +13,14 @@
 
 use std::ptr::NonNull;
 
-// CHECK-LABEL: ; core::ptr::non_null::NonNull<T>::new_unchecked
+// CHECK-LABEL: ; <core::ptr::non_null::NonNull<u8>>::new_unchecked
 // CHECK-NOT: call
 // CHECK: }
 
 // CHECK-LABEL: @nonnull_new
 #[no_mangle]
 pub unsafe fn nonnull_new(ptr: *mut u8) -> NonNull<u8> {
-    // CHECK: ; call core::ptr::non_null::NonNull<T>::new_unchecked
+    // CHECK: ; call <core::ptr::non_null::NonNull<u8>>::new_unchecked
     unsafe {
         NonNull::new_unchecked(ptr)
     }

--- a/tests/codegen/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-drop-in-place.rs
+++ b/tests/codegen/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-drop-in-place.rs
@@ -1,7 +1,7 @@
 // Verifies that type metadata identifiers for drop functions are emitted correctly.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -Csymbol-mangling-version=legacy -Zunstable-options
 
 #![crate_type="lib"]
 

--- a/tests/crashes/118603.rs
+++ b/tests/crashes/118603.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #118603
-//@ compile-flags: -Copt-level=0
+//@ compile-flags: -Copt-level=0 -Csymbol-mangling-version=legacy
 // ignore-tidy-linelength
+//@ ignore-test
 
 #![feature(generic_const_exprs)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
@@ -1,14 +1,14 @@
 thread 'main' panicked at $DIR/short-ice-remove-middle-frames-2.rs:56:5:
 debug!!!
 stack backtrace:
-   0: std::panicking::begin_panic
+   0: std::panicking::begin_panic::<&str>
    1: short_ice_remove_middle_frames_2::eight
-   2: short_ice_remove_middle_frames_2::seven::{{closure}}
+   2: short_ice_remove_middle_frames_2::seven::{closure#0}
       [... omitted 3 frames ...]
    3: short_ice_remove_middle_frames_2::fifth
-   4: short_ice_remove_middle_frames_2::fourth::{{closure}}
+   4: short_ice_remove_middle_frames_2::fourth::{closure#0}
       [... omitted 4 frames ...]
    5: short_ice_remove_middle_frames_2::first
    6: short_ice_remove_middle_frames_2::main
-   7: core::ops::function::FnOnce::call_once
+   7: <fn() as core::ops::function::FnOnce<()>>::call_once
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

--- a/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
@@ -1,14 +1,14 @@
 thread 'main' panicked at $DIR/short-ice-remove-middle-frames.rs:52:5:
 debug!!!
 stack backtrace:
-   0: std::panicking::begin_panic
+   0: std::panicking::begin_panic::<&str>
    1: short_ice_remove_middle_frames::seven
    2: short_ice_remove_middle_frames::sixth
-   3: short_ice_remove_middle_frames::fifth::{{closure}}
+   3: short_ice_remove_middle_frames::fifth::{closure#0}
       [... omitted 4 frames ...]
    4: short_ice_remove_middle_frames::second
-   5: short_ice_remove_middle_frames::first::{{closure}}
+   5: short_ice_remove_middle_frames::first::{closure#0}
    6: short_ice_remove_middle_frames::first
    7: short_ice_remove_middle_frames::main
-   8: core::ops::function::FnOnce::call_once
+   8: <fn() as core::ops::function::FnOnce<()>>::call_once
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

--- a/tests/ui/symbol-names/const-generics-str-demangling.stderr
+++ b/tests/ui/symbol-names/const-generics-str-demangling.stderr
@@ -1,4 +1,4 @@
-error: symbol-name(_RMCsCRATE_HASH_1cINtB<REF>_3StrKRe616263_E)
+error: symbol-name(_RMCsCRATE_HASH_1cINtB<REF>_3StrC10_KRe616263_E)
   --> $DIR/const-generics-str-demangling.rs:9:1
    |
 LL | #[rustc_symbol_name]
@@ -16,7 +16,7 @@ error: demangling-alt(<c::Str<"abc">>)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs_CsCRATE_HASH_1cINtB<REF>_3StrKRe27_E)
+error: symbol-name(_RMs_CsCRATE_HASH_1cINtB<REF>_3StrC6_KRe27_E)
   --> $DIR/const-generics-str-demangling.rs:15:1
    |
 LL | #[rustc_symbol_name]
@@ -34,7 +34,7 @@ error: demangling-alt(<c::Str<"'">>)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs0_CsCRATE_HASH_1cINtB<REF>_3StrKRe090a_E)
+error: symbol-name(_RMs0_CsCRATE_HASH_1cINtB<REF>_3StrC8_KRe090a_E)
   --> $DIR/const-generics-str-demangling.rs:21:1
    |
 LL | #[rustc_symbol_name]
@@ -52,7 +52,7 @@ error: demangling-alt(<c::Str<"\t\n">>)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs1_CsCRATE_HASH_1cINtB<REF>_3StrKRee28882c3bc_E)
+error: symbol-name(_RMs1_CsCRATE_HASH_1cINtB<REF>_3StrC14_KRee28882c3bc_E)
   --> $DIR/const-generics-str-demangling.rs:27:1
    |
 LL | #[rustc_symbol_name]
@@ -70,7 +70,7 @@ error: demangling-alt(<c::Str<"∂ü">>)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs2_CsCRATE_HASH_1cINtB<REF>_3StrKRee183a1e18390e183ade1839be18394e1839ae18390e183935fe18392e18394e1839be183a0e18398e18394e1839ae183985fe183a1e18390e18393e18398e1839ae18398_E)
+error: symbol-name(_RMs2_CsCRATE_HASH_1cINtB<REF>_3StrC140_KRee183a1e18390e183ade1839be18394e1839ae18390e183935fe18392e18394e1839be183a0e18398e18394e1839ae183985fe183a1e18390e18393e18398e1839ae18398_E)
   --> $DIR/const-generics-str-demangling.rs:33:1
    |
 LL | #[rustc_symbol_name]
@@ -88,7 +88,7 @@ error: demangling-alt(<c::Str<"საჭმელად_გემრიელი
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs3_CsCRATE_HASH_1cINtB<REF>_3StrKRef09f908af09fa688f09fa686f09f90ae20c2a720f09f90b6f09f9192e29895f09f94a520c2a720f09fa7a1f09f929bf09f929af09f9299f09f929c_E)
+error: symbol-name(_RMs3_CsCRATE_HASH_1cINtB<REF>_3StrC122_KRef09f908af09fa688f09fa686f09f90ae20c2a720f09f90b6f09f9192e29895f09f94a520c2a720f09fa7a1f09f929bf09f929af09f9299f09f929c_E)
   --> $DIR/const-generics-str-demangling.rs:39:1
    |
 LL | #[rustc_symbol_name]

--- a/tests/ui/symbol-names/const-generics-structural-demangling.stderr
+++ b/tests/ui/symbol-names/const-generics-structural-demangling.stderr
@@ -1,4 +1,4 @@
-error: symbol-name(_RMCsCRATE_HASH_1cINtB<REF>_7RefByteKRh7b_E)
+error: symbol-name(_RMCsCRATE_HASH_1cINtB<REF>_7RefByteC6_KRh7b_E)
   --> $DIR/const-generics-structural-demangling.rs:13:1
    |
 LL | #[rustc_symbol_name]
@@ -16,7 +16,7 @@ error: demangling-alt(<c::RefByte<{&123}>>)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs_CsCRATE_HASH_1cINtB<REF>_6RefZstKRAEE)
+error: symbol-name(_RMs_CsCRATE_HASH_1cINtB<REF>_6RefZstC4_KRAEE)
   --> $DIR/const-generics-structural-demangling.rs:23:1
    |
 LL | #[rustc_symbol_name]
@@ -34,7 +34,7 @@ error: demangling-alt(<c::RefZst<{&[]}>>)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs0_CsCRATE_HASH_1cINtB<REF>_11Array3BytesKAh1_h2_h3_EE)
+error: symbol-name(_RMs0_CsCRATE_HASH_1cINtB<REF>_11Array3BytesC12_KAh1_h2_h3_EE)
   --> $DIR/const-generics-structural-demangling.rs:31:1
    |
 LL | #[rustc_symbol_name]
@@ -52,7 +52,7 @@ error: demangling-alt(<c::Array3Bytes<{[1, 2, 3]}>>)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs1_CsCRATE_HASH_1cINtB<REF>_13TupleByteBoolKTh1_b0_EE)
+error: symbol-name(_RMs1_CsCRATE_HASH_1cINtB<REF>_13TupleByteBoolC9_KTh1_b0_EE)
   --> $DIR/const-generics-structural-demangling.rs:39:1
    |
 LL | #[rustc_symbol_name]
@@ -70,7 +70,7 @@ error: demangling-alt(<c::TupleByteBool<{(1, false)}>>)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs2_CsCRATE_HASH_1cINtB<REF>_11OptionUsizeKVNtINtB<REF>_8MyOptionjE4NoneUE)
+error: symbol-name(_RMs2_CsCRATE_HASH_1cINtB<REF>_11OptionUsizeC27_KVNtINtB<REF>_8MyOptionjE4NoneUE)
   --> $DIR/const-generics-structural-demangling.rs:55:1
    |
 LL | #[rustc_symbol_name]
@@ -88,7 +88,7 @@ error: demangling-alt(<c::OptionUsize<{c::MyOption::<usize>::None}>>)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs3_CsCRATE_HASH_1cINtB<REF>_11OptionUsizeKVNtINtB<REF>_8MyOptionjE4SomeTj0_EE)
+error: symbol-name(_RMs3_CsCRATE_HASH_1cINtB<REF>_11OptionUsizeC31_KVNtINtB<REF>_8MyOptionjE4SomeTj0_EE)
   --> $DIR/const-generics-structural-demangling.rs:63:1
    |
 LL | #[rustc_symbol_name]
@@ -106,7 +106,7 @@ error: demangling-alt(<c::OptionUsize<{c::MyOption::<usize>::Some(0)}>>)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs4_CsCRATE_HASH_1cINtB<REF>_4Foo_KVNtB<REF>_3FooS1sRe616263_2chc78_5sliceRAh1_h2_h3_EEE)
+error: symbol-name(_RMs4_CsCRATE_HASH_1cINtB<REF>_4Foo_C49_KVNtB<REF>_3FooS1sRe616263_2chc78_5sliceRAh1_h2_h3_EEE)
   --> $DIR/const-generics-structural-demangling.rs:77:1
    |
 LL | #[rustc_symbol_name]
@@ -124,7 +124,7 @@ error: demangling-alt(<c::Foo_<{c::Foo { s: "abc", ch: 'x', slice: &[1, 2, 3] }}
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMsd_CsCRATE_HASH_1cINtB<REF>_4Bar_KVNtB<REF>_3BarS1xh7b_s_1xt1000_EE)
+error: symbol-name(_RMsd_CsCRATE_HASH_1cINtB<REF>_4Bar_C29_KVNtB<REF>_3BarS1xh7b_s_1xt1000_EE)
   --> $DIR/const-generics-structural-demangling.rs:93:5
    |
 LL |     #[rustc_symbol_name]


### PR DESCRIPTION
This PR changes v0 symbol names to enable graceful degradation for demanglers that don't support newer language features yet (as described in [MCP 737](https://github.com/rust-lang/compiler-team/issues/737)).

The corresponding changes in rustc-demangle are at https://github.com/michaelwoerister/rustc-demangle/tree/skip_unknown.

This proof-of-concept implementation is meant to help evaluating if MCP 737 is viable. 

r? @ghost
