### PR TITLE
rustdoc-json: Add test for keywords with `--document-private-items`

### DIFF
--- a/tests/rustdoc-json/keyword_private.rs
+++ b/tests/rustdoc-json/keyword_private.rs
@@ -1,0 +1,20 @@
+// Ensure keyword docs are present with --document-private-items
+
+//@ compile-flags: --document-private-items
+#![feature(rustdoc_internals)]
+
+// @!has "$.index[*][?(@.name=='match')]"
+// @has  "$.index[*][?(@.name=='foo')]"
+// @is   "$.index[*][?(@.name=='foo')].attrs" '["#[doc(keyword = \"match\")]"]'
+// @is   "$.index[*][?(@.name=='foo')].docs" '"this is a test!"'
+#[doc(keyword = "match")]
+/// this is a test!
+pub mod foo {}
+
+// @!has "$.index[*][?(@.name=='hello')]"
+// @has "$.index[*][?(@.name=='bar')]"
+// @is   "$.index[*][?(@.name=='bar')].attrs" '["#[doc(keyword = \"hello\")]"]'
+// @is   "$.index[*][?(@.name=='bar')].docs" '"hello"'
+#[doc(keyword = "hello")]
+/// hello
+mod bar {}


### PR DESCRIPTION
Turns out this does work as-expected. I was worried that the rustdoc's clean would produce a `ItemKind::KeywordItem` for the module, and loose the module itself. But turns out we get this right.

Prompted by [this discussion on zulip](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/Where.20to.20find.20keyword.20entries.20in.20JSON.20rustdoc)

r? @GuillaumeGomez 