### PR TITLE
Stop SRoA'ing `DynMetadata` in MIR

### DIFF
--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -70,6 +70,11 @@ fn escaping_locals<'tcx>(
                 // Exclude #[repr(simd)] types so that they are not de-optimized into an array
                 return true;
             }
+            if Some(def.did()) == tcx.lang_items().dyn_metadata() {
+                // codegen wants to see the `DynMetadata<T>`,
+                // not the inner reference-to-opaque-type.
+                return true;
+            }
             // We already excluded unions and enums, so this ADT must have one variant
             let variant = def.variant(FIRST_VARIANT);
             if variant.fields.len() > 1 {

--- a/tests/ui/mir/dyn_metadata_sroa.rs
+++ b/tests/ui/mir/dyn_metadata_sroa.rs
@@ -1,0 +1,19 @@
+//@ run-pass
+//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir
+
+#![feature(ptr_metadata)]
+
+// Regression for <https://github.com/rust-lang/rust/issues/125506>,
+// which failed because of SRoA would project into `DynMetadata`.
+
+trait Foo {}
+
+struct Bar;
+
+impl Foo for Bar {}
+
+fn main() {
+    let a: *mut dyn Foo = &mut Bar;
+
+    let _d = a.to_raw_parts().0 as usize;
+}


### PR DESCRIPTION
Fixes #125506

