### PR TITLE
Structurally resolve before `builtin_index` in EUV

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -1741,7 +1741,11 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
             }
 
             PatKind::Slice(before, ref slice, after) => {
-                let Some(element_ty) = place_with_id.place.ty().builtin_index() else {
+                let Some(element_ty) = self
+                    .cx
+                    .try_structurally_resolve_type(pat.span, place_with_id.place.ty())
+                    .builtin_index()
+                else {
                     debug!("explicit index of non-indexable type {:?}", place_with_id);
                     return Err(self
                         .cx

--- a/compiler/rustc_mir_build/src/build/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_place.rs
@@ -4,7 +4,6 @@ use crate::build::expr::category::Category;
 use crate::build::ForGuard::{OutsideGuard, RefWithinGuard};
 use crate::build::{BlockAnd, BlockAndExtension, Builder, Capture, CaptureMap};
 use rustc_hir::def_id::LocalDefId;
-use rustc_middle::bug;
 use rustc_middle::hir::place::Projection as HirProjection;
 use rustc_middle::hir::place::ProjectionKind as HirProjectionKind;
 use rustc_middle::middle::region;
@@ -13,6 +12,7 @@ use rustc_middle::mir::*;
 use rustc_middle::thir::*;
 use rustc_middle::ty::AdtDef;
 use rustc_middle::ty::{self, CanonicalUserTypeAnnotation, Ty, Variance};
+use rustc_middle::{bug, span_bug};
 use rustc_span::Span;
 use rustc_target::abi::{FieldIdx, VariantIdx, FIRST_VARIANT};
 use tracing::{debug, instrument, trace};
@@ -252,7 +252,18 @@ fn strip_prefix<'a, 'tcx>(
 
 impl<'tcx> PlaceBuilder<'tcx> {
     pub(in crate::build) fn to_place(&self, cx: &Builder<'_, 'tcx>) -> Place<'tcx> {
-        self.try_to_place(cx).unwrap()
+        self.try_to_place(cx).unwrap_or_else(|| match self.base {
+            PlaceBase::Local(local) => span_bug!(
+                cx.local_decls[local].source_info.span,
+                "could not resolve local: {local:#?} + {:?}",
+                self.projection
+            ),
+            PlaceBase::Upvar { var_hir_id, closure_def_id: _ } => span_bug!(
+                cx.tcx.hir().span(var_hir_id.0),
+                "could not resolve upvar: {var_hir_id:?} + {:?}",
+                self.projection
+            ),
+        })
     }
 
     /// Creates a `Place` or returns `None` if an upvar cannot be resolved

--- a/tests/ui/traits/next-solver/typeck/index-of-projection.rs
+++ b/tests/ui/traits/next-solver/typeck/index-of-projection.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Fixes a regression in `rustc_attr` where we weren't normalizing the
+// output type of a index operator performing a `Ty::builtin_index` call,
+// leading to an ICE.
+
+fn main() {
+    let mut vec = [1, 2, 3];
+    let x = || {
+        let [..] = &vec[..];
+    };
+}


### PR DESCRIPTION
r? lcnr