### PR TITLE
cleanup dependence of `ExtCtxt` in transcribe when macro expansion

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -224,7 +224,8 @@ fn expand_macro<'cx>(
             let arm_span = rhses[i].span();
 
             // rhs has holes ( `$id` and `$(...)` that need filled)
-            let tts = match transcribe(cx, &named_matches, rhs, rhs_span, transparency) {
+            let id = cx.current_expansion.id;
+            let tts = match transcribe(psess, &named_matches, rhs, rhs_span, transparency, id) {
                 Ok(tts) => tts,
                 Err(err) => {
                     let guar = err.emit();


### PR DESCRIPTION
part of #125356 
We can remove `transcribe`’s dependence on `ExtCtxt` to facilitate subsequent work (such as moving macro expansion into the incremental compilation system)

r? @petrochenkov 
Thanks for the reviewing!