### PR TITLE
Make lint: `lint_dropping_references` `lint_forgetting_copy_types` `lint_forgetting_references` give suggestion if possible. 

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -237,8 +237,6 @@ lint_dropping_copy_types = calls to `std::mem::drop` with a value that implement
 
 lint_dropping_references = calls to `std::mem::drop` with a reference instead of an owned value does nothing
     .label = argument has type `{$arg_ty}`
-    .note = use `let _ = ...` to ignore the expression or result
-    .suggestion = use `let _ = ...` to ignore the expression or result
 
 lint_duplicate_macro_attribute =
     duplicated attribute
@@ -273,12 +271,9 @@ lint_for_loops_over_fallibles =
 
 lint_forgetting_copy_types = calls to `std::mem::forget` with a value that implements `Copy` does nothing
     .label = argument has type `{$arg_ty}`
-    .note = use `let _ = ...` to ignore the expression or result
-    .suggestion = use `let _ = ...` to ignore the expression or result
 
 lint_forgetting_references = calls to `std::mem::forget` with a reference instead of an owned value does nothing
     .label = argument has type `{$arg_ty}`
-    .note = use `let _ = ...` to ignore the expression or result
 
 lint_hidden_glob_reexport = private item shadows public glob re-export
     .note_glob_reexport = the name `{$name}` in the {$namespace} namespace is supposed to be publicly re-exported here
@@ -896,6 +891,8 @@ lint_unused_op = unused {$op} that must be used
     .suggestion = use `let _ = ...` to ignore the resulting value
 
 lint_unused_result = unused result of type `{$ty}`
+
+lint_use_let_underscore_ignore_suggestion = use `let _ = ...` to ignore the expression or result
 
 lint_variant_size_differences =
     enum variant is more than three times larger ({$largest} bytes) than the next largest

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -238,6 +238,7 @@ lint_dropping_copy_types = calls to `std::mem::drop` with a value that implement
 lint_dropping_references = calls to `std::mem::drop` with a reference instead of an owned value does nothing
     .label = argument has type `{$arg_ty}`
     .note = use `let _ = ...` to ignore the expression or result
+    .suggestion = use `let _ = ...` to ignore the expression or result
 
 lint_duplicate_macro_attribute =
     duplicated attribute

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -232,8 +232,6 @@ lint_drop_trait_constraints =
 
 lint_dropping_copy_types = calls to `std::mem::drop` with a value that implements `Copy` does nothing
     .label = argument has type `{$arg_ty}`
-    .note = use `let _ = ...` to ignore the expression or result
-    .suggestion = use `let _ = ...` to ignore the expression or result
 
 lint_dropping_references = calls to `std::mem::drop` with a reference instead of an owned value does nothing
     .label = argument has type `{$arg_ty}`

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -274,6 +274,8 @@ lint_for_loops_over_fallibles =
 lint_forgetting_copy_types = calls to `std::mem::forget` with a value that implements `Copy` does nothing
     .label = argument has type `{$arg_ty}`
     .note = use `let _ = ...` to ignore the expression or result
+    .suggestion = use `let _ = ...` to ignore the expression or result
+
 lint_forgetting_references = calls to `std::mem::forget` with a reference instead of an owned value does nothing
     .label = argument has type `{$arg_ty}`
     .note = use `let _ = ...` to ignore the expression or result

--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -5,9 +5,8 @@ use rustc_span::sym;
 
 use crate::{
     lints::{
-        DropCopyDiag, DropCopySuggestion, DropRefDiag, ForgetCopyDiag, ForgetRefDiag,
-        UndroppedManuallyDropsDiag, UndroppedManuallyDropsSuggestion,
-        UseLetUnderscoreIgnoreSuggestion,
+        DropCopyDiag, DropRefDiag, ForgetCopyDiag, ForgetRefDiag, UndroppedManuallyDropsDiag,
+        UndroppedManuallyDropsSuggestion, UseLetUnderscoreIgnoreSuggestion,
     },
     LateContext, LateLintPass, LintContext,
 };
@@ -183,23 +182,14 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetUseless {
                     );
                 }
                 sym::mem_drop if is_copy && !drop_is_single_call_in_arm => {
-                    let sugg = if let Some((_, node)) = cx.tcx.hir().parent_iter(expr.hir_id).nth(0)
-                        && let Node::Stmt(stmt) = node
-                        && let StmtKind::Semi(e) = stmt.kind
-                        && e.hir_id == expr.hir_id
-                    {
-                        DropCopySuggestion::Suggestion {
-                            start_span: expr.span.shrink_to_lo().until(arg.span),
-                            end_span: arg.span.shrink_to_hi().until(expr.span.shrink_to_hi()),
-                        }
-                    } else {
-                        DropCopySuggestion::Note
-                    };
-
                     cx.emit_span_lint(
                         DROPPING_COPY_TYPES,
                         expr.span,
-                        DropCopyDiag { arg_ty, label: arg.span, sugg },
+                        DropCopyDiag {
+                            arg_ty,
+                            label: arg.span,
+                            sugg: let_underscore_ignore_sugg(),
+                        },
                     );
                 }
                 sym::mem_forget if is_copy => {

--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -5,8 +5,9 @@ use rustc_span::sym;
 
 use crate::{
     lints::{
-        DropCopyDiag, DropRefDiag, ForgetCopyDiag, ForgetRefDiag, IgnoreDropSuggestion,
+        DropCopyDiag, DropCopySuggestion, DropRefDiag, ForgetCopyDiag, ForgetRefDiag,
         UndroppedManuallyDropsDiag, UndroppedManuallyDropsSuggestion,
+        UseLetUnderscoreIgnoreSuggestion,
     },
     LateContext, LateLintPass, LintContext,
 };
@@ -148,31 +149,37 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetUseless {
             let arg_ty = cx.typeck_results().expr_ty(arg);
             let is_copy = arg_ty.is_copy_modulo_regions(cx.tcx, cx.param_env);
             let drop_is_single_call_in_arm = is_single_call_in_arm(cx, arg, expr);
-            let sugg = if let Some((_, node)) = cx.tcx.hir().parent_iter(expr.hir_id).nth(0)
-                && let Node::Stmt(stmt) = node
-                && let StmtKind::Semi(e) = stmt.kind
-                && e.hir_id == expr.hir_id
-            {
-                IgnoreDropSuggestion::Suggestion {
-                    start_span: expr.span.shrink_to_lo().until(arg.span),
-                    end_span: arg.span.shrink_to_hi().until(expr.span.shrink_to_hi()),
+            let let_underscore_ignore_sugg = || {
+                if let Some((_, node)) = cx.tcx.hir().parent_iter(expr.hir_id).nth(0)
+                    && let Node::Stmt(stmt) = node
+                    && let StmtKind::Semi(e) = stmt.kind
+                    && e.hir_id == expr.hir_id
+                {
+                    UseLetUnderscoreIgnoreSuggestion::Suggestion {
+                        start_span: expr.span.shrink_to_lo().until(arg.span),
+                        end_span: arg.span.shrink_to_hi().until(expr.span.shrink_to_hi()),
+                    }
+                } else {
+                    UseLetUnderscoreIgnoreSuggestion::Note
                 }
-            } else {
-                IgnoreDropSuggestion::Note
             };
             match fn_name {
                 sym::mem_drop if arg_ty.is_ref() && !drop_is_single_call_in_arm => {
                     cx.emit_span_lint(
                         DROPPING_REFERENCES,
                         expr.span,
-                        DropRefDiag { arg_ty, label: arg.span, sugg },
+                        DropRefDiag { arg_ty, label: arg.span, sugg: let_underscore_ignore_sugg() },
                     );
                 }
                 sym::mem_forget if arg_ty.is_ref() => {
                     cx.emit_span_lint(
                         FORGETTING_REFERENCES,
                         expr.span,
-                        ForgetRefDiag { arg_ty, label: arg.span },
+                        ForgetRefDiag {
+                            arg_ty,
+                            label: arg.span,
+                            sugg: let_underscore_ignore_sugg(),
+                        },
                     );
                 }
                 sym::mem_drop if is_copy && !drop_is_single_call_in_arm => {
@@ -199,7 +206,11 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetUseless {
                     cx.emit_span_lint(
                         FORGETTING_COPY_TYPES,
                         expr.span,
-                        ForgetCopyDiag { arg_ty, label: arg.span, sugg },
+                        ForgetCopyDiag {
+                            arg_ty,
+                            label: arg.span,
+                            sugg: let_underscore_ignore_sugg(),
+                        },
                     );
                 }
                 sym::mem_drop

--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -5,7 +5,7 @@ use rustc_span::sym;
 
 use crate::{
     lints::{
-        DropCopyDiag, DropCopySuggestion, DropRefDiag, ForgetCopyDiag, ForgetRefDiag,
+        DropCopyDiag, DropRefDiag, ForgetCopyDiag, ForgetRefDiag, IgnoreDropSuggestion,
         UndroppedManuallyDropsDiag, UndroppedManuallyDropsSuggestion,
     },
     LateContext, LateLintPass, LintContext,
@@ -148,12 +148,24 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetUseless {
             let arg_ty = cx.typeck_results().expr_ty(arg);
             let is_copy = arg_ty.is_copy_modulo_regions(cx.tcx, cx.param_env);
             let drop_is_single_call_in_arm = is_single_call_in_arm(cx, arg, expr);
+            let sugg = if let Some((_, node)) = cx.tcx.hir().parent_iter(expr.hir_id).nth(0)
+                && let Node::Stmt(stmt) = node
+                && let StmtKind::Semi(e) = stmt.kind
+                && e.hir_id == expr.hir_id
+            {
+                IgnoreDropSuggestion::Suggestion {
+                    start_span: expr.span.shrink_to_lo().until(arg.span),
+                    end_span: arg.span.shrink_to_hi().until(expr.span.shrink_to_hi()),
+                }
+            } else {
+                IgnoreDropSuggestion::Note
+            };
             match fn_name {
                 sym::mem_drop if arg_ty.is_ref() && !drop_is_single_call_in_arm => {
                     cx.emit_span_lint(
                         DROPPING_REFERENCES,
                         expr.span,
-                        DropRefDiag { arg_ty, label: arg.span },
+                        DropRefDiag { arg_ty, label: arg.span, sugg },
                     );
                 }
                 sym::mem_forget if arg_ty.is_ref() => {

--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -199,7 +199,7 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetUseless {
                     cx.emit_span_lint(
                         FORGETTING_COPY_TYPES,
                         expr.span,
-                        ForgetCopyDiag { arg_ty, label: arg.span },
+                        ForgetCopyDiag { arg_ty, label: arg.span, sugg },
                     );
                 }
                 sym::mem_drop

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -656,14 +656,28 @@ pub struct ForLoopsOverFalliblesSuggestion<'a> {
     pub end_span: Span,
 }
 
+#[derive(Subdiagnostic)]
+pub enum IgnoreDropSuggestion {
+    #[note(lint_note)]
+    Note,
+    #[multipart_suggestion(lint_suggestion, style = "verbose", applicability = "maybe-incorrect")]
+    Suggestion {
+        #[suggestion_part(code = "let _ = ")]
+        start_span: Span,
+        #[suggestion_part(code = "")]
+        end_span: Span,
+    },
+}
+
 // drop_forget_useless.rs
 #[derive(LintDiagnostic)]
 #[diag(lint_dropping_references)]
-#[note]
 pub struct DropRefDiag<'a> {
     pub arg_ty: Ty<'a>,
     #[label]
     pub label: Span,
+    #[subdiagnostic]
+    pub sugg: IgnoreDropSuggestion,
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -691,20 +691,7 @@ pub struct DropCopyDiag<'a> {
     #[label]
     pub label: Span,
     #[subdiagnostic]
-    pub sugg: DropCopySuggestion,
-}
-
-#[derive(Subdiagnostic)]
-pub enum DropCopySuggestion {
-    #[note(lint_note)]
-    Note,
-    #[multipart_suggestion(lint_suggestion, style = "verbose", applicability = "maybe-incorrect")]
-    Suggestion {
-        #[suggestion_part(code = "let _ = ")]
-        start_span: Span,
-        #[suggestion_part(code = "")]
-        end_span: Span,
-    },
+    pub sugg: UseLetUnderscoreIgnoreSuggestion,
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -657,10 +657,14 @@ pub struct ForLoopsOverFalliblesSuggestion<'a> {
 }
 
 #[derive(Subdiagnostic)]
-pub enum IgnoreDropSuggestion {
-    #[note(lint_note)]
+pub enum UseLetUnderscoreIgnoreSuggestion {
+    #[note(lint_use_let_underscore_ignore_suggestion)]
     Note,
-    #[multipart_suggestion(lint_suggestion, style = "verbose", applicability = "maybe-incorrect")]
+    #[multipart_suggestion(
+        lint_use_let_underscore_ignore_suggestion,
+        style = "verbose",
+        applicability = "maybe-incorrect"
+    )]
     Suggestion {
         #[suggestion_part(code = "let _ = ")]
         start_span: Span,
@@ -677,7 +681,7 @@ pub struct DropRefDiag<'a> {
     #[label]
     pub label: Span,
     #[subdiagnostic]
-    pub sugg: IgnoreDropSuggestion,
+    pub sugg: UseLetUnderscoreIgnoreSuggestion,
 }
 
 #[derive(LintDiagnostic)]
@@ -705,11 +709,12 @@ pub enum DropCopySuggestion {
 
 #[derive(LintDiagnostic)]
 #[diag(lint_forgetting_references)]
-#[note]
 pub struct ForgetRefDiag<'a> {
     pub arg_ty: Ty<'a>,
     #[label]
     pub label: Span,
+    #[subdiagnostic]
+    pub sugg: UseLetUnderscoreIgnoreSuggestion,
 }
 
 #[derive(LintDiagnostic)]
@@ -719,7 +724,7 @@ pub struct ForgetCopyDiag<'a> {
     #[label]
     pub label: Span,
     #[subdiagnostic]
-    pub sugg: IgnoreDropSuggestion,
+    pub sugg: UseLetUnderscoreIgnoreSuggestion,
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -714,11 +714,12 @@ pub struct ForgetRefDiag<'a> {
 
 #[derive(LintDiagnostic)]
 #[diag(lint_forgetting_copy_types)]
-#[note]
 pub struct ForgetCopyDiag<'a> {
     pub arg_ty: Ty<'a>,
     #[label]
     pub label: Span,
+    #[subdiagnostic]
+    pub sugg: IgnoreDropSuggestion,
 }
 
 #[derive(LintDiagnostic)]

--- a/tests/ui/lint/dropping_copy_types.stderr
+++ b/tests/ui/lint/dropping_copy_types.stderr
@@ -39,8 +39,12 @@ LL |     drop(s3);
    |          |
    |          argument has type `&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
    = note: `#[warn(dropping_references)]` on by default
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(s3);
+LL +     let _ = s3;
+   |
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
   --> $DIR/dropping_copy_types.rs:37:5
@@ -64,7 +68,11 @@ LL |     drop(s5);
    |          |
    |          argument has type `&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(s5);
+LL +     let _ = s5;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_copy_types.rs:50:5
@@ -74,7 +82,11 @@ LL |     drop(a2);
    |          |
    |          argument has type `&AnotherStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(a2);
+LL +     let _ = a2;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_copy_types.rs:52:5
@@ -84,7 +96,11 @@ LL |     drop(a4);
    |          |
    |          argument has type `&AnotherStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(a4);
+LL +     let _ = a4;
+   |
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
   --> $DIR/dropping_copy_types.rs:71:13

--- a/tests/ui/lint/dropping_references-can-fixed.fixed
+++ b/tests/ui/lint/dropping_references-can-fixed.fixed
@@ -1,0 +1,31 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(dropping_references)]
+
+struct SomeStruct;
+
+fn main() {
+    let _ = &SomeStruct; //~ ERROR calls to `std::mem::drop`
+
+    let mut owned1 = SomeStruct;
+    let _ = &owned1; //~ ERROR calls to `std::mem::drop`
+    let _ = &&owned1; //~ ERROR calls to `std::mem::drop`
+    let _ = &mut owned1; //~ ERROR calls to `std::mem::drop`
+    drop(owned1);
+
+    let reference1 = &SomeStruct;
+    let _ = reference1; //~ ERROR calls to `std::mem::drop`
+
+    let reference2 = &mut SomeStruct;
+    let _ = reference2; //~ ERROR calls to `std::mem::drop`
+
+    let ref reference3 = SomeStruct;
+    let _ = reference3; //~ ERROR calls to `std::mem::drop`
+}
+
+#[allow(dead_code)]
+fn test_generic_fn_drop<T>(val: T) {
+    let _ = &val; //~ ERROR calls to `std::mem::drop`
+    drop(val);
+}

--- a/tests/ui/lint/dropping_references-can-fixed.rs
+++ b/tests/ui/lint/dropping_references-can-fixed.rs
@@ -1,0 +1,31 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(dropping_references)]
+
+struct SomeStruct;
+
+fn main() {
+    drop(&SomeStruct); //~ ERROR calls to `std::mem::drop`
+
+    let mut owned1 = SomeStruct;
+    drop(&owned1); //~ ERROR calls to `std::mem::drop`
+    drop(&&owned1); //~ ERROR calls to `std::mem::drop`
+    drop(&mut owned1); //~ ERROR calls to `std::mem::drop`
+    drop(owned1);
+
+    let reference1 = &SomeStruct;
+    drop(reference1); //~ ERROR calls to `std::mem::drop`
+
+    let reference2 = &mut SomeStruct;
+    drop(reference2); //~ ERROR calls to `std::mem::drop`
+
+    let ref reference3 = SomeStruct;
+    drop(reference3); //~ ERROR calls to `std::mem::drop`
+}
+
+#[allow(dead_code)]
+fn test_generic_fn_drop<T>(val: T) {
+    drop(&val); //~ ERROR calls to `std::mem::drop`
+    drop(val);
+}

--- a/tests/ui/lint/dropping_references-can-fixed.stderr
+++ b/tests/ui/lint/dropping_references-can-fixed.stderr
@@ -1,0 +1,119 @@
+error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+  --> $DIR/dropping_references-can-fixed.rs:9:5
+   |
+LL |     drop(&SomeStruct);
+   |     ^^^^^-----------^
+   |          |
+   |          argument has type `&SomeStruct`
+   |
+note: the lint level is defined here
+  --> $DIR/dropping_references-can-fixed.rs:4:9
+   |
+LL | #![deny(dropping_references)]
+   |         ^^^^^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(&SomeStruct);
+LL +     let _ = &SomeStruct;
+   |
+
+error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+  --> $DIR/dropping_references-can-fixed.rs:12:5
+   |
+LL |     drop(&owned1);
+   |     ^^^^^-------^
+   |          |
+   |          argument has type `&SomeStruct`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(&owned1);
+LL +     let _ = &owned1;
+   |
+
+error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+  --> $DIR/dropping_references-can-fixed.rs:13:5
+   |
+LL |     drop(&&owned1);
+   |     ^^^^^--------^
+   |          |
+   |          argument has type `&&SomeStruct`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(&&owned1);
+LL +     let _ = &&owned1;
+   |
+
+error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+  --> $DIR/dropping_references-can-fixed.rs:14:5
+   |
+LL |     drop(&mut owned1);
+   |     ^^^^^-----------^
+   |          |
+   |          argument has type `&mut SomeStruct`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(&mut owned1);
+LL +     let _ = &mut owned1;
+   |
+
+error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+  --> $DIR/dropping_references-can-fixed.rs:18:5
+   |
+LL |     drop(reference1);
+   |     ^^^^^----------^
+   |          |
+   |          argument has type `&SomeStruct`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(reference1);
+LL +     let _ = reference1;
+   |
+
+error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+  --> $DIR/dropping_references-can-fixed.rs:21:5
+   |
+LL |     drop(reference2);
+   |     ^^^^^----------^
+   |          |
+   |          argument has type `&mut SomeStruct`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(reference2);
+LL +     let _ = reference2;
+   |
+
+error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+  --> $DIR/dropping_references-can-fixed.rs:24:5
+   |
+LL |     drop(reference3);
+   |     ^^^^^----------^
+   |          |
+   |          argument has type `&SomeStruct`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(reference3);
+LL +     let _ = reference3;
+   |
+
+error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+  --> $DIR/dropping_references-can-fixed.rs:29:5
+   |
+LL |     drop(&val);
+   |     ^^^^^----^
+   |          |
+   |          argument has type `&T`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(&val);
+LL +     let _ = &val;
+   |
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui/lint/dropping_references.stderr
+++ b/tests/ui/lint/dropping_references.stderr
@@ -6,12 +6,16 @@ LL |     drop(&SomeStruct);
    |          |
    |          argument has type `&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
 note: the lint level is defined here
   --> $DIR/dropping_references.rs:3:9
    |
 LL | #![warn(dropping_references)]
    |         ^^^^^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(&SomeStruct);
+LL +     let _ = &SomeStruct;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_references.rs:11:5
@@ -21,7 +25,11 @@ LL |     drop(&owned1);
    |          |
    |          argument has type `&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(&owned1);
+LL +     let _ = &owned1;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_references.rs:12:5
@@ -31,7 +39,11 @@ LL |     drop(&&owned1);
    |          |
    |          argument has type `&&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(&&owned1);
+LL +     let _ = &&owned1;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_references.rs:13:5
@@ -41,7 +53,11 @@ LL |     drop(&mut owned1);
    |          |
    |          argument has type `&mut SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(&mut owned1);
+LL +     let _ = &mut owned1;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_references.rs:17:5
@@ -51,7 +67,11 @@ LL |     drop(reference1);
    |          |
    |          argument has type `&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(reference1);
+LL +     let _ = reference1;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_references.rs:20:5
@@ -61,7 +81,11 @@ LL |     drop(reference2);
    |          |
    |          argument has type `&mut SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(reference2);
+LL +     let _ = reference2;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_references.rs:23:5
@@ -71,7 +95,11 @@ LL |     drop(reference3);
    |          |
    |          argument has type `&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(reference3);
+LL +     let _ = reference3;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_references.rs:28:5
@@ -81,7 +109,11 @@ LL |     drop(&val);
    |          |
    |          argument has type `&T`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(&val);
+LL +     let _ = &val;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_references.rs:36:5
@@ -91,7 +123,11 @@ LL |     std::mem::drop(&SomeStruct);
    |                    |
    |                    argument has type `&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     std::mem::drop(&SomeStruct);
+LL +     let _ = &SomeStruct;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_references.rs:91:13
@@ -101,7 +137,11 @@ LL |             drop(println_and(&13));
    |                  |
    |                  argument has type `&i32`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -             drop(println_and(&13));
+LL +             let _ = println_and(&13);
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_references.rs:94:14

--- a/tests/ui/lint/forgetting_copy_types-can-fixed.fixed
+++ b/tests/ui/lint/forgetting_copy_types-can-fixed.fixed
@@ -1,0 +1,22 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(forgetting_copy_types)]
+#![allow(unused_mut)]
+#![allow(unused_imports)]
+
+use std::vec::Vec;
+use std::mem::forget;
+
+#[derive(Copy, Clone)]
+struct SomeStruct;
+
+fn main() {
+    let s1 = SomeStruct {};
+    let s2 = s1;
+    let mut s3 = s1;
+
+    let _ = s1; //~ ERROR calls to `std::mem::forget`
+    let _ = s2; //~ ERROR calls to `std::mem::forget`
+    let _ = s3; //~ ERROR calls to `std::mem::forget`
+}

--- a/tests/ui/lint/forgetting_copy_types-can-fixed.rs
+++ b/tests/ui/lint/forgetting_copy_types-can-fixed.rs
@@ -1,0 +1,22 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(forgetting_copy_types)]
+#![allow(unused_mut)]
+#![allow(unused_imports)]
+
+use std::vec::Vec;
+use std::mem::forget;
+
+#[derive(Copy, Clone)]
+struct SomeStruct;
+
+fn main() {
+    let s1 = SomeStruct {};
+    let s2 = s1;
+    let mut s3 = s1;
+
+    forget(s1); //~ ERROR calls to `std::mem::forget`
+    forget(s2); //~ ERROR calls to `std::mem::forget`
+    forget(s3); //~ ERROR calls to `std::mem::forget`
+}

--- a/tests/ui/lint/forgetting_copy_types-can-fixed.stderr
+++ b/tests/ui/lint/forgetting_copy_types-can-fixed.stderr
@@ -1,0 +1,49 @@
+error: calls to `std::mem::forget` with a value that implements `Copy` does nothing
+  --> $DIR/forgetting_copy_types-can-fixed.rs:19:5
+   |
+LL |     forget(s1);
+   |     ^^^^^^^--^
+   |            |
+   |            argument has type `SomeStruct`
+   |
+note: the lint level is defined here
+  --> $DIR/forgetting_copy_types-can-fixed.rs:4:9
+   |
+LL | #![deny(forgetting_copy_types)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     forget(s1);
+LL +     let _ = s1;
+   |
+
+error: calls to `std::mem::forget` with a value that implements `Copy` does nothing
+  --> $DIR/forgetting_copy_types-can-fixed.rs:20:5
+   |
+LL |     forget(s2);
+   |     ^^^^^^^--^
+   |            |
+   |            argument has type `SomeStruct`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     forget(s2);
+LL +     let _ = s2;
+   |
+
+error: calls to `std::mem::forget` with a value that implements `Copy` does nothing
+  --> $DIR/forgetting_copy_types-can-fixed.rs:21:5
+   |
+LL |     forget(s3);
+   |     ^^^^^^^--^
+   |            |
+   |            argument has type `SomeStruct`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     forget(s3);
+LL +     let _ = s3;
+   |
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lint/forgetting_copy_types.stderr
+++ b/tests/ui/lint/forgetting_copy_types.stderr
@@ -6,12 +6,16 @@ LL |     forget(s1);
    |            |
    |            argument has type `SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
 note: the lint level is defined here
   --> $DIR/forgetting_copy_types.rs:3:9
    |
 LL | #![warn(forgetting_copy_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     forget(s1);
+LL +     let _ = s1;
+   |
 
 warning: calls to `std::mem::forget` with a value that implements `Copy` does nothing
   --> $DIR/forgetting_copy_types.rs:35:5
@@ -21,7 +25,11 @@ LL |     forget(s2);
    |            |
    |            argument has type `SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     forget(s2);
+LL +     let _ = s2;
+   |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
   --> $DIR/forgetting_copy_types.rs:36:5
@@ -42,7 +50,11 @@ LL |     forget(s4);
    |            |
    |            argument has type `SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     forget(s4);
+LL +     let _ = s4;
+   |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
   --> $DIR/forgetting_copy_types.rs:38:5

--- a/tests/ui/lint/forgetting_copy_types.stderr
+++ b/tests/ui/lint/forgetting_copy_types.stderr
@@ -39,8 +39,12 @@ LL |     forget(s3);
    |            |
    |            argument has type `&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
    = note: `#[warn(forgetting_references)]` on by default
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     forget(s3);
+LL +     let _ = s3;
+   |
 
 warning: calls to `std::mem::forget` with a value that implements `Copy` does nothing
   --> $DIR/forgetting_copy_types.rs:37:5
@@ -64,7 +68,11 @@ LL |     forget(s5);
    |            |
    |            argument has type `&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     forget(s5);
+LL +     let _ = s5;
+   |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
   --> $DIR/forgetting_copy_types.rs:50:5
@@ -74,7 +82,11 @@ LL |     forget(a2);
    |            |
    |            argument has type `&AnotherStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     forget(a2);
+LL +     let _ = a2;
+   |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
   --> $DIR/forgetting_copy_types.rs:52:5
@@ -84,7 +96,11 @@ LL |     forget(a3);
    |            |
    |            argument has type `&AnotherStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     forget(a3);
+LL +     let _ = a3;
+   |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
   --> $DIR/forgetting_copy_types.rs:53:5
@@ -94,7 +110,11 @@ LL |     forget(a4);
    |            |
    |            argument has type `&AnotherStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     forget(a4);
+LL +     let _ = a4;
+   |
 
 warning: 8 warnings emitted
 

--- a/tests/ui/lint/forgetting_references-can-fixed.fixed
+++ b/tests/ui/lint/forgetting_references-can-fixed.fixed
@@ -1,0 +1,40 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(forgetting_references)]
+
+use std::mem::forget;
+
+struct SomeStruct;
+
+fn main() {
+    let _ = &SomeStruct; //~ ERROR calls to `std::mem::forget`
+
+    let mut owned = SomeStruct;
+    let _ = &owned; //~ ERROR calls to `std::mem::forget`
+    let _ = &&owned; //~ ERROR calls to `std::mem::forget`
+    let _ = &mut owned; //~ ERROR calls to `std::mem::forget`
+    forget(owned);
+
+    let reference1 = &SomeStruct;
+    let _ = &*reference1; //~ ERROR calls to `std::mem::forget`
+
+    let reference2 = &mut SomeStruct;
+    let _ = reference2; //~ ERROR calls to `std::mem::forget`
+
+    let ref reference3 = SomeStruct;
+    let _ = reference3; //~ ERROR calls to `std::mem::forget`
+}
+
+#[allow(dead_code)]
+fn test_generic_fn_forget<T>(val: T) {
+    let _ = &val; //~ ERROR calls to `std::mem::forget`
+    forget(val);
+}
+
+#[allow(dead_code)]
+fn test_similarly_named_function() {
+    fn forget<T>(_val: T) {}
+    forget(&SomeStruct); //OK; call to unrelated function which happens to have the same name
+    let _ = &SomeStruct; //~ ERROR calls to `std::mem::forget`
+}

--- a/tests/ui/lint/forgetting_references-can-fixed.rs
+++ b/tests/ui/lint/forgetting_references-can-fixed.rs
@@ -1,0 +1,40 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(forgetting_references)]
+
+use std::mem::forget;
+
+struct SomeStruct;
+
+fn main() {
+    forget(&SomeStruct); //~ ERROR calls to `std::mem::forget`
+
+    let mut owned = SomeStruct;
+    forget(&owned); //~ ERROR calls to `std::mem::forget`
+    forget(&&owned); //~ ERROR calls to `std::mem::forget`
+    forget(&mut owned); //~ ERROR calls to `std::mem::forget`
+    forget(owned);
+
+    let reference1 = &SomeStruct;
+    forget(&*reference1); //~ ERROR calls to `std::mem::forget`
+
+    let reference2 = &mut SomeStruct;
+    forget(reference2); //~ ERROR calls to `std::mem::forget`
+
+    let ref reference3 = SomeStruct;
+    forget(reference3); //~ ERROR calls to `std::mem::forget`
+}
+
+#[allow(dead_code)]
+fn test_generic_fn_forget<T>(val: T) {
+    forget(&val); //~ ERROR calls to `std::mem::forget`
+    forget(val);
+}
+
+#[allow(dead_code)]
+fn test_similarly_named_function() {
+    fn forget<T>(_val: T) {}
+    forget(&SomeStruct); //OK; call to unrelated function which happens to have the same name
+    std::mem::forget(&SomeStruct); //~ ERROR calls to `std::mem::forget`
+}

--- a/tests/ui/lint/forgetting_references-can-fixed.stderr
+++ b/tests/ui/lint/forgetting_references-can-fixed.stderr
@@ -1,5 +1,5 @@
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:10:5
+error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+  --> $DIR/forgetting_references-can-fixed.rs:11:5
    |
 LL |     forget(&SomeStruct);
    |     ^^^^^^^-----------^
@@ -7,9 +7,9 @@ LL |     forget(&SomeStruct);
    |            argument has type `&SomeStruct`
    |
 note: the lint level is defined here
-  --> $DIR/forgetting_references.rs:3:9
+  --> $DIR/forgetting_references-can-fixed.rs:4:9
    |
-LL | #![warn(forgetting_references)]
+LL | #![deny(forgetting_references)]
    |         ^^^^^^^^^^^^^^^^^^^^^
 help: use `let _ = ...` to ignore the expression or result
    |
@@ -17,8 +17,8 @@ LL -     forget(&SomeStruct);
 LL +     let _ = &SomeStruct;
    |
 
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:13:5
+error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+  --> $DIR/forgetting_references-can-fixed.rs:14:5
    |
 LL |     forget(&owned);
    |     ^^^^^^^------^
@@ -31,8 +31,8 @@ LL -     forget(&owned);
 LL +     let _ = &owned;
    |
 
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:14:5
+error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+  --> $DIR/forgetting_references-can-fixed.rs:15:5
    |
 LL |     forget(&&owned);
    |     ^^^^^^^-------^
@@ -45,8 +45,8 @@ LL -     forget(&&owned);
 LL +     let _ = &&owned;
    |
 
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:15:5
+error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+  --> $DIR/forgetting_references-can-fixed.rs:16:5
    |
 LL |     forget(&mut owned);
    |     ^^^^^^^----------^
@@ -59,8 +59,8 @@ LL -     forget(&mut owned);
 LL +     let _ = &mut owned;
    |
 
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:19:5
+error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+  --> $DIR/forgetting_references-can-fixed.rs:20:5
    |
 LL |     forget(&*reference1);
    |     ^^^^^^^------------^
@@ -73,8 +73,8 @@ LL -     forget(&*reference1);
 LL +     let _ = &*reference1;
    |
 
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:22:5
+error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+  --> $DIR/forgetting_references-can-fixed.rs:23:5
    |
 LL |     forget(reference2);
    |     ^^^^^^^----------^
@@ -87,8 +87,8 @@ LL -     forget(reference2);
 LL +     let _ = reference2;
    |
 
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:25:5
+error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+  --> $DIR/forgetting_references-can-fixed.rs:26:5
    |
 LL |     forget(reference3);
    |     ^^^^^^^----------^
@@ -101,38 +101,8 @@ LL -     forget(reference3);
 LL +     let _ = reference3;
    |
 
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:31:14
-   |
-LL |         1 => forget(&*reference1),
-   |              ^^^^^^^------------^
-   |                     |
-   |                     argument has type `&SomeStruct`
-   |
-   = note: use `let _ = ...` to ignore the expression or result
-
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:32:14
-   |
-LL |         2 => forget(reference3),
-   |              ^^^^^^^----------^
-   |                     |
-   |                     argument has type `&SomeStruct`
-   |
-   = note: use `let _ = ...` to ignore the expression or result
-
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:33:14
-   |
-LL |         3 => forget(reference4),
-   |              ^^^^^^^----------^
-   |                     |
-   |                     argument has type `&SomeStruct`
-   |
-   = note: use `let _ = ...` to ignore the expression or result
-
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:40:5
+error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+  --> $DIR/forgetting_references-can-fixed.rs:31:5
    |
 LL |     forget(&val);
    |     ^^^^^^^----^
@@ -145,8 +115,8 @@ LL -     forget(&val);
 LL +     let _ = &val;
    |
 
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references.rs:48:5
+error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+  --> $DIR/forgetting_references-can-fixed.rs:39:5
    |
 LL |     std::mem::forget(&SomeStruct);
    |     ^^^^^^^^^^^^^^^^^-----------^
@@ -159,5 +129,5 @@ LL -     std::mem::forget(&SomeStruct);
 LL +     let _ = &SomeStruct;
    |
 
-warning: 12 warnings emitted
+error: aborting due to 9 previous errors
 

--- a/tests/ui/lint/forgetting_references.rs
+++ b/tests/ui/lint/forgetting_references.rs
@@ -23,6 +23,16 @@ fn main() {
 
     let ref reference3 = SomeStruct;
     forget(reference3); //~ WARN calls to `std::mem::forget`
+
+    let ref reference4 = SomeStruct;
+
+    let a = 1;
+    match a {
+        1 => forget(&*reference1), //~ WARN calls to `std::mem::forget`
+        2 => forget(reference3), //~ WARN calls to `std::mem::forget`
+        3 => forget(reference4), //~ WARN calls to `std::mem::forget`
+        _ => {}
+    }
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
This is a follow-up PR of  #125433. When it's merged, I want change lint `dropping_copy_types` to use the same `Subdiagnostic` struct `UseLetUnderscoreIgnoreSuggestion` which is added in this PR.

Hi, Thank you(@Urgau ) again for your help in the previous PR.  If your time permits, please also take a look at this one. 

r? compiler

<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->