### PR TITLE
Also mention my-self for other check-cfg docs changes

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -794,6 +794,9 @@ cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 [mentions."src/doc/rustc/src/check-cfg.md"]
 cc = ["@Urgau"]
 
+[mentions."src/doc/rustc/src/check-cfg"]
+cc = ["@Urgau"]
+
 [mentions."src/doc/rustc/src/platform-support"]
 cc = ["@Nilstrieb"]
 


### PR DESCRIPTION
This PR adds a mention for my-self for the recently added `src/doc/rustc/src/check-cfg` directory.

*I had to add a second mention just for the directory since [`Path::starts_with`](https://doc.rust-lang.org/std/path/struct.Path.html#method.starts_with) as used by [triagebot](https://github.com/rust-lang/triagebot/blob/48f29f351cae774caa90f555fbbc6d0df7dce80e/src/handlers/mentions.rs#L69), matches on path components and so can never return true for a file and directory at the same time.*