### PR TITLE
Try to not reinstall tools in mingw CI

### DIFF
--- a/src/ci/scripts/install-mingw.sh
+++ b/src/ci/scripts/install-mingw.sh
@@ -12,7 +12,7 @@ source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 MINGW_ARCHIVE_32="i686-12.2.0-release-posix-dwarf-rt_v10-rev0.7z"
 MINGW_ARCHIVE_64="x86_64-12.2.0-release-posix-seh-rt_v10-rev0.7z"
 
-if isWindows; then
+if isWindows && isKnownToBeMingwBuild; then
     case "${CI_JOB_NAME}" in
         *i686*)
             bits=32
@@ -39,10 +39,7 @@ if isWindows; then
     esac
 
     if [[ "${CUSTOM_MINGW:-0}" == 0 ]]; then
-        pacboy -S --noconfirm toolchain:p
-        # According to the comment in the Windows part of install-clang.sh, in the future we might
-        # want to do this instead:
-        # pacboy -S --noconfirm clang:p ...
+        pacman -S --noconfirm --needed mingw-w64-$arch-toolchain
     else
         mingw_dir="mingw${bits}"
 

--- a/src/ci/scripts/install-msys2.sh
+++ b/src/ci/scripts/install-msys2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Clean up and prepare the MSYS2 installation. MSYS2 is needed primarily for
-# the test suite (run-make), but is also used by the MinGW toolchain for assembling things.
+# Clean up and prepare the MSYS2 installation.
+# MSYS2 is used by the MinGW toolchain for assembling things.
 
 set -euo pipefail
 IFS=$'\n\t'
@@ -24,38 +24,4 @@ if isWindows; then
     fi
     ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64"
     ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64\\Scripts"
-
-    # Install pacboy for easily installing packages
-    pacman -S --noconfirm pactoys
-
-    # Remove these pre-installed tools so we can't accidentally use them, because we are using the
-    # MSYS2 setup action versions instead. Because `rm -r`-ing them is slow, we mv them off path
-    # instead.
-    # Remove pre-installed version of MSYS2
-    echo "Cleaning up existing tools in PATH"
-    notpath="/c/NOT/ON/PATH/"
-    mkdir --parents "$notpath"
-    mv -t "$notpath" "/c/msys64/"
-    # Remove Strawberry Perl, which contains a version of mingw
-    mv -t "$notpath" "/c/Strawberry/"
-    # Remove these other copies of mingw, I don't even know where they come from.
-    mv -t "$notpath" "/c/mingw64/"
-    mv -t "$notpath" "/c/mingw32/"
-    echo "Finished cleaning up tools in PATH"
-
-    if isKnownToBeMingwBuild; then
-        # Use the mingw version of CMake for mingw builds.
-        # However, the MSVC build needs native CMake, as it fails with the mingw one.
-        # Delete native CMake
-        rm -r "/c/Program Files/CMake/"
-        # Install mingw-w64-$arch-cmake
-        pacboy -S --noconfirm cmake:p
-
-        # It would be nice to use MSYS's git in MinGW builds so that it's tested and known to
-        # work. But it makes everything extremely slow, so it's commented out for now.
-        # # Delete Windows-Git
-        # rm -r "/c/Program Files/Git/"
-        # # Install MSYS2 git
-        # pacman -S --noconfirm git
-    fi
 fi


### PR DESCRIPTION
Reinstalling the tools seems prone to failure (e.g. [latest](https://github.com/rust-lang/rust/pull/125529#issuecomment-2130919307)) and is more work. It also seems unnecessary as CI actually uses a vendored tarball for builds.

cc @mati865