### PR TITLE
Simplify dropck remark on PhantomData

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -724,9 +724,9 @@ impl<T: ?Sized> !Sync for *mut T {}
 ///
 /// The exact interaction of `PhantomData` with drop check **may change in the future**.
 ///
-/// Currently, adding a field of type `PhantomData<T>` indicates that your type *owns* data of type
-/// `T` in very rare circumstances. This in turn has effects on the Rust compiler's [drop check]
-/// analysis. For the exact rules, see the [drop check] documentation.
+/// Currently, adding a field of type `PhantomData<T>` indicates the type *owns* data of type `T`.
+/// In very rare circumstances, this has effects on the Rust compiler's [drop check] analysis.
+/// For the exact rules, see the [drop check] documentation.
 ///
 /// ## Layout
 ///


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/125540

This is more similar to the original draft but there was a recommended change to the current form, along with injecting the caveat above it. I don't understand why, I found the previous phrasing more clear: "this indicates (thing) but (thing) matters only rarely".

r? @lcnr