### PR TITLE
Recover statics better

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -403,7 +403,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<Ty
 
         Node::Item(item) => match item.kind {
             ItemKind::Static(ty, .., body_id) => {
-                if ty.is_suggestable_infer_ty() {
+                if ty.is_suggestable_infer_ty() || ty.references_error().is_some() {
                     infer_placeholder_type(
                         tcx,
                         def_id,

--- a/tests/crashes/124164.rs
+++ b/tests/crashes/124164.rs
@@ -1,4 +1,0 @@
-//@ known-bug: #124164
-static S_COUNT: = std::sync::atomic::AtomicUsize::new(0);
-
-fn main() {}

--- a/tests/ui/generic-const-items/assoc-const-missing-type.rs
+++ b/tests/ui/generic-const-items/assoc-const-missing-type.rs
@@ -13,6 +13,7 @@ impl Trait for () {
     //~^ ERROR missing type for `const` item
     //~| ERROR mismatched types
     //~| ERROR mismatched types
+    //~| ERROR implemented const `K` has an incompatible type for trait
     const Q = "";
     //~^ ERROR missing type for `const` item
     //~| ERROR lifetime parameters or bounds on const `Q` do not match the trait declaration

--- a/tests/ui/generic-const-items/assoc-const-missing-type.stderr
+++ b/tests/ui/generic-const-items/assoc-const-missing-type.stderr
@@ -15,8 +15,24 @@ error: missing type for `const` item
 LL |     const K<T> = ();
    |               ^ help: provide a type for the associated constant: `()`
 
+error[E0326]: implemented const `K` has an incompatible type for trait
+  --> $DIR/assoc-const-missing-type.rs:12:15
+   |
+LL |     const K<T> = ();
+   |             - ^ expected type parameter `T`, found `()`
+   |             |
+   |             expected this type parameter
+   |
+note: type in trait
+  --> $DIR/assoc-const-missing-type.rs:7:17
+   |
+LL |     const K<T>: T;
+   |                 ^
+   = note: expected type parameter `T`
+                   found unit type `()`
+
 error[E0195]: lifetime parameters or bounds on const `Q` do not match the trait declaration
-  --> $DIR/assoc-const-missing-type.rs:16:12
+  --> $DIR/assoc-const-missing-type.rs:17:12
    |
 LL |     const Q<'a>: &'a str;
    |            ---- lifetimes in impl do not match this const in trait
@@ -25,7 +41,7 @@ LL |     const Q = "";
    |            ^ lifetimes do not match const in trait
 
 error: missing type for `const` item
-  --> $DIR/assoc-const-missing-type.rs:16:12
+  --> $DIR/assoc-const-missing-type.rs:17:12
    |
 LL |     const Q = "";
    |            ^ help: provide a type for the associated constant: `: &str`
@@ -42,7 +58,7 @@ LL |     const K<T> = ();
                    found unit type `()`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0195, E0308.
+Some errors have detailed explanations: E0195, E0308, E0326.
 For more information about an error, try `rustc --explain E0195`.

--- a/tests/ui/impl-trait/issues/issue-86642.rs
+++ b/tests/ui/impl-trait/issues/issue-86642.rs
@@ -1,5 +1,7 @@
 static x: impl Fn(&str) -> Result<&str, ()> = move |source| {
-    //~^ `impl Trait` is not allowed in static types
+    //~^ ERROR `impl Trait` is not allowed in static types
+    //~| ERROR cycle detected when computing type of `x`
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for static variables
     let res = (move |source| Ok(source))(source);
     let res = res.or((move |source| Ok(source))(source));
     res

--- a/tests/ui/impl-trait/issues/issue-86642.stderr
+++ b/tests/ui/impl-trait/issues/issue-86642.stderr
@@ -6,6 +6,37 @@ LL | static x: impl Fn(&str) -> Result<&str, ()> = move |source| {
    |
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
-error: aborting due to 1 previous error
+error[E0391]: cycle detected when computing type of `x`
+  --> $DIR/issue-86642.rs:1:1
+   |
+LL | static x: impl Fn(&str) -> Result<&str, ()> = move |source| {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires type-checking `x`...
+  --> $DIR/issue-86642.rs:1:1
+   |
+LL | static x: impl Fn(&str) -> Result<&str, ()> = move |source| {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires computing the opaque types defined by `x`...
+  --> $DIR/issue-86642.rs:1:1
+   |
+LL | static x: impl Fn(&str) -> Result<&str, ()> = move |source| {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires computing type of `x`, completing the cycle
+note: cycle used when checking that `x` is well-formed
+  --> $DIR/issue-86642.rs:1:1
+   |
+LL | static x: impl Fn(&str) -> Result<&str, ()> = move |source| {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-For more information about this error, try `rustc --explain E0562`.
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
+  --> $DIR/issue-86642.rs:1:11
+   |
+LL | static x: impl Fn(&str) -> Result<&str, ()> = move |source| {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not allowed in type signatures
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0121, E0391, E0562.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/static/error-type-interior-mutable.rs
+++ b/tests/ui/static/error-type-interior-mutable.rs
@@ -1,0 +1,8 @@
+// A regression test for #124164
+// const-eval used to complain because the allocation was mutable (due to the atomic)
+// while it expected `{type error}` allocations to be immutable.
+
+static S_COUNT: = std::sync::atomic::AtomicUsize::new(0);
+//~^ ERROR missing type for `static` item
+
+fn main() {}

--- a/tests/ui/static/error-type-interior-mutable.stderr
+++ b/tests/ui/static/error-type-interior-mutable.stderr
@@ -1,0 +1,8 @@
+error: missing type for `static` item
+  --> $DIR/error-type-interior-mutable.rs:5:16
+   |
+LL | static S_COUNT: = std::sync::atomic::AtomicUsize::new(0);
+   |                ^ help: provide a type for the static variable: `AtomicUsize`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -583,7 +583,10 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:209:14
    |
 LL |     const D: _ = 42;
-   |              ^ not allowed in type signatures
+   |              ^
+   |              |
+   |              not allowed in type signatures
+   |              help: replace with the correct type: `i32`
 
 error[E0046]: not all trait items implemented, missing: `F`
   --> $DIR/typeck_type_placeholder_item.rs:200:1


### PR DESCRIPTION
The const interner uses the body to intern static allocations.
This means that an allocation will be mutable if the resulting type contains interior mutability.
Const eval contains an assertion that types that are `Freeze` do not have mutable allocations, which was failing for cases where the type was a type error.

The first two commits fix this by forwarding the inferred type through `type_of`, while the last commit disables the assertion for remaining cases where type errors are involved.

Note that the erased region mapping is not fully correct, and causes this spurious error now:
```rust
struct X<'a>(&'a ());
impl<'a> X<'a> {
  const A: &'a () = &();
  const B = Self::A;
}
```
```
error: lifetime may not live long enough
 --> uwu.rs:4:13
  |
2 | impl<'a> X<'a> {
  |      -- lifetime `'a` defined here
3 |   const A: &'a () = &();
4 |   const B = Self::A;
  |             ^^^^^^^ using this value as a constant requires that `'a` must outlive `'static`
```
I deem that acceptable, that you may disagree.

note: the commit messages contain more information

fixes #124164

r? oli-obk 