### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -224,7 +224,8 @@ fn expand_macro<'cx>(
             let arm_span = rhses[i].span();
 
             // rhs has holes ( `$id` and `$(...)` that need filled)
-            let tts = match transcribe(cx, &named_matches, rhs, rhs_span, transparency) {
+            let id = cx.current_expansion.id;
+            let tts = match transcribe(psess, &named_matches, rhs, rhs_span, transparency, id) {
                 Ok(tts) => tts,
                 Err(err) => {
                     let guar = err.emit();

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -197,6 +197,7 @@ lint_drop_trait_constraints =
 lint_dropping_copy_types = calls to `std::mem::drop` with a value that implements `Copy` does nothing
     .label = argument has type `{$arg_ty}`
     .note = use `let _ = ...` to ignore the expression or result
+    .suggestion = use `let _ = ...` to ignore the expression or result
 
 lint_dropping_references = calls to `std::mem::drop` with a reference instead of an owned value does nothing
     .label = argument has type `{$arg_ty}`

--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -1,11 +1,11 @@
-use rustc_hir::{Arm, Expr, ExprKind, Node};
+use rustc_hir::{Arm, Expr, ExprKind, Node, StmtKind};
 use rustc_middle::ty;
 use rustc_span::sym;
 
 use crate::{
     lints::{
-        DropCopyDiag, DropRefDiag, ForgetCopyDiag, ForgetRefDiag, UndroppedManuallyDropsDiag,
-        UndroppedManuallyDropsSuggestion,
+        DropCopyDiag, DropCopySuggestion, DropRefDiag, ForgetCopyDiag, ForgetRefDiag,
+        UndroppedManuallyDropsDiag, UndroppedManuallyDropsSuggestion,
     },
     LateContext, LateLintPass, LintContext,
 };
@@ -163,10 +163,23 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetUseless {
                     );
                 }
                 sym::mem_drop if is_copy && !drop_is_single_call_in_arm => {
+                    let sugg = if let Some((_, node)) = cx.tcx.hir().parent_iter(expr.hir_id).nth(0)
+                        && let Node::Stmt(stmt) = node
+                        && let StmtKind::Semi(e) = stmt.kind
+                        && e.hir_id == expr.hir_id
+                    {
+                        DropCopySuggestion::Suggestion {
+                            start_span: expr.span.shrink_to_lo().until(arg.span),
+                            end_span: arg.span.shrink_to_hi().until(expr.span.shrink_to_hi()),
+                        }
+                    } else {
+                        DropCopySuggestion::Note
+                    };
+
                     cx.emit_span_lint(
                         DROPPING_COPY_TYPES,
                         expr.span,
-                        DropCopyDiag { arg_ty, label: arg.span },
+                        DropCopyDiag { arg_ty, label: arg.span, sugg },
                     );
                 }
                 sym::mem_forget if is_copy => {

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -669,11 +669,25 @@ pub struct DropRefDiag<'a> {
 
 #[derive(LintDiagnostic)]
 #[diag(lint_dropping_copy_types)]
-#[note]
 pub struct DropCopyDiag<'a> {
     pub arg_ty: Ty<'a>,
     #[label]
     pub label: Span,
+    #[subdiagnostic]
+    pub sugg: DropCopySuggestion,
+}
+
+#[derive(Subdiagnostic)]
+pub enum DropCopySuggestion {
+    #[note(lint_note)]
+    Note,
+    #[multipart_suggestion(lint_suggestion, style = "verbose", applicability = "maybe-incorrect")]
+    Suggestion {
+        #[suggestion_part(code = "let _ = ")]
+        start_span: Span,
+        #[suggestion_part(code = "")]
+        end_span: Span,
+    },
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -70,6 +70,11 @@ fn escaping_locals<'tcx>(
                 // Exclude #[repr(simd)] types so that they are not de-optimized into an array
                 return true;
             }
+            if Some(def.did()) == tcx.lang_items().dyn_metadata() {
+                // codegen wants to see the `DynMetadata<T>`,
+                // not the inner reference-to-opaque-type.
+                return true;
+            }
             // We already excluded unions and enums, so this ADT must have one variant
             let variant = def.variant(FIRST_VARIANT);
             if variant.fields.len() > 1 {

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
@@ -99,6 +99,13 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
             previous call to `try_evaluate_added_goals!`"
         );
 
+        // We only check for leaks from universes which were entered inside
+        // of the query.
+        self.infcx.leak_check(self.max_input_universe, None).map_err(|e| {
+            trace!(?e, "failed the leak check");
+            NoSolution
+        })?;
+
         // When normalizing, we've replaced the expected term with an unconstrained
         // inference variable. This means that we dropped information which could
         // have been important. We handle this by instead returning the nested goals
@@ -121,7 +128,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         };
 
         let external_constraints =
-            self.compute_external_query_constraints(normalization_nested_goals)?;
+            self.compute_external_query_constraints(certainty, normalization_nested_goals);
         let (var_values, mut external_constraints) =
             (self.var_values, external_constraints).fold_with(&mut EagerResolver::new(self.infcx));
         // Remove any trivial region constraints once we've resolved regions
@@ -170,30 +177,37 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
     #[instrument(level = "trace", skip(self), ret)]
     fn compute_external_query_constraints(
         &self,
+        certainty: Certainty,
         normalization_nested_goals: NestedNormalizationGoals<'tcx>,
-    ) -> Result<ExternalConstraintsData<'tcx>, NoSolution> {
-        // We only check for leaks from universes which were entered inside
-        // of the query.
-        self.infcx.leak_check(self.max_input_universe, None).map_err(|e| {
-            trace!(?e, "failed the leak check");
-            NoSolution
-        })?;
+    ) -> ExternalConstraintsData<'tcx> {
+        // We only return region constraints once the certainty is `Yes`. This
+        // is necessary as we may drop nested goals on ambiguity, which may result
+        // in unconstrained inference variables in the region constraints. It also
+        // prevents us from emitting duplicate region constraints, avoiding some
+        // unnecessary work. This slightly weakens the leak check in case it uses
+        // region constraints from an ambiguous nested goal. This is tested in both
+        // `tests/ui/higher-ranked/leak-check/leak-check-in-selection-5-ambig.rs` and
+        // `tests/ui/higher-ranked/leak-check/leak-check-in-selection-6-ambig-unify.rs`.
+        let region_constraints = if certainty == Certainty::Yes {
+            // Cannot use `take_registered_region_obligations` as we may compute the response
+            // inside of a `probe` whenever we have multiple choices inside of the solver.
+            let region_obligations = self.infcx.inner.borrow().region_obligations().to_owned();
+            let mut region_constraints = self.infcx.with_region_constraints(|region_constraints| {
+                make_query_region_constraints(
+                    self.tcx(),
+                    region_obligations.iter().map(|r_o| {
+                        (r_o.sup_type, r_o.sub_region, r_o.origin.to_constraint_category())
+                    }),
+                    region_constraints,
+                )
+            });
 
-        // Cannot use `take_registered_region_obligations` as we may compute the response
-        // inside of a `probe` whenever we have multiple choices inside of the solver.
-        let region_obligations = self.infcx.inner.borrow().region_obligations().to_owned();
-        let mut region_constraints = self.infcx.with_region_constraints(|region_constraints| {
-            make_query_region_constraints(
-                self.tcx(),
-                region_obligations
-                    .iter()
-                    .map(|r_o| (r_o.sup_type, r_o.sub_region, r_o.origin.to_constraint_category())),
-                region_constraints,
-            )
-        });
-
-        let mut seen = FxHashSet::default();
-        region_constraints.outlives.retain(|outlives| seen.insert(*outlives));
+            let mut seen = FxHashSet::default();
+            region_constraints.outlives.retain(|outlives| seen.insert(*outlives));
+            region_constraints
+        } else {
+            Default::default()
+        };
 
         let mut opaque_types = self.infcx.clone_opaque_types_for_query_response();
         // Only return opaque type keys for newly-defined opaques
@@ -201,7 +215,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
             self.predefined_opaques_in_body.opaque_types.iter().all(|(pa, _)| pa != a)
         });
 
-        Ok(ExternalConstraintsData { region_constraints, opaque_types, normalization_nested_goals })
+        ExternalConstraintsData { region_constraints, opaque_types, normalization_nested_goals }
     }
 
     /// After calling a canonical query, we apply the constraints returned

--- a/src/ci/scripts/install-mingw.sh
+++ b/src/ci/scripts/install-mingw.sh
@@ -39,10 +39,10 @@ if isWindows; then
     esac
 
     if [[ "${CUSTOM_MINGW:-0}" == 0 ]]; then
-        pacboy -S --noconfirm toolchain:p
-        # According to the comment in the Windows part of install-clang.sh, in the future we might
-        # want to do this instead:
-        # pacboy -S --noconfirm clang:p ...
+        pacman -S --noconfirm --needed mingw-w64-$arch-toolchain mingw-w64-$arch-cmake \
+            mingw-w64-$arch-gcc \
+            mingw-w64-$arch-python # the python package is actually for python3
+        ciCommandAddPath "$(ciCheckoutPath)/msys2/mingw${bits}/bin"
     else
         mingw_dir="mingw${bits}"
 

--- a/src/ci/scripts/install-msys2.sh
+++ b/src/ci/scripts/install-msys2.sh
@@ -7,6 +7,8 @@ IFS=$'\n\t'
 
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 if isWindows; then
+    ciCommandAddPath "c:/msys64/usr/bin"
+
     # Detect the native Python version installed on the agent. On GitHub
     # Actions, the C:\hostedtoolcache\windows\Python directory contains a
     # subdirectory for each installed Python version.
@@ -24,38 +26,4 @@ if isWindows; then
     fi
     ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64"
     ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64\\Scripts"
-
-    # Install pacboy for easily installing packages
-    pacman -S --noconfirm pactoys
-
-    # Remove these pre-installed tools so we can't accidentally use them, because we are using the
-    # MSYS2 setup action versions instead. Because `rm -r`-ing them is slow, we mv them off path
-    # instead.
-    # Remove pre-installed version of MSYS2
-    echo "Cleaning up existing tools in PATH"
-    notpath="/c/NOT/ON/PATH/"
-    mkdir --parents "$notpath"
-    mv -t "$notpath" "/c/msys64/"
-    # Remove Strawberry Perl, which contains a version of mingw
-    mv -t "$notpath" "/c/Strawberry/"
-    # Remove these other copies of mingw, I don't even know where they come from.
-    mv -t "$notpath" "/c/mingw64/"
-    mv -t "$notpath" "/c/mingw32/"
-    echo "Finished cleaning up tools in PATH"
-
-    if isKnownToBeMingwBuild; then
-        # Use the mingw version of CMake for mingw builds.
-        # However, the MSVC build needs native CMake, as it fails with the mingw one.
-        # Delete native CMake
-        rm -r "/c/Program Files/CMake/"
-        # Install mingw-w64-$arch-cmake
-        pacboy -S --noconfirm cmake:p
-
-        # It would be nice to use MSYS's git in MinGW builds so that it's tested and known to
-        # work. But it makes everything extremely slow, so it's commented out for now.
-        # # Delete Windows-Git
-        # rm -r "/c/Program Files/Git/"
-        # # Install MSYS2 git
-        # pacman -S --noconfirm git
-    fi
 fi

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -16,7 +16,6 @@ const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 
 const ISSUES_ENTRY_LIMIT: usize = 1676;
-const ROOT_ENTRY_LIMIT: usize = 757;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files
@@ -63,14 +62,10 @@ fn check_entries(tests_path: &Path, bad: &mut bool) {
         }
     }
 
-    let (mut max, mut max_root, mut max_issues) = (0usize, 0usize, 0usize);
+    let (mut max, mut max_issues) = (0usize, 0usize);
     for (dir_path, count) in directories {
-        // Use special values for these dirs.
-        let is_root = tests_path.join("ui") == dir_path;
         let is_issues_dir = tests_path.join("ui/issues") == dir_path;
-        let (limit, maxcnt) = if is_root {
-            (ROOT_ENTRY_LIMIT, &mut max_root)
-        } else if is_issues_dir {
+        let (limit, maxcnt) = if is_issues_dir {
             (ISSUES_ENTRY_LIMIT, &mut max_issues)
         } else {
             (ENTRY_LIMIT, &mut max)
@@ -86,12 +81,6 @@ fn check_entries(tests_path: &Path, bad: &mut bool) {
                 dir_path.display()
             );
         }
-    }
-    if ROOT_ENTRY_LIMIT > max_root {
-        tidy_error!(
-            bad,
-            "`ROOT_ENTRY_LIMIT` is too high (is {ROOT_ENTRY_LIMIT}, should be {max_root})"
-        );
     }
     if ISSUES_ENTRY_LIMIT > max_issues {
         tidy_error!(

--- a/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
@@ -6,8 +6,12 @@ LL |     drop(origin);
    |          |
    |          argument has type `<T as UncheckedCopy>::Output`
    |
-   = note: use `let _ = ...` to ignore the expression or result
    = note: `#[warn(dropping_copy_types)]` on by default
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(origin);
+LL +     let _ = origin;
+   |
 
 warning: 1 warning emitted
 

--- a/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
@@ -6,8 +6,12 @@ LL |     drop(origin);
    |          |
    |          argument has type `<T as UncheckedCopy>::Output`
    |
-   = note: use `let _ = ...` to ignore the expression or result
    = note: `#[warn(dropping_copy_types)]` on by default
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(origin);
+LL +     let _ = origin;
+   |
 
 warning: 1 warning emitted
 

--- a/tests/ui/higher-ranked/leak-check/leak-check-in-selection-5-ambig.rs
+++ b/tests/ui/higher-ranked/leak-check/leak-check-in-selection-5-ambig.rs
@@ -1,0 +1,28 @@
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// The new trait solver does not return region constraints if the goal
+// is still ambiguous. This causes the following test to fail with ambiguity,
+// even though `(): LeakCheckFailure<'!a, V>` would return `'!a: 'static`
+// which would have caused a leak check failure.
+
+trait Ambig {}
+impl Ambig for u32 {}
+impl Ambig for u16 {}
+
+trait Id<T> {}
+impl Id<u32> for u32 {}
+impl Id<u16> for u16 {}
+
+
+trait LeakCheckFailure<'a, V: ?Sized> {}
+impl<V: ?Sized + Ambig> LeakCheckFailure<'static, V> for () {}
+
+trait Trait<U, V> {}
+impl<V> Trait<u32, V> for () where for<'a> (): LeakCheckFailure<'a, V> {}
+impl<V> Trait<u16, V> for () {}
+fn impls_trait<T: Trait<U, V>, U: Id<V>, V>() {}
+fn main() {
+    impls_trait::<(), _, _>()
+}

--- a/tests/ui/higher-ranked/leak-check/leak-check-in-selection-6-ambig-unify.next.stderr
+++ b/tests/ui/higher-ranked/leak-check/leak-check-in-selection-6-ambig-unify.next.stderr
@@ -1,0 +1,22 @@
+error[E0283]: type annotations needed
+  --> $DIR/leak-check-in-selection-6-ambig-unify.rs:30:5
+   |
+LL |     impls_trait::<(), _, _>()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `U` declared on the function `impls_trait`
+   |
+note: multiple `impl`s satisfying `(): Trait<_, _>` found
+  --> $DIR/leak-check-in-selection-6-ambig-unify.rs:26:1
+   |
+LL | impl<V> Trait<u32, V> for () where for<'b> (): LeakCheckFailure<'static, 'b, V> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | impl<V> Trait<u16, V> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `impls_trait`
+  --> $DIR/leak-check-in-selection-6-ambig-unify.rs:28:19
+   |
+LL | fn impls_trait<T: Trait<U, V>, U: Id<V>, V>() {}
+   |                   ^^^^^^^^^^^ required by this bound in `impls_trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/higher-ranked/leak-check/leak-check-in-selection-6-ambig-unify.old.stderr
+++ b/tests/ui/higher-ranked/leak-check/leak-check-in-selection-6-ambig-unify.old.stderr
@@ -1,0 +1,22 @@
+error[E0283]: type annotations needed
+  --> $DIR/leak-check-in-selection-6-ambig-unify.rs:30:5
+   |
+LL |     impls_trait::<(), _, _>()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `U` declared on the function `impls_trait`
+   |
+note: multiple `impl`s satisfying `(): Trait<_, _>` found
+  --> $DIR/leak-check-in-selection-6-ambig-unify.rs:26:1
+   |
+LL | impl<V> Trait<u32, V> for () where for<'b> (): LeakCheckFailure<'static, 'b, V> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | impl<V> Trait<u16, V> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `impls_trait`
+  --> $DIR/leak-check-in-selection-6-ambig-unify.rs:28:19
+   |
+LL | fn impls_trait<T: Trait<U, V>, U: Id<V>, V>() {}
+   |                   ^^^^^^^^^^^ required by this bound in `impls_trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/higher-ranked/leak-check/leak-check-in-selection-6-ambig-unify.rs
+++ b/tests/ui/higher-ranked/leak-check/leak-check-in-selection-6-ambig-unify.rs
@@ -1,0 +1,32 @@
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver
+
+// The new trait solver does not return region constraints if the goal
+// is still ambiguous. This should cause the following test to fail with
+// ambiguity as even if  `(): LeakCheckFailure<'static, '!b, V>` unifies
+// `'!b` with `'static`, we erase all region constraints.
+//
+// However, we do still unify the var_value for `'b` with `'static`,
+// causing us to return this requirement via the `var_values` even if
+// we don't return any region constraints. This is a bit inconsistent
+// but isn't something we should really worry about imo.
+trait Ambig {}
+impl Ambig for u32 {}
+impl Ambig for u16 {}
+
+trait Id<T> {}
+impl Id<u32> for u32 {}
+impl Id<u16> for u16 {}
+
+
+trait LeakCheckFailure<'a, 'b, V: ?Sized> {}
+impl<'a, 'b: 'a, V: ?Sized + Ambig> LeakCheckFailure<'a, 'b, V> for () {}
+
+trait Trait<U, V> {}
+impl<V> Trait<u32, V> for () where for<'b> (): LeakCheckFailure<'static, 'b, V> {}
+impl<V> Trait<u16, V> for () {}
+fn impls_trait<T: Trait<U, V>, U: Id<V>, V>() {}
+fn main() {
+    impls_trait::<(), _, _>()
+    //~^ ERROR type annotations needed
+}

--- a/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.rs
+++ b/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.rs
@@ -1,0 +1,14 @@
+//@ check-fail
+
+#![deny(dropping_copy_types)]
+
+fn main() {
+    let y = 1;
+    let z = 2;
+    match y {
+        0 => drop(y), //~ ERROR calls to `std::mem::drop`
+        1 => drop(z), //~ ERROR calls to `std::mem::drop`
+        2 => drop(3), //~ ERROR calls to `std::mem::drop`
+        _ => {},
+    }
+}

--- a/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.stderr
+++ b/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.stderr
@@ -1,0 +1,37 @@
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-issue-125189-can-not-fixed.rs:9:14
+   |
+LL |         0 => drop(y),
+   |              ^^^^^-^
+   |                   |
+   |                   argument has type `i32`
+   |
+   = note: use `let _ = ...` to ignore the expression or result
+note: the lint level is defined here
+  --> $DIR/dropping_copy_types-issue-125189-can-not-fixed.rs:3:9
+   |
+LL | #![deny(dropping_copy_types)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-issue-125189-can-not-fixed.rs:10:14
+   |
+LL |         1 => drop(z),
+   |              ^^^^^-^
+   |                   |
+   |                   argument has type `i32`
+   |
+   = note: use `let _ = ...` to ignore the expression or result
+
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-issue-125189-can-not-fixed.rs:11:14
+   |
+LL |         2 => drop(3),
+   |              ^^^^^-^
+   |                   |
+   |                   argument has type `i32`
+   |
+   = note: use `let _ = ...` to ignore the expression or result
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lint/dropping_copy_types-issue-125189.fixed
+++ b/tests/ui/lint/dropping_copy_types-issue-125189.fixed
@@ -1,0 +1,10 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(dropping_copy_types)]
+
+fn main() {
+    let y = 1;
+    let _ = 3.2; //~ ERROR calls to `std::mem::drop`
+    let _ = y; //~ ERROR calls to `std::mem::drop`
+}

--- a/tests/ui/lint/dropping_copy_types-issue-125189.rs
+++ b/tests/ui/lint/dropping_copy_types-issue-125189.rs
@@ -1,0 +1,10 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(dropping_copy_types)]
+
+fn main() {
+    let y = 1;
+    drop(3.2); //~ ERROR calls to `std::mem::drop`
+    drop(y); //~ ERROR calls to `std::mem::drop`
+}

--- a/tests/ui/lint/dropping_copy_types-issue-125189.stderr
+++ b/tests/ui/lint/dropping_copy_types-issue-125189.stderr
@@ -1,0 +1,35 @@
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-issue-125189.rs:8:5
+   |
+LL |     drop(3.2);
+   |     ^^^^^---^
+   |          |
+   |          argument has type `f64`
+   |
+note: the lint level is defined here
+  --> $DIR/dropping_copy_types-issue-125189.rs:4:9
+   |
+LL | #![deny(dropping_copy_types)]
+   |         ^^^^^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(3.2);
+LL +     let _ = 3.2;
+   |
+
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-issue-125189.rs:9:5
+   |
+LL |     drop(y);
+   |     ^^^^^-^
+   |          |
+   |          argument has type `i32`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(y);
+LL +     let _ = y;
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/lint/dropping_copy_types.stderr
+++ b/tests/ui/lint/dropping_copy_types.stderr
@@ -6,12 +6,16 @@ LL |     drop(s1);
    |          |
    |          argument has type `SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
 note: the lint level is defined here
   --> $DIR/dropping_copy_types.rs:3:9
    |
 LL | #![warn(dropping_copy_types)]
    |         ^^^^^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(s1);
+LL +     let _ = s1;
+   |
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
   --> $DIR/dropping_copy_types.rs:35:5
@@ -21,7 +25,11 @@ LL |     drop(s2);
    |          |
    |          argument has type `SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(s2);
+LL +     let _ = s2;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_copy_types.rs:36:5
@@ -42,7 +50,11 @@ LL |     drop(s4);
    |          |
    |          argument has type `SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(s4);
+LL +     let _ = s4;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_copy_types.rs:38:5
@@ -82,7 +94,11 @@ LL |             drop(println_and(13));
    |                  |
    |                  argument has type `i32`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -             drop(println_and(13));
+LL +             let _ = println_and(13);
+   |
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
   --> $DIR/dropping_copy_types.rs:74:14

--- a/tests/ui/mir/dyn_metadata_sroa.rs
+++ b/tests/ui/mir/dyn_metadata_sroa.rs
@@ -1,0 +1,19 @@
+//@ run-pass
+//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir
+
+#![feature(ptr_metadata)]
+
+// Regression for <https://github.com/rust-lang/rust/issues/125506>,
+// which failed because of SRoA would project into `DynMetadata`.
+
+trait Foo {}
+
+struct Bar;
+
+impl Foo for Bar {}
+
+fn main() {
+    let a: *mut dyn Foo = &mut Bar;
+
+    let _d = a.to_raw_parts().0 as usize;
+}

--- a/tests/ui/traits/next-solver/normalize/ambig-goal-infer-in-type-oulives.rs
+++ b/tests/ui/traits/next-solver/normalize/ambig-goal-infer-in-type-oulives.rs
@@ -1,0 +1,29 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicitly enabled)
+
+// Regression test for an ICE when trying to bootstrap rustc
+// with #125343. An ambiguous goal returned a `TypeOutlives`
+// constraint referencing an inference variable. This inference
+// variable was created inside of the goal, causing it to be
+// unconstrained in the caller. This then caused an ICE in MIR
+// borrowck.
+
+struct Foo<T>(T);
+trait Extend<T> {
+    fn extend<I: IntoIterator<Item = T>>(iter: I);
+}
+
+impl<T> Extend<T> for Foo<T> {
+    fn extend<I: IntoIterator<Item = T>>(_: I) {
+        todo!()
+    }
+}
+
+impl<'a, T: 'a + Copy> Extend<&'a T> for Foo<T> {
+    fn extend<I: IntoIterator<Item = &'a T>>(iter: I) {
+        <Self as Extend<T>>::extend(iter.into_iter().copied())
+    }
+}
+
+fn main() {}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -122,6 +122,8 @@ issues).
 """
 label = "O-apple"
 
+# This ping group is meant for situations where a rustc/stdlib change breaks RfL.
+# In that case, we want to notify the RfL group.
 [ping.rust-for-linux]
 alias = ["rfl"]
 message = """\

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -794,6 +794,9 @@ cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 [mentions."src/doc/rustc/src/check-cfg.md"]
 cc = ["@Urgau"]
 
+[mentions."src/doc/rustc/src/check-cfg"]
+cc = ["@Urgau"]
+
 [mentions."src/doc/rustc/src/platform-support"]
 cc = ["@Nilstrieb"]
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -122,6 +122,17 @@ issues).
 """
 label = "O-apple"
 
+[ping.rust-for-linux]
+alias = ["rfl"]
+message = """\
+Hey Rust for Linux group! It looks like something broke the Rust for Linux integration.
+Could you try to take a look?
+In case it's useful, here are some [instructions] for tackling these sorts of issues.
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/rust-for-linux.html
+"""
+label = "O-rfl"
+
 [prioritize]
 label = "I-prioritize"
 


### PR DESCRIPTION
Successful merges:

 - #125307 (tidy: stop special-casing tests/ui entry limit)
 - #125375 (Create a triagebot ping group for Rust for Linux)
 - #125413 (drop region constraints for ambiguous goals)
 - #125433 (A small diagnostic improvement for dropping_copy_types)
 - #125508 (Stop SRoA'ing `DynMetadata` in MIR)
 - #125530 (cleanup dependence of `ExtCtxt` in transcribe when macro expansion)
 - #125544 (Also mention my-self for other check-cfg docs changes)
 - #125546 (Try to not reinstall tools in mingw CI)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=125307,125375,125413,125433,125508,125530,125544,125546)
<!-- homu-ignore:end -->