### PR TITLE
Simplify the `unchecked_sh[lr]` ub-checks a bit

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1282,8 +1282,7 @@ macro_rules! int_impl {
                 concat!(stringify!($SelfT), "::unchecked_shl cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.
@@ -1381,8 +1380,7 @@ macro_rules! int_impl {
                 concat!(stringify!($SelfT), "::unchecked_shr cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1369,8 +1369,7 @@ macro_rules! uint_impl {
                 concat!(stringify!($SelfT), "::unchecked_shl cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.
@@ -1468,8 +1467,7 @@ macro_rules! uint_impl {
                 concat!(stringify!($SelfT), "::unchecked_shr cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4, const core::num::<impl u16>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4, const core::num::<impl u16>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-abort.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4, const core::num::<impl i64>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4, const core::num::<impl i64>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {


### PR DESCRIPTION
It can use the constant in the check, rather than passing it as a parameter.