### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -224,7 +224,8 @@ fn expand_macro<'cx>(
             let arm_span = rhses[i].span();
 
             // rhs has holes ( `$id` and `$(...)` that need filled)
-            let tts = match transcribe(cx, &named_matches, rhs, rhs_span, transparency) {
+            let id = cx.current_expansion.id;
+            let tts = match transcribe(psess, &named_matches, rhs, rhs_span, transparency, id) {
                 Ok(tts) => tts,
                 Err(err) => {
                     let guar = err.emit();

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -197,6 +197,7 @@ lint_drop_trait_constraints =
 lint_dropping_copy_types = calls to `std::mem::drop` with a value that implements `Copy` does nothing
     .label = argument has type `{$arg_ty}`
     .note = use `let _ = ...` to ignore the expression or result
+    .suggestion = use `let _ = ...` to ignore the expression or result
 
 lint_dropping_references = calls to `std::mem::drop` with a reference instead of an owned value does nothing
     .label = argument has type `{$arg_ty}`

--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -1,11 +1,11 @@
-use rustc_hir::{Arm, Expr, ExprKind, Node};
+use rustc_hir::{Arm, Expr, ExprKind, Node, StmtKind};
 use rustc_middle::ty;
 use rustc_span::sym;
 
 use crate::{
     lints::{
-        DropCopyDiag, DropRefDiag, ForgetCopyDiag, ForgetRefDiag, UndroppedManuallyDropsDiag,
-        UndroppedManuallyDropsSuggestion,
+        DropCopyDiag, DropCopySuggestion, DropRefDiag, ForgetCopyDiag, ForgetRefDiag,
+        UndroppedManuallyDropsDiag, UndroppedManuallyDropsSuggestion,
     },
     LateContext, LateLintPass, LintContext,
 };
@@ -163,10 +163,23 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetUseless {
                     );
                 }
                 sym::mem_drop if is_copy && !drop_is_single_call_in_arm => {
+                    let sugg = if let Some((_, node)) = cx.tcx.hir().parent_iter(expr.hir_id).nth(0)
+                        && let Node::Stmt(stmt) = node
+                        && let StmtKind::Semi(e) = stmt.kind
+                        && e.hir_id == expr.hir_id
+                    {
+                        DropCopySuggestion::Suggestion {
+                            start_span: expr.span.shrink_to_lo().until(arg.span),
+                            end_span: arg.span.shrink_to_hi().until(expr.span.shrink_to_hi()),
+                        }
+                    } else {
+                        DropCopySuggestion::Note
+                    };
+
                     cx.emit_span_lint(
                         DROPPING_COPY_TYPES,
                         expr.span,
-                        DropCopyDiag { arg_ty, label: arg.span },
+                        DropCopyDiag { arg_ty, label: arg.span, sugg },
                     );
                 }
                 sym::mem_forget if is_copy => {

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -669,11 +669,25 @@ pub struct DropRefDiag<'a> {
 
 #[derive(LintDiagnostic)]
 #[diag(lint_dropping_copy_types)]
-#[note]
 pub struct DropCopyDiag<'a> {
     pub arg_ty: Ty<'a>,
     #[label]
     pub label: Span,
+    #[subdiagnostic]
+    pub sugg: DropCopySuggestion,
+}
+
+#[derive(Subdiagnostic)]
+pub enum DropCopySuggestion {
+    #[note(lint_note)]
+    Note,
+    #[multipart_suggestion(lint_suggestion, style = "verbose", applicability = "maybe-incorrect")]
+    Suggestion {
+        #[suggestion_part(code = "let _ = ")]
+        start_span: Span,
+        #[suggestion_part(code = "")]
+        end_span: Span,
+    },
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -70,6 +70,11 @@ fn escaping_locals<'tcx>(
                 // Exclude #[repr(simd)] types so that they are not de-optimized into an array
                 return true;
             }
+            if Some(def.did()) == tcx.lang_items().dyn_metadata() {
+                // codegen wants to see the `DynMetadata<T>`,
+                // not the inner reference-to-opaque-type.
+                return true;
+            }
             // We already excluded unions and enums, so this ADT must have one variant
             let variant = def.variant(FIRST_VARIANT);
             if variant.fields.len() > 1 {

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1282,8 +1282,7 @@ macro_rules! int_impl {
                 concat!(stringify!($SelfT), "::unchecked_shl cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.
@@ -1381,8 +1380,7 @@ macro_rules! int_impl {
                 concat!(stringify!($SelfT), "::unchecked_shr cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1369,8 +1369,7 @@ macro_rules! uint_impl {
                 concat!(stringify!($SelfT), "::unchecked_shl cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.
@@ -1468,8 +1467,7 @@ macro_rules! uint_impl {
                 concat!(stringify!($SelfT), "::unchecked_shr cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -16,7 +16,6 @@ const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 
 const ISSUES_ENTRY_LIMIT: usize = 1676;
-const ROOT_ENTRY_LIMIT: usize = 757;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files
@@ -63,14 +62,10 @@ fn check_entries(tests_path: &Path, bad: &mut bool) {
         }
     }
 
-    let (mut max, mut max_root, mut max_issues) = (0usize, 0usize, 0usize);
+    let (mut max, mut max_issues) = (0usize, 0usize);
     for (dir_path, count) in directories {
-        // Use special values for these dirs.
-        let is_root = tests_path.join("ui") == dir_path;
         let is_issues_dir = tests_path.join("ui/issues") == dir_path;
-        let (limit, maxcnt) = if is_root {
-            (ROOT_ENTRY_LIMIT, &mut max_root)
-        } else if is_issues_dir {
+        let (limit, maxcnt) = if is_issues_dir {
             (ISSUES_ENTRY_LIMIT, &mut max_issues)
         } else {
             (ENTRY_LIMIT, &mut max)
@@ -86,12 +81,6 @@ fn check_entries(tests_path: &Path, bad: &mut bool) {
                 dir_path.display()
             );
         }
-    }
-    if ROOT_ENTRY_LIMIT > max_root {
-        tidy_error!(
-            bad,
-            "`ROOT_ENTRY_LIMIT` is too high (is {ROOT_ENTRY_LIMIT}, should be {max_root})"
-        );
     }
     if ISSUES_ENTRY_LIMIT > max_issues {
         tidy_error!(

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4, const core::num::<impl u16>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4, const core::num::<impl u16>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-abort.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4, const core::num::<impl i64>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4, const core::num::<impl i64>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {

--- a/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
@@ -6,8 +6,12 @@ LL |     drop(origin);
    |          |
    |          argument has type `<T as UncheckedCopy>::Output`
    |
-   = note: use `let _ = ...` to ignore the expression or result
    = note: `#[warn(dropping_copy_types)]` on by default
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(origin);
+LL +     let _ = origin;
+   |
 
 warning: 1 warning emitted
 

--- a/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
@@ -6,8 +6,12 @@ LL |     drop(origin);
    |          |
    |          argument has type `<T as UncheckedCopy>::Output`
    |
-   = note: use `let _ = ...` to ignore the expression or result
    = note: `#[warn(dropping_copy_types)]` on by default
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(origin);
+LL +     let _ = origin;
+   |
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.rs
+++ b/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.rs
@@ -1,0 +1,14 @@
+//@ check-fail
+
+#![deny(dropping_copy_types)]
+
+fn main() {
+    let y = 1;
+    let z = 2;
+    match y {
+        0 => drop(y), //~ ERROR calls to `std::mem::drop`
+        1 => drop(z), //~ ERROR calls to `std::mem::drop`
+        2 => drop(3), //~ ERROR calls to `std::mem::drop`
+        _ => {},
+    }
+}

--- a/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.stderr
+++ b/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.stderr
@@ -1,0 +1,37 @@
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-issue-125189-can-not-fixed.rs:9:14
+   |
+LL |         0 => drop(y),
+   |              ^^^^^-^
+   |                   |
+   |                   argument has type `i32`
+   |
+   = note: use `let _ = ...` to ignore the expression or result
+note: the lint level is defined here
+  --> $DIR/dropping_copy_types-issue-125189-can-not-fixed.rs:3:9
+   |
+LL | #![deny(dropping_copy_types)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-issue-125189-can-not-fixed.rs:10:14
+   |
+LL |         1 => drop(z),
+   |              ^^^^^-^
+   |                   |
+   |                   argument has type `i32`
+   |
+   = note: use `let _ = ...` to ignore the expression or result
+
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-issue-125189-can-not-fixed.rs:11:14
+   |
+LL |         2 => drop(3),
+   |              ^^^^^-^
+   |                   |
+   |                   argument has type `i32`
+   |
+   = note: use `let _ = ...` to ignore the expression or result
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lint/dropping_copy_types-issue-125189.fixed
+++ b/tests/ui/lint/dropping_copy_types-issue-125189.fixed
@@ -1,0 +1,10 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(dropping_copy_types)]
+
+fn main() {
+    let y = 1;
+    let _ = 3.2; //~ ERROR calls to `std::mem::drop`
+    let _ = y; //~ ERROR calls to `std::mem::drop`
+}

--- a/tests/ui/lint/dropping_copy_types-issue-125189.rs
+++ b/tests/ui/lint/dropping_copy_types-issue-125189.rs
@@ -1,0 +1,10 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(dropping_copy_types)]
+
+fn main() {
+    let y = 1;
+    drop(3.2); //~ ERROR calls to `std::mem::drop`
+    drop(y); //~ ERROR calls to `std::mem::drop`
+}

--- a/tests/ui/lint/dropping_copy_types-issue-125189.stderr
+++ b/tests/ui/lint/dropping_copy_types-issue-125189.stderr
@@ -1,0 +1,35 @@
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-issue-125189.rs:8:5
+   |
+LL |     drop(3.2);
+   |     ^^^^^---^
+   |          |
+   |          argument has type `f64`
+   |
+note: the lint level is defined here
+  --> $DIR/dropping_copy_types-issue-125189.rs:4:9
+   |
+LL | #![deny(dropping_copy_types)]
+   |         ^^^^^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(3.2);
+LL +     let _ = 3.2;
+   |
+
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-issue-125189.rs:9:5
+   |
+LL |     drop(y);
+   |     ^^^^^-^
+   |          |
+   |          argument has type `i32`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(y);
+LL +     let _ = y;
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/lint/dropping_copy_types.stderr
+++ b/tests/ui/lint/dropping_copy_types.stderr
@@ -6,12 +6,16 @@ LL |     drop(s1);
    |          |
    |          argument has type `SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
 note: the lint level is defined here
   --> $DIR/dropping_copy_types.rs:3:9
    |
 LL | #![warn(dropping_copy_types)]
    |         ^^^^^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(s1);
+LL +     let _ = s1;
+   |
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
   --> $DIR/dropping_copy_types.rs:35:5
@@ -21,7 +25,11 @@ LL |     drop(s2);
    |          |
    |          argument has type `SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(s2);
+LL +     let _ = s2;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_copy_types.rs:36:5
@@ -42,7 +50,11 @@ LL |     drop(s4);
    |          |
    |          argument has type `SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(s4);
+LL +     let _ = s4;
+   |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> $DIR/dropping_copy_types.rs:38:5
@@ -82,7 +94,11 @@ LL |             drop(println_and(13));
    |                  |
    |                  argument has type `i32`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -             drop(println_and(13));
+LL +             let _ = println_and(13);
+   |
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
   --> $DIR/dropping_copy_types.rs:74:14

--- a/tests/ui/mir/dyn_metadata_sroa.rs
+++ b/tests/ui/mir/dyn_metadata_sroa.rs
@@ -1,0 +1,19 @@
+//@ run-pass
+//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir
+
+#![feature(ptr_metadata)]
+
+// Regression for <https://github.com/rust-lang/rust/issues/125506>,
+// which failed because of SRoA would project into `DynMetadata`.
+
+trait Foo {}
+
+struct Bar;
+
+impl Foo for Bar {}
+
+fn main() {
+    let a: *mut dyn Foo = &mut Bar;
+
+    let _d = a.to_raw_parts().0 as usize;
+}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -122,6 +122,8 @@ issues).
 """
 label = "O-apple"
 
+# This ping group is meant for situations where a rustc/stdlib change breaks RfL.
+# In that case, we want to notify the RfL group.
 [ping.rust-for-linux]
 alias = ["rfl"]
 message = """\

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -794,6 +794,9 @@ cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 [mentions."src/doc/rustc/src/check-cfg.md"]
 cc = ["@Urgau"]
 
+[mentions."src/doc/rustc/src/check-cfg"]
+cc = ["@Urgau"]
+
 [mentions."src/doc/rustc/src/platform-support"]
 cc = ["@Nilstrieb"]
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -122,6 +122,17 @@ issues).
 """
 label = "O-apple"
 
+[ping.rust-for-linux]
+alias = ["rfl"]
+message = """\
+Hey Rust for Linux group! It looks like something broke the Rust for Linux integration.
+Could you try to take a look?
+In case it's useful, here are some [instructions] for tackling these sorts of issues.
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/rust-for-linux.html
+"""
+label = "O-rfl"
+
 [prioritize]
 label = "I-prioritize"
 


### PR DESCRIPTION
Successful merges:

 - #125307 (tidy: stop special-casing tests/ui entry limit)
 - #125375 (Create a triagebot ping group for Rust for Linux)
 - #125433 (A small diagnostic improvement for dropping_copy_types)
 - #125508 (Stop SRoA'ing `DynMetadata` in MIR)
 - #125530 (cleanup dependence of `ExtCtxt` in transcribe when macro expansion)
 - #125544 (Also mention my-self for other check-cfg docs changes)
 - #125559 (Simplify the `unchecked_sh[lr]` ub-checks a bit)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=125307,125375,125433,125508,125530,125544,125559)
<!-- homu-ignore:end -->