### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -70,6 +70,11 @@ fn escaping_locals<'tcx>(
                 // Exclude #[repr(simd)] types so that they are not de-optimized into an array
                 return true;
             }
+            if Some(def.did()) == tcx.lang_items().dyn_metadata() {
+                // codegen wants to see the `DynMetadata<T>`,
+                // not the inner reference-to-opaque-type.
+                return true;
+            }
             // We already excluded unions and enums, so this ADT must have one variant
             let variant = def.variant(FIRST_VARIANT);
             if variant.fields.len() > 1 {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2643,15 +2643,13 @@ impl<T, A: Allocator, const N: usize> Vec<[T; N], A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(slice_flatten)]
-    ///
     /// let mut vec = vec![[1, 2, 3], [4, 5, 6], [7, 8, 9]];
     /// assert_eq!(vec.pop(), Some([7, 8, 9]));
     ///
     /// let mut flattened = vec.into_flattened();
     /// assert_eq!(flattened.pop(), Some(6));
     /// ```
-    #[unstable(feature = "slice_flatten", issue = "95629")]
+    #[stable(feature = "slice_flatten", since = "CURRENT_RUSTC_VERSION")]
     pub fn into_flattened(self) -> Vec<T, A> {
         let (ptr, len, cap, alloc) = self.into_raw_parts_with_alloc();
         let (new_len, new_cap) = if T::IS_ZST {

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -36,7 +36,6 @@
 #![feature(const_str_from_utf8)]
 #![feature(panic_update_hook)]
 #![feature(pointer_is_aligned_to)]
-#![feature(slice_flatten)]
 #![feature(thin_box)]
 #![feature(strict_provenance)]
 #![feature(drain_keep_rest)]

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -901,8 +901,8 @@ impl f32 {
     #[stable(feature = "f32_deg_rad_conversions", since = "1.7.0")]
     #[inline]
     pub fn to_radians(self) -> f32 {
-        let value: f32 = consts::PI;
-        self * (value / 180.0f32)
+        const RADS_PER_DEG: f32 = consts::PI / 180.0;
+        self * RADS_PER_DEG
     }
 
     /// Returns the maximum of the two numbers, ignoring NaN.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -912,8 +912,8 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn to_radians(self) -> f64 {
-        let value: f64 = consts::PI;
-        self * (value / 180.0)
+        const RADS_PER_DEG: f64 = consts::PI / 180.0;
+        self * RADS_PER_DEG
     }
 
     /// Returns the maximum of the two numbers, ignoring NaN.

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -4531,8 +4531,6 @@ impl<T, const N: usize> [[T; N]] {
     /// # Examples
     ///
     /// ```
-    /// #![feature(slice_flatten)]
-    ///
     /// assert_eq!([[1, 2, 3], [4, 5, 6]].as_flattened(), &[1, 2, 3, 4, 5, 6]);
     ///
     /// assert_eq!(
@@ -4546,7 +4544,8 @@ impl<T, const N: usize> [[T; N]] {
     /// let empty_slice_of_arrays: &[[u32; 10]] = &[];
     /// assert!(empty_slice_of_arrays.as_flattened().is_empty());
     /// ```
-    #[unstable(feature = "slice_flatten", issue = "95629")]
+    #[stable(feature = "slice_flatten", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_slice_flatten", issue = "95629")]
     pub const fn as_flattened(&self) -> &[T] {
         let len = if T::IS_ZST {
             self.len().checked_mul(N).expect("slice len overflow")
@@ -4572,8 +4571,6 @@ impl<T, const N: usize> [[T; N]] {
     /// # Examples
     ///
     /// ```
-    /// #![feature(slice_flatten)]
-    ///
     /// fn add_5_to_all(slice: &mut [i32]) {
     ///     for i in slice {
     ///         *i += 5;
@@ -4584,7 +4581,7 @@ impl<T, const N: usize> [[T; N]] {
     /// add_5_to_all(array.as_flattened_mut());
     /// assert_eq!(array, [[6, 7, 8], [9, 10, 11], [12, 13, 14]]);
     /// ```
-    #[unstable(feature = "slice_flatten", issue = "95629")]
+    #[stable(feature = "slice_flatten", since = "CURRENT_RUSTC_VERSION")]
     pub fn as_flattened_mut(&mut self) -> &mut [T] {
         let len = if T::IS_ZST {
             self.len().checked_mul(N).expect("slice len overflow")

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -112,7 +112,6 @@
 #![feature(const_array_from_ref)]
 #![feature(const_slice_from_ref)]
 #![feature(waker_getters)]
-#![feature(slice_flatten)]
 #![feature(error_generic_member_access)]
 #![feature(error_in_core)]
 #![feature(trait_upcasting)]

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -16,7 +16,6 @@ const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 
 const ISSUES_ENTRY_LIMIT: usize = 1676;
-const ROOT_ENTRY_LIMIT: usize = 757;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files
@@ -63,14 +62,10 @@ fn check_entries(tests_path: &Path, bad: &mut bool) {
         }
     }
 
-    let (mut max, mut max_root, mut max_issues) = (0usize, 0usize, 0usize);
+    let (mut max, mut max_issues) = (0usize, 0usize);
     for (dir_path, count) in directories {
-        // Use special values for these dirs.
-        let is_root = tests_path.join("ui") == dir_path;
         let is_issues_dir = tests_path.join("ui/issues") == dir_path;
-        let (limit, maxcnt) = if is_root {
-            (ROOT_ENTRY_LIMIT, &mut max_root)
-        } else if is_issues_dir {
+        let (limit, maxcnt) = if is_issues_dir {
             (ISSUES_ENTRY_LIMIT, &mut max_issues)
         } else {
             (ENTRY_LIMIT, &mut max)
@@ -86,12 +81,6 @@ fn check_entries(tests_path: &Path, bad: &mut bool) {
                 dir_path.display()
             );
         }
-    }
-    if ROOT_ENTRY_LIMIT > max_root {
-        tidy_error!(
-            bad,
-            "`ROOT_ENTRY_LIMIT` is too high (is {ROOT_ENTRY_LIMIT}, should be {max_root})"
-        );
     }
     if ISSUES_ENTRY_LIMIT > max_issues {
         tidy_error!(

--- a/tests/ui/mir/dyn_metadata_sroa.rs
+++ b/tests/ui/mir/dyn_metadata_sroa.rs
@@ -1,0 +1,19 @@
+//@ run-pass
+//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir
+
+#![feature(ptr_metadata)]
+
+// Regression for <https://github.com/rust-lang/rust/issues/125506>,
+// which failed because of SRoA would project into `DynMetadata`.
+
+trait Foo {}
+
+struct Bar;
+
+impl Foo for Bar {}
+
+fn main() {
+    let a: *mut dyn Foo = &mut Bar;
+
+    let _d = a.to_raw_parts().0 as usize;
+}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -122,6 +122,8 @@ issues).
 """
 label = "O-apple"
 
+# This ping group is meant for situations where a rustc/stdlib change breaks RfL.
+# In that case, we want to notify the RfL group.
 [ping.rust-for-linux]
 alias = ["rfl"]
 message = """\

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -122,6 +122,17 @@ issues).
 """
 label = "O-apple"
 
+[ping.rust-for-linux]
+alias = ["rfl"]
+message = """\
+Hey Rust for Linux group! It looks like something broke the Rust for Linux integration.
+Could you try to take a look?
+In case it's useful, here are some [instructions] for tackling these sorts of issues.
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/rust-for-linux.html
+"""
+label = "O-rfl"
+
 [prioritize]
 label = "I-prioritize"
 


### PR DESCRIPTION
Successful merges:

 - #125307 (tidy: stop special-casing tests/ui entry limit)
 - #125375 (Create a triagebot ping group for Rust for Linux)
 - #125473 (fix(opt-dist): respect existing config.toml)
 - #125508 (Stop SRoA'ing `DynMetadata` in MIR)
 - #125561 (Stabilize `slice_flatten`)
 - #125571 (f32: use constants instead of reassigning a dummy value as PI)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=125307,125375,125473,125508,125561,125571)
<!-- homu-ignore:end -->