### PR TITLE
Avoid a `FieldIdx::from_usize` in InstSimplify

### DIFF
--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -142,10 +142,10 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
                     _ => return,
                 };
                 if let Some(variant_target_idx) = variant_target {
-                    for (field_index, operand) in operands.iter().enumerate() {
+                    for (field_index, operand) in operands.iter_enumerated() {
                         if let Some(field) = self.map().apply(
                             variant_target_idx,
-                            TrackElem::Field(FieldIdx::from_usize(field_index)),
+                            TrackElem::Field(field_index),
                         ) {
                             self.assign_operand(state, field, operand);
                         }

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -9,7 +9,6 @@ use rustc_middle::ty::layout::ValidityRequirement;
 use rustc_middle::ty::{self, GenericArgsRef, ParamEnv, Ty, TyCtxt};
 use rustc_span::sym;
 use rustc_span::symbol::Symbol;
-use rustc_target::abi::FieldIdx;
 use rustc_target::spec::abi::Abi;
 
 pub struct InstSimplify;
@@ -217,11 +216,11 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
                     && let Some(place) = operand.place()
                 {
                     let variant = adt_def.non_enum_variant();
-                    for (i, field) in variant.fields.iter().enumerate() {
+                    for (i, field) in variant.fields.iter_enumerated() {
                         let field_ty = field.ty(self.tcx, args);
                         if field_ty == *cast_ty {
                             let place = place.project_deeper(
-                                &[ProjectionElem::Field(FieldIdx::from_usize(i), *cast_ty)],
+                                &[ProjectionElem::Field(i, *cast_ty)],
                                 self.tcx,
                             );
                             let operand = if operand.is_move() {


### PR DESCRIPTION
Just a tiny cleanup I noticed in passing while looking at something unrelated.