### PR TITLE
[EXPIREMENT] Test the effect of removing python setup

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -78,12 +78,23 @@ pr:
   - image: mingw-check-tidy
     continue_on_error: true
     <<: *job-linux-4c
-  - image: x86_64-gnu-llvm-17
+  - image: x86_64-msvc
     env:
-      ENABLE_GCC_CODEGEN: "1"
-    <<: *job-linux-16c
-  - image: x86_64-gnu-tools
-    <<: *job-linux-16c
+      RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
+      SCRIPT: make ci-msvc
+    <<: *job-windows-8c
+  - image: x86_64-mingw
+    env:
+      SCRIPT: make ci-mingw
+      RUST_CONFIGURE_ARGS: >-
+        --build=x86_64-pc-windows-gnu
+        --enable-profiler
+      # We are intentionally allowing an old toolchain on this builder (and that's
+      # incompatible with LLVM downloads today).
+      NO_DOWNLOAD_CI_LLVM: 1
+      CUSTOM_MINGW: 1
+    <<: *job-windows-8c
+  
 
 # Jobs that run when you perform a try build (@bors try)
 # These jobs automatically inherit envs.try, to avoid repeating

--- a/src/ci/scripts/install-msys2.sh
+++ b/src/ci/scripts/install-msys2.sh
@@ -6,22 +6,3 @@ set -euo pipefail
 IFS=$'\n\t'
 
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
-if isWindows; then
-    # Detect the native Python version installed on the agent. On GitHub
-    # Actions, the C:\hostedtoolcache\windows\Python directory contains a
-    # subdirectory for each installed Python version.
-    #
-    # The -V flag of the sort command sorts the input by version number.
-    native_python_version="$(ls /c/hostedtoolcache/windows/Python | sort -Vr | head -n 1)"
-
-    # Make sure we use the native python interpreter instead of some msys equivalent
-    # one way or another. The msys interpreters seem to have weird path conversions
-    # baked in which break LLVM's build system one way or another, so let's use the
-    # native version which keeps everything as native as possible.
-    python_home="/c/hostedtoolcache/windows/Python/${native_python_version}/x64"
-    if ! [[ -f "${python_home}/python3.exe" ]]; then
-        cp "${python_home}/python.exe" "${python_home}/python3.exe"
-    fi
-    ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64"
-    ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64\\Scripts"
-fi


### PR DESCRIPTION
This will almost certainly break. I think the fix will be to add the python setup action  `if: runner.os = 'Windows'`.

r? ghost