### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -327,6 +327,18 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                     } else {
                         codegen_fn_attrs.linkage = linkage;
                     }
+                    if tcx.is_mutable_static(did.into()) {
+                        let mut diag = tcx.dcx().struct_span_err(
+                            attr.span,
+                            "mutable statics are not allowed with `#[linkage]`",
+                        );
+                        diag.note(
+                            "making the static mutable would allow changing which symbol the \
+                             static references rather than make the target of the symbol \
+                             mutable",
+                        );
+                        diag.emit();
+                    }
                 }
             }
             sym::link_section => {

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -224,7 +224,8 @@ fn expand_macro<'cx>(
             let arm_span = rhses[i].span();
 
             // rhs has holes ( `$id` and `$(...)` that need filled)
-            let tts = match transcribe(cx, &named_matches, rhs, rhs_span, transparency) {
+            let id = cx.current_expansion.id;
+            let tts = match transcribe(psess, &named_matches, rhs, rhs_span, transparency, id) {
                 Ok(tts) => tts,
                 Err(err) => {
                     let guar = err.emit();

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1871,11 +1871,8 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
         // If this is due to a block, then maybe we forgot a `return`/`break`.
         if due_to_block
             && let Some(expr) = expression
-            && let Some((parent_fn_decl, parent_id)) = fcx
-                .tcx
-                .hir()
-                .parent_iter(block_or_return_id)
-                .find_map(|(_, node)| Some((node.fn_decl()?, node.associated_body()?.0)))
+            && let Some(parent_fn_decl) =
+                fcx.tcx.hir().fn_decl_by_hir_id(fcx.tcx.local_def_id_to_hir_id(fcx.body_id))
         {
             fcx.suggest_missing_break_or_return_expr(
                 &mut err,
@@ -1884,7 +1881,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                 expected,
                 found,
                 block_or_return_id,
-                parent_id,
+                fcx.body_id,
             );
         }
 

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -395,8 +395,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // ambiguous.
         if let Some(bad_ty) = &steps.opt_bad_ty {
             if is_suggestion.0 {
-                // Ambiguity was encountered during a suggestion. Just keep going.
-                debug!("ProbeContext: encountered ambiguity in suggestion");
+                // Ambiguity was encountered during a suggestion. There's really
+                // not much use in suggesting methods in this case.
+                return Err(MethodError::NoMatch(NoMatchData {
+                    static_candidates: Vec::new(),
+                    unsatisfied_predicates: Vec::new(),
+                    out_of_scope_traits: Vec::new(),
+                    similar_candidate: None,
+                    mode,
+                }));
             } else if bad_ty.reached_raw_pointer
                 && !self.tcx.features().arbitrary_self_types
                 && !self.tcx.sess.at_least_rust_2018()

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -142,10 +142,10 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
                     _ => return,
                 };
                 if let Some(variant_target_idx) = variant_target {
-                    for (field_index, operand) in operands.iter().enumerate() {
+                    for (field_index, operand) in operands.iter_enumerated() {
                         if let Some(field) = self.map().apply(
                             variant_target_idx,
-                            TrackElem::Field(FieldIdx::from_usize(field_index)),
+                            TrackElem::Field(field_index),
                         ) {
                             self.assign_operand(state, field, operand);
                         }

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -9,7 +9,6 @@ use rustc_middle::ty::layout::ValidityRequirement;
 use rustc_middle::ty::{self, GenericArgsRef, ParamEnv, Ty, TyCtxt};
 use rustc_span::sym;
 use rustc_span::symbol::Symbol;
-use rustc_target::abi::FieldIdx;
 use rustc_target::spec::abi::Abi;
 
 pub struct InstSimplify;
@@ -217,11 +216,11 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
                     && let Some(place) = operand.place()
                 {
                     let variant = adt_def.non_enum_variant();
-                    for (i, field) in variant.fields.iter().enumerate() {
+                    for (i, field) in variant.fields.iter_enumerated() {
                         let field_ty = field.ty(self.tcx, args);
                         if field_ty == *cast_ty {
                             let place = place.project_deeper(
-                                &[ProjectionElem::Field(FieldIdx::from_usize(i), *cast_ty)],
+                                &[ProjectionElem::Field(i, *cast_ty)],
                                 self.tcx,
                             );
                             let operand = if operand.is_move() {

--- a/config.example.toml
+++ b/config.example.toml
@@ -904,9 +904,6 @@
 # on linux
 #src-tarball = true
 
-# Whether to allow failures when building tools
-#missing-tools = false
-
 # List of compression formats to use when generating dist tarballs. The list of
 # formats is provided to rust-installer, which must support all of them.
 #

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1282,8 +1282,7 @@ macro_rules! int_impl {
                 concat!(stringify!($SelfT), "::unchecked_shl cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.
@@ -1381,8 +1380,7 @@ macro_rules! int_impl {
                 concat!(stringify!($SelfT), "::unchecked_shr cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1369,8 +1369,7 @@ macro_rules! uint_impl {
                 concat!(stringify!($SelfT), "::unchecked_shl cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.
@@ -1468,8 +1467,7 @@ macro_rules! uint_impl {
                 concat!(stringify!($SelfT), "::unchecked_shr cannot overflow"),
                 (
                     rhs: u32 = rhs,
-                    bits: u32 = Self::BITS,
-                ) => rhs < bits,
+                ) => rhs < <$ActualT>::BITS,
             );
 
             // SAFETY: this is guaranteed to be safe by the caller.

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -314,7 +314,6 @@ pub struct Config {
     pub save_toolstates: Option<PathBuf>,
     pub print_step_timings: bool,
     pub print_step_rusage: bool,
-    pub missing_tools: bool, // FIXME: Deprecated field. Remove it at 2024.
 
     // Fallback musl-root for all targets
     pub musl_root: Option<PathBuf>,
@@ -892,7 +891,6 @@ define_config! {
         sign_folder: Option<String> = "sign-folder",
         upload_addr: Option<String> = "upload-addr",
         src_tarball: Option<bool> = "src-tarball",
-        missing_tools: Option<bool> = "missing-tools",
         compression_formats: Option<Vec<String>> = "compression-formats",
         compression_profile: Option<String> = "compression-profile",
         include_mingw_linker: Option<bool> = "include-mingw-linker",
@@ -1923,7 +1921,6 @@ impl Config {
                 sign_folder,
                 upload_addr,
                 src_tarball,
-                missing_tools,
                 compression_formats,
                 compression_profile,
                 include_mingw_linker,
@@ -1933,7 +1930,6 @@ impl Config {
             config.dist_compression_formats = compression_formats;
             set(&mut config.dist_compression_profile, compression_profile);
             set(&mut config.rust_dist_src, src_tarball);
-            set(&mut config.missing_tools, missing_tools);
             set(&mut config.dist_include_mingw_linker, include_mingw_linker)
         }
 

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -190,4 +190,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "`rust.lld` has a new default value of `true` on `x86_64-unknown-linux-gnu`. Starting at stage1, `rust-lld` will thus be this target's default linker. No config changes should be necessary.",
     },
+    ChangeInfo {
+        change_id: 125535,
+        severity: ChangeSeverity::Warning,
+        summary: "Removed `dist.missing-tools` configuration as it was deprecated long time ago.",
+    },
 ];

--- a/tests/crashes/123255.rs
+++ b/tests/crashes/123255.rs
@@ -1,0 +1,13 @@
+//@ known-bug: rust-lang/rust#123255
+//@ edition:2021
+#![crate_type = "lib"]
+
+pub fn a() {}
+
+mod handlers {
+    pub struct C(&());
+    pub fn c() -> impl Fn() -> C {
+        let a1 = ();
+        || C((crate::a(), a1).into())
+    }
+}

--- a/tests/crashes/123276.rs
+++ b/tests/crashes/123276.rs
@@ -1,0 +1,25 @@
+//@ known-bug: rust-lang/rust#123276
+//@ edition:2021
+
+async fn create_task() {
+    _ = Some(async { bind(documentation_filter()) });
+}
+
+async fn bind<Fut, F: Filter<Future = Fut>>(_: F) {}
+
+fn documentation_filter() -> impl Filter {
+    AndThen
+}
+
+trait Filter {
+    type Future;
+}
+
+struct AndThen;
+
+impl Filter for AndThen
+where
+    Foo: Filter,
+{
+    type Future = ();
+}

--- a/tests/crashes/123887.rs
+++ b/tests/crashes/123887.rs
@@ -1,0 +1,15 @@
+//@ known-bug: rust-lang/rust#123887
+//@ compile-flags: -Clink-dead-code
+
+#![feature(extern_types)]
+#![feature(unsized_fn_params)]
+
+extern "C" {
+    pub type ExternType;
+}
+
+impl ExternType {
+    pub fn f(self) {}
+}
+
+pub fn main() {}

--- a/tests/crashes/125013-1.rs
+++ b/tests/crashes/125013-1.rs
@@ -1,0 +1,5 @@
+//@ known-bug: rust-lang/rust#125013
+//@ edition:2021
+use io::{self as std};
+use std::ops::Deref::{self as io};
+pub fn main() {}

--- a/tests/crashes/125013-2.rs
+++ b/tests/crashes/125013-2.rs
@@ -1,0 +1,16 @@
+//@ known-bug: rust-lang/rust#125013
+//@ edition:2021
+mod a {
+  pub mod b {
+    pub mod c {
+      pub trait D {}
+    }
+  }
+}
+
+use a::*;
+
+use e as b;
+use b::c::D as e;
+
+fn main() { }

--- a/tests/crashes/125014.rs
+++ b/tests/crashes/125014.rs
@@ -1,0 +1,17 @@
+//@ known-bug: rust-lang/rust#125014
+//@ compile-flags: -Znext-solver=coherence
+#![feature(specialization)]
+
+trait Foo {}
+
+impl Foo for <u16 as Assoc>::Output {}
+
+impl Foo for u32 {}
+
+trait Assoc {
+    type Output;
+}
+impl Output for u32 {}
+impl Assoc for <u16 as Assoc>::Output {
+    default type Output = bool;
+}

--- a/tests/crashes/125059.rs
+++ b/tests/crashes/125059.rs
@@ -1,0 +1,12 @@
+//@ known-bug: rust-lang/rust#125059
+#![feature(deref_patterns)]
+#![allow(incomplete_features)]
+
+fn simple_vec(vec: Vec<u32>) -> u32 {
+   (|| match Vec::<u32>::new() {
+        deref!([]) => 100,
+        _ => 2000,
+    })()
+}
+
+fn main() {}

--- a/tests/crashes/125323.rs
+++ b/tests/crashes/125323.rs
@@ -1,0 +1,6 @@
+//@ known-bug: rust-lang/rust#125323
+fn main() {
+    for _ in 0..0 {
+        [(); loop {}];
+    }
+}

--- a/tests/crashes/125370.rs
+++ b/tests/crashes/125370.rs
@@ -1,0 +1,16 @@
+//@ known-bug: rust-lang/rust#125370
+
+type Field3 = i64;
+
+#[repr(C)]
+union DummyUnion {
+    field3: Field3,
+}
+
+const UNION: DummyUnion = loop {};
+
+const fn read_field2() -> Field2 {
+    const FIELD2: Field2 = loop {
+        UNION.field3
+    };
+}

--- a/tests/crashes/125432.rs
+++ b/tests/crashes/125432.rs
@@ -1,0 +1,17 @@
+//@ known-bug: rust-lang/rust#125432
+
+fn separate_arms() {
+    // Here both arms perform assignments, but only one is illegal.
+
+    let mut x = None;
+    match x {
+        None => {
+            // It is ok to reassign x here, because there is in
+            // fact no outstanding loan of x!
+            x = Some(0);
+        }
+        Some(right) => consume(right),
+    }
+}
+
+fn main() {}

--- a/tests/crashes/125476.rs
+++ b/tests/crashes/125476.rs
@@ -1,0 +1,3 @@
+//@ known-bug: rust-lang/rust#125476
+pub struct Data([u8; usize::MAX >> 16]);
+const _: &'static [Data] = &[];

--- a/tests/crashes/125512.rs
+++ b/tests/crashes/125512.rs
@@ -1,0 +1,10 @@
+//@ known-bug: rust-lang/rust#125512
+//@ edition:2021
+#![feature(object_safe_for_dispatch)]
+trait B {
+    fn f(a: A) -> A;
+}
+trait A {
+    fn concrete(b: B) -> B;
+}
+fn main() {}

--- a/tests/crashes/125520.rs
+++ b/tests/crashes/125520.rs
@@ -1,0 +1,16 @@
+//@ known-bug: #125520
+#![feature(generic_const_exprs)]
+
+struct Outer<const A: i64, const B: i64>();
+impl<const A: usize, const B: usize> Outer<A, B>
+where
+    [(); A + (B * 2)]:,
+{
+    fn i() -> Self {
+        Self
+    }
+}
+
+fn main() {
+    Outer::<1, 1>::o();
+}

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4, const core::num::<impl u16>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4, const core::num::<impl u16>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-abort.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4, const core::num::<impl i64>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
@@ -29,7 +29,7 @@
       }
   
       bb1: {
-+         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4, const core::num::<impl i64>::BITS) -> [return: bb2, unwind unreachable];
++         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(_4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {

--- a/tests/ui/issues/issue-33992.rs
+++ b/tests/ui/issues/issue-33992.rs
@@ -5,9 +5,6 @@
 
 #![feature(linkage)]
 
-#[linkage = "common"]
-pub static mut TEST1: u32 = 0u32;
-
 #[linkage = "external"]
 pub static TEST2: bool = true;
 

--- a/tests/ui/linkage-attr/linkage-attr-mutable-static.rs
+++ b/tests/ui/linkage-attr/linkage-attr-mutable-static.rs
@@ -1,0 +1,15 @@
+//! The symbols are resolved by the linker. It doesn't make sense to change
+//! them at runtime, so deny mutable statics with #[linkage].
+
+#![feature(linkage)]
+
+fn main() {
+    extern "C" {
+        #[linkage = "weak"] //~ ERROR mutable statics are not allowed with `#[linkage]`
+        static mut ABC: *const u8;
+    }
+
+    unsafe {
+        assert_eq!(ABC as usize, 0);
+    }
+}

--- a/tests/ui/linkage-attr/linkage-attr-mutable-static.stderr
+++ b/tests/ui/linkage-attr/linkage-attr-mutable-static.stderr
@@ -1,0 +1,10 @@
+error: mutable statics are not allowed with `#[linkage]`
+  --> $DIR/linkage-attr-mutable-static.rs:8:9
+   |
+LL |         #[linkage = "weak"]
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: making the static mutable would allow changing which symbol the static references rather than make the target of the symbol mutable
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/methods/suggest-method-on-call-for-ambig-receiver.rs
+++ b/tests/ui/methods/suggest-method-on-call-for-ambig-receiver.rs
@@ -1,0 +1,16 @@
+// Fix for <https://github.com/rust-lang/rust/issues/125432>.
+
+fn separate_arms() {
+    let mut x = None;
+    match x {
+        None => {
+            x = Some(0);
+        }
+        Some(right) => {
+            consume(right);
+            //~^ ERROR cannot find function `consume` in this scope
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/methods/suggest-method-on-call-for-ambig-receiver.stderr
+++ b/tests/ui/methods/suggest-method-on-call-for-ambig-receiver.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find function `consume` in this scope
+  --> $DIR/suggest-method-on-call-for-ambig-receiver.rs:10:13
+   |
+LL |             consume(right);
+   |             ^^^^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/return/dont-suggest-through-inner-const.rs
+++ b/tests/ui/return/dont-suggest-through-inner-const.rs
@@ -1,0 +1,9 @@
+const fn f() -> usize {
+    //~^ ERROR mismatched types
+    const FIELD: usize = loop {
+        0
+        //~^ ERROR mismatched types
+    };
+}
+
+fn main() {}

--- a/tests/ui/return/dont-suggest-through-inner-const.stderr
+++ b/tests/ui/return/dont-suggest-through-inner-const.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-through-inner-const.rs:4:9
+   |
+LL |         0
+   |         ^ expected `()`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-through-inner-const.rs:1:17
+   |
+LL | const fn f() -> usize {
+   |          -      ^^^^^ expected `usize`, found `()`
+   |          |
+   |          implicitly returns `()` as its body has no tail or `return` expression
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -453,6 +453,19 @@ message_on_close = "PR #{number} has been closed. Thanks for participating!"
 message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
 
 # FIXME: Patch triagebot to support `notify-zulip.<label>` getting mapped to an array of actions.
+#        At the moment, the beta-accepted+T-rustdoc action fully occupies the beta-accepted slot
+#        preventing others from adding more beta-accepted actions.
+[notify-zulip."beta-accepted"]
+required_labels = ["T-rustdoc"]
+zulip_stream = 266220 # #t-rustdoc
+# Put it in the same thread as beta-nominated.
+topic = "beta-nominated: #{number}"
+message_on_add = "PR #{number} has been **accepted** for beta backport."
+message_on_remove = "PR #{number}'s beta-acceptance has been **removed**."
+message_on_close = "PR #{number} has been closed. Thanks for participating!"
+message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
+
+# FIXME: Patch triagebot to support `notify-zulip.<label>` getting mapped to an array of actions.
 #        At the moment, the stable-nominated+T-rustdoc action fully occupies the stable-nominated slot
 #        preventing others from adding more stable-nominated actions.
 [notify-zulip."stable-nominated"]
@@ -473,6 +486,19 @@ don't know
 """,
 ]
 message_on_remove = "PR #{number}'s stable-nomination has been removed."
+message_on_close = "PR #{number} has been closed. Thanks for participating!"
+message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
+
+# FIXME: Patch triagebot to support `notify-zulip.<label>` getting mapped to an array of actions.
+#        At the moment, the stable-accepted+T-rustdoc action fully occupies the stable-accepted slot
+#        preventing others from adding more stable-accepted actions.
+[notify-zulip."stable-accepted"]
+required_labels = ["T-rustdoc"]
+zulip_stream = 266220 # #t-rustdoc
+# Put it in the same thread as stable-nominated.
+topic = "stable-nominated: #{number}"
+message_on_add = "PR #{number} has been **accepted** for stable backport."
+message_on_remove = "PR #{number}'s stable-acceptance has been **removed**."
 message_on_close = "PR #{number} has been closed. Thanks for participating!"
 message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -794,6 +794,9 @@ cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 [mentions."src/doc/rustc/src/check-cfg.md"]
 cc = ["@Urgau"]
 
+[mentions."src/doc/rustc/src/check-cfg"]
+cc = ["@Urgau"]
+
 [mentions."src/doc/rustc/src/platform-support"]
 cc = ["@Nilstrieb"]
 


### PR DESCRIPTION
Successful merges:

 - #125046 (Only allow immutable statics with #[linkage])
 - #125466 (Don't continue probing for method if in suggestion and autoderef hits ambiguity)
 - #125469 (Don't skip out of inner const when looking for body for suggestion)
 - #125530 (cleanup dependence of `ExtCtxt` in transcribe when macro expansion)
 - #125535 (clean-up: remove deprecated field `dist.missing-tools`)
 - #125539 (crashes: increment the number of tracked ones)
 - #125544 (Also mention my-self for other check-cfg docs changes)
 - #125559 (Simplify the `unchecked_sh[lr]` ub-checks a bit)
 - #125566 (Notify T-rustdoc for beta-accepted and stable-accepted too)
 - #125582 (Avoid a `FieldIdx::from_usize` in InstSimplify)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=125046,125466,125469,125530,125535,125539,125544,125559,125566,125582)
<!-- homu-ignore:end -->