### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -97,9 +97,6 @@ ast_passes_fn_body_extern = incorrect function inside `extern` block
 ast_passes_fn_param_c_var_args_not_last =
     `...` must be the last argument of a C-variadic function
 
-ast_passes_fn_param_c_var_args_only =
-    C-variadic function must be declared with at least one named argument
-
 ast_passes_fn_param_doc_comment =
     documentation comments cannot be applied to function parameters
     .label = doc comments are not allowed here

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -365,7 +365,7 @@ impl<'a> AstValidator<'a> {
 
     fn check_fn_decl(&self, fn_decl: &FnDecl, self_semantic: SelfSemantic) {
         self.check_decl_num_args(fn_decl);
-        self.check_decl_cvaradic_pos(fn_decl);
+        self.check_decl_cvariadic_pos(fn_decl);
         self.check_decl_attrs(fn_decl);
         self.check_decl_self_param(fn_decl, self_semantic);
     }
@@ -380,13 +380,11 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn check_decl_cvaradic_pos(&self, fn_decl: &FnDecl) {
+    /// Emits an error if a function declaration has a variadic parameter in the
+    /// beginning or middle of parameter list.
+    /// Example: `fn foo(..., x: i32)` will emit an error.
+    fn check_decl_cvariadic_pos(&self, fn_decl: &FnDecl) {
         match &*fn_decl.inputs {
-            [Param { ty, span, .. }] => {
-                if let TyKind::CVarArgs = ty.kind {
-                    self.dcx().emit_err(errors::FnParamCVarArgsOnly { span: *span });
-                }
-            }
             [ps @ .., _] => {
                 for Param { ty, span, .. } in ps {
                     if let TyKind::CVarArgs = ty.kind {

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -93,13 +93,6 @@ pub struct FnParamTooMany {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes_fn_param_c_var_args_only)]
-pub struct FnParamCVarArgsOnly {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(ast_passes_fn_param_c_var_args_not_last)]
 pub struct FnParamCVarArgsNotLast {
     #[primary_span]

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -327,6 +327,18 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                     } else {
                         codegen_fn_attrs.linkage = linkage;
                     }
+                    if tcx.is_mutable_static(did.into()) {
+                        let mut diag = tcx.dcx().struct_span_err(
+                            attr.span,
+                            "mutable statics are not allowed with `#[linkage]`",
+                        );
+                        diag.note(
+                            "making the static mutable would allow changing which symbol the \
+                             static references rather than make the target of the symbol \
+                             mutable",
+                        );
+                        diag.emit();
+                    }
                 }
             }
             sym::link_section => {

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -224,7 +224,8 @@ fn expand_macro<'cx>(
             let arm_span = rhses[i].span();
 
             // rhs has holes ( `$id` and `$(...)` that need filled)
-            let tts = match transcribe(cx, &named_matches, rhs, rhs_span, transparency) {
+            let id = cx.current_expansion.id;
+            let tts = match transcribe(psess, &named_matches, rhs, rhs_span, transparency, id) {
                 Ok(tts) => tts,
                 Err(err) => {
                     let guar = err.emit();

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1871,11 +1871,8 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
         // If this is due to a block, then maybe we forgot a `return`/`break`.
         if due_to_block
             && let Some(expr) = expression
-            && let Some((parent_fn_decl, parent_id)) = fcx
-                .tcx
-                .hir()
-                .parent_iter(block_or_return_id)
-                .find_map(|(_, node)| Some((node.fn_decl()?, node.associated_body()?.0)))
+            && let Some(parent_fn_decl) =
+                fcx.tcx.hir().fn_decl_by_hir_id(fcx.tcx.local_def_id_to_hir_id(fcx.body_id))
         {
             fcx.suggest_missing_break_or_return_expr(
                 &mut err,
@@ -1884,7 +1881,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                 expected,
                 found,
                 block_or_return_id,
-                parent_id,
+                fcx.body_id,
             );
         }
 

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -142,10 +142,10 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
                     _ => return,
                 };
                 if let Some(variant_target_idx) = variant_target {
-                    for (field_index, operand) in operands.iter().enumerate() {
+                    for (field_index, operand) in operands.iter_enumerated() {
                         if let Some(field) = self.map().apply(
                             variant_target_idx,
-                            TrackElem::Field(FieldIdx::from_usize(field_index)),
+                            TrackElem::Field(field_index),
                         ) {
                             self.assign_operand(state, field, operand);
                         }

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -9,7 +9,6 @@ use rustc_middle::ty::layout::ValidityRequirement;
 use rustc_middle::ty::{self, GenericArgsRef, ParamEnv, Ty, TyCtxt};
 use rustc_span::sym;
 use rustc_span::symbol::Symbol;
-use rustc_target::abi::FieldIdx;
 use rustc_target::spec::abi::Abi;
 
 pub struct InstSimplify;
@@ -217,11 +216,11 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
                     && let Some(place) = operand.place()
                 {
                     let variant = adt_def.non_enum_variant();
-                    for (i, field) in variant.fields.iter().enumerate() {
+                    for (i, field) in variant.fields.iter_enumerated() {
                         let field_ty = field.ty(self.tcx, args);
                         if field_ty == *cast_ty {
                             let place = place.project_deeper(
-                                &[ProjectionElem::Field(FieldIdx::from_usize(i), *cast_ty)],
+                                &[ProjectionElem::Field(i, *cast_ty)],
                                 self.tcx,
                             );
                             let operand = if operand.is_move() {

--- a/tests/crashes/123255.rs
+++ b/tests/crashes/123255.rs
@@ -1,0 +1,13 @@
+//@ known-bug: rust-lang/rust#123255
+//@ edition:2021
+#![crate_type = "lib"]
+
+pub fn a() {}
+
+mod handlers {
+    pub struct C(&());
+    pub fn c() -> impl Fn() -> C {
+        let a1 = ();
+        || C((crate::a(), a1).into())
+    }
+}

--- a/tests/crashes/123276.rs
+++ b/tests/crashes/123276.rs
@@ -1,0 +1,25 @@
+//@ known-bug: rust-lang/rust#123276
+//@ edition:2021
+
+async fn create_task() {
+    _ = Some(async { bind(documentation_filter()) });
+}
+
+async fn bind<Fut, F: Filter<Future = Fut>>(_: F) {}
+
+fn documentation_filter() -> impl Filter {
+    AndThen
+}
+
+trait Filter {
+    type Future;
+}
+
+struct AndThen;
+
+impl Filter for AndThen
+where
+    Foo: Filter,
+{
+    type Future = ();
+}

--- a/tests/crashes/123887.rs
+++ b/tests/crashes/123887.rs
@@ -1,0 +1,15 @@
+//@ known-bug: rust-lang/rust#123887
+//@ compile-flags: -Clink-dead-code
+
+#![feature(extern_types)]
+#![feature(unsized_fn_params)]
+
+extern "C" {
+    pub type ExternType;
+}
+
+impl ExternType {
+    pub fn f(self) {}
+}
+
+pub fn main() {}

--- a/tests/crashes/125013-1.rs
+++ b/tests/crashes/125013-1.rs
@@ -1,0 +1,5 @@
+//@ known-bug: rust-lang/rust#125013
+//@ edition:2021
+use io::{self as std};
+use std::ops::Deref::{self as io};
+pub fn main() {}

--- a/tests/crashes/125013-2.rs
+++ b/tests/crashes/125013-2.rs
@@ -1,0 +1,16 @@
+//@ known-bug: rust-lang/rust#125013
+//@ edition:2021
+mod a {
+  pub mod b {
+    pub mod c {
+      pub trait D {}
+    }
+  }
+}
+
+use a::*;
+
+use e as b;
+use b::c::D as e;
+
+fn main() { }

--- a/tests/crashes/125014.rs
+++ b/tests/crashes/125014.rs
@@ -1,0 +1,17 @@
+//@ known-bug: rust-lang/rust#125014
+//@ compile-flags: -Znext-solver=coherence
+#![feature(specialization)]
+
+trait Foo {}
+
+impl Foo for <u16 as Assoc>::Output {}
+
+impl Foo for u32 {}
+
+trait Assoc {
+    type Output;
+}
+impl Output for u32 {}
+impl Assoc for <u16 as Assoc>::Output {
+    default type Output = bool;
+}

--- a/tests/crashes/125059.rs
+++ b/tests/crashes/125059.rs
@@ -1,0 +1,12 @@
+//@ known-bug: rust-lang/rust#125059
+#![feature(deref_patterns)]
+#![allow(incomplete_features)]
+
+fn simple_vec(vec: Vec<u32>) -> u32 {
+   (|| match Vec::<u32>::new() {
+        deref!([]) => 100,
+        _ => 2000,
+    })()
+}
+
+fn main() {}

--- a/tests/crashes/125323.rs
+++ b/tests/crashes/125323.rs
@@ -1,0 +1,6 @@
+//@ known-bug: rust-lang/rust#125323
+fn main() {
+    for _ in 0..0 {
+        [(); loop {}];
+    }
+}

--- a/tests/crashes/125370.rs
+++ b/tests/crashes/125370.rs
@@ -1,0 +1,16 @@
+//@ known-bug: rust-lang/rust#125370
+
+type Field3 = i64;
+
+#[repr(C)]
+union DummyUnion {
+    field3: Field3,
+}
+
+const UNION: DummyUnion = loop {};
+
+const fn read_field2() -> Field2 {
+    const FIELD2: Field2 = loop {
+        UNION.field3
+    };
+}

--- a/tests/crashes/125432.rs
+++ b/tests/crashes/125432.rs
@@ -1,0 +1,17 @@
+//@ known-bug: rust-lang/rust#125432
+
+fn separate_arms() {
+    // Here both arms perform assignments, but only one is illegal.
+
+    let mut x = None;
+    match x {
+        None => {
+            // It is ok to reassign x here, because there is in
+            // fact no outstanding loan of x!
+            x = Some(0);
+        }
+        Some(right) => consume(right),
+    }
+}
+
+fn main() {}

--- a/tests/crashes/125476.rs
+++ b/tests/crashes/125476.rs
@@ -1,0 +1,3 @@
+//@ known-bug: rust-lang/rust#125476
+pub struct Data([u8; usize::MAX >> 16]);
+const _: &'static [Data] = &[];

--- a/tests/crashes/125512.rs
+++ b/tests/crashes/125512.rs
@@ -1,0 +1,10 @@
+//@ known-bug: rust-lang/rust#125512
+//@ edition:2021
+#![feature(object_safe_for_dispatch)]
+trait B {
+    fn f(a: A) -> A;
+}
+trait A {
+    fn concrete(b: B) -> B;
+}
+fn main() {}

--- a/tests/crashes/125520.rs
+++ b/tests/crashes/125520.rs
@@ -1,0 +1,16 @@
+//@ known-bug: #125520
+#![feature(generic_const_exprs)]
+
+struct Outer<const A: i64, const B: i64>();
+impl<const A: usize, const B: usize> Outer<A, B>
+where
+    [(); A + (B * 2)]:,
+{
+    fn i() -> Self {
+        Self
+    }
+}
+
+fn main() {
+    Outer::<1, 1>::o();
+}

--- a/tests/ui/c-variadic/variadic-ffi-no-fixed-args.rs
+++ b/tests/ui/c-variadic/variadic-ffi-no-fixed-args.rs
@@ -1,6 +1,9 @@
+//@ build-pass
+
+// Supported since C23
+// https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2975.pdf
 extern "C" {
     fn foo(...);
-//~^ ERROR C-variadic function must be declared with at least one named argument
 }
 
 fn main() {}

--- a/tests/ui/c-variadic/variadic-ffi-no-fixed-args.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-no-fixed-args.stderr
@@ -1,8 +1,0 @@
-error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-no-fixed-args.rs:2:12
-   |
-LL |     fn foo(...);
-   |            ^^^
-
-error: aborting due to 1 previous error
-

--- a/tests/ui/issues/issue-33992.rs
+++ b/tests/ui/issues/issue-33992.rs
@@ -5,9 +5,6 @@
 
 #![feature(linkage)]
 
-#[linkage = "common"]
-pub static mut TEST1: u32 = 0u32;
-
 #[linkage = "external"]
 pub static TEST2: bool = true;
 

--- a/tests/ui/linkage-attr/linkage-attr-mutable-static.rs
+++ b/tests/ui/linkage-attr/linkage-attr-mutable-static.rs
@@ -1,0 +1,15 @@
+//! The symbols are resolved by the linker. It doesn't make sense to change
+//! them at runtime, so deny mutable statics with #[linkage].
+
+#![feature(linkage)]
+
+fn main() {
+    extern "C" {
+        #[linkage = "weak"] //~ ERROR mutable statics are not allowed with `#[linkage]`
+        static mut ABC: *const u8;
+    }
+
+    unsafe {
+        assert_eq!(ABC as usize, 0);
+    }
+}

--- a/tests/ui/linkage-attr/linkage-attr-mutable-static.stderr
+++ b/tests/ui/linkage-attr/linkage-attr-mutable-static.stderr
@@ -1,0 +1,10 @@
+error: mutable statics are not allowed with `#[linkage]`
+  --> $DIR/linkage-attr-mutable-static.rs:8:9
+   |
+LL |         #[linkage = "weak"]
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: making the static mutable would allow changing which symbol the static references rather than make the target of the symbol mutable
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/variadic-ffi-semantic-restrictions.rs
+++ b/tests/ui/parser/variadic-ffi-semantic-restrictions.rs
@@ -8,14 +8,12 @@ fn f1_1(x: isize, ...) {}
 
 fn f1_2(...) {}
 //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
-//~| ERROR C-variadic function must be declared with at least one named argument
 
 extern "C" fn f2_1(x: isize, ...) {}
 //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
 
 extern "C" fn f2_2(...) {}
 //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
-//~| ERROR C-variadic function must be declared with at least one named argument
 
 extern "C" fn f2_3(..., x: isize) {}
 //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
@@ -26,7 +24,6 @@ extern "C" fn f3_1(x: isize, ...) {}
 
 extern "C" fn f3_2(...) {}
 //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
-//~| ERROR C-variadic function must be declared with at least one named argument
 
 extern "C" fn f3_3(..., x: isize) {}
 //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
@@ -47,8 +44,6 @@ const extern "C" fn f4_3(..., x: isize, ...) {}
 //~| ERROR `...` must be the last argument of a C-variadic function
 
 extern "C" {
-    fn e_f1(...);
-    //~^ ERROR C-variadic function must be declared with at least one named argument
     fn e_f2(..., x: isize);
     //~^ ERROR `...` must be the last argument of a C-variadic function
 }
@@ -60,7 +55,6 @@ impl X {
     //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
     fn i_f2(...) {}
     //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
-    //~| ERROR C-variadic function must be declared with at least one named argument
     fn i_f3(..., x: isize, ...) {}
     //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
     //~| ERROR `...` must be the last argument of a C-variadic function
@@ -80,10 +74,8 @@ trait T {
     //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
     fn t_f3(...) {}
     //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
-    //~| ERROR C-variadic function must be declared with at least one named argument
     fn t_f4(...);
     //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
-    //~| ERROR C-variadic function must be declared with at least one named argument
     fn t_f5(..., x: isize) {}
     //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
     //~| ERROR `...` must be the last argument of a C-variadic function

--- a/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
+++ b/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
@@ -4,12 +4,6 @@ error: only foreign or `unsafe extern "C"` functions may be C-variadic
 LL | fn f1_1(x: isize, ...) {}
    |                   ^^^
 
-error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:9:9
-   |
-LL | fn f1_2(...) {}
-   |         ^^^
-
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
   --> $DIR/variadic-ffi-semantic-restrictions.rs:9:9
    |
@@ -17,91 +11,79 @@ LL | fn f1_2(...) {}
    |         ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:13:30
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:12:30
    |
 LL | extern "C" fn f2_1(x: isize, ...) {}
    |                              ^^^
 
-error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:16:20
-   |
-LL | extern "C" fn f2_2(...) {}
-   |                    ^^^
-
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:16:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:15:20
    |
 LL | extern "C" fn f2_2(...) {}
    |                    ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:20:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:18:20
    |
 LL | extern "C" fn f2_3(..., x: isize) {}
    |                    ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:20:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:18:20
    |
 LL | extern "C" fn f2_3(..., x: isize) {}
    |                    ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:24:30
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:22:30
    |
 LL | extern "C" fn f3_1(x: isize, ...) {}
    |                              ^^^
 
-error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:27:20
-   |
-LL | extern "C" fn f3_2(...) {}
-   |                    ^^^
-
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:27:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:25:20
    |
 LL | extern "C" fn f3_2(...) {}
    |                    ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:31:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:28:20
    |
 LL | extern "C" fn f3_3(..., x: isize) {}
    |                    ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:31:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:28:20
    |
 LL | extern "C" fn f3_3(..., x: isize) {}
    |                    ^^^
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:35:1
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:32:1
    |
 LL | const unsafe extern "C" fn f4_1(x: isize, ...) {}
    | ^^^^^ `const` because of this             ^^^ C-variadic because of this
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:1
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:36:1
    |
 LL | const extern "C" fn f4_2(x: isize, ...) {}
    | ^^^^^ `const` because of this      ^^^ C-variadic because of this
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:36
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:36:36
    |
 LL | const extern "C" fn f4_2(x: isize, ...) {}
    |                                    ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:44:26
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:41:26
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    |                          ^^^
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:44:1
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:41:1
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    | ^^^^^                    ^^^            ^^^ C-variadic because of this
@@ -110,67 +92,55 @@ LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    | `const` because of this
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:44:26
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:41:26
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    |                          ^^^            ^^^
 
-error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:50:13
-   |
-LL |     fn e_f1(...);
-   |             ^^^
-
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:52:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:47:13
    |
 LL |     fn e_f2(..., x: isize);
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:59:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:54:23
    |
 LL |     fn i_f1(x: isize, ...) {}
    |                       ^^^
 
-error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:61:13
-   |
-LL |     fn i_f2(...) {}
-   |             ^^^
-
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:61:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:56:13
    |
 LL |     fn i_f2(...) {}
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:58:13
    |
 LL |     fn i_f3(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:58:13
    |
 LL |     fn i_f3(..., x: isize, ...) {}
    |             ^^^            ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:67:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:61:13
    |
 LL |     fn i_f4(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:67:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:61:13
    |
 LL |     fn i_f4(..., x: isize, ...) {}
    |             ^^^            ^^^
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:5
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:5
    |
 LL |     const fn i_f5(x: isize, ...) {}
    |     ^^^^^                   ^^^ C-variadic because of this
@@ -178,73 +148,61 @@ LL |     const fn i_f5(x: isize, ...) {}
    |     `const` because of this
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:29
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:29
    |
 LL |     const fn i_f5(x: isize, ...) {}
    |                             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:77:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:71:23
    |
 LL |     fn t_f1(x: isize, ...) {}
    |                       ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:79:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:73:23
    |
 LL |     fn t_f2(x: isize, ...);
    |                       ^^^
 
-error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:81:13
+error: only foreign or `unsafe extern "C"` functions may be C-variadic
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:75:13
    |
 LL |     fn t_f3(...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:81:13
-   |
-LL |     fn t_f3(...) {}
-   |             ^^^
-
-error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:84:13
-   |
-LL |     fn t_f4(...);
-   |             ^^^
-
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:84:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:77:13
    |
 LL |     fn t_f4(...);
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:87:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:79:13
    |
 LL |     fn t_f5(..., x: isize) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:87:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:79:13
    |
 LL |     fn t_f5(..., x: isize) {}
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:90:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:82:13
    |
 LL |     fn t_f6(..., x: isize);
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:90:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:82:13
    |
 LL |     fn t_f6(..., x: isize);
    |             ^^^
 
 error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:35:43
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:32:43
    |
 LL | const unsafe extern "C" fn f4_1(x: isize, ...) {}
    |                                           ^^^   - value is dropped here
@@ -252,7 +210,7 @@ LL | const unsafe extern "C" fn f4_1(x: isize, ...) {}
    |                                           the destructor for this type cannot be evaluated in constant functions
 
 error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:36
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:36:36
    |
 LL | const extern "C" fn f4_2(x: isize, ...) {}
    |                                    ^^^   - value is dropped here
@@ -260,13 +218,13 @@ LL | const extern "C" fn f4_2(x: isize, ...) {}
    |                                    the destructor for this type cannot be evaluated in constant functions
 
 error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:29
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:29
    |
 LL |     const fn i_f5(x: isize, ...) {}
    |                             ^^^   - value is dropped here
    |                             |
    |                             the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 43 previous errors
+error: aborting due to 36 previous errors
 
 For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/return/dont-suggest-through-inner-const.rs
+++ b/tests/ui/return/dont-suggest-through-inner-const.rs
@@ -1,0 +1,9 @@
+const fn f() -> usize {
+    //~^ ERROR mismatched types
+    const FIELD: usize = loop {
+        0
+        //~^ ERROR mismatched types
+    };
+}
+
+fn main() {}

--- a/tests/ui/return/dont-suggest-through-inner-const.stderr
+++ b/tests/ui/return/dont-suggest-through-inner-const.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-through-inner-const.rs:4:9
+   |
+LL |         0
+   |         ^ expected `()`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-through-inner-const.rs:1:17
+   |
+LL | const fn f() -> usize {
+   |          -      ^^^^^ expected `usize`, found `()`
+   |          |
+   |          implicitly returns `()` as its body has no tail or `return` expression
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -453,6 +453,19 @@ message_on_close = "PR #{number} has been closed. Thanks for participating!"
 message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
 
 # FIXME: Patch triagebot to support `notify-zulip.<label>` getting mapped to an array of actions.
+#        At the moment, the beta-accepted+T-rustdoc action fully occupies the beta-accepted slot
+#        preventing others from adding more beta-accepted actions.
+[notify-zulip."beta-accepted"]
+required_labels = ["T-rustdoc"]
+zulip_stream = 266220 # #t-rustdoc
+# Put it in the same thread as beta-nominated.
+topic = "beta-nominated: #{number}"
+message_on_add = "PR #{number} has been **accepted** for beta backport."
+message_on_remove = "PR #{number}'s beta-acceptance has been **removed**."
+message_on_close = "PR #{number} has been closed. Thanks for participating!"
+message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
+
+# FIXME: Patch triagebot to support `notify-zulip.<label>` getting mapped to an array of actions.
 #        At the moment, the stable-nominated+T-rustdoc action fully occupies the stable-nominated slot
 #        preventing others from adding more stable-nominated actions.
 [notify-zulip."stable-nominated"]
@@ -473,6 +486,19 @@ don't know
 """,
 ]
 message_on_remove = "PR #{number}'s stable-nomination has been removed."
+message_on_close = "PR #{number} has been closed. Thanks for participating!"
+message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
+
+# FIXME: Patch triagebot to support `notify-zulip.<label>` getting mapped to an array of actions.
+#        At the moment, the stable-accepted+T-rustdoc action fully occupies the stable-accepted slot
+#        preventing others from adding more stable-accepted actions.
+[notify-zulip."stable-accepted"]
+required_labels = ["T-rustdoc"]
+zulip_stream = 266220 # #t-rustdoc
+# Put it in the same thread as stable-nominated.
+topic = "stable-nominated: #{number}"
+message_on_add = "PR #{number} has been **accepted** for stable backport."
+message_on_remove = "PR #{number}'s stable-acceptance has been **removed**."
 message_on_close = "PR #{number} has been closed. Thanks for participating!"
 message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -794,6 +794,9 @@ cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 [mentions."src/doc/rustc/src/check-cfg.md"]
 cc = ["@Urgau"]
 
+[mentions."src/doc/rustc/src/check-cfg"]
+cc = ["@Urgau"]
+
 [mentions."src/doc/rustc/src/platform-support"]
 cc = ["@Nilstrieb"]
 


### PR DESCRIPTION
Successful merges:

 - #124048 (Support C23's Variadics Without a Named Parameter)
 - #125046 (Only allow immutable statics with #[linkage])
 - #125469 (Don't skip out of inner const when looking for body for suggestion)
 - #125530 (cleanup dependence of `ExtCtxt` in transcribe when macro expansion)
 - #125539 (crashes: increment the number of tracked ones)
 - #125544 (Also mention my-self for other check-cfg docs changes)
 - #125566 (Notify T-rustdoc for beta-accepted and stable-accepted too)
 - #125582 (Avoid a `FieldIdx::from_usize` in InstSimplify)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=124048,125046,125469,125530,125539,125544,125566,125582)
<!-- homu-ignore:end -->