### PR TITLE
Adds `cfg(not(no_global_oom_handling))` for `FromUtf16Error`

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -420,6 +420,7 @@ pub struct FromUtf8Error {
 ///
 /// assert!(String::from_utf16(v).is_err());
 /// ```
+#[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
 pub struct FromUtf16Error(());
@@ -2069,6 +2070,7 @@ impl fmt::Display for FromUtf8Error {
     }
 }
 
+#[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for FromUtf16Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -2084,6 +2086,7 @@ impl Error for FromUtf8Error {
     }
 }
 
+#[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Error for FromUtf16Error {
     #[allow(deprecated)]


### PR DESCRIPTION
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->

`FromUtf16Error` is only used when `cfg(not(no_global_oom_handling))`.