### PR TITLE
impl `From<&[T; N]>` for `Option<&[T]>`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2096,6 +2096,7 @@ impl<T> From<T> for Option<T> {
     }
 }
 
+#[stable(feature = "option_slice_from_array_ref", since = "CURRENT_RUSTC_VERSION")]
 impl<'a, T, const N: usize> From<&'a [T; N]> for Option<&'a [T]> {
     /// Converts a reference to an array into a reference to an array slice.
     ///

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2096,6 +2096,22 @@ impl<T> From<T> for Option<T> {
     }
 }
 
+impl<'a, T, const N: usize> From<&'a [T; N]> for Option<&'a [T]> {
+    /// Converts a reference to an array into a reference to an array slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let array = [1, 2, 3];
+    /// let option: Option<&[i32]> = Option::from(&array);
+    ///
+    /// assert_eq!(option, Some(&[1, 2, 3][..]));
+    /// ```
+    fn from(slice: &'a [T; N]) -> Option<&'a [T]> {
+        Some(slice.as_slice())
+    }
+}
+
 #[stable(feature = "option_ref_from_ref_option", since = "1.30.0")]
 impl<'a, T> From<&'a Option<T>> for Option<&'a T> {
     /// Converts from `&Option<T>` to `Option<&T>`.


### PR DESCRIPTION
This PR addresses issue #125600 by implementing `From<&[T; N]>` for `Option<&[T]>`. This would enable the following use case

```rust
fn foo<'a>(arg: impl Into<Option<&'a [i32]>>) { }

fn main() {
    foo(&[1,2,3]);
}
```

which currently only supports using `&[1,2,3][..]` as the argument. 