### PR TITLE
Always use the general case char count with `optimize_for_size`

### DIFF
--- a/library/core/src/str/count.rs
+++ b/library/core/src/str/count.rs
@@ -24,7 +24,7 @@ const UNROLL_INNER: usize = 4;
 
 #[inline]
 pub(super) fn count_chars(s: &str) -> usize {
-    if s.len() < USIZE_SIZE * UNROLL_INNER {
+    if cfg!(feature = "optimize_for_size") || s.len() < USIZE_SIZE * UNROLL_INNER {
         // Avoid entering the optimized implementation for strings where the
         // difference is not likely to matter, or where it might even be slower.
         // That said, a ton of thought was not spent on the particular threshold


### PR DESCRIPTION
The faster algo is really expensive, over a kilobyte if the full algo is present in a binary.
With this PR the general case algo is picked always instead of only for small strings.

In a test of mine this change makes the total binary go from 3116 bytes to 2032 bytes in opt-level 3 and from 1652 bytes to 1428 bytes in opt-level z. I've seen it much worse in real application, so the savings (especially on 'z') will be higher in many cases.

This is the second pr of this kind after #125606