### PR TITLE
Support `./x doc run-make-support --open`

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1028,6 +1028,14 @@ tool_doc!(
     is_library = true,
     crates = ["bootstrap"]
 );
+tool_doc!(
+    RunMakeSupport,
+    "run_make_support",
+    "src/tools/run-make-support",
+    rustc_tool = false,
+    is_library = true,
+    crates = ["run_make_support"]
+);
 
 #[derive(Ord, PartialOrd, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct ErrorIndex {

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -888,6 +888,7 @@ impl<'a> Builder<'a> {
                 doc::Tidy,
                 doc::Bootstrap,
                 doc::Releases,
+                doc::RunMakeSupport,
             ),
             Kind::Dist => describe!(
                 dist::Docs,

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -351,7 +351,7 @@ macro_rules! impl_common_helpers {
                 self
             }
 
-            /// Inspect what the underlying [`Command`][::std::process::Command] is up to the
+            /// Inspect what the underlying [`Command`] is up to the
             /// current construction.
             pub fn inspect<I>(&mut self, inspector: I) -> &mut Self
             where

--- a/src/tools/run-make-support/src/rustc.rs
+++ b/src/tools/run-make-support/src/rustc.rs
@@ -203,7 +203,7 @@ impl Rustc {
         self
     }
 
-    /// Get the [`Output`][::std::process::Output] of the finished process.
+    /// Get the [`Output`] of the finished process.
     #[track_caller]
     pub fn command_output(&mut self) -> ::std::process::Output {
         // let's make sure we piped all the input and outputs

--- a/src/tools/run-make-support/src/rustdoc.rs
+++ b/src/tools/run-make-support/src/rustdoc.rs
@@ -94,7 +94,7 @@ impl Rustdoc {
         self
     }
 
-    /// Get the [`Output`][::std::process::Output] of the finished process.
+    /// Get the [`Output`] of the finished process.
     #[track_caller]
     pub fn command_output(&mut self) -> ::std::process::Output {
         // let's make sure we piped all the input and outputs


### PR DESCRIPTION
Having easy access to the run-make-support documentation is invaluable when creating run-make tests using the new Rust recipes.