### PR TITLE
Don't suggest turning non-char-literal exprs of ty `char` into string literals

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2064,10 +2064,15 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 // If a string was expected and the found expression is a character literal,
                 // perhaps the user meant to write `"s"` to specify a string literal.
                 (ty::Ref(_, r, _), ty::Char) if r.is_str() => {
-                    suggestions.push(TypeErrorAdditionalDiags::MeantStrLiteral {
-                        start: span.with_hi(span.lo() + BytePos(1)),
-                        end: span.with_lo(span.hi() - BytePos(1)),
-                    })
+                    if let Ok(code) = self.tcx.sess().source_map().span_to_snippet(span)
+                        && code.starts_with("'")
+                        && code.ends_with("'")
+                    {
+                        suggestions.push(TypeErrorAdditionalDiags::MeantStrLiteral {
+                            start: span.with_hi(span.lo() + BytePos(1)),
+                            end: span.with_lo(span.hi() - BytePos(1)),
+                        });
+                    }
                 }
                 // For code `if Some(..) = expr `, the type mismatch may be expected `bool` but found `()`,
                 // we try to suggest to add the missing `let` for `if let Some(..) = expr`

--- a/tests/crashes/125081.rs
+++ b/tests/crashes/125081.rs
@@ -1,7 +1,0 @@
-//@ known-bug: rust-lang/rust#125081
-
-use std::cell::Cell;
-
-fn main() {
-    let _: Cell<&str, "a"> = Cell::new('β);
-}

--- a/tests/ui/inference/str-as-char-butchered.rs
+++ b/tests/ui/inference/str-as-char-butchered.rs
@@ -1,0 +1,7 @@
+// issue: rust-lang/rust#125081
+
+fn main() {
+    let _: &str = 'β;
+    //~^ ERROR expected `while`, `for`, `loop` or `{` after a label
+    //~| ERROR mismatched types
+}

--- a/tests/ui/inference/str-as-char-butchered.stderr
+++ b/tests/ui/inference/str-as-char-butchered.stderr
@@ -1,0 +1,22 @@
+error: expected `while`, `for`, `loop` or `{` after a label
+  --> $DIR/str-as-char-butchered.rs:4:21
+   |
+LL |     let _: &str = 'β;
+   |                     ^ expected `while`, `for`, `loop` or `{` after a label
+   |
+help: add `'` to close the char literal
+   |
+LL |     let _: &str = 'β';
+   |                     +
+
+error[E0308]: mismatched types
+  --> $DIR/str-as-char-butchered.rs:4:19
+   |
+LL |     let _: &str = 'β;
+   |            ----   ^^ expected `&str`, found `char`
+   |            |
+   |            expected due to this
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/inference/str-as-char-non-lit.rs
+++ b/tests/ui/inference/str-as-char-non-lit.rs
@@ -1,0 +1,9 @@
+// Don't suggest double quotes when encountering an expr of type `char` where a `&str`
+// is expected if the expr is not a char literal.
+// issue: rust-lang/rust#125595
+
+fn main() {
+    let _: &str = ('a'); //~ ERROR mismatched types
+    let token = || 'a';
+    let _: &str = token(); //~ ERROR mismatched types
+}

--- a/tests/ui/inference/str-as-char-non-lit.stderr
+++ b/tests/ui/inference/str-as-char-non-lit.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/str-as-char-non-lit.rs:6:19
+   |
+LL |     let _: &str = ('a');
+   |            ----   ^^^^^ expected `&str`, found `char`
+   |            |
+   |            expected due to this
+
+error[E0308]: mismatched types
+  --> $DIR/str-as-char-non-lit.rs:8:19
+   |
+LL |     let _: &str = token();
+   |            ----   ^^^^^^^ expected `&str`, found `char`
+   |            |
+   |            expected due to this
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #125595.
Fixes #125081.

r? estebank (#122217) or compiler