### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4062,6 +4062,7 @@ dependencies = [
  "rustc_feature",
  "rustc_fluent_macro",
  "rustc_hir",
+ "rustc_hir_pretty",
  "rustc_index",
  "rustc_infer",
  "rustc_macros",

--- a/compiler/rustc_lint/Cargo.toml
+++ b/compiler/rustc_lint/Cargo.toml
@@ -13,6 +13,7 @@ rustc_errors = { path = "../rustc_errors" }
 rustc_feature = { path = "../rustc_feature" }
 rustc_fluent_macro = { path = "../rustc_fluent_macro" }
 rustc_hir = { path = "../rustc_hir" }
+rustc_hir_pretty = { path = "../rustc_hir_pretty" }
 rustc_index = { path = "../rustc_index" }
 rustc_infer = { path = "../rustc_infer" }
 rustc_macros = { path = "../rustc_macros" }

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -543,17 +543,18 @@ lint_non_local_definitions_cargo_update = the {$macro_kind} `{$macro_name}` may 
 lint_non_local_definitions_deprecation = this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 lint_non_local_definitions_impl = non-local `impl` definition, `impl` blocks should be written at the same level as their item
-    .move_help =
-        move this `impl` block outside of the current {$body_kind_descr} {$depth ->
-            [one] `{$body_name}`
-           *[other] `{$body_name}` and up {$depth} bodies
-        }
     .remove_help = remove `{$may_remove_part}` to make the `impl` local
     .without_trait = methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
     .with_trait = an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
     .bounds = `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
     .exception = items in an anonymous const item (`const _: () = {"{"} ... {"}"}`) are treated as in the same scope as the anonymous const's declaration
     .const_anon = use a const-anon item to suppress this lint
+
+lint_non_local_definitions_impl_move_help =
+    move the `impl` block outside of this {$body_kind_descr} {$depth ->
+        [one] `{$body_name}`
+       *[other] `{$body_name}` and up {$depth} bodies
+    }
 
 lint_non_local_definitions_macro_rules = non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
     .help =

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -543,11 +543,12 @@ lint_non_local_definitions_cargo_update = the {$macro_kind} `{$macro_name}` may 
 lint_non_local_definitions_deprecation = this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 lint_non_local_definitions_impl = non-local `impl` definition, `impl` blocks should be written at the same level as their item
-    .help =
+    .move_help =
         move this `impl` block outside of the current {$body_kind_descr} {$depth ->
             [one] `{$body_name}`
            *[other] `{$body_name}` and up {$depth} bodies
         }
+    .remove_help = remove `{$may_remove_part}` to make the `impl` local
     .without_trait = methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
     .with_trait = an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
     .bounds = `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -548,8 +548,10 @@ lint_non_local_definitions_impl = non-local `impl` definition, `impl` blocks sho
             [one] `{$body_name}`
            *[other] `{$body_name}` and up {$depth} bodies
         }
-    .non_local = an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-    .exception = one exception to the rule are anon-const (`const _: () = {"{"} ... {"}"}`) at top-level module and anon-const at the same nesting as the trait or type
+    .without_trait = methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+    .with_trait = an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+    .bounds = `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+    .exception = anon-const (`const _: () = {"{"} ... {"}"}`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
     .const_anon = use a const-anon item to suppress this lint
 
 lint_non_local_definitions_macro_rules = non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -544,7 +544,7 @@ lint_non_local_definitions_deprecation = this lint may become deny-by-default in
 
 lint_non_local_definitions_impl = non-local `impl` definition, `impl` blocks should be written at the same level as their item
     .help =
-        move this `impl` block outside the of the current {$body_kind_descr} {$depth ->
+        move this `impl` block outside of the current {$body_kind_descr} {$depth ->
             [one] `{$body_name}`
            *[other] `{$body_name}` and up {$depth} bodies
         }
@@ -564,6 +564,8 @@ lint_non_local_definitions_macro_rules = non-local `macro_rules!` definition, `#
         remove the `#[macro_export]` or make this doc-test a standalone test with its own `fn main() {"{"} ... {"}"}`
     .non_local = a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
     .exception = one exception to the rule are anon-const (`const _: () = {"{"} ... {"}"}`) at top-level module
+
+lint_non_local_definitions_may_move = may need to be moved as well
 
 lint_non_snake_case = {$sort} `{$name}` should have a snake case name
     .rename_or_convert_suggestion = rename the identifier or convert it to a snake case raw identifier

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -548,7 +548,7 @@ lint_non_local_definitions_impl = non-local `impl` definition, `impl` blocks sho
             [one] `{$body_name}`
            *[other] `{$body_name}` and up {$depth} bodies
         }
-    .without_trait = methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+    .without_trait = methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
     .with_trait = an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
     .bounds = `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
     .exception = items in an anonymous const item (`const _: () = {"{"} ... {"}"}`) are treated as in the same scope as the anonymous const's declaration

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -551,7 +551,7 @@ lint_non_local_definitions_impl = non-local `impl` definition, `impl` blocks sho
     .without_trait = methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
     .with_trait = an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
     .bounds = `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
-    .exception = anon-const (`const _: () = {"{"} ... {"}"}`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
+    .exception = items in an anonymous const item (`const _: () = {"{"} ... {"}"}`) are treated as in the same scope as the anonymous const's declaration
     .const_anon = use a const-anon item to suppress this lint
 
 lint_non_local_definitions_macro_rules = non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
@@ -563,7 +563,6 @@ lint_non_local_definitions_macro_rules = non-local `macro_rules!` definition, `#
     .help_doctest =
         remove the `#[macro_export]` or make this doc-test a standalone test with its own `fn main() {"{"} ... {"}"}`
     .non_local = a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
-    .exception = one exception to the rule are anon-const (`const _: () = {"{"} ... {"}"}`) at top-level module
 
 lint_non_local_definitions_may_move = may need to be moved as well
 

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -542,7 +542,7 @@ lint_non_local_definitions_cargo_update = the {$macro_kind} `{$macro_name}` may 
 
 lint_non_local_definitions_deprecation = this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-lint_non_local_definitions_impl = non-local `impl` definition, they should be avoided as they go against expectation
+lint_non_local_definitions_impl = non-local `impl` definition, `impl` blocks should be written at the same level as their item
     .help =
         move this `impl` block outside the of the current {$body_kind_descr} {$depth ->
             [one] `{$body_name}`
@@ -552,7 +552,7 @@ lint_non_local_definitions_impl = non-local `impl` definition, they should be av
     .exception = one exception to the rule are anon-const (`const _: () = {"{"} ... {"}"}`) at top-level module and anon-const at the same nesting as the trait or type
     .const_anon = use a const-anon item to suppress this lint
 
-lint_non_local_definitions_macro_rules = non-local `macro_rules!` definition, they should be avoided as they go against expectation
+lint_non_local_definitions_macro_rules = non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
     .help =
         remove the `#[macro_export]` or move this `macro_rules!` outside the of the current {$body_kind_descr} {$depth ->
             [one] `{$body_name}`

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -567,6 +567,10 @@ lint_non_local_definitions_macro_rules = non-local `macro_rules!` definition, `#
 
 lint_non_local_definitions_may_move = may need to be moved as well
 
+lint_non_local_definitions_of_trait_not_local = `{$of_trait_str}` is not local
+
+lint_non_local_definitions_self_ty_not_local = `{$self_ty_str}` is not local
+
 lint_non_snake_case = {$sort} `{$name}` should have a snake case name
     .rename_or_convert_suggestion = rename the identifier or convert it to a snake case raw identifier
     .cannot_convert_note = `{$sc}` cannot be used as a raw identifier

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1421,7 +1421,6 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                 }
 
                 diag.note(fluent::lint_non_local);
-                diag.note(fluent::lint_exception);
                 diag.note(fluent::lint_non_local_definitions_deprecation);
 
                 if let Some(cargo_update) = cargo_update {

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1338,6 +1338,7 @@ pub enum NonLocalDefinitionsDiag {
         const_anon: Option<Option<Span>>,
         move_help: Span,
         may_move: Vec<Span>,
+        may_remove: Option<(Span, String)>,
         has_trait: bool,
     },
     MacroRules {
@@ -1361,6 +1362,7 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                 const_anon,
                 move_help,
                 may_move,
+                may_remove,
                 has_trait,
             } => {
                 diag.primary_message(fluent::lint_non_local_definitions_impl);
@@ -1379,7 +1381,17 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                 for sp in may_move {
                     ms.push_span_label(sp, fluent::lint_non_local_definitions_may_move);
                 }
-                diag.span_help(ms, fluent::lint_help);
+                diag.span_help(ms, fluent::lint_move_help);
+
+                if let Some((span, part)) = may_remove {
+                    diag.arg("may_remove_part", part);
+                    diag.span_suggestion(
+                        span,
+                        fluent::lint_remove_help,
+                        "",
+                        Applicability::MaybeIncorrect,
+                    );
+                }
 
                 if let Some(cargo_update) = cargo_update {
                     diag.subdiagnostic(&diag.dcx, cargo_update);

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1337,8 +1337,7 @@ pub enum NonLocalDefinitionsDiag {
         cargo_update: Option<NonLocalDefinitionsCargoUpdateNote>,
         const_anon: Option<Option<Span>>,
         move_help: Span,
-        self_ty: Span,
-        of_trait: Option<Span>,
+        may_move: Vec<Span>,
         has_trait: bool,
     },
     MacroRules {
@@ -1361,8 +1360,7 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                 cargo_update,
                 const_anon,
                 move_help,
-                self_ty,
-                of_trait,
+                may_move,
                 has_trait,
             } => {
                 diag.primary_message(fluent::lint_non_local_definitions_impl);
@@ -1376,10 +1374,10 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                 } else {
                     diag.note(fluent::lint_without_trait);
                 }
+
                 let mut ms = MultiSpan::from_span(move_help);
-                ms.push_span_label(self_ty, fluent::lint_non_local_definitions_may_move);
-                if let Some(of_trait) = of_trait {
-                    ms.push_span_label(of_trait, fluent::lint_non_local_definitions_may_move);
+                for sp in may_move {
+                    ms.push_span_label(sp, fluent::lint_non_local_definitions_may_move);
                 }
                 diag.span_help(ms, fluent::lint_help);
 

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1340,6 +1340,8 @@ pub enum NonLocalDefinitionsDiag {
         may_move: Vec<Span>,
         may_remove: Option<(Span, String)>,
         has_trait: bool,
+        self_ty_str: String,
+        of_trait_str: Option<String>,
     },
     MacroRules {
         depth: u32,
@@ -1364,11 +1366,17 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                 may_move,
                 may_remove,
                 has_trait,
+                self_ty_str,
+                of_trait_str,
             } => {
                 diag.primary_message(fluent::lint_non_local_definitions_impl);
                 diag.arg("depth", depth);
                 diag.arg("body_kind_descr", body_kind_descr);
                 diag.arg("body_name", body_name);
+                diag.arg("self_ty_str", self_ty_str);
+                if let Some(of_trait_str) = of_trait_str {
+                    diag.arg("of_trait_str", of_trait_str);
+                }
 
                 if has_trait {
                     diag.note(fluent::lint_bounds);

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1336,8 +1336,7 @@ pub enum NonLocalDefinitionsDiag {
         body_name: String,
         cargo_update: Option<NonLocalDefinitionsCargoUpdateNote>,
         const_anon: Option<Option<Span>>,
-        move_help: Span,
-        may_move: Vec<Span>,
+        move_to: Option<(Span, Vec<Span>)>,
         may_remove: Option<(Span, String)>,
         has_trait: bool,
         self_ty_str: String,
@@ -1362,8 +1361,7 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                 body_name,
                 cargo_update,
                 const_anon,
-                move_help,
-                may_move,
+                move_to,
                 may_remove,
                 has_trait,
                 self_ty_str,
@@ -1385,11 +1383,13 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                     diag.note(fluent::lint_without_trait);
                 }
 
-                let mut ms = MultiSpan::from_span(move_help);
-                for sp in may_move {
-                    ms.push_span_label(sp, fluent::lint_non_local_definitions_may_move);
+                if let Some((move_help, may_move)) = move_to {
+                    let mut ms = MultiSpan::from_span(move_help);
+                    for sp in may_move {
+                        ms.push_span_label(sp, fluent::lint_non_local_definitions_may_move);
+                    }
+                    diag.span_help(ms, fluent::lint_non_local_definitions_impl_move_help);
                 }
-                diag.span_help(ms, fluent::lint_move_help);
 
                 if let Some((span, part)) = may_remove {
                     diag.arg("may_remove_part", part);

--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -222,6 +222,9 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                     item.span.shrink_to_lo().to(impl_.self_ty.span),
                     NonLocalDefinitionsDiag::Impl {
                         depth: self.body_depth,
+                        move_help: item.span,
+                        self_ty: impl_.self_ty.span,
+                        of_trait: impl_.of_trait.map(|t| t.path.span),
                         body_kind_descr: cx.tcx.def_kind_descr(parent_def_kind, parent),
                         body_name: parent_opt_item_name
                             .map(|s| s.to_ident_string())

--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -219,7 +219,7 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
 
                 cx.emit_span_lint(
                     NON_LOCAL_DEFINITIONS,
-                    item.span,
+                    item.span.shrink_to_lo().to(impl_.self_ty.span),
                     NonLocalDefinitionsDiag::Impl {
                         depth: self.body_depth,
                         body_kind_descr: cx.tcx.def_kind_descr(parent_def_kind, parent),

--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -250,7 +250,6 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                         cargo_update: cargo_update(),
                         help: (!is_at_toplevel_doctest).then_some(()),
                         doctest_help: is_at_toplevel_doctest.then_some(()),
-                        notes: (),
                     },
                 )
             }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -218,6 +218,13 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.check_and_mk_args(def_id, args)
     }
 
+    fn intern_canonical_goal_evaluation_step(
+        self,
+        step: solve::inspect::CanonicalGoalEvaluationStep<TyCtxt<'tcx>>,
+    ) -> &'tcx solve::inspect::CanonicalGoalEvaluationStep<TyCtxt<'tcx>> {
+        self.arena.alloc(step)
+    }
+
     fn parent(self, def_id: Self::DefId) -> Self::DefId {
         self.parent(def_id)
     }

--- a/compiler/rustc_middle/src/ty/predicate.rs
+++ b/compiler/rustc_middle/src/ty/predicate.rs
@@ -121,17 +121,14 @@ impl<'tcx> Predicate<'tcx> {
     #[inline]
     pub fn allow_normalization(self) -> bool {
         match self.kind().skip_binder() {
-            PredicateKind::Clause(ClauseKind::WellFormed(_)) => false,
-            // `NormalizesTo` is only used in the new solver, so this shouldn't
-            // matter. Normalizing `term` would be 'wrong' however, as it changes whether
-            // `normalizes-to(<T as Trait>::Assoc, <T as Trait>::Assoc)` holds.
-            PredicateKind::NormalizesTo(..) => false,
+            PredicateKind::Clause(ClauseKind::WellFormed(_))
+            | PredicateKind::AliasRelate(..)
+            | PredicateKind::NormalizesTo(..) => false,
             PredicateKind::Clause(ClauseKind::Trait(_))
             | PredicateKind::Clause(ClauseKind::RegionOutlives(_))
             | PredicateKind::Clause(ClauseKind::TypeOutlives(_))
             | PredicateKind::Clause(ClauseKind::Projection(_))
             | PredicateKind::Clause(ClauseKind::ConstArgHasType(..))
-            | PredicateKind::AliasRelate(..)
             | PredicateKind::ObjectSafe(_)
             | PredicateKind::Subtype(_)
             | PredicateKind::Coerce(_)

--- a/compiler/rustc_trait_selection/src/solve/alias_relate.rs
+++ b/compiler/rustc_trait_selection/src/solve/alias_relate.rs
@@ -28,6 +28,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
     ) -> QueryResult<'tcx> {
         let tcx = self.tcx();
         let Goal { param_env, predicate: (lhs, rhs, direction) } = goal;
+        debug_assert!(lhs.to_alias_term().is_some() || rhs.to_alias_term().is_some());
 
         // Structurally normalize the lhs.
         let lhs = if let Some(alias) = lhs.to_alias_term() {

--- a/compiler/rustc_trait_selection/src/solve/alias_relate.rs
+++ b/compiler/rustc_trait_selection/src/solve/alias_relate.rs
@@ -26,7 +26,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         &mut self,
         goal: Goal<'tcx, (ty::Term<'tcx>, ty::Term<'tcx>, ty::AliasRelationDirection)>,
     ) -> QueryResult<'tcx> {
-        let tcx = self.tcx();
+        let tcx = self.interner();
         let Goal { param_env, predicate: (lhs, rhs, direction) } = goal;
 
         // Structurally normalize the lhs.

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
@@ -71,7 +71,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
             QueryInput {
                 goal,
                 predefined_opaques_in_body: self
-                    .tcx()
+                    .interner()
                     .mk_predefined_opaques_in_body(PredefinedOpaquesData { opaque_types }),
             },
         );
@@ -144,7 +144,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
             Response {
                 var_values,
                 certainty,
-                external_constraints: self.tcx().mk_external_constraints(external_constraints),
+                external_constraints: self.interner().mk_external_constraints(external_constraints),
             },
         );
 
@@ -160,7 +160,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         maybe_cause: MaybeCause,
     ) -> CanonicalResponse<'tcx> {
         response_no_constraints_raw(
-            self.tcx(),
+            self.interner(),
             self.max_input_universe,
             self.variables,
             Certainty::Maybe(maybe_cause),
@@ -194,7 +194,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
             let region_obligations = self.infcx.inner.borrow().region_obligations().to_owned();
             let mut region_constraints = self.infcx.with_region_constraints(|region_constraints| {
                 make_query_region_constraints(
-                    self.tcx(),
+                    self.interner(),
                     region_obligations.iter().map(|r_o| {
                         (r_o.sup_type, r_o.sub_region, r_o.origin.to_constraint_category())
                     }),
@@ -239,7 +239,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         );
 
         let Response { var_values, external_constraints, certainty } =
-            response.instantiate(self.tcx(), &instantiation);
+            response.instantiate(self.interner(), &instantiation);
 
         Self::unify_query_var_values(self.infcx, param_env, &original_values, var_values);
 

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
@@ -344,7 +344,7 @@ impl<'a, 'tcx> EvalCtxt<'a, InferCtxt<'tcx>> {
         let mut goal_evaluation =
             self.inspect.new_goal_evaluation(goal, &orig_values, goal_evaluation_kind);
         let canonical_response = EvalCtxt::evaluate_canonical_goal(
-            self.tcx(),
+            self.interner(),
             self.search_graph,
             canonical_goal,
             &mut goal_evaluation,
@@ -447,7 +447,7 @@ impl<'a, 'tcx> EvalCtxt<'a, InferCtxt<'tcx>> {
             }
         } else {
             self.infcx.enter_forall(kind, |kind| {
-                let goal = goal.with(self.tcx(), ty::Binder::dummy(kind));
+                let goal = goal.with(self.interner(), ty::Binder::dummy(kind));
                 self.add_goal(GoalSource::InstantiateHigherRanked, goal);
                 self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
             })
@@ -498,7 +498,7 @@ impl<'a, 'tcx> EvalCtxt<'a, InferCtxt<'tcx>> {
     ///
     /// Goals for the next step get directly added to the nested goals of the `EvalCtxt`.
     fn evaluate_added_goals_step(&mut self) -> Result<Option<Certainty>, NoSolution> {
-        let tcx = self.tcx();
+        let tcx = self.interner();
         let mut goals = core::mem::take(&mut self.nested_goals);
 
         // If this loop did not result in any progress, what's our final certainty.
@@ -584,11 +584,13 @@ impl<'a, 'tcx> EvalCtxt<'a, InferCtxt<'tcx>> {
     }
 }
 
-impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
-    pub(super) fn tcx(&self) -> TyCtxt<'tcx> {
-        self.infcx.tcx
+impl<Infcx: InferCtxtLike<Interner = I>, I: Interner> EvalCtxt<'_, Infcx> {
+    pub(super) fn interner(&self) -> I {
+        self.infcx.interner()
     }
+}
 
+impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
     pub(super) fn next_ty_infer(&mut self) -> Ty<'tcx> {
         let ty = self.infcx.next_ty_var(DUMMY_SP);
         self.inspect.add_var_value(ty);
@@ -746,7 +748,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         // NOTE: this check is purely an optimization, the structural eq would
         // always fail if the term is not an inference variable.
         if term.is_infer() {
-            let tcx = self.tcx();
+            let tcx = self.interner();
             // We need to relate `alias` to `term` treating only the outermost
             // constructor as rigid, relating any contained generic arguments as
             // normal. We do this by first structurally equating the `term`
@@ -1041,10 +1043,10 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
     ) -> Option<ty::Const<'tcx>> {
         use rustc_middle::mir::interpret::ErrorHandled;
         match self.infcx.const_eval_resolve(param_env, unevaluated, DUMMY_SP) {
-            Ok(Some(val)) => Some(ty::Const::new_value(self.tcx(), val, ty)),
+            Ok(Some(val)) => Some(ty::Const::new_value(self.interner(), val, ty)),
             Ok(None) | Err(ErrorHandled::TooGeneric(_)) => None,
             Err(ErrorHandled::Reported(e, _)) => {
-                Some(ty::Const::new_error(self.tcx(), e.into(), ty))
+                Some(ty::Const::new_error(self.interner(), e.into(), ty))
             }
         }
     }
@@ -1057,7 +1059,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         principal: ty::PolyTraitRef<'tcx>,
         mut supertrait_visitor: impl FnMut(&mut Self, ty::PolyTraitRef<'tcx>, usize, Option<usize>),
     ) {
-        let tcx = self.tcx();
+        let tcx = self.interner();
         let mut offset = 0;
         prepare_vtable_segments::<()>(tcx, principal, |segment| {
             match segment {

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
@@ -95,7 +95,7 @@ pub struct EvalCtxt<
     // evaluation code.
     tainted: Result<(), NoSolution>,
 
-    pub(super) inspect: ProofTreeBuilder<I>,
+    pub(super) inspect: ProofTreeBuilder<Infcx>,
 }
 
 #[derive(derivative::Derivative)]
@@ -215,7 +215,7 @@ impl<'a, 'tcx> EvalCtxt<'a, InferCtxt<'tcx>> {
         tcx: TyCtxt<'tcx>,
         search_graph: &'a mut search_graph::SearchGraph<TyCtxt<'tcx>>,
         canonical_input: CanonicalInput<'tcx>,
-        canonical_goal_evaluation: &mut ProofTreeBuilder<TyCtxt<'tcx>>,
+        canonical_goal_evaluation: &mut ProofTreeBuilder<InferCtxt<'tcx>>,
         f: impl FnOnce(&mut EvalCtxt<'_, InferCtxt<'tcx>>, Goal<'tcx, ty::Predicate<'tcx>>) -> R,
     ) -> R {
         let intercrate = match search_graph.solver_mode() {
@@ -277,7 +277,7 @@ impl<'a, 'tcx> EvalCtxt<'a, InferCtxt<'tcx>> {
         tcx: TyCtxt<'tcx>,
         search_graph: &'a mut search_graph::SearchGraph<TyCtxt<'tcx>>,
         canonical_input: CanonicalInput<'tcx>,
-        goal_evaluation: &mut ProofTreeBuilder<TyCtxt<'tcx>>,
+        goal_evaluation: &mut ProofTreeBuilder<InferCtxt<'tcx>>,
     ) -> QueryResult<'tcx> {
         let mut canonical_goal_evaluation =
             goal_evaluation.new_canonical_goal_evaluation(canonical_input);

--- a/compiler/rustc_trait_selection/src/solve/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/mod.rs
@@ -133,7 +133,7 @@ impl<'a, 'tcx> EvalCtxt<'a, InferCtxt<'tcx>> {
     }
 
     fn compute_object_safe_goal(&mut self, trait_def_id: DefId) -> QueryResult<'tcx> {
-        if self.tcx().check_is_object_safe(trait_def_id) {
+        if self.interner().check_is_object_safe(trait_def_id) {
             self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
         } else {
             Err(NoSolution)
@@ -274,7 +274,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         if let ty::Alias(..) = ty.kind() {
             let normalized_ty = self.next_ty_infer();
             let alias_relate_goal = Goal::new(
-                self.tcx(),
+                self.interner(),
                 param_env,
                 ty::PredicateKind::AliasRelate(
                     ty.into(),

--- a/compiler/rustc_trait_selection/src/solve/normalizes_to/anon_const.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalizes_to/anon_const.rs
@@ -12,7 +12,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         if let Some(normalized_const) = self.try_const_eval_resolve(
             goal.param_env,
             ty::UnevaluatedConst::new(goal.predicate.alias.def_id, goal.predicate.alias.args),
-            self.tcx()
+            self.interner()
                 .type_of(goal.predicate.alias.def_id)
                 .no_bound_vars()
                 .expect("const ty should not rely on other generics"),

--- a/compiler/rustc_trait_selection/src/solve/normalizes_to/inherent.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalizes_to/inherent.rs
@@ -15,7 +15,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         &mut self,
         goal: Goal<'tcx, ty::NormalizesTo<'tcx>>,
     ) -> QueryResult<'tcx> {
-        let tcx = self.tcx();
+        let tcx = self.interner();
         let inherent = goal.predicate.alias.expect_ty(tcx);
 
         let impl_def_id = tcx.parent(inherent.def_id);

--- a/compiler/rustc_trait_selection/src/solve/normalizes_to/opaque_types.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalizes_to/opaque_types.rs
@@ -15,7 +15,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         &mut self,
         goal: Goal<'tcx, ty::NormalizesTo<'tcx>>,
     ) -> QueryResult<'tcx> {
-        let tcx = self.tcx();
+        let tcx = self.interner();
         let opaque_ty = goal.predicate.alias;
         let expected = goal.predicate.term.ty().expect("no such thing as an opaque const");
 
@@ -31,7 +31,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
                     return Err(NoSolution);
                 }
                 // FIXME: This may have issues when the args contain aliases...
-                match self.tcx().uses_unique_placeholders_ignoring_regions(opaque_ty.args) {
+                match self.interner().uses_unique_placeholders_ignoring_regions(opaque_ty.args) {
                     Err(NotUniqueParam::NotParam(param)) if param.is_non_region_infer() => {
                         return self.evaluate_added_goals_and_make_canonical_response(
                             Certainty::AMBIGUOUS,

--- a/compiler/rustc_trait_selection/src/solve/normalizes_to/weak_types.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalizes_to/weak_types.rs
@@ -14,7 +14,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         &mut self,
         goal: Goal<'tcx, ty::NormalizesTo<'tcx>>,
     ) -> QueryResult<'tcx> {
-        let tcx = self.tcx();
+        let tcx = self.interner();
         let weak_ty = goal.predicate.alias;
 
         // Check where clauses

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -11,7 +11,7 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         &mut self,
         goal: Goal<'tcx, ProjectionPredicate<'tcx>>,
     ) -> QueryResult<'tcx> {
-        let tcx = self.tcx();
+        let tcx = self.interner();
         let projection_term = goal.predicate.projection_term.to_term(tcx);
         let goal = goal.with(
             tcx,

--- a/compiler/rustc_trait_selection/src/solve/search_graph.rs
+++ b/compiler/rustc_trait_selection/src/solve/search_graph.rs
@@ -3,6 +3,7 @@ use std::mem;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_index::Idx;
 use rustc_index::IndexVec;
+use rustc_infer::infer::InferCtxt;
 use rustc_middle::dep_graph::dep_kinds;
 use rustc_middle::traits::solve::CacheData;
 use rustc_middle::traits::solve::EvaluationCache;
@@ -261,10 +262,10 @@ impl<'tcx> SearchGraph<TyCtxt<'tcx>> {
         &mut self,
         tcx: TyCtxt<'tcx>,
         input: CanonicalInput<TyCtxt<'tcx>>,
-        inspect: &mut ProofTreeBuilder<TyCtxt<'tcx>>,
+        inspect: &mut ProofTreeBuilder<InferCtxt<'tcx>>,
         mut prove_goal: impl FnMut(
             &mut Self,
-            &mut ProofTreeBuilder<TyCtxt<'tcx>>,
+            &mut ProofTreeBuilder<InferCtxt<'tcx>>,
         ) -> QueryResult<TyCtxt<'tcx>>,
     ) -> QueryResult<TyCtxt<'tcx>> {
         self.check_invariants();
@@ -426,7 +427,7 @@ impl<'tcx> SearchGraph<TyCtxt<'tcx>> {
         tcx: TyCtxt<'tcx>,
         input: CanonicalInput<TyCtxt<'tcx>>,
         available_depth: Limit,
-        inspect: &mut ProofTreeBuilder<TyCtxt<'tcx>>,
+        inspect: &mut ProofTreeBuilder<InferCtxt<'tcx>>,
     ) -> Option<QueryResult<TyCtxt<'tcx>>> {
         let CacheData { result, proof_tree, additional_depth, encountered_overflow } = self
             .global_cache(tcx)
@@ -473,11 +474,11 @@ impl<'tcx> SearchGraph<TyCtxt<'tcx>> {
         &mut self,
         tcx: TyCtxt<'tcx>,
         input: CanonicalInput<TyCtxt<'tcx>>,
-        inspect: &mut ProofTreeBuilder<TyCtxt<'tcx>>,
+        inspect: &mut ProofTreeBuilder<InferCtxt<'tcx>>,
         prove_goal: &mut F,
     ) -> StepResult<TyCtxt<'tcx>>
     where
-        F: FnMut(&mut Self, &mut ProofTreeBuilder<TyCtxt<'tcx>>) -> QueryResult<TyCtxt<'tcx>>,
+        F: FnMut(&mut Self, &mut ProofTreeBuilder<InferCtxt<'tcx>>) -> QueryResult<TyCtxt<'tcx>>,
     {
         let result = prove_goal(self, inspect);
         let stack_entry = self.pop_stack();

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -132,7 +132,14 @@ pub trait GenericArgs<I: Interner<GenericArgs = Self>>:
 }
 
 pub trait Predicate<I: Interner<Predicate = Self>>:
-    Copy + Debug + Hash + Eq + TypeSuperVisitable<I> + TypeSuperFoldable<I> + Flags
+    Copy
+    + Debug
+    + Hash
+    + Eq
+    + TypeSuperVisitable<I>
+    + TypeSuperFoldable<I>
+    + Flags
+    + UpcastFrom<I, ty::NormalizesTo<I>>
 {
     fn is_coinductive(self, interner: I) -> bool;
 }

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Deref;
 
+use crate::fold::TypeFoldable;
 use crate::inherent::*;
 use crate::ir_print::IrPrint;
 use crate::solve::inspect::CanonicalGoalEvaluationStep;
@@ -90,7 +91,7 @@ pub trait Interner:
     type PlaceholderRegion: PlaceholderLike;
 
     // Predicates
-    type ParamEnv: Copy + Debug + Hash + Eq;
+    type ParamEnv: Copy + Debug + Hash + Eq + TypeFoldable<Self>;
     type Predicate: Predicate<Self>;
     type Clause: Clause<Self>;
     type Clauses: Copy + Debug + Hash + Eq + TypeSuperVisitable<Self> + Flags;
@@ -114,14 +115,17 @@ pub trait Interner:
     ) -> (ty::TraitRef<Self>, Self::OwnItemArgs);
 
     fn mk_args(self, args: &[Self::GenericArg]) -> Self::GenericArgs;
-
     fn mk_args_from_iter(self, args: impl Iterator<Item = Self::GenericArg>) -> Self::GenericArgs;
-
     fn check_and_mk_args(
         self,
         def_id: Self::DefId,
         args: impl IntoIterator<Item: Into<Self::GenericArg>>,
     ) -> Self::GenericArgs;
+
+    fn intern_canonical_goal_evaluation_step(
+        self,
+        step: CanonicalGoalEvaluationStep<Self>,
+    ) -> Self::CanonicalGoalEvaluationStepRef;
 
     fn parent(self, def_id: Self::DefId) -> Self::DefId;
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -174,7 +174,6 @@
 #![feature(duration_consts_float)]
 #![feature(internal_impls_macro)]
 #![feature(ip)]
-#![feature(ip_bits)]
 #![feature(is_ascii_octdigit)]
 #![feature(isqrt)]
 #![feature(link_cfg)]

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -460,12 +460,11 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip_bits)]
     /// use std::net::Ipv4Addr;
     ///
     /// assert_eq!(Ipv4Addr::BITS, 32);
     /// ```
-    #[unstable(feature = "ip_bits", issue = "113744")]
+    #[stable(feature = "ip_bits", since = "CURRENT_RUSTC_VERSION")]
     pub const BITS: u32 = 32;
 
     /// Converts an IPv4 address into a `u32` representation using native byte order.
@@ -479,7 +478,6 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip_bits)]
     /// use std::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::new(0x12, 0x34, 0x56, 0x78);
@@ -487,7 +485,6 @@ impl Ipv4Addr {
     /// ```
     ///
     /// ```
-    /// #![feature(ip_bits)]
     /// use std::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::new(0x12, 0x34, 0x56, 0x78);
@@ -495,8 +492,8 @@ impl Ipv4Addr {
     /// assert_eq!(Ipv4Addr::new(0x12, 0x34, 0x56, 0x00), Ipv4Addr::from_bits(addr_bits));
     ///
     /// ```
-    #[rustc_const_unstable(feature = "ip_bits", issue = "113744")]
-    #[unstable(feature = "ip_bits", issue = "113744")]
+    #[rustc_const_stable(feature = "ip_bits", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "ip_bits", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     #[inline]
     pub const fn to_bits(self) -> u32 {
@@ -510,14 +507,13 @@ impl Ipv4Addr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip_bits)]
     /// use std::net::Ipv4Addr;
     ///
     /// let addr = Ipv4Addr::from(0x12345678);
     /// assert_eq!(Ipv4Addr::new(0x12, 0x34, 0x56, 0x78), addr);
     /// ```
-    #[rustc_const_unstable(feature = "ip_bits", issue = "113744")]
-    #[unstable(feature = "ip_bits", issue = "113744")]
+    #[rustc_const_stable(feature = "ip_bits", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "ip_bits", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     #[inline]
     pub const fn from_bits(bits: u32) -> Ipv4Addr {
@@ -1238,12 +1234,11 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip_bits)]
     /// use std::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::BITS, 128);
     /// ```
-    #[unstable(feature = "ip_bits", issue = "113744")]
+    #[stable(feature = "ip_bits", since = "CURRENT_RUSTC_VERSION")]
     pub const BITS: u32 = 128;
 
     /// Converts an IPv6 address into a `u128` representation using native byte order.
@@ -1257,7 +1252,6 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip_bits)]
     /// use std::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::new(
@@ -1268,7 +1262,6 @@ impl Ipv6Addr {
     /// ```
     ///
     /// ```
-    /// #![feature(ip_bits)]
     /// use std::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::new(
@@ -1284,8 +1277,8 @@ impl Ipv6Addr {
     ///     Ipv6Addr::from_bits(addr_bits));
     ///
     /// ```
-    #[rustc_const_unstable(feature = "ip_bits", issue = "113744")]
-    #[unstable(feature = "ip_bits", issue = "113744")]
+    #[rustc_const_stable(feature = "ip_bits", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "ip_bits", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     #[inline]
     pub const fn to_bits(self) -> u128 {
@@ -1299,7 +1292,6 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip_bits)]
     /// use std::net::Ipv6Addr;
     ///
     /// let addr = Ipv6Addr::from(0x102030405060708090A0B0C0D0E0F00D_u128);
@@ -1310,8 +1302,8 @@ impl Ipv6Addr {
     ///     ),
     ///     addr);
     /// ```
-    #[rustc_const_unstable(feature = "ip_bits", issue = "113744")]
-    #[unstable(feature = "ip_bits", issue = "113744")]
+    #[rustc_const_stable(feature = "ip_bits", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "ip_bits", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     #[inline]
     pub const fn from_bits(bits: u128) -> Ipv6Addr {

--- a/tests/rustdoc-ui/doctest/non_local_defs.stderr
+++ b/tests/rustdoc-ui/doctest/non_local_defs.stderr
@@ -6,7 +6,6 @@ LL | macro_rules! a_macro { () => {} }
    |
    = help: remove the `#[macro_export]` or make this doc-test a standalone test with its own `fn main() { ... }`
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 

--- a/tests/rustdoc-ui/doctest/non_local_defs.stderr
+++ b/tests/rustdoc-ui/doctest/non_local_defs.stderr
@@ -1,4 +1,4 @@
-warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
+warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
   --> $DIR/non_local_defs.rs:9:1
    |
 LL | macro_rules! a_macro { () => {} }

--- a/tests/ui/coherence/coherence-overlap-unnormalizable-projection-1.next.stderr
+++ b/tests/ui/coherence/coherence-overlap-unnormalizable-projection-1.next.stderr
@@ -12,7 +12,7 @@ LL |   impl<T> Trait for Box<T> {}
    |   ^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Box<_>`
    |
    = note: downstream crates may implement trait `WithAssoc<'a>` for type `std::boxed::Box<_>`
-   = note: downstream crates may implement trait `WhereBound` for type `std::boxed::Box<<std::boxed::Box<_> as WithAssoc<'a>>::Assoc>`
+   = note: downstream crates may implement trait `WhereBound` for type `std::boxed::Box<_>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coherence/occurs-check/opaques.next.stderr
+++ b/tests/ui/coherence/occurs-check/opaques.next.stderr
@@ -11,7 +11,7 @@ error[E0282]: type annotations needed
   --> $DIR/opaques.rs:13:20
    |
 LL |     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
-   |                    ^ cannot infer type for associated type `<T as Trait<T>>::Assoc`
+   |                    ^ cannot infer type
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.next.stderr
@@ -16,6 +16,22 @@ LL |     where
 LL |         T: AsExpression<Self::SqlType>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Foo::check`
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `&str: AsExpression<Integer>` is not satisfied
+  --> $DIR/as_expression.rs:57:15
+   |
+LL |     SelectInt.check("bar");
+   |               ^^^^^ the trait `AsExpression<Integer>` is not implemented for `&str`
+   |
+   = help: the trait `AsExpression<Text>` is implemented for `&str`
+   = help: for that trait implementation, expected `Text`, found `Integer`
 
-For more information about this error, try `rustc --explain E0277`.
+error[E0271]: type mismatch resolving `<&str as AsExpression<<SelectInt as Expression>::SqlType>>::Expression == _`
+  --> $DIR/as_expression.rs:57:5
+   |
+LL |     SelectInt.check("bar");
+   |     ^^^^^^^^^^^^^^^^^^^^^^ types differ
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.rs
@@ -55,6 +55,7 @@ impl<T> Foo for T where T: Expression {}
 
 fn main() {
     SelectInt.check("bar");
-    //[next]~^ ERROR the trait bound `&str: AsExpression<<SelectInt as Expression>::SqlType>` is not satisfied
-    //[current]~^^ ERROR the trait bound `&str: AsExpression<Integer>` is not satisfied
+    //~^ ERROR the trait bound `&str: AsExpression<Integer>` is not satisfied
+    //[next]~| the trait bound `&str: AsExpression<<SelectInt as Expression>::SqlType>` is not satisfied
+    //[next]~| type mismatch
 }

--- a/tests/ui/lint/non-local-defs/cargo-update.stderr
+++ b/tests/ui/lint/non-local-defs/cargo-update.stderr
@@ -4,9 +4,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL | non_local_macro::non_local_impl!(LocalStruct);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current constant `_IMPL_DEBUG`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current constant `_IMPL_DEBUG`
+  --> $DIR/cargo-update.rs:17:1
+   |
+LL | non_local_macro::non_local_impl!(LocalStruct);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | may need to be moved as well
+   | may need to be moved as well
    = note: the macro `non_local_macro::non_local_impl` may come from an old version of the `non_local_macro` crate, try updating your dependency with `cargo update -p non_local_macro`
    = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>

--- a/tests/ui/lint/non-local-defs/cargo-update.stderr
+++ b/tests/ui/lint/non-local-defs/cargo-update.stderr
@@ -3,6 +3,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
    |
 LL | non_local_macro::non_local_impl!(LocalStruct);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | `LocalStruct` is not local
+   | `Debug` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`

--- a/tests/ui/lint/non-local-defs/cargo-update.stderr
+++ b/tests/ui/lint/non-local-defs/cargo-update.stderr
@@ -1,4 +1,4 @@
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/cargo-update.rs:17:1
    |
 LL | non_local_macro::non_local_impl!(LocalStruct);

--- a/tests/ui/lint/non-local-defs/cargo-update.stderr
+++ b/tests/ui/lint/non-local-defs/cargo-update.stderr
@@ -6,14 +6,10 @@ LL | non_local_macro::non_local_impl!(LocalStruct);
    | |
    | `LocalStruct` is not local
    | `Debug` is not local
+   | move the `impl` block outside of this constant `_IMPL_DEBUG`
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current constant `_IMPL_DEBUG`
-  --> $DIR/cargo-update.rs:17:1
-   |
-LL | non_local_macro::non_local_impl!(LocalStruct);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the macro `non_local_macro::non_local_impl` may come from an old version of the `non_local_macro` crate, try updating your dependency with `cargo update -p non_local_macro`
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>

--- a/tests/ui/lint/non-local-defs/cargo-update.stderr
+++ b/tests/ui/lint/non-local-defs/cargo-update.stderr
@@ -11,9 +11,6 @@ help: move this `impl` block outside of the current constant `_IMPL_DEBUG`
    |
 LL | non_local_macro::non_local_impl!(LocalStruct);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | may need to be moved as well
-   | may need to be moved as well
    = note: the macro `non_local_macro::non_local_impl` may come from an old version of the `non_local_macro` crate, try updating your dependency with `cargo update -p non_local_macro`
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>

--- a/tests/ui/lint/non-local-defs/cargo-update.stderr
+++ b/tests/ui/lint/non-local-defs/cargo-update.stderr
@@ -15,7 +15,7 @@ LL | non_local_macro::non_local_impl!(LocalStruct);
    | may need to be moved as well
    | may need to be moved as well
    = note: the macro `non_local_macro::non_local_impl` may come from an old version of the `non_local_macro` crate, try updating your dependency with `cargo update -p non_local_macro`
-   = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
+   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
    = note: this warning originates in the macro `non_local_macro::non_local_impl` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/lint/non-local-defs/cargo-update.stderr
+++ b/tests/ui/lint/non-local-defs/cargo-update.stderr
@@ -5,10 +5,11 @@ LL | non_local_macro::non_local_impl!(LocalStruct);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant `_IMPL_DEBUG`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
-   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: the macro `non_local_macro::non_local_impl` may come from an old version of the `non_local_macro` crate, try updating your dependency with `cargo update -p non_local_macro`
+   = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
+   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
    = note: this warning originates in the macro `non_local_macro::non_local_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -2,7 +2,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:13:5
    |
 LL | const Z: () = {
-   |       - help: use a const-anon item to suppress this lint: `_`
+   | -----------
+   | |     |
+   | |     help: use a const-anon item to suppress this lint: `_`
+   | move the `impl` block outside of this constant `Z`
 ...
 LL |     impl Uto for &Test {}
    |     ^^^^^---^^^^^-----
@@ -12,11 +15,6 @@ LL |     impl Uto for &Test {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current constant `Z`
-  --> $DIR/consts.rs:13:5
-   |
-LL |     impl Uto for &Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
@@ -24,6 +22,8 @@ LL |     impl Uto for &Test {}
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:24:5
    |
+LL | static A: u32 = {
+   | ------------- move the `impl` block outside of this static `A`
 LL |     impl Uto2 for Test {}
    |     ^^^^^----^^^^^----
    |          |        |
@@ -32,17 +32,14 @@ LL |     impl Uto2 for Test {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current static `A`
-  --> $DIR/consts.rs:24:5
-   |
-LL |     impl Uto2 for Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:32:5
    |
+LL | const B: u32 = {
+   | ------------ move the `impl` block outside of this constant `B`
 LL |     impl Uto3 for Test {}
    |     ^^^^^----^^^^^----
    |          |        |
@@ -51,75 +48,60 @@ LL |     impl Uto3 for Test {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current constant `B`
-  --> $DIR/consts.rs:32:5
-   |
-LL |     impl Uto3 for Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:43:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
 LL |     impl Test {
    |     ^^^^^----
    |          |
    |          `Test` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/consts.rs:43:5
-   |
-LL | /     impl Test {
-LL | |
-LL | |         fn foo() {}
-LL | |     }
-   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:50:9
    |
-LL |         impl Test {
-   |         ^^^^^----
-   |              |
-   |              `Test` is not local
-   |
-   = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
-help: move this `impl` block outside of the current inline constant `<unnameable>` and up 2 bodies
-  --> $DIR/consts.rs:50:9
-   |
-LL | /         impl Test {
+LL |       const {
+   |  ___________-
+LL | |         impl Test {
+   | |         ^^^^^----
+   | |              |
+   | |              `Test` is not local
 LL | |
 LL | |             fn hoo() {}
-LL | |         }
-   | |_________^
+...  |
+LL | |         1
+LL | |     };
+   | |_____- move the `impl` block outside of this inline constant `<unnameable>` and up 2 bodies
+   |
+   = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:59:9
    |
+LL |     const _: u32 = {
+   |     ------------ move the `impl` block outside of this constant `_` and up 2 bodies
 LL |         impl Test {
    |         ^^^^^----
    |              |
    |              `Test` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
-help: move this `impl` block outside of the current constant `_` and up 2 bodies
-  --> $DIR/consts.rs:59:9
-   |
-LL | /         impl Test {
-LL | |
-LL | |             fn foo2() {}
-LL | |         }
-   | |_________^
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:72:9
    |
+LL |     let _a = || {
+   |              -- move the `impl` block outside of this closure `<unnameable>` and up 2 bodies
 LL |         impl Uto9 for Test {}
    |         ^^^^^----^^^^^----
    |              |        |
@@ -128,29 +110,25 @@ LL |         impl Uto9 for Test {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current closure `<unnameable>` and up 2 bodies
-  --> $DIR/consts.rs:72:9
-   |
-LL |         impl Uto9 for Test {}
-   |         ^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:79:9
    |
-LL |         impl Uto10 for Test {}
-   |         ^^^^^-----^^^^^----
-   |              |         |
-   |              |         `Test` is not local
-   |              `Uto10` is not local
+LL |       type A = [u32; {
+   |  ____________________-
+LL | |         impl Uto10 for Test {}
+   | |         ^^^^^-----^^^^^----
+   | |              |         |
+   | |              |         `Test` is not local
+   | |              `Uto10` is not local
+LL | |
+...  |
+LL | |     }];
+   | |_____- move the `impl` block outside of this constant expression `<unnameable>` and up 2 bodies
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
-  --> $DIR/consts.rs:79:9
-   |
-LL |         impl Uto10 for Test {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 8 warnings emitted

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -1,4 +1,4 @@
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:13:5
    |
 LL | const Z: () = {
@@ -13,7 +13,7 @@ LL |     impl Uto for &Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:24:5
    |
 LL |     impl Uto2 for Test {}
@@ -24,7 +24,7 @@ LL |     impl Uto2 for Test {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:32:5
    |
 LL |     impl Uto3 for Test {}
@@ -35,7 +35,7 @@ LL |     impl Uto3 for Test {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:43:5
    |
 LL | /     impl Test {
@@ -49,7 +49,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:50:9
    |
 LL | /         impl Test {
@@ -63,7 +63,7 @@ LL | |         }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:59:9
    |
 LL | /         impl Test {
@@ -77,7 +77,7 @@ LL | |         }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:72:9
    |
 LL |         impl Uto9 for Test {}
@@ -88,7 +88,7 @@ LL |         impl Uto9 for Test {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:79:9
    |
 LL |         impl Uto10 for Test {}

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -56,7 +56,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Test {
    |     ^^^^^^^^^
    |
-   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+   = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current function `main`
   --> $DIR/consts.rs:43:5
    |
@@ -73,7 +73,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Test {
    |         ^^^^^^^^^
    |
-   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+   = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current inline constant `<unnameable>` and up 2 bodies
   --> $DIR/consts.rs:50:9
    |
@@ -90,7 +90,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Test {
    |         ^^^^^^^^^
    |
-   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+   = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current constant `_` and up 2 bodies
   --> $DIR/consts.rs:59:9
    |

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -5,7 +5,7 @@ LL | const Z: () = {
    |       - help: use a const-anon item to suppress this lint: `_`
 ...
 LL |     impl Uto for &Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant `Z`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -18,7 +18,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:24:5
    |
 LL |     impl Uto2 for Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current static `A`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -30,7 +30,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:32:5
    |
 LL |     impl Uto3 for Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant `B`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -41,11 +41,8 @@ LL |     impl Uto3 for Test {}
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:43:5
    |
-LL | /     impl Test {
-LL | |
-LL | |         fn foo() {}
-LL | |     }
-   | |_____^
+LL |     impl Test {
+   |     ^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
@@ -54,11 +51,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:50:9
    |
-LL | /         impl Test {
-LL | |
-LL | |             fn hoo() {}
-LL | |         }
-   | |_________^
+LL |         impl Test {
+   |         ^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current inline constant `<unnameable>` and up 2 bodies
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
@@ -67,11 +61,8 @@ LL | |         }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/consts.rs:59:9
    |
-LL | /         impl Test {
-LL | |
-LL | |             fn foo2() {}
-LL | |         }
-   | |_________^
+LL |         impl Test {
+   |         ^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant `_` and up 2 bodies
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
@@ -82,7 +73,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:72:9
    |
 LL |         impl Uto9 for Test {}
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current closure `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -93,7 +84,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:79:9
    |
 LL |         impl Uto10 for Test {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -7,9 +7,16 @@ LL | const Z: () = {
 LL |     impl Uto for &Test {}
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current constant `Z`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current constant `Z`
+  --> $DIR/consts.rs:13:5
+   |
+LL |     impl Uto for &Test {}
+   |     ^^^^^---^^^^^-----^^^
+   |          |       |
+   |          |       may need to be moved as well
+   |          may need to be moved as well
    = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
@@ -20,9 +27,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Uto2 for Test {}
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current static `A`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current static `A`
+  --> $DIR/consts.rs:24:5
+   |
+LL |     impl Uto2 for Test {}
+   |     ^^^^^----^^^^^----^^^
+   |          |        |
+   |          |        may need to be moved as well
+   |          may need to be moved as well
    = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
@@ -32,9 +46,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Uto3 for Test {}
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current constant `B`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current constant `B`
+  --> $DIR/consts.rs:32:5
+   |
+LL |     impl Uto3 for Test {}
+   |     ^^^^^----^^^^^----^^^
+   |          |        |
+   |          |        may need to be moved as well
+   |          may need to be moved as well
    = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
@@ -44,8 +65,18 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Test {
    |     ^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/consts.rs:43:5
+   |
+LL |       impl Test {
+   |       ^    ---- may need to be moved as well
+   |  _____|
+   | |
+LL | |
+LL | |         fn foo() {}
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -54,8 +85,18 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Test {
    |         ^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current inline constant `<unnameable>` and up 2 bodies
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+help: move this `impl` block outside of the current inline constant `<unnameable>` and up 2 bodies
+  --> $DIR/consts.rs:50:9
+   |
+LL |           impl Test {
+   |           ^    ---- may need to be moved as well
+   |  _________|
+   | |
+LL | |
+LL | |             fn hoo() {}
+LL | |         }
+   | |_________^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -64,8 +105,18 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Test {
    |         ^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current constant `_` and up 2 bodies
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+help: move this `impl` block outside of the current constant `_` and up 2 bodies
+  --> $DIR/consts.rs:59:9
+   |
+LL |           impl Test {
+   |           ^    ---- may need to be moved as well
+   |  _________|
+   | |
+LL | |
+LL | |             fn foo2() {}
+LL | |         }
+   | |_________^
    = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
@@ -75,9 +126,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Uto9 for Test {}
    |         ^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current closure `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current closure `<unnameable>` and up 2 bodies
+  --> $DIR/consts.rs:72:9
+   |
+LL |         impl Uto9 for Test {}
+   |         ^^^^^----^^^^^----^^^
+   |              |        |
+   |              |        may need to be moved as well
+   |              may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -86,9 +144,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Uto10 for Test {}
    |         ^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
+  --> $DIR/consts.rs:79:9
+   |
+LL |         impl Uto10 for Test {}
+   |         ^^^^^-----^^^^^----^^^
+   |              |         |
+   |              |         may need to be moved as well
+   |              may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 8 warnings emitted

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -5,7 +5,10 @@ LL | const Z: () = {
    |       - help: use a const-anon item to suppress this lint: `_`
 ...
 LL |     impl Uto for &Test {}
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^---^^^^^-----
+   |          |       |
+   |          |       `&'_ Test` is not local
+   |          `Uto` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -22,7 +25,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:24:5
    |
 LL |     impl Uto2 for Test {}
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^----^^^^^----
+   |          |        |
+   |          |        `Test` is not local
+   |          `Uto2` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -38,7 +44,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:32:5
    |
 LL |     impl Uto3 for Test {}
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^----^^^^^----
+   |          |        |
+   |          |        `Test` is not local
+   |          `Uto3` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -54,7 +63,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:43:5
    |
 LL |     impl Test {
-   |     ^^^^^^^^^
+   |     ^^^^^----
+   |          |
+   |          `Test` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current function `main`
@@ -71,7 +82,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:50:9
    |
 LL |         impl Test {
-   |         ^^^^^^^^^
+   |         ^^^^^----
+   |              |
+   |              `Test` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current inline constant `<unnameable>` and up 2 bodies
@@ -88,7 +101,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:59:9
    |
 LL |         impl Test {
-   |         ^^^^^^^^^
+   |         ^^^^^----
+   |              |
+   |              `Test` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current constant `_` and up 2 bodies
@@ -106,7 +121,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:72:9
    |
 LL |         impl Uto9 for Test {}
-   |         ^^^^^^^^^^^^^^^^^^
+   |         ^^^^^----^^^^^----
+   |              |        |
+   |              |        `Test` is not local
+   |              `Uto9` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -121,7 +139,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/consts.rs:79:9
    |
 LL |         impl Uto10 for Test {}
-   |         ^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^-----^^^^^----
+   |              |         |
+   |              |         `Test` is not local
+   |              `Uto10` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -13,10 +13,7 @@ help: move this `impl` block outside of the current constant `Z`
   --> $DIR/consts.rs:13:5
    |
 LL |     impl Uto for &Test {}
-   |     ^^^^^---^^^^^-----^^^
-   |          |       |
-   |          |       may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
@@ -33,10 +30,7 @@ help: move this `impl` block outside of the current static `A`
   --> $DIR/consts.rs:24:5
    |
 LL |     impl Uto2 for Test {}
-   |     ^^^^^----^^^^^----^^^
-   |          |        |
-   |          |        may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
@@ -52,10 +46,7 @@ help: move this `impl` block outside of the current constant `B`
   --> $DIR/consts.rs:32:5
    |
 LL |     impl Uto3 for Test {}
-   |     ^^^^^----^^^^^----^^^
-   |          |        |
-   |          |        may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
@@ -69,10 +60,7 @@ LL |     impl Test {
 help: move this `impl` block outside of the current function `main`
   --> $DIR/consts.rs:43:5
    |
-LL |       impl Test {
-   |       ^    ---- may need to be moved as well
-   |  _____|
-   | |
+LL | /     impl Test {
 LL | |
 LL | |         fn foo() {}
 LL | |     }
@@ -89,10 +77,7 @@ LL |         impl Test {
 help: move this `impl` block outside of the current inline constant `<unnameable>` and up 2 bodies
   --> $DIR/consts.rs:50:9
    |
-LL |           impl Test {
-   |           ^    ---- may need to be moved as well
-   |  _________|
-   | |
+LL | /         impl Test {
 LL | |
 LL | |             fn hoo() {}
 LL | |         }
@@ -109,10 +94,7 @@ LL |         impl Test {
 help: move this `impl` block outside of the current constant `_` and up 2 bodies
   --> $DIR/consts.rs:59:9
    |
-LL |           impl Test {
-   |           ^    ---- may need to be moved as well
-   |  _________|
-   | |
+LL | /         impl Test {
 LL | |
 LL | |             fn foo2() {}
 LL | |         }
@@ -132,10 +114,7 @@ help: move this `impl` block outside of the current closure `<unnameable>` and u
   --> $DIR/consts.rs:72:9
    |
 LL |         impl Uto9 for Test {}
-   |         ^^^^^----^^^^^----^^^
-   |              |        |
-   |              |        may need to be moved as well
-   |              may need to be moved as well
+   |         ^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -150,10 +129,7 @@ help: move this `impl` block outside of the current constant expression `<unname
   --> $DIR/consts.rs:79:9
    |
 LL |         impl Uto10 for Test {}
-   |         ^^^^^-----^^^^^----^^^
-   |              |         |
-   |              |         may need to be moved as well
-   |              may need to be moved as well
+   |         ^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 8 warnings emitted

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -8,8 +8,9 @@ LL |     impl Uto for &Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant `Z`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+   = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -20,8 +21,9 @@ LL |     impl Uto2 for Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current static `A`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+   = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -31,8 +33,9 @@ LL |     impl Uto3 for Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant `B`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+   = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -45,8 +48,7 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -59,8 +61,7 @@ LL | |         }
    | |_________^
    |
    = help: move this `impl` block outside the of the current inline constant `<unnameable>` and up 2 bodies
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -73,8 +74,8 @@ LL | |         }
    | |_________^
    |
    = help: move this `impl` block outside the of the current constant `_` and up 2 bodies
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+   = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -84,8 +85,8 @@ LL |         impl Uto9 for Test {}
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current closure `<unnameable>` and up 2 bodies
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -95,8 +96,8 @@ LL |         impl Uto10 for Test {}
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 8 warnings emitted

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -17,7 +17,7 @@ LL |     impl Uto for &Test {}
    |          |       |
    |          |       may need to be moved as well
    |          may need to be moved as well
-   = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
+   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -37,7 +37,7 @@ LL |     impl Uto2 for Test {}
    |          |        |
    |          |        may need to be moved as well
    |          may need to be moved as well
-   = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
+   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -56,7 +56,7 @@ LL |     impl Uto3 for Test {}
    |          |        |
    |          |        may need to be moved as well
    |          may need to be moved as well
-   = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
+   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -117,7 +117,7 @@ LL | |
 LL | |             fn foo2() {}
 LL | |         }
    | |_________^
-   = note: anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type are consider to be transparent regarding the nesting level
+   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
@@ -1,4 +1,4 @@
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:7:5
    |
 LL | /     impl PartialEq<()> for Dog {
@@ -15,7 +15,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:14:5
    |
 LL | /     impl PartialEq<()> for &Dog {
@@ -31,7 +31,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:21:5
    |
 LL | /     impl PartialEq<Dog> for () {
@@ -47,7 +47,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:28:5
    |
 LL | /     impl PartialEq<&Dog> for () {
@@ -63,7 +63,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:35:5
    |
 LL | /     impl PartialEq<Dog> for &Dog {
@@ -79,7 +79,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:42:5
    |
 LL | /     impl PartialEq<&Dog> for &Dog {

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
@@ -1,6 +1,8 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:7:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
 LL |     impl PartialEq<()> for Dog {
    |     ^^^^^---------^^^^^^^^^---
    |          |                 |
@@ -9,22 +11,15 @@ LL |     impl PartialEq<()> for Dog {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive-trait.rs:7:5
-   |
-LL | /     impl PartialEq<()> for Dog {
-LL | |
-LL | |         fn eq(&self, _: &()) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:14:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl PartialEq<()> for &Dog {
    |     ^^^^^---------^^^^^^^^^----
    |          |                 |
@@ -33,21 +28,14 @@ LL |     impl PartialEq<()> for &Dog {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive-trait.rs:14:5
-   |
-LL | /     impl PartialEq<()> for &Dog {
-LL | |
-LL | |         fn eq(&self, _: &()) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:21:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl PartialEq<Dog> for () {
    |     ^^^^^---------^^^^^^^^^^--
    |          |                  |
@@ -56,21 +44,14 @@ LL |     impl PartialEq<Dog> for () {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive-trait.rs:21:5
-   |
-LL | /     impl PartialEq<Dog> for () {
-LL | |
-LL | |         fn eq(&self, _: &Dog) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:28:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl PartialEq<&Dog> for () {
    |     ^^^^^---------^^^^^^^^^^^--
    |          |                   |
@@ -79,21 +60,14 @@ LL |     impl PartialEq<&Dog> for () {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive-trait.rs:28:5
-   |
-LL | /     impl PartialEq<&Dog> for () {
-LL | |
-LL | |         fn eq(&self, _: &&Dog) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:35:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl PartialEq<Dog> for &Dog {
    |     ^^^^^---------^^^^^^^^^^----
    |          |                  |
@@ -102,21 +76,14 @@ LL |     impl PartialEq<Dog> for &Dog {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive-trait.rs:35:5
-   |
-LL | /     impl PartialEq<Dog> for &Dog {
-LL | |
-LL | |         fn eq(&self, _: &Dog) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:42:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl PartialEq<&Dog> for &Dog {
    |     ^^^^^---------^^^^^^^^^^^----
    |          |                   |
@@ -125,16 +92,6 @@ LL |     impl PartialEq<&Dog> for &Dog {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive-trait.rs:42:5
-   |
-LL | /     impl PartialEq<&Dog> for &Dog {
-LL | |
-LL | |         fn eq(&self, _: &&Dog) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 6 warnings emitted

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
@@ -10,8 +10,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -27,8 +27,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -43,8 +43,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -59,8 +59,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -75,8 +75,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -91,8 +91,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 6 warnings emitted

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
@@ -9,11 +9,7 @@ LL |     impl PartialEq<()> for Dog {
 help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive-trait.rs:7:5
    |
-LL |       impl PartialEq<()> for Dog {
-   |       ^    -------------     --- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
-   | |
+LL | /     impl PartialEq<()> for Dog {
 LL | |
 LL | |         fn eq(&self, _: &()) -> bool {
 LL | |             todo!()
@@ -34,11 +30,7 @@ LL |     impl PartialEq<()> for &Dog {
 help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive-trait.rs:14:5
    |
-LL |       impl PartialEq<()> for &Dog {
-   |       ^    -------------     ---- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
-   | |
+LL | /     impl PartialEq<()> for &Dog {
 LL | |
 LL | |         fn eq(&self, _: &()) -> bool {
 LL | |             todo!()
@@ -58,11 +50,7 @@ LL |     impl PartialEq<Dog> for () {
 help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive-trait.rs:21:5
    |
-LL |       impl PartialEq<Dog> for () {
-   |       ^    --------------     -- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
-   | |
+LL | /     impl PartialEq<Dog> for () {
 LL | |
 LL | |         fn eq(&self, _: &Dog) -> bool {
 LL | |             todo!()
@@ -82,11 +70,7 @@ LL |     impl PartialEq<&Dog> for () {
 help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive-trait.rs:28:5
    |
-LL |       impl PartialEq<&Dog> for () {
-   |       ^    ---------------     -- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
-   | |
+LL | /     impl PartialEq<&Dog> for () {
 LL | |
 LL | |         fn eq(&self, _: &&Dog) -> bool {
 LL | |             todo!()
@@ -106,11 +90,7 @@ LL |     impl PartialEq<Dog> for &Dog {
 help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive-trait.rs:35:5
    |
-LL |       impl PartialEq<Dog> for &Dog {
-   |       ^    --------------     ---- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
-   | |
+LL | /     impl PartialEq<Dog> for &Dog {
 LL | |
 LL | |         fn eq(&self, _: &Dog) -> bool {
 LL | |             todo!()
@@ -130,11 +110,7 @@ LL |     impl PartialEq<&Dog> for &Dog {
 help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive-trait.rs:42:5
    |
-LL |       impl PartialEq<&Dog> for &Dog {
-   |       ^    ---------------     ---- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
-   | |
+LL | /     impl PartialEq<&Dog> for &Dog {
 LL | |
 LL | |         fn eq(&self, _: &&Dog) -> bool {
 LL | |             todo!()

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
@@ -2,7 +2,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive-trait.rs:7:5
    |
 LL |     impl PartialEq<()> for Dog {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^---------^^^^^^^^^---
+   |          |                 |
+   |          |                 `Dog` is not local
+   |          `PartialEq` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -23,7 +26,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive-trait.rs:14:5
    |
 LL |     impl PartialEq<()> for &Dog {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^---------^^^^^^^^^----
+   |          |                 |
+   |          |                 `&'_ Dog` is not local
+   |          `PartialEq` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -43,7 +49,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive-trait.rs:21:5
    |
 LL |     impl PartialEq<Dog> for () {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^---------^^^^^^^^^^--
+   |          |                  |
+   |          |                  `()` is not local
+   |          `PartialEq` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -63,7 +72,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive-trait.rs:28:5
    |
 LL |     impl PartialEq<&Dog> for () {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^---------^^^^^^^^^^^--
+   |          |                   |
+   |          |                   `()` is not local
+   |          `PartialEq` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -83,7 +95,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive-trait.rs:35:5
    |
 LL |     impl PartialEq<Dog> for &Dog {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^---------^^^^^^^^^^----
+   |          |                  |
+   |          |                  `&'_ Dog` is not local
+   |          `PartialEq` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -103,7 +118,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive-trait.rs:42:5
    |
 LL |     impl PartialEq<&Dog> for &Dog {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^---------^^^^^^^^^^^----
+   |          |                   |
+   |          |                   `&'_ Dog` is not local
+   |          `PartialEq` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
@@ -4,9 +4,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl PartialEq<()> for Dog {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive-trait.rs:7:5
+   |
+LL |       impl PartialEq<()> for Dog {
+   |       ^    -------------     --- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn eq(&self, _: &()) -> bool {
+LL | |             todo!()
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -16,9 +29,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl PartialEq<()> for &Dog {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive-trait.rs:14:5
+   |
+LL |       impl PartialEq<()> for &Dog {
+   |       ^    -------------     ---- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn eq(&self, _: &()) -> bool {
+LL | |             todo!()
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -27,9 +53,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl PartialEq<Dog> for () {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive-trait.rs:21:5
+   |
+LL |       impl PartialEq<Dog> for () {
+   |       ^    --------------     -- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn eq(&self, _: &Dog) -> bool {
+LL | |             todo!()
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -38,9 +77,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl PartialEq<&Dog> for () {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive-trait.rs:28:5
+   |
+LL |       impl PartialEq<&Dog> for () {
+   |       ^    ---------------     -- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn eq(&self, _: &&Dog) -> bool {
+LL | |             todo!()
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -49,9 +101,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl PartialEq<Dog> for &Dog {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive-trait.rs:35:5
+   |
+LL |       impl PartialEq<Dog> for &Dog {
+   |       ^    --------------     ---- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn eq(&self, _: &Dog) -> bool {
+LL | |             todo!()
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -60,9 +125,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl PartialEq<&Dog> for &Dog {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive-trait.rs:42:5
+   |
+LL |       impl PartialEq<&Dog> for &Dog {
+   |       ^    ---------------     ---- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn eq(&self, _: &&Dog) -> bool {
+LL | |             todo!()
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 6 warnings emitted

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
@@ -1,13 +1,8 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:7:5
    |
-LL | /     impl PartialEq<()> for Dog {
-LL | |
-LL | |         fn eq(&self, _: &()) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl PartialEq<()> for Dog {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -18,13 +13,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:14:5
    |
-LL | /     impl PartialEq<()> for &Dog {
-LL | |
-LL | |         fn eq(&self, _: &()) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl PartialEq<()> for &Dog {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -34,13 +24,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:21:5
    |
-LL | /     impl PartialEq<Dog> for () {
-LL | |
-LL | |         fn eq(&self, _: &Dog) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl PartialEq<Dog> for () {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -50,13 +35,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:28:5
    |
-LL | /     impl PartialEq<&Dog> for () {
-LL | |
-LL | |         fn eq(&self, _: &&Dog) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl PartialEq<&Dog> for () {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -66,13 +46,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:35:5
    |
-LL | /     impl PartialEq<Dog> for &Dog {
-LL | |
-LL | |         fn eq(&self, _: &Dog) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl PartialEq<Dog> for &Dog {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -82,13 +57,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive-trait.rs:42:5
    |
-LL | /     impl PartialEq<&Dog> for &Dog {
-LL | |
-LL | |         fn eq(&self, _: &&Dog) -> bool {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl PartialEq<&Dog> for &Dog {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -1,11 +1,8 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:10:5
    |
-LL | /     impl Test {
-LL | |
-LL | |         fn foo() {}
-LL | |     }
-   | |_____^
+LL |     impl Test {
+   |     ^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
@@ -15,13 +12,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:15:5
    |
-LL | /     impl Display for Test {
-LL | |
-LL | |         fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl Display for Test {
+   |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -32,7 +24,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:22:5
    |
 LL |     impl dyn Trait {}
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
@@ -42,7 +34,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:25:5
    |
 LL |     impl<T: Trait> Trait for Vec<T> { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -53,7 +45,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:28:5
    |
 LL |     impl Trait for &dyn Trait {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -64,7 +56,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:31:5
    |
 LL |     impl Trait for *mut Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -75,7 +67,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:34:5
    |
 LL |     impl Trait for *mut [Test] {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -86,7 +78,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:37:5
    |
 LL |     impl Trait for [Test; 8] {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -97,7 +89,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:40:5
    |
 LL |     impl Trait for (Test,) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -108,7 +100,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:43:5
    |
 LL |     impl Trait for fn(Test) -> () {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -119,7 +111,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:46:5
    |
 LL |     impl Trait for fn() -> Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -130,7 +122,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:50:9
    |
 LL |         impl Trait for Test {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current closure `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -141,7 +133,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:58:5
    |
 LL |     impl Trait for *mut InsideMain {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -152,7 +144,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:60:5
    |
 LL |     impl Trait for *mut [InsideMain] {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -163,7 +155,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:62:5
    |
 LL |     impl Trait for [InsideMain; 8] {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -174,7 +166,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:64:5
    |
 LL |     impl Trait for (InsideMain,) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -185,7 +177,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:66:5
    |
 LL |     impl Trait for fn(InsideMain) -> () {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -196,7 +188,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:68:5
    |
 LL |     impl Trait for fn() -> InsideMain {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -206,13 +198,8 @@ LL |     impl Trait for fn() -> InsideMain {}
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:72:9
    |
-LL | /         impl Display for InsideMain {
-LL | |
-LL | |             fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-LL | |                 todo!()
-LL | |             }
-LL | |         }
-   | |_________^
+LL |         impl Display for InsideMain {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `inside_inside` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -222,11 +209,8 @@ LL | |         }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:79:9
    |
-LL | /         impl InsideMain {
-LL | |
-LL | |             fn bar() {}
-LL | |         }
-   | |_________^
+LL |         impl InsideMain {
+   |         ^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `inside_inside` and up 2 bodies
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -4,7 +4,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Test {
    |     ^^^^^^^^^
    |
-   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+   = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:10:5
    |
@@ -42,7 +42,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl dyn Trait {}
    |     ^^^^^^^^^^^^^^
    |
-   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+   = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:22:5
    |
@@ -313,7 +313,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl InsideMain {
    |         ^^^^^^^^^^^^^^^
    |
-   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+   = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current function `inside_inside` and up 2 bodies
   --> $DIR/exhaustive.rs:79:9
    |

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -8,10 +8,7 @@ LL |     impl Test {
 help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:10:5
    |
-LL |       impl Test {
-   |       ^    ---- may need to be moved as well
-   |  _____|
-   | |
+LL | /     impl Test {
 LL | |
 LL | |         fn foo() {}
 LL | |     }
@@ -30,11 +27,7 @@ LL |     impl Display for Test {
 help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:15:5
    |
-LL |       impl Display for Test {
-   |       ^    -------     ---- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
-   | |
+LL | /     impl Display for Test {
 LL | |
 LL | |         fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 LL | |             todo!()
@@ -54,9 +47,7 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:22:5
    |
 LL |     impl dyn Trait {}
-   |     ^^^^^---------^^^
-   |          |
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -71,10 +62,7 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:25:5
    |
 LL |     impl<T: Trait> Trait for Vec<T> { }
-   |     ^^^^^^^^^^^^^^^-----^^^^^------^^^^
-   |                    |         |
-   |                    |         may need to be moved as well
-   |                    may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -89,10 +77,7 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:28:5
    |
 LL |     impl Trait for &dyn Trait {}
-   |     ^^^^^-----^^^^^----------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -107,10 +92,7 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:31:5
    |
 LL |     impl Trait for *mut Test {}
-   |     ^^^^^-----^^^^^---------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -125,10 +107,7 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:34:5
    |
 LL |     impl Trait for *mut [Test] {}
-   |     ^^^^^-----^^^^^-----------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -143,10 +122,7 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:37:5
    |
 LL |     impl Trait for [Test; 8] {}
-   |     ^^^^^-----^^^^^---------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -161,10 +137,7 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:40:5
    |
 LL |     impl Trait for (Test,) {}
-   |     ^^^^^-----^^^^^-------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -179,10 +152,7 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:43:5
    |
 LL |     impl Trait for fn(Test) -> () {}
-   |     ^^^^^-----^^^^^--------------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -197,10 +167,7 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:46:5
    |
 LL |     impl Trait for fn() -> Test {}
-   |     ^^^^^-----^^^^^------------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -215,10 +182,7 @@ help: move this `impl` block outside of the current closure `<unnameable>` and u
   --> $DIR/exhaustive.rs:50:9
    |
 LL |         impl Trait for Test {}
-   |         ^^^^^-----^^^^^----^^^
-   |              |         |
-   |              |         may need to be moved as well
-   |              may need to be moved as well
+   |         ^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -233,10 +197,9 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:58:5
    |
 LL |     impl Trait for *mut InsideMain {}
-   |     ^^^^^-----^^^^^---------------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^----------^^^
+   |                         |
+   |                         may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -251,10 +214,9 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:60:5
    |
 LL |     impl Trait for *mut [InsideMain] {}
-   |     ^^^^^-----^^^^^-----------------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^----------^^^^
+   |                          |
+   |                          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -269,10 +231,9 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:62:5
    |
 LL |     impl Trait for [InsideMain; 8] {}
-   |     ^^^^^-----^^^^^---------------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^----------^^^^^^^
+   |                     |
+   |                     may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -287,10 +248,9 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:64:5
    |
 LL |     impl Trait for (InsideMain,) {}
-   |     ^^^^^-----^^^^^-------------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^----------^^^^^
+   |                     |
+   |                     may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -305,10 +265,9 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:66:5
    |
 LL |     impl Trait for fn(InsideMain) -> () {}
-   |     ^^^^^-----^^^^^--------------------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^----------^^^^^^^^^^
+   |                       |
+   |                       may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -323,10 +282,9 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/exhaustive.rs:68:5
    |
 LL |     impl Trait for fn() -> InsideMain {}
-   |     ^^^^^-----^^^^^------------------^^^
-   |          |         |
-   |          |         may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^----------^^^
+   |                            |
+   |                            may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -340,11 +298,7 @@ LL |         impl Display for InsideMain {
 help: move this `impl` block outside of the current function `inside_inside` and up 2 bodies
   --> $DIR/exhaustive.rs:72:9
    |
-LL |           impl Display for InsideMain {
-   |           ^    -------     ---------- may need to be moved as well
-   |           |    |
-   |  _________|    may need to be moved as well
-   | |
+LL | /         impl Display for InsideMain {
 LL | |
 LL | |             fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 LL | |                 todo!()
@@ -363,10 +317,7 @@ LL |         impl InsideMain {
 help: move this `impl` block outside of the current function `inside_inside` and up 2 bodies
   --> $DIR/exhaustive.rs:79:9
    |
-LL |           impl InsideMain {
-   |           ^    ---------- may need to be moved as well
-   |  _________|
-   | |
+LL | /         impl InsideMain {
 LL | |
 LL | |             fn bar() {}
 LL | |         }

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -1,26 +1,23 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:10:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
 LL |     impl Test {
    |     ^^^^^----
    |          |
    |          `Test` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:10:5
-   |
-LL | /     impl Test {
-LL | |
-LL | |         fn foo() {}
-LL | |     }
-   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:15:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl Display for Test {
    |     ^^^^^-------^^^^^----
    |          |           |
@@ -29,37 +26,28 @@ LL |     impl Display for Test {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:15:5
-   |
-LL | /     impl Display for Test {
-LL | |
-LL | |         fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:22:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl dyn Trait {}
    |     ^^^^^^^^^-----
    |              |
    |              `Trait` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:22:5
-   |
-LL |     impl dyn Trait {}
-   |     ^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:25:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl<T: Trait> Trait for Vec<T> { }
    |     ^^^^^^^^^^^^^^^-----^^^^^---^^^
    |                    |         |
@@ -68,16 +56,14 @@ LL |     impl<T: Trait> Trait for Vec<T> { }
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:25:5
-   |
-LL |     impl<T: Trait> Trait for Vec<T> { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:28:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl Trait for &dyn Trait {}
    |     ^^^^^-----^^^^^----------
    |          |         |
@@ -86,16 +72,14 @@ LL |     impl Trait for &dyn Trait {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:28:5
-   |
-LL |     impl Trait for &dyn Trait {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:31:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl Trait for *mut Test {}
    |     ^^^^^-----^^^^^---------
    |          |         |
@@ -104,16 +88,14 @@ LL |     impl Trait for *mut Test {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:31:5
-   |
-LL |     impl Trait for *mut Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:34:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl Trait for *mut [Test] {}
    |     ^^^^^-----^^^^^-----------
    |          |         |
@@ -122,16 +104,14 @@ LL |     impl Trait for *mut [Test] {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:34:5
-   |
-LL |     impl Trait for *mut [Test] {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:37:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl Trait for [Test; 8] {}
    |     ^^^^^-----^^^^^---------
    |          |         |
@@ -140,16 +120,14 @@ LL |     impl Trait for [Test; 8] {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:37:5
-   |
-LL |     impl Trait for [Test; 8] {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:40:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl Trait for (Test,) {}
    |     ^^^^^-----^^^^^-------
    |          |         |
@@ -158,16 +136,14 @@ LL |     impl Trait for (Test,) {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:40:5
-   |
-LL |     impl Trait for (Test,) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:43:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl Trait for fn(Test) -> () {}
    |     ^^^^^-----^^^^^--------------
    |          |         |
@@ -176,16 +152,14 @@ LL |     impl Trait for fn(Test) -> () {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:43:5
-   |
-LL |     impl Trait for fn(Test) -> () {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:46:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
+...
 LL |     impl Trait for fn() -> Test {}
    |     ^^^^^-----^^^^^------------
    |          |         |
@@ -194,16 +168,13 @@ LL |     impl Trait for fn() -> Test {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:46:5
-   |
-LL |     impl Trait for fn() -> Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:50:9
    |
+LL |     let _a = || {
+   |              -- move the `impl` block outside of this closure `<unnameable>` and up 2 bodies
 LL |         impl Trait for Test {}
    |         ^^^^^-----^^^^^----
    |              |         |
@@ -212,11 +183,6 @@ LL |         impl Trait for Test {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current closure `<unnameable>` and up 2 bodies
-  --> $DIR/exhaustive.rs:50:9
-   |
-LL |         impl Trait for Test {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -231,13 +197,14 @@ LL |     impl Trait for *mut InsideMain {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:58:5
+help: move the `impl` block outside of this function `main`
+  --> $DIR/exhaustive.rs:9:1
    |
-LL |     impl Trait for *mut InsideMain {}
-   |     ^^^^^^^^^^^^^^^^^^^^----------^^^
-   |                         |
-   |                         may need to be moved as well
+LL | fn main() {
+   | ^^^^^^^^^
+...
+LL |     struct InsideMain;
+   |     ----------------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -251,13 +218,14 @@ LL |     impl Trait for *mut [InsideMain] {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:60:5
+help: move the `impl` block outside of this function `main`
+  --> $DIR/exhaustive.rs:9:1
    |
-LL |     impl Trait for *mut [InsideMain] {}
-   |     ^^^^^^^^^^^^^^^^^^^^^----------^^^^
-   |                          |
-   |                          may need to be moved as well
+LL | fn main() {
+   | ^^^^^^^^^
+...
+LL |     struct InsideMain;
+   |     ----------------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -271,13 +239,14 @@ LL |     impl Trait for [InsideMain; 8] {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:62:5
+help: move the `impl` block outside of this function `main`
+  --> $DIR/exhaustive.rs:9:1
    |
-LL |     impl Trait for [InsideMain; 8] {}
-   |     ^^^^^^^^^^^^^^^^----------^^^^^^^
-   |                     |
-   |                     may need to be moved as well
+LL | fn main() {
+   | ^^^^^^^^^
+...
+LL |     struct InsideMain;
+   |     ----------------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -291,13 +260,14 @@ LL |     impl Trait for (InsideMain,) {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:64:5
+help: move the `impl` block outside of this function `main`
+  --> $DIR/exhaustive.rs:9:1
    |
-LL |     impl Trait for (InsideMain,) {}
-   |     ^^^^^^^^^^^^^^^^----------^^^^^
-   |                     |
-   |                     may need to be moved as well
+LL | fn main() {
+   | ^^^^^^^^^
+...
+LL |     struct InsideMain;
+   |     ----------------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -311,13 +281,14 @@ LL |     impl Trait for fn(InsideMain) -> () {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:66:5
+help: move the `impl` block outside of this function `main`
+  --> $DIR/exhaustive.rs:9:1
    |
-LL |     impl Trait for fn(InsideMain) -> () {}
-   |     ^^^^^^^^^^^^^^^^^^----------^^^^^^^^^^
-   |                       |
-   |                       may need to be moved as well
+LL | fn main() {
+   | ^^^^^^^^^
+...
+LL |     struct InsideMain;
+   |     ----------------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -331,18 +302,21 @@ LL |     impl Trait for fn() -> InsideMain {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/exhaustive.rs:68:5
+help: move the `impl` block outside of this function `main`
+  --> $DIR/exhaustive.rs:9:1
    |
-LL |     impl Trait for fn() -> InsideMain {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^----------^^^
-   |                            |
-   |                            may need to be moved as well
+LL | fn main() {
+   | ^^^^^^^^^
+...
+LL |     struct InsideMain;
+   |     ----------------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:72:9
    |
+LL |     fn inside_inside() {
+   |     ------------------ move the `impl` block outside of this function `inside_inside` and up 2 bodies
 LL |         impl Display for InsideMain {
    |         ^^^^^-------^^^^^----------
    |              |           |
@@ -351,35 +325,20 @@ LL |         impl Display for InsideMain {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `inside_inside` and up 2 bodies
-  --> $DIR/exhaustive.rs:72:9
-   |
-LL | /         impl Display for InsideMain {
-LL | |
-LL | |             fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-LL | |                 todo!()
-LL | |             }
-LL | |         }
-   | |_________^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:79:9
    |
+LL |     fn inside_inside() {
+   |     ------------------ move the `impl` block outside of this function `inside_inside` and up 2 bodies
+...
 LL |         impl InsideMain {
    |         ^^^^^----------
    |              |
    |              `InsideMain` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
-help: move this `impl` block outside of the current function `inside_inside` and up 2 bodies
-  --> $DIR/exhaustive.rs:79:9
-   |
-LL | /         impl InsideMain {
-LL | |
-LL | |             fn bar() {}
-LL | |         }
-   | |_________^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 20 warnings emitted

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -189,7 +189,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:58:5
    |
 LL |     impl Trait for *mut InsideMain {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^-----^^^^^^^^^^
+   |                    |
+   |                    help: remove `*mut ` to make the `impl` local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -2,7 +2,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:10:5
    |
 LL |     impl Test {
-   |     ^^^^^^^^^
+   |     ^^^^^----
+   |          |
+   |          `Test` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current function `main`
@@ -20,7 +22,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:15:5
    |
 LL |     impl Display for Test {
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-------^^^^^----
+   |          |           |
+   |          |           `Test` is not local
+   |          `Display` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -40,7 +45,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:22:5
    |
 LL |     impl dyn Trait {}
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^-----
+   |              |
+   |              `Trait` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current function `main`
@@ -54,7 +61,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:25:5
    |
 LL |     impl<T: Trait> Trait for Vec<T> { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^-----^^^^^---^^^
+   |                    |         |
+   |                    |         `Vec` is not local
+   |                    `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -69,7 +79,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:28:5
    |
 LL |     impl Trait for &dyn Trait {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^----------
+   |          |         |
+   |          |         `&'_ dyn Trait` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -84,7 +97,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:31:5
    |
 LL |     impl Trait for *mut Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^---------
+   |          |         |
+   |          |         `*mut Test` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -99,7 +115,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:34:5
    |
 LL |     impl Trait for *mut [Test] {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^-----------
+   |          |         |
+   |          |         `*mut [Test]` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -114,7 +133,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:37:5
    |
 LL |     impl Trait for [Test; 8] {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^---------
+   |          |         |
+   |          |         `[Test; 8]` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -129,7 +151,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:40:5
    |
 LL |     impl Trait for (Test,) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^-------
+   |          |         |
+   |          |         `(Test,)` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -144,7 +169,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:43:5
    |
 LL |     impl Trait for fn(Test) -> () {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^--------------
+   |          |         |
+   |          |         `fn(: Test) -> ()` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -159,7 +187,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:46:5
    |
 LL |     impl Trait for fn() -> Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^------------
+   |          |         |
+   |          |         `fn() -> Test` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -174,7 +205,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:50:9
    |
 LL |         impl Trait for Test {}
-   |         ^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^-----^^^^^----
+   |              |         |
+   |              |         `Test` is not local
+   |              `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -189,9 +223,11 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:58:5
    |
 LL |     impl Trait for *mut InsideMain {}
-   |     ^^^^^^^^^^^^^^^-----^^^^^^^^^^
-   |                    |
-   |                    help: remove `*mut ` to make the `impl` local
+   |     ^^^^^-----^^^^^---------------
+   |          |         |
+   |          |         `*mut InsideMain` is not local
+   |          |         help: remove `*mut ` to make the `impl` local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -208,7 +244,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:60:5
    |
 LL |     impl Trait for *mut [InsideMain] {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^-----------------
+   |          |         |
+   |          |         `*mut [InsideMain]` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -225,7 +264,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:62:5
    |
 LL |     impl Trait for [InsideMain; 8] {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^---------------
+   |          |         |
+   |          |         `[InsideMain; 8]` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -242,7 +284,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:64:5
    |
 LL |     impl Trait for (InsideMain,) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^-------------
+   |          |         |
+   |          |         `(InsideMain,)` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -259,7 +304,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:66:5
    |
 LL |     impl Trait for fn(InsideMain) -> () {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^--------------------
+   |          |         |
+   |          |         `fn(: InsideMain) -> ()` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -276,7 +324,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:68:5
    |
 LL |     impl Trait for fn() -> InsideMain {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^------------------
+   |          |         |
+   |          |         `fn() -> InsideMain` is not local
+   |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -293,7 +344,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:72:9
    |
 LL |         impl Display for InsideMain {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^-------^^^^^----------
+   |              |           |
+   |              |           `InsideMain` is not local
+   |              `Display` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -313,7 +367,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/exhaustive.rs:79:9
    |
 LL |         impl InsideMain {
-   |         ^^^^^^^^^^^^^^^
+   |         ^^^^^----------
+   |              |
+   |              `InsideMain` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current function `inside_inside` and up 2 bodies

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -8,8 +8,7 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -25,8 +24,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -36,8 +35,7 @@ LL |     impl dyn Trait {}
    |     ^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -47,8 +45,8 @@ LL |     impl<T: Trait> Trait for Vec<T> { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -58,8 +56,8 @@ LL |     impl Trait for &dyn Trait {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -69,8 +67,8 @@ LL |     impl Trait for *mut Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -80,8 +78,8 @@ LL |     impl Trait for *mut [Test] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -91,8 +89,8 @@ LL |     impl Trait for [Test; 8] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -102,8 +100,8 @@ LL |     impl Trait for (Test,) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -113,8 +111,8 @@ LL |     impl Trait for fn(Test) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -124,8 +122,8 @@ LL |     impl Trait for fn() -> Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -135,8 +133,8 @@ LL |         impl Trait for Test {}
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current closure `<unnameable>` and up 2 bodies
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -146,8 +144,8 @@ LL |     impl Trait for *mut InsideMain {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -157,8 +155,8 @@ LL |     impl Trait for *mut [InsideMain] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -168,8 +166,8 @@ LL |     impl Trait for [InsideMain; 8] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -179,8 +177,8 @@ LL |     impl Trait for (InsideMain,) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -190,8 +188,8 @@ LL |     impl Trait for fn(InsideMain) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -201,8 +199,8 @@ LL |     impl Trait for fn() -> InsideMain {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -217,8 +215,8 @@ LL | |         }
    | |_________^
    |
    = help: move this `impl` block outside the of the current function `inside_inside` and up 2 bodies
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -231,8 +229,7 @@ LL | |         }
    | |_________^
    |
    = help: move this `impl` block outside the of the current function `inside_inside` and up 2 bodies
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 20 warnings emitted

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -1,4 +1,4 @@
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:10:5
    |
 LL | /     impl Test {
@@ -13,7 +13,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:15:5
    |
 LL | /     impl Display for Test {
@@ -29,7 +29,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:22:5
    |
 LL |     impl dyn Trait {}
@@ -40,7 +40,7 @@ LL |     impl dyn Trait {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:25:5
    |
 LL |     impl<T: Trait> Trait for Vec<T> { }
@@ -51,7 +51,7 @@ LL |     impl<T: Trait> Trait for Vec<T> { }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:28:5
    |
 LL |     impl Trait for &dyn Trait {}
@@ -62,7 +62,7 @@ LL |     impl Trait for &dyn Trait {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:31:5
    |
 LL |     impl Trait for *mut Test {}
@@ -73,7 +73,7 @@ LL |     impl Trait for *mut Test {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:34:5
    |
 LL |     impl Trait for *mut [Test] {}
@@ -84,7 +84,7 @@ LL |     impl Trait for *mut [Test] {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:37:5
    |
 LL |     impl Trait for [Test; 8] {}
@@ -95,7 +95,7 @@ LL |     impl Trait for [Test; 8] {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:40:5
    |
 LL |     impl Trait for (Test,) {}
@@ -106,7 +106,7 @@ LL |     impl Trait for (Test,) {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:43:5
    |
 LL |     impl Trait for fn(Test) -> () {}
@@ -117,7 +117,7 @@ LL |     impl Trait for fn(Test) -> () {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:46:5
    |
 LL |     impl Trait for fn() -> Test {}
@@ -128,7 +128,7 @@ LL |     impl Trait for fn() -> Test {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:50:9
    |
 LL |         impl Trait for Test {}
@@ -139,7 +139,7 @@ LL |         impl Trait for Test {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:58:5
    |
 LL |     impl Trait for *mut InsideMain {}
@@ -150,7 +150,7 @@ LL |     impl Trait for *mut InsideMain {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:60:5
    |
 LL |     impl Trait for *mut [InsideMain] {}
@@ -161,7 +161,7 @@ LL |     impl Trait for *mut [InsideMain] {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:62:5
    |
 LL |     impl Trait for [InsideMain; 8] {}
@@ -172,7 +172,7 @@ LL |     impl Trait for [InsideMain; 8] {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:64:5
    |
 LL |     impl Trait for (InsideMain,) {}
@@ -183,7 +183,7 @@ LL |     impl Trait for (InsideMain,) {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:66:5
    |
 LL |     impl Trait for fn(InsideMain) -> () {}
@@ -194,7 +194,7 @@ LL |     impl Trait for fn(InsideMain) -> () {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:68:5
    |
 LL |     impl Trait for fn() -> InsideMain {}
@@ -205,7 +205,7 @@ LL |     impl Trait for fn() -> InsideMain {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:72:9
    |
 LL | /         impl Display for InsideMain {
@@ -221,7 +221,7 @@ LL | |         }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:79:9
    |
 LL | /         impl InsideMain {

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -4,8 +4,18 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Test {
    |     ^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:10:5
+   |
+LL |       impl Test {
+   |       ^    ---- may need to be moved as well
+   |  _____|
+   | |
+LL | |
+LL | |         fn foo() {}
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -15,9 +25,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Display for Test {
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:15:5
+   |
+LL |       impl Display for Test {
+   |       ^    -------     ---- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+LL | |             todo!()
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -26,8 +49,14 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl dyn Trait {}
    |     ^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:22:5
+   |
+LL |     impl dyn Trait {}
+   |     ^^^^^---------^^^
+   |          |
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -36,9 +65,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl<T: Trait> Trait for Vec<T> { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:25:5
+   |
+LL |     impl<T: Trait> Trait for Vec<T> { }
+   |     ^^^^^^^^^^^^^^^-----^^^^^------^^^^
+   |                    |         |
+   |                    |         may need to be moved as well
+   |                    may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -47,9 +83,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for &dyn Trait {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:28:5
+   |
+LL |     impl Trait for &dyn Trait {}
+   |     ^^^^^-----^^^^^----------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -58,9 +101,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for *mut Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:31:5
+   |
+LL |     impl Trait for *mut Test {}
+   |     ^^^^^-----^^^^^---------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -69,9 +119,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for *mut [Test] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:34:5
+   |
+LL |     impl Trait for *mut [Test] {}
+   |     ^^^^^-----^^^^^-----------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -80,9 +137,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for [Test; 8] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:37:5
+   |
+LL |     impl Trait for [Test; 8] {}
+   |     ^^^^^-----^^^^^---------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -91,9 +155,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for (Test,) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:40:5
+   |
+LL |     impl Trait for (Test,) {}
+   |     ^^^^^-----^^^^^-------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -102,9 +173,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for fn(Test) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:43:5
+   |
+LL |     impl Trait for fn(Test) -> () {}
+   |     ^^^^^-----^^^^^--------------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -113,9 +191,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for fn() -> Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:46:5
+   |
+LL |     impl Trait for fn() -> Test {}
+   |     ^^^^^-----^^^^^------------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -124,9 +209,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Trait for Test {}
    |         ^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current closure `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current closure `<unnameable>` and up 2 bodies
+  --> $DIR/exhaustive.rs:50:9
+   |
+LL |         impl Trait for Test {}
+   |         ^^^^^-----^^^^^----^^^
+   |              |         |
+   |              |         may need to be moved as well
+   |              may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -135,9 +227,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for *mut InsideMain {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:58:5
+   |
+LL |     impl Trait for *mut InsideMain {}
+   |     ^^^^^-----^^^^^---------------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -146,9 +245,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for *mut [InsideMain] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:60:5
+   |
+LL |     impl Trait for *mut [InsideMain] {}
+   |     ^^^^^-----^^^^^-----------------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -157,9 +263,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for [InsideMain; 8] {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:62:5
+   |
+LL |     impl Trait for [InsideMain; 8] {}
+   |     ^^^^^-----^^^^^---------------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -168,9 +281,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for (InsideMain,) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:64:5
+   |
+LL |     impl Trait for (InsideMain,) {}
+   |     ^^^^^-----^^^^^-------------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -179,9 +299,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for fn(InsideMain) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:66:5
+   |
+LL |     impl Trait for fn(InsideMain) -> () {}
+   |     ^^^^^-----^^^^^--------------------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -190,9 +317,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Trait for fn() -> InsideMain {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/exhaustive.rs:68:5
+   |
+LL |     impl Trait for fn() -> InsideMain {}
+   |     ^^^^^-----^^^^^------------------^^^
+   |          |         |
+   |          |         may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -201,9 +335,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Display for InsideMain {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `inside_inside` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `inside_inside` and up 2 bodies
+  --> $DIR/exhaustive.rs:72:9
+   |
+LL |           impl Display for InsideMain {
+   |           ^    -------     ---------- may need to be moved as well
+   |           |    |
+   |  _________|    may need to be moved as well
+   | |
+LL | |
+LL | |             fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+LL | |                 todo!()
+LL | |             }
+LL | |         }
+   | |_________^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -212,8 +359,18 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl InsideMain {
    |         ^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `inside_inside` and up 2 bodies
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+help: move this `impl` block outside of the current function `inside_inside` and up 2 bodies
+  --> $DIR/exhaustive.rs:79:9
+   |
+LL |           impl InsideMain {
+   |           ^    ---------- may need to be moved as well
+   |  _________|
+   | |
+LL | |
+LL | |             fn bar() {}
+LL | |         }
+   | |_________^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 20 warnings emitted

--- a/tests/ui/lint/non-local-defs/from-local-for-global.stderr
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.stderr
@@ -4,9 +4,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl From<Cat> for () {
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/from-local-for-global.rs:8:5
+   |
+LL |       impl From<Cat> for () {
+   |       ^    ---------     -- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn from(_: Cat) -> () {
+LL | |             todo!()
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -16,9 +29,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl From<Wrap<Wrap<Elephant>>> for () {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/from-local-for-global.rs:18:5
+   |
+LL |       impl From<Wrap<Wrap<Elephant>>> for () {
+   |       ^    --------------------------     -- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn from(_: Wrap<Wrap<Elephant>>) -> Self {
+LL | |             todo!()
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -27,9 +53,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl StillNonLocal for &Foo {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `only_global`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `only_global`
+  --> $DIR/from-local-for-global.rs:32:5
+   |
+LL |     impl StillNonLocal for &Foo {}
+   |     ^^^^^-------------^^^^^----^^^
+   |          |                 |
+   |          |                 may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -38,9 +71,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl From<Local1> for GlobalSameFunction {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `same_function`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `same_function`
+  --> $DIR/from-local-for-global.rs:40:5
+   |
+LL |       impl From<Local1> for GlobalSameFunction {
+   |       ^    ------------     ------------------ may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn from(x: Local1) -> GlobalSameFunction {
+LL | |             x.0
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -49,9 +95,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl From<Local2> for GlobalSameFunction {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `same_function`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `same_function`
+  --> $DIR/from-local-for-global.rs:48:5
+   |
+LL |       impl From<Local2> for GlobalSameFunction {
+   |       ^    ------------     ------------------ may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn from(x: Local2) -> GlobalSameFunction {
+LL | |             x.0
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 5 warnings emitted

--- a/tests/ui/lint/non-local-defs/from-local-for-global.stderr
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.stderr
@@ -2,7 +2,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/from-local-for-global.rs:8:5
    |
 LL |     impl From<Cat> for () {
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^----^^^^^^^^^^--
+   |          |             |
+   |          |             `()` is not local
+   |          `From` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -23,7 +26,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/from-local-for-global.rs:18:5
    |
 LL |     impl From<Wrap<Wrap<Elephant>>> for () {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^----^^^^^^^^^^^^^^^^^^^^^^^^^^^--
+   |          |                              |
+   |          `From` is not local            `()` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -46,9 +51,11 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/from-local-for-global.rs:32:5
    |
 LL |     impl StillNonLocal for &Foo {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^-^^^
-   |                            |
-   |                            help: remove `&` to make the `impl` local
+   |     ^^^^^-------------^^^^^----
+   |          |                 |
+   |          |                 `&'_ Foo` is not local
+   |          |                 help: remove `&` to make the `impl` local
+   |          `StillNonLocal` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -65,7 +72,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/from-local-for-global.rs:40:5
    |
 LL |     impl From<Local1> for GlobalSameFunction {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^----^^^^^^^^^^^^^------------------
+   |          |                |
+   |          |                `GlobalSameFunction` is not local
+   |          `From` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -88,7 +98,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/from-local-for-global.rs:48:5
    |
 LL |     impl From<Local2> for GlobalSameFunction {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^----^^^^^^^^^^^^^------------------
+   |          |                |
+   |          |                `GlobalSameFunction` is not local
+   |          `From` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`

--- a/tests/ui/lint/non-local-defs/from-local-for-global.stderr
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.stderr
@@ -10,8 +10,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -27,8 +27,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -38,8 +38,8 @@ LL |     impl StillNonLocal for &Foo {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `only_global`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -54,8 +54,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `same_function`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -70,8 +70,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `same_function`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 5 warnings emitted

--- a/tests/ui/lint/non-local-defs/from-local-for-global.stderr
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.stderr
@@ -1,13 +1,8 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/from-local-for-global.rs:8:5
    |
-LL | /     impl From<Cat> for () {
-LL | |
-LL | |         fn from(_: Cat) -> () {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl From<Cat> for () {
+   |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -18,13 +13,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/from-local-for-global.rs:18:5
    |
-LL | /     impl From<Wrap<Wrap<Elephant>>> for () {
-LL | |
-LL | |         fn from(_: Wrap<Wrap<Elephant>>) -> Self {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl From<Wrap<Wrap<Elephant>>> for () {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -35,7 +25,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/from-local-for-global.rs:32:5
    |
 LL |     impl StillNonLocal for &Foo {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `only_global`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -45,13 +35,8 @@ LL |     impl StillNonLocal for &Foo {}
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/from-local-for-global.rs:40:5
    |
-LL | /     impl From<Local1> for GlobalSameFunction {
-LL | |
-LL | |         fn from(x: Local1) -> GlobalSameFunction {
-LL | |             x.0
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl From<Local1> for GlobalSameFunction {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `same_function`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -61,13 +46,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/from-local-for-global.rs:48:5
    |
-LL | /     impl From<Local2> for GlobalSameFunction {
-LL | |
-LL | |         fn from(x: Local2) -> GlobalSameFunction {
-LL | |             x.0
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl From<Local2> for GlobalSameFunction {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `same_function`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type

--- a/tests/ui/lint/non-local-defs/from-local-for-global.stderr
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.stderr
@@ -1,4 +1,4 @@
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/from-local-for-global.rs:8:5
    |
 LL | /     impl From<Cat> for () {
@@ -15,7 +15,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/from-local-for-global.rs:18:5
    |
 LL | /     impl From<Wrap<Wrap<Elephant>>> for () {
@@ -31,7 +31,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/from-local-for-global.rs:32:5
    |
 LL |     impl StillNonLocal for &Foo {}
@@ -42,7 +42,7 @@ LL |     impl StillNonLocal for &Foo {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/from-local-for-global.rs:40:5
    |
 LL | /     impl From<Local1> for GlobalSameFunction {
@@ -58,7 +58,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/from-local-for-global.rs:48:5
    |
 LL | /     impl From<Local2> for GlobalSameFunction {

--- a/tests/ui/lint/non-local-defs/from-local-for-global.stderr
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.stderr
@@ -1,6 +1,8 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/from-local-for-global.rs:8:5
    |
+LL | fn main() {
+   | --------- move the `impl` block outside of this function `main`
 LL |     impl From<Cat> for () {
    |     ^^^^^----^^^^^^^^^^--
    |          |             |
@@ -9,16 +11,6 @@ LL |     impl From<Cat> for () {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/from-local-for-global.rs:8:5
-   |
-LL | /     impl From<Cat> for () {
-LL | |
-LL | |         fn from(_: Cat) -> () {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -32,19 +24,14 @@ LL |     impl From<Wrap<Wrap<Elephant>>> for () {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/from-local-for-global.rs:18:5
+help: move the `impl` block outside of this function `main`
+  --> $DIR/from-local-for-global.rs:7:1
    |
-LL |       impl From<Wrap<Wrap<Elephant>>> for () {
-   |       ^                   -------- may need to be moved as well
-   |  _____|
-   | |
-LL | |
-LL | |         fn from(_: Wrap<Wrap<Elephant>>) -> Self {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL | fn main() {
+   | ^^^^^^^^^
+...
+LL |     struct Elephant;
+   |     --------------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -59,13 +46,13 @@ LL |     impl StillNonLocal for &Foo {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `only_global`
-  --> $DIR/from-local-for-global.rs:32:5
+help: move the `impl` block outside of this function `only_global`
+  --> $DIR/from-local-for-global.rs:30:1
    |
-LL |     impl StillNonLocal for &Foo {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^---^^^
-   |                             |
-   |                             may need to be moved as well
+LL | fn only_global() {
+   | ^^^^^^^^^^^^^^^^
+LL |     struct Foo;
+   |     ---------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -79,19 +66,13 @@ LL |     impl From<Local1> for GlobalSameFunction {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `same_function`
-  --> $DIR/from-local-for-global.rs:40:5
+help: move the `impl` block outside of this function `same_function`
+  --> $DIR/from-local-for-global.rs:38:1
    |
-LL |       impl From<Local1> for GlobalSameFunction {
-   |       ^         ------ may need to be moved as well
-   |  _____|
-   | |
-LL | |
-LL | |         fn from(x: Local1) -> GlobalSameFunction {
-LL | |             x.0
-LL | |         }
-LL | |     }
-   | |_____^
+LL | fn same_function() {
+   | ^^^^^^^^^^^^^^^^^^
+LL |     struct Local1(GlobalSameFunction);
+   |     ------------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -105,19 +86,14 @@ LL |     impl From<Local2> for GlobalSameFunction {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `same_function`
-  --> $DIR/from-local-for-global.rs:48:5
+help: move the `impl` block outside of this function `same_function`
+  --> $DIR/from-local-for-global.rs:38:1
    |
-LL |       impl From<Local2> for GlobalSameFunction {
-   |       ^         ------ may need to be moved as well
-   |  _____|
-   | |
-LL | |
-LL | |         fn from(x: Local2) -> GlobalSameFunction {
-LL | |             x.0
-LL | |         }
-LL | |     }
-   | |_____^
+LL | fn same_function() {
+   | ^^^^^^^^^^^^^^^^^^
+...
+LL |     struct Local2(GlobalSameFunction);
+   |     ------------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 5 warnings emitted

--- a/tests/ui/lint/non-local-defs/from-local-for-global.stderr
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.stderr
@@ -46,7 +46,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/from-local-for-global.rs:32:5
    |
 LL |     impl StillNonLocal for &Foo {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^-^^^
+   |                            |
+   |                            help: remove `&` to make the `impl` local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`

--- a/tests/ui/lint/non-local-defs/from-local-for-global.stderr
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.stderr
@@ -9,11 +9,7 @@ LL |     impl From<Cat> for () {
 help: move this `impl` block outside of the current function `main`
   --> $DIR/from-local-for-global.rs:8:5
    |
-LL |       impl From<Cat> for () {
-   |       ^    ---------     -- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
-   | |
+LL | /     impl From<Cat> for () {
 LL | |
 LL | |         fn from(_: Cat) -> () {
 LL | |             todo!()
@@ -35,9 +31,8 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/from-local-for-global.rs:18:5
    |
 LL |       impl From<Wrap<Wrap<Elephant>>> for () {
-   |       ^    --------------------------     -- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
+   |       ^                   -------- may need to be moved as well
+   |  _____|
    | |
 LL | |
 LL | |         fn from(_: Wrap<Wrap<Elephant>>) -> Self {
@@ -59,10 +54,9 @@ help: move this `impl` block outside of the current function `only_global`
   --> $DIR/from-local-for-global.rs:32:5
    |
 LL |     impl StillNonLocal for &Foo {}
-   |     ^^^^^-------------^^^^^----^^^
-   |          |                 |
-   |          |                 may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^---^^^
+   |                             |
+   |                             may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -77,9 +71,8 @@ help: move this `impl` block outside of the current function `same_function`
   --> $DIR/from-local-for-global.rs:40:5
    |
 LL |       impl From<Local1> for GlobalSameFunction {
-   |       ^    ------------     ------------------ may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
+   |       ^         ------ may need to be moved as well
+   |  _____|
    | |
 LL | |
 LL | |         fn from(x: Local1) -> GlobalSameFunction {
@@ -101,9 +94,8 @@ help: move this `impl` block outside of the current function `same_function`
   --> $DIR/from-local-for-global.rs:48:5
    |
 LL |       impl From<Local2> for GlobalSameFunction {
-   |       ^    ------------     ------------------ may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
+   |       ^         ------ may need to be moved as well
+   |  _____|
    | |
 LL | |
 LL | |         fn from(x: Local2) -> GlobalSameFunction {

--- a/tests/ui/lint/non-local-defs/generics.stderr
+++ b/tests/ui/lint/non-local-defs/generics.stderr
@@ -1,4 +1,4 @@
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:9:5
    |
 LL |     impl<T: Local> Global for Vec<T> { }
@@ -10,7 +10,7 @@ LL |     impl<T: Local> Global for Vec<T> { }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:20:5
    |
 LL |     impl Uto7 for Test where Local: std::any::Any {}
@@ -21,7 +21,7 @@ LL |     impl Uto7 for Test where Local: std::any::Any {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:23:5
    |
 LL |     impl<T> Uto8 for T {}
@@ -32,7 +32,7 @@ LL |     impl<T> Uto8 for T {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:32:5
    |
 LL | /     impl Default for UwU<OwO> {
@@ -48,7 +48,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:43:5
    |
 LL | /     impl AsRef<Cat> for () {
@@ -62,7 +62,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:54:5
    |
 LL | /     impl PartialEq<B> for G {
@@ -78,7 +78,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:69:5
    |
 LL | /     impl From<Wrap<Wrap<Lion>>> for () {
@@ -94,7 +94,7 @@ LL | |     }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:76:5
    |
 LL | /     impl From<()> for Wrap<Lion> {

--- a/tests/ui/lint/non-local-defs/generics.stderr
+++ b/tests/ui/lint/non-local-defs/generics.stderr
@@ -2,7 +2,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/generics.rs:9:5
    |
 LL |     impl<T: Local> Global for Vec<T> { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^------^^^^^---^^^
+   |                    |          |
+   |                    |          `Vec` is not local
+   |                    `Global` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -20,7 +23,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/generics.rs:20:5
    |
 LL |     impl Uto7 for Test where Local: std::any::Any {}
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^----^^^^^----
+   |          |        |
+   |          |        `Test` is not local
+   |          `Uto7` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -37,7 +43,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/generics.rs:23:5
    |
 LL |     impl<T> Uto8 for T {}
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^----^^^^^-
+   |             |        |
+   |             |        `T` is not local
+   |             `Uto8` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -52,7 +61,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/generics.rs:32:5
    |
 LL |     impl Default for UwU<OwO> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-------^^^^^---^^^^^
+   |          |           |
+   |          |           `UwU` is not local
+   |          `Default` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -75,7 +87,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/generics.rs:43:5
    |
 LL |     impl AsRef<Cat> for () {
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^-----^^^^^^^^^^--
+   |          |              |
+   |          |              `()` is not local
+   |          `AsRef` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -96,7 +111,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/generics.rs:54:5
    |
 LL |     impl PartialEq<B> for G {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^---------^^^^^^^^-
+   |          |                |
+   |          |                `G` is not local
+   |          `PartialEq` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -119,7 +137,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/generics.rs:69:5
    |
 LL |     impl From<Wrap<Wrap<Lion>>> for () {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^----^^^^^^^^^^^^^^^^^^^^^^^--
+   |          |                          |
+   |          `From` is not local        `()` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -142,7 +162,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/generics.rs:76:5
    |
 LL |     impl From<()> for Wrap<Lion> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^----^^^^^^^^^----^^^^^^
+   |          |            |
+   |          |            `Wrap` is not local
+   |          `From` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`

--- a/tests/ui/lint/non-local-defs/generics.stderr
+++ b/tests/ui/lint/non-local-defs/generics.stderr
@@ -2,7 +2,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/generics.rs:9:5
    |
 LL |     impl<T: Local> Global for Vec<T> { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -14,7 +14,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/generics.rs:20:5
    |
 LL |     impl Uto7 for Test where Local: std::any::Any {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `bad`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -25,7 +25,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/generics.rs:23:5
    |
 LL |     impl<T> Uto8 for T {}
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `bad`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -35,13 +35,8 @@ LL |     impl<T> Uto8 for T {}
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:32:5
    |
-LL | /     impl Default for UwU<OwO> {
-LL | |
-LL | |         fn default() -> Self {
-LL | |             UwU(OwO)
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl Default for UwU<OwO> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `fun`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -51,11 +46,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:43:5
    |
-LL | /     impl AsRef<Cat> for () {
-LL | |
-LL | |         fn as_ref(&self) -> &Cat { &Cat }
-LL | |     }
-   | |_____^
+LL |     impl AsRef<Cat> for () {
+   |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `meow`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -65,13 +57,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:54:5
    |
-LL | /     impl PartialEq<B> for G {
-LL | |
-LL | |         fn eq(&self, _: &B) -> bool {
-LL | |             true
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl PartialEq<B> for G {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `fun2`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -81,13 +68,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:69:5
    |
-LL | /     impl From<Wrap<Wrap<Lion>>> for () {
-LL | |
-LL | |         fn from(_: Wrap<Wrap<Lion>>) -> Self {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl From<Wrap<Wrap<Lion>>> for () {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `rawr`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -97,13 +79,8 @@ LL | |     }
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:76:5
    |
-LL | /     impl From<()> for Wrap<Lion> {
-LL | |
-LL | |         fn from(_: ()) -> Self {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl From<()> for Wrap<Lion> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `rawr`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type

--- a/tests/ui/lint/non-local-defs/generics.stderr
+++ b/tests/ui/lint/non-local-defs/generics.stderr
@@ -5,8 +5,8 @@ LL |     impl<T: Local> Global for Vec<T> { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -17,8 +17,8 @@ LL |     impl Uto7 for Test where Local: std::any::Any {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `bad`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -28,8 +28,8 @@ LL |     impl<T> Uto8 for T {}
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `bad`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -44,8 +44,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `fun`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -58,8 +58,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `meow`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -74,8 +74,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `fun2`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -90,8 +90,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `rawr`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -106,8 +106,8 @@ LL | |     }
    | |_____^
    |
    = help: move this `impl` block outside the of the current function `rawr`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 8 warnings emitted

--- a/tests/ui/lint/non-local-defs/generics.stderr
+++ b/tests/ui/lint/non-local-defs/generics.stderr
@@ -4,9 +4,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl<T: Local> Global for Vec<T> { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/generics.rs:9:5
+   |
+LL |     impl<T: Local> Global for Vec<T> { }
+   |     ^^^^^^^^^^^^^^^------^^^^^------^^^^
+   |                    |          |
+   |                    |          may need to be moved as well
+   |                    may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -16,9 +23,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Uto7 for Test where Local: std::any::Any {}
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `bad`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `bad`
+  --> $DIR/generics.rs:20:5
+   |
+LL |     impl Uto7 for Test where Local: std::any::Any {}
+   |     ^^^^^----^^^^^----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |        |
+   |          |        may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -27,9 +41,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl<T> Uto8 for T {}
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `bad`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `bad`
+  --> $DIR/generics.rs:23:5
+   |
+LL |     impl<T> Uto8 for T {}
+   |     ^^^^^^^^----^^^^^-^^^
+   |             |        |
+   |             |        may need to be moved as well
+   |             may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -38,9 +59,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Default for UwU<OwO> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `fun`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `fun`
+  --> $DIR/generics.rs:32:5
+   |
+LL |       impl Default for UwU<OwO> {
+   |       ^    -------     -------- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn default() -> Self {
+LL | |             UwU(OwO)
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -49,9 +83,20 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl AsRef<Cat> for () {
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `meow`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `meow`
+  --> $DIR/generics.rs:43:5
+   |
+LL |       impl AsRef<Cat> for () {
+   |       ^    ----------     -- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn as_ref(&self) -> &Cat { &Cat }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -60,9 +105,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl PartialEq<B> for G {
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `fun2`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `fun2`
+  --> $DIR/generics.rs:54:5
+   |
+LL |       impl PartialEq<B> for G {
+   |       ^    ------------     - may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn eq(&self, _: &B) -> bool {
+LL | |             true
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -71,9 +129,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl From<Wrap<Wrap<Lion>>> for () {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `rawr`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `rawr`
+  --> $DIR/generics.rs:69:5
+   |
+LL |       impl From<Wrap<Wrap<Lion>>> for () {
+   |       ^    ----------------------     -- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn from(_: Wrap<Wrap<Lion>>) -> Self {
+LL | |             todo!()
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -82,9 +153,22 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl From<()> for Wrap<Lion> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `rawr`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `rawr`
+  --> $DIR/generics.rs:76:5
+   |
+LL |       impl From<()> for Wrap<Lion> {
+   |       ^    --------     ---------- may need to be moved as well
+   |       |    |
+   |  _____|    may need to be moved as well
+   | |
+LL | |
+LL | |         fn from(_: ()) -> Self {
+LL | |             todo!()
+LL | |         }
+LL | |     }
+   | |_____^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 8 warnings emitted

--- a/tests/ui/lint/non-local-defs/generics.stderr
+++ b/tests/ui/lint/non-local-defs/generics.stderr
@@ -9,13 +9,13 @@ LL |     impl<T: Local> Global for Vec<T> { }
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/generics.rs:9:5
+help: move the `impl` block outside of this function `main`
+  --> $DIR/generics.rs:6:1
    |
-LL |     impl<T: Local> Global for Vec<T> { }
-   |     ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
-   |             |
-   |             may need to be moved as well
+LL | fn main() {
+   | ^^^^^^^^^
+LL |     trait Local {};
+   |     ----------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -30,18 +30,21 @@ LL |     impl Uto7 for Test where Local: std::any::Any {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `bad`
-  --> $DIR/generics.rs:20:5
+help: move the `impl` block outside of this function `bad`
+  --> $DIR/generics.rs:18:1
    |
-LL |     impl Uto7 for Test where Local: std::any::Any {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^
-   |                              |
-   |                              may need to be moved as well
+LL | fn bad() {
+   | ^^^^^^^^
+LL |     struct Local;
+   |     ------------ may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/generics.rs:23:5
    |
+LL | fn bad() {
+   | -------- move the `impl` block outside of this function `bad`
+...
 LL |     impl<T> Uto8 for T {}
    |     ^^^^^^^^----^^^^^-
    |             |        |
@@ -50,11 +53,6 @@ LL |     impl<T> Uto8 for T {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `bad`
-  --> $DIR/generics.rs:23:5
-   |
-LL |     impl<T> Uto8 for T {}
-   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -68,19 +66,14 @@ LL |     impl Default for UwU<OwO> {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `fun`
-  --> $DIR/generics.rs:32:5
+help: move the `impl` block outside of this function `fun`
+  --> $DIR/generics.rs:29:1
    |
-LL |       impl Default for UwU<OwO> {
-   |       ^                    --- may need to be moved as well
-   |  _____|
-   | |
-LL | |
-LL | |         fn default() -> Self {
-LL | |             UwU(OwO)
-LL | |         }
-LL | |     }
-   | |_____^
+LL | fn fun() {
+   | ^^^^^^^^
+LL |     #[derive(Debug)]
+LL |     struct OwO;
+   |     ---------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -94,17 +87,14 @@ LL |     impl AsRef<Cat> for () {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `meow`
-  --> $DIR/generics.rs:43:5
+help: move the `impl` block outside of this function `meow`
+  --> $DIR/generics.rs:40:1
    |
-LL |       impl AsRef<Cat> for () {
-   |       ^          --- may need to be moved as well
-   |  _____|
-   | |
-LL | |
-LL | |         fn as_ref(&self) -> &Cat { &Cat }
-LL | |     }
-   | |_____^
+LL | fn meow() {
+   | ^^^^^^^^^
+LL |     #[derive(Debug)]
+LL |     struct Cat;
+   |     ---------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -118,19 +108,14 @@ LL |     impl PartialEq<B> for G {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `fun2`
-  --> $DIR/generics.rs:54:5
+help: move the `impl` block outside of this function `fun2`
+  --> $DIR/generics.rs:51:1
    |
-LL |       impl PartialEq<B> for G {
-   |       ^              - may need to be moved as well
-   |  _____|
-   | |
-LL | |
-LL | |         fn eq(&self, _: &B) -> bool {
-LL | |             true
-LL | |         }
-LL | |     }
-   | |_____^
+LL | fn fun2() {
+   | ^^^^^^^^^
+LL |     #[derive(Debug, Default)]
+LL |     struct B;
+   |     -------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -143,19 +128,13 @@ LL |     impl From<Wrap<Wrap<Lion>>> for () {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `rawr`
-  --> $DIR/generics.rs:69:5
+help: move the `impl` block outside of this function `rawr`
+  --> $DIR/generics.rs:66:1
    |
-LL |       impl From<Wrap<Wrap<Lion>>> for () {
-   |       ^                   ---- may need to be moved as well
-   |  _____|
-   | |
-LL | |
-LL | |         fn from(_: Wrap<Wrap<Lion>>) -> Self {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL | fn rawr() {
+   | ^^^^^^^^^
+LL |     struct Lion;
+   |     ----------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -169,19 +148,13 @@ LL |     impl From<()> for Wrap<Lion> {
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `rawr`
-  --> $DIR/generics.rs:76:5
+help: move the `impl` block outside of this function `rawr`
+  --> $DIR/generics.rs:66:1
    |
-LL |       impl From<()> for Wrap<Lion> {
-   |       ^                      ---- may need to be moved as well
-   |  _____|
-   | |
-LL | |
-LL | |         fn from(_: ()) -> Self {
-LL | |             todo!()
-LL | |         }
-LL | |     }
-   | |_____^
+LL | fn rawr() {
+   | ^^^^^^^^^
+LL |     struct Lion;
+   |     ----------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 8 warnings emitted

--- a/tests/ui/lint/non-local-defs/generics.stderr
+++ b/tests/ui/lint/non-local-defs/generics.stderr
@@ -10,10 +10,9 @@ help: move this `impl` block outside of the current function `main`
   --> $DIR/generics.rs:9:5
    |
 LL |     impl<T: Local> Global for Vec<T> { }
-   |     ^^^^^^^^^^^^^^^------^^^^^------^^^^
-   |                    |          |
-   |                    |          may need to be moved as well
-   |                    may need to be moved as well
+   |     ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
+   |             |
+   |             may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -29,10 +28,9 @@ help: move this `impl` block outside of the current function `bad`
   --> $DIR/generics.rs:20:5
    |
 LL |     impl Uto7 for Test where Local: std::any::Any {}
-   |     ^^^^^----^^^^^----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |          |        |
-   |          |        may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -47,10 +45,7 @@ help: move this `impl` block outside of the current function `bad`
   --> $DIR/generics.rs:23:5
    |
 LL |     impl<T> Uto8 for T {}
-   |     ^^^^^^^^----^^^^^-^^^
-   |             |        |
-   |             |        may need to be moved as well
-   |             may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -65,9 +60,8 @@ help: move this `impl` block outside of the current function `fun`
   --> $DIR/generics.rs:32:5
    |
 LL |       impl Default for UwU<OwO> {
-   |       ^    -------     -------- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
+   |       ^                    --- may need to be moved as well
+   |  _____|
    | |
 LL | |
 LL | |         fn default() -> Self {
@@ -89,9 +83,8 @@ help: move this `impl` block outside of the current function `meow`
   --> $DIR/generics.rs:43:5
    |
 LL |       impl AsRef<Cat> for () {
-   |       ^    ----------     -- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
+   |       ^          --- may need to be moved as well
+   |  _____|
    | |
 LL | |
 LL | |         fn as_ref(&self) -> &Cat { &Cat }
@@ -111,9 +104,8 @@ help: move this `impl` block outside of the current function `fun2`
   --> $DIR/generics.rs:54:5
    |
 LL |       impl PartialEq<B> for G {
-   |       ^    ------------     - may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
+   |       ^              - may need to be moved as well
+   |  _____|
    | |
 LL | |
 LL | |         fn eq(&self, _: &B) -> bool {
@@ -135,9 +127,8 @@ help: move this `impl` block outside of the current function `rawr`
   --> $DIR/generics.rs:69:5
    |
 LL |       impl From<Wrap<Wrap<Lion>>> for () {
-   |       ^    ----------------------     -- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
+   |       ^                   ---- may need to be moved as well
+   |  _____|
    | |
 LL | |
 LL | |         fn from(_: Wrap<Wrap<Lion>>) -> Self {
@@ -159,9 +150,8 @@ help: move this `impl` block outside of the current function `rawr`
   --> $DIR/generics.rs:76:5
    |
 LL |       impl From<()> for Wrap<Lion> {
-   |       ^    --------     ---------- may need to be moved as well
-   |       |    |
-   |  _____|    may need to be moved as well
+   |       ^                      ---- may need to be moved as well
+   |  _____|
    | |
 LL | |
 LL | |         fn from(_: ()) -> Self {

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
@@ -8,8 +8,8 @@ LL | m!();
    | ---- in this macro invocation
    |
    = help: move this `impl` block outside the of the current function `my_func`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
    = note: this warning originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
@@ -13,10 +13,7 @@ help: move this `impl` block outside of the current function `my_func`
   --> $DIR/inside-macro_rules.rs:9:13
    |
 LL |             impl MacroTrait for OutsideStruct {}
-   |             ^^^^^----------^^^^^-------------^^^
-   |                  |              |
-   |                  |              may need to be moved as well
-   |                  may need to be moved as well
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | m!();
    | ---- in this macro invocation

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
@@ -2,7 +2,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/inside-macro_rules.rs:9:13
    |
 LL |             impl MacroTrait for OutsideStruct {}
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^----------^^^^^-------------
+   |                  |              |
+   |                  |              `OutsideStruct` is not local
+   |                  `MacroTrait` is not local
 ...
 LL | m!();
    | ---- in this macro invocation

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
@@ -1,4 +1,4 @@
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/inside-macro_rules.rs:9:13
    |
 LL |             impl MacroTrait for OutsideStruct {}

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
@@ -1,6 +1,8 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/inside-macro_rules.rs:9:13
    |
+LL |         fn my_func() {
+   |         ------------ move the `impl` block outside of this function `my_func`
 LL |             impl MacroTrait for OutsideStruct {}
    |             ^^^^^----------^^^^^-------------
    |                  |              |
@@ -12,14 +14,6 @@ LL | m!();
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `my_func`
-  --> $DIR/inside-macro_rules.rs:9:13
-   |
-LL |             impl MacroTrait for OutsideStruct {}
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | m!();
-   | ---- in this macro invocation
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
    = note: this warning originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
@@ -7,9 +7,19 @@ LL |             impl MacroTrait for OutsideStruct {}
 LL | m!();
    | ---- in this macro invocation
    |
-   = help: move this `impl` block outside the of the current function `my_func`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `my_func`
+  --> $DIR/inside-macro_rules.rs:9:13
+   |
+LL |             impl MacroTrait for OutsideStruct {}
+   |             ^^^^^----------^^^^^-------------^^^
+   |                  |              |
+   |                  |              may need to be moved as well
+   |                  may need to be moved as well
+...
+LL | m!();
+   | ---- in this macro invocation
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
    = note: this warning originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
@@ -2,7 +2,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/inside-macro_rules.rs:9:13
    |
 LL |             impl MacroTrait for OutsideStruct {}
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | m!();
    | ---- in this macro invocation

--- a/tests/ui/lint/non-local-defs/macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/macro_rules.stderr
@@ -6,7 +6,6 @@ LL |     macro_rules! m0 { () => { } };
    |
    = help: remove the `#[macro_export]` or move this `macro_rules!` outside the of the current constant `B`
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -18,7 +17,6 @@ LL | non_local_macro::non_local_macro_rules!(my_macro);
    |
    = help: remove the `#[macro_export]` or move this `macro_rules!` outside the of the current constant `_MACRO_EXPORT`
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: the macro `non_local_macro::non_local_macro_rules` may come from an old version of the `non_local_macro` crate, try updating your dependency with `cargo update -p non_local_macro`
    = note: this warning originates in the macro `non_local_macro::non_local_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -31,7 +29,6 @@ LL |     macro_rules! m { () => { } };
    |
    = help: remove the `#[macro_export]` or move this `macro_rules!` outside the of the current function `main`
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
@@ -42,7 +39,6 @@ LL |             macro_rules! m2 { () => { } };
    |
    = help: remove the `#[macro_export]` or move this `macro_rules!` outside the of the current associated function `bar` and up 2 bodies
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 4 warnings emitted

--- a/tests/ui/lint/non-local-defs/macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/macro_rules.stderr
@@ -1,4 +1,4 @@
-warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
+warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
   --> $DIR/macro_rules.rs:10:5
    |
 LL |     macro_rules! m0 { () => { } };
@@ -10,7 +10,7 @@ LL |     macro_rules! m0 { () => { } };
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
-warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
+warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
   --> $DIR/macro_rules.rs:16:1
    |
 LL | non_local_macro::non_local_macro_rules!(my_macro);
@@ -23,7 +23,7 @@ LL | non_local_macro::non_local_macro_rules!(my_macro);
    = note: the macro `non_local_macro::non_local_macro_rules` may come from an old version of the `non_local_macro` crate, try updating your dependency with `cargo update -p non_local_macro`
    = note: this warning originates in the macro `non_local_macro::non_local_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
+warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
   --> $DIR/macro_rules.rs:21:5
    |
 LL |     macro_rules! m { () => { } };
@@ -34,7 +34,7 @@ LL |     macro_rules! m { () => { } };
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
+warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
   --> $DIR/macro_rules.rs:29:13
    |
 LL |             macro_rules! m2 { () => { } };

--- a/tests/ui/lint/non-local-defs/suggest-moving-inner.rs
+++ b/tests/ui/lint/non-local-defs/suggest-moving-inner.rs
@@ -1,0 +1,17 @@
+//@ check-pass
+
+trait Trait<T> {}
+
+fn main() {
+    mod below {
+        pub struct Type<T>(T);
+    }
+    struct InsideMain;
+    trait HasFoo {}
+
+    impl<T> Trait<InsideMain> for &Vec<below::Type<(InsideMain, T)>>
+    //~^ WARN non-local `impl` definition
+    where
+        T: HasFoo
+    {}
+}

--- a/tests/ui/lint/non-local-defs/suggest-moving-inner.stderr
+++ b/tests/ui/lint/non-local-defs/suggest-moving-inner.stderr
@@ -2,7 +2,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/suggest-moving-inner.rs:12:5
    |
 LL |     impl<T> Trait<InsideMain> for &Vec<below::Type<(InsideMain, T)>>
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^-----^^^^^^^^^^^^^^^^^----------------------------------
+   |             |                     |
+   |             |                     `&'_ Vec<below::Type<(InsideMain, T)>>` is not local
+   |             `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`

--- a/tests/ui/lint/non-local-defs/suggest-moving-inner.stderr
+++ b/tests/ui/lint/non-local-defs/suggest-moving-inner.stderr
@@ -1,18 +1,26 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/trait-solver-overflow-123573.rs:12:5
+  --> $DIR/suggest-moving-inner.rs:12:5
    |
-LL |     impl Test for &Local {}
-   |     ^^^^^^^^^^^^^^^^^^^^
+LL |     impl<T> Trait<InsideMain> for &Vec<below::Type<(InsideMain, T)>>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move this `impl` block outside of the current function `main`
-  --> $DIR/trait-solver-overflow-123573.rs:12:5
+  --> $DIR/suggest-moving-inner.rs:12:5
    |
-LL |     impl Test for &Local {}
-   |     ^^^^^^^^^^^^^^^-----^^^
-   |                    |
-   |                    may need to be moved as well
+LL |       impl<T> Trait<InsideMain> for &Vec<below::Type<(InsideMain, T)>>
+   |       ^             ----------           -----------  ---------- may need to be moved as well
+   |       |             |                    |
+   |       |             |                    may need to be moved as well
+   |  _____|             may need to be moved as well
+   | |
+LL | |
+LL | |     where
+LL | |         T: HasFoo
+   | |            ------ may need to be moved as well
+LL | |     {}
+   | |______^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 

--- a/tests/ui/lint/non-local-defs/suggest-moving-inner.stderr
+++ b/tests/ui/lint/non-local-defs/suggest-moving-inner.stderr
@@ -9,21 +9,19 @@ LL |     impl<T> Trait<InsideMain> for &Vec<below::Type<(InsideMain, T)>>
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/suggest-moving-inner.rs:12:5
+help: move the `impl` block outside of this function `main`
+  --> $DIR/suggest-moving-inner.rs:5:1
    |
-LL |       impl<T> Trait<InsideMain> for &Vec<below::Type<(InsideMain, T)>>
-   |       ^             ----------           -----------  ---------- may need to be moved as well
-   |       |             |                    |
-   |       |             |                    may need to be moved as well
-   |  _____|             may need to be moved as well
-   | |
-LL | |
-LL | |     where
-LL | |         T: HasFoo
-   | |            ------ may need to be moved as well
-LL | |     {}
-   | |______^
+LL | fn main() {
+   | ^^^^^^^^^
+LL |     mod below {
+LL |         pub struct Type<T>(T);
+   |         ------------------ may need to be moved as well
+LL |     }
+LL |     struct InsideMain;
+   |     ----------------- may need to be moved as well
+LL |     trait HasFoo {}
+   |     ------------ may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
@@ -5,8 +5,8 @@ LL |     impl Test for &Local {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
@@ -10,13 +10,13 @@ LL |     impl Test for &Local {}
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current function `main`
-  --> $DIR/trait-solver-overflow-123573.rs:12:5
+help: move the `impl` block outside of this function `main`
+  --> $DIR/trait-solver-overflow-123573.rs:10:1
    |
-LL |     impl Test for &Local {}
-   |     ^^^^^^^^^^^^^^^-----^^^
-   |                    |
-   |                    may need to be moved as well
+LL | fn main() {
+   | ^^^^^^^^^
+LL |     struct Local {}
+   |     ------------ may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
@@ -2,9 +2,11 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/trait-solver-overflow-123573.rs:12:5
    |
 LL |     impl Test for &Local {}
-   |     ^^^^^^^^^^^^^^-^^^^^
-   |                   |
-   |                   help: remove `&` to make the `impl` local
+   |     ^^^^^----^^^^^------
+   |          |        |
+   |          |        `&'_ Local` is not local
+   |          |        help: remove `&` to make the `impl` local
+   |          `Test` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
@@ -1,4 +1,4 @@
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/trait-solver-overflow-123573.rs:12:5
    |
 LL |     impl Test for &Local {}

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
@@ -2,7 +2,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/trait-solver-overflow-123573.rs:12:5
    |
 LL |     impl Test for &Local {}
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^-^^^^^
+   |                   |
+   |                   help: remove `&` to make the `impl` local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
@@ -4,9 +4,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Test for &Local {}
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current function `main`
+  --> $DIR/trait-solver-overflow-123573.rs:12:5
+   |
+LL |     impl Test for &Local {}
+   |     ^^^^^----^^^^^------^^^
+   |          |        |
+   |          |        may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
@@ -2,7 +2,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/trait-solver-overflow-123573.rs:12:5
    |
 LL |     impl Test for &Local {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current function `main`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type

--- a/tests/ui/lint/non-local-defs/weird-exprs.stderr
+++ b/tests/ui/lint/non-local-defs/weird-exprs.stderr
@@ -35,7 +35,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Test {
    |         ^^^^^^^^^
    |
-   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+   = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
   --> $DIR/weird-exprs.rs:25:9
    |

--- a/tests/ui/lint/non-local-defs/weird-exprs.stderr
+++ b/tests/ui/lint/non-local-defs/weird-exprs.stderr
@@ -1,111 +1,116 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:8:5
    |
-LL |     impl Uto for *mut Test {}
-   |     ^^^^^---^^^^^---------
-   |          |       |
-   |          |       `*mut Test` is not local
-   |          `Uto` is not local
+LL |   type A = [u32; {
+   |  ________________-
+LL | |     impl Uto for *mut Test {}
+   | |     ^^^^^---^^^^^---------
+   | |          |       |
+   | |          |       `*mut Test` is not local
+   | |          `Uto` is not local
+LL | |
+...  |
+LL | | }];
+   | |_- move the `impl` block outside of this constant expression `<unnameable>`
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current constant expression `<unnameable>`
-  --> $DIR/weird-exprs.rs:8:5
-   |
-LL |     impl Uto for *mut Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:16:9
    |
-LL |         impl Uto for Test {}
-   |         ^^^^^---^^^^^----
-   |              |       |
-   |              |       `Test` is not local
-   |              `Uto` is not local
+LL |       Discr = {
+   |  _____________-
+LL | |         impl Uto for Test {}
+   | |         ^^^^^---^^^^^----
+   | |              |       |
+   | |              |       `Test` is not local
+   | |              `Uto` is not local
+LL | |
+...  |
+LL | |     }
+   | |_____- move the `impl` block outside of this constant expression `<unnameable>`
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current constant expression `<unnameable>`
-  --> $DIR/weird-exprs.rs:16:9
-   |
-LL |         impl Uto for Test {}
-   |         ^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:25:9
    |
-LL |         impl Test {
-   |         ^^^^^----
-   |              |
-   |              `Test` is not local
-   |
-   = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
-help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
-  --> $DIR/weird-exprs.rs:25:9
-   |
-LL | /         impl Test {
+LL |       let _array = [0i32; {
+   |  _________________________-
+LL | |         impl Test {
+   | |         ^^^^^----
+   | |              |
+   | |              `Test` is not local
 LL | |
 LL | |             fn bar() {}
-LL | |         }
-   | |_________^
+...  |
+LL | |         1
+LL | |     }];
+   | |_____- move the `impl` block outside of this constant expression `<unnameable>` and up 2 bodies
+   |
+   = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:34:9
    |
-LL |         impl Uto for &Test {}
-   |         ^^^^^---^^^^^-----
-   |              |       |
-   |              |       `&'_ Test` is not local
-   |              `Uto` is not local
+LL |       type A = [u32; {
+   |  ____________________-
+LL | |         impl Uto for &Test {}
+   | |         ^^^^^---^^^^^-----
+   | |              |       |
+   | |              |       `&'_ Test` is not local
+   | |              `Uto` is not local
+LL | |
+...  |
+LL | |     }];
+   | |_____- move the `impl` block outside of this constant expression `<unnameable>` and up 2 bodies
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
-  --> $DIR/weird-exprs.rs:34:9
-   |
-LL |         impl Uto for &Test {}
-   |         ^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:41:9
    |
-LL |         impl Uto for &(Test,) {}
-   |         ^^^^^---^^^^^--------
-   |              |       |
-   |              |       `&'_ (Test,)` is not local
-   |              `Uto` is not local
+LL |       fn a(_: [u32; {
+   |  ___________________-
+LL | |         impl Uto for &(Test,) {}
+   | |         ^^^^^---^^^^^--------
+   | |              |       |
+   | |              |       `&'_ (Test,)` is not local
+   | |              `Uto` is not local
+LL | |
+...  |
+LL | |     }]) {}
+   | |_____- move the `impl` block outside of this constant expression `<unnameable>` and up 2 bodies
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
-  --> $DIR/weird-exprs.rs:41:9
-   |
-LL |         impl Uto for &(Test,) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:48:9
    |
-LL |         impl Uto for &(Test,Test) {}
-   |         ^^^^^---^^^^^------------
-   |              |       |
-   |              |       `&'_ (Test, Test)` is not local
-   |              `Uto` is not local
+LL |       fn b() -> [u32; {
+   |  _____________________-
+LL | |         impl Uto for &(Test,Test) {}
+   | |         ^^^^^---^^^^^------------
+   | |              |       |
+   | |              |       `&'_ (Test, Test)` is not local
+   | |              `Uto` is not local
+LL | |
+...  |
+LL | |     }] { todo!() }
+   | |_____- move the `impl` block outside of this constant expression `<unnameable>` and up 2 bodies
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
-  --> $DIR/weird-exprs.rs:48:9
-   |
-LL |         impl Uto for &(Test,Test) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 6 warnings emitted

--- a/tests/ui/lint/non-local-defs/weird-exprs.stderr
+++ b/tests/ui/lint/non-local-defs/weird-exprs.stderr
@@ -4,9 +4,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |     impl Uto for *mut Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current constant expression `<unnameable>`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current constant expression `<unnameable>`
+  --> $DIR/weird-exprs.rs:8:5
+   |
+LL |     impl Uto for *mut Test {}
+   |     ^^^^^---^^^^^---------^^^
+   |          |       |
+   |          |       may need to be moved as well
+   |          may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -16,9 +23,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Uto for Test {}
    |         ^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current constant expression `<unnameable>`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current constant expression `<unnameable>`
+  --> $DIR/weird-exprs.rs:16:9
+   |
+LL |         impl Uto for Test {}
+   |         ^^^^^---^^^^^----^^^
+   |              |       |
+   |              |       may need to be moved as well
+   |              may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -27,8 +41,18 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Test {
    |         ^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
+help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
+  --> $DIR/weird-exprs.rs:25:9
+   |
+LL |           impl Test {
+   |           ^    ---- may need to be moved as well
+   |  _________|
+   | |
+LL | |
+LL | |             fn bar() {}
+LL | |         }
+   | |_________^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -37,9 +61,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Uto for &Test {}
    |         ^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
+  --> $DIR/weird-exprs.rs:34:9
+   |
+LL |         impl Uto for &Test {}
+   |         ^^^^^---^^^^^-----^^^
+   |              |       |
+   |              |       may need to be moved as well
+   |              may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -48,9 +79,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Uto for &(Test,) {}
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
+  --> $DIR/weird-exprs.rs:41:9
+   |
+LL |         impl Uto for &(Test,) {}
+   |         ^^^^^---^^^^^--------^^^
+   |              |       |
+   |              |       may need to be moved as well
+   |              may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -59,9 +97,16 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
 LL |         impl Uto for &(Test,Test) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
+  --> $DIR/weird-exprs.rs:48:9
+   |
+LL |         impl Uto for &(Test,Test) {}
+   |         ^^^^^---^^^^^------------^^^
+   |              |       |
+   |              |       may need to be moved as well
+   |              may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 6 warnings emitted

--- a/tests/ui/lint/non-local-defs/weird-exprs.stderr
+++ b/tests/ui/lint/non-local-defs/weird-exprs.stderr
@@ -1,4 +1,4 @@
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:8:5
    |
 LL |     impl Uto for *mut Test {}
@@ -10,7 +10,7 @@ LL |     impl Uto for *mut Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:16:9
    |
 LL |         impl Uto for Test {}
@@ -21,7 +21,7 @@ LL |         impl Uto for Test {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:25:9
    |
 LL | /         impl Test {
@@ -35,7 +35,7 @@ LL | |         }
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:34:9
    |
 LL |         impl Uto for &Test {}
@@ -46,7 +46,7 @@ LL |         impl Uto for &Test {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:41:9
    |
 LL |         impl Uto for &(Test,) {}
@@ -57,7 +57,7 @@ LL |         impl Uto for &(Test,) {}
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: non-local `impl` definition, they should be avoided as they go against expectation
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:48:9
    |
 LL |         impl Uto for &(Test,Test) {}

--- a/tests/ui/lint/non-local-defs/weird-exprs.stderr
+++ b/tests/ui/lint/non-local-defs/weird-exprs.stderr
@@ -2,7 +2,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/weird-exprs.rs:8:5
    |
 LL |     impl Uto for *mut Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -14,7 +14,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/weird-exprs.rs:16:9
    |
 LL |         impl Uto for Test {}
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>`
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -24,11 +24,8 @@ LL |         impl Uto for Test {}
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/weird-exprs.rs:25:9
    |
-LL | /         impl Test {
-LL | |
-LL | |             fn bar() {}
-LL | |         }
-   | |_________^
+LL |         impl Test {
+   |         ^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
    = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
@@ -38,7 +35,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/weird-exprs.rs:34:9
    |
 LL |         impl Uto for &Test {}
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -49,7 +46,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/weird-exprs.rs:41:9
    |
 LL |         impl Uto for &(Test,) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
@@ -60,7 +57,7 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/weird-exprs.rs:48:9
    |
 LL |         impl Uto for &(Test,Test) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type

--- a/tests/ui/lint/non-local-defs/weird-exprs.stderr
+++ b/tests/ui/lint/non-local-defs/weird-exprs.stderr
@@ -2,7 +2,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/weird-exprs.rs:8:5
    |
 LL |     impl Uto for *mut Test {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^---^^^^^---------
+   |          |       |
+   |          |       `*mut Test` is not local
+   |          `Uto` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -18,7 +21,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/weird-exprs.rs:16:9
    |
 LL |         impl Uto for Test {}
-   |         ^^^^^^^^^^^^^^^^^
+   |         ^^^^^---^^^^^----
+   |              |       |
+   |              |       `Test` is not local
+   |              `Uto` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -33,7 +39,9 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/weird-exprs.rs:25:9
    |
 LL |         impl Test {
-   |         ^^^^^^^^^
+   |         ^^^^^----
+   |              |
+   |              `Test` is not local
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
 help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
@@ -50,7 +58,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/weird-exprs.rs:34:9
    |
 LL |         impl Uto for &Test {}
-   |         ^^^^^^^^^^^^^^^^^^
+   |         ^^^^^---^^^^^-----
+   |              |       |
+   |              |       `&'_ Test` is not local
+   |              `Uto` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -65,7 +76,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/weird-exprs.rs:41:9
    |
 LL |         impl Uto for &(Test,) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^---^^^^^--------
+   |              |       |
+   |              |       `&'_ (Test,)` is not local
+   |              `Uto` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
@@ -80,7 +94,10 @@ warning: non-local `impl` definition, `impl` blocks should be written at the sam
   --> $DIR/weird-exprs.rs:48:9
    |
 LL |         impl Uto for &(Test,Test) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^---^^^^^------------
+   |              |       |
+   |              |       `&'_ (Test, Test)` is not local
+   |              `Uto` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`

--- a/tests/ui/lint/non-local-defs/weird-exprs.stderr
+++ b/tests/ui/lint/non-local-defs/weird-exprs.stderr
@@ -5,8 +5,8 @@ LL |     impl Uto for *mut Test {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -17,8 +17,8 @@ LL |         impl Uto for Test {}
    |         ^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>`
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -31,8 +31,7 @@ LL | |         }
    | |_________^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: methods and assoc const are still usable outside the current expression, only `impl Local` and `impl dyn Local` are local and only if the `Local` type is at the same nesting as the `impl` block
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -42,8 +41,8 @@ LL |         impl Uto for &Test {}
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -53,8 +52,8 @@ LL |         impl Uto for &(Test,) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -64,8 +63,8 @@ LL |         impl Uto for &(Test,Test) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: move this `impl` block outside the of the current constant expression `<unnameable>` and up 2 bodies
-   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 6 warnings emitted

--- a/tests/ui/lint/non-local-defs/weird-exprs.stderr
+++ b/tests/ui/lint/non-local-defs/weird-exprs.stderr
@@ -10,10 +10,7 @@ help: move this `impl` block outside of the current constant expression `<unname
   --> $DIR/weird-exprs.rs:8:5
    |
 LL |     impl Uto for *mut Test {}
-   |     ^^^^^---^^^^^---------^^^
-   |          |       |
-   |          |       may need to be moved as well
-   |          may need to be moved as well
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `#[warn(non_local_definitions)]` on by default
 
@@ -29,10 +26,7 @@ help: move this `impl` block outside of the current constant expression `<unname
   --> $DIR/weird-exprs.rs:16:9
    |
 LL |         impl Uto for Test {}
-   |         ^^^^^---^^^^^----^^^
-   |              |       |
-   |              |       may need to be moved as well
-   |              may need to be moved as well
+   |         ^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -45,10 +39,7 @@ LL |         impl Test {
 help: move this `impl` block outside of the current constant expression `<unnameable>` and up 2 bodies
   --> $DIR/weird-exprs.rs:25:9
    |
-LL |           impl Test {
-   |           ^    ---- may need to be moved as well
-   |  _________|
-   | |
+LL | /         impl Test {
 LL | |
 LL | |             fn bar() {}
 LL | |         }
@@ -67,10 +58,7 @@ help: move this `impl` block outside of the current constant expression `<unname
   --> $DIR/weird-exprs.rs:34:9
    |
 LL |         impl Uto for &Test {}
-   |         ^^^^^---^^^^^-----^^^
-   |              |       |
-   |              |       may need to be moved as well
-   |              may need to be moved as well
+   |         ^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -85,10 +73,7 @@ help: move this `impl` block outside of the current constant expression `<unname
   --> $DIR/weird-exprs.rs:41:9
    |
 LL |         impl Uto for &(Test,) {}
-   |         ^^^^^---^^^^^--------^^^
-   |              |       |
-   |              |       may need to be moved as well
-   |              may need to be moved as well
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
@@ -103,10 +88,7 @@ help: move this `impl` block outside of the current constant expression `<unname
   --> $DIR/weird-exprs.rs:48:9
    |
 LL |         impl Uto for &(Test,Test) {}
-   |         ^^^^^---^^^^^------------^^^
-   |              |       |
-   |              |       may need to be moved as well
-   |              may need to be moved as well
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: 6 warnings emitted

--- a/tests/ui/proc-macro/nested-macro-rules.stderr
+++ b/tests/ui/proc-macro/nested-macro-rules.stderr
@@ -1,4 +1,4 @@
-warning: non-local `macro_rules!` definition, they should be avoided as they go against expectation
+warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
   --> $DIR/auxiliary/nested-macro-rules.rs:7:9
    |
 LL |   macro_rules! outer_macro {

--- a/tests/ui/proc-macro/nested-macro-rules.stderr
+++ b/tests/ui/proc-macro/nested-macro-rules.stderr
@@ -19,7 +19,6 @@ LL |       nested_macro_rules::outer_macro!(SecondStruct, SecondAttrStruct);
    |
    = help: remove the `#[macro_export]` or move this `macro_rules!` outside the of the current function `main`
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
-   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 note: the lint level is defined here
   --> $DIR/nested-macro-rules.rs:8:9

--- a/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.stderr
+++ b/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.stderr
@@ -1,8 +1,8 @@
-error[E0284]: type annotations needed: cannot satisfy `the constant `{ || {} }` can be evaluated`
+error[E0284]: type annotations needed: cannot satisfy `{ || {} } == _`
   --> $DIR/const-region-infer-to-static-in-binder.rs:4:10
    |
 LL | struct X<const FN: fn() = { || {} }>;
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot satisfy `the constant `{ || {} }` can be evaluated`
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot satisfy `{ || {} } == _`
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/const-region-infer-to-static-in-binder.rs:4:20

--- a/tests/ui/traits/next-solver/cycles/cycle-modulo-ambig-aliases.rs
+++ b/tests/ui/traits/next-solver/cycles/cycle-modulo-ambig-aliases.rs
@@ -1,0 +1,89 @@
+//@ compile-flags: -Znext-solver
+
+// A regression test for #125269. We previously ended up
+// recursively proving `&<_ as SpeciesPackedElem>::Assoc: Typed`
+// for all aliases which ended up causing exponential blowup.
+//
+// This has been fixed by eagerly normalizing the associated
+// type before computing the nested goals, resulting in an
+// immediate inductive cycle.
+
+pub trait Typed {}
+
+pub struct SpeciesCases<E>(E);
+
+pub trait SpeciesPackedElim {
+    type Ogre;
+    type Cyclops;
+    type Wendigo;
+    type Cavetroll;
+    type Mountaintroll;
+    type Swamptroll;
+    type Dullahan;
+    type Werewolf;
+    type Occultsaurok;
+    type Mightysaurok;
+    type Slysaurok;
+    type Mindflayer;
+    type Minotaur;
+    type Tidalwarrior;
+    type Yeti;
+    type Harvester;
+    type Blueoni;
+    type Redoni;
+    type Cultistwarlord;
+    type Cultistwarlock;
+    type Huskbrute;
+    type Tursus;
+    type Gigasfrost;
+    type AdletElder;
+    type SeaBishop;
+    type HaniwaGeneral;
+    type TerracottaBesieger;
+    type TerracottaDemolisher;
+    type TerracottaPunisher;
+    type TerracottaPursuer;
+    type Cursekeeper;
+}
+
+impl<'b, E: SpeciesPackedElim> Typed for &'b SpeciesCases<E>
+where
+    &'b E::Ogre: Typed,
+    &'b E::Cyclops: Typed,
+    &'b E::Wendigo: Typed,
+    &'b E::Cavetroll: Typed,
+    &'b E::Mountaintroll: Typed,
+    &'b E::Swamptroll: Typed,
+    &'b E::Dullahan: Typed,
+    &'b E::Werewolf: Typed,
+    &'b E::Occultsaurok: Typed,
+    &'b E::Mightysaurok: Typed,
+    &'b E::Slysaurok: Typed,
+    &'b E::Mindflayer: Typed,
+    &'b E::Minotaur: Typed,
+    &'b E::Tidalwarrior: Typed,
+    &'b E::Yeti: Typed,
+    &'b E::Harvester: Typed,
+    &'b E::Blueoni: Typed,
+    &'b E::Redoni: Typed,
+    &'b E::Cultistwarlord: Typed,
+    &'b E::Cultistwarlock: Typed,
+    &'b E::Huskbrute: Typed,
+    &'b E::Tursus: Typed,
+    &'b E::Gigasfrost: Typed,
+    &'b E::AdletElder: Typed,
+    &'b E::SeaBishop: Typed,
+    &'b E::HaniwaGeneral: Typed,
+    &'b E::TerracottaBesieger: Typed,
+    &'b E::TerracottaDemolisher: Typed,
+    &'b E::TerracottaPunisher: Typed,
+    &'b E::TerracottaPursuer: Typed,
+    &'b E::Cursekeeper: Typed,
+{}
+
+fn foo<T: Typed>() {}
+
+fn main() {
+    foo::<&_>();
+    //~^ ERROR overflow evaluating the requirement `&_: Typed`
+}

--- a/tests/ui/traits/next-solver/cycles/cycle-modulo-ambig-aliases.stderr
+++ b/tests/ui/traits/next-solver/cycles/cycle-modulo-ambig-aliases.stderr
@@ -1,0 +1,15 @@
+error[E0275]: overflow evaluating the requirement `&_: Typed`
+  --> $DIR/cycle-modulo-ambig-aliases.rs:87:11
+   |
+LL |     foo::<&_>();
+   |           ^^
+   |
+note: required by a bound in `foo`
+  --> $DIR/cycle-modulo-ambig-aliases.rs:84:11
+   |
+LL | fn foo<T: Typed>() {}
+   |           ^^^^^ required by this bound in `foo`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/next-solver/dyn-any-dont-prefer-impl.rs
+++ b/tests/ui/traits/next-solver/dyn-any-dont-prefer-impl.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: -Znext-solver
-//@ check-pass
+//@ run-pass
 
 // Test that selection prefers the builtin trait object impl for `Any`
 // instead of the user defined impl. Both impls apply to the trait


### PR DESCRIPTION
Successful merges:

 - #125089 (Improve diagnostic output the `non_local_definitions` lint)
 - #125343 (`-Znext-solver`: eagerly normalize when adding goals)
 - #125551 (Stabilise `IpvNAddr::{BITS, to_bits, from_bits}` (`ip_bits`))
 - #125598 (Make `ProofTreeBuilder` actually generic over `Interner`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=125089,125343,125551,125598)
<!-- homu-ignore:end -->