### PR TITLE
Remove usage of `isize` in example

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -142,7 +142,7 @@ declare_lint! {
     /// ```rust,compile_fail
     /// #![deny(box_pointers)]
     /// struct Foo {
-    ///     x: Box<isize>,
+    ///     x: Box<i32>,
     /// }
     /// ```
     ///


### PR DESCRIPTION
`isize` is a rare integer type, replace it with a more common one.