### PR TITLE
git ignore `.helix`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Session.vim
 .favorites.json
 .settings/
 .vs/
+.helix
 
 ## Tool
 .valgrindrc


### PR DESCRIPTION
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
I'm using [helix](https://github.com/helix-editor/helix) editor to dev rustc, and helix use [.helix](https://docs.helix-editor.com/languages.html#languagestoml-files) to configure languages. I would appreciate it if this folder could be ignored by git.