### PR TITLE
Tweak relations to no longer rely on `TypeTrace`

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1158,7 +1158,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let (a_sig, b_sig) = self.normalize(new.span, (a_sig, b_sig));
             let sig = self
                 .at(cause, self.param_env)
-                .trace(prev_ty, new_ty)
                 .lub(DefineOpaqueTypes::Yes, a_sig, b_sig)
                 .map(|ok| self.register_infer_ok_obligations(ok))?;
 

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -156,6 +156,23 @@ impl<'a, 'tcx> At<'a, 'tcx> {
         self.trace(expected, actual).eq(define_opaque_types, expected, actual)
     }
 
+    /// Equates `expected` and `found` while structurally relating aliases.
+    /// This should only be used inside of the next generation trait solver
+    /// when relating rigid aliases.
+    pub fn eq_structurally_relating_aliases<T>(
+        self,
+        expected: T,
+        actual: T,
+    ) -> InferResult<'tcx, ()>
+    where
+        T: ToTrace<'tcx>,
+    {
+        self.trace(expected, actual).eq_structurally_relating_aliases(
+            expected,
+            actual,
+        )
+    }
+
     pub fn relate<T>(
         self,
         define_opaque_types: DefineOpaqueTypes,

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -48,11 +48,6 @@ pub struct At<'a, 'tcx> {
     pub param_env: ty::ParamEnv<'tcx>,
 }
 
-pub struct Trace<'a, 'tcx> {
-    at: At<'a, 'tcx>,
-    trace: TypeTrace<'tcx>,
-}
-
 impl<'tcx> InferCtxt<'tcx> {
     #[inline]
     pub fn at<'a>(
@@ -109,9 +104,6 @@ impl<'a, 'tcx> At<'a, 'tcx> {
     /// call like `foo(x)`, where `foo: fn(i32)`, you might have
     /// `sup(i32, x)`, since the "expected" type is the type that
     /// appears in the signature.
-    ///
-    /// See [`At::trace`] and [`Trace::sub`] for a version of
-    /// this method that only requires `T: Relate<'tcx>`
     pub fn sup<T>(
         self,
         define_opaque_types: DefineOpaqueTypes,
@@ -121,13 +113,19 @@ impl<'a, 'tcx> At<'a, 'tcx> {
     where
         T: ToTrace<'tcx>,
     {
-        self.trace(expected, actual).sup(define_opaque_types, expected, actual)
+        let mut fields = CombineFields::new(
+            self.infcx,
+            ToTrace::to_trace(self.cause, true, expected, actual),
+            self.param_env,
+            define_opaque_types,
+        );
+        fields
+            .sup()
+            .relate(expected, actual)
+            .map(|_| InferOk { value: (), obligations: fields.obligations })
     }
 
     /// Makes `expected <: actual`.
-    ///
-    /// See [`At::trace`] and [`Trace::sub`] for a version of
-    /// this method that only requires `T: Relate<'tcx>`
     pub fn sub<T>(
         self,
         define_opaque_types: DefineOpaqueTypes,
@@ -137,13 +135,19 @@ impl<'a, 'tcx> At<'a, 'tcx> {
     where
         T: ToTrace<'tcx>,
     {
-        self.trace(expected, actual).sub(define_opaque_types, expected, actual)
+        let mut fields = CombineFields::new(
+            self.infcx,
+            ToTrace::to_trace(self.cause, true, expected, actual),
+            self.param_env,
+            define_opaque_types,
+        );
+        fields
+            .sub()
+            .relate(expected, actual)
+            .map(|_| InferOk { value: (), obligations: fields.obligations })
     }
 
-    /// Makes `expected <: actual`.
-    ///
-    /// See [`At::trace`] and [`Trace::eq`] for a version of
-    /// this method that only requires `T: Relate<'tcx>`
+    /// Makes `expected == actual`.
     pub fn eq<T>(
         self,
         define_opaque_types: DefineOpaqueTypes,
@@ -153,7 +157,16 @@ impl<'a, 'tcx> At<'a, 'tcx> {
     where
         T: ToTrace<'tcx>,
     {
-        self.trace(expected, actual).eq(define_opaque_types, expected, actual)
+        let mut fields = CombineFields::new(
+            self.infcx,
+            ToTrace::to_trace(self.cause, true, expected, actual),
+            self.param_env,
+            define_opaque_types,
+        );
+        fields
+            .equate(StructurallyRelateAliases::No)
+            .relate(expected, actual)
+            .map(|_| InferOk { value: (), obligations: fields.obligations })
     }
 
     /// Equates `expected` and `found` while structurally relating aliases.
@@ -167,10 +180,17 @@ impl<'a, 'tcx> At<'a, 'tcx> {
     where
         T: ToTrace<'tcx>,
     {
-        self.trace(expected, actual).eq_structurally_relating_aliases(
-            expected,
-            actual,
-        )
+        assert!(self.infcx.next_trait_solver());
+        let mut fields = CombineFields::new(
+            self.infcx,
+            ToTrace::to_trace(self.cause, true, expected, actual),
+            self.param_env,
+            DefineOpaqueTypes::Yes,
+        );
+        fields
+            .equate(StructurallyRelateAliases::Yes)
+            .relate(expected, actual)
+            .map(|_| InferOk { value: (), obligations: fields.obligations })
     }
 
     pub fn relate<T>(
@@ -202,9 +222,6 @@ impl<'a, 'tcx> At<'a, 'tcx> {
     /// this can result in an error (e.g., if asked to compute LUB of
     /// u32 and i32), it is meaningful to call one of them the
     /// "expected type".
-    ///
-    /// See [`At::trace`] and [`Trace::lub`] for a version of
-    /// this method that only requires `T: Relate<'tcx>`
     pub fn lub<T>(
         self,
         define_opaque_types: DefineOpaqueTypes,
@@ -214,15 +231,21 @@ impl<'a, 'tcx> At<'a, 'tcx> {
     where
         T: ToTrace<'tcx>,
     {
-        self.trace(expected, actual).lub(define_opaque_types, expected, actual)
+        let mut fields = CombineFields::new(
+            self.infcx,
+            ToTrace::to_trace(self.cause, true, expected, actual),
+            self.param_env,
+            define_opaque_types,
+        );
+        fields
+            .lub()
+            .relate(expected, actual)
+            .map(|value| InferOk { value, obligations: fields.obligations })
     }
 
     /// Computes the greatest-lower-bound, or mutual subtype, of two
     /// values. As with `lub` order doesn't matter, except for error
     /// cases.
-    ///
-    /// See [`At::trace`] and [`Trace::glb`] for a version of
-    /// this method that only requires `T: Relate<'tcx>`
     pub fn glb<T>(
         self,
         define_opaque_types: DefineOpaqueTypes,
@@ -232,105 +255,16 @@ impl<'a, 'tcx> At<'a, 'tcx> {
     where
         T: ToTrace<'tcx>,
     {
-        self.trace(expected, actual).glb(define_opaque_types, expected, actual)
-    }
-
-    /// Sets the "trace" values that will be used for
-    /// error-reporting, but doesn't actually perform any operation
-    /// yet (this is useful when you want to set the trace using
-    /// distinct values from those you wish to operate upon).
-    pub fn trace<T>(self, expected: T, actual: T) -> Trace<'a, 'tcx>
-    where
-        T: ToTrace<'tcx>,
-    {
-        let trace = ToTrace::to_trace(self.cause, true, expected, actual);
-        Trace { at: self, trace }
-    }
-}
-
-impl<'a, 'tcx> Trace<'a, 'tcx> {
-    /// Makes `a <: b`.
-    #[instrument(skip(self), level = "debug")]
-    pub fn sub<T>(self, define_opaque_types: DefineOpaqueTypes, a: T, b: T) -> InferResult<'tcx, ()>
-    where
-        T: Relate<'tcx>,
-    {
-        let Trace { at, trace } = self;
-        let mut fields = at.infcx.combine_fields(trace, at.param_env, define_opaque_types);
-        fields
-            .sub()
-            .relate(a, b)
-            .map(move |_| InferOk { value: (), obligations: fields.obligations })
-    }
-
-    /// Makes `a :> b`.
-    #[instrument(skip(self), level = "debug")]
-    pub fn sup<T>(self, define_opaque_types: DefineOpaqueTypes, a: T, b: T) -> InferResult<'tcx, ()>
-    where
-        T: Relate<'tcx>,
-    {
-        let Trace { at, trace } = self;
-        let mut fields = at.infcx.combine_fields(trace, at.param_env, define_opaque_types);
-        fields
-            .sup()
-            .relate(a, b)
-            .map(move |_| InferOk { value: (), obligations: fields.obligations })
-    }
-
-    /// Makes `a == b`.
-    #[instrument(skip(self), level = "debug")]
-    pub fn eq<T>(self, define_opaque_types: DefineOpaqueTypes, a: T, b: T) -> InferResult<'tcx, ()>
-    where
-        T: Relate<'tcx>,
-    {
-        let Trace { at, trace } = self;
-        let mut fields = at.infcx.combine_fields(trace, at.param_env, define_opaque_types);
-        fields
-            .equate(StructurallyRelateAliases::No)
-            .relate(a, b)
-            .map(move |_| InferOk { value: (), obligations: fields.obligations })
-    }
-
-    /// Equates `a` and `b` while structurally relating aliases. This should only
-    /// be used inside of the next generation trait solver when relating rigid aliases.
-    #[instrument(skip(self), level = "debug")]
-    pub fn eq_structurally_relating_aliases<T>(self, a: T, b: T) -> InferResult<'tcx, ()>
-    where
-        T: Relate<'tcx>,
-    {
-        let Trace { at, trace } = self;
-        debug_assert!(at.infcx.next_trait_solver());
-        let mut fields = at.infcx.combine_fields(trace, at.param_env, DefineOpaqueTypes::Yes);
-        fields
-            .equate(StructurallyRelateAliases::Yes)
-            .relate(a, b)
-            .map(move |_| InferOk { value: (), obligations: fields.obligations })
-    }
-
-    #[instrument(skip(self), level = "debug")]
-    pub fn lub<T>(self, define_opaque_types: DefineOpaqueTypes, a: T, b: T) -> InferResult<'tcx, T>
-    where
-        T: Relate<'tcx>,
-    {
-        let Trace { at, trace } = self;
-        let mut fields = at.infcx.combine_fields(trace, at.param_env, define_opaque_types);
-        fields
-            .lub()
-            .relate(a, b)
-            .map(move |t| InferOk { value: t, obligations: fields.obligations })
-    }
-
-    #[instrument(skip(self), level = "debug")]
-    pub fn glb<T>(self, define_opaque_types: DefineOpaqueTypes, a: T, b: T) -> InferResult<'tcx, T>
-    where
-        T: Relate<'tcx>,
-    {
-        let Trace { at, trace } = self;
-        let mut fields = at.infcx.combine_fields(trace, at.param_env, define_opaque_types);
+        let mut fields = CombineFields::new(
+            self.infcx,
+            ToTrace::to_trace(self.cause, true, expected, actual),
+            self.param_env,
+            define_opaque_types,
+        );
         fields
             .glb()
-            .relate(a, b)
-            .map(move |t| InferOk { value: t, obligations: fields.obligations })
+            .relate(expected, actual)
+            .map(|value| InferOk { value, obligations: fields.obligations })
     }
 }
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -836,21 +836,6 @@ impl<'tcx> InferCtxt<'tcx> {
             .collect()
     }
 
-    fn combine_fields<'a>(
-        &'a self,
-        trace: TypeTrace<'tcx>,
-        param_env: ty::ParamEnv<'tcx>,
-        define_opaque_types: DefineOpaqueTypes,
-    ) -> CombineFields<'a, 'tcx> {
-        CombineFields {
-            infcx: self,
-            trace,
-            param_env,
-            obligations: PredicateObligations::new(),
-            define_opaque_types,
-        }
-    }
-
     pub fn can_sub<T>(&self, param_env: ty::ParamEnv<'tcx>, expected: T, actual: T) -> bool
     where
         T: at::ToTrace<'tcx>,

--- a/compiler/rustc_infer/src/infer/relate/combine.rs
+++ b/compiler/rustc_infer/src/infer/relate/combine.rs
@@ -42,6 +42,17 @@ pub struct CombineFields<'infcx, 'tcx> {
     pub define_opaque_types: DefineOpaqueTypes,
 }
 
+impl<'infcx, 'tcx> CombineFields<'infcx, 'tcx> {
+    pub fn new(
+        infcx: &'infcx InferCtxt<'tcx>,
+        trace: TypeTrace<'tcx>,
+        param_env: ty::ParamEnv<'tcx>,
+        define_opaque_types: DefineOpaqueTypes,
+    ) -> Self {
+        Self { infcx, trace, param_env, define_opaque_types, obligations: vec![] }
+    }
+}
+
 impl<'tcx> InferCtxt<'tcx> {
     pub fn super_combine_tys<R>(
         &self,

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
@@ -362,7 +362,6 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         for (&orig, response) in iter::zip(original_values, var_values.var_values) {
             let InferOk { value: (), obligations } = infcx
                 .at(&cause, param_env)
-                .trace(orig, response)
                 .eq_structurally_relating_aliases(orig, response)
                 .unwrap();
             assert!(obligations.is_empty());

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
@@ -774,7 +774,6 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
             let InferOk { value: (), obligations } = self
                 .infcx
                 .at(&ObligationCause::dummy(), param_env)
-                .trace(term, ctor_term)
                 .eq_structurally_relating_aliases(term, ctor_term)?;
             debug_assert!(obligations.is_empty());
             self.relate(param_env, alias, variance, rigid_ctor)
@@ -794,11 +793,8 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
         rhs: T,
     ) -> Result<(), NoSolution> {
         let cause = ObligationCause::dummy();
-        let InferOk { value: (), obligations } = self
-            .infcx
-            .at(&cause, param_env)
-            .trace(lhs, rhs)
-            .eq_structurally_relating_aliases(lhs, rhs)?;
+        let InferOk { value: (), obligations } =
+            self.infcx.at(&cause, param_env).eq_structurally_relating_aliases(lhs, rhs)?;
         assert!(obligations.is_empty());
         Ok(())
     }

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -566,10 +566,13 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                             {
                                 if let Ok(new_obligations) = infcx
                                     .at(&obligation.cause, obligation.param_env)
-                                    .trace(c1, c2)
                                     // Can define opaque types as this is only reachable with
                                     // `generic_const_exprs`
-                                    .eq(DefineOpaqueTypes::Yes, a.args, b.args)
+                                    .eq(
+                                        DefineOpaqueTypes::Yes,
+                                        ty::AliasTerm::from(a),
+                                        ty::AliasTerm::from(b),
+                                    )
                                 {
                                     return ProcessResult::Changed(mk_pending(
                                         new_obligations.into_obligations(),

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -910,10 +910,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                 if let Ok(InferOk { obligations, value: () }) = self
                                     .infcx
                                     .at(&obligation.cause, obligation.param_env)
-                                    .trace(c1, c2)
                                     // Can define opaque types as this is only reachable with
                                     // `generic_const_exprs`
-                                    .eq(DefineOpaqueTypes::Yes, a.args, b.args)
+                                    .eq(
+                                        DefineOpaqueTypes::Yes,
+                                        ty::AliasTerm::from(a),
+                                        ty::AliasTerm::from(b),
+                                    )
                                 {
                                     return self.evaluate_predicates_recursively(
                                         previous_stack,


### PR DESCRIPTION
Remove `At::trace`, and inline all of the `Trace::equate`,etc methods into `At`.

The only nontrivial change is that we use `AliasTerm` to relate two unevaluated consts in the old-solver impl of `ConstEquate`, since `AliasTerm` does implement `ToTrace` and will relate the args structurally (shallowly).

r? lcnr