### PR TITLE
Silence follow-up errors directly based on error types and regions

### DIFF
--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -29,7 +29,8 @@ use rustc_middle::ty::{self, InlineConstArgs, InlineConstArgsParts, RegionVid, T
 use rustc_middle::ty::{GenericArgs, GenericArgsRef};
 use rustc_middle::{bug, span_bug};
 use rustc_span::symbol::{kw, sym};
-use rustc_span::Symbol;
+use rustc_span::{ErrorGuaranteed, Symbol};
+use std::cell::Cell;
 use std::iter;
 
 use crate::renumber::RegionCtxt;
@@ -186,6 +187,10 @@ struct UniversalRegionIndices<'tcx> {
 
     /// The vid assigned to `'static`. Used only for diagnostics.
     pub fr_static: RegionVid,
+
+    /// Whether we've encountered an error region. If we have, cancel all
+    /// outlives errors, as they are likely bogus.
+    pub tainted_by_errors: Cell<Option<ErrorGuaranteed>>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -407,6 +412,10 @@ impl<'tcx> UniversalRegions<'tcx> {
                 ));
             }
         }
+    }
+
+    pub fn tainted_by_errors(&self) -> Option<ErrorGuaranteed> {
+        self.indices.tainted_by_errors.get()
     }
 }
 
@@ -663,7 +672,11 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
         let global_mapping = iter::once((tcx.lifetimes.re_static, fr_static));
         let arg_mapping = iter::zip(identity_args.regions(), fr_args.regions().map(|r| r.as_var()));
 
-        UniversalRegionIndices { indices: global_mapping.chain(arg_mapping).collect(), fr_static }
+        UniversalRegionIndices {
+            indices: global_mapping.chain(arg_mapping).collect(),
+            fr_static,
+            tainted_by_errors: Cell::new(None),
+        }
     }
 
     fn compute_inputs_and_output(
@@ -868,7 +881,8 @@ impl<'tcx> UniversalRegionIndices<'tcx> {
     pub fn to_region_vid(&self, r: ty::Region<'tcx>) -> RegionVid {
         if let ty::ReVar(..) = *r {
             r.as_var()
-        } else if r.is_error() {
+        } else if let ty::ReError(guar) = *r {
+            self.tainted_by_errors.set(Some(guar));
             // We use the `'static` `RegionVid` because `ReError` doesn't actually exist in the
             // `UniversalRegionIndices`. This is fine because 1) it is a fallback only used if
             // errors are being emitted and 2) it leaves the happy path unaffected.

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -502,7 +502,9 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
             bug!("unexpected sort of node in type_of(): {:?}", x);
         }
     };
-    if let Err(e) = icx.check_tainted_by_errors() {
+    if let Err(e) = icx.check_tainted_by_errors()
+        && !output.references_error()
+    {
         ty::EarlyBinder::bind(Ty::new_error(tcx, e))
     } else {
         ty::EarlyBinder::bind(output)

--- a/tests/rustdoc-ui/unable-fulfill-trait.rs
+++ b/tests/rustdoc-ui/unable-fulfill-trait.rs
@@ -1,13 +1,16 @@
 // This test ensures that it's not crashing rustdoc.
 
 pub struct Foo<'a, 'b, T> {
-    field1: dyn Bar<'a, 'b,>,
+    field1: dyn Bar<'a, 'b>,
     //~^ ERROR
+    //~| ERROR
     //~| ERROR
 }
 
 pub trait Bar<'x, 's, U>
-    where U: 'x,
-    Self:'x,
-    Self:'s
-{}
+where
+    U: 'x,
+    Self: 'x,
+    Self: 's,
+{
+}

--- a/tests/rustdoc-ui/unable-fulfill-trait.stderr
+++ b/tests/rustdoc-ui/unable-fulfill-trait.stderr
@@ -1,26 +1,43 @@
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/unable-fulfill-trait.rs:4:17
    |
-LL |     field1: dyn Bar<'a, 'b,>,
+LL |     field1: dyn Bar<'a, 'b>,
    |                 ^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `U`
-  --> $DIR/unable-fulfill-trait.rs:9:11
+  --> $DIR/unable-fulfill-trait.rs:10:11
    |
 LL | pub trait Bar<'x, 's, U>
    |           ^^^         -
 help: add missing generic argument
    |
-LL |     field1: dyn Bar<'a, 'b, U,>,
+LL |     field1: dyn Bar<'a, 'b, U>,
    |                           +++
 
 error[E0227]: ambiguous lifetime bound, explicit lifetime bound required
   --> $DIR/unable-fulfill-trait.rs:4:13
    |
-LL |     field1: dyn Bar<'a, 'b,>,
-   |             ^^^^^^^^^^^^^^^^
+LL |     field1: dyn Bar<'a, 'b>,
+   |             ^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0478]: lifetime bound not satisfied
+  --> $DIR/unable-fulfill-trait.rs:4:13
+   |
+LL |     field1: dyn Bar<'a, 'b>,
+   |             ^^^^^^^^^^^^^^^
+   |
+note: lifetime parameter instantiated with the lifetime `'b` as defined here
+  --> $DIR/unable-fulfill-trait.rs:3:20
+   |
+LL | pub struct Foo<'a, 'b, T> {
+   |                    ^^
+note: but lifetime parameter must outlive the lifetime `'a` as defined here
+  --> $DIR/unable-fulfill-trait.rs:3:16
+   |
+LL | pub struct Foo<'a, 'b, T> {
+   |                ^^
 
-Some errors have detailed explanations: E0107, E0227.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0227, E0478.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/associated-inherent-types/issue-109071.rs
+++ b/tests/ui/associated-inherent-types/issue-109071.rs
@@ -13,7 +13,7 @@ impl<T> Windows { //~ ERROR: missing generics for struct `Windows`
 
 impl<T> Windows<T> {
     fn T() -> Option<Self::Item> {}
-    //~^ ERROR: ambiguous associated type
+    //[no_gate]~^ ERROR: ambiguous associated type
 }
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/issue-109071.with_gate.stderr
+++ b/tests/ui/associated-inherent-types/issue-109071.with_gate.stderr
@@ -20,20 +20,7 @@ help: add missing generic argument
 LL | impl<T> Windows<T> {
    |                +++
 
-error[E0223]: ambiguous associated type
-  --> $DIR/issue-109071.rs:15:22
-   |
-LL |     fn T() -> Option<Self::Item> {}
-   |                      ^^^^^^^^^^
-   |
-help: use fully-qualified syntax
-   |
-LL |     fn T() -> Option<<Windows<T> as IntoAsyncIterator>::Item> {}
-   |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-LL |     fn T() -> Option<<Windows<T> as IntoIterator>::Item> {}
-   |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0107, E0223, E0637.
+Some errors have detailed explanations: E0107, E0637.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/associated-inherent-types/issue-109299.rs
+++ b/tests/ui/associated-inherent-types/issue-109299.rs
@@ -8,6 +8,5 @@ impl Lexer<'d> { //~ ERROR use of undeclared lifetime name `'d`
 }
 
 fn test(_: Lexer::Cursor) {}
-//~^ ERROR: lifetime may not live long enough
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/issue-109299.stderr
+++ b/tests/ui/associated-inherent-types/issue-109299.stderr
@@ -6,15 +6,6 @@ LL | impl Lexer<'d> {
    |     |
    |     help: consider introducing lifetime `'d` here: `<'d>`
 
-error: lifetime may not live long enough
-  --> $DIR/issue-109299.rs:10:1
-   |
-LL | fn test(_: Lexer::Cursor) {}
-   | ^^^^^^^^-^^^^^^^^^^^^^^^^
-   | |       |
-   | |       has type `Lexer<'1>::Cursor`
-   | requires that `'1` must outlive `'static`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0261`.

--- a/tests/ui/borrowck/generic_const_early_param.rs
+++ b/tests/ui/borrowck/generic_const_early_param.rs
@@ -5,7 +5,6 @@ struct DataWrapper<'static> {
     //~^ ERROR invalid lifetime parameter name: `'static`
     data: &'a [u8; Self::SIZE],
     //~^ ERROR use of undeclared lifetime name `'a`
-    //~^^ ERROR lifetime may not live long enough
 }
 
 impl DataWrapper<'a> {

--- a/tests/ui/borrowck/generic_const_early_param.stderr
+++ b/tests/ui/borrowck/generic_const_early_param.stderr
@@ -14,7 +14,7 @@ LL |     data: &'a [u8; Self::SIZE],
    |            ^^ undeclared lifetime
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/generic_const_early_param.rs:11:18
+  --> $DIR/generic_const_early_param.rs:10:18
    |
 LL | impl DataWrapper<'a> {
    |     -            ^^ undeclared lifetime
@@ -30,13 +30,7 @@ LL | #![feature(generic_const_exprs)]
    = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error: lifetime may not live long enough
-  --> $DIR/generic_const_early_param.rs:6:20
-   |
-LL |     data: &'a [u8; Self::SIZE],
-   |                    ^^^^^^^^^^ requires that `'_` must outlive `'static`
-
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 3 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0261, E0262.
 For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/const-generics/issues/issue-71381.full.stderr
+++ b/tests/ui/const-generics/issues/issue-71381.full.stderr
@@ -7,7 +7,7 @@ LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "
    = note: type parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
-  --> $DIR/issue-71381.rs:22:40
+  --> $DIR/issue-71381.rs:23:40
    |
 LL |         const FN: unsafe extern "C" fn(Args),
    |                                        ^^^^ the type must not depend on the parameter `Args`

--- a/tests/ui/const-generics/issues/issue-71381.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71381.min.stderr
@@ -7,13 +7,29 @@ LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "
    = note: type parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
-  --> $DIR/issue-71381.rs:22:40
+  --> $DIR/issue-71381.rs:23:40
    |
 LL |         const FN: unsafe extern "C" fn(Args),
    |                                        ^^^^ the type must not depend on the parameter `Args`
    |
    = note: type parameters may not be used in the type of const parameters
 
-error: aborting due to 2 previous errors
+error: using function pointers as const generic parameters is forbidden
+  --> $DIR/issue-71381.rs:14:61
+   |
+LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
+   |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+
+error: using function pointers as const generic parameters is forbidden
+  --> $DIR/issue-71381.rs:23:19
+   |
+LL |         const FN: unsafe extern "C" fn(Args),
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/const-generics/issues/issue-71381.rs
+++ b/tests/ui/const-generics/issues/issue-71381.rs
@@ -13,6 +13,7 @@ unsafe extern "C" fn pass(args: PassArg) {
 impl Test {
     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
         //~^ ERROR: the type of const parameters must not depend on other generic parameters
+        //[min]~^^ ERROR: using function pointers as const generic parameters is forbidden
         self.0 = Self::trampiline::<Args, IDX, FN> as _
     }
 
@@ -21,6 +22,7 @@ impl Test {
         const IDX: usize,
         const FN: unsafe extern "C" fn(Args),
         //~^ ERROR: the type of const parameters must not depend on other generic parameters
+        //[min]~^^ ERROR: using function pointers as const generic parameters is forbidden
     >(
         args: Args,
     ) {

--- a/tests/ui/const-generics/issues/issue-71611.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71611.min.stderr
@@ -6,6 +6,14 @@ LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |
    = note: type parameters may not be used in the type of const parameters
 
-error: aborting due to 1 previous error
+error: using function pointers as const generic parameters is forbidden
+  --> $DIR/issue-71611.rs:5:21
+   |
+LL | fn func<A, const F: fn(inner: A)>(outer: A) {
+   |                     ^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/const-generics/issues/issue-71611.rs
+++ b/tests/ui/const-generics/issues/issue-71611.rs
@@ -4,6 +4,7 @@
 
 fn func<A, const F: fn(inner: A)>(outer: A) {
     //~^ ERROR: the type of const parameters must not depend on other generic parameters
+    //[min]~| ERROR: using function pointers as const generic parameters is forbidden
     F(outer);
 }
 

--- a/tests/ui/const_prop/ice-type-mismatch-when-copying-112824.rs
+++ b/tests/ui/const_prop/ice-type-mismatch-when-copying-112824.rs
@@ -13,6 +13,7 @@ impl Opcode2 {
 pub fn example2(msg_type: Opcode2) -> impl FnMut(&[u8]) {
     move |i| match msg_type {
         Opcode2::OP2 => unimplemented!(),
+        //~^ ERROR: could not evaluate constant pattern
     }
 }
 

--- a/tests/ui/const_prop/ice-type-mismatch-when-copying-112824.stderr
+++ b/tests/ui/const_prop/ice-type-mismatch-when-copying-112824.stderr
@@ -17,7 +17,13 @@ help: you might be missing a type parameter
 LL | pub struct Opcode2<S>(&'a S);
    |                   +++
 
-error: aborting due to 2 previous errors
+error: could not evaluate constant pattern
+  --> $DIR/ice-type-mismatch-when-copying-112824.rs:15:9
+   |
+LL |         Opcode2::OP2 => unimplemented!(),
+   |         ^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0261, E0412.
 For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
@@ -9,7 +9,6 @@ impl<T> X for T { //~ ERROR: not all trait items implemented
     //~^ ERROR missing generics for associated type
     //~^^ ERROR missing generics for associated type
     //~| ERROR method `foo` has 1 type parameter but its trait declaration has 0 type parameters
-    //~| ERROR may not live long enough
     t
   }
 }

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
@@ -51,16 +51,7 @@ help: add missing lifetime argument
 LL |   fn foo<'a, T1: X<Y<'a> = T1>>(t : T1) -> T1::Y<'a> {
    |                     ++++
 
-error: lifetime may not live long enough
-  --> $DIR/gat-trait-path-missing-lifetime.rs:8:3
-   |
-LL |   fn foo<'a, T1: X<Y = T1>>(t : T1) -> T1::Y<'a> {
-   |   ^^^^^^^--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |   |      |
-   |   |      lifetime `'a` defined here
-   |   requires that `'a` must outlive `'static`
-
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0046, E0049, E0107.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/generic-associated-types/issue-70304.rs
+++ b/tests/ui/generic-associated-types/issue-70304.rs
@@ -52,5 +52,4 @@ fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'_>> {
 pub fn main() {
     let doc = create_doc();
     let lexer: Lexer<'_, DocCursorImpl<'_>> = Lexer::from(&doc);
-    //~^ ERROR: `doc` does not live long enough
 }

--- a/tests/ui/generic-associated-types/issue-70304.stderr
+++ b/tests/ui/generic-associated-types/issue-70304.stderr
@@ -27,21 +27,7 @@ LL |     type Cursor<'a>: DocCursor<'a>;
    = note: this bound is currently required to ensure that impls have maximum flexibility
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error[E0597]: `doc` does not live long enough
-  --> $DIR/issue-70304.rs:54:59
-   |
-LL |     let doc = create_doc();
-   |         --- binding `doc` declared here
-LL |     let lexer: Lexer<'_, DocCursorImpl<'_>> = Lexer::from(&doc);
-   |                                               ------------^^^^-
-   |                                               |           |
-   |                                               |           borrowed value does not live long enough
-   |                                               argument requires that `doc` is borrowed for `'static`
-LL |
-LL | }
-   | - `doc` dropped here while still borrowed
+error: aborting due to 3 previous errors
 
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0106, E0597, E0637.
+Some errors have detailed explanations: E0106, E0637.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/generic-associated-types/issue-71176.rs
+++ b/tests/ui/generic-associated-types/issue-71176.rs
@@ -9,6 +9,9 @@ impl Provider for () {
 struct Holder<B> {
   inner: Box<dyn Provider<A = B>>,
   //~^ ERROR: missing generics for associated type
+  //~| ERROR: missing generics for associated type
+  //~| ERROR: missing generics for associated type
+  //~| ERROR: the trait `Provider` cannot be made into an object
 }
 
 fn main() {

--- a/tests/ui/generic-associated-types/issue-71176.stderr
+++ b/tests/ui/generic-associated-types/issue-71176.stderr
@@ -14,6 +14,57 @@ help: add missing lifetime argument
 LL |   inner: Box<dyn Provider<A<'a> = B>>,
    |                            ++++
 
-error: aborting due to 1 previous error
+error[E0107]: missing generics for associated type `Provider::A`
+  --> $DIR/issue-71176.rs:10:27
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL |     type A<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   inner: Box<dyn Provider<A<'a> = B>>,
+   |                            ++++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: missing generics for associated type `Provider::A`
+  --> $DIR/issue-71176.rs:10:27
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL |     type A<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   inner: Box<dyn Provider<A<'a> = B>>,
+   |                            ++++
+
+error[E0038]: the trait `Provider` cannot be made into an object
+  --> $DIR/issue-71176.rs:10:14
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |              ^^^^^^^^^^^^^^^^^^^ `Provider` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL | trait Provider {
+   |       -------- this trait cannot be made into an object...
+LL |     type A<'a>;
+   |          ^ ...because it contains the generic associated type `A`
+   = help: consider moving `A` to another trait
+   = help: only type `()` implements the trait, consider using it directly instead
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/issue-80433.rs
+++ b/tests/ui/generic-associated-types/issue-80433.rs
@@ -22,8 +22,7 @@ fn test_simpler<'a>(dst: &'a mut impl TestMut<Output = &'a mut f32>)
   //~^ ERROR missing generics for associated type
 {
     for n in 0i16..100 {
-        *dst.test_mut() = n.into(); //~ ERROR: cannot borrow
-        //~^ ERROR: borrowed data escapes outside of function
+        *dst.test_mut() = n.into();
     }
 }
 

--- a/tests/ui/generic-associated-types/issue-80433.stderr
+++ b/tests/ui/generic-associated-types/issue-80433.stderr
@@ -25,30 +25,6 @@ help: add missing lifetime argument
 LL | fn test_simpler<'a>(dst: &'a mut impl TestMut<Output<'a> = &'a mut f32>)
    |                                                     ++++
 
-error[E0499]: cannot borrow `*dst` as mutable more than once at a time
-  --> $DIR/issue-80433.rs:25:10
-   |
-LL |         *dst.test_mut() = n.into();
-   |          ^^^-----------
-   |          |
-   |          `*dst` was mutably borrowed here in the previous iteration of the loop
-   |          argument requires that `*dst` is borrowed for `'static`
+error: aborting due to 2 previous errors
 
-error[E0521]: borrowed data escapes outside of function
-  --> $DIR/issue-80433.rs:25:10
-   |
-LL | fn test_simpler<'a>(dst: &'a mut impl TestMut<Output = &'a mut f32>)
-   |                 --  --- `dst` is a reference that is only valid in the function body
-   |                 |
-   |                 lifetime `'a` defined here
-...
-LL |         *dst.test_mut() = n.into();
-   |          ^^^^^^^^^^^^^^
-   |          |
-   |          `dst` escapes the function body here
-   |          argument requires that `'a` must outlive `'static`
-
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0107, E0499, E0521.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.rs
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.rs
@@ -1,11 +1,9 @@
 // issue: 114146
 
-
 trait Foo {
     fn bar<'other: 'a>() -> impl Sized + 'a {}
     //~^ ERROR use of undeclared lifetime name `'a`
     //~| ERROR use of undeclared lifetime name `'a`
-    //~| ERROR expected generic lifetime parameter, found `'static`
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit-2.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/bad-item-bound-within-rpitit-2.rs:5:20
+  --> $DIR/bad-item-bound-within-rpitit-2.rs:4:20
    |
 LL |     fn bar<'other: 'a>() -> impl Sized + 'a {}
    |                    ^^ undeclared lifetime
@@ -14,7 +14,7 @@ LL | trait Foo<'a> {
    |          ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/bad-item-bound-within-rpitit-2.rs:5:42
+  --> $DIR/bad-item-bound-within-rpitit-2.rs:4:42
    |
 LL |     fn bar<'other: 'a>() -> impl Sized + 'a {}
    |                                          ^^ undeclared lifetime
@@ -28,15 +28,6 @@ help: consider introducing lifetime `'a` here
 LL | trait Foo<'a> {
    |          ++++
 
-error[E0792]: expected generic lifetime parameter, found `'static`
-  --> $DIR/bad-item-bound-within-rpitit-2.rs:5:45
-   |
-LL |     fn bar<'other: 'a>() -> impl Sized + 'a {}
-   |            ------                           ^^
-   |            |
-   |            cannot use static lifetime; use a bound lifetime instead or remove the lifetime parameter from the opaque type
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0261, E0792.
-For more information about an error, try `rustc --explain E0261`.
+For more information about this error, try `rustc --explain E0261`.

--- a/tests/ui/impl-trait/issues/issue-67830.rs
+++ b/tests/ui/impl-trait/issues/issue-67830.rs
@@ -7,7 +7,7 @@ struct Wrap<F>(F);
 
 impl<A, B, F> MyFn<A> for Wrap<F>
 where
-    F: Fn(A) -> B
+    F: Fn(A) -> B,
 {
     type Output = B;
 
@@ -16,13 +16,10 @@ where
     }
 }
 
-
 struct A;
-fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
+fn test() -> impl for<'a> MyFn<&'a A, Output = impl Iterator + 'a> {
     //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
     Wrap(|a| Some(a).into_iter())
-    //~^ ERROR implementation of `FnOnce` is not general enough
-    //~| ERROR implementation of `FnOnce` is not general enough
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issues/issue-67830.stderr
+++ b/tests/ui/impl-trait/issues/issue-67830.stderr
@@ -1,34 +1,15 @@
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/issue-67830.rs:21:62
+  --> $DIR/issue-67830.rs:20:64
    |
-LL | fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
-   |                                                              ^^
+LL | fn test() -> impl for<'a> MyFn<&'a A, Output = impl Iterator + 'a> {
+   |                                                                ^^
    |
 note: lifetime declared here
-  --> $DIR/issue-67830.rs:21:23
+  --> $DIR/issue-67830.rs:20:23
    |
-LL | fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
+LL | fn test() -> impl for<'a> MyFn<&'a A, Output = impl Iterator + 'a> {
    |                       ^^
 
-error: implementation of `FnOnce` is not general enough
-  --> $DIR/issue-67830.rs:23:5
-   |
-LL |     Wrap(|a| Some(a).into_iter())
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
-   |
-   = note: closure with signature `fn(&'2 A) -> std::option::IntoIter<&A>` must implement `FnOnce<(&'1 A,)>`, for any lifetime `'1`...
-   = note: ...but it actually implements `FnOnce<(&'2 A,)>`, for some specific lifetime `'2`
-
-error: implementation of `FnOnce` is not general enough
-  --> $DIR/issue-67830.rs:23:5
-   |
-LL |     Wrap(|a| Some(a).into_iter())
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
-   |
-   = note: closure with signature `fn(&'2 A) -> std::option::IntoIter<&A>` must implement `FnOnce<(&'1 A,)>`, for any lifetime `'1`...
-   = note: ...but it actually implements `FnOnce<(&'2 A,)>`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 3 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/impl-trait/issues/issue-88236-2.rs
+++ b/tests/ui/impl-trait/issues/issue-88236-2.rs
@@ -18,16 +18,11 @@ fn make_impl() -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {}
 fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
     //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
     &()
-    //~^ ERROR implementation of `Hrtb` is not general enough
-    //~| ERROR implementation of `Hrtb` is not general enough
 }
 
 fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
     //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
     x
-    //~^ ERROR implementation of `Hrtb` is not general enough
-    //~| ERROR implementation of `Hrtb` is not general enough
-    //~| ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issues/issue-88236-2.stderr
+++ b/tests/ui/impl-trait/issues/issue-88236-2.stderr
@@ -22,72 +22,18 @@ note: lifetime declared here
 LL | fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                               ^^
 
-error: implementation of `Hrtb` is not general enough
-  --> $DIR/issue-88236-2.rs:20:5
-   |
-LL |     &()
-   |     ^^^ implementation of `Hrtb` is not general enough
-   |
-   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
-   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
-
-error: implementation of `Hrtb` is not general enough
-  --> $DIR/issue-88236-2.rs:20:5
-   |
-LL |     &()
-   |     ^^^ implementation of `Hrtb` is not general enough
-   |
-   = note: `Hrtb<'a>` would have to be implemented for the type `&()`
-   = note: ...but `Hrtb<'0>` is actually implemented for the type `&'0 ()`, for some specific lifetime `'0`
-
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/issue-88236-2.rs:25:78
+  --> $DIR/issue-88236-2.rs:23:78
    |
 LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                                                              ^^
    |
 note: lifetime declared here
-  --> $DIR/issue-88236-2.rs:25:45
+  --> $DIR/issue-88236-2.rs:23:45
    |
 LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                             ^^
 
-error: lifetime may not live long enough
-  --> $DIR/issue-88236-2.rs:27:5
-   |
-LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
-   |                  -- lifetime `'b` defined here
-LL |
-LL |     x
-   |     ^ returning this value requires that `'b` must outlive `'static`
-   |
-help: to declare that `impl for<'a> Hrtb<'a, Assoc = impl Send + '_>` captures data from argument `x`, you can add an explicit `'b` lifetime bound
-   |
-LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> + 'b {
-   |                                                                                  ++++
-help: to declare that `impl Send + 'a` captures data from argument `x`, you can add an explicit `'b` lifetime bound
-   |
-LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a + 'b> {
-   |                                                                                 ++++
-
-error: implementation of `Hrtb` is not general enough
-  --> $DIR/issue-88236-2.rs:27:5
-   |
-LL |     x
-   |     ^ implementation of `Hrtb` is not general enough
-   |
-   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
-   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
-
-error: implementation of `Hrtb` is not general enough
-  --> $DIR/issue-88236-2.rs:27:5
-   |
-LL |     x
-   |     ^ implementation of `Hrtb` is not general enough
-   |
-   = note: `Hrtb<'a>` would have to be implemented for the type `&()`
-   = note: ...but `Hrtb<'0>` is actually implemented for the type `&'0 ()`, for some specific lifetime `'0`
-
-error: aborting due to 8 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/impl-trait/nested-rpit-hrtb.rs
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.rs
@@ -31,7 +31,6 @@ fn one_hrtb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl Qux<'a>> {}
 
 fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
 //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-//~| ERROR implementation of `Bar` is not general enough
 
 fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
 //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
@@ -64,6 +63,5 @@ fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<
 // `'b` is not in scope for the outlives bound.
 fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
 //~^ ERROR use of undeclared lifetime name `'b` [E0261]
-//~| ERROR implementation of `Bar` is not general enough
 
 fn main() {}

--- a/tests/ui/impl-trait/nested-rpit-hrtb.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:57:77
+  --> $DIR/nested-rpit-hrtb.rs:56:77
    |
 LL | fn two_htrb_outlives() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                             ^^ undeclared lifetime
@@ -15,7 +15,7 @@ LL | fn two_htrb_outlives<'b>() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Siz
    |                     ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:65:82
+  --> $DIR/nested-rpit-hrtb.rs:64:82
    |
 LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                                  ^^ undeclared lifetime
@@ -65,29 +65,20 @@ note: lifetime declared here
 LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
    |                                         ^^
 
-error: implementation of `Bar` is not general enough
-  --> $DIR/nested-rpit-hrtb.rs:32:78
-   |
-LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
-   |                                                                              ^^ implementation of `Bar` is not general enough
-   |
-   = note: `()` must implement `Bar<'a>`
-   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
-
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/nested-rpit-hrtb.rs:36:73
+  --> $DIR/nested-rpit-hrtb.rs:35:73
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                                                         ^^
    |
 note: lifetime declared here
-  --> $DIR/nested-rpit-hrtb.rs:36:44
+  --> $DIR/nested-rpit-hrtb.rs:35:44
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                            ^^
 
 error[E0277]: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
-  --> $DIR/nested-rpit-hrtb.rs:46:79
+  --> $DIR/nested-rpit-hrtb.rs:45:79
    |
 LL | fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
    |                                                                               ^^^^^^^^^^^^ the trait `for<'a> Qux<'b>` is not implemented for `&'a ()`
@@ -96,7 +87,7 @@ LL | fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
 error: implementation of `Bar` is not general enough
-  --> $DIR/nested-rpit-hrtb.rs:50:93
+  --> $DIR/nested-rpit-hrtb.rs:49:93
    |
 LL | fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}
    |                                                                                             ^^ implementation of `Bar` is not general enough
@@ -105,7 +96,7 @@ LL | fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = 
    = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
 
 error[E0277]: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
-  --> $DIR/nested-rpit-hrtb.rs:61:64
+  --> $DIR/nested-rpit-hrtb.rs:60:64
    |
 LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
    |                                                                ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Qux<'b>` is not implemented for `&'a ()`
@@ -113,16 +104,7 @@ LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b>
    = help: the trait `Qux<'_>` is implemented for `()`
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
-error: implementation of `Bar` is not general enough
-  --> $DIR/nested-rpit-hrtb.rs:65:86
-   |
-LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
-   |                                                                                      ^^ implementation of `Bar` is not general enough
-   |
-   = note: `()` must implement `Bar<'a>`
-   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
-
-error: aborting due to 11 previous errors
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0261, E0277, E0657.
 For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/layout/issue-84108.rs
+++ b/tests/ui/layout/issue-84108.rs
@@ -8,6 +8,9 @@ static FOO: (dyn AsRef<OsStr>, u8) = ("hello", 42);
 
 const BAR: (&Path, [u8], usize) = ("hello", [], 42);
 //~^ ERROR cannot find type `Path` in this scope
+//~| ERROR the size for values of type `[u8]` cannot be known at compilation time
+//~| ERROR the size for values of type `[u8]` cannot be known at compilation time
+//~| ERROR mismatched types
 
 static BAZ: ([u8], usize) = ([], 0);
 //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui/layout/issue-84108.stderr
+++ b/tests/ui/layout/issue-84108.stderr
@@ -21,7 +21,35 @@ LL + use std::path::Path;
    |
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/issue-84108.rs:12:13
+  --> $DIR/issue-84108.rs:9:12
+   |
+LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
+   |            ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: only the last element of a tuple may have a dynamically sized type
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/issue-84108.rs:9:12
+   |
+LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
+   |            ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: only the last element of a tuple may have a dynamically sized type
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-84108.rs:9:45
+   |
+LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
+   |                                             ^^ expected `[u8]`, found `[_; 0]`
+   |
+   = note: expected slice `[u8]`
+              found array `[_; 0]`
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/issue-84108.rs:15:13
    |
 LL | static BAZ: ([u8], usize) = ([], 0);
    |             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -30,7 +58,7 @@ LL | static BAZ: ([u8], usize) = ([], 0);
    = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/issue-84108.rs:12:13
+  --> $DIR/issue-84108.rs:15:13
    |
 LL | static BAZ: ([u8], usize) = ([], 0);
    |             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -40,7 +68,7 @@ LL | static BAZ: ([u8], usize) = ([], 0);
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-84108.rs:12:30
+  --> $DIR/issue-84108.rs:15:30
    |
 LL | static BAZ: ([u8], usize) = ([], 0);
    |                              ^^ expected `[u8]`, found `[_; 0]`
@@ -48,7 +76,7 @@ LL | static BAZ: ([u8], usize) = ([], 0);
    = note: expected slice `[u8]`
               found array `[_; 0]`
 
-error: aborting due to 5 previous errors
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0277, E0308, E0412.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/lifetimes/issue-69314.fixed
+++ b/tests/ui/lifetimes/issue-69314.fixed
@@ -11,7 +11,7 @@ impl A {
     }
     async fn f() {
         let mut buf = [0; 512];
-        let m2 = &buf[..]; //~ ERROR `buf` does not live long enough
+        let m2 = &buf[..];
         let m = Self::g(m2).await;
         Self::f2(m).await;
     }

--- a/tests/ui/lifetimes/issue-69314.rs
+++ b/tests/ui/lifetimes/issue-69314.rs
@@ -11,7 +11,7 @@ impl A {
     }
     async fn f() {
         let mut buf = [0; 512];
-        let m2 = &buf[..]; //~ ERROR `buf` does not live long enough
+        let m2 = &buf[..];
         let m = Self::g(m2).await;
         Self::f2(m).await;
     }

--- a/tests/ui/lifetimes/issue-69314.stderr
+++ b/tests/ui/lifetimes/issue-69314.stderr
@@ -9,20 +9,6 @@ help: indicate the anonymous lifetime
 LL |     async fn f2(m: Msg<'_>) {}
    |                       ++++
 
-error[E0597]: `buf` does not live long enough
-  --> $DIR/issue-69314.rs:14:19
-   |
-LL |         let mut buf = [0; 512];
-   |             ------- binding `buf` declared here
-LL |         let m2 = &buf[..];
-   |                   ^^^ borrowed value does not live long enough
-LL |         let m = Self::g(m2).await;
-   |                 ----------- argument requires that `buf` is borrowed for `'static`
-LL |         Self::f2(m).await;
-LL |     }
-   |     - `buf` dropped here while still borrowed
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0597, E0726.
-For more information about an error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0726`.

--- a/tests/ui/lifetimes/unusual-rib-combinations.rs
+++ b/tests/ui/lifetimes/unusual-rib-combinations.rs
@@ -2,9 +2,8 @@ struct S<'a>(&'a u8);
 fn foo() {}
 
 // Paren generic args in AnonConst
-fn a() -> [u8; foo::()] {
-//~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
-//~| ERROR mismatched types
+fn a() -> [u8; foo()] {
+    //~^ ERROR mismatched types
     panic!()
 }
 
@@ -26,5 +25,6 @@ fn d<const C: S>() {}
 trait Foo<'a> {}
 struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
 //~^ ERROR the type of const parameters must not depend on other generic parameters
+//~| ERROR `&dyn for<'a> Foo<'a>` is forbidden as the type of a const generic parameter
 
 fn main() {}

--- a/tests/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/tests/ui/lifetimes/unusual-rib-combinations.stderr
@@ -1,11 +1,11 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/unusual-rib-combinations.rs:22:15
+  --> $DIR/unusual-rib-combinations.rs:21:15
    |
 LL | fn d<const C: S>() {}
    |               ^ expected named lifetime parameter
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
-  --> $DIR/unusual-rib-combinations.rs:27:22
+  --> $DIR/unusual-rib-combinations.rs:26:22
    |
 LL | struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
    |                      ^^ the type must not depend on the parameter `'a`
@@ -13,25 +13,19 @@ LL | struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
    = note: lifetime parameters may not be used in the type of const parameters
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/unusual-rib-combinations.rs:5:16
-   |
-LL | fn a() -> [u8; foo::()] {
-   |                ^^^^^^^ only `Fn` traits may use parentheses
-
-error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/unusual-rib-combinations.rs:12:15
+  --> $DIR/unusual-rib-combinations.rs:11:15
    |
 LL | fn b<const C: u8()>() {}
    |               ^^^^ only `Fn` traits may use parentheses
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/unusual-rib-combinations.rs:16:10
+  --> $DIR/unusual-rib-combinations.rs:15:10
    |
 LL | fn c<T = u8()>() {}
    |          ^^^^ only `Fn` traits may use parentheses
 
 error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/unusual-rib-combinations.rs:16:6
+  --> $DIR/unusual-rib-combinations.rs:15:6
    |
 LL | fn c<T = u8()>() {}
    |      ^^^^^^^^
@@ -43,17 +37,26 @@ LL | fn c<T = u8()>() {}
 error[E0308]: mismatched types
   --> $DIR/unusual-rib-combinations.rs:5:16
    |
-LL | fn a() -> [u8; foo::()] {
-   |                ^^^^^^^ expected `usize`, found fn item
-   |
-   = note: expected type `usize`
-           found fn item `fn() {foo}`
+LL | fn a() -> [u8; foo()] {
+   |                ^^^^^ expected `usize`, found `()`
 
 error: `S<'_>` is forbidden as the type of a const generic parameter
-  --> $DIR/unusual-rib-combinations.rs:22:15
+  --> $DIR/unusual-rib-combinations.rs:21:15
    |
 LL | fn d<const C: S>() {}
    |               ^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+   |
+LL + #![feature(adt_const_params)]
+   |
+
+error: `&dyn for<'a> Foo<'a>` is forbidden as the type of a const generic parameter
+  --> $DIR/unusual-rib-combinations.rs:26:21
+   |
+LL | struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types

--- a/tests/ui/parser/issues/issue-103748-ICE-wrong-braces.rs
+++ b/tests/ui/parser/issues/issue-103748-ICE-wrong-braces.rs
@@ -5,3 +5,4 @@ struct Apple((Apple, Option(Banana ? Citron)));
 //~| ERROR expected one of `)` or `,`, found `Citron`
 //~| ERROR cannot find type `Citron` in this scope [E0412]
 //~| ERROR parenthesized type parameters may only be used with a `Fn` trait [E0214]
+//~| ERROR `Apple` has infinite size

--- a/tests/ui/parser/issues/issue-103748-ICE-wrong-braces.stderr
+++ b/tests/ui/parser/issues/issue-103748-ICE-wrong-braces.stderr
@@ -34,7 +34,18 @@ help: use angle brackets instead
 LL | struct Apple((Apple, Option<Banana ? Citron>));
    |                            ~               ~
 
-error: aborting due to 4 previous errors
+error[E0072]: recursive type `Apple` has infinite size
+  --> $DIR/issue-103748-ICE-wrong-braces.rs:3:1
+   |
+LL | struct Apple((Apple, Option(Banana ? Citron)));
+   | ^^^^^^^^^^^^  ----- recursive without indirection
+   |
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
+   |
+LL | struct Apple((Box<Apple>, Option(Banana ? Citron)));
+   |               ++++     +
 
-Some errors have detailed explanations: E0214, E0412.
-For more information about an error, try `rustc --explain E0214`.
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0072, E0214, E0412.
+For more information about an error, try `rustc --explain E0072`.


### PR DESCRIPTION
During type_of, we used to just return an error type if there were any errors encountered. This is problematic, because it means a struct declared as `struct Foo<'static>` will end up not finding any inherent or trait impls because those impl blocks' `Self` type will be `{type error}` instead of `Foo<'re_error>`. Now it's the latter, silencing nonsensical follow-up errors about `Foo` not having any methods.

Unfortunately that now allows for new follow-up errors, because borrowck treats `'re_error` as `'static`, causing nonsensical errors about non-error lifetimes not outliving `'static`. So what I also did was to just strip all outlives bounds that borrowck found, thus never letting it check them. There are probably more nuanced ways to do this, but I worried there would be other nonsensical errors if some outlives bounds were missing. Also from the test changes, it looked like an improvement everywhere.