### PR TITLE
Remove `ignore-compare-mode-next-solver` from tests that don't hang anymore

### DIFF
--- a/tests/ui/type-alias-impl-trait/self-referential-3.rs
+++ b/tests/ui/type-alias-impl-trait/self-referential-3.rs
@@ -1,5 +1,3 @@
-//@ ignore-compare-mode-next-solver (hangs)
-
 #![feature(type_alias_impl_trait)]
 
 type Bar<'a, 'b> = impl PartialEq<Bar<'a, 'b>> + std::fmt::Debug;

--- a/tests/ui/type-alias-impl-trait/self-referential-4.rs
+++ b/tests/ui/type-alias-impl-trait/self-referential-4.rs
@@ -1,5 +1,3 @@
-//@ ignore-compare-mode-next-solver (hangs)
-
 #![feature(type_alias_impl_trait)]
 
 type Bar<'a, 'b> = impl PartialEq<Bar<'b, 'static>> + std::fmt::Debug;

--- a/tests/ui/type-alias-impl-trait/self-referential.rs
+++ b/tests/ui/type-alias-impl-trait/self-referential.rs
@@ -1,5 +1,3 @@
-//@ ignore-compare-mode-next-solver (hangs)
-
 #![feature(type_alias_impl_trait)]
 
 type Bar<'a, 'b> = impl PartialEq<Bar<'b, 'a>> + std::fmt::Debug;


### PR DESCRIPTION
self-explanatory

r? lcnr or anyone really