### PR TITLE
add `LazyLock` to "Higher-level sync" docs

### DIFF
--- a/library/std/src/sync/mod.rs
+++ b/library/std/src/sync/mod.rs
@@ -125,6 +125,9 @@
 //! - [`Condvar`]: Condition Variable, providing the ability to block
 //!   a thread while waiting for an event to occur.
 //!
+//! - [`LazyLock`]: Used for thread-safe, lazy initialization of a
+//!   global variable (initialization routine provided at declaration).
+//!
 //! - [`mpsc`]: Multi-producer, single-consumer queues, used for
 //!   message-based communication. Can provide a lightweight
 //!   inter-thread synchronisation mechanism, at the cost of some
@@ -133,10 +136,10 @@
 //! - [`Mutex`]: Mutual Exclusion mechanism, which ensures that at
 //!   most one thread at a time is able to access some data.
 //!
-//! - [`Once`]: Used for a thread-safe, one-time global initialization routine
+//! - [`Once`]: Used for a thread-safe, one-time global initialization routine.
 //!
 //! - [`OnceLock`]: Used for thread-safe, one-time initialization of a
-//!   global variable.
+//!   global variable (initialization routine provided at point of use).
 //!
 //! - [`RwLock`]: Provides a mutual exclusion mechanism which allows
 //!   multiple readers at the same time, while allowing only one
@@ -149,6 +152,7 @@
 //! [`mpsc`]: crate::sync::mpsc
 //! [`Mutex`]: crate::sync::Mutex
 //! [`Once`]: crate::sync::Once
+//! [`LazyLock`]: crate::sync::LazyLock
 //! [`OnceLock`]: crate::sync::OnceLock
 //! [`RwLock`]: crate::sync::RwLock
 


### PR DESCRIPTION
Partially addresses #125615

There's room for improvement but I figured it would be good to get something in there sooner rather than later.

<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->