### PR TITLE
enable ABI compat tests for nvptx

### DIFF
--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -520,7 +520,8 @@ fn fn_abi_sanity_check<'tcx>(
                     assert!(
                         matches!(&*cx.tcx.sess.target.arch, "wasm32" | "wasm64")
                             || matches!(spec_abi, SpecAbi::PtxKernel | SpecAbi::Unadjusted),
-                        r#"`PassMode::Direct` for aggregates only allowed for "unadjusted" and "ptx-kernel" functions and on wasm\nProblematic type: {:#?}"#,
+                        "`PassMode::Direct` for aggregates only allowed for \"unadjusted\" and \"ptx-kernel\" functions and on wasm\n
+                          Problematic type: {:#?}",
                         arg.layout,
                     );
                 }

--- a/tests/ui/abi/compatibility.rs
+++ b/tests/ui/abi/compatibility.rs
@@ -52,17 +52,12 @@
 //@ revisions: m68k
 //@[m68k] compile-flags: --target m68k-unknown-linux-gnu
 //@[m68k] needs-llvm-components: m68k
-// FIXME: disabled on nvptx64 since the target ABI fails the sanity check
-// see https://github.com/rust-lang/rust/issues/117480
-/* revisions: nvptx64
-  [nvptx64] compile-flags: --target nvptx64-nvidia-cuda
-  [nvptx64] needs-llvm-components: nvptx
-*/
-// FIXME: disabled since it fails on CI saying the csky component is missing
-/* revisions: csky
-  [csky] compile-flags: --target csky-unknown-linux-gnuabiv2
-  [csky] needs-llvm-components: csky
-*/
+//@revisions: nvptx64
+//@[nvptx64] compile-flags: --target nvptx64-nvidia-cuda
+//@[nvptx64] needs-llvm-components: nvptx
+//@revisions: csky
+//@[csky] compile-flags: --target csky-unknown-linux-gnuabiv2
+//@[csky] needs-llvm-components: csky
 #![feature(rustc_attrs, unsized_fn_params, transparent_unions)]
 #![cfg_attr(not(host), feature(no_core, lang_items), no_std, no_core)]
 #![allow(unused, improper_ctypes_definitions, internal_features)]


### PR DESCRIPTION
Looks like this was forgotten in https://github.com/rust-lang/rust/pull/117671.

Fixes https://github.com/rust-lang/rust/issues/117480 for real.