### PR TITLE
fn_arg_sanity_check: fix panic message

### DIFF
--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -520,7 +520,8 @@ fn fn_abi_sanity_check<'tcx>(
                     assert!(
                         matches!(&*cx.tcx.sess.target.arch, "wasm32" | "wasm64")
                             || matches!(spec_abi, SpecAbi::PtxKernel | SpecAbi::Unadjusted),
-                        r#"`PassMode::Direct` for aggregates only allowed for "unadjusted" and "ptx-kernel" functions and on wasm\nProblematic type: {:#?}"#,
+                        "`PassMode::Direct` for aggregates only allowed for \"unadjusted\" and \"ptx-kernel\" functions and on wasm\n\
+                          Problematic type: {:#?}",
                         arg.layout,
                     );
                 }

--- a/tests/ui/abi/compatibility.rs
+++ b/tests/ui/abi/compatibility.rs
@@ -59,6 +59,7 @@
   [nvptx64] needs-llvm-components: nvptx
 */
 // FIXME: disabled since it fails on CI saying the csky component is missing
+// see https://github.com/rust-lang/rust/issues/125697
 /* revisions: csky
   [csky] compile-flags: --target csky-unknown-linux-gnuabiv2
   [csky] needs-llvm-components: csky


### PR DESCRIPTION
The `\n` inside a raw string doesn't actually make a newline...