### PR TITLE
[ACP 362] genericize `ptr::from_raw_parts`

### DIFF
--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -120,7 +120,7 @@ pub const fn metadata<T: ?Sized>(ptr: *const T) -> <T as Pointee>::Metadata {
 #[rustc_const_unstable(feature = "ptr_metadata", issue = "81513")]
 #[inline]
 pub const fn from_raw_parts<T: ?Sized>(
-    data_pointer: *const (),
+    data_pointer: *const impl Thin,
     metadata: <T as Pointee>::Metadata,
 ) -> *const T {
     aggregate_raw_ptr(data_pointer, metadata)
@@ -134,7 +134,7 @@ pub const fn from_raw_parts<T: ?Sized>(
 #[rustc_const_unstable(feature = "ptr_metadata", issue = "81513")]
 #[inline]
 pub const fn from_raw_parts_mut<T: ?Sized>(
-    data_pointer: *mut (),
+    data_pointer: *mut impl Thin,
     metadata: <T as Pointee>::Metadata,
 ) -> *mut T {
     aggregate_raw_ptr(data_pointer, metadata)

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -565,7 +565,7 @@ pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
 #[rustc_allow_const_fn_unstable(ptr_metadata)]
 #[rustc_diagnostic_item = "ptr_null"]
 pub const fn null<T: ?Sized + Thin>() -> *const T {
-    from_raw_parts(without_provenance(0), ())
+    from_raw_parts(without_provenance::<()>(0), ())
 }
 
 /// Creates a null mutable raw pointer.
@@ -591,7 +591,7 @@ pub const fn null<T: ?Sized + Thin>() -> *const T {
 #[rustc_allow_const_fn_unstable(ptr_metadata)]
 #[rustc_diagnostic_item = "ptr_null_mut"]
 pub const fn null_mut<T: ?Sized + Thin>() -> *mut T {
-    from_raw_parts_mut(without_provenance_mut(0), ())
+    from_raw_parts_mut(without_provenance_mut::<()>(0), ())
 }
 
 /// Creates a pointer with the given address and no provenance.
@@ -835,7 +835,7 @@ pub const fn from_mut<T: ?Sized>(r: &mut T) -> *mut T {
 #[rustc_allow_const_fn_unstable(ptr_metadata)]
 #[rustc_diagnostic_item = "ptr_slice_from_raw_parts"]
 pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
-    intrinsics::aggregate_raw_ptr(data, len)
+    from_raw_parts(data, len)
 }
 
 /// Forms a raw mutable slice from a pointer and a length.
@@ -881,7 +881,7 @@ pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
 #[rustc_const_unstable(feature = "const_slice_from_raw_parts_mut", issue = "67456")]
 #[rustc_diagnostic_item = "ptr_slice_from_raw_parts_mut"]
 pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
-    intrinsics::aggregate_raw_ptr(data, len)
+    from_raw_parts_mut(data, len)
 }
 
 /// Swaps the values at two mutable locations of the same type, without

--- a/library/core/src/str/converts.rs
+++ b/library/core/src/str/converts.rs
@@ -222,7 +222,7 @@ pub const unsafe fn from_utf8_unchecked_mut(v: &mut [u8]) -> &mut str {
 #[rustc_const_unstable(feature = "str_from_raw_parts", issue = "119206")]
 pub const unsafe fn from_raw_parts<'a>(ptr: *const u8, len: usize) -> &'a str {
     // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.
-    unsafe { &*ptr::from_raw_parts(ptr.cast(), len) }
+    unsafe { &*ptr::from_raw_parts(ptr, len) }
 }
 
 /// Creates an `&mut str` from a pointer and a length.
@@ -241,5 +241,5 @@ pub const unsafe fn from_raw_parts<'a>(ptr: *const u8, len: usize) -> &'a str {
 #[rustc_const_unstable(feature = "const_str_from_raw_parts_mut", issue = "119206")]
 pub const unsafe fn from_raw_parts_mut<'a>(ptr: *mut u8, len: usize) -> &'a mut str {
     // SAFETY: the caller must uphold the safety contract for `from_raw_parts_mut`.
-    unsafe { &mut *ptr::from_raw_parts_mut(ptr.cast(), len) }
+    unsafe { &mut *ptr::from_raw_parts_mut(ptr, len) }
 }

--- a/library/core/tests/mem.rs
+++ b/library/core/tests/mem.rs
@@ -83,12 +83,12 @@ fn align_of_val_raw_packed() {
         f: [u32],
     }
     let storage = [0u8; 4];
-    let b: *const B = ptr::from_raw_parts(storage.as_ptr().cast(), 1);
+    let b: *const B = ptr::from_raw_parts(storage.as_ptr(), 1);
     assert_eq!(unsafe { align_of_val_raw(b) }, 1);
 
     const ALIGN_OF_VAL_RAW: usize = {
         let storage = [0u8; 4];
-        let b: *const B = ptr::from_raw_parts(storage.as_ptr().cast(), 1);
+        let b: *const B = ptr::from_raw_parts(storage.as_ptr(), 1);
         unsafe { align_of_val_raw(b) }
     };
     assert_eq!(ALIGN_OF_VAL_RAW, 1);

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -965,7 +965,7 @@ fn thin_box() {
         fn value_ptr(&self) -> *const T {
             let (_, offset) = self.layout();
             let data_ptr = unsafe { self.ptr.cast::<u8>().as_ptr().add(offset) };
-            ptr::from_raw_parts(data_ptr.cast(), self.meta())
+            ptr::from_raw_parts(data_ptr, self.meta())
         }
 
         fn value_mut_ptr(&mut self) -> *mut T {
@@ -973,7 +973,7 @@ fn thin_box() {
             // FIXME: can this line be shared with the same in `value_ptr()`
             // without upsetting Stacked Borrows?
             let data_ptr = unsafe { self.ptr.cast::<u8>().as_ptr().add(offset) };
-            from_raw_parts_mut(data_ptr.cast(), self.meta())
+            from_raw_parts_mut(data_ptr, self.meta())
         }
     }
 

--- a/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
@@ -27,10 +27,12 @@
 +                 }
 +             }
 +             scope 7 (inlined slice_from_raw_parts_mut::<A>) {
++                 scope 8 (inlined std::ptr::from_raw_parts_mut::<[A], A>) {
++                 }
 +             }
 +         }
 +     }
-+     scope 8 (inlined std::ptr::drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
++     scope 9 (inlined std::ptr::drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
 +         let mut _14: isize;
 +         let mut _15: isize;
 +     }

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-abort.mir
@@ -16,7 +16,7 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
             let mut _6: usize;
             scope 5 (inlined std::ptr::metadata::<[u32]>) {
             }
-            scope 6 (inlined std::ptr::from_raw_parts::<[u32]>) {
+            scope 6 (inlined std::ptr::from_raw_parts::<[u32], ()>) {
             }
         }
     }

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_fat.PreCodegen.after.panic-unwind.mir
@@ -16,7 +16,7 @@ fn demo_byte_add_fat(_1: *const [u32], _2: usize) -> *const [u32] {
             let mut _6: usize;
             scope 5 (inlined std::ptr::metadata::<[u32]>) {
             }
-            scope 6 (inlined std::ptr::from_raw_parts::<[u32]>) {
+            scope 6 (inlined std::ptr::from_raw_parts::<[u32], ()>) {
             }
         }
     }

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-abort.mir
@@ -14,7 +14,7 @@ fn demo_byte_add_thin(_1: *const u32, _2: usize) -> *const u32 {
         scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<u32>) {
             scope 5 (inlined std::ptr::metadata::<u32>) {
             }
-            scope 6 (inlined std::ptr::from_raw_parts::<u32>) {
+            scope 6 (inlined std::ptr::from_raw_parts::<u32, ()>) {
             }
         }
     }

--- a/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/ptr_offset.demo_byte_add_thin.PreCodegen.after.panic-unwind.mir
@@ -14,7 +14,7 @@ fn demo_byte_add_thin(_1: *const u32, _2: usize) -> *const u32 {
         scope 4 (inlined std::ptr::const_ptr::<impl *const u8>::with_metadata_of::<u32>) {
             scope 5 (inlined std::ptr::metadata::<u32>) {
             }
-            scope 6 (inlined std::ptr::from_raw_parts::<u32>) {
+            scope 6 (inlined std::ptr::from_raw_parts::<u32, ()>) {
             }
         }
     }

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
@@ -37,6 +37,10 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
             scope 11 (inlined slice_from_raw_parts::<u8>) {
                 debug data => _4;
                 debug len => _5;
+                scope 12 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
+                    debug data_pointer => _4;
+                    debug metadata => _5;
+                }
             }
         }
     }

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
@@ -37,6 +37,10 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
             scope 11 (inlined slice_from_raw_parts::<u8>) {
                 debug data => _4;
                 debug len => _5;
+                scope 12 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
+                    debug data_pointer => _4;
+                    debug metadata => _5;
+                }
             }
         }
     }

--- a/tests/ui/unsized/unsized3-rpass.rs
+++ b/tests/ui/unsized/unsized3-rpass.rs
@@ -87,7 +87,7 @@ pub fn main() {
         let obj: Box<St> = Box::new(St { f: 42 });
         let obj: &Tr = &*obj;
         let data: Box<_> = Box::new(Qux_ { f: St { f: 234 } });
-        let x: &Qux = &*ptr::from_raw_parts::<Qux>((&*data as *const _).cast(), ptr::metadata(obj));
+        let x: &Qux = &*ptr::from_raw_parts::<Qux>(&*data as *const _, ptr::metadata(obj));
         assert_eq!(x.f.foo(), 234);
     }
 }


### PR DESCRIPTION
This implements https://github.com/rust-lang/libs-team/issues/362

As such, it can partially undo https://github.com/rust-lang/rust/pull/124795 , letting `slice_from_raw_parts` just call `from_raw_parts` again without re-introducing the unnecessary cast to MIR.

By doing this it also removes a spurious cast from `str::from_raw_parts`.  And I think it does a good job of showing the value of the ACP, since the only thing that needed new turbofishing because of this is inside `ptr::null(_mut)`, but only because `ptr::without_provenance(_mut)` doesn't support pointers to extern types, which it absolutely could (without even changing the implementation).