### PR TITLE
Reintroduce name resolution check for trying to access locals from an inline const

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4502,6 +4502,11 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
                 self.visit_expr(elem);
                 self.resolve_anon_const(ct, AnonConstKind::ConstArg(IsRepeatExpr::Yes));
             }
+            ExprKind::ConstBlock(ref expr) => {
+                self.resolve_anon_const_manual(false, AnonConstKind::InlineConst, |this| {
+                    this.visit_expr(expr)
+                });
+            }
             ExprKind::Index(ref elem, ref idx, _) => {
                 self.resolve_expr(elem, Some(expr));
                 self.visit_expr(idx);

--- a/tests/ui/inline-const/referencing_local_variables.rs
+++ b/tests/ui/inline-const/referencing_local_variables.rs
@@ -1,0 +1,6 @@
+const fn test_me<T>(a: usize) -> usize {
+    const { a }
+    //~^ ERROR:  attempt to use a non-constant value in a constant
+}
+
+fn main() {}

--- a/tests/ui/inline-const/referencing_local_variables.stderr
+++ b/tests/ui/inline-const/referencing_local_variables.stderr
@@ -1,0 +1,11 @@
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/referencing_local_variables.rs:2:13
+   |
+LL | const fn test_me<T>(a: usize) -> usize {
+   |                     - this would need to be a `const`
+LL |     const { a }
+   |             ^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0435`.


### PR DESCRIPTION
fixes #125676

I removed this without replacement in https://github.com/rust-lang/rust/pull/124650 without considering the consequences