### PR TITLE
tier 3 target policy: clarify the point about producing assembly

### DIFF
--- a/src/doc/rustc/src/target-tier-policy.md
+++ b/src/doc/rustc/src/target-tier-policy.md
@@ -247,7 +247,8 @@ approved by the appropriate team for that shared code before acceptance.
     target may not have; use conditional compilation or runtime detection, as
     appropriate, to let each target run code supported by that target.
 - Tier 3 targets must be able to produce assembly using at least one of
-  rustc's supported backends from any host target.
+  rustc's supported backends from any host target. (Having support in a fork
+  of the backend is not sufficient, it must be upstream.)
 
 If a tier 3 target stops meeting these requirements, or the target maintainers
 no longer have interest or time, or the target shows no signs of activity and


### PR DESCRIPTION
I think that is already the intended meaning of the policy, but I am not sure.

Cc @rust-lang/compiler 