### PR TITLE
compiletest: clarify COMPILETEST_NEEDS_ALL_LLVM_COMPONENTS error

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -90,7 +90,7 @@ RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --dist-compression-formats=xz"
 if [ "$EXTERNAL_LLVM" = "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.optimized-compiler-builtins"
   # Likewise, only demand we test all LLVM components if we know we built LLVM with them
-  export COMPILETEST_NEEDS_ALL_LLVM_COMPONENTS=1
+  export COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS=1
 elif [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
     echo "error: dist builds should always use optimized compiler-rt!" >&2
     exit 1

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1436,7 +1436,7 @@ pub fn make_test_description<R: Read>(
             if config.target == "wasm32-unknown-unknown" {
                 if config.parse_name_directive(ln, directives::CHECK_RUN_RESULTS) {
                     decision!(IgnoreDecision::Ignore {
-                        reason: "ignored when checking the run results on WASM".into(),
+                        reason: "ignored on WASM as the run results cannot be checked there".into(),
                     });
                 }
             }
@@ -1577,8 +1577,11 @@ fn ignore_llvm(config: &Config, line: &str) -> IgnoreDecision {
             .split_whitespace()
             .find(|needed_component| !components.contains(needed_component))
         {
-            if env::var_os("COMPILETEST_NEEDS_ALL_LLVM_COMPONENTS").is_some() {
-                panic!("missing LLVM component: {}", missing_component);
+            if env::var_os("COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS").is_some() {
+                panic!(
+                    "missing LLVM component {}, and COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS is set",
+                    missing_component
+                );
             }
             return IgnoreDecision::Ignore {
                 reason: format!("ignored when the {missing_component} LLVM component is missing"),

--- a/src/tools/tidy/src/target_specific_tests.rs
+++ b/src/tools/tidy/src/target_specific_tests.rs
@@ -90,6 +90,9 @@ pub fn check(path: &Path, bad: &mut bool) {
             }
             if let Some(llvm_components) = llvm_components {
                 for component in llvm_components {
+                    // Ensure the given component even exists.
+                    // This is somewhat redundant with COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS,
+                    // but helps detect such problems earlier (PR CI rather than bors CI).
                     if !KNOWN_LLVM_COMPONENTS.contains(component) {
                         eprintln!(
                             "{}: revision {} specifies unknown LLVM component `{}`",


### PR DESCRIPTION
COMPILETEST_NEEDS_ALL_LLVM_COMPONENTS is a confusing name because elsewhere "needs" means "ignore when requirement not met", but here it means "fail when requirement not met".