### PR TITLE
remove unneeded extern crate in rmake test

### DIFF
--- a/tests/run-make/rust-lld-by-default/rmake.rs
+++ b/tests/run-make/rust-lld-by-default/rmake.rs
@@ -4,8 +4,6 @@
 //@ needs-rust-lld
 //@ only-x86_64-unknown-linux-gnu
 
-extern crate run_make_support;
-
 use run_make_support::regex::Regex;
 use run_make_support::rustc;
 use std::process::Output;


### PR DESCRIPTION
Cleanup requested in https://github.com/rust-lang/rust/pull/125493#discussion_r1618644630

r? jieyouxu
@bors rollup=always