### PR TITLE
make `ptr::rotate` smaller when using `optimize_for_size`

### DIFF
--- a/library/core/src/slice/rotate.rs
+++ b/library/core/src/slice/rotate.rs
@@ -71,7 +71,9 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mut mid: *mut T, mut right: usize) 
         if (right == 0) || (left == 0) {
             return;
         }
-        if (left + right < 24) || (mem::size_of::<T>() > mem::size_of::<[usize; 4]>()) {
+        if !cfg!(feature = "optimize_for_size")
+            && ((left + right < 24) || (mem::size_of::<T>() > mem::size_of::<[usize; 4]>()))
+        {
             // Algorithm 1
             // Microbenchmarks indicate that the average performance for random shifts is better all
             // the way until about `left + right == 32`, but the worst case performance breaks even
@@ -158,7 +160,9 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mut mid: *mut T, mut right: usize) 
             }
             return;
         // `T` is not a zero-sized type, so it's okay to divide by its size.
-        } else if cmp::min(left, right) <= mem::size_of::<BufType>() / mem::size_of::<T>() {
+        } else if !cfg!(feature = "optimize_for_size")
+            && cmp::min(left, right) <= mem::size_of::<BufType>() / mem::size_of::<T>()
+        {
             // Algorithm 2
             // The `[T; 0]` here is to ensure this is appropriately aligned for T
             let mut rawarray = MaybeUninit::<(BufType, [T; 0])>::uninit();


### PR DESCRIPTION
code to reproduce https://github.com/folkertdev/optimize_for_size-slice-rotate

In the example the size of `.text` goes down from 1624 to 276 bytes.

```
> cargo size --release --features "left-std"  -- -A 

slice-rotate  :
section              size        addr
.vector_table        1024         0x0
.text                1624       0x400
.rodata                 0       0xa58
.data                   0  0x20000000
.gnu.sgstubs            0       0xa60
.bss                    0  0x20000000
.uninit                 0  0x20000000
.debug_loc            591         0x0
.debug_abbrev        1452         0x0
.debug_info         10634         0x0
.debug_aranges        480         0x0
.debug_ranges        1504         0x0
.debug_str          11716         0x0
.comment               72         0x0
.ARM.attributes        56         0x0
.debug_frame         1036         0x0
.debug_line          5837         0x0
Total               36026


> cargo size --release --features "left-size"  -- -A

slice-rotate  :
section             size        addr
.vector_table       1024         0x0
.text                276       0x400
.rodata                0       0x514
.data                  0  0x20000000
.gnu.sgstubs           0       0x520
.bss                   0  0x20000000
.uninit                0  0x20000000
.debug_loc           347         0x0
.debug_abbrev        965         0x0
.debug_info         4216         0x0
.debug_aranges       168         0x0
.debug_ranges        216         0x0
.debug_str          3615         0x0
.comment              72         0x0
.ARM.attributes       56         0x0
.debug_frame         232         0x0
.debug_line          723         0x0
Total              11910
```


tracking issue: https://github.com/rust-lang/rust/issues/125612