### PR TITLE
Return Node directly from a query instead of having a query for the HirId and then loading the `Node`

### DIFF
--- a/compiler/rustc_ast_lowering/src/index.rs
+++ b/compiler/rustc_ast_lowering/src/index.rs
@@ -55,7 +55,7 @@ pub(super) fn index_hir<'hir>(
         OwnerNode::TraitItem(item) => collector.visit_trait_item(item),
         OwnerNode::ImplItem(item) => collector.visit_impl_item(item),
         OwnerNode::ForeignItem(item) => collector.visit_foreign_item(item),
-        OwnerNode::Synthetic => unreachable!(),
+        OwnerNode::Synthetic(_) => unreachable!(),
     };
 
     for (local_id, node) in collector.nodes.iter_enumerated() {

--- a/compiler/rustc_ast_lowering/src/index.rs
+++ b/compiler/rustc_ast_lowering/src/index.rs
@@ -75,6 +75,7 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
         debug_assert_eq!(self.owner, hir_id.owner);
         debug_assert_ne!(hir_id.local_id.as_u32(), 0);
         debug_assert_ne!(hir_id.local_id, self.parent_node);
+        debug_assert_eq!(hir_id, node.hir_id());
 
         // Make sure that the DepNode of some node coincides with the HirId
         // owner of that node.

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -981,10 +981,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             "closure_span: def_id={:?} target_place={:?} places={:?}",
             def_id, target_place, places
         );
-        let hir_id = self.infcx.tcx.local_def_id_to_hir_id(def_id);
-        let expr = &self.infcx.tcx.hir().expect_expr(hir_id).kind;
-        debug!("closure_span: hir_id={:?} expr={:?}", hir_id, expr);
-        if let hir::ExprKind::Closure(&hir::Closure { kind, fn_decl_span, .. }) = expr {
+        let expr = self.infcx.tcx.local_def_id_to_hir_node(def_id).expect_expr();
+        debug!("closure_span: hir_id={:?} expr={:?}", expr.hir_id, expr.kind);
+        if let hir::ExprKind::Closure(&hir::Closure { kind, fn_decl_span, .. }) = expr.kind {
             for (captured_place, place) in
                 self.infcx.tcx.closure_captures(def_id).iter().zip(places)
             {

--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -319,7 +319,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         let Some(use_spans) = use_spans else { return };
         // We only care about the case where a closure captured a binding.
         let UseSpans::ClosureUse { args_span, .. } = use_spans else { return };
-        let Some(body_id) = tcx.hir_node(self.mir_hir_id()).body_id() else { return };
+        let Some(body_id) = self.mir_hir().body_id() else { return };
         // Fetch the type of the expression corresponding to the closure-captured binding.
         let Some(captured_ty) = typeck_results.node_type_opt(upvar_hir_id) else { return };
         if !self.implements_clone(captured_ty) {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2,7 +2,7 @@ use crate::def::{CtorKind, DefKind, Res};
 use crate::def_id::{DefId, LocalDefIdMap};
 pub(crate) use crate::hir_id::{HirId, ItemLocalId, ItemLocalMap, OwnerId};
 use crate::intravisit::FnKind;
-use crate::LangItem;
+use crate::{LangItem, CRATE_HIR_ID};
 use rustc_ast as ast;
 use rustc_ast::util::parser::ExprPrecedence;
 use rustc_ast::{Attribute, FloatTy, IntTy, Label, LitKind, TraitObjectSyntax, UintTy};
@@ -3817,6 +3817,41 @@ impl<'hir> Node<'hir> {
                 _ => None,
             },
             _ => None,
+        }
+    }
+
+    pub fn hir_id(self) -> HirId {
+        match self {
+            Node::Param(p) => p.hir_id,
+            Node::Item(i) => i.hir_id(),
+            Node::ForeignItem(n) => n.hir_id(),
+            Node::TraitItem(n) => n.hir_id(),
+            Node::ImplItem(n) => n.hir_id(),
+            Node::Variant(n) => n.hir_id,
+            Node::Field(n) => n.hir_id,
+            Node::AnonConst(n) => n.hir_id,
+            Node::Expr(n) => n.hir_id,
+            Node::ExprField(n) => n.hir_id,
+            Node::Stmt(n) => n.hir_id,
+            Node::PathSegment(n) => n.hir_id,
+            Node::Ty(n) => n.hir_id,
+            Node::TypeBinding(n) => n.hir_id,
+            Node::TraitRef(n) => n.hir_ref_id,
+            Node::Pat(n) => n.hir_id,
+            Node::PatField(n) => n.hir_id,
+            Node::Arm(n) => n.hir_id,
+            Node::Block(n) => n.hir_id,
+            Node::LetStmt(n) => n.hir_id,
+            Node::Ctor(n) => n.ctor_hir_id().unwrap(),
+            Node::Lifetime(n) => n.hir_id,
+            Node::GenericParam(n) => n.hir_id,
+            Node::Crate(_) => CRATE_HIR_ID,
+            Node::Infer(n) => n.hir_id,
+            Node::WhereBoundPredicate(n) => n.hir_id,
+            Node::ArrayLenInfer(n) => n.hir_id,
+            Node::PreciseCapturingNonLifetimeArg(n) => n.hir_id,
+            Node::Synthetic => unreachable!(),
+            Node::Err(span) => todo!("tried to get hir id of error node: {span:?}"),
         }
     }
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3465,7 +3465,7 @@ pub enum OwnerNode<'hir> {
     TraitItem(&'hir TraitItem<'hir>),
     ImplItem(&'hir ImplItem<'hir>),
     Crate(&'hir Mod<'hir>),
-    Synthetic,
+    Synthetic(HirId),
 }
 
 impl<'hir> OwnerNode<'hir> {
@@ -3475,7 +3475,7 @@ impl<'hir> OwnerNode<'hir> {
             | OwnerNode::ForeignItem(ForeignItem { ident, .. })
             | OwnerNode::ImplItem(ImplItem { ident, .. })
             | OwnerNode::TraitItem(TraitItem { ident, .. }) => Some(*ident),
-            OwnerNode::Crate(..) | OwnerNode::Synthetic => None,
+            OwnerNode::Crate(..) | OwnerNode::Synthetic(_) => None,
         }
     }
 
@@ -3486,7 +3486,7 @@ impl<'hir> OwnerNode<'hir> {
             | OwnerNode::ImplItem(ImplItem { span, .. })
             | OwnerNode::TraitItem(TraitItem { span, .. }) => *span,
             OwnerNode::Crate(Mod { spans: ModSpans { inner_span, .. }, .. }) => *inner_span,
-            OwnerNode::Synthetic => unreachable!(),
+            OwnerNode::Synthetic(_) => unreachable!(),
         }
     }
 
@@ -3545,7 +3545,7 @@ impl<'hir> OwnerNode<'hir> {
             | OwnerNode::ImplItem(ImplItem { owner_id, .. })
             | OwnerNode::ForeignItem(ForeignItem { owner_id, .. }) => *owner_id,
             OwnerNode::Crate(..) => crate::CRATE_HIR_ID.owner,
-            OwnerNode::Synthetic => unreachable!(),
+            OwnerNode::Synthetic(_) => unreachable!(),
         }
     }
 
@@ -3589,7 +3589,7 @@ impl<'hir> Into<Node<'hir>> for OwnerNode<'hir> {
             OwnerNode::ImplItem(n) => Node::ImplItem(n),
             OwnerNode::TraitItem(n) => Node::TraitItem(n),
             OwnerNode::Crate(n) => Node::Crate(n),
-            OwnerNode::Synthetic => Node::Synthetic,
+            OwnerNode::Synthetic(id) => Node::Synthetic(id),
         }
     }
 }
@@ -3628,7 +3628,7 @@ pub enum Node<'hir> {
     ArrayLenInfer(&'hir InferArg),
     PreciseCapturingNonLifetimeArg(&'hir PreciseCapturingNonLifetimeArg),
     // Created by query feeding
-    Synthetic,
+    Synthetic(HirId),
     Err(Span),
 }
 
@@ -3677,7 +3677,7 @@ impl<'hir> Node<'hir> {
             | Node::Infer(..)
             | Node::WhereBoundPredicate(..)
             | Node::ArrayLenInfer(..)
-            | Node::Synthetic
+            | Node::Synthetic(_)
             | Node::Err(..) => None,
         }
     }
@@ -3789,7 +3789,7 @@ impl<'hir> Node<'hir> {
             Node::TraitItem(i) => Some(OwnerNode::TraitItem(i)),
             Node::ImplItem(i) => Some(OwnerNode::ImplItem(i)),
             Node::Crate(i) => Some(OwnerNode::Crate(i)),
-            Node::Synthetic => Some(OwnerNode::Synthetic),
+            Node::Synthetic(id) => Some(OwnerNode::Synthetic(id)),
             _ => None,
         }
     }
@@ -3850,7 +3850,7 @@ impl<'hir> Node<'hir> {
             Node::WhereBoundPredicate(n) => n.hir_id,
             Node::ArrayLenInfer(n) => n.hir_id,
             Node::PreciseCapturingNonLifetimeArg(n) => n.hir_id,
-            Node::Synthetic => unreachable!(),
+            Node::Synthetic(hir_id) => hir_id,
             Node::Err(span) => todo!("tried to get hir id of error node: {span:?}"),
         }
     }

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -460,8 +460,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
 
     let trait_to_impl_args = impl_trait_ref.args;
 
-    let impl_m_hir_id = tcx.local_def_id_to_hir_id(impl_m_def_id);
-    let return_span = tcx.hir().fn_decl_by_hir_id(impl_m_hir_id).unwrap().output.span();
+    let return_span = tcx.local_def_id_to_hir_node(impl_m_def_id).fn_decl().unwrap().output.span();
     let cause = ObligationCause::new(
         return_span,
         impl_m_def_id,

--- a/compiler/rustc_hir_analysis/src/check/entry.rs
+++ b/compiler/rustc_hir_analysis/src/check/entry.rs
@@ -195,12 +195,13 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: DefId) {
 
 fn check_start_fn_ty(tcx: TyCtxt<'_>, start_def_id: DefId) {
     let start_def_id = start_def_id.expect_local();
-    let start_id = tcx.local_def_id_to_hir_id(start_def_id);
+    let start_node = tcx.local_def_id_to_hir_node(start_def_id);
+    let start_id = start_node.hir_id();
     let start_span = tcx.def_span(start_def_id);
     let start_t = tcx.type_of(start_def_id).instantiate_identity();
     match start_t.kind() {
         ty::FnDef(..) => {
-            if let Node::Item(it) = tcx.hir_node(start_id) {
+            if let Node::Item(it) = start_node {
                 if let hir::ItemKind::Fn(sig, generics, _) = &it.kind {
                     let mut error = false;
                     if !generics.params.is_empty() {

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -202,7 +202,7 @@ fn check_well_formed(tcx: TyCtxt<'_>, def_id: hir::OwnerId) -> Result<(), ErrorG
         hir::OwnerNode::TraitItem(item) => check_trait_item(tcx, item),
         hir::OwnerNode::ImplItem(item) => check_impl_item(tcx, item),
         hir::OwnerNode::ForeignItem(item) => check_foreign_item(tcx, item),
-        hir::OwnerNode::Synthetic => unreachable!(),
+        hir::OwnerNode::Synthetic(_) => unreachable!(),
     };
 
     if let Some(generics) = node.generics() {

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -261,7 +261,7 @@ fn resolve_bound_vars(tcx: TyCtxt<'_>, local_def_id: hir::OwnerId) -> ResolveBou
             visitor.visit_impl_item(item)
         }
         hir::OwnerNode::Crate(_) => {}
-        hir::OwnerNode::Synthetic => unreachable!(),
+        hir::OwnerNode::Synthetic(_) => unreachable!(),
     }
 
     let mut rl = ResolveBoundVars::default();

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -118,7 +118,7 @@ impl<'a> State<'a> {
                 self.print_bounds(":", pred.bounds);
             }
             Node::ArrayLenInfer(_) => self.word("_"),
-            Node::Synthetic => unreachable!(),
+            Node::Synthetic(_) => unreachable!(),
             Node::Err(_) => self.word("/*ERROR*/"),
         }
     }

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -299,7 +299,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for WritebackCx<'cx, 'tcx> {
             hir::ExprKind::ConstBlock(_) => {
                 let feed = self.tcx().create_def(self.fcx.body_id, kw::Empty, DefKind::InlineConst);
                 feed.def_span(e.span);
-                feed.local_def_id_to_hir_id(e.hir_id);
+                feed.local_def_id_to_hir_node(hir::Node::Synthetic(e.hir_id));
                 self.typeck_results.inline_consts.insert(e.hir_id.local_id, feed.def_id());
             }
             _ => {}

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2587,7 +2587,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             hir::OwnerNode::ImplItem(i) => visitor.visit_impl_item(i),
             hir::OwnerNode::TraitItem(i) => visitor.visit_trait_item(i),
             hir::OwnerNode::Crate(_) => bug!("OwnerNode::Crate doesn't not have generics"),
-            hir::OwnerNode::Synthetic => unreachable!(),
+            hir::OwnerNode::Synthetic(_) => unreachable!(),
         }
 
         let ast_generics = self.tcx.hir().get_generics(lifetime_scope).unwrap();

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -193,7 +193,7 @@ fn shallow_lint_levels_on(tcx: TyCtxt<'_>, owner: hir::OwnerId) -> ShallowLintLe
                 levels.add_id(hir::CRATE_HIR_ID);
                 levels.visit_mod(mod_, mod_.spans.inner_span, hir::CRATE_HIR_ID)
             }
-            hir::OwnerNode::Synthetic => unreachable!(),
+            hir::OwnerNode::Synthetic(_) => unreachable!(),
         },
     }
 

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -1,6 +1,6 @@
 use crate::hir::ModuleItems;
 use crate::middle::debugger_visualizer::DebuggerVisualizerFile;
-use crate::query::LocalCrate;
+use crate::query::{IntoQueryParam, LocalCrate};
 use crate::ty::TyCtxt;
 use rustc_ast as ast;
 use rustc_ast::visit::{walk_list, VisitorResult};
@@ -125,6 +125,12 @@ impl<'tcx> TyCtxt<'tcx> {
     #[inline]
     pub fn hir_node_by_def_id(self, id: LocalDefId) -> Node<'tcx> {
         self.hir_node(self.local_def_id_to_hir_id(id))
+    }
+
+    /// Returns HIR ID for the given `LocalDefId`.
+    #[inline]
+    pub fn local_def_id_to_hir_id(self, id: impl IntoQueryParam<LocalDefId>) -> HirId {
+        self.local_def_id_to_hir_node(id).hir_id()
     }
 
     /// Returns `HirId` of the parent HIR node of node with this `hir_id`.
@@ -925,7 +931,7 @@ impl<'hir> Map<'hir> {
             Node::WhereBoundPredicate(pred) => pred.span,
             Node::ArrayLenInfer(inf) => inf.span,
             Node::PreciseCapturingNonLifetimeArg(param) => param.ident.span,
-            Node::Synthetic => unreachable!(),
+            Node::Synthetic(_) => unreachable!(),
             Node::Err(span) => span,
         }
     }
@@ -1195,7 +1201,7 @@ fn hir_id_to_string(map: Map<'_>, id: HirId) -> String {
         Node::Crate(..) => String::from("(root_crate)"),
         Node::WhereBoundPredicate(_) => node_str("where bound predicate"),
         Node::ArrayLenInfer(_) => node_str("array len infer"),
-        Node::Synthetic => unreachable!(),
+        Node::Synthetic(_) => unreachable!(),
         Node::Err(_) => node_str("error"),
         Node::PreciseCapturingNonLifetimeArg(_param) => node_str("parameter"),
     }

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -338,6 +338,7 @@ macro_rules! tcx_lifetime {
 }
 
 tcx_lifetime! {
+    rustc_hir::Node,
     rustc_middle::middle::exported_symbols::ExportedSymbol,
     rustc_middle::mir::Const,
     rustc_middle::mir::DestructuredConstant,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -175,9 +175,9 @@ rustc_queries! {
         cache_on_disk_if { true }
     }
 
-    /// Returns HIR ID for the given `LocalDefId`.
-    query local_def_id_to_hir_id(key: LocalDefId) -> hir::HirId {
-        desc { |tcx| "getting HIR ID of `{}`", tcx.def_path_str(key) }
+    /// Returns the HIR for the given `LocalDefId`.
+    query local_def_id_to_hir_node(key: LocalDefId) -> hir::Node<'tcx> {
+        desc { |tcx| "getting HIR of `{}`", tcx.def_path_str(key) }
         feedable
     }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -729,9 +729,10 @@ impl<'tcx> TyCtxtFeed<'tcx, LocalDefId> {
 
     // Fills in all the important parts needed by HIR queries
     pub fn feed_hir(&self) {
-        self.local_def_id_to_hir_id(HirId::make_owner(self.def_id()));
+        let hir_id = HirId::make_owner(self.def_id());
+        self.local_def_id_to_hir_node(hir::Node::Synthetic(hir_id));
 
-        let node = hir::OwnerNode::Synthetic;
+        let node = hir::OwnerNode::Synthetic(hir_id);
         let bodies = Default::default();
         let attrs = hir::AttributeMap::EMPTY;
 

--- a/compiler/rustc_passes/src/reachable.rs
+++ b/compiler/rustc_passes/src/reachable.rs
@@ -273,7 +273,7 @@ impl<'tcx> ReachableContext<'tcx> {
             | Node::Field(_)
             | Node::Ty(_)
             | Node::Crate(_)
-            | Node::Synthetic => {}
+            | Node::Synthetic(_) => {}
             _ => {
                 bug!(
                     "found unexpected node kind in worklist: {} ({:?})",


### PR DESCRIPTION
r? @ghost

This may have performance implications. If it is clean, it will be very useful for query feeding, as we can feed nodes directly instead of having to feed the def_id->hir_id query and the hir owner query for going from hir ids to bodies and nodes