### PR TITLE
run-make-support: add wrapper for `fs` operations

### DIFF
--- a/src/tools/run-make-support/src/fs_wrapper.rs
+++ b/src/tools/run-make-support/src/fs_wrapper.rs
@@ -1,0 +1,113 @@
+use std::fs;
+use std::path::Path;
+
+/// A wrapper around [`std::fs::remove_file`] which includes the file path in the panic message..
+#[track_caller]
+pub fn remove_file<P: AsRef<Path>>(path: P) {
+    fs::remove_file(path.as_ref())
+        .expect(&format!("the file in path \"{}\" could not be removed", path.as_ref().display()));
+}
+
+/// A wrapper around [`std::fs::copy`] which includes the file path in the panic message.
+#[track_caller]
+pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) {
+    fs::copy(from.as_ref(), to.as_ref()).expect(&format!(
+        "the file \"{}\" could not be copied over to \"{}\"",
+        from.as_ref().display(),
+        to.as_ref().display(),
+    ));
+}
+
+/// A wrapper around [`std::fs::File::create`] which includes the file path in the panic message..
+#[track_caller]
+pub fn create_file<P: AsRef<Path>>(path: P) {
+    fs::File::create(path.as_ref())
+        .expect(&format!("the file in path \"{}\" could not be created", path.as_ref().display()));
+}
+
+/// A wrapper around [`std::fs::read`] which includes the file path in the panic message..
+#[track_caller]
+pub fn read<P: AsRef<Path>>(path: P) -> Vec<u8> {
+    fs::read(path.as_ref())
+        .expect(&format!("the file in path \"{}\" could not be read", path.as_ref().display()))
+}
+
+/// A wrapper around [`std::fs::read_to_string`] which includes the file path in the panic message..
+#[track_caller]
+pub fn read_to_string<P: AsRef<Path>>(path: P) -> String {
+    fs::read_to_string(path.as_ref()).expect(&format!(
+        "the file in path \"{}\" could not be read into a String",
+        path.as_ref().display()
+    ))
+}
+
+/// A wrapper around [`std::fs::read_dir`] which includes the file path in the panic message..
+#[track_caller]
+pub fn read_dir<P: AsRef<Path>>(path: P) -> fs::ReadDir {
+    fs::read_dir(path.as_ref())
+        .expect(&format!("the directory in path \"{}\" could not be read", path.as_ref().display()))
+}
+
+/// A wrapper around [`std::fs::write`] which includes the file path in the panic message..
+#[track_caller]
+pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) {
+    fs::write(path.as_ref(), contents.as_ref()).expect(&format!(
+        "the file in path \"{}\" could not be written to",
+        path.as_ref().display()
+    ));
+}
+
+/// A wrapper around [`std::fs::remove_dir_all`] which includes the file path in the panic message..
+#[track_caller]
+pub fn remove_dir_all<P: AsRef<Path>>(path: P) {
+    fs::remove_dir_all(path.as_ref()).expect(&format!(
+        "the directory in path \"{}\" could not be removed alongside all its contents",
+        path.as_ref().display(),
+    ));
+}
+
+/// A wrapper around [`std::fs::create_dir`] which includes the file path in the panic message..
+#[track_caller]
+pub fn create_dir<P: AsRef<Path>>(path: P) {
+    fs::create_dir(path.as_ref()).expect(&format!(
+        "the directory in path \"{}\" could not be created",
+        path.as_ref().display()
+    ));
+}
+
+/// A wrapper around [`std::fs::create_dir_all`] which includes the file path in the panic message..
+#[track_caller]
+pub fn create_dir_all<P: AsRef<Path>>(path: P) {
+    fs::create_dir_all(path.as_ref()).expect(&format!(
+        "the directory (and all its parents) in path \"{}\" could not be created",
+        path.as_ref().display()
+    ));
+}
+
+/// A wrapper around [`std::fs::metadata`] which includes the file path in the panic message..
+#[track_caller]
+pub fn metadata<P: AsRef<Path>>(path: P) -> fs::Metadata {
+    fs::metadata(path.as_ref()).expect(&format!(
+        "the file's metadata in path \"{}\" could not be read",
+        path.as_ref().display()
+    ))
+}
+
+/// A wrapper around [`std::fs::rename`] which includes the file path in the panic message.
+#[track_caller]
+pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) {
+    fs::rename(from.as_ref(), to.as_ref()).expect(&format!(
+        "the file \"{}\" could not be moved over to \"{}\"",
+        from.as_ref().display(),
+        to.as_ref().display(),
+    ));
+}
+
+/// A wrapper around [`std::fs::set_permissions`] which includes the file path in the panic message.
+#[track_caller]
+pub fn set_permissions<P: AsRef<Path>>(path: P, perm: fs::Permissions) {
+    fs::set_permissions(path.as_ref(), perm).expect(&format!(
+        "the file's permissions in path \"{}\" could not be changed",
+        path.as_ref().display()
+    ));
+}

--- a/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
+++ b/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use run_make_support::{aux_build, rustc, source_root};
+use run_make_support::{aux_build, fs_wrapper, rustc, source_root};
 
 fn main() {
     aux_build().input("stable.rs").emit("metadata").run();
@@ -13,7 +13,7 @@ fn main() {
     let output =
         rustc().input("main.rs").emit("metadata").extern_("stable", "libstable.rmeta").run();
 
-    let version = std::fs::read_to_string(source_root().join("src/version")).unwrap();
+    let version = fs_wrapper::read_to_string(source_root().join("src/version"));
     let expected_string = format!("stable since {}", version.trim());
     output.assert_stderr_contains(expected_string);
 }

--- a/tests/run-make/c-link-to-rust-dylib/rmake.rs
+++ b/tests/run-make/c-link-to-rust-dylib/rmake.rs
@@ -3,9 +3,9 @@
 
 //@ ignore-cross-compile
 
-use std::fs::remove_file;
-
-use run_make_support::{cc, cwd, dynamic_lib_extension, is_msvc, read_dir, run, run_fail, rustc};
+use run_make_support::{
+    cc, cwd, dynamic_lib_extension, fs_wrapper, is_msvc, read_dir, run, run_fail, rustc,
+};
 
 fn main() {
     rustc().input("foo.rs").run();
@@ -28,7 +28,7 @@ fn main() {
                 name.ends_with(".so") || name.ends_with(".dll") || name.ends_with(".dylib")
             })
         {
-            remove_file(path).unwrap();
+            fs_wrapper::remove_file(path);
         }
     });
     run_fail("bar");

--- a/tests/run-make/c-link-to-rust-staticlib/rmake.rs
+++ b/tests/run-make/c-link-to-rust-staticlib/rmake.rs
@@ -3,6 +3,7 @@
 
 //@ ignore-cross-compile
 
+use run_make_support::fs_wrapper::remove_file;
 use run_make_support::{cc, extra_c_flags, run, rustc, static_lib_name};
 use std::fs;
 
@@ -10,6 +11,6 @@ fn main() {
     rustc().input("foo.rs").run();
     cc().input("bar.c").input(static_lib_name("foo")).out_exe("bar").args(&extra_c_flags()).run();
     run("bar");
-    fs::remove_file(static_lib_name("foo"));
+    remove_file(static_lib_name("foo"));
     run("bar");
 }

--- a/tests/run-make/cdylib/rmake.rs
+++ b/tests/run-make/cdylib/rmake.rs
@@ -10,9 +10,7 @@
 
 //@ ignore-cross-compile
 
-use std::fs::remove_file;
-
-use run_make_support::{cc, cwd, dynamic_lib_name, is_msvc, run, rustc};
+use run_make_support::{cc, cwd, dynamic_lib_name, fs_wrapper, is_msvc, run, rustc};
 
 fn main() {
     rustc().input("bar.rs").run();
@@ -25,7 +23,7 @@ fn main() {
     }
 
     run("foo");
-    remove_file(dynamic_lib_name("foo")).unwrap();
+    fs_wrapper::remove_file(dynamic_lib_name("foo"));
 
     rustc().input("foo.rs").arg("-Clto").run();
     run("foo");

--- a/tests/run-make/compiler-builtins/rmake.rs
+++ b/tests/run-make/compiler-builtins/rmake.rs
@@ -14,6 +14,7 @@
 
 #![deny(warnings)]
 
+use run_make_support::fs_wrapper::{read, read_dir};
 use run_make_support::object::read::archive::ArchiveFile;
 use run_make_support::object::read::Object;
 use run_make_support::object::ObjectSection;
@@ -55,8 +56,7 @@ fn main() {
     cmd.run();
 
     let rlibs_path = target_dir.join(target).join("debug").join("deps");
-    let compiler_builtins_rlib = std::fs::read_dir(rlibs_path)
-        .unwrap()
+    let compiler_builtins_rlib = read_dir(rlibs_path)
         .find_map(|e| {
             let path = e.unwrap().path();
             let file_name = path.file_name().unwrap().to_str().unwrap();
@@ -70,7 +70,7 @@ fn main() {
 
     // rlib files are archives, where the archive members each a CGU, and we also have one called
     // lib.rmeta which is the encoded metadata. Each of the CGUs is an object file.
-    let data = std::fs::read(compiler_builtins_rlib).unwrap();
+    let data = read(compiler_builtins_rlib);
 
     let mut defined_symbols = HashSet::new();
     let mut undefined_relocations = HashSet::new();

--- a/tests/run-make/const-prop-lint/rmake.rs
+++ b/tests/run-make/const-prop-lint/rmake.rs
@@ -1,13 +1,11 @@
 // Tests that const prop lints interrupting codegen don't leave `.o` files around.
 
-use std::fs;
-
-use run_make_support::{cwd, rustc};
+use run_make_support::{cwd, fs_wrapper, rustc};
 
 fn main() {
     rustc().input("input.rs").run_fail().assert_exit_code(1);
 
-    for entry in fs::read_dir(cwd()).unwrap() {
+    for entry in fs_wrapper::read_dir(cwd()) {
         let entry = entry.unwrap();
         let path = entry.path();
 

--- a/tests/run-make/doctests-keep-binaries/rmake.rs
+++ b/tests/run-make/doctests-keep-binaries/rmake.rs
@@ -1,13 +1,13 @@
 // Check that valid binaries are persisted by running them, regardless of whether the
 // --run or --no-run option is used.
 
+use run_make_support::fs_wrapper::{create_dir, remove_dir_all};
 use run_make_support::{run, rustc, rustdoc};
-use std::fs::{create_dir, remove_dir_all};
 use std::path::Path;
 
 fn setup_test_env<F: FnOnce(&Path, &Path)>(callback: F) {
     let out_dir = Path::new("doctests");
-    create_dir(&out_dir).expect("failed to create doctests folder");
+    create_dir(&out_dir);
     rustc().input("t.rs").crate_type("rlib").run();
     callback(&out_dir, Path::new("libt.rlib"));
     remove_dir_all(out_dir);
@@ -43,9 +43,9 @@ fn main() {
         check_generated_binaries();
     });
     // Behavior with --test-run-directory with relative paths.
-    setup_test_env(|_out_dir, extern_path| {
+    setup_test_env(|_out_dir, _extern_path| {
         let run_dir_path = Path::new("rundir");
-        create_dir(&run_dir_path).expect("failed to create rundir folder");
+        create_dir(&run_dir_path);
 
         rustdoc()
             .input("t.rs")

--- a/tests/run-make/doctests-runtool/rmake.rs
+++ b/tests/run-make/doctests-runtool/rmake.rs
@@ -1,12 +1,12 @@
 // Tests behavior of rustdoc `--runtool`.
 
+use run_make_support::fs_wrapper::{create_dir, remove_dir_all};
 use run_make_support::{rustc, rustdoc};
-use std::fs::{create_dir, remove_dir_all};
 use std::path::PathBuf;
 
 fn mkdir(name: &str) -> PathBuf {
     let dir = PathBuf::from(name);
-    create_dir(&dir).expect("failed to create doctests folder");
+    create_dir(&dir);
     dir
 }
 

--- a/tests/run-make/emit-named-files/rmake.rs
+++ b/tests/run-make/emit-named-files/rmake.rs
@@ -1,7 +1,6 @@
-use std::fs::create_dir;
 use std::path::Path;
 
-use run_make_support::rustc;
+use run_make_support::{fs_wrapper, rustc};
 
 fn emit_and_check(out_dir: &Path, out_file: &str, format: &str) {
     let out_file = out_dir.join(out_file);
@@ -12,7 +11,7 @@ fn emit_and_check(out_dir: &Path, out_file: &str, format: &str) {
 fn main() {
     let out_dir = Path::new("emit");
 
-    create_dir(&out_dir).unwrap();
+    fs_wrapper::create_dir(&out_dir);
 
     emit_and_check(&out_dir, "libfoo.s", "asm");
     emit_and_check(&out_dir, "libfoo.bc", "llvm-bc");

--- a/tests/run-make/incr-prev-body-beyond-eof/rmake.rs
+++ b/tests/run-make/incr-prev-body-beyond-eof/rmake.rs
@@ -13,15 +13,14 @@
 //@ ignore-nvptx64-nvidia-cuda
 // FIXME: can't find crate for `std`
 
+use run_make_support::fs_wrapper as fs;
 use run_make_support::rustc;
-use std::fs;
 
 fn main() {
-    // FIXME(Oneirical): Use run_make_support::fs_wrapper here.
-    fs::create_dir("src").unwrap();
-    fs::create_dir("incr").unwrap();
-    fs::copy("a.rs", "src/main.rs").unwrap();
+    fs::create_dir("src");
+    fs::create_dir("incr");
+    fs::copy("a.rs", "src/main.rs");
     rustc().incremental("incr").input("src/main.rs").run();
-    fs::copy("b.rs", "src/main.rs").unwrap();
+    fs::copy("b.rs", "src/main.rs");
     rustc().incremental("incr").input("src/main.rs").run();
 }

--- a/tests/run-make/issue-107495-archive-permissions/rmake.rs
+++ b/tests/run-make/issue-107495-archive-permissions/rmake.rs
@@ -3,8 +3,8 @@
 #[cfg(unix)]
 extern crate libc;
 
-use run_make_support::aux_build;
-use std::fs;
+use run_make_support::{aux_build, fs_wrapper};
+
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn verify(path: &Path) {
-    let perm = fs::metadata(path).unwrap().permissions();
+    let perm = fs_wrapper::metadata(path).permissions();
 
     assert!(!perm.readonly());
 

--- a/tests/run-make/mixing-formats/rmake.rs
+++ b/tests/run-make/mixing-formats/rmake.rs
@@ -13,7 +13,6 @@
 //@ ignore-cross-compile
 
 use run_make_support::{run_in_tmpdir, rustc};
-use std::fs;
 
 fn main() {
     run_in_tmpdir(|| {

--- a/tests/run-make/non-unicode-env/rmake.rs
+++ b/tests/run-make/non-unicode-env/rmake.rs
@@ -1,3 +1,4 @@
+use run_make_support::fs_wrapper;
 use run_make_support::rustc;
 
 fn main() {
@@ -6,6 +7,6 @@ fn main() {
     #[cfg(windows)]
     let non_unicode: std::ffi::OsString = std::os::windows::ffi::OsStringExt::from_wide(&[0xD800]);
     let output = rustc().input("non_unicode_env.rs").env("NON_UNICODE_VAR", non_unicode).run_fail();
-    let expected = std::fs::read_to_string("non_unicode_env.stderr").unwrap();
+    let expected = fs_wrapper::read_to_string("non_unicode_env.stderr");
     output.assert_stderr_equals(expected);
 }

--- a/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
+++ b/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
@@ -1,4 +1,4 @@
-use run_make_support::rustc;
+use run_make_support::{fs_wrapper, rustc};
 
 fn main() {
     #[cfg(unix)]
@@ -17,8 +17,8 @@ fn main() {
     }
     let incr_dir = "incr-dir";
     rustc().input("foo.rs").incremental(&incr_dir).run();
-    for crate_dir in std::fs::read_dir(&incr_dir).unwrap() {
-        std::fs::create_dir(crate_dir.unwrap().path().join(&non_unicode)).unwrap();
+    for crate_dir in fs_wrapper::read_dir(&incr_dir) {
+        fs_wrapper::create_dir(crate_dir.unwrap().path().join(&non_unicode));
     }
     rustc().input("foo.rs").incremental(&incr_dir).run();
 }

--- a/tests/run-make/print-cfg/rmake.rs
+++ b/tests/run-make/print-cfg/rmake.rs
@@ -10,7 +10,7 @@ use std::ffi::OsString;
 use std::iter::FromIterator;
 use std::path::PathBuf;
 
-use run_make_support::rustc;
+use run_make_support::{fs_wrapper, rustc};
 
 struct PrintCfg {
     target: &'static str,
@@ -96,7 +96,7 @@ fn check(PrintCfg { target, includes, disallow }: PrintCfg) {
 
         rustc().target(target).arg(print_arg).run();
 
-        let output = std::fs::read_to_string(&tmp_path).unwrap();
+        let output = fs_wrapper::read_to_string(&tmp_path);
 
         check_(&output, includes, disallow);
     }

--- a/tests/run-make/print-to-output/rmake.rs
+++ b/tests/run-make/print-to-output/rmake.rs
@@ -4,7 +4,7 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use run_make_support::{rustc, target};
+use run_make_support::{fs_wrapper, rustc, target};
 
 struct Option<'a> {
     target: &'a str,
@@ -49,7 +49,7 @@ fn check(args: Option) {
 
         rustc().target(args.target).arg(print_arg).run();
 
-        std::fs::read_to_string(&tmp_path).unwrap()
+        fs_wrapper::read_to_string(&tmp_path)
     };
 
     check_(&stdout, args.includes);

--- a/tests/run-make/repr128-dwarf/rmake.rs
+++ b/tests/run-make/repr128-dwarf/rmake.rs
@@ -3,7 +3,7 @@
 
 use gimli::{AttributeValue, EndianRcSlice, Reader, RunTimeEndian};
 use object::{Object, ObjectSection};
-use run_make_support::{gimli, object, rustc};
+use run_make_support::{fs_wrapper, gimli, object, rustc};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -19,8 +19,7 @@ fn main() {
         .join("DWARF")
         .join("repr128");
     let output =
-        std::fs::read(if dsym_location.try_exists().unwrap() { dsym_location } else { output })
-            .unwrap();
+        fs_wrapper::read(if dsym_location.try_exists().unwrap() { dsym_location } else { output });
     let obj = object::File::parse(output.as_slice()).unwrap();
     let endian = if obj.is_little_endian() { RunTimeEndian::Little } else { RunTimeEndian::Big };
     let dwarf = gimli::Dwarf::load(|section| -> Result<_, ()> {

--- a/tests/run-make/reset-codegen-1/rmake.rs
+++ b/tests/run-make/reset-codegen-1/rmake.rs
@@ -7,8 +7,8 @@
 
 //@ ignore-cross-compile
 
-use run_make_support::rustc;
-use std::fs;
+use run_make_support::{bin_name, fs_wrapper, rustc};
+use std::path::Path;
 
 fn compile(output_file: &str, emit: Option<&str>) {
     let mut rustc = rustc();
@@ -28,11 +28,15 @@ fn main() {
         ("link-output", Some("link")),
         ("obj-output", Some("obj")),
         ("dep-output", Some("dep-info")),
-        ("multi-output", Some("asm,obj")),
     ];
     for (output_file, emit) in flags {
-        fs::remove_file(output_file).unwrap_or_default();
+        // In the None case, bin_name is required for successful Windows compilation.
+        let output_file = &bin_name(output_file);
         compile(output_file, emit);
-        fs::remove_file(output_file);
+        assert!(Path::new(output_file).is_file());
     }
+
+    compile("multi-output", Some("asm,obj"));
+    assert!(Path::new("multi-output.s").is_file());
+    assert!(Path::new("multi-output.o").is_file());
 }

--- a/tests/run-make/resolve-rename/rmake.rs
+++ b/tests/run-make/resolve-rename/rmake.rs
@@ -5,11 +5,12 @@
 // the renamed library.
 // See https://github.com/rust-lang/rust/pull/49253
 
+use run_make_support::fs_wrapper;
 use run_make_support::rustc;
-use std::fs;
+
 fn main() {
     rustc().extra_filename("-hash").input("foo.rs").run();
     rustc().input("bar.rs").run();
-    fs::rename("libfoo-hash.rlib", "libfoo-another-hash.rlib").unwrap();
+    fs_wrapper::rename("libfoo-hash.rlib", "libfoo-another-hash.rlib");
     rustc().input("baz.rs").run();
 }

--- a/tests/run-make/rustdoc-scrape-examples-remap/scrape.rs
+++ b/tests/run-make/rustdoc-scrape-examples-remap/scrape.rs
@@ -1,12 +1,10 @@
-use run_make_support::{htmldocck, rustc, rustdoc, source_root};
-use std::fs::read_dir;
+use run_make_support::{fs_wrapper, htmldocck, rustc, rustdoc, source_root};
 use std::path::Path;
 
 pub fn scrape(extra_args: &[&str]) {
     let out_dir = Path::new("rustdoc");
     let crate_name = "foobar";
-    let deps = read_dir("examples")
-        .unwrap()
+    let deps = fs_wrapper::read_dir("examples")
         .filter_map(|entry| entry.ok().map(|e| e.path()))
         .filter(|path| path.is_file() && path.extension().is_some_and(|ext| ext == "rs"))
         .collect::<Vec<_>>();

--- a/tests/run-make/rustdoc-test-args/rmake.rs
+++ b/tests/run-make/rustdoc-test-args/rmake.rs
@@ -1,10 +1,10 @@
-use run_make_support::rustdoc;
+use run_make_support::{fs_wrapper, rustdoc};
+use std::iter;
 use std::path::Path;
-use std::{fs, iter};
 
 fn generate_a_lot_of_cfgs(path: &Path) {
     let content = iter::repeat("--cfg=a\n").take(100_000).collect::<String>();
-    fs::write(path, content.as_bytes()).expect("failed to create args file");
+    fs_wrapper::write(path, content.as_bytes());
 }
 
 fn main() {

--- a/tests/run-make/rustdoc-themes/rmake.rs
+++ b/tests/run-make/rustdoc-themes/rmake.rs
@@ -1,15 +1,15 @@
 // Test that rustdoc will properly load in a theme file and display it in the theme selector.
 
-use run_make_support::{htmldocck, rustdoc, source_root};
+use run_make_support::{fs_wrapper, htmldocck, rustdoc, source_root};
 use std::path::Path;
 
 fn main() {
     let out_dir = Path::new("rustdoc-themes");
     let test_css = "test.css";
 
-    let no_script =
-        std::fs::read_to_string(source_root().join("src/librustdoc/html/static/css/noscript.css"))
-            .unwrap();
+    let no_script = fs_wrapper::read_to_string(
+        source_root().join("src/librustdoc/html/static/css/noscript.css"),
+    );
 
     let mut test_content = String::new();
     let mut found_begin_light = false;
@@ -24,8 +24,8 @@ fn main() {
         }
     }
     assert!(!test_content.is_empty());
-    std::fs::create_dir_all(&out_dir).unwrap();
-    std::fs::write(&test_css, test_content).unwrap();
+    fs_wrapper::create_dir_all(&out_dir);
+    fs_wrapper::write(&test_css, test_content);
 
     rustdoc().output(&out_dir).input("foo.rs").arg("--theme").arg(&test_css).run();
     htmldocck().arg(out_dir).arg("foo.rs").run();

--- a/tests/run-make/rustdoc-verify-output-files/rmake.rs
+++ b/tests/run-make/rustdoc-verify-output-files/rmake.rs
@@ -1,4 +1,4 @@
-use std::fs::copy;
+use run_make_support::fs_wrapper::copy;
 use std::path::{Path, PathBuf};
 
 use run_make_support::{copy_dir_all, recursive_diff, rustdoc};
@@ -38,7 +38,7 @@ fn main() {
     assert!(out_dir.join("foobar.json").is_file());
 
     // Copy first json output to check if it's exactly same after second compilation.
-    copy(out_dir.join("foobar.json"), tmp_out_dir.join("foobar.json")).unwrap();
+    copy(out_dir.join("foobar.json"), tmp_out_dir.join("foobar.json"));
 
     // Generate json doc on the same output.
     generate_docs(&out_dir, JsonOutput::Yes);

--- a/tests/run-make/wasm-custom-section/rmake.rs
+++ b/tests/run-make/wasm-custom-section/rmake.rs
@@ -1,13 +1,13 @@
 //@ only-wasm32-wasip1
 
-use run_make_support::{rustc, wasmparser};
+use run_make_support::{fs_wrapper, rustc, wasmparser};
 use std::collections::HashMap;
 
 fn main() {
     rustc().input("foo.rs").target("wasm32-wasip1").run();
     rustc().input("bar.rs").target("wasm32-wasip1").arg("-Clto").opt().run();
 
-    let file = std::fs::read("bar.wasm").unwrap();
+    let file = fs_wrapper::read("bar.wasm");
 
     let mut custom = HashMap::new();
     for payload in wasmparser::Parser::new(0).parse_all(&file) {

--- a/tests/run-make/wasm-custom-sections-opt/rmake.rs
+++ b/tests/run-make/wasm-custom-sections-opt/rmake.rs
@@ -1,18 +1,18 @@
 //@ only-wasm32-wasip1
 
-use run_make_support::{rustc, wasmparser};
+use run_make_support::{fs_wrapper, rustc, wasmparser};
 use std::collections::HashMap;
 use std::path::Path;
 
 fn main() {
     rustc().input("foo.rs").target("wasm32-wasip1").opt().run();
 
-    verify(&Path::new("foo.wasm"));
+    verify(Path::new("foo.wasm"));
 }
 
 fn verify(path: &Path) {
     eprintln!("verify {path:?}");
-    let file = std::fs::read(&path).unwrap();
+    let file = fs_wrapper::read(&path);
 
     let mut custom = HashMap::new();
     for payload in wasmparser::Parser::new(0).parse_all(&file) {

--- a/tests/run-make/wasm-export-all-symbols/rmake.rs
+++ b/tests/run-make/wasm-export-all-symbols/rmake.rs
@@ -1,6 +1,6 @@
 //@ only-wasm32-wasip1
 
-use run_make_support::{rustc, wasmparser};
+use run_make_support::{fs_wrapper, rustc, wasmparser};
 use std::collections::HashMap;
 use std::path::Path;
 use wasmparser::ExternalKind::*;
@@ -33,7 +33,7 @@ fn test(args: &[&str]) {
 
 fn verify_exports(path: &Path, exports: &[(&str, wasmparser::ExternalKind)]) {
     println!("verify {path:?}");
-    let file = std::fs::read(path).unwrap();
+    let file = fs_wrapper::read(path);
     let mut wasm_exports = HashMap::new();
     for payload in wasmparser::Parser::new(0).parse_all(&file) {
         let payload = payload.unwrap();

--- a/tests/run-make/wasm-import-module/rmake.rs
+++ b/tests/run-make/wasm-import-module/rmake.rs
@@ -1,6 +1,6 @@
 //@ only-wasm32-wasip1
 
-use run_make_support::{rustc, wasmparser};
+use run_make_support::{fs_wrapper, rustc, wasmparser};
 use std::collections::HashMap;
 use wasmparser::TypeRef::Func;
 
@@ -8,7 +8,7 @@ fn main() {
     rustc().input("foo.rs").target("wasm32-wasip1").run();
     rustc().input("bar.rs").target("wasm32-wasip1").arg("-Clto").opt().run();
 
-    let file = std::fs::read("bar.wasm").unwrap();
+    let file = fs_wrapper::read("bar.wasm");
 
     let mut imports = HashMap::new();
     for payload in wasmparser::Parser::new(0).parse_all(&file) {

--- a/tests/run-make/wasm-panic-small/rmake.rs
+++ b/tests/run-make/wasm-panic-small/rmake.rs
@@ -1,7 +1,7 @@
 //@ only-wasm32-wasip1
 #![deny(warnings)]
 
-use run_make_support::rustc;
+use run_make_support::{fs_wrapper, rustc};
 
 fn main() {
     test("a");
@@ -15,7 +15,7 @@ fn test(cfg: &str) {
 
     rustc().input("foo.rs").target("wasm32-wasip1").arg("-Clto").opt().cfg(cfg).run();
 
-    let bytes = std::fs::read("foo.wasm").unwrap();
+    let bytes = fs_wrapper::read("foo.wasm");
     println!("{}", bytes.len());
     assert!(bytes.len() < 40_000);
 }

--- a/tests/run-make/wasm-spurious-import/rmake.rs
+++ b/tests/run-make/wasm-spurious-import/rmake.rs
@@ -1,6 +1,6 @@
 //@ only-wasm32-wasip1
 
-use run_make_support::{rustc, wasmparser};
+use run_make_support::{fs_wrapper, rustc, wasmparser};
 use std::collections::HashMap;
 
 fn main() {
@@ -13,7 +13,7 @@ fn main() {
         .arg("-Copt-level=z")
         .run();
 
-    let file = std::fs::read("main.wasm").unwrap();
+    let file = fs_wrapper::read("main.wasm");
 
     let mut imports = HashMap::new();
     for payload in wasmparser::Parser::new(0).parse_all(&file) {

--- a/tests/run-make/wasm-stringify-ints-small/rmake.rs
+++ b/tests/run-make/wasm-stringify-ints-small/rmake.rs
@@ -1,12 +1,12 @@
 //@ only-wasm32-wasip1
 #![deny(warnings)]
 
-use run_make_support::rustc;
+use run_make_support::{fs_wrapper, rustc};
 
 fn main() {
     rustc().input("foo.rs").target("wasm32-wasip1").arg("-Clto").opt().run();
 
-    let bytes = std::fs::read("foo.wasm").unwrap();
+    let bytes = fs_wrapper::read("foo.wasm");
     println!("{}", bytes.len());
     assert!(bytes.len() < 50_000);
 }

--- a/tests/run-make/wasm-symbols-different-module/rmake.rs
+++ b/tests/run-make/wasm-symbols-different-module/rmake.rs
@@ -1,6 +1,6 @@
 //@ only-wasm32-wasip1
 
-use run_make_support::{rustc, wasmparser};
+use run_make_support::{fs_wrapper, rustc, wasmparser};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
@@ -23,7 +23,7 @@ fn test(file: &str, args: &[&str], expected_imports: &[(&str, &[&str])]) {
 
     rustc().input(file).target("wasm32-wasip1").args(args).run();
 
-    let file = std::fs::read(Path::new(file).with_extension("wasm")).unwrap();
+    let file = fs_wrapper::read(Path::new(file).with_extension("wasm"));
 
     let mut imports = HashMap::new();
     for payload in wasmparser::Parser::new(0).parse_all(&file) {

--- a/tests/run-make/wasm-symbols-not-exported/rmake.rs
+++ b/tests/run-make/wasm-symbols-not-exported/rmake.rs
@@ -1,6 +1,6 @@
 //@ only-wasm32-wasip1
 
-use run_make_support::{rustc, wasmparser};
+use run_make_support::{fs_wrapper, rustc, wasmparser};
 use std::path::Path;
 
 fn main() {
@@ -17,7 +17,7 @@ fn main() {
 
 fn verify_symbols(path: &Path) {
     eprintln!("verify {path:?}");
-    let file = std::fs::read(&path).unwrap();
+    let file = fs_wrapper::read(&path);
 
     for payload in wasmparser::Parser::new(0).parse_all(&file) {
         let payload = payload.unwrap();

--- a/tests/run-make/wasm-symbols-not-imported/rmake.rs
+++ b/tests/run-make/wasm-symbols-not-imported/rmake.rs
@@ -1,6 +1,6 @@
 //@ only-wasm32-wasip1
 
-use run_make_support::{rustc, wasmparser};
+use run_make_support::{fs_wrapper, rustc, wasmparser};
 use std::path::Path;
 
 fn main() {
@@ -16,7 +16,7 @@ fn main() {
 
 fn verify_symbols(path: &Path) {
     eprintln!("verify {path:?}");
-    let file = std::fs::read(&path).unwrap();
+    let file = fs_wrapper::read(&path);
 
     for payload in wasmparser::Parser::new(0).parse_all(&file) {
         let payload = payload.unwrap();

--- a/tests/run-make/windows-ws2_32/rmake.rs
+++ b/tests/run-make/windows-ws2_32/rmake.rs
@@ -3,8 +3,7 @@
 // Tests that WS2_32.dll is not unnecessarily linked, see issue #85441
 
 use run_make_support::object::{self, read::Object};
-use run_make_support::rustc;
-use std::fs;
+use run_make_support::{fs_wrapper, rustc};
 
 fn main() {
     rustc().input("empty.rs").run();
@@ -15,7 +14,7 @@ fn main() {
 }
 
 fn links_ws2_32(exe: &str) -> bool {
-    let binary_data = fs::read(exe).unwrap();
+    let binary_data = fs_wrapper::read(exe);
     let file = object::File::parse(&*binary_data).unwrap();
     for import in file.imports().unwrap() {
         if import.library().eq_ignore_ascii_case(b"WS2_32.dll") {


### PR DESCRIPTION
Suggested by #125728.

The point of this wrapper is to stop silent fails caused by forgetting to `unwrap` `fs` functions. However, functions like `fs::read` which return something and get stored in a variable should cause a failure on their own if they are not unwrapped (as the `Result` will be stored in the variable, and something will be done on that `Result` that should have been done to its contents). Is it still pertinent to wrap `fs::read_to_string`, `fs::metadata` and so on?

Closes: https://github.com/rust-lang/rust/issues/125728

try-job: x86_64-msvc
try-job: i686-mingw