### PR TITLE
drop_in_place: weaken the claim of equivalence with drop(ptr.read())

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -450,7 +450,7 @@ mod mut_ptr;
 
 /// Executes the destructor (if any) of the pointed-to value.
 ///
-/// This is semantically equivalent to calling [`ptr::read`] and discarding
+/// This is almost the same as calling [`ptr::read`] and discarding
 /// the result, but has the following advantages:
 ///
 /// * It is *required* to use `drop_in_place` to drop unsized types like

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -452,6 +452,11 @@ mod mut_ptr;
 ///
 /// This is almost the same as calling [`ptr::read`] and discarding
 /// the result, but has the following advantages:
+// FIXME: say something more useful than "almost the same"?
+// There are open questions here: `read` requires the value to be fully valid, e.g. if `T` is a
+// `bool` it must be 0 or 1, if it is a reference then it must be dereferenceable. `drop_in_place`
+// only requires that `*to_drop` be "valid for dropping" and we have not defined what that means. In
+// Miri it currently (May 2024) requires nothing at all for types without drop glue.
 ///
 /// * It is *required* to use `drop_in_place` to drop unsized types like
 ///   trait objects, because they can't be read out onto the stack and

--- a/src/tools/miri/tests/pass/drop_in_place.rs
+++ b/src/tools/miri/tests/pass/drop_in_place.rs
@@ -1,0 +1,12 @@
+// Miri currently doesn't require types without drop glue to be
+// valid when dropped. This test confirms that behavior.
+// This is not a stable guarantee!
+
+use std::ptr;
+
+fn main() {
+    let mut not_a_bool = 13u8;
+    unsafe {
+        ptr::drop_in_place(&mut not_a_bool as *mut u8 as *mut bool)
+    };
+}


### PR DESCRIPTION
The two are *not* semantically equivalent in all cases, so let's not be so definite about this.

Fixes https://github.com/rust-lang/rust/issues/112015