### PR TITLE
Stop using `translate_args` in the new solver

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
@@ -12,7 +12,6 @@ use rustc_middle::bug;
 use rustc_middle::traits::solve::{
     inspect, CanonicalInput, CanonicalResponse, Certainty, PredefinedOpaquesData, QueryResult,
 };
-use rustc_middle::traits::specialization_graph;
 use rustc_middle::ty::AliasRelationDirection;
 use rustc_middle::ty::TypeFolder;
 use rustc_middle::ty::{
@@ -898,16 +897,6 @@ impl<'tcx> EvalCtxt<'_, InferCtxt<'tcx>> {
             self.inspect.add_var_value(arg);
         }
         args
-    }
-
-    pub(super) fn translate_args(
-        &self,
-        param_env: ty::ParamEnv<'tcx>,
-        source_impl: DefId,
-        source_args: ty::GenericArgsRef<'tcx>,
-        target_node: specialization_graph::Node,
-    ) -> ty::GenericArgsRef<'tcx> {
-        crate::traits::translate_args(self.infcx, param_env, source_impl, source_args, target_node)
     }
 
     pub(super) fn register_ty_outlives(&self, ty: Ty<'tcx>, lt: ty::Region<'tcx>) {

--- a/tests/ui/specialization/source-impl-requires-constraining-predicates-ambig.next.stderr
+++ b/tests/ui/specialization/source-impl-requires-constraining-predicates-ambig.next.stderr
@@ -1,0 +1,12 @@
+warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/source-impl-requires-constraining-predicates-ambig.rs:14:12
+   |
+LL | #![feature(specialization)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
+   = help: consider using `min_specialization` instead, which is more stable and complete
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/specialization/source-impl-requires-constraining-predicates-ambig.rs
+++ b/tests/ui/specialization/source-impl-requires-constraining-predicates-ambig.rs
@@ -1,0 +1,29 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@[next] check-pass
+//@[current] known-bug: unknown
+//@[current] failure-status: 101
+//@[current] dont-check-compiler-stderr
+
+// Tests that rebasing from the concrete impl to the default impl also processes the
+// `[u32; 0]: IntoIterator<Item = ?U>` predicate to constrain the `?U` impl arg.
+// This test also makes sure that we don't do anything weird when rebasing the args
+// is ambiguous.
+
+#![feature(specialization)]
+//[next]~^ WARN the feature `specialization` is incomplete
+
+trait Spec {
+    type Assoc;
+}
+
+default impl<T, U> Spec for T where T: IntoIterator<Item = U> {
+    type Assoc = U;
+}
+
+impl<T> Spec for [T; 0] {}
+
+fn main() {
+    let x: <[_; 0] as Spec>::Assoc = 1;
+}

--- a/tests/ui/specialization/source-impl-requires-constraining-predicates.current.stderr
+++ b/tests/ui/specialization/source-impl-requires-constraining-predicates.current.stderr
@@ -1,0 +1,12 @@
+warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/source-impl-requires-constraining-predicates.rs:9:12
+   |
+LL | #![feature(specialization)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
+   = help: consider using `min_specialization` instead, which is more stable and complete
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/specialization/source-impl-requires-constraining-predicates.next.stderr
+++ b/tests/ui/specialization/source-impl-requires-constraining-predicates.next.stderr
@@ -1,0 +1,12 @@
+warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/source-impl-requires-constraining-predicates.rs:9:12
+   |
+LL | #![feature(specialization)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
+   = help: consider using `min_specialization` instead, which is more stable and complete
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/specialization/source-impl-requires-constraining-predicates.rs
+++ b/tests/ui/specialization/source-impl-requires-constraining-predicates.rs
@@ -1,0 +1,24 @@
+//@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+// Tests that rebasing from the concrete impl to the default impl also processes the
+// `[u32; 0]: IntoIterator<Item = ?U>` predicate to constrain the `?U` impl arg.
+
+#![feature(specialization)]
+//~^ WARN the feature `specialization` is incomplete
+
+trait Spec {
+    type Assoc;
+}
+
+default impl<T, U> Spec for T where T: IntoIterator<Item = U> {
+    type Assoc = U;
+}
+
+impl<T> Spec for [T; 0] {}
+
+fn main() {
+    let x: <[u32; 0] as Spec>::Assoc = 1;
+}


### PR DESCRIPTION
It was unnecessary and also sketchy, since it was doing an out-of-search-graph fulfillment loop. Added a test for the only really minor subtlety of translating args, though not sure if it was being tested before, though I wouldn't be surprised if it wasn't.

r? lcnr