### PR TITLE
Use parenthetical notation for `Fn` traits

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1362,7 +1362,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     match *predicate.self_ty().kind() {
                         ty::Param(param_ty) => Ok((
                             generics.type_param(param_ty, tcx),
-                            predicate.trait_ref.print_only_trait_path().to_string(),
+                            predicate.trait_ref.print_trait_sugared().to_string(),
                         )),
                         _ => Err(()),
                     }

--- a/compiler/rustc_const_eval/src/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/check_consts/ops.rs
@@ -113,7 +113,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
                     if let Some(generics) = tcx.hir_node_by_def_id(caller).generics() {
                         let constraint = with_no_trimmed_paths!(format!(
                             "~const {}",
-                            trait_ref.print_only_trait_path()
+                            trait_ref.print_trait_sugared(),
                         ));
                         suggest_constraining_type_param(
                             tcx,

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -554,7 +554,7 @@ fn infringing_fields_error(
                         if let ty::Param(_) = ty.kind() {
                             bounds.push((
                                 format!("{ty}"),
-                                trait_ref.print_only_trait_path().to_string(),
+                                trait_ref.print_trait_sugared().to_string(),
                                 Some(trait_ref.def_id),
                             ));
                         }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3197,7 +3197,7 @@ define_print_and_forward_display! {
         if let ty::PredicatePolarity::Negative = self.0.polarity {
             p!("!")
         }
-        p!(print(self.0.trait_ref.print_only_trait_path()));
+        p!(print(self.0.trait_ref.print_trait_sugared()));
     }
 
     PrintClosureAsImpl<'tcx> {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -29,10 +29,11 @@ use rustc_macros::extension;
 use rustc_middle::hir::map;
 use rustc_middle::traits::IsConstable;
 use rustc_middle::ty::error::TypeError::{self, Sorts};
+use rustc_middle::ty::print::PrintPolyTraitRefExt;
 use rustc_middle::ty::{
     self, suggest_arbitrary_trait_bound, suggest_constraining_type_param, AdtKind, GenericArgs,
-    InferTy, IsSuggestable, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
-    TypeVisitableExt, TypeckResults, Upcast,
+    InferTy, IsSuggestable, ToPolyTraitRef, Ty, TyCtxt, TypeFoldable, TypeFolder,
+    TypeSuperFoldable, TypeVisitableExt, TypeckResults, Upcast,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::def_id::LocalDefId;
@@ -219,15 +220,15 @@ pub fn suggest_restriction<'tcx, G: EmissionGuarantee>(
             (_, None) => predicate_constraint(hir_generics, trait_pred.upcast(tcx)),
             (None, Some((ident, []))) => (
                 ident.span.shrink_to_hi(),
-                format!(": {}", trait_pred.print_modifiers_and_trait_path()),
+                format!(": {}", trait_pred.to_poly_trait_ref().print_trait_sugared()),
             ),
             (_, Some((_, [.., bounds]))) => (
                 bounds.span().shrink_to_hi(),
-                format!(" + {}", trait_pred.print_modifiers_and_trait_path()),
+                format!(" + {}", trait_pred.to_poly_trait_ref().print_trait_sugared()),
             ),
             (Some(_), Some((_, []))) => (
                 hir_generics.span.shrink_to_hi(),
-                format!(": {}", trait_pred.print_modifiers_and_trait_path()),
+                format!(": {}", trait_pred.to_poly_trait_ref().print_trait_sugared()),
             ),
         };
 

--- a/tests/ui/async-await/async-fn/impl-header.stderr
+++ b/tests/ui/async-await/async-fn/impl-header.stderr
@@ -28,7 +28,7 @@ error[E0277]: expected a `FnMut()` closure, found `F`
 LL | impl async Fn<()> for F {}
    |                       ^ expected an `FnMut()` closure, found `F`
    |
-   = help: the trait `FnMut<()>` is not implemented for `F`
+   = help: the trait `FnMut()` is not implemented for `F`
    = note: wrap the `F` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/closures/closure-expected.stderr
+++ b/tests/ui/closures/closure-expected.stderr
@@ -6,7 +6,7 @@ LL |     let y = x.or_else(4);
    |               |
    |               required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<()>` is not implemented for `{integer}`
+   = help: the trait `FnOnce()` is not implemented for `{integer}`
    = note: wrap the `{integer}` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Option::<T>::or_else`
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/ui/closures/coerce-unsafe-to-closure.stderr
+++ b/tests/ui/closures/coerce-unsafe-to-closure.stderr
@@ -6,7 +6,7 @@ LL |     let x: Option<&[u8]> = Some("foo").map(std::mem::transmute);
    |                                        |
    |                                        required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<(&str,)>` is not implemented for fn item `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
+   = help: the trait `FnOnce(&str)` is not implemented for fn item `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `Option::<T>::map`
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -107,8 +107,8 @@ LL |     f()
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider further restricting this bound
    |
-LL |     T: ~const Fn<()> + ~const Destruct + ~const std::ops::Fn<()>,
-   |                                        +++++++++++++++++++++++++
+LL |     T: ~const Fn<()> + ~const Destruct + ~const Fn(),
+   |                                        +++++++++++++
 help: add `#![feature(effects)]` to the crate attributes to enable
    |
 LL + #![feature(effects)]
@@ -132,8 +132,8 @@ LL |     f()
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider further restricting this bound
    |
-LL |     T: ~const FnMut<()> + ~const Destruct + ~const std::ops::FnMut<()>,
-   |                                           ++++++++++++++++++++++++++++
+LL |     T: ~const FnMut<()> + ~const Destruct + ~const FnMut(),
+   |                                           ++++++++++++++++
 help: add `#![feature(effects)]` to the crate attributes to enable
    |
 LL + #![feature(effects)]
@@ -157,8 +157,8 @@ LL |     f()
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider further restricting this bound
    |
-LL |     T: ~const FnOnce<()> + ~const std::ops::FnOnce<()>,
-   |                          +++++++++++++++++++++++++++++
+LL |     T: ~const FnOnce<()> + ~const FnOnce(),
+   |                          +++++++++++++++++
 help: add `#![feature(effects)]` to the crate attributes to enable
    |
 LL + #![feature(effects)]

--- a/tests/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/tests/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -13,8 +13,8 @@ LL |             Opt::None => f(),
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider further restricting this bound
    |
-LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T + ~const std::ops::FnOnce<()>>(self, f: F) -> T {
-   |                                                     +++++++++++++++++++++++++++++
+LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T + ~const FnOnce()>(self, f: F) -> T {
+   |                                                     +++++++++++++++++
 help: add `#![feature(effects)]` to the crate attributes to enable
    |
 LL + #![feature(effects)]

--- a/tests/ui/expr/malformed_closure/block_instead_of_closure_in_arg.stderr
+++ b/tests/ui/expr/malformed_closure/block_instead_of_closure_in_arg.stderr
@@ -14,7 +14,7 @@ LL | ||         }
 LL | |      });
    | |______^ expected an `FnOnce(&bool)` closure, found `bool`
    |
-   = help: the trait `for<'a> FnOnce<(&'a bool,)>` is not implemented for `bool`
+   = help: the trait `for<'a> FnOnce(&'a bool)` is not implemented for `bool`
 note: required by a bound in `Option::<T>::filter`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 help: you might have meant to create the closure instead of a block

--- a/tests/ui/expr/malformed_closure/ruby_style_closure_successful_parse.stderr
+++ b/tests/ui/expr/malformed_closure/ruby_style_closure_successful_parse.stderr
@@ -11,7 +11,7 @@ LL | |         Some(x * 2)
 LL | |     });
    | |_____^ expected an `FnOnce({integer})` closure, found `Option<usize>`
    |
-   = help: the trait `FnOnce<({integer},)>` is not implemented for `Option<usize>`
+   = help: the trait `FnOnce({integer})` is not implemented for `Option<usize>`
 note: required by a bound in `Option::<T>::and_then`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 help: you might have meant to open the closure body instead of placing a closure within a block

--- a/tests/ui/extern/extern-wrong-value-type.stderr
+++ b/tests/ui/extern/extern-wrong-value-type.stderr
@@ -6,7 +6,7 @@ LL |     is_fn(f);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for fn item `extern "C" fn() {f}`
+   = help: the trait `Fn()` is not implemented for fn item `extern "C" fn() {f}`
    = note: wrap the `extern "C" fn() {f}` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `is_fn`
   --> $DIR/extern-wrong-value-type.rs:4:28

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -80,7 +80,7 @@ error[E0277]: expected a `FnMut()` closure, found `Foo`
 LL | impl Fn<()> for Foo {
    |                 ^^^ expected an `FnMut()` closure, found `Foo`
    |
-   = help: the trait `FnMut<()>` is not implemented for `Foo`
+   = help: the trait `FnMut()` is not implemented for `Foo`
    = note: wrap the `Foo` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -149,7 +149,7 @@ error[E0277]: expected a `FnOnce()` closure, found `Bar`
 LL | impl FnMut<()> for Bar {
    |                    ^^^ expected an `FnOnce()` closure, found `Bar`
    |
-   = help: the trait `FnOnce<()>` is not implemented for `Bar`
+   = help: the trait `FnOnce()` is not implemented for `Bar`
    = note: wrap the `Bar` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `FnMut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/fn/fn-trait-formatting.stderr
+++ b/tests/ui/fn/fn-trait-formatting.stderr
@@ -47,7 +47,7 @@ LL |     needs_fn(1);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<(isize,)>` is not implemented for `{integer}`
+   = help: the trait `Fn(isize)` is not implemented for `{integer}`
 note: required by a bound in `needs_fn`
   --> $DIR/fn-trait-formatting.rs:1:31
    |

--- a/tests/ui/fn/issue-39259.stderr
+++ b/tests/ui/fn/issue-39259.stderr
@@ -16,7 +16,7 @@ error[E0277]: expected a `FnMut(u32)` closure, found `S`
 LL | impl Fn(u32) -> u32 for S {
    |                         ^ expected an `FnMut(u32)` closure, found `S`
    |
-   = help: the trait `FnMut<(u32,)>` is not implemented for `S`
+   = help: the trait `FnMut(u32)` is not implemented for `S`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 

--- a/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
+++ b/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
@@ -12,8 +12,8 @@ LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
 help: consider restricting type parameter `T`
    |
-LL | impl<T: std::ops::Fn<()>> Fun for T {
-   |       ++++++++++++++++++
+LL | impl<T: Fn()> Fun for T {
+   |       ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generic-associated-types/issue-68643-broken-mir.stderr
+++ b/tests/ui/generic-associated-types/issue-68643-broken-mir.stderr
@@ -12,8 +12,8 @@ LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
 help: consider restricting type parameter `T`
    |
-LL | impl<T: std::ops::Fn<()>> Fun for T {
-   |       ++++++++++++++++++
+LL | impl<T: Fn()> Fun for T {
+   |       ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generic-associated-types/issue-68644-codegen-selection.stderr
+++ b/tests/ui/generic-associated-types/issue-68644-codegen-selection.stderr
@@ -12,8 +12,8 @@ LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
 help: consider restricting type parameter `T`
    |
-LL | impl<T: std::ops::Fn<()>> Fun for T {
-   |       ++++++++++++++++++
+LL | impl<T: Fn()> Fun for T {
+   |       ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
+++ b/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
@@ -12,8 +12,8 @@ LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
 help: consider restricting type parameter `T`
    |
-LL | impl<T: std::ops::Fn<()>> Fun for T {
-   |       ++++++++++++++++++
+LL | impl<T: Fn()> Fun for T {
+   |       ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/normalize-tait-in-const.stderr
+++ b/tests/ui/impl-trait/normalize-tait-in-const.stderr
@@ -13,8 +13,8 @@ LL |     fun(filter_positive());
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider further restricting this bound
    |
-LL | const fn with_positive<F: ~const for<'a> Fn(&'a Alias<'a>) + ~const Destruct + ~const std::ops::Fn<(&Alias<'_>,)>>(fun: F) {
-   |                                                                              ++++++++++++++++++++++++++++++++++++
+LL | const fn with_positive<F: ~const for<'a> Fn(&'a Alias<'a>) + ~const Destruct + ~const Fn(&Alias<'_>)>(fun: F) {
+   |                                                                              +++++++++++++++++++++++
 help: add `#![feature(effects)]` to the crate attributes to enable
    |
 LL + #![feature(effects)]

--- a/tests/ui/intrinsics/const-eval-select-bad.stderr
+++ b/tests/ui/intrinsics/const-eval-select-bad.stderr
@@ -24,7 +24,7 @@ LL |     const_eval_select((), 42, 0xDEADBEEF);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<()>` is not implemented for `{integer}`
+   = help: the trait `FnOnce()` is not implemented for `{integer}`
    = note: wrap the `{integer}` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `const_eval_select`
   --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
@@ -37,7 +37,7 @@ LL |     const_eval_select((), 42, 0xDEADBEEF);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<()>` is not implemented for `{integer}`
+   = help: the trait `FnOnce()` is not implemented for `{integer}`
    = note: wrap the `{integer}` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `const_eval_select`
   --> $SRC_DIR/core/src/intrinsics.rs:LL:COL

--- a/tests/ui/issues/issue-22034.stderr
+++ b/tests/ui/issues/issue-22034.stderr
@@ -4,7 +4,7 @@ error[E0277]: expected a `Fn()` closure, found `()`
 LL |         &mut *(ptr as *mut dyn Fn())
    |                ^^^ expected an `Fn()` closure, found `()`
    |
-   = help: the trait `Fn<()>` is not implemented for `()`
+   = help: the trait `Fn()` is not implemented for `()`
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`
    = note: required for the cast from `*mut ()` to `*mut dyn Fn()`
 

--- a/tests/ui/issues/issue-23966.stderr
+++ b/tests/ui/issues/issue-23966.stderr
@@ -6,7 +6,7 @@ LL |     "".chars().fold(|_, _| (), ());
    |                |
    |                required by a bound introduced by this call
    |
-   = help: the trait `FnMut<(_, char)>` is not implemented for `()`
+   = help: the trait `FnMut(_, char)` is not implemented for `()`
 note: required by a bound in `fold`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
@@ -10,7 +10,7 @@ LL | | F:,
 LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
    | |__________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
-   = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
 error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:10
@@ -18,7 +18,7 @@ error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 LL | async fn wrapper<F>(f: F)
    |          ^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
-   = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
 error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:1
@@ -32,7 +32,7 @@ LL | | F:,
 LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
    | |__________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
-   = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
 error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:1
@@ -46,7 +46,7 @@ LL | | F:,
 LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
    | |__________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
-   = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
@@ -59,7 +59,7 @@ LL | |     &mut i;
 LL | | }
    | |_^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
-   = help: the trait `for<'a> FnOnce<(&'a mut i32,)>` is not implemented for `i32`
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/lifetimes/issue-95023.stderr
+++ b/tests/ui/lifetimes/issue-95023.stderr
@@ -38,7 +38,7 @@ error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
 LL | impl Fn(&isize) for Error {
    |                     ^^^^^ expected an `FnMut(&isize)` closure, found `Error`
    |
-   = help: the trait `FnMut<(&isize,)>` is not implemented for `Error`
+   = help: the trait `FnMut(&isize)` is not implemented for `Error`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 

--- a/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
+++ b/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
@@ -26,7 +26,7 @@ LL |     let _ = produces_string().and_then(takes_str_but_wrong_abi);
    |                               |
    |                               required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<(String,)>` is not implemented for fn item `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+   = help: the trait `FnOnce(String)` is not implemented for fn item `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
 note: required by a bound in `Option::<T>::and_then`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 
@@ -38,7 +38,7 @@ LL |     let _ = produces_string().and_then(takes_str_but_unsafe);
    |                               |
    |                               required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<(String,)>` is not implemented for fn item `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+   = help: the trait `FnOnce(String)` is not implemented for fn item `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `Option::<T>::and_then`
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
@@ -6,7 +6,7 @@ LL |     call(foo);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for fn item `fn() {foo}`
+   = help: the trait `Fn()` is not implemented for fn item `fn() {foo}`
    = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call`
@@ -23,7 +23,7 @@ LL |     call_mut(foo);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnMut<()>` is not implemented for fn item `fn() {foo}`
+   = help: the trait `FnMut()` is not implemented for fn item `fn() {foo}`
    = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_mut`
@@ -40,7 +40,7 @@ LL |     call_once(foo);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<()>` is not implemented for fn item `fn() {foo}`
+   = help: the trait `FnOnce()` is not implemented for fn item `fn() {foo}`
    = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_once`
@@ -57,7 +57,7 @@ LL |     call(foo_unsafe);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for fn item `unsafe fn() {foo_unsafe}`
+   = help: the trait `Fn()` is not implemented for fn item `unsafe fn() {foo_unsafe}`
    = note: unsafe function cannot be called generically without an unsafe block
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
@@ -75,7 +75,7 @@ LL |     call_mut(foo_unsafe);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnMut<()>` is not implemented for fn item `unsafe fn() {foo_unsafe}`
+   = help: the trait `FnMut()` is not implemented for fn item `unsafe fn() {foo_unsafe}`
    = note: unsafe function cannot be called generically without an unsafe block
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
@@ -93,7 +93,7 @@ LL |     call_once(foo_unsafe);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<()>` is not implemented for fn item `unsafe fn() {foo_unsafe}`
+   = help: the trait `FnOnce()` is not implemented for fn item `unsafe fn() {foo_unsafe}`
    = note: unsafe function cannot be called generically without an unsafe block
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method-fail.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method-fail.stderr
@@ -13,8 +13,8 @@ LL |     x(())
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider further restricting this bound
    |
-LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const std::ops::FnOnce<((),)>>(x: T) -> i32 {
-   |                                                         ++++++++++++++++++++++++++++++++
+LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const FnOnce(())>(x: T) -> i32 {
+   |                                                         +++++++++++++++++++
 help: add `#![feature(effects)]` to the crate attributes to enable
    |
 LL + #![feature(effects)]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method.stderr
@@ -13,8 +13,8 @@ LL |     x(())
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider further restricting this bound
    |
-LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const std::ops::FnOnce<((),)>>(x: T) -> i32 {
-   |                                                         ++++++++++++++++++++++++++++++++
+LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const FnOnce(())>(x: T) -> i32 {
+   |                                                         +++++++++++++++++++
 help: add `#![feature(effects)]` to the crate attributes to enable
    |
 LL + #![feature(effects)]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closures.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closures.stderr
@@ -31,8 +31,8 @@ LL |     f() + f()
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider further restricting this bound
    |
-LL | const fn answer<F: ~const Fn() -> u8 + ~const std::ops::Fn<()>>(f: &F) -> u8 {
-   |                                      +++++++++++++++++++++++++
+LL | const fn answer<F: ~const Fn() -> u8 + ~const Fn()>(f: &F) -> u8 {
+   |                                      +++++++++++++
 help: add `#![feature(effects)]` to the crate attributes to enable
    |
 LL + #![feature(effects)]
@@ -47,8 +47,8 @@ LL |     f() + f()
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider further restricting this bound
    |
-LL | const fn answer<F: ~const Fn() -> u8 + ~const std::ops::Fn<()>>(f: &F) -> u8 {
-   |                                      +++++++++++++++++++++++++
+LL | const fn answer<F: ~const Fn() -> u8 + ~const Fn()>(f: &F) -> u8 {
+   |                                      +++++++++++++
 help: add `#![feature(effects)]` to the crate attributes to enable
    |
 LL + #![feature(effects)]
@@ -63,8 +63,8 @@ LL |     f() * 7
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider further restricting this bound
    |
-LL |         F: ~const FnOnce() -> u8 + ~const std::ops::Fn<()>,
-   |                                  +++++++++++++++++++++++++
+LL |         F: ~const FnOnce() -> u8 + ~const Fn(),
+   |                                  +++++++++++++
 help: add `#![feature(effects)]` to the crate attributes to enable
    |
 LL + #![feature(effects)]

--- a/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.stderr
+++ b/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.stderr
@@ -4,7 +4,7 @@ error[E0277]: expected a `FnOnce(&i32)` closure, found `i32`
 LL |     f::<dyn for<'x> X<'x, F = i32>>();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnOnce(&i32)` closure, found `i32`
    |
-   = help: the trait `for<'a> FnOnce<(&'a i32,)>` is not implemented for `i32`
+   = help: the trait `for<'a> FnOnce(&'a i32)` is not implemented for `i32`
 note: required by a bound in `f`
   --> $DIR/check-trait-object-bounds-2.rs:8:9
    |

--- a/tests/ui/traits/bound/assoc-fn-bound-root-obligation.rs
+++ b/tests/ui/traits/bound/assoc-fn-bound-root-obligation.rs
@@ -2,7 +2,7 @@ fn strip_lf(s: &str) -> &str {
     s.strip_suffix(b'\n').unwrap_or(s)
     //~^ ERROR expected a `FnMut(char)` closure, found `u8`
     //~| NOTE expected an `FnMut(char)` closure, found `u8`
-    //~| HELP the trait `FnMut<(char,)>` is not implemented for `u8`
+    //~| HELP the trait `FnMut(char)` is not implemented for `u8`
     //~| HELP the following other types implement trait `Pattern<'a>`:
     //~| NOTE required for `u8` to implement `Pattern<'_>`
 

--- a/tests/ui/traits/bound/assoc-fn-bound-root-obligation.stderr
+++ b/tests/ui/traits/bound/assoc-fn-bound-root-obligation.stderr
@@ -4,7 +4,7 @@ error[E0277]: expected a `FnMut(char)` closure, found `u8`
 LL |     s.strip_suffix(b'\n').unwrap_or(s)
    |       ^^^^^^^^^^^^ expected an `FnMut(char)` closure, found `u8`
    |
-   = help: the trait `FnMut<(char,)>` is not implemented for `u8`, which is required by `u8: Pattern<'_>`
+   = help: the trait `FnMut(char)` is not implemented for `u8`, which is required by `u8: Pattern<'_>`
    = help: the following other types implement trait `Pattern<'a>`:
              &'b String
              &'b [char; N]

--- a/tests/ui/traits/issue-87558.stderr
+++ b/tests/ui/traits/issue-87558.stderr
@@ -30,7 +30,7 @@ error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
 LL | impl Fn(&isize) for Error {
    |                     ^^^^^ expected an `FnMut(&isize)` closure, found `Error`
    |
-   = help: the trait `FnMut<(&isize,)>` is not implemented for `Error`
+   = help: the trait `FnMut(&isize)` is not implemented for `Error`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 

--- a/tests/ui/traits/next-solver/fn-trait.stderr
+++ b/tests/ui/traits/next-solver/fn-trait.stderr
@@ -6,7 +6,7 @@ LL |     require_fn(f as unsafe fn() -> i32);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for `unsafe fn() -> i32`
+   = help: the trait `Fn()` is not implemented for `unsafe fn() -> i32`
    = note: unsafe function cannot be called generically without an unsafe block
    = note: wrap the `unsafe fn() -> i32` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `require_fn`
@@ -37,7 +37,7 @@ LL |     require_fn(g);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for fn item `extern "C" fn() -> i32 {g}`
+   = help: the trait `Fn()` is not implemented for fn item `extern "C" fn() -> i32 {g}`
    = note: wrap the `extern "C" fn() -> i32 {g}` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `require_fn`
   --> $DIR/fn-trait.rs:3:23
@@ -67,7 +67,7 @@ LL |     require_fn(g as extern "C" fn() -> i32);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for `extern "C" fn() -> i32`
+   = help: the trait `Fn()` is not implemented for `extern "C" fn() -> i32`
    = note: wrap the `extern "C" fn() -> i32` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `require_fn`
   --> $DIR/fn-trait.rs:3:23
@@ -97,7 +97,7 @@ LL |     require_fn(h);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for fn item `unsafe fn() -> i32 {h}`
+   = help: the trait `Fn()` is not implemented for fn item `unsafe fn() -> i32 {h}`
    = note: unsafe function cannot be called generically without an unsafe block
    = note: wrap the `unsafe fn() -> i32 {h}` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `require_fn`

--- a/tests/ui/traits/suggest-dereferences/root-obligation.stderr
+++ b/tests/ui/traits/suggest-dereferences/root-obligation.stderr
@@ -2,11 +2,11 @@ error[E0277]: the trait bound `&char: Pattern<'_>` is not satisfied
   --> $DIR/root-obligation.rs:6:38
    |
 LL |         .filter(|c| "aeiou".contains(c))
-   |                             -------- ^ the trait `Fn<(char,)>` is not implemented for `&char`, which is required by `&char: Pattern<'_>`
+   |                             -------- ^ the trait `Fn(char)` is not implemented for `&char`, which is required by `&char: Pattern<'_>`
    |                             |
    |                             required by a bound introduced by this call
    |
-   = note: required for `&char` to implement `FnOnce<(char,)>`
+   = note: required for `&char` to implement `FnOnce(char)`
    = note: required for `&char` to implement `Pattern<'_>`
 note: required by a bound in `core::str::<impl str>::contains`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL

--- a/tests/ui/type-alias-impl-trait/issue-63279.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-63279.stderr
@@ -4,7 +4,7 @@ error[E0277]: expected a `FnOnce()` closure, found `()`
 LL | fn c() -> Closure {
    |           ^^^^^^^ expected an `FnOnce()` closure, found `()`
    |
-   = help: the trait `FnOnce<()>` is not implemented for `()`
+   = help: the trait `FnOnce()` is not implemented for `()`
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`
 
 error[E0277]: expected a `FnOnce()` closure, found `()`
@@ -13,7 +13,7 @@ error[E0277]: expected a `FnOnce()` closure, found `()`
 LL |     || -> Closure { || () }
    |           ^^^^^^^ expected an `FnOnce()` closure, found `()`
    |
-   = help: the trait `FnOnce<()>` is not implemented for `()`
+   = help: the trait `FnOnce()` is not implemented for `()`
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`
 
 error[E0308]: mismatched types

--- a/tests/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -6,7 +6,7 @@ LL |     let x = call_it(&S, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `Fn<(isize,)>` is not implemented for `S`
+   = help: the trait `Fn(isize)` is not implemented for `S`
    = note: `S` implements `FnMut`, but it must implement `Fn`, which is more general
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-fnmut-as-fn.rs:22:14

--- a/tests/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
@@ -6,7 +6,7 @@ LL |     let x = call_it(&square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> Fn<(&'a isize,)>` is not implemented for fn item `for<'a> unsafe fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> Fn(&'a isize)` is not implemented for fn item `for<'a> unsafe fn(&'a isize) -> isize {square}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:9:15
@@ -22,7 +22,7 @@ LL |     let y = call_it_mut(&mut square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnMut<(&'a isize,)>` is not implemented for fn item `for<'a> unsafe fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> FnMut(&'a isize)` is not implemented for fn item `for<'a> unsafe fn(&'a isize) -> isize {square}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_mut`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:19
@@ -38,7 +38,7 @@ LL |     let z = call_it_once(square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnOnce<(&'a isize,)>` is not implemented for fn item `for<'a> unsafe fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> FnOnce(&'a isize)` is not implemented for fn item `for<'a> unsafe fn(&'a isize) -> isize {square}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_once`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:15:20

--- a/tests/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
@@ -6,7 +6,7 @@ LL |     let x = call_it(&square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> Fn<(&'a isize,)>` is not implemented for fn item `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> Fn(&'a isize)` is not implemented for fn item `for<'a> extern "C" fn(&'a isize) -> isize {square}`
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-wrong-abi.rs:9:15
    |
@@ -21,7 +21,7 @@ LL |     let y = call_it_mut(&mut square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnMut<(&'a isize,)>` is not implemented for fn item `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> FnMut(&'a isize)` is not implemented for fn item `for<'a> extern "C" fn(&'a isize) -> isize {square}`
 note: required by a bound in `call_it_mut`
   --> $DIR/unboxed-closures-wrong-abi.rs:12:19
    |
@@ -36,7 +36,7 @@ LL |     let z = call_it_once(square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnOnce<(&'a isize,)>` is not implemented for fn item `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> FnOnce(&'a isize)` is not implemented for fn item `for<'a> extern "C" fn(&'a isize) -> isize {square}`
 note: required by a bound in `call_it_once`
   --> $DIR/unboxed-closures-wrong-abi.rs:15:20
    |

--- a/tests/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
@@ -6,7 +6,7 @@ LL |     let x = call_it(&square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> Fn<(&'a isize,)>` is not implemented for fn item `unsafe fn(isize) -> isize {square}`
+   = help: the trait `for<'a> Fn(&'a isize)` is not implemented for fn item `unsafe fn(isize) -> isize {square}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:10:15
@@ -22,7 +22,7 @@ LL |     let y = call_it_mut(&mut square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnMut<(&'a isize,)>` is not implemented for fn item `unsafe fn(isize) -> isize {square}`
+   = help: the trait `for<'a> FnMut(&'a isize)` is not implemented for fn item `unsafe fn(isize) -> isize {square}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_mut`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:19
@@ -38,7 +38,7 @@ LL |     let z = call_it_once(square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnOnce<(&'a isize,)>` is not implemented for fn item `unsafe fn(isize) -> isize {square}`
+   = help: the trait `for<'a> FnOnce(&'a isize)` is not implemented for fn item `unsafe fn(isize) -> isize {square}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_once`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:16:20

--- a/tests/ui/unsafe/initializing-ranged-via-ctor.stderr
+++ b/tests/ui/unsafe/initializing-ranged-via-ctor.stderr
@@ -6,7 +6,7 @@ LL |     println!("{:?}", Some(1).map(NonZeroAndOneU8).unwrap());
    |                              |
    |                              required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<({integer},)>` is not implemented for fn item `unsafe fn(u8) -> NonZeroAndOneU8 {NonZeroAndOneU8}`
+   = help: the trait `FnOnce({integer})` is not implemented for fn item `unsafe fn(u8) -> NonZeroAndOneU8 {NonZeroAndOneU8}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `Option::<T>::map`
   --> $SRC_DIR/core/src/option.rs:LL:COL


### PR DESCRIPTION
Always use the `Fn(T) -> R` format when printing closure traits instead of `Fn<(T,), Output = R>`.

Address #67100:

```
error[E0277]: expected a `Fn()` closure, found `F`
 --> file.rs:6:13
  |
6 |     call_fn(f)
  |     ------- ^ expected an `Fn()` closure, found `F`
  |     |
  |     required by a bound introduced by this call
  |
  = note: wrap the `F` in a closure with no arguments: `|| { /* code */ }`
note: required by a bound in `call_fn`
 --> file.rs:1:15
  |
1 | fn call_fn<F: Fn() -> ()>(f: &F) {
  |               ^^^^^^^^^^ required by this bound in `call_fn`
help: consider further restricting this bound
  |
5 | fn call_any<F: std::any::Any + Fn()>(f: &F) {
  |                              ++++++
```