### PR TITLE
Fold item bounds before proving them in `check_type_bounds` in new solver

### DIFF
--- a/tests/ui/associated-types/defaults-suitability.current.stderr
+++ b/tests/ui/associated-types/defaults-suitability.current.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `NotClone: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:13:22
+  --> $DIR/defaults-suitability.rs:16:22
    |
 LL |     type Ty: Clone = NotClone;
    |                      ^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
    |
 note: required by a bound in `Tr::Ty`
-  --> $DIR/defaults-suitability.rs:13:14
+  --> $DIR/defaults-suitability.rs:16:14
    |
 LL |     type Ty: Clone = NotClone;
    |              ^^^^^ required by this bound in `Tr::Ty`
@@ -16,13 +16,13 @@ LL | struct NotClone;
    |
 
 error[E0277]: the trait bound `NotClone: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:22:15
+  --> $DIR/defaults-suitability.rs:25:15
    |
 LL |     type Ty = NotClone;
    |               ^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
    |
 note: required by a bound in `Tr2::Ty`
-  --> $DIR/defaults-suitability.rs:20:15
+  --> $DIR/defaults-suitability.rs:23:15
    |
 LL |     Self::Ty: Clone,
    |               ^^^^^ required by this bound in `Tr2::Ty`
@@ -36,14 +36,14 @@ LL | struct NotClone;
    |
 
 error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:28:23
+  --> $DIR/defaults-suitability.rs:31:23
    |
 LL |     type Bar: Clone = Vec<T>;
    |                       ^^^^^^ the trait `Clone` is not implemented for `T`, which is required by `Vec<T>: Clone`
    |
    = note: required for `Vec<T>` to implement `Clone`
 note: required by a bound in `Foo::Bar`
-  --> $DIR/defaults-suitability.rs:28:15
+  --> $DIR/defaults-suitability.rs:31:15
    |
 LL |     type Bar: Clone = Vec<T>;
    |               ^^^^^ required by this bound in `Foo::Bar`
@@ -53,30 +53,30 @@ LL | trait Foo<T: std::clone::Clone> {
    |            +++++++++++++++++++
 
 error[E0277]: the trait bound `(): Foo<Self>` is not satisfied
-  --> $DIR/defaults-suitability.rs:34:29
+  --> $DIR/defaults-suitability.rs:37:29
    |
 LL |     type Assoc: Foo<Self> = ();
    |                             ^^ the trait `Foo<Self>` is not implemented for `()`
    |
 help: this trait has no implementations, consider adding one
-  --> $DIR/defaults-suitability.rs:27:1
+  --> $DIR/defaults-suitability.rs:30:1
    |
 LL | trait Foo<T> {
    | ^^^^^^^^^^^^
 note: required by a bound in `Bar::Assoc`
-  --> $DIR/defaults-suitability.rs:34:17
+  --> $DIR/defaults-suitability.rs:37:17
    |
 LL |     type Assoc: Foo<Self> = ();
    |                 ^^^^^^^^^ required by this bound in `Bar::Assoc`
 
 error[E0277]: the trait bound `NotClone: IsU8<NotClone>` is not satisfied
-  --> $DIR/defaults-suitability.rs:56:18
+  --> $DIR/defaults-suitability.rs:59:18
    |
 LL |     type Assoc = NotClone;
    |                  ^^^^^^^^ the trait `IsU8<NotClone>` is not implemented for `NotClone`
    |
 note: required by a bound in `D::Assoc`
-  --> $DIR/defaults-suitability.rs:53:18
+  --> $DIR/defaults-suitability.rs:56:18
    |
 LL |     Self::Assoc: IsU8<Self::Assoc>,
    |                  ^^^^^^^^^^^^^^^^^ required by this bound in `D::Assoc`
@@ -85,14 +85,14 @@ LL |     type Assoc = NotClone;
    |          ----- required by a bound in this associated type
 
 error[E0277]: the trait bound `<Self as Foo2<T>>::Baz: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:65:23
+  --> $DIR/defaults-suitability.rs:68:23
    |
 LL |     type Bar: Clone = Vec<Self::Baz>;
    |                       ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo2<T>>::Baz`, which is required by `Vec<<Self as Foo2<T>>::Baz>: Clone`
    |
    = note: required for `Vec<<Self as Foo2<T>>::Baz>` to implement `Clone`
 note: required by a bound in `Foo2::Bar`
-  --> $DIR/defaults-suitability.rs:65:15
+  --> $DIR/defaults-suitability.rs:68:15
    |
 LL |     type Bar: Clone = Vec<Self::Baz>;
    |               ^^^^^ required by this bound in `Foo2::Bar`
@@ -102,14 +102,14 @@ LL | trait Foo2<T> where <Self as Foo2<T>>::Baz: Clone {
    |               +++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `<Self as Foo25<T>>::Baz: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:74:23
+  --> $DIR/defaults-suitability.rs:77:23
    |
 LL |     type Bar: Clone = Vec<Self::Baz>;
    |                       ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo25<T>>::Baz`, which is required by `Vec<<Self as Foo25<T>>::Baz>: Clone`
    |
    = note: required for `Vec<<Self as Foo25<T>>::Baz>` to implement `Clone`
 note: required by a bound in `Foo25::Bar`
-  --> $DIR/defaults-suitability.rs:74:15
+  --> $DIR/defaults-suitability.rs:77:15
    |
 LL |     type Bar: Clone = Vec<Self::Baz>;
    |               ^^^^^ required by this bound in `Foo25::Bar`
@@ -119,13 +119,13 @@ LL | trait Foo25<T: Clone> where <Self as Foo25<T>>::Baz: Clone {
    |                       ++++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:87:16
+  --> $DIR/defaults-suitability.rs:90:16
    |
 LL |     type Baz = T;
    |                ^ the trait `Clone` is not implemented for `T`
    |
 note: required by a bound in `Foo3::Baz`
-  --> $DIR/defaults-suitability.rs:84:16
+  --> $DIR/defaults-suitability.rs:87:16
    |
 LL |     Self::Baz: Clone,
    |                ^^^^^ required by this bound in `Foo3::Baz`

--- a/tests/ui/associated-types/defaults-suitability.next.stderr
+++ b/tests/ui/associated-types/defaults-suitability.next.stderr
@@ -1,0 +1,142 @@
+error[E0277]: the trait bound `NotClone: Clone` is not satisfied
+  --> $DIR/defaults-suitability.rs:16:22
+   |
+LL |     type Ty: Clone = NotClone;
+   |                      ^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
+   |
+note: required by a bound in `Tr::Ty`
+  --> $DIR/defaults-suitability.rs:16:14
+   |
+LL |     type Ty: Clone = NotClone;
+   |              ^^^^^ required by this bound in `Tr::Ty`
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0277]: the trait bound `NotClone: Clone` is not satisfied
+  --> $DIR/defaults-suitability.rs:25:15
+   |
+LL |     type Ty = NotClone;
+   |               ^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
+   |
+note: required by a bound in `Tr2::Ty`
+  --> $DIR/defaults-suitability.rs:23:15
+   |
+LL |     Self::Ty: Clone,
+   |               ^^^^^ required by this bound in `Tr2::Ty`
+LL | {
+LL |     type Ty = NotClone;
+   |          -- required by a bound in this associated type
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct NotClone;
+   |
+
+error[E0277]: the trait bound `T: Clone` is not satisfied
+  --> $DIR/defaults-suitability.rs:31:23
+   |
+LL |     type Bar: Clone = Vec<T>;
+   |                       ^^^^^^ the trait `Clone` is not implemented for `T`, which is required by `Vec<T>: Clone`
+   |
+   = note: required for `Vec<T>` to implement `Clone`
+note: required by a bound in `Foo::Bar`
+  --> $DIR/defaults-suitability.rs:31:15
+   |
+LL |     type Bar: Clone = Vec<T>;
+   |               ^^^^^ required by this bound in `Foo::Bar`
+help: consider restricting type parameter `T`
+   |
+LL | trait Foo<T: std::clone::Clone> {
+   |            +++++++++++++++++++
+
+error[E0277]: the trait bound `(): Foo<Self>` is not satisfied
+  --> $DIR/defaults-suitability.rs:37:29
+   |
+LL |     type Assoc: Foo<Self> = ();
+   |                             ^^ the trait `Foo<Self>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/defaults-suitability.rs:30:1
+   |
+LL | trait Foo<T> {
+   | ^^^^^^^^^^^^
+note: required by a bound in `Bar::Assoc`
+  --> $DIR/defaults-suitability.rs:37:17
+   |
+LL |     type Assoc: Foo<Self> = ();
+   |                 ^^^^^^^^^ required by this bound in `Bar::Assoc`
+
+error[E0277]: the trait bound `NotClone: IsU8<NotClone>` is not satisfied
+  --> $DIR/defaults-suitability.rs:59:18
+   |
+LL |     type Assoc = NotClone;
+   |                  ^^^^^^^^ the trait `IsU8<NotClone>` is not implemented for `NotClone`
+   |
+note: required by a bound in `D::Assoc`
+  --> $DIR/defaults-suitability.rs:56:18
+   |
+LL |     Self::Assoc: IsU8<Self::Assoc>,
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `D::Assoc`
+...
+LL |     type Assoc = NotClone;
+   |          ----- required by a bound in this associated type
+
+error[E0277]: the trait bound `<Self as Foo2<T>>::Baz: Clone` is not satisfied
+  --> $DIR/defaults-suitability.rs:68:23
+   |
+LL |     type Bar: Clone = Vec<Self::Baz>;
+   |                       ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo2<T>>::Baz`, which is required by `Vec<<Self as Foo2<T>>::Baz>: Clone`
+   |
+   = note: required for `Vec<<Self as Foo2<T>>::Baz>` to implement `Clone`
+note: required by a bound in `Foo2::Bar`
+  --> $DIR/defaults-suitability.rs:68:15
+   |
+LL |     type Bar: Clone = Vec<Self::Baz>;
+   |               ^^^^^ required by this bound in `Foo2::Bar`
+help: consider further restricting the associated type
+   |
+LL | trait Foo2<T> where <Self as Foo2<T>>::Baz: Clone {
+   |               +++++++++++++++++++++++++++++++++++
+
+error[E0277]: the trait bound `<Self as Foo25<T>>::Baz: Clone` is not satisfied
+  --> $DIR/defaults-suitability.rs:77:23
+   |
+LL |     type Bar: Clone = Vec<Self::Baz>;
+   |                       ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo25<T>>::Baz`, which is required by `Vec<<Self as Foo25<T>>::Baz>: Clone`
+   |
+   = note: required for `Vec<<Self as Foo25<T>>::Baz>` to implement `Clone`
+note: required by a bound in `Foo25::Bar`
+  --> $DIR/defaults-suitability.rs:77:15
+   |
+LL |     type Bar: Clone = Vec<Self::Baz>;
+   |               ^^^^^ required by this bound in `Foo25::Bar`
+help: consider further restricting the associated type
+   |
+LL | trait Foo25<T: Clone> where <Self as Foo25<T>>::Baz: Clone {
+   |                       ++++++++++++++++++++++++++++++++++++
+
+error[E0277]: the trait bound `T: Clone` is not satisfied
+  --> $DIR/defaults-suitability.rs:90:16
+   |
+LL |     type Baz = T;
+   |                ^ the trait `Clone` is not implemented for `T`
+   |
+note: required by a bound in `Foo3::Baz`
+  --> $DIR/defaults-suitability.rs:87:16
+   |
+LL |     Self::Baz: Clone,
+   |                ^^^^^ required by this bound in `Foo3::Baz`
+...
+LL |     type Baz = T;
+   |          --- required by a bound in this associated type
+help: consider further restricting type parameter `T`
+   |
+LL |     Self::Baz: Clone, T: std::clone::Clone
+   |                     ~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/defaults-suitability.rs
+++ b/tests/ui/associated-types/defaults-suitability.rs
@@ -1,3 +1,6 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
 //! Checks that associated type defaults are properly validated.
 //!
 //! This means:

--- a/tests/ui/associated-types/defaults-unsound-62211-1.current.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.current.stderr
@@ -1,12 +1,12 @@
 error[E0277]: `Self` doesn't implement `std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-1.rs:26:96
+  --> $DIR/defaults-unsound-62211-1.rs:24:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
    |
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:26:86
+  --> $DIR/defaults-unsound-62211-1.rs:24:86
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -16,13 +16,13 @@ LL | trait UncheckedCopy: Sized + std::fmt::Display {
    |                            +++++++++++++++++++
 
 error[E0277]: cannot add-assign `&'static str` to `Self`
-  --> $DIR/defaults-unsound-62211-1.rs:26:96
+  --> $DIR/defaults-unsound-62211-1.rs:24:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ no implementation for `Self += &'static str`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:26:47
+  --> $DIR/defaults-unsound-62211-1.rs:24:47
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -32,13 +32,13 @@ LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
    |                            +++++++++++++++++++++++++
 
 error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-1.rs:26:96
+  --> $DIR/defaults-unsound-62211-1.rs:24:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:26:25
+  --> $DIR/defaults-unsound-62211-1.rs:24:25
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -48,13 +48,13 @@ LL | trait UncheckedCopy: Sized + Deref {
    |                            +++++++
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
-  --> $DIR/defaults-unsound-62211-1.rs:26:96
+  --> $DIR/defaults-unsound-62211-1.rs:24:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:26:18
+  --> $DIR/defaults-unsound-62211-1.rs:24:18
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                  ^^^^ required by this bound in `UncheckedCopy::Output`

--- a/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
@@ -1,17 +1,81 @@
-warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
-  --> $DIR/defaults-unsound-62211-1.rs:52:5
+error[E0277]: `Self` doesn't implement `std::fmt::Display`
+  --> $DIR/defaults-unsound-62211-1.rs:24:96
    |
-LL |     drop(origin);
-   |     ^^^^^------^
-   |          |
-   |          argument has type `<T as UncheckedCopy>::Output`
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
    |
-   = note: `#[warn(dropping_copy_types)]` on by default
-help: use `let _ = ...` to ignore the expression or result
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-1.rs:24:86
    |
-LL -     drop(origin);
-LL +     let _ = origin;
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
+help: consider further restricting `Self`
    |
+LL | trait UncheckedCopy: Sized + std::fmt::Display {
+   |                            +++++++++++++++++++
 
-warning: 1 warning emitted
+error[E0277]: cannot add-assign `&'static str` to `Self`
+  --> $DIR/defaults-unsound-62211-1.rs:24:96
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                                ^^^^ no implementation for `Self += &'static str`
+   |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-1.rs:24:47
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
+help: consider further restricting `Self`
+   |
+LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
+   |                            +++++++++++++++++++++++++
 
+error[E0271]: type mismatch resolving `<Self as Deref>::Target == str`
+  --> $DIR/defaults-unsound-62211-1.rs:24:96
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                                ^^^^ types differ
+   |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-1.rs:24:31
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                               ^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
+
+error[E0277]: the trait bound `Self: Deref` is not satisfied
+  --> $DIR/defaults-unsound-62211-1.rs:24:96
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
+   |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-1.rs:24:25
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
+help: consider further restricting `Self`
+   |
+LL | trait UncheckedCopy: Sized + Deref {
+   |                            +++++++
+
+error[E0277]: the trait bound `Self: Copy` is not satisfied
+  --> $DIR/defaults-unsound-62211-1.rs:24:96
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
+   |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-1.rs:24:18
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                  ^^^^ required by this bound in `UncheckedCopy::Output`
+help: consider further restricting `Self`
+   |
+LL | trait UncheckedCopy: Sized + Copy {
+   |                            ++++++
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/associated-types/defaults-unsound-62211-1.rs
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.rs
@@ -1,8 +1,6 @@
 //@ revisions: current next
 //@[next] compile-flags: -Znext-solver
 //@ ignore-compare-mode-next-solver (explicit revisions)
-//@[next] known-bug: rust-lang/trait-system-refactor-initiative#46
-//@[next] check-pass
 
 //! Regression test for https://github.com/rust-lang/rust/issues/62211
 //!
@@ -24,10 +22,11 @@ trait UncheckedCopy: Sized {
     // This Output is said to be Copy. Yet we default to Self
     // and it's accepted, not knowing if Self ineed is Copy
     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-    //[current]~^ ERROR the trait bound `Self: Copy` is not satisfied
-    //[current]~| ERROR the trait bound `Self: Deref` is not satisfied
-    //[current]~| ERROR cannot add-assign `&'static str` to `Self`
-    //[current]~| ERROR `Self` doesn't implement `std::fmt::Display`
+    //~^ ERROR the trait bound `Self: Copy` is not satisfied
+    //~| ERROR the trait bound `Self: Deref` is not satisfied
+    //~| ERROR cannot add-assign `&'static str` to `Self`
+    //~| ERROR `Self` doesn't implement `std::fmt::Display`
+    //[next]~| ERROR type mismatch resolving `<Self as Deref>::Target == str`
 
     // We said the Output type was Copy, so we can Copy it freely!
     fn unchecked_copy(other: &Self::Output) -> Self::Output {

--- a/tests/ui/associated-types/defaults-unsound-62211-2.current.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.current.stderr
@@ -1,12 +1,12 @@
 error[E0277]: `Self` doesn't implement `std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-2.rs:26:96
+  --> $DIR/defaults-unsound-62211-2.rs:24:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
    |
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:26:86
+  --> $DIR/defaults-unsound-62211-2.rs:24:86
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -16,13 +16,13 @@ LL | trait UncheckedCopy: Sized + std::fmt::Display {
    |                            +++++++++++++++++++
 
 error[E0277]: cannot add-assign `&'static str` to `Self`
-  --> $DIR/defaults-unsound-62211-2.rs:26:96
+  --> $DIR/defaults-unsound-62211-2.rs:24:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ no implementation for `Self += &'static str`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:26:47
+  --> $DIR/defaults-unsound-62211-2.rs:24:47
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -32,13 +32,13 @@ LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
    |                            +++++++++++++++++++++++++
 
 error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-2.rs:26:96
+  --> $DIR/defaults-unsound-62211-2.rs:24:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:26:25
+  --> $DIR/defaults-unsound-62211-2.rs:24:25
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
@@ -48,13 +48,13 @@ LL | trait UncheckedCopy: Sized + Deref {
    |                            +++++++
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
-  --> $DIR/defaults-unsound-62211-2.rs:26:96
+  --> $DIR/defaults-unsound-62211-2.rs:24:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:26:18
+  --> $DIR/defaults-unsound-62211-2.rs:24:18
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                  ^^^^ required by this bound in `UncheckedCopy::Output`

--- a/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
@@ -1,17 +1,81 @@
-warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
-  --> $DIR/defaults-unsound-62211-2.rs:52:5
+error[E0277]: `Self` doesn't implement `std::fmt::Display`
+  --> $DIR/defaults-unsound-62211-2.rs:24:96
    |
-LL |     drop(origin);
-   |     ^^^^^------^
-   |          |
-   |          argument has type `<T as UncheckedCopy>::Output`
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
    |
-   = note: `#[warn(dropping_copy_types)]` on by default
-help: use `let _ = ...` to ignore the expression or result
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-2.rs:24:86
    |
-LL -     drop(origin);
-LL +     let _ = origin;
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
+help: consider further restricting `Self`
    |
+LL | trait UncheckedCopy: Sized + std::fmt::Display {
+   |                            +++++++++++++++++++
 
-warning: 1 warning emitted
+error[E0277]: cannot add-assign `&'static str` to `Self`
+  --> $DIR/defaults-unsound-62211-2.rs:24:96
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                                ^^^^ no implementation for `Self += &'static str`
+   |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-2.rs:24:47
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
+help: consider further restricting `Self`
+   |
+LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
+   |                            +++++++++++++++++++++++++
 
+error[E0271]: type mismatch resolving `<Self as Deref>::Target == str`
+  --> $DIR/defaults-unsound-62211-2.rs:24:96
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                                ^^^^ types differ
+   |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-2.rs:24:31
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                               ^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
+
+error[E0277]: the trait bound `Self: Deref` is not satisfied
+  --> $DIR/defaults-unsound-62211-2.rs:24:96
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
+   |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-2.rs:24:25
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
+help: consider further restricting `Self`
+   |
+LL | trait UncheckedCopy: Sized + Deref {
+   |                            +++++++
+
+error[E0277]: the trait bound `Self: Copy` is not satisfied
+  --> $DIR/defaults-unsound-62211-2.rs:24:96
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
+   |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-2.rs:24:18
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                  ^^^^ required by this bound in `UncheckedCopy::Output`
+help: consider further restricting `Self`
+   |
+LL | trait UncheckedCopy: Sized + Copy {
+   |                            ++++++
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/associated-types/defaults-unsound-62211-2.rs
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.rs
@@ -1,8 +1,6 @@
 //@ revisions: current next
 //@[next] compile-flags: -Znext-solver
 //@ ignore-compare-mode-next-solver (explicit revisions)
-//@[next] known-bug: rust-lang/trait-system-refactor-initiative#46
-//@[next] check-pass
 
 //! Regression test for https://github.com/rust-lang/rust/issues/62211
 //!
@@ -24,10 +22,11 @@ trait UncheckedCopy: Sized {
     // This Output is said to be Copy. Yet we default to Self
     // and it's accepted, not knowing if Self ineed is Copy
     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-    //[current]~^ ERROR the trait bound `Self: Copy` is not satisfied
-    //[current]~| ERROR the trait bound `Self: Deref` is not satisfied
-    //[current]~| ERROR cannot add-assign `&'static str` to `Self`
-    //[current]~| ERROR `Self` doesn't implement `std::fmt::Display`
+    //~^ ERROR the trait bound `Self: Copy` is not satisfied
+    //~| ERROR the trait bound `Self: Deref` is not satisfied
+    //~| ERROR cannot add-assign `&'static str` to `Self`
+    //~| ERROR `Self` doesn't implement `std::fmt::Display`
+    //[next]~| ERROR type mismatch resolving `<Self as Deref>::Target == str`
 
     // We said the Output type was Copy, so we can Copy it freely!
     fn unchecked_copy(other: &Self::Output) -> Self::Output {

--- a/tests/ui/associated-types/issue-54108.current.stderr
+++ b/tests/ui/associated-types/issue-54108.current.stderr
@@ -1,12 +1,12 @@
 error[E0277]: cannot add `<T as SubEncoder>::ActualSize` to `<T as SubEncoder>::ActualSize`
-  --> $DIR/issue-54108.rs:19:17
+  --> $DIR/issue-54108.rs:23:17
    |
 LL |     type Size = <Self as SubEncoder>::ActualSize;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `<T as SubEncoder>::ActualSize + <T as SubEncoder>::ActualSize`
    |
    = help: the trait `Add` is not implemented for `<T as SubEncoder>::ActualSize`
 note: required by a bound in `Encoder::Size`
-  --> $DIR/issue-54108.rs:4:16
+  --> $DIR/issue-54108.rs:8:16
    |
 LL |     type Size: Add<Output = Self::Size>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Encoder::Size`

--- a/tests/ui/associated-types/issue-54108.next.stderr
+++ b/tests/ui/associated-types/issue-54108.next.stderr
@@ -1,0 +1,33 @@
+error[E0271]: type mismatch resolving `<<T as SubEncoder>::ActualSize as Add>::Output == <T as SubEncoder>::ActualSize`
+  --> $DIR/issue-54108.rs:23:17
+   |
+LL |     type Size = <Self as SubEncoder>::ActualSize;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ
+   |
+note: required by a bound in `Encoder::Size`
+  --> $DIR/issue-54108.rs:8:20
+   |
+LL |     type Size: Add<Output = Self::Size>;
+   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `Encoder::Size`
+
+error[E0277]: cannot add `<T as SubEncoder>::ActualSize` to `<T as SubEncoder>::ActualSize`
+  --> $DIR/issue-54108.rs:23:17
+   |
+LL |     type Size = <Self as SubEncoder>::ActualSize;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `<T as SubEncoder>::ActualSize + <T as SubEncoder>::ActualSize`
+   |
+   = help: the trait `Add` is not implemented for `<T as SubEncoder>::ActualSize`
+note: required by a bound in `Encoder::Size`
+  --> $DIR/issue-54108.rs:8:16
+   |
+LL |     type Size: Add<Output = Self::Size>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Encoder::Size`
+help: consider further restricting the associated type
+   |
+LL |     T: SubEncoder, <T as SubEncoder>::ActualSize: Add
+   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/associated-types/issue-54108.rs
+++ b/tests/ui/associated-types/issue-54108.rs
@@ -1,3 +1,7 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
 use std::ops::Add;
 
 pub trait Encoder {
@@ -18,6 +22,7 @@ where
 {
     type Size = <Self as SubEncoder>::ActualSize;
     //~^ ERROR: cannot add `<T as SubEncoder>::ActualSize` to `<T as SubEncoder>::ActualSize`
+    //[next]~| ERROR type mismatch resolving `<<T as SubEncoder>::ActualSize as Add>::Output == <T as SubEncoder>::ActualSize`
 
     fn foo(&self) -> Self::Size {
         self.bar() + self.bar()

--- a/tests/ui/associated-types/issue-63593.current.stderr
+++ b/tests/ui/associated-types/issue-63593.current.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-63593.rs:9:17
+  --> $DIR/issue-63593.rs:13:17
    |
 LL |     type This = Self;
    |                 ^^^^ doesn't have a size known at compile-time
    |
 note: required by a bound in `MyTrait::This`
-  --> $DIR/issue-63593.rs:9:5
+  --> $DIR/issue-63593.rs:13:5
    |
 LL |     type This = Self;
    |     ^^^^^^^^^^^^^^^^^ required by this bound in `MyTrait::This`

--- a/tests/ui/associated-types/issue-63593.next.stderr
+++ b/tests/ui/associated-types/issue-63593.next.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-63593.rs:13:17
+   |
+LL |     type This = Self;
+   |                 ^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `MyTrait::This`
+  --> $DIR/issue-63593.rs:13:5
+   |
+LL |     type This = Self;
+   |     ^^^^^^^^^^^^^^^^^ required by this bound in `MyTrait::This`
+help: consider further restricting `Self`
+   |
+LL | trait MyTrait: Sized {
+   |              +++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/issue-63593.rs
+++ b/tests/ui/associated-types/issue-63593.rs
@@ -1,3 +1,7 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
 #![feature(associated_type_defaults)]
 
 // Tests that `Self` is not assumed to implement `Sized` when used as an

--- a/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.next.stderr
+++ b/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.next.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `<Self as Foo>::Bar<()>: Eq<i32>` is not satisfied
+error[E0277]: the trait bound `i32: Baz<Self>` is not satisfied
   --> $DIR/assume-gat-normalization-for-nested-goals.rs:9:30
    |
 LL |     type Bar<T>: Baz<Self> = i32;
-   |                              ^^^ the trait `Eq<i32>` is not implemented for `<Self as Foo>::Bar<()>`, which is required by `i32: Baz<Self>`
+   |                              ^^^ the trait `Eq<i32>` is not implemented for `i32`, which is required by `i32: Baz<Self>`
    |
 note: required for `i32` to implement `Baz<Self>`
   --> $DIR/assume-gat-normalization-for-nested-goals.rs:16:23

--- a/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.rs
+++ b/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.rs
@@ -1,8 +1,7 @@
 //@ revisions: current next
 //@[next] compile-flags: -Znext-solver
 //@ ignore-compare-mode-next-solver (explicit revisions)
-//@[current] known-bug: #117606
-//@[next] check-pass
+//@ known-bug: #117606
 
 #![feature(associated_type_defaults)]
 

--- a/tests/ui/generic-associated-types/issue-74816.current.stderr
+++ b/tests/ui/generic-associated-types/issue-74816.current.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `Self: Trait1` is not satisfied
-  --> $DIR/issue-74816.rs:8:31
+  --> $DIR/issue-74816.rs:12:31
    |
 LL |     type Associated: Trait1 = Self;
    |                               ^^^^ the trait `Trait1` is not implemented for `Self`
    |
 note: required by a bound in `Trait2::Associated`
-  --> $DIR/issue-74816.rs:8:22
+  --> $DIR/issue-74816.rs:12:22
    |
 LL |     type Associated: Trait1 = Self;
    |                      ^^^^^^ required by this bound in `Trait2::Associated`
@@ -15,13 +15,13 @@ LL | trait Trait2: Trait1 {
    |             ++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-74816.rs:8:31
+  --> $DIR/issue-74816.rs:12:31
    |
 LL |     type Associated: Trait1 = Self;
    |                               ^^^^ doesn't have a size known at compile-time
    |
 note: required by a bound in `Trait2::Associated`
-  --> $DIR/issue-74816.rs:8:5
+  --> $DIR/issue-74816.rs:12:5
    |
 LL |     type Associated: Trait1 = Self;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Trait2::Associated`

--- a/tests/ui/generic-associated-types/issue-74816.next.stderr
+++ b/tests/ui/generic-associated-types/issue-74816.next.stderr
@@ -1,0 +1,35 @@
+error[E0277]: the trait bound `Self: Trait1` is not satisfied
+  --> $DIR/issue-74816.rs:12:31
+   |
+LL |     type Associated: Trait1 = Self;
+   |                               ^^^^ the trait `Trait1` is not implemented for `Self`
+   |
+note: required by a bound in `Trait2::Associated`
+  --> $DIR/issue-74816.rs:12:22
+   |
+LL |     type Associated: Trait1 = Self;
+   |                      ^^^^^^ required by this bound in `Trait2::Associated`
+help: consider further restricting `Self`
+   |
+LL | trait Trait2: Trait1 {
+   |             ++++++++
+
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-74816.rs:12:31
+   |
+LL |     type Associated: Trait1 = Self;
+   |                               ^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Trait2::Associated`
+  --> $DIR/issue-74816.rs:12:5
+   |
+LL |     type Associated: Trait1 = Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Trait2::Associated`
+help: consider further restricting `Self`
+   |
+LL | trait Trait2: Sized {
+   |             +++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/generic-associated-types/issue-74816.rs
+++ b/tests/ui/generic-associated-types/issue-74816.rs
@@ -1,3 +1,7 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
 #![feature(associated_type_defaults)]
 
 trait Trait1 {

--- a/tests/ui/generic-associated-types/issue-74824.current.stderr
+++ b/tests/ui/generic-associated-types/issue-74824.current.stderr
@@ -1,17 +1,17 @@
 error[E0277]: the trait bound `Box<T>: Copy` is not satisfied
-  --> $DIR/issue-74824.rs:6:26
+  --> $DIR/issue-74824.rs:10:26
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                          ^^^^^^ the trait `Copy` is not implemented for `Box<T>`
    |
 note: required by a bound in `UnsafeCopy::Copy`
-  --> $DIR/issue-74824.rs:6:19
+  --> $DIR/issue-74824.rs:10:19
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
 
 error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> $DIR/issue-74824.rs:6:26
+  --> $DIR/issue-74824.rs:10:26
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                          ^^^^^^ the trait `Clone` is not implemented for `T`, which is required by `<Self as UnsafeCopy>::Copy<T>: Copy`
@@ -19,7 +19,7 @@ LL |     type Copy<T>: Copy = Box<T>;
    = note: required for `Box<T>` to implement `Clone`
    = note: required for `<Self as UnsafeCopy>::Copy<T>` to implement `Copy`
 note: required by a bound in `UnsafeCopy::Copy`
-  --> $DIR/issue-74824.rs:6:19
+  --> $DIR/issue-74824.rs:10:19
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                   ^^^^ required by this bound in `UnsafeCopy::Copy`

--- a/tests/ui/generic-associated-types/issue-74824.next.stderr
+++ b/tests/ui/generic-associated-types/issue-74824.next.stderr
@@ -1,0 +1,33 @@
+error[E0277]: the trait bound `Box<T>: Copy` is not satisfied
+  --> $DIR/issue-74824.rs:10:26
+   |
+LL |     type Copy<T>: Copy = Box<T>;
+   |                          ^^^^^^ the trait `Copy` is not implemented for `Box<T>`
+   |
+note: required by a bound in `UnsafeCopy::Copy`
+  --> $DIR/issue-74824.rs:10:19
+   |
+LL |     type Copy<T>: Copy = Box<T>;
+   |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
+
+error[E0277]: the trait bound `T: Clone` is not satisfied
+  --> $DIR/issue-74824.rs:10:26
+   |
+LL |     type Copy<T>: Copy = Box<T>;
+   |                          ^^^^^^ the trait `Clone` is not implemented for `T`, which is required by `<Self as UnsafeCopy>::Copy<T>: Copy`
+   |
+   = note: required for `Box<T>` to implement `Clone`
+   = note: required for `<Self as UnsafeCopy>::Copy<T>` to implement `Copy`
+note: required by a bound in `UnsafeCopy::Copy`
+  --> $DIR/issue-74824.rs:10:19
+   |
+LL |     type Copy<T>: Copy = Box<T>;
+   |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
+help: consider restricting type parameter `T`
+   |
+LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;
+   |                +++++++++++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/generic-associated-types/issue-74824.rs
+++ b/tests/ui/generic-associated-types/issue-74824.rs
@@ -1,3 +1,7 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
 #![feature(associated_type_defaults)]
 
 use std::ops::Deref;

--- a/tests/ui/specialization/specialization-default-items-drop-coherence.next.stderr
+++ b/tests/ui/specialization/specialization-default-items-drop-coherence.next.stderr
@@ -7,13 +7,6 @@ LL | impl Overlap for u32 {
 LL | impl Overlap for <u32 as Default>::Id {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `u32`
 
-error[E0282]: type annotations needed
-  --> $DIR/specialization-default-items-drop-coherence.rs:18:23
-   |
-LL |     default type Id = T;
-   |                       ^ cannot infer type for associated type `<T as Default>::Id`
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0119, E0282.
-For more information about an error, try `rustc --explain E0119`.
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/specialization/specialization-default-items-drop-coherence.rs
+++ b/tests/ui/specialization/specialization-default-items-drop-coherence.rs
@@ -15,7 +15,7 @@ trait Default {
 }
 
 impl<T> Default for T {
-    default type Id = T; //[next]~ ERROR type annotations needed
+    default type Id = T;
 }
 
 trait Overlap {

--- a/tests/ui/specialization/specialization-overlap-projection.next.stderr
+++ b/tests/ui/specialization/specialization-overlap-projection.next.stderr
@@ -9,7 +9,7 @@ LL | #![feature(specialization)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0119]: conflicting implementations of trait `Foo` for type `u32`
-  --> $DIR/specialization-overlap-projection.rs:28:1
+  --> $DIR/specialization-overlap-projection.rs:25:1
    |
 LL | impl Foo for u32 {}
    | ---------------- first implementation here
@@ -17,7 +17,7 @@ LL | impl Foo for <u8 as Assoc>::Output {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `u32`
 
 error[E0119]: conflicting implementations of trait `Foo` for type `u32`
-  --> $DIR/specialization-overlap-projection.rs:30:1
+  --> $DIR/specialization-overlap-projection.rs:27:1
    |
 LL | impl Foo for u32 {}
    | ---------------- first implementation here
@@ -25,25 +25,6 @@ LL | impl Foo for u32 {}
 LL | impl Foo for <u16 as Assoc>::Output {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `u32`
 
-error[E0282]: type annotations needed
-  --> $DIR/specialization-overlap-projection.rs:17:27
-   |
-LL |     default type Output = bool;
-   |                           ^^^^ cannot infer type for associated type `<T as Assoc>::Output`
+error: aborting due to 2 previous errors; 1 warning emitted
 
-error[E0282]: type annotations needed
-  --> $DIR/specialization-overlap-projection.rs:21:35
-   |
-LL | impl Assoc for u8 { type Output = u8; }
-   |                                   ^^ cannot infer type for associated type `<u8 as Assoc>::Output`
-
-error[E0282]: type annotations needed
-  --> $DIR/specialization-overlap-projection.rs:23:36
-   |
-LL | impl Assoc for u16 { type Output = u16; }
-   |                                    ^^^ cannot infer type for associated type `<u16 as Assoc>::Output`
-
-error: aborting due to 5 previous errors; 1 warning emitted
-
-Some errors have detailed explanations: E0119, E0282.
-For more information about an error, try `rustc --explain E0119`.
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/specialization/specialization-overlap-projection.rs
+++ b/tests/ui/specialization/specialization-overlap-projection.rs
@@ -15,13 +15,10 @@ trait Assoc {
 
 impl<T> Assoc for T {
     default type Output = bool;
-    //[next]~^ ERROR type annotations needed
 }
 
 impl Assoc for u8 { type Output = u8; }
-//[next]~^ ERROR type annotations needed
 impl Assoc for u16 { type Output = u16; }
-//[next]~^ ERROR type annotations needed
 
 trait Foo {}
 impl Foo for u32 {}

--- a/tests/ui/traits/next-solver/specialization-transmute.rs
+++ b/tests/ui/traits/next-solver/specialization-transmute.rs
@@ -10,7 +10,7 @@ trait Default {
 }
 
 impl<T> Default for T {
-    default type Id = T; //~ ERROR type annotations needed
+    default type Id = T;
     // This will be fixed by #111994
     fn intu(&self) -> &Self::Id {
         //~^ ERROR type annotations needed

--- a/tests/ui/traits/next-solver/specialization-transmute.stderr
+++ b/tests/ui/traits/next-solver/specialization-transmute.stderr
@@ -34,13 +34,6 @@ note: required by a bound in `transmute`
 LL | fn transmute<T: Default<Id = U>, U: Copy>(t: T) -> U {
    |                         ^^^^^^ required by this bound in `transmute`
 
-error[E0282]: type annotations needed
-  --> $DIR/specialization-transmute.rs:13:23
-   |
-LL |     default type Id = T;
-   |                       ^ cannot infer type for associated type `<T as Default>::Id`
+error: aborting due to 4 previous errors; 1 warning emitted
 
-error: aborting due to 5 previous errors; 1 warning emitted
-
-Some errors have detailed explanations: E0282, E0284.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/traits/next-solver/specialization-unconstrained.rs
+++ b/tests/ui/traits/next-solver/specialization-unconstrained.rs
@@ -11,7 +11,7 @@ trait Default {
 }
 
 impl<T> Default for T {
-   default type Id = T; //~ ERROR type annotations needed
+   default type Id = T;
 }
 
 fn test<T: Default<Id = U>, U>() {}

--- a/tests/ui/traits/next-solver/specialization-unconstrained.stderr
+++ b/tests/ui/traits/next-solver/specialization-unconstrained.stderr
@@ -20,13 +20,6 @@ note: required by a bound in `test`
 LL | fn test<T: Default<Id = U>, U>() {}
    |                    ^^^^^^ required by this bound in `test`
 
-error[E0282]: type annotations needed
-  --> $DIR/specialization-unconstrained.rs:14:22
-   |
-LL |    default type Id = T;
-   |                      ^ cannot infer type for associated type `<T as Default>::Id`
+error: aborting due to 1 previous error; 1 warning emitted
 
-error: aborting due to 2 previous errors; 1 warning emitted
-
-Some errors have detailed explanations: E0282, E0284.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/traits/next-solver/unsound-region-obligation.rs
+++ b/tests/ui/traits/next-solver/unsound-region-obligation.rs
@@ -1,4 +1,4 @@
-//~ ERROR the type `<() as StaticTy>::Item<'a>` does not fulfill the required lifetime
+//~ ERROR the type `&'a ()` does not fulfill the required lifetime
 //@ compile-flags: -Znext-solver
 // Regression test for rust-lang/trait-system-refactor-initiative#59
 

--- a/tests/ui/traits/next-solver/unsound-region-obligation.stderr
+++ b/tests/ui/traits/next-solver/unsound-region-obligation.stderr
@@ -1,4 +1,4 @@
-error[E0477]: the type `<() as StaticTy>::Item<'a>` does not fulfill the required lifetime
+error[E0477]: the type `&'a ()` does not fulfill the required lifetime
    |
    = note: type must satisfy the static lifetime
 


### PR DESCRIPTION
Vaguely confident that this is sufficient to prevent rust-lang/trait-system-refactor-initiative#46 and rust-lang/trait-system-refactor-initiative#62.

This is not the "correct" solution, but will probably suffice until coinduction, at which point we implement the right solution (`check_type_bounds` must prove `Assoc<...> alias-eq ConcreteType`, normalizing requires proving item bounds).

r? lcnr