### PR TITLE
Don't recompute `tail` in `lower_stmts`

### DIFF
--- a/compiler/rustc_ast_lowering/src/block.rs
+++ b/compiler/rustc_ast_lowering/src/block.rs
@@ -76,7 +76,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 StmtKind::Empty => {}
                 StmtKind::MacCall(..) => panic!("shouldn't exist here"),
             }
-            ast_stmts = &ast_stmts[1..];
+            ast_stmts = tail;
         }
         (self.arena.alloc_from_iter(stmts), expr)
     }


### PR DESCRIPTION
Does not really matter, but this is slightly nicer.

@bors rollup