### PR TITLE
Improve renaming suggestion for names with leading underscores

### DIFF
--- a/tests/ui/macros/expand-full-no-resolution.stderr
+++ b/tests/ui/macros/expand-full-no-resolution.stderr
@@ -7,7 +7,7 @@ LL |         macro_rules! _a {
 LL |     format_args!(a!());
    |                  ^
    |
-help: a macro with a similar name exists, consider renaming `_a` into `a`
+help: the leading underscore in `_a` marks it as unused, consider renaming it to `a`
    |
 LL |         macro_rules! a {
    |                      ~
@@ -21,7 +21,7 @@ LL |         macro_rules! _a {
 LL |     env!(a!());
    |          ^
    |
-help: a macro with a similar name exists, consider renaming `_a` into `a`
+help: the leading underscore in `_a` marks it as unused, consider renaming it to `a`
    |
 LL |         macro_rules! a {
    |                      ~

--- a/tests/ui/suggestions/silenced-binding-typo.stderr
+++ b/tests/ui/suggestions/silenced-binding-typo.stderr
@@ -1,10 +1,12 @@
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/silenced-binding-typo.rs:4:14
    |
+LL |     let _x = 42;
+   |         -- `_x` defined here
 LL |     let _y = x;
    |              ^
    |
-help: a local variable with a similar name exists, consider renaming `_x` into `x`
+help: the leading underscore in `_x` marks it as unused, consider renaming it to `x`
    |
 LL |     let x = 42;
    |         ~


### PR DESCRIPTION
Fixes #125650

Before:
```
error[E0425]: cannot find value `p` in this scope
 --> test.rs:2:13
  |
2 |     let _ = p;
  |             ^
  |
help: a local variable with a similar name exists, consider renaming `_p` into `p`
  |
1 | fn a(p: i32) {
  |      ~
```

After:
```
error[E0425]: cannot find value `p` in this scope
 --> test.rs:2:13
  |
1 | fn a(_p: i32) {
  |      -- `_p` defined here
2 |     let _ = p;
  |             ^
  |
help: the leading underscore in `_p` marks it as unused, consider renaming it to `p`
  |
1 | fn a(p: i32) {
  |      ~
```

This change doesn't exactly conform to what was proposed in the issue:

1. I've kept the suggested code instead of solely replacing it with the label
2. I've removed the "...similar name exists..." message instead of relocating to the usage span
3. You could argue that it still isn't completely clear that the change is referring to the definition (not the usage), but I'm not sure how to do this without playing down the fact that the error was caused by the usage of an undefined name.