### PR TITLE
Also InstSimplify `&raw*`

### DIFF
--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -123,7 +123,7 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
 
     /// Transform `&(*a)` ==> `a`.
     fn simplify_ref_deref(&self, source_info: &SourceInfo, rvalue: &mut Rvalue<'tcx>) {
-        if let Rvalue::Ref(_, _, place) = rvalue {
+        if let Rvalue::Ref(_, _, place) | Rvalue::AddressOf(_, place) = rvalue {
             if let Some((base, ProjectionElem::Deref)) = place.as_ref().last_projection() {
                 if rvalue.ty(self.local_decls, self.tcx) != base.ty(self.local_decls, self.tcx).ty {
                     return;

--- a/tests/mir-opt/instsimplify/ref_of_deref.pointers.InstSimplify.diff
+++ b/tests/mir-opt/instsimplify/ref_of_deref.pointers.InstSimplify.diff
@@ -1,0 +1,58 @@
+- // MIR for `pointers` before InstSimplify
++ // MIR for `pointers` after InstSimplify
+  
+  fn pointers(_1: *const [i32], _2: *mut i32) -> () {
+      debug const_ptr => _1;
+      debug mut_ptr => _2;
+      let mut _0: ();
+      let _3: &[i32];
+      scope 1 {
+          debug _a => _3;
+          let _4: &i32;
+          scope 2 {
+              debug _b => _4;
+              let _5: &mut i32;
+              scope 3 {
+                  debug _c => _5;
+                  let _6: *const [i32];
+                  scope 4 {
+                      debug _d => _6;
+                      let _7: *const i32;
+                      scope 5 {
+                          debug _e => _7;
+                          let _8: *mut i32;
+                          scope 6 {
+                              debug _f => _8;
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_3);
+          _3 = &(*_1);
+          StorageLive(_4);
+          _4 = &(*_2);
+          StorageLive(_5);
+          _5 = &mut (*_2);
+          StorageLive(_6);
+-         _6 = &raw const (*_1);
++         _6 = _1;
+          StorageLive(_7);
+          _7 = &raw const (*_2);
+          StorageLive(_8);
+-         _8 = &raw mut (*_2);
++         _8 = _2;
+          _0 = const ();
+          StorageDead(_8);
+          StorageDead(_7);
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageDead(_4);
+          StorageDead(_3);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/instsimplify/ref_of_deref.references.InstSimplify.diff
+++ b/tests/mir-opt/instsimplify/ref_of_deref.references.InstSimplify.diff
@@ -1,0 +1,58 @@
+- // MIR for `references` before InstSimplify
++ // MIR for `references` after InstSimplify
+  
+  fn references(_1: &i32, _2: &mut [i32]) -> () {
+      debug const_ref => _1;
+      debug mut_ref => _2;
+      let mut _0: ();
+      let _3: &i32;
+      scope 1 {
+          debug _a => _3;
+          let _4: &[i32];
+          scope 2 {
+              debug _b => _4;
+              let _5: &mut [i32];
+              scope 3 {
+                  debug _c => _5;
+                  let _6: *const i32;
+                  scope 4 {
+                      debug _d => _6;
+                      let _7: *const [i32];
+                      scope 5 {
+                          debug _e => _7;
+                          let _8: *mut [i32];
+                          scope 6 {
+                              debug _f => _8;
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_3);
+-         _3 = &(*_1);
++         _3 = _1;
+          StorageLive(_4);
+          _4 = &(*_2);
+          StorageLive(_5);
+-         _5 = &mut (*_2);
++         _5 = _2;
+          StorageLive(_6);
+          _6 = &raw const (*_1);
+          StorageLive(_7);
+          _7 = &raw const (*_2);
+          StorageLive(_8);
+          _8 = &raw mut (*_2);
+          _0 = const ();
+          StorageDead(_8);
+          StorageDead(_7);
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageDead(_4);
+          StorageDead(_3);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/instsimplify/ref_of_deref.rs
+++ b/tests/mir-opt/instsimplify/ref_of_deref.rs
@@ -1,0 +1,40 @@
+//@ test-mir-pass: InstSimplify
+#![crate_type = "lib"]
+#![feature(raw_ref_op)]
+
+// For each of these, only 2 of the 6 should simplify,
+// as the others have the wrong types.
+
+// EMIT_MIR ref_of_deref.references.InstSimplify.diff
+// CHECK-LABEL: references
+pub fn references(const_ref: &i32, mut_ref: &mut [i32]) {
+    // CHECK: _3 = _1;
+    let _a = &*const_ref;
+    // CHECK: _4 = &(*_2);
+    let _b = &*mut_ref;
+    // CHECK: _5 = _2;
+    let _c = &mut *mut_ref;
+    // CHECK: _6 = &raw const (*_1);
+    let _d = &raw const *const_ref;
+    // CHECK: _7 = &raw const (*_2);
+    let _e = &raw const *mut_ref;
+    // CHECK: _8 = &raw mut (*_2);
+    let _f = &raw mut *mut_ref;
+}
+
+// EMIT_MIR ref_of_deref.pointers.InstSimplify.diff
+// CHECK-LABEL: pointers
+pub unsafe fn pointers(const_ptr: *const [i32], mut_ptr: *mut i32) {
+    // CHECK: _3 = &(*_1);
+    let _a = &*const_ptr;
+    // CHECK: _4 = &(*_2);
+    let _b = &*mut_ptr;
+    // CHECK: _5 = &mut (*_2);
+    let _c = &mut *mut_ptr;
+    // CHECK: _6 = _1;
+    let _d = &raw const *const_ptr;
+    // CHECK: _7 = &raw const (*_2);
+    let _e = &raw const *mut_ptr;
+    // CHECK: _8 = _2;
+    let _f = &raw mut *mut_ptr;
+}


### PR DESCRIPTION
We do this for `&*` and `&mut*` already; might as well do it for raw pointers too.

r? mir-opt