### PR TITLE
Create const blocks on the fly during typeck instead of waiting until writeback.

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -76,7 +76,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 ExprKind::Array(exprs) => hir::ExprKind::Array(self.lower_exprs(exprs)),
                 ExprKind::ConstBlock(c) => {
                     self.has_inline_consts = true;
-                    hir::ExprKind::ConstBlock(self.lower_expr(c))
+                    self.with_new_scopes(e.span, |this| {
+                        hir::ExprKind::ConstBlock(this.lower_expr(c))
+                    })
                 }
                 ExprKind::Repeat(expr, count) => {
                     let expr = self.lower_expr(expr);

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -77,7 +77,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 ExprKind::ConstBlock(c) => {
                     self.has_inline_consts = true;
                     self.with_new_scopes(e.span, |this| {
-                        hir::ExprKind::ConstBlock(this.lower_expr(c))
+                        let coroutine_kind = this.coroutine_kind.take();
+                        let e = hir::ExprKind::ConstBlock(this.lower_expr(c));
+                        this.coroutine_kind = coroutine_kind;
+                        e
                     })
                 }
                 ExprKind::Repeat(expr, count) => {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2131,6 +2131,7 @@ impl LoopSource {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, HashStable_Generic)]
+// FIXME: eagerly report these errors and remove this enum and the wfcheck.
 pub enum LoopIdError {
     OutsideLoopScope,
     UnlabeledCfInWhileCondition,

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -3,7 +3,6 @@
 // generic parameters.
 
 use crate::FnCtxt;
-use hir::def::DefKind;
 use rustc_data_structures::unord::ExtendUnord;
 use rustc_errors::{ErrorGuaranteed, StashKey};
 use rustc_hir as hir;
@@ -17,7 +16,7 @@ use rustc_middle::ty::fold::{TypeFoldable, TypeFolder};
 use rustc_middle::ty::visit::TypeVisitableExt;
 use rustc_middle::ty::TypeSuperFoldable;
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_span::symbol::{kw, sym};
+use rustc_span::symbol::sym;
 use rustc_span::Span;
 use rustc_trait_selection::solve;
 use rustc_trait_selection::traits::error_reporting::TypeErrCtxtExt;
@@ -83,6 +82,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         wbcx.typeck_results.treat_byte_string_as_slice =
             mem::take(&mut self.typeck_results.borrow_mut().treat_byte_string_as_slice);
+
+        wbcx.typeck_results.inline_consts =
+            mem::take(&mut self.typeck_results.borrow_mut().inline_consts);
 
         debug!("writeback: typeck results for {:?} are {:#?}", item_def_id, wbcx.typeck_results);
 
@@ -295,12 +297,6 @@ impl<'cx, 'tcx> Visitor<'tcx> for WritebackCx<'cx, 'tcx> {
             }
             hir::ExprKind::Field(..) | hir::ExprKind::OffsetOf(..) => {
                 self.visit_field_id(e.hir_id);
-            }
-            hir::ExprKind::ConstBlock(_) => {
-                let feed = self.tcx().create_def(self.fcx.body_id, kw::Empty, DefKind::InlineConst);
-                feed.def_span(e.span);
-                feed.local_def_id_to_hir_id(e.hir_id);
-                self.typeck_results.inline_consts.insert(e.hir_id.local_id, feed.def_id());
             }
             _ => {}
         }

--- a/tests/ui/inline-const/cross_const_control_flow.rs
+++ b/tests/ui/inline-const/cross_const_control_flow.rs
@@ -33,8 +33,7 @@ fn loop_continue() {
 
 async fn await_across_const_block() {
     const { async {}.await }
-    //~^ ERROR: mismatched types
-    //~| ERROR: yield expression outside of coroutine literal
+    //~^ ERROR: `await` is only allowed inside `async` functions and blocks
 }
 
 fn main() {}

--- a/tests/ui/inline-const/cross_const_control_flow.rs
+++ b/tests/ui/inline-const/cross_const_control_flow.rs
@@ -1,0 +1,40 @@
+//@edition:2021
+
+fn foo() {
+    const { return }
+    //~^ ERROR: return statement outside of function body
+}
+
+fn labelled_block_break() {
+    'a: { const { break 'a } }
+    //~^ ERROR: `break` outside of a loop or labeled block
+    //~| ERROR: use of unreachable label
+}
+
+fn loop_break() {
+    loop {
+        const { break }
+        //~^ ERROR: `break` outside of a loop or labeled block
+    }
+}
+
+fn continue_to_labelled_block() {
+    'a: { const { continue 'a } }
+    //~^ ERROR: `continue` outside of a loop
+    //~| ERROR: use of unreachable label
+}
+
+fn loop_continue() {
+    loop {
+        const { continue }
+        //~^ ERROR: `continue` outside of a loop
+    }
+}
+
+async fn await_across_const_block() {
+    const { async {}.await }
+    //~^ ERROR: mismatched types
+    //~| ERROR: yield expression outside of coroutine literal
+}
+
+fn main() {}

--- a/tests/ui/inline-const/cross_const_control_flow.stderr
+++ b/tests/ui/inline-const/cross_const_control_flow.stderr
@@ -1,0 +1,76 @@
+error[E0767]: use of unreachable label `'a`
+  --> $DIR/cross_const_control_flow.rs:9:25
+   |
+LL |     'a: { const { break 'a } }
+   |     --                  ^^ unreachable label `'a`
+   |     |
+   |     unreachable label defined here
+   |
+   = note: labels are unreachable through functions, closures, async blocks and modules
+
+error[E0767]: use of unreachable label `'a`
+  --> $DIR/cross_const_control_flow.rs:22:28
+   |
+LL |     'a: { const { continue 'a } }
+   |     --                     ^^ unreachable label `'a`
+   |     |
+   |     unreachable label defined here
+   |
+   = note: labels are unreachable through functions, closures, async blocks and modules
+
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/cross_const_control_flow.rs:9:19
+   |
+LL |     'a: { const { break 'a } }
+   |                   ^^^^^^^^ cannot `break` outside of a loop or labeled block
+
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/cross_const_control_flow.rs:16:17
+   |
+LL |         const { break }
+   |                 ^^^^^ cannot `break` outside of a loop or labeled block
+
+error[E0268]: `continue` outside of a loop
+  --> $DIR/cross_const_control_flow.rs:22:19
+   |
+LL |     'a: { const { continue 'a } }
+   |                   ^^^^^^^^^^^ cannot `continue` outside of a loop
+
+error[E0268]: `continue` outside of a loop
+  --> $DIR/cross_const_control_flow.rs:29:17
+   |
+LL |         const { continue }
+   |                 ^^^^^^^^ cannot `continue` outside of a loop
+
+error[E0627]: yield expression outside of coroutine literal
+  --> $DIR/cross_const_control_flow.rs:35:22
+   |
+LL |     const { async {}.await }
+   |                      ^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/cross_const_control_flow.rs:35:22
+   |
+LL |   async fn await_across_const_block() {
+   |  _____________________________________-
+LL | |     const { async {}.await }
+   | |                      ^^^^^ expected `ResumeTy`, found `()`
+LL | |
+LL | |
+LL | | }
+   | |_- expected due to this parameter type
+
+error[E0572]: return statement outside of function body
+  --> $DIR/cross_const_control_flow.rs:4:13
+   |
+LL | / fn foo() {
+LL | |     const { return }
+   | |     --------^^^^^^-- the return is part of this body...
+LL | |
+LL | | }
+   | |_- ...not the enclosing function body
+
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0268, E0308, E0572, E0627, E0767.
+For more information about an error, try `rustc --explain E0268`.

--- a/tests/ui/inline-const/cross_const_control_flow.stderr
+++ b/tests/ui/inline-const/cross_const_control_flow.stderr
@@ -18,6 +18,15 @@ LL |     'a: { const { continue 'a } }
    |
    = note: labels are unreachable through functions, closures, async blocks and modules
 
+error[E0728]: `await` is only allowed inside `async` functions and blocks
+  --> $DIR/cross_const_control_flow.rs:35:22
+   |
+LL |     const { async {}.await }
+   |     -----------------^^^^^--
+   |     |                |
+   |     |                only allowed inside `async` functions and blocks
+   |     this is not `async`
+
 error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/cross_const_control_flow.rs:9:19
    |
@@ -42,24 +51,6 @@ error[E0268]: `continue` outside of a loop
 LL |         const { continue }
    |                 ^^^^^^^^ cannot `continue` outside of a loop
 
-error[E0627]: yield expression outside of coroutine literal
-  --> $DIR/cross_const_control_flow.rs:35:22
-   |
-LL |     const { async {}.await }
-   |                      ^^^^^
-
-error[E0308]: mismatched types
-  --> $DIR/cross_const_control_flow.rs:35:22
-   |
-LL |   async fn await_across_const_block() {
-   |  _____________________________________-
-LL | |     const { async {}.await }
-   | |                      ^^^^^ expected `ResumeTy`, found `()`
-LL | |
-LL | |
-LL | | }
-   | |_- expected due to this parameter type
-
 error[E0572]: return statement outside of function body
   --> $DIR/cross_const_control_flow.rs:4:13
    |
@@ -70,7 +61,7 @@ LL | |
 LL | | }
    | |_- ...not the enclosing function body
 
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0268, E0308, E0572, E0627, E0767.
+Some errors have detailed explanations: E0268, E0572, E0728, E0767.
 For more information about an error, try `rustc --explain E0268`.


### PR DESCRIPTION
This allows us to spawn a nested FnCtxt, creating a barrier that control flow statements cannot cross.

fixes #125670

The issues were caused by #124650 where I failed to account for the lack of changing scopes for const blocks