### PR TITLE
Also resolve the type of constants, even if we already turned it into an error constant

### DIFF
--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -865,6 +865,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Resolver<'cx, 'tcx> {
         self.handle_term(ct, ty::Const::outer_exclusive_binder, |tcx, guar| {
             ty::Const::new_error(tcx, guar, ct.ty())
         })
+        .super_fold_with(self)
     }
 
     fn fold_predicate(&mut self, predicate: ty::Predicate<'tcx>) -> ty::Predicate<'tcx> {

--- a/tests/ui/type-alias-impl-trait/const_generic_type.infer.stderr
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.infer.stderr
@@ -1,0 +1,10 @@
+error: `Bar` is forbidden as the type of a const generic parameter
+  --> $DIR/const_generic_type.rs:7:24
+   |
+LL | async fn test<const N: crate::Bar>() {
+   |                        ^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/type-alias-impl-trait/const_generic_type.no_infer.stderr
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.no_infer.stderr
@@ -1,15 +1,15 @@
 error[E0283]: type annotations needed
-  --> $DIR/const_generic_type.rs:6:1
+  --> $DIR/const_generic_type.rs:7:1
    |
-LL | async fn test<const N: crate::Bar>() {}
+LL | async fn test<const N: crate::Bar>() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
    |
    = note: cannot satisfy `_: std::fmt::Display`
 
 error: `Bar` is forbidden as the type of a const generic parameter
-  --> $DIR/const_generic_type.rs:6:24
+  --> $DIR/const_generic_type.rs:7:24
    |
-LL | async fn test<const N: crate::Bar>() {}
+LL | async fn test<const N: crate::Bar>() {
    |                        ^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`

--- a/tests/ui/type-alias-impl-trait/const_generic_type.rs
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.rs
@@ -1,0 +1,10 @@
+//@edition: 2021
+
+#![feature(type_alias_impl_trait)]
+type Bar = impl std::fmt::Display;
+
+async fn test<const N: crate::Bar>() {}
+//~^ ERROR: type annotations needed
+//~| ERROR: `Bar` is forbidden as the type of a const generic parameter
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/const_generic_type.rs
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.rs
@@ -1,10 +1,14 @@
 //@edition: 2021
+//@revisions: infer no_infer
 
 #![feature(type_alias_impl_trait)]
 type Bar = impl std::fmt::Display;
 
-async fn test<const N: crate::Bar>() {}
-//~^ ERROR: type annotations needed
-//~| ERROR: `Bar` is forbidden as the type of a const generic parameter
+async fn test<const N: crate::Bar>() {
+    //[no_infer]~^ ERROR: type annotations needed
+    //~^^ ERROR: `Bar` is forbidden as the type of a const generic parameter
+    #[cfg(infer)]
+    let x: u32 = N;
+}
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/const_generic_type.stderr
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.stderr
@@ -1,0 +1,19 @@
+error[E0283]: type annotations needed
+  --> $DIR/const_generic_type.rs:6:1
+   |
+LL | async fn test<const N: crate::Bar>() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: cannot satisfy `_: std::fmt::Display`
+
+error: `Bar` is forbidden as the type of a const generic parameter
+  --> $DIR/const_generic_type.rs:6:24
+   |
+LL | async fn test<const N: crate::Bar>() {}
+   |                        ^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
error constants can still have arbitrary types, and in this case it was turned into an error constant because there was an infer var in the *type* not the *const*.

fixes #125760