### PR TITLE
Handle no values cfgs with `--print=check-cfg`

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -814,13 +814,17 @@ fn print_crate_info(
                     match expected_values {
                         ExpectedValues::Any => check_cfgs.push(format!("{name}=any()")),
                         ExpectedValues::Some(values) => {
-                            check_cfgs.extend(values.iter().map(|value| {
-                                if let Some(value) = value {
-                                    format!("{name}=\"{value}\"")
-                                } else {
-                                    name.to_string()
-                                }
-                            }))
+                            if !values.is_empty() {
+                                check_cfgs.extend(values.iter().map(|value| {
+                                    if let Some(value) = value {
+                                        format!("{name}=\"{value}\"")
+                                    } else {
+                                        name.to_string()
+                                    }
+                                }))
+                            } else {
+                                check_cfgs.push(format!("{name}="))
+                            }
                         }
                     }
                 }

--- a/src/doc/unstable-book/src/compiler-flags/print-check-cfg.md
+++ b/src/doc/unstable-book/src/compiler-flags/print-check-cfg.md
@@ -1,6 +1,6 @@
 # `print=check-cfg`
 
-The tracking issue for this feature is: [#XXXXXX](https://github.com/rust-lang/rust/issues/XXXXXX).
+The tracking issue for this feature is: [#125704](https://github.com/rust-lang/rust/issues/125704).
 
 ------------------------
 

--- a/src/doc/unstable-book/src/compiler-flags/print-check-cfg.md
+++ b/src/doc/unstable-book/src/compiler-flags/print-check-cfg.md
@@ -15,6 +15,7 @@ This print option works similarly to `--print=cfg` (modulo check-cfg specifics):
  - `cfg(feature, values("foo", "bar"))`: `feature="foo"` and `feature="bar"`
  - `cfg(feature, values(none(), ""))`: `feature` and `feature=""`
  - `cfg(feature, values(any()))`: `feature=any()`
+ - `cfg(feature, values())`: `feature=`
  - `cfg(any())`: `any()`
  - *nothing*: `any()=any()`
 

--- a/tests/run-make/print-check-cfg/rmake.rs
+++ b/tests/run-make/print-check-cfg/rmake.rs
@@ -49,6 +49,20 @@ fn main() {
         },
     });
     check(CheckCfg {
+        args: &["--check-cfg=cfg(feature, values())"],
+        contains: Contains::Some {
+            contains: &["feature="],
+            doesnt_contain: &["any()", "any()=any()", "feature=none()", "feature"],
+        },
+    });
+    check(CheckCfg {
+        args: &["--check-cfg=cfg(feature, values())", "--check-cfg=cfg(feature, values(none()))"],
+        contains: Contains::Some {
+            contains: &["feature"],
+            doesnt_contain: &["any()", "any()=any()", "feature=none()", "feature="],
+        },
+    });
+    check(CheckCfg {
         args: &[
             r#"--check-cfg=cfg(feature, values(any()))"#,
             r#"--check-cfg=cfg(feature, values("tmp"))"#,


### PR DESCRIPTION
This PR fix a bug with `--print=check-cfg`, where no values cfgs where not printed since we only printed cfgs that had at least one values.

The representation I choose is `CFG=`, since it doesn't correspond to any valid config, it also IMO nicely complements the `values()` part of `--check-cfg` (to indicate no values). Representing the absence of value by the absence of value.

So for `cfg(feature, values())` we would print `feature=`.

I also added the missing tracking issue number in the doc.

r? @petrochenkov