### PR TITLE
Avoid checking the edition as much as possible

### DIFF
--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -47,7 +47,7 @@ impl<'a> Parser<'a> {
                 token.can_begin_expr()
                 // This exception is here for backwards compatibility.
                 && !token.is_keyword(kw::Let)
-                && (token.span.edition().at_least_rust_2024() || !token.is_keyword(kw::Const))
+                && (!token.is_keyword(kw::Const) || token.span.edition().at_least_rust_2024())
             }
             NonterminalKind::Ty => token.can_begin_type(),
             NonterminalKind::Ident => get_macro_ident(token).is_some(),


### PR DESCRIPTION
Inside https://github.com/rust-lang/rust/pull/123865, we are adding support for the new semantics for expr2024, but we have noted a performance issue.

While talking with @eholk, we realized there is a redundant check for each token regarding an edition. This commit moves the edition check to the end, avoiding some extra checks that can slow down compilation time.

However, we should keep this issue under observation because we may want to improve the edition check if we are unable to significantly improve compiler performance.

r? ghost