### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -477,9 +477,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 
 [[package]]
 name = "cfg-if"
@@ -593,7 +593,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -620,7 +620,7 @@ dependencies = [
  "regex",
  "rustc_tools_util",
  "serde",
- "syn 2.0.64",
+ "syn 2.0.66",
  "tempfile",
  "termize",
  "tokio",
@@ -730,7 +730,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -854,18 +854,18 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -966,7 +966,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -977,7 +977,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1003,7 +1003,7 @@ version = "0.1.80"
 dependencies = [
  "itertools 0.12.1",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1044,7 +1044,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1054,7 +1054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1077,7 +1077,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1166,7 +1166,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1480,7 +1480,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1552,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1710,7 +1710,7 @@ dependencies = [
  "markup5ever 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1842,7 +1842,7 @@ checksum = "d2abdd3a62551e8337af119c5899e600ca0c88ec8f23a46c60ba216c803dcf1a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2149,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.16"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
  "libc",
@@ -2494,9 +2494,9 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.49.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+checksum = "dd2800e1520bdc966782168a627aa5d1ad92e33b984bf7c7615d31280c83ff14"
 dependencies = [
  "windows-sys 0.48.0",
 ]
@@ -2704,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2786,7 +2786,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2947,9 +2947,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -3032,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "4.4.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47196f636c4cc0634b73b0405323d177753c2e15e866952c64ea22902567a34"
+checksum = "e9e935efc5854715dfc0a4c9ef18dc69dee0ec3bf9cc3ab740db831c0fdd86a3"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
@@ -3835,7 +3835,7 @@ dependencies = [
  "fluent-syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "unic-langid",
 ]
 
@@ -3969,7 +3969,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "synstructure",
 ]
 
@@ -4116,7 +4116,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "synstructure",
 ]
 
@@ -4694,7 +4694,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "synstructure",
 ]
 
@@ -4792,7 +4792,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4928,22 +4928,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5055,9 +5055,9 @@ dependencies = [
 
 [[package]]
 name = "spanned"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdf4f5590b7e6fbd4f2e80d442789079a6fff7c12ef921a9de358b7b353098e"
+checksum = "ed14ba8b4b82241bd5daba2c49185d4a0581a0058355fe96537338f002b8605d"
 dependencies = [
  "bstr",
  "color-eyre",
@@ -5237,9 +5237,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.64"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5254,7 +5254,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5399,7 +5399,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5587,7 +5587,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5642,11 +5642,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-tree"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65139ecd2c3f6484c3b99bc01c77afe21e95473630747c7aca525e78b0666675"
+checksum = "b56c62d2c80033cb36fae448730a2f2ef99410fe3ecbffc916681a32f6807dbe"
 dependencies = [
- "nu-ansi-term 0.49.0",
+ "nu-ansi-term 0.50.0",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
@@ -5787,7 +5787,7 @@ checksum = "1ed7f4237ba393424195053097c1516bd4590dc82b84f2f97c5c69e12704555b"
 dependencies = [
  "proc-macro-hack",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "unic-langid-impl",
 ]
 
@@ -6010,7 +6010,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -6032,7 +6032,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6113,7 +6113,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "syn 2.0.64",
+ "syn 2.0.66",
  "windows-metadata",
 ]
 
@@ -6335,7 +6335,7 @@ checksum = "9e6936f0cce458098a201c245a11bef556c6a0181129c7034d10d76d1ec3a2b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "synstructure",
 ]
 
@@ -6356,7 +6356,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6376,7 +6376,7 @@ checksum = "e6a647510471d372f2e6c2e6b7219e44d8c574d24fdc11c610a61455782f18c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "synstructure",
 ]
 
@@ -6399,5 +6399,5 @@ checksum = "7b4e5997cbf58990550ef1f0e5124a05e47e1ebd33a84af25739be6031a62c20"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -27,8 +27,9 @@ use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::cast::CastTy;
 use rustc_middle::ty::visit::TypeVisitableExt;
 use rustc_middle::ty::{
-    self, Binder, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations, Dynamic,
-    OpaqueHiddenType, OpaqueTypeKey, RegionVid, Ty, TyCtxt, UserType, UserTypeAnnotationIndex,
+    self, Binder, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations, CoroutineArgsExt,
+    Dynamic, OpaqueHiddenType, OpaqueTypeKey, RegionVid, Ty, TyCtxt, UserType,
+    UserTypeAnnotationIndex,
 };
 use rustc_middle::ty::{GenericArgsRef, UserArgs};
 use rustc_middle::{bug, span_bug};

--- a/compiler/rustc_codegen_gcc/src/type_of.rs
+++ b/compiler/rustc_codegen_gcc/src/type_of.rs
@@ -5,7 +5,7 @@ use rustc_codegen_ssa::traits::{BaseTypeMethods, DerivedTypeMethods, LayoutTypeM
 use rustc_middle::bug;
 use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::ty::print::with_no_trimmed_paths;
-use rustc_middle::ty::{self, Ty, TypeVisitableExt};
+use rustc_middle::ty::{self, CoroutineArgsExt, Ty, TypeVisitableExt};
 use rustc_target::abi::call::{CastTarget, FnAbi, Reg};
 use rustc_target::abi::{
     self, Abi, Align, FieldsShape, Float, Int, Integer, PointeeInfo, Pointer, Size, TyAbiInterface,

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -31,7 +31,8 @@ use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::bug;
 use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::ty::{
-    self, AdtKind, Instance, ParamEnv, PolyExistentialTraitRef, Ty, TyCtxt, Visibility,
+    self, AdtKind, CoroutineArgsExt, Instance, ParamEnv, PolyExistentialTraitRef, Ty, TyCtxt,
+    Visibility,
 };
 use rustc_session::config::{self, DebugInfo, Lto};
 use rustc_span::symbol::Symbol;

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/cpp_like.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/cpp_like.rs
@@ -12,7 +12,7 @@ use rustc_middle::{
     ty::{
         self,
         layout::{LayoutOf, TyAndLayout},
-        AdtDef, CoroutineArgs, Ty,
+        AdtDef, CoroutineArgs, CoroutineArgsExt, Ty,
     },
 };
 use rustc_target::abi::{Align, Endian, Size, TagEncoding, VariantIdx, Variants};

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/mod.rs
@@ -10,7 +10,7 @@ use rustc_middle::{
     ty::{
         self,
         layout::{IntegerExt, LayoutOf, PrimitiveExt, TyAndLayout},
-        AdtDef, CoroutineArgs, Ty, VariantDef,
+        AdtDef, CoroutineArgs, CoroutineArgsExt, Ty, VariantDef,
     },
 };
 use rustc_span::Symbol;

--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -4,7 +4,7 @@ use rustc_codegen_ssa::traits::*;
 use rustc_middle::bug;
 use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::ty::print::{with_no_trimmed_paths, with_no_visible_paths};
-use rustc_middle::ty::{self, Ty, TypeVisitableExt};
+use rustc_middle::ty::{self, CoroutineArgsExt, Ty, TypeVisitableExt};
 use rustc_target::abi::{Abi, Align, FieldsShape};
 use rustc_target::abi::{Float, Int, Pointer};
 use rustc_target::abi::{Scalar, Size, Variants};

--- a/compiler/rustc_const_eval/src/interpret/discriminant.rs
+++ b/compiler/rustc_const_eval/src/interpret/discriminant.rs
@@ -3,7 +3,7 @@
 use rustc_middle::mir;
 use rustc_middle::span_bug;
 use rustc_middle::ty::layout::{LayoutOf, PrimitiveExt};
-use rustc_middle::ty::{self, ScalarInt, Ty};
+use rustc_middle::ty::{self, CoroutineArgsExt, ScalarInt, Ty};
 use rustc_target::abi::{self, TagEncoding};
 use rustc_target::abi::{VariantIdx, Variants};
 use tracing::{instrument, trace};

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -1,7 +1,7 @@
 //! Values computed by queries that use MIR.
 
 use crate::mir;
-use crate::ty::{self, OpaqueHiddenType, Ty, TyCtxt};
+use crate::ty::{self, CoroutineArgsExt, OpaqueHiddenType, Ty, TyCtxt};
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::LocalDefId;

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -113,7 +113,6 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
 
     type ErrorGuaranteed = ErrorGuaranteed;
     type BoundExistentialPredicates = &'tcx List<PolyExistentialPredicate<'tcx>>;
-    type PolyFnSig = PolyFnSig<'tcx>;
     type AllocId = crate::mir::interpret::AllocId;
 
     type Pat = Pattern<'tcx>;

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -90,7 +90,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     type AdtDef = ty::AdtDef<'tcx>;
 
     type GenericArgs = ty::GenericArgsRef<'tcx>;
-    type OwnItemArgs = &'tcx [ty::GenericArg<'tcx>];
+    type GenericArgsSlice = &'tcx [ty::GenericArg<'tcx>];
     type GenericArg = ty::GenericArg<'tcx>;
     type Term = ty::Term<'tcx>;
 
@@ -190,7 +190,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self,
         def_id: Self::DefId,
         args: Self::GenericArgs,
-    ) -> (rustc_type_ir::TraitRef<Self>, Self::OwnItemArgs) {
+    ) -> (rustc_type_ir::TraitRef<Self>, Self::GenericArgsSlice) {
         assert_matches!(self.def_kind(def_id), DefKind::AssocTy | DefKind::AssocConst);
         let trait_def_id = self.parent(def_id);
         assert_matches!(self.def_kind(trait_def_id), DefKind::Trait);

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2,7 +2,7 @@ use crate::error::UnsupportedFnAbi;
 use crate::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use crate::query::TyCtxtAt;
 use crate::ty::normalize_erasing_regions::NormalizationError;
-use crate::ty::{self, Ty, TyCtxt, TypeVisitableExt};
+use crate::ty::{self, CoroutineArgsExt, Ty, TyCtxt, TypeVisitableExt};
 use rustc_error_messages::DiagMessage;
 use rustc_errors::{
     Diag, DiagArgValue, DiagCtxt, Diagnostic, EmissionGuarantee, IntoDiagArg, Level,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -113,10 +113,8 @@ pub use self::region::{
 pub use self::rvalue_scopes::RvalueScopes;
 pub use self::sty::{
     AliasTy, Article, Binder, BoundTy, BoundTyKind, BoundVariableKind, CanonicalPolyFnSig,
-    ClosureArgs, ClosureArgsParts, CoroutineArgs, CoroutineArgsParts, CoroutineClosureArgs,
-    CoroutineClosureArgsParts, CoroutineClosureSignature, EarlyBinder, FnSig, GenSig,
-    InlineConstArgs, InlineConstArgsParts, ParamConst, ParamTy, PolyFnSig, TyKind, TypeAndMut,
-    UpvarArgs, VarianceDiagInfo,
+    CoroutineArgsExt, EarlyBinder, FnSig, InlineConstArgs, InlineConstArgsParts, ParamConst,
+    ParamTy, PolyFnSig, TyKind, TypeAndMut, UpvarArgs, VarianceDiagInfo,
 };
 pub use self::trait_def::TraitDef;
 pub use self::typeck_results::{

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1938,7 +1938,10 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         Ok(())
     }
 
-    fn pretty_closure_as_impl(&mut self, closure: ty::ClosureArgs<'tcx>) -> Result<(), PrintError> {
+    fn pretty_closure_as_impl(
+        &mut self,
+        closure: ty::ClosureArgs<TyCtxt<'tcx>>,
+    ) -> Result<(), PrintError> {
         let sig = closure.sig();
         let kind = closure.kind_ty().to_opt_closure_kind().unwrap_or(ty::ClosureKind::Fn);
 
@@ -2973,7 +2976,7 @@ impl<'tcx> ty::PolyTraitPredicate<'tcx> {
 
 #[derive(Debug, Copy, Clone, Lift)]
 pub struct PrintClosureAsImpl<'tcx> {
-    pub closure: ty::ClosureArgs<'tcx>,
+    pub closure: ty::ClosureArgs<TyCtxt<'tcx>>,
 }
 
 macro_rules! forward_display_to_print {

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -756,28 +756,6 @@ impl<'tcx> Relate<'tcx> for &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>> {
     }
 }
 
-impl<'tcx> Relate<'tcx> for ty::ClosureArgs<'tcx> {
-    fn relate<R: TypeRelation<'tcx>>(
-        relation: &mut R,
-        a: ty::ClosureArgs<'tcx>,
-        b: ty::ClosureArgs<'tcx>,
-    ) -> RelateResult<'tcx, ty::ClosureArgs<'tcx>> {
-        let args = relate_args_invariantly(relation, a.args, b.args)?;
-        Ok(ty::ClosureArgs { args })
-    }
-}
-
-impl<'tcx> Relate<'tcx> for ty::CoroutineArgs<'tcx> {
-    fn relate<R: TypeRelation<'tcx>>(
-        relation: &mut R,
-        a: ty::CoroutineArgs<'tcx>,
-        b: ty::CoroutineArgs<'tcx>,
-    ) -> RelateResult<'tcx, ty::CoroutineArgs<'tcx>> {
-        let args = relate_args_invariantly(relation, a.args, b.args)?;
-        Ok(ty::CoroutineArgs { args })
-    }
-}
-
 impl<'tcx> Relate<'tcx> for GenericArgsRef<'tcx> {
     fn relate<R: TypeRelation<'tcx>>(
         relation: &mut R,

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -259,18 +259,6 @@ impl<'tcx> DebugWithInfcx<TyCtxt<'tcx>> for Region<'tcx> {
     }
 }
 
-impl<'tcx, T: DebugWithInfcx<TyCtxt<'tcx>>> DebugWithInfcx<TyCtxt<'tcx>> for ty::Binder<'tcx, T> {
-    fn fmt<Infcx: InferCtxtLike<Interner = TyCtxt<'tcx>>>(
-        this: WithInfcx<'_, Infcx, &Self>,
-        f: &mut core::fmt::Formatter<'_>,
-    ) -> core::fmt::Result {
-        f.debug_tuple("Binder")
-            .field(&this.map(|data| data.as_ref().skip_binder()))
-            .field(&this.data.bound_vars())
-            .finish()
-    }
-}
-
 ///////////////////////////////////////////////////////////////////////////
 // Atomic structs
 //

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -16,7 +16,7 @@ use rustc_errors::{ErrorGuaranteed, MultiSpan};
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_hir::LangItem;
-use rustc_macros::{HashStable, Lift, TyDecodable, TyEncodable, TypeFoldable};
+use rustc_macros::{extension, HashStable, TyDecodable, TyEncodable, TypeFoldable};
 use rustc_span::symbol::{sym, Symbol};
 use rustc_span::{Span, DUMMY_SP};
 use rustc_target::abi::{FieldIdx, VariantIdx, FIRST_VARIANT};
@@ -30,7 +30,6 @@ use ty::util::{AsyncDropGlueMorphology, IntTypeExt};
 use rustc_type_ir::TyKind::*;
 use rustc_type_ir::{self as ir, BoundVar, CollectAndApply, DynKind};
 
-use super::fold::FnMutDelegate;
 use super::GenericParamDefKind;
 
 // Re-export and re-parameterize some `I = TyCtxt<'tcx>` types here
@@ -60,670 +59,14 @@ impl<'tcx> Article for TyKind<'tcx> {
     }
 }
 
-/// A closure can be modeled as a struct that looks like:
-/// ```ignore (illustrative)
-/// struct Closure<'l0...'li, T0...Tj, CK, CS, U>(...U);
-/// ```
-/// where:
-///
-/// - 'l0...'li and T0...Tj are the generic parameters
-///   in scope on the function that defined the closure,
-/// - CK represents the *closure kind* (Fn vs FnMut vs FnOnce). This
-///   is rather hackily encoded via a scalar type. See
-///   `Ty::to_opt_closure_kind` for details.
-/// - CS represents the *closure signature*, representing as a `fn()`
-///   type. For example, `fn(u32, u32) -> u32` would mean that the closure
-///   implements `CK<(u32, u32), Output = u32>`, where `CK` is the trait
-///   specified above.
-/// - U is a type parameter representing the types of its upvars, tupled up
-///   (borrowed, if appropriate; that is, if a U field represents a by-ref upvar,
-///    and the up-var has the type `Foo`, then that field of U will be `&Foo`).
-///
-/// So, for example, given this function:
-/// ```ignore (illustrative)
-/// fn foo<'a, T>(data: &'a mut T) {
-///      do(|| data.count += 1)
-/// }
-/// ```
-/// the type of the closure would be something like:
-/// ```ignore (illustrative)
-/// struct Closure<'a, T, U>(...U);
-/// ```
-/// Note that the type of the upvar is not specified in the struct.
-/// You may wonder how the impl would then be able to use the upvar,
-/// if it doesn't know it's type? The answer is that the impl is
-/// (conceptually) not fully generic over Closure but rather tied to
-/// instances with the expected upvar types:
-/// ```ignore (illustrative)
-/// impl<'b, 'a, T> FnMut() for Closure<'a, T, (&'b mut &'a mut T,)> {
-///     ...
-/// }
-/// ```
-/// You can see that the *impl* fully specified the type of the upvar
-/// and thus knows full well that `data` has type `&'b mut &'a mut T`.
-/// (Here, I am assuming that `data` is mut-borrowed.)
-///
-/// Now, the last question you may ask is: Why include the upvar types
-/// in an extra type parameter? The reason for this design is that the
-/// upvar types can reference lifetimes that are internal to the
-/// creating function. In my example above, for example, the lifetime
-/// `'b` represents the scope of the closure itself; this is some
-/// subset of `foo`, probably just the scope of the call to the to
-/// `do()`. If we just had the lifetime/type parameters from the
-/// enclosing function, we couldn't name this lifetime `'b`. Note that
-/// there can also be lifetimes in the types of the upvars themselves,
-/// if one of them happens to be a reference to something that the
-/// creating fn owns.
-///
-/// OK, you say, so why not create a more minimal set of parameters
-/// that just includes the extra lifetime parameters? The answer is
-/// primarily that it would be hard --- we don't know at the time when
-/// we create the closure type what the full types of the upvars are,
-/// nor do we know which are borrowed and which are not. In this
-/// design, we can just supply a fresh type parameter and figure that
-/// out later.
-///
-/// All right, you say, but why include the type parameters from the
-/// original function then? The answer is that codegen may need them
-/// when monomorphizing, and they may not appear in the upvars. A
-/// closure could capture no variables but still make use of some
-/// in-scope type parameter with a bound (e.g., if our example above
-/// had an extra `U: Default`, and the closure called `U::default()`).
-///
-/// There is another reason. This design (implicitly) prohibits
-/// closures from capturing themselves (except via a trait
-/// object). This simplifies closure inference considerably, since it
-/// means that when we infer the kind of a closure or its upvars, we
-/// don't have to handle cycles where the decisions we make for
-/// closure C wind up influencing the decisions we ought to make for
-/// closure C (which would then require fixed point iteration to
-/// handle). Plus it fixes an ICE. :P
-///
-/// ## Coroutines
-///
-/// Coroutines are handled similarly in `CoroutineArgs`. The set of
-/// type parameters is similar, but `CK` and `CS` are replaced by the
-/// following type parameters:
-///
-/// * `GS`: The coroutine's "resume type", which is the type of the
-///   argument passed to `resume`, and the type of `yield` expressions
-///   inside the coroutine.
-/// * `GY`: The "yield type", which is the type of values passed to
-///   `yield` inside the coroutine.
-/// * `GR`: The "return type", which is the type of value returned upon
-///   completion of the coroutine.
-/// * `GW`: The "coroutine witness".
-#[derive(Copy, Clone, PartialEq, Eq, Debug, TypeFoldable, TypeVisitable, Lift)]
-pub struct ClosureArgs<'tcx> {
-    /// Lifetime and type parameters from the enclosing function,
-    /// concatenated with a tuple containing the types of the upvars.
-    ///
-    /// These are separated out because codegen wants to pass them around
-    /// when monomorphizing.
-    pub args: GenericArgsRef<'tcx>,
-}
-
-/// Struct returned by `split()`.
-pub struct ClosureArgsParts<'tcx> {
-    /// This is the args of the typeck root.
-    pub parent_args: &'tcx [GenericArg<'tcx>],
-    /// Represents the maximum calling capability of the closure.
-    pub closure_kind_ty: Ty<'tcx>,
-    /// Captures the closure's signature. This closure signature is "tupled", and
-    /// thus has a peculiar signature of `extern "rust-call" fn((Args, ...)) -> Ty`.
-    pub closure_sig_as_fn_ptr_ty: Ty<'tcx>,
-    /// The upvars captured by the closure. Remains an inference variable
-    /// until the upvar analysis, which happens late in HIR typeck.
-    pub tupled_upvars_ty: Ty<'tcx>,
-}
-
-impl<'tcx> ClosureArgs<'tcx> {
-    /// Construct `ClosureArgs` from `ClosureArgsParts`, containing `Args`
-    /// for the closure parent, alongside additional closure-specific components.
-    pub fn new(tcx: TyCtxt<'tcx>, parts: ClosureArgsParts<'tcx>) -> ClosureArgs<'tcx> {
-        ClosureArgs {
-            args: tcx.mk_args_from_iter(parts.parent_args.iter().copied().chain([
-                parts.closure_kind_ty.into(),
-                parts.closure_sig_as_fn_ptr_ty.into(),
-                parts.tupled_upvars_ty.into(),
-            ])),
-        }
-    }
-
-    /// Divides the closure args into their respective components.
-    /// The ordering assumed here must match that used by `ClosureArgs::new` above.
-    fn split(self) -> ClosureArgsParts<'tcx> {
-        match self.args[..] {
-            [ref parent_args @ .., closure_kind_ty, closure_sig_as_fn_ptr_ty, tupled_upvars_ty] => {
-                ClosureArgsParts {
-                    parent_args,
-                    closure_kind_ty: closure_kind_ty.expect_ty(),
-                    closure_sig_as_fn_ptr_ty: closure_sig_as_fn_ptr_ty.expect_ty(),
-                    tupled_upvars_ty: tupled_upvars_ty.expect_ty(),
-                }
-            }
-            _ => bug!("closure args missing synthetics"),
-        }
-    }
-
-    /// Returns the generic parameters of the closure's parent.
-    pub fn parent_args(self) -> &'tcx [GenericArg<'tcx>] {
-        self.split().parent_args
-    }
-
-    /// Returns an iterator over the list of types of captured paths by the closure.
-    /// In case there was a type error in figuring out the types of the captured path, an
-    /// empty iterator is returned.
-    #[inline]
-    pub fn upvar_tys(self) -> &'tcx List<Ty<'tcx>> {
-        match *self.tupled_upvars_ty().kind() {
-            TyKind::Error(_) => ty::List::empty(),
-            TyKind::Tuple(tys) => tys,
-            TyKind::Infer(_) => bug!("upvar_tys called before capture types are inferred"),
-            ty => bug!("Unexpected representation of upvar types tuple {:?}", ty),
-        }
-    }
-
-    /// Returns the tuple type representing the upvars for this closure.
-    #[inline]
-    pub fn tupled_upvars_ty(self) -> Ty<'tcx> {
-        self.split().tupled_upvars_ty
-    }
-
-    /// Returns the closure kind for this closure; may return a type
-    /// variable during inference. To get the closure kind during
-    /// inference, use `infcx.closure_kind(args)`.
-    pub fn kind_ty(self) -> Ty<'tcx> {
-        self.split().closure_kind_ty
-    }
-
-    /// Returns the `fn` pointer type representing the closure signature for this
-    /// closure.
-    // FIXME(eddyb) this should be unnecessary, as the shallowly resolved
-    // type is known at the time of the creation of `ClosureArgs`,
-    // see `rustc_hir_analysis::check::closure`.
-    pub fn sig_as_fn_ptr_ty(self) -> Ty<'tcx> {
-        self.split().closure_sig_as_fn_ptr_ty
-    }
-
-    /// Returns the closure kind for this closure; only usable outside
-    /// of an inference context, because in that context we know that
-    /// there are no type variables.
-    ///
-    /// If you have an inference context, use `infcx.closure_kind()`.
-    pub fn kind(self) -> ty::ClosureKind {
-        self.kind_ty().to_opt_closure_kind().unwrap()
-    }
-
-    /// Extracts the signature from the closure.
-    pub fn sig(self) -> ty::PolyFnSig<'tcx> {
-        match *self.sig_as_fn_ptr_ty().kind() {
-            ty::FnPtr(sig) => sig,
-            ty => bug!("closure_sig_as_fn_ptr_ty is not a fn-ptr: {ty:?}"),
-        }
-    }
-
-    pub fn print_as_impl_trait(self) -> ty::print::PrintClosureAsImpl<'tcx> {
-        ty::print::PrintClosureAsImpl { closure: self }
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug, TypeFoldable, TypeVisitable, Lift)]
-pub struct CoroutineClosureArgs<'tcx> {
-    pub args: GenericArgsRef<'tcx>,
-}
-
-/// See docs for explanation of how each argument is used.
-///
-/// See [`CoroutineClosureSignature`] for how these arguments are put together
-/// to make a callable [`FnSig`] suitable for typeck and borrowck.
-pub struct CoroutineClosureArgsParts<'tcx> {
-    /// This is the args of the typeck root.
-    pub parent_args: &'tcx [GenericArg<'tcx>],
-    /// Represents the maximum calling capability of the closure.
-    pub closure_kind_ty: Ty<'tcx>,
-    /// Represents all of the relevant parts of the coroutine returned by this
-    /// coroutine-closure. This signature parts type will have the general
-    /// shape of `fn(tupled_inputs, resume_ty) -> (return_ty, yield_ty)`, where
-    /// `resume_ty`, `return_ty`, and `yield_ty` are the respective types for the
-    /// coroutine returned by the coroutine-closure.
-    ///
-    /// Use `coroutine_closure_sig` to break up this type rather than using it
-    /// yourself.
-    pub signature_parts_ty: Ty<'tcx>,
-    /// The upvars captured by the closure. Remains an inference variable
-    /// until the upvar analysis, which happens late in HIR typeck.
-    pub tupled_upvars_ty: Ty<'tcx>,
-    /// a function pointer that has the shape `for<'env> fn() -> (&'env T, ...)`.
-    /// This allows us to represent the binder of the self-captures of the closure.
-    ///
-    /// For example, if the coroutine returned by the closure borrows `String`
-    /// from the closure's upvars, this will be `for<'env> fn() -> (&'env String,)`,
-    /// while the `tupled_upvars_ty`, representing the by-move version of the same
-    /// captures, will be `(String,)`.
-    pub coroutine_captures_by_ref_ty: Ty<'tcx>,
-    /// Witness type returned by the generator produced by this coroutine-closure.
-    pub coroutine_witness_ty: Ty<'tcx>,
-}
-
-impl<'tcx> CoroutineClosureArgs<'tcx> {
-    pub fn new(
-        tcx: TyCtxt<'tcx>,
-        parts: CoroutineClosureArgsParts<'tcx>,
-    ) -> CoroutineClosureArgs<'tcx> {
-        CoroutineClosureArgs {
-            args: tcx.mk_args_from_iter(parts.parent_args.iter().copied().chain([
-                parts.closure_kind_ty.into(),
-                parts.signature_parts_ty.into(),
-                parts.tupled_upvars_ty.into(),
-                parts.coroutine_captures_by_ref_ty.into(),
-                parts.coroutine_witness_ty.into(),
-            ])),
-        }
-    }
-
-    fn split(self) -> CoroutineClosureArgsParts<'tcx> {
-        match self.args[..] {
-            [
-                ref parent_args @ ..,
-                closure_kind_ty,
-                signature_parts_ty,
-                tupled_upvars_ty,
-                coroutine_captures_by_ref_ty,
-                coroutine_witness_ty,
-            ] => CoroutineClosureArgsParts {
-                parent_args,
-                closure_kind_ty: closure_kind_ty.expect_ty(),
-                signature_parts_ty: signature_parts_ty.expect_ty(),
-                tupled_upvars_ty: tupled_upvars_ty.expect_ty(),
-                coroutine_captures_by_ref_ty: coroutine_captures_by_ref_ty.expect_ty(),
-                coroutine_witness_ty: coroutine_witness_ty.expect_ty(),
-            },
-            _ => bug!("closure args missing synthetics"),
-        }
-    }
-
-    pub fn parent_args(self) -> &'tcx [GenericArg<'tcx>] {
-        self.split().parent_args
-    }
-
-    #[inline]
-    pub fn upvar_tys(self) -> &'tcx List<Ty<'tcx>> {
-        match self.tupled_upvars_ty().kind() {
-            TyKind::Error(_) => ty::List::empty(),
-            TyKind::Tuple(..) => self.tupled_upvars_ty().tuple_fields(),
-            TyKind::Infer(_) => bug!("upvar_tys called before capture types are inferred"),
-            ty => bug!("Unexpected representation of upvar types tuple {:?}", ty),
-        }
-    }
-
-    #[inline]
-    pub fn tupled_upvars_ty(self) -> Ty<'tcx> {
-        self.split().tupled_upvars_ty
-    }
-
-    pub fn kind_ty(self) -> Ty<'tcx> {
-        self.split().closure_kind_ty
-    }
-
-    pub fn kind(self) -> ty::ClosureKind {
-        self.kind_ty().to_opt_closure_kind().unwrap()
-    }
-
-    pub fn signature_parts_ty(self) -> Ty<'tcx> {
-        self.split().signature_parts_ty
-    }
-
-    pub fn coroutine_closure_sig(self) -> Binder<'tcx, CoroutineClosureSignature<'tcx>> {
-        let interior = self.coroutine_witness_ty();
-        let ty::FnPtr(sig) = self.signature_parts_ty().kind() else { bug!() };
-        sig.map_bound(|sig| {
-            let [resume_ty, tupled_inputs_ty] = *sig.inputs() else {
-                bug!();
-            };
-            let [yield_ty, return_ty] = **sig.output().tuple_fields() else { bug!() };
-            CoroutineClosureSignature {
-                interior,
-                tupled_inputs_ty,
-                resume_ty,
-                yield_ty,
-                return_ty,
-                c_variadic: sig.c_variadic,
-                safety: sig.safety,
-                abi: sig.abi,
-            }
-        })
-    }
-
-    pub fn coroutine_captures_by_ref_ty(self) -> Ty<'tcx> {
-        self.split().coroutine_captures_by_ref_ty
-    }
-
-    pub fn coroutine_witness_ty(self) -> Ty<'tcx> {
-        self.split().coroutine_witness_ty
-    }
-
-    pub fn has_self_borrows(&self) -> bool {
-        match self.coroutine_captures_by_ref_ty().kind() {
-            ty::FnPtr(sig) => sig
-                .skip_binder()
-                .visit_with(&mut HasRegionsBoundAt { binder: ty::INNERMOST })
-                .is_break(),
-            ty::Error(_) => true,
-            _ => bug!(),
-        }
-    }
-}
-/// Unlike `has_escaping_bound_vars` or `outermost_exclusive_binder`, this will
-/// detect only regions bound *at* the debruijn index.
-struct HasRegionsBoundAt {
-    binder: ty::DebruijnIndex,
-}
-// FIXME: Could be optimized to not walk into components with no escaping bound vars.
-impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for HasRegionsBoundAt {
-    type Result = ControlFlow<()>;
-    fn visit_binder<T: TypeVisitable<TyCtxt<'tcx>>>(
-        &mut self,
-        t: &ty::Binder<'tcx, T>,
-    ) -> Self::Result {
-        self.binder.shift_in(1);
-        t.super_visit_with(self)?;
-        self.binder.shift_out(1);
-        ControlFlow::Continue(())
-    }
-
-    fn visit_region(&mut self, r: ty::Region<'tcx>) -> Self::Result {
-        if let ty::ReBound(binder, _) = *r
-            && self.binder == binder
-        {
-            ControlFlow::Break(())
-        } else {
-            ControlFlow::Continue(())
-        }
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug, TypeFoldable, TypeVisitable)]
-pub struct CoroutineClosureSignature<'tcx> {
-    pub interior: Ty<'tcx>,
-    pub tupled_inputs_ty: Ty<'tcx>,
-    pub resume_ty: Ty<'tcx>,
-    pub yield_ty: Ty<'tcx>,
-    pub return_ty: Ty<'tcx>,
-
-    // Like the `fn_sig_as_fn_ptr_ty` of a regular closure, these types
-    // never actually differ. But we save them rather than recreating them
-    // from scratch just for good measure.
-    /// Always false
-    pub c_variadic: bool,
-    /// Always [`hir::Safety::Safe`]
-    pub safety: hir::Safety,
-    /// Always [`abi::Abi::RustCall`]
-    pub abi: abi::Abi,
-}
-
-impl<'tcx> CoroutineClosureSignature<'tcx> {
-    /// Construct a coroutine from the closure signature. Since a coroutine signature
-    /// is agnostic to the type of generator that is returned (by-ref/by-move),
-    /// the caller must specify what "flavor" of generator that they'd like to
-    /// create. Additionally, they must manually compute the upvars of the closure.
-    ///
-    /// This helper is not really meant to be used directly except for early on
-    /// during typeck, when we want to put inference vars into the kind and upvars tys.
-    /// When the kind and upvars are known, use the other helper functions.
-    pub fn to_coroutine(
-        self,
-        tcx: TyCtxt<'tcx>,
-        parent_args: &'tcx [GenericArg<'tcx>],
-        coroutine_kind_ty: Ty<'tcx>,
-        coroutine_def_id: DefId,
-        tupled_upvars_ty: Ty<'tcx>,
-    ) -> Ty<'tcx> {
-        let coroutine_args = ty::CoroutineArgs::new(
-            tcx,
-            ty::CoroutineArgsParts {
-                parent_args,
-                kind_ty: coroutine_kind_ty,
-                resume_ty: self.resume_ty,
-                yield_ty: self.yield_ty,
-                return_ty: self.return_ty,
-                witness: self.interior,
-                tupled_upvars_ty,
-            },
-        );
-
-        Ty::new_coroutine(tcx, coroutine_def_id, coroutine_args.args)
-    }
-
-    /// Given known upvars and a [`ClosureKind`](ty::ClosureKind), compute the coroutine
-    /// returned by that corresponding async fn trait.
-    ///
-    /// This function expects the upvars to have been computed already, and doesn't check
-    /// that the `ClosureKind` is actually supported by the coroutine-closure.
-    pub fn to_coroutine_given_kind_and_upvars(
-        self,
-        tcx: TyCtxt<'tcx>,
-        parent_args: &'tcx [GenericArg<'tcx>],
-        coroutine_def_id: DefId,
-        goal_kind: ty::ClosureKind,
-        env_region: ty::Region<'tcx>,
-        closure_tupled_upvars_ty: Ty<'tcx>,
-        coroutine_captures_by_ref_ty: Ty<'tcx>,
-    ) -> Ty<'tcx> {
-        let tupled_upvars_ty = Self::tupled_upvars_by_closure_kind(
-            tcx,
-            goal_kind,
-            self.tupled_inputs_ty,
-            closure_tupled_upvars_ty,
-            coroutine_captures_by_ref_ty,
-            env_region,
-        );
-
-        self.to_coroutine(
-            tcx,
-            parent_args,
-            Ty::from_coroutine_closure_kind(tcx, goal_kind),
-            coroutine_def_id,
-            tupled_upvars_ty,
-        )
-    }
-
-    /// Compute the tupled upvars that a coroutine-closure's output coroutine
-    /// would return for the given `ClosureKind`.
-    ///
-    /// When `ClosureKind` is `FnMut`/`Fn`, then this will use the "captures by ref"
-    /// to return a set of upvars which are borrowed with the given `env_region`.
-    ///
-    /// This ensures that the `AsyncFn::call` will return a coroutine whose upvars'
-    /// lifetimes are related to the lifetime of the borrow on the closure made for
-    /// the call. This allows borrowck to enforce the self-borrows correctly.
-    pub fn tupled_upvars_by_closure_kind(
-        tcx: TyCtxt<'tcx>,
-        kind: ty::ClosureKind,
-        tupled_inputs_ty: Ty<'tcx>,
-        closure_tupled_upvars_ty: Ty<'tcx>,
-        coroutine_captures_by_ref_ty: Ty<'tcx>,
-        env_region: ty::Region<'tcx>,
-    ) -> Ty<'tcx> {
-        match kind {
-            ty::ClosureKind::Fn | ty::ClosureKind::FnMut => {
-                let ty::FnPtr(sig) = *coroutine_captures_by_ref_ty.kind() else {
-                    bug!();
-                };
-                let coroutine_captures_by_ref_ty = tcx.replace_escaping_bound_vars_uncached(
-                    sig.output().skip_binder(),
-                    FnMutDelegate {
-                        consts: &mut |c, t| ty::Const::new_bound(tcx, ty::INNERMOST, c, t),
-                        types: &mut |t| Ty::new_bound(tcx, ty::INNERMOST, t),
-                        regions: &mut |_| env_region,
-                    },
-                );
-                Ty::new_tup_from_iter(
-                    tcx,
-                    tupled_inputs_ty
-                        .tuple_fields()
-                        .iter()
-                        .chain(coroutine_captures_by_ref_ty.tuple_fields()),
-                )
-            }
-            ty::ClosureKind::FnOnce => Ty::new_tup_from_iter(
-                tcx,
-                tupled_inputs_ty
-                    .tuple_fields()
-                    .iter()
-                    .chain(closure_tupled_upvars_ty.tuple_fields()),
-            ),
-        }
-    }
-}
-/// Similar to `ClosureArgs`; see the above documentation for more.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, TypeFoldable, TypeVisitable)]
-pub struct CoroutineArgs<'tcx> {
-    pub args: GenericArgsRef<'tcx>,
-}
-
-pub struct CoroutineArgsParts<'tcx> {
-    /// This is the args of the typeck root.
-    pub parent_args: &'tcx [GenericArg<'tcx>],
-
-    /// The coroutines returned by a coroutine-closure's `AsyncFnOnce`/`AsyncFnMut`
-    /// implementations must be distinguished since the former takes the closure's
-    /// upvars by move, and the latter takes the closure's upvars by ref.
-    ///
-    /// This field distinguishes these fields so that codegen can select the right
-    /// body for the coroutine. This has the same type representation as the closure
-    /// kind: `i8`/`i16`/`i32`.
-    ///
-    /// For regular coroutines, this field will always just be `()`.
-    pub kind_ty: Ty<'tcx>,
-
-    pub resume_ty: Ty<'tcx>,
-    pub yield_ty: Ty<'tcx>,
-    pub return_ty: Ty<'tcx>,
-
-    /// The interior type of the coroutine.
-    /// Represents all types that are stored in locals
-    /// in the coroutine's body.
-    pub witness: Ty<'tcx>,
-
-    /// The upvars captured by the closure. Remains an inference variable
-    /// until the upvar analysis, which happens late in HIR typeck.
-    pub tupled_upvars_ty: Ty<'tcx>,
-}
-
-impl<'tcx> CoroutineArgs<'tcx> {
-    /// Construct `CoroutineArgs` from `CoroutineArgsParts`, containing `Args`
-    /// for the coroutine parent, alongside additional coroutine-specific components.
-    pub fn new(tcx: TyCtxt<'tcx>, parts: CoroutineArgsParts<'tcx>) -> CoroutineArgs<'tcx> {
-        CoroutineArgs {
-            args: tcx.mk_args_from_iter(parts.parent_args.iter().copied().chain([
-                parts.kind_ty.into(),
-                parts.resume_ty.into(),
-                parts.yield_ty.into(),
-                parts.return_ty.into(),
-                parts.witness.into(),
-                parts.tupled_upvars_ty.into(),
-            ])),
-        }
-    }
-
-    /// Divides the coroutine args into their respective components.
-    /// The ordering assumed here must match that used by `CoroutineArgs::new` above.
-    fn split(self) -> CoroutineArgsParts<'tcx> {
-        match self.args[..] {
-            [
-                ref parent_args @ ..,
-                kind_ty,
-                resume_ty,
-                yield_ty,
-                return_ty,
-                witness,
-                tupled_upvars_ty,
-            ] => CoroutineArgsParts {
-                parent_args,
-                kind_ty: kind_ty.expect_ty(),
-                resume_ty: resume_ty.expect_ty(),
-                yield_ty: yield_ty.expect_ty(),
-                return_ty: return_ty.expect_ty(),
-                witness: witness.expect_ty(),
-                tupled_upvars_ty: tupled_upvars_ty.expect_ty(),
-            },
-            _ => bug!("coroutine args missing synthetics"),
-        }
-    }
-
-    /// Returns the generic parameters of the coroutine's parent.
-    pub fn parent_args(self) -> &'tcx [GenericArg<'tcx>] {
-        self.split().parent_args
-    }
-
-    // Returns the kind of the coroutine. See docs on the `kind_ty` field.
-    pub fn kind_ty(self) -> Ty<'tcx> {
-        self.split().kind_ty
-    }
-
-    /// This describes the types that can be contained in a coroutine.
-    /// It will be a type variable initially and unified in the last stages of typeck of a body.
-    /// It contains a tuple of all the types that could end up on a coroutine frame.
-    /// The state transformation MIR pass may only produce layouts which mention types
-    /// in this tuple. Upvars are not counted here.
-    pub fn witness(self) -> Ty<'tcx> {
-        self.split().witness
-    }
-
-    /// Returns an iterator over the list of types of captured paths by the coroutine.
-    /// In case there was a type error in figuring out the types of the captured path, an
-    /// empty iterator is returned.
-    #[inline]
-    pub fn upvar_tys(self) -> &'tcx List<Ty<'tcx>> {
-        match *self.tupled_upvars_ty().kind() {
-            TyKind::Error(_) => ty::List::empty(),
-            TyKind::Tuple(tys) => tys,
-            TyKind::Infer(_) => bug!("upvar_tys called before capture types are inferred"),
-            ty => bug!("Unexpected representation of upvar types tuple {:?}", ty),
-        }
-    }
-
-    /// Returns the tuple type representing the upvars for this coroutine.
-    #[inline]
-    pub fn tupled_upvars_ty(self) -> Ty<'tcx> {
-        self.split().tupled_upvars_ty
-    }
-
-    /// Returns the type representing the resume type of the coroutine.
-    pub fn resume_ty(self) -> Ty<'tcx> {
-        self.split().resume_ty
-    }
-
-    /// Returns the type representing the yield type of the coroutine.
-    pub fn yield_ty(self) -> Ty<'tcx> {
-        self.split().yield_ty
-    }
-
-    /// Returns the type representing the return type of the coroutine.
-    pub fn return_ty(self) -> Ty<'tcx> {
-        self.split().return_ty
-    }
-
-    /// Returns the "coroutine signature", which consists of its resume, yield
-    /// and return types.
-    pub fn sig(self) -> GenSig<'tcx> {
-        let parts = self.split();
-        ty::GenSig {
-            resume_ty: parts.resume_ty,
-            yield_ty: parts.yield_ty,
-            return_ty: parts.return_ty,
-        }
-    }
-}
-
-impl<'tcx> CoroutineArgs<'tcx> {
+#[extension(pub trait CoroutineArgsExt<'tcx>)]
+impl<'tcx> ty::CoroutineArgs<TyCtxt<'tcx>> {
     /// Coroutine has not been resumed yet.
-    pub const UNRESUMED: usize = 0;
+    const UNRESUMED: usize = 0;
     /// Coroutine has returned or is completed.
-    pub const RETURNED: usize = 1;
+    const RETURNED: usize = 1;
     /// Coroutine has been poisoned.
-    pub const POISONED: usize = 2;
+    const POISONED: usize = 2;
 
     const UNRESUMED_NAME: &'static str = "Unresumed";
     const RETURNED_NAME: &'static str = "Returned";
@@ -731,7 +74,7 @@ impl<'tcx> CoroutineArgs<'tcx> {
 
     /// The valid variant indices of this coroutine.
     #[inline]
-    pub fn variant_range(&self, def_id: DefId, tcx: TyCtxt<'tcx>) -> Range<VariantIdx> {
+    fn variant_range(&self, def_id: DefId, tcx: TyCtxt<'tcx>) -> Range<VariantIdx> {
         // FIXME requires optimized MIR
         FIRST_VARIANT
             ..tcx.coroutine_layout(def_id, tcx.types.unit).unwrap().variant_fields.next_index()
@@ -740,7 +83,7 @@ impl<'tcx> CoroutineArgs<'tcx> {
     /// The discriminant for the given variant. Panics if the `variant_index` is
     /// out of range.
     #[inline]
-    pub fn discriminant_for_variant(
+    fn discriminant_for_variant(
         &self,
         def_id: DefId,
         tcx: TyCtxt<'tcx>,
@@ -755,7 +98,7 @@ impl<'tcx> CoroutineArgs<'tcx> {
     /// The set of all discriminants for the coroutine, enumerated with their
     /// variant indices.
     #[inline]
-    pub fn discriminants(
+    fn discriminants(
         self,
         def_id: DefId,
         tcx: TyCtxt<'tcx>,
@@ -767,7 +110,7 @@ impl<'tcx> CoroutineArgs<'tcx> {
 
     /// Calls `f` with a reference to the name of the enumerator for the given
     /// variant `v`.
-    pub fn variant_name(v: VariantIdx) -> Cow<'static, str> {
+    fn variant_name(v: VariantIdx) -> Cow<'static, str> {
         match v.as_usize() {
             Self::UNRESUMED => Cow::from(Self::UNRESUMED_NAME),
             Self::RETURNED => Cow::from(Self::RETURNED_NAME),
@@ -778,7 +121,7 @@ impl<'tcx> CoroutineArgs<'tcx> {
 
     /// The type of the state discriminant used in the coroutine type.
     #[inline]
-    pub fn discr_ty(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
+    fn discr_ty(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
         tcx.types.u32
     }
 
@@ -789,7 +132,7 @@ impl<'tcx> CoroutineArgs<'tcx> {
     /// The locals are grouped by their variant number. Note that some locals may
     /// be repeated in multiple variants.
     #[inline]
-    pub fn state_tys(
+    fn state_tys(
         self,
         def_id: DefId,
         tcx: TyCtxt<'tcx>,
@@ -805,7 +148,7 @@ impl<'tcx> CoroutineArgs<'tcx> {
     /// This is the types of the fields of a coroutine which are not stored in a
     /// variant.
     #[inline]
-    pub fn prefix_tys(self) -> &'tcx List<Ty<'tcx>> {
+    fn prefix_tys(self) -> &'tcx List<Ty<'tcx>> {
         self.upvar_tys()
     }
 }
@@ -936,13 +279,6 @@ impl BoundVariableKind {
             _ => bug!("expected a const, but found another kind"),
         }
     }
-}
-
-#[derive(Copy, Clone, Debug, TypeFoldable, TypeVisitable)]
-pub struct GenSig<'tcx> {
-    pub resume_ty: Ty<'tcx>,
-    pub yield_ty: Ty<'tcx>,
-    pub return_ty: Ty<'tcx>,
 }
 
 pub type PolyFnSig<'tcx> = Binder<'tcx, FnSig<'tcx>>;
@@ -1450,6 +786,41 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         alias_ty: ty::AliasTy<'tcx>,
     ) -> Self {
         Ty::new_alias(interner, kind, alias_ty)
+    }
+
+    fn new_coroutine(
+        interner: TyCtxt<'tcx>,
+        def_id: DefId,
+        args: ty::GenericArgsRef<'tcx>,
+    ) -> Self {
+        Ty::new_coroutine(interner, def_id, args)
+    }
+
+    fn new_tup_from_iter<It, T>(interner: TyCtxt<'tcx>, iter: It) -> T::Output
+    where
+        It: Iterator<Item = T>,
+        T: CollectAndApply<Self, Self>,
+    {
+        Ty::new_tup_from_iter(interner, iter)
+    }
+
+    fn tuple_fields(self) -> &'tcx ty::List<Ty<'tcx>> {
+        self.tuple_fields()
+    }
+
+    fn to_opt_closure_kind(self) -> Option<ty::ClosureKind> {
+        self.to_opt_closure_kind()
+    }
+
+    fn from_closure_kind(interner: TyCtxt<'tcx>, kind: ty::ClosureKind) -> Self {
+        Ty::from_closure_kind(interner, kind)
+    }
+
+    fn from_coroutine_closure_kind(
+        interner: TyCtxt<'tcx>,
+        kind: rustc_type_ir::ClosureKind,
+    ) -> Self {
+        Ty::from_coroutine_closure_kind(interner, kind)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -69,7 +69,7 @@ use rustc_middle::mir::visit::{MutVisitor, PlaceContext, Visitor};
 use rustc_middle::mir::*;
 use rustc_middle::ty::CoroutineArgs;
 use rustc_middle::ty::InstanceDef;
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::{self, CoroutineArgsExt, Ty, TyCtxt};
 use rustc_middle::{bug, span_bug};
 use rustc_mir_dataflow::impls::{
     MaybeBorrowedLocals, MaybeLiveLocals, MaybeRequiresStorage, MaybeStorageLive,

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -4,7 +4,7 @@ use rustc_hir::lang_items::LangItem;
 use rustc_middle::mir::*;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::GenericArgs;
-use rustc_middle::ty::{self, CoroutineArgs, EarlyBinder, Ty, TyCtxt};
+use rustc_middle::ty::{self, CoroutineArgs, CoroutineArgsExt, EarlyBinder, Ty, TyCtxt};
 use rustc_middle::{bug, span_bug};
 use rustc_target::abi::{FieldIdx, VariantIdx, FIRST_VARIANT};
 
@@ -634,7 +634,7 @@ impl<'tcx> CloneShimBuilder<'tcx> {
         dest: Place<'tcx>,
         src: Place<'tcx>,
         coroutine_def_id: DefId,
-        args: CoroutineArgs<'tcx>,
+        args: CoroutineArgs<TyCtxt<'tcx>>,
     ) {
         self.block(vec![], TerminatorKind::Goto { target: self.block_index_offset(3) }, false);
         let unwind = self.block(vec![], TerminatorKind::UnwindResume, true);

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -8,7 +8,9 @@ use rustc_middle::mir::coverage::CoverageKind;
 use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::mir::visit::{NonUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::*;
-use rustc_middle::ty::{self, InstanceDef, ParamEnv, Ty, TyCtxt, TypeVisitableExt, Variance};
+use rustc_middle::ty::{
+    self, CoroutineArgsExt, InstanceDef, ParamEnv, Ty, TyCtxt, TypeVisitableExt, Variance,
+};
 use rustc_middle::{bug, span_bug};
 use rustc_target::abi::{Size, FIRST_VARIANT};
 use rustc_target::spec::abi::Abi;

--- a/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
@@ -554,8 +554,8 @@ fn coroutine_closure_to_certain_coroutine<'tcx>(
     goal_kind: ty::ClosureKind,
     goal_region: ty::Region<'tcx>,
     def_id: DefId,
-    args: ty::CoroutineClosureArgs<'tcx>,
-    sig: ty::CoroutineClosureSignature<'tcx>,
+    args: ty::CoroutineClosureArgs<TyCtxt<'tcx>>,
+    sig: ty::CoroutineClosureSignature<TyCtxt<'tcx>>,
 ) -> Ty<'tcx> {
     sig.to_coroutine_given_kind_and_upvars(
         tcx,
@@ -578,8 +578,8 @@ fn coroutine_closure_to_ambiguous_coroutine<'tcx>(
     goal_kind: ty::ClosureKind,
     goal_region: ty::Region<'tcx>,
     def_id: DefId,
-    args: ty::CoroutineClosureArgs<'tcx>,
-    sig: ty::CoroutineClosureSignature<'tcx>,
+    args: ty::CoroutineClosureArgs<TyCtxt<'tcx>>,
+    sig: ty::CoroutineClosureSignature<TyCtxt<'tcx>>,
 ) -> Ty<'tcx> {
     let upvars_projection_def_id = tcx.require_lang_item(LangItem::AsyncFnKindUpvars, None);
     let tupled_upvars_ty = Ty::new_projection(

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -295,7 +295,7 @@ pub fn coroutine_trait_ref_and_outputs<'tcx>(
     tcx: TyCtxt<'tcx>,
     fn_trait_def_id: DefId,
     self_ty: Ty<'tcx>,
-    sig: ty::GenSig<'tcx>,
+    sig: ty::GenSig<TyCtxt<'tcx>>,
 ) -> (ty::TraitRef<'tcx>, Ty<'tcx>, Ty<'tcx>) {
     assert!(!self_ty.has_escaping_bound_vars());
     let trait_ref = ty::TraitRef::new(tcx, fn_trait_def_id, [self_ty, sig.resume_ty]);
@@ -306,7 +306,7 @@ pub fn future_trait_ref_and_outputs<'tcx>(
     tcx: TyCtxt<'tcx>,
     fn_trait_def_id: DefId,
     self_ty: Ty<'tcx>,
-    sig: ty::GenSig<'tcx>,
+    sig: ty::GenSig<TyCtxt<'tcx>>,
 ) -> (ty::TraitRef<'tcx>, Ty<'tcx>) {
     assert!(!self_ty.has_escaping_bound_vars());
     let trait_ref = ty::TraitRef::new(tcx, fn_trait_def_id, [self_ty]);
@@ -317,7 +317,7 @@ pub fn iterator_trait_ref_and_outputs<'tcx>(
     tcx: TyCtxt<'tcx>,
     iterator_def_id: DefId,
     self_ty: Ty<'tcx>,
-    sig: ty::GenSig<'tcx>,
+    sig: ty::GenSig<TyCtxt<'tcx>>,
 ) -> (ty::TraitRef<'tcx>, Ty<'tcx>) {
     assert!(!self_ty.has_escaping_bound_vars());
     let trait_ref = ty::TraitRef::new(tcx, iterator_def_id, [self_ty]);
@@ -328,7 +328,7 @@ pub fn async_iterator_trait_ref_and_outputs<'tcx>(
     tcx: TyCtxt<'tcx>,
     async_iterator_def_id: DefId,
     self_ty: Ty<'tcx>,
-    sig: ty::GenSig<'tcx>,
+    sig: ty::GenSig<TyCtxt<'tcx>>,
 ) -> (ty::TraitRef<'tcx>, Ty<'tcx>) {
     assert!(!self_ty.has_escaping_bound_vars());
     let trait_ref = ty::TraitRef::new(tcx, async_iterator_def_id, [self_ty]);

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -10,7 +10,8 @@ use rustc_middle::ty::layout::{
 };
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
-    self, AdtDef, EarlyBinder, FieldDef, GenericArgsRef, Ty, TyCtxt, TypeVisitableExt,
+    self, AdtDef, CoroutineArgsExt, EarlyBinder, FieldDef, GenericArgsRef, Ty, TyCtxt,
+    TypeVisitableExt,
 };
 use rustc_session::{DataTypeKind, FieldInfo, FieldKind, SizeKind, VariantInfo};
 use rustc_span::sym;

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -8,11 +8,12 @@ use rustc_macros::{HashStable_NoContext, TyDecodable, TyEncodable};
 use rustc_serialize::Decodable;
 use tracing::debug;
 
+use crate::debug::{DebugWithInfcx, WithInfcx};
 use crate::fold::{FallibleTypeFolder, TypeFoldable, TypeFolder, TypeSuperFoldable};
 use crate::inherent::*;
 use crate::lift::Lift;
 use crate::visit::{Flags, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor};
-use crate::{self as ty, Interner, SsoHashSet};
+use crate::{self as ty, InferCtxtLike, Interner, SsoHashSet};
 
 /// Binder is a binder for higher-ranked lifetimes or types. It is part of the
 /// compiler's representation for things like `for<'a> Fn(&'a isize)`
@@ -52,6 +53,18 @@ where
             value: self.value.lift_to_tcx(tcx)?,
             bound_vars: self.bound_vars.lift_to_tcx(tcx)?,
         })
+    }
+}
+
+impl<I: Interner, T: DebugWithInfcx<I>> DebugWithInfcx<I> for ty::Binder<I, T> {
+    fn fmt<Infcx: InferCtxtLike<Interner = I>>(
+        this: WithInfcx<'_, Infcx, &Self>,
+        f: &mut core::fmt::Formatter<'_>,
+    ) -> core::fmt::Result {
+        f.debug_tuple("Binder")
+            .field(&this.map(|data| data.as_ref().skip_binder()))
+            .field(&this.data.bound_vars())
+            .finish()
     }
 }
 

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -69,7 +69,6 @@ pub trait Interner:
     // Things stored inside of tys
     type ErrorGuaranteed: Copy + Debug + Hash + Eq;
     type BoundExistentialPredicates: Copy + DebugWithInfcx<Self> + Hash + Eq;
-    type PolyFnSig: Copy + DebugWithInfcx<Self> + Hash + Eq;
     type AllocId: Copy + Debug + Hash + Eq;
     type Pat: Copy + Debug + Hash + Eq + DebugWithInfcx<Self>;
     type Safety: Safety<Self>;

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -29,9 +29,7 @@ pub trait Interner:
     type AdtDef: Copy + Debug + Hash + Eq;
 
     type GenericArgs: GenericArgs<Self>;
-    /// The slice of args for a specific item. For a GAT like `type Foo<'a>`, it will be `['a]`,
-    /// not including the args from the parent item (trait or impl).
-    type OwnItemArgs: Copy + Debug + Hash + Eq;
+    type GenericArgsSlice: Copy + Debug + Hash + Eq + Deref<Target = [Self::GenericArg]>;
     type GenericArg: Copy
         + DebugWithInfcx<Self>
         + Hash
@@ -111,7 +109,7 @@ pub trait Interner:
         self,
         def_id: Self::DefId,
         args: Self::GenericArgs,
-    ) -> (ty::TraitRef<Self>, Self::OwnItemArgs);
+    ) -> (ty::TraitRef<Self>, Self::GenericArgsSlice);
 
     fn mk_args(self, args: &[Self::GenericArg]) -> Self::GenericArgs;
     fn mk_args_from_iter(self, args: impl Iterator<Item = Self::GenericArg>) -> Self::GenericArgs;

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -604,7 +604,7 @@ impl<I: Interner> AliasTerm<I> {
     /// For example, if this is a projection of `<T as StreamingIterator>::Item<'a>`,
     /// then this function would return a `T: StreamingIterator` trait reference and
     /// `['a]` as the own args.
-    pub fn trait_ref_and_own_args(self, interner: I) -> (TraitRef<I>, I::OwnItemArgs) {
+    pub fn trait_ref_and_own_args(self, interner: I) -> (TraitRef<I>, I::GenericArgsSlice) {
         interner.trait_ref_and_own_args_for_alias(self.def_id, self.args)
     }
 

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -141,7 +141,7 @@ pub enum TyKind<I: Interner> {
     /// fn foo() -> i32 { 1 }
     /// let bar: fn() -> i32 = foo;
     /// ```
-    FnPtr(I::PolyFnSig),
+    FnPtr(ty::Binder<I, FnSig<I>>),
 
     /// A trait object. Written as `dyn for<'b> Trait<'b, Assoc = u32> + Send + 'a`.
     Dynamic(I::BoundExistentialPredicates, I::Region, DynKind),

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -7,12 +7,14 @@ use rustc_macros::{Decodable, Encodable, HashStable_NoContext, TyDecodable, TyEn
 use rustc_type_ir_macros::{Lift_Generic, TypeFoldable_Generic, TypeVisitable_Generic};
 use std::fmt;
 
+pub use self::closure::*;
+use self::TyKind::*;
 use crate::inherent::*;
 use crate::{self as ty, DebruijnIndex, DebugWithInfcx, InferCtxtLike, Interner, WithInfcx};
 
-use self::TyKind::*;
-
 use rustc_ast_ir::Mutability;
+
+mod closure;
 
 /// Specifies how a trait object is represented.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -514,7 +516,7 @@ impl<I: Interner> AliasTy<I> {
     /// For example, if this is a projection of `<T as StreamingIterator>::Item<'a>`,
     /// then this function would return a `T: StreamingIterator` trait reference and
     /// `['a]` as the own args.
-    pub fn trait_ref_and_own_args(self, interner: I) -> (ty::TraitRef<I>, I::OwnItemArgs) {
+    pub fn trait_ref_and_own_args(self, interner: I) -> (ty::TraitRef<I>, I::GenericArgsSlice) {
         debug_assert_eq!(self.kind(interner), AliasTyKind::Projection);
         interner.trait_ref_and_own_args_for_alias(self.def_id, self.args)
     }

--- a/compiler/rustc_type_ir/src/ty_kind/closure.rs
+++ b/compiler/rustc_type_ir/src/ty_kind/closure.rs
@@ -1,0 +1,696 @@
+use std::ops::ControlFlow;
+
+use rustc_type_ir_macros::{Lift_Generic, TypeFoldable_Generic, TypeVisitable_Generic};
+
+use crate::fold::{shift_region, TypeFoldable, TypeFolder, TypeSuperFoldable};
+use crate::inherent::*;
+use crate::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitor};
+use crate::{self as ty, Interner};
+
+/// A closure can be modeled as a struct that looks like:
+/// ```ignore (illustrative)
+/// struct Closure<'l0...'li, T0...Tj, CK, CS, U>(...U);
+/// ```
+/// where:
+///
+/// - 'l0...'li and T0...Tj are the generic parameters
+///   in scope on the function that defined the closure,
+/// - CK represents the *closure kind* (Fn vs FnMut vs FnOnce). This
+///   is rather hackily encoded via a scalar type. See
+///   `Ty::to_opt_closure_kind` for details.
+/// - CS represents the *closure signature*, representing as a `fn()`
+///   type. For example, `fn(u32, u32) -> u32` would mean that the closure
+///   implements `CK<(u32, u32), Output = u32>`, where `CK` is the trait
+///   specified above.
+/// - U is a type parameter representing the types of its upvars, tupled up
+///   (borrowed, if appropriate; that is, if a U field represents a by-ref upvar,
+///    and the up-var has the type `Foo`, then that field of U will be `&Foo`).
+///
+/// So, for example, given this function:
+/// ```ignore (illustrative)
+/// fn foo<'a, T>(data: &'a mut T) {
+///      do(|| data.count += 1)
+/// }
+/// ```
+/// the type of the closure would be something like:
+/// ```ignore (illustrative)
+/// struct Closure<'a, T, U>(...U);
+/// ```
+/// Note that the type of the upvar is not specified in the struct.
+/// You may wonder how the impl would then be able to use the upvar,
+/// if it doesn't know it's type? The answer is that the impl is
+/// (conceptually) not fully generic over Closure but rather tied to
+/// instances with the expected upvar types:
+/// ```ignore (illustrative)
+/// impl<'b, 'a, T> FnMut() for Closure<'a, T, (&'b mut &'a mut T,)> {
+///     ...
+/// }
+/// ```
+/// You can see that the *impl* fully specified the type of the upvar
+/// and thus knows full well that `data` has type `&'b mut &'a mut T`.
+/// (Here, I am assuming that `data` is mut-borrowed.)
+///
+/// Now, the last question you may ask is: Why include the upvar types
+/// in an extra type parameter? The reason for this design is that the
+/// upvar types can reference lifetimes that are internal to the
+/// creating function. In my example above, for example, the lifetime
+/// `'b` represents the scope of the closure itself; this is some
+/// subset of `foo`, probably just the scope of the call to the to
+/// `do()`. If we just had the lifetime/type parameters from the
+/// enclosing function, we couldn't name this lifetime `'b`. Note that
+/// there can also be lifetimes in the types of the upvars themselves,
+/// if one of them happens to be a reference to something that the
+/// creating fn owns.
+///
+/// OK, you say, so why not create a more minimal set of parameters
+/// that just includes the extra lifetime parameters? The answer is
+/// primarily that it would be hard --- we don't know at the time when
+/// we create the closure type what the full types of the upvars are,
+/// nor do we know which are borrowed and which are not. In this
+/// design, we can just supply a fresh type parameter and figure that
+/// out later.
+///
+/// All right, you say, but why include the type parameters from the
+/// original function then? The answer is that codegen may need them
+/// when monomorphizing, and they may not appear in the upvars. A
+/// closure could capture no variables but still make use of some
+/// in-scope type parameter with a bound (e.g., if our example above
+/// had an extra `U: Default`, and the closure called `U::default()`).
+///
+/// There is another reason. This design (implicitly) prohibits
+/// closures from capturing themselves (except via a trait
+/// object). This simplifies closure inference considerably, since it
+/// means that when we infer the kind of a closure or its upvars, we
+/// don't have to handle cycles where the decisions we make for
+/// closure C wind up influencing the decisions we ought to make for
+/// closure C (which would then require fixed point iteration to
+/// handle). Plus it fixes an ICE. :P
+///
+/// ## Coroutines
+///
+/// Coroutines are handled similarly in `CoroutineArgs`. The set of
+/// type parameters is similar, but `CK` and `CS` are replaced by the
+/// following type parameters:
+///
+/// * `GS`: The coroutine's "resume type", which is the type of the
+///   argument passed to `resume`, and the type of `yield` expressions
+///   inside the coroutine.
+/// * `GY`: The "yield type", which is the type of values passed to
+///   `yield` inside the coroutine.
+/// * `GR`: The "return type", which is the type of value returned upon
+///   completion of the coroutine.
+/// * `GW`: The "coroutine witness".
+#[derive(derivative::Derivative)]
+#[derivative(
+    Clone(bound = ""),
+    Copy(bound = ""),
+    Hash(bound = ""),
+    PartialEq(bound = ""),
+    Eq(bound = ""),
+    Debug(bound = "")
+)]
+#[derive(TypeVisitable_Generic, TypeFoldable_Generic, Lift_Generic)]
+pub struct ClosureArgs<I: Interner> {
+    /// Lifetime and type parameters from the enclosing function,
+    /// concatenated with a tuple containing the types of the upvars.
+    ///
+    /// These are separated out because codegen wants to pass them around
+    /// when monomorphizing.
+    pub args: I::GenericArgs,
+}
+
+/// Struct returned by `split()`.
+pub struct ClosureArgsParts<I: Interner> {
+    /// This is the args of the typeck root.
+    pub parent_args: I::GenericArgsSlice,
+    /// Represents the maximum calling capability of the closure.
+    pub closure_kind_ty: I::Ty,
+    /// Captures the closure's signature. This closure signature is "tupled", and
+    /// thus has a peculiar signature of `extern "rust-call" fn((Args, ...)) -> Ty`.
+    pub closure_sig_as_fn_ptr_ty: I::Ty,
+    /// The upvars captured by the closure. Remains an inference variable
+    /// until the upvar analysis, which happens late in HIR typeck.
+    pub tupled_upvars_ty: I::Ty,
+}
+
+impl<I: Interner> ClosureArgs<I> {
+    /// Construct `ClosureArgs` from `ClosureArgsParts`, containing `Args`
+    /// for the closure parent, alongside additional closure-specific components.
+    pub fn new(tcx: I, parts: ClosureArgsParts<I>) -> ClosureArgs<I> {
+        ClosureArgs {
+            args: tcx.mk_args_from_iter(parts.parent_args.iter().copied().chain([
+                parts.closure_kind_ty.into(),
+                parts.closure_sig_as_fn_ptr_ty.into(),
+                parts.tupled_upvars_ty.into(),
+            ])),
+        }
+    }
+
+    /// Divides the closure args into their respective components.
+    /// The ordering assumed here must match that used by `ClosureArgs::new` above.
+    fn split(self) -> ClosureArgsParts<I> {
+        self.args.split_closure_args()
+    }
+
+    /// Returns the generic parameters of the closure's parent.
+    pub fn parent_args(self) -> I::GenericArgsSlice {
+        self.split().parent_args
+    }
+
+    /// Returns an iterator over the list of types of captured paths by the closure.
+    /// In case there was a type error in figuring out the types of the captured path, an
+    /// empty iterator is returned.
+    #[inline]
+    pub fn upvar_tys(self) -> I::Tys {
+        match self.tupled_upvars_ty().kind() {
+            ty::Error(_) => Default::default(),
+            ty::Tuple(tys) => tys,
+            ty::Infer(_) => panic!("upvar_tys called before capture types are inferred"),
+            ty => panic!("Unexpected representation of upvar types tuple {:?}", ty),
+        }
+    }
+
+    /// Returns the tuple type representing the upvars for this closure.
+    #[inline]
+    pub fn tupled_upvars_ty(self) -> I::Ty {
+        self.split().tupled_upvars_ty
+    }
+
+    /// Returns the closure kind for this closure; may return a type
+    /// variable during inference. To get the closure kind during
+    /// inference, use `infcx.closure_kind(args)`.
+    pub fn kind_ty(self) -> I::Ty {
+        self.split().closure_kind_ty
+    }
+
+    /// Returns the `fn` pointer type representing the closure signature for this
+    /// closure.
+    // FIXME(eddyb) this should be unnecessary, as the shallowly resolved
+    // type is known at the time of the creation of `ClosureArgs`,
+    // see `rustc_hir_analysis::check::closure`.
+    pub fn sig_as_fn_ptr_ty(self) -> I::Ty {
+        self.split().closure_sig_as_fn_ptr_ty
+    }
+
+    /// Returns the closure kind for this closure; only usable outside
+    /// of an inference context, because in that context we know that
+    /// there are no type variables.
+    ///
+    /// If you have an inference context, use `infcx.closure_kind()`.
+    pub fn kind(self) -> ty::ClosureKind {
+        self.kind_ty().to_opt_closure_kind().unwrap()
+    }
+
+    /// Extracts the signature from the closure.
+    pub fn sig(self) -> ty::Binder<I, ty::FnSig<I>> {
+        match self.sig_as_fn_ptr_ty().kind() {
+            ty::FnPtr(sig) => sig,
+            ty => panic!("closure_sig_as_fn_ptr_ty is not a fn-ptr: {ty:?}"),
+        }
+    }
+}
+
+#[derive(derivative::Derivative)]
+#[derivative(
+    Clone(bound = ""),
+    Copy(bound = ""),
+    Hash(bound = ""),
+    PartialEq(bound = ""),
+    Eq(bound = ""),
+    Debug(bound = "")
+)]
+#[derive(TypeVisitable_Generic, TypeFoldable_Generic, Lift_Generic)]
+pub struct CoroutineClosureArgs<I: Interner> {
+    pub args: I::GenericArgs,
+}
+
+/// See docs for explanation of how each argument is used.
+///
+/// See [`CoroutineClosureSignature`] for how these arguments are put together
+/// to make a callable [`FnSig`] suitable for typeck and borrowck.
+pub struct CoroutineClosureArgsParts<I: Interner> {
+    /// This is the args of the typeck root.
+    pub parent_args: I::GenericArgsSlice,
+    /// Represents the maximum calling capability of the closure.
+    pub closure_kind_ty: I::Ty,
+    /// Represents all of the relevant parts of the coroutine returned by this
+    /// coroutine-closure. This signature parts type will have the general
+    /// shape of `fn(tupled_inputs, resume_ty) -> (return_ty, yield_ty)`, where
+    /// `resume_ty`, `return_ty`, and `yield_ty` are the respective types for the
+    /// coroutine returned by the coroutine-closure.
+    ///
+    /// Use `coroutine_closure_sig` to break up this type rather than using it
+    /// yourself.
+    pub signature_parts_ty: I::Ty,
+    /// The upvars captured by the closure. Remains an inference variable
+    /// until the upvar analysis, which happens late in HIR typeck.
+    pub tupled_upvars_ty: I::Ty,
+    /// a function pointer that has the shape `for<'env> fn() -> (&'env T, ...)`.
+    /// This allows us to represent the binder of the self-captures of the closure.
+    ///
+    /// For example, if the coroutine returned by the closure borrows `String`
+    /// from the closure's upvars, this will be `for<'env> fn() -> (&'env String,)`,
+    /// while the `tupled_upvars_ty`, representing the by-move version of the same
+    /// captures, will be `(String,)`.
+    pub coroutine_captures_by_ref_ty: I::Ty,
+    /// Witness type returned by the generator produced by this coroutine-closure.
+    pub coroutine_witness_ty: I::Ty,
+}
+
+impl<I: Interner> CoroutineClosureArgs<I> {
+    pub fn new(tcx: I, parts: CoroutineClosureArgsParts<I>) -> CoroutineClosureArgs<I> {
+        CoroutineClosureArgs {
+            args: tcx.mk_args_from_iter(parts.parent_args.iter().copied().chain([
+                parts.closure_kind_ty.into(),
+                parts.signature_parts_ty.into(),
+                parts.tupled_upvars_ty.into(),
+                parts.coroutine_captures_by_ref_ty.into(),
+                parts.coroutine_witness_ty.into(),
+            ])),
+        }
+    }
+
+    fn split(self) -> CoroutineClosureArgsParts<I> {
+        self.args.split_coroutine_closure_args()
+    }
+
+    pub fn parent_args(self) -> I::GenericArgsSlice {
+        self.split().parent_args
+    }
+
+    #[inline]
+    pub fn upvar_tys(self) -> I::Tys {
+        match self.tupled_upvars_ty().kind() {
+            ty::Error(_) => Default::default(),
+            ty::Tuple(..) => self.tupled_upvars_ty().tuple_fields(),
+            ty::Infer(_) => panic!("upvar_tys called before capture types are inferred"),
+            ty => panic!("Unexpected representation of upvar types tuple {:?}", ty),
+        }
+    }
+
+    #[inline]
+    pub fn tupled_upvars_ty(self) -> I::Ty {
+        self.split().tupled_upvars_ty
+    }
+
+    pub fn kind_ty(self) -> I::Ty {
+        self.split().closure_kind_ty
+    }
+
+    pub fn kind(self) -> ty::ClosureKind {
+        self.kind_ty().to_opt_closure_kind().unwrap()
+    }
+
+    pub fn signature_parts_ty(self) -> I::Ty {
+        self.split().signature_parts_ty
+    }
+
+    pub fn coroutine_closure_sig(self) -> ty::Binder<I, CoroutineClosureSignature<I>> {
+        let interior = self.coroutine_witness_ty();
+        let ty::FnPtr(sig) = self.signature_parts_ty().kind() else { panic!() };
+        sig.map_bound(|sig| {
+            let [resume_ty, tupled_inputs_ty] = *sig.inputs() else {
+                panic!();
+            };
+            let [yield_ty, return_ty] = **sig.output().tuple_fields() else { panic!() };
+            CoroutineClosureSignature {
+                interior,
+                tupled_inputs_ty,
+                resume_ty,
+                yield_ty,
+                return_ty,
+                c_variadic: sig.c_variadic,
+                safety: sig.safety,
+                abi: sig.abi,
+            }
+        })
+    }
+
+    pub fn coroutine_captures_by_ref_ty(self) -> I::Ty {
+        self.split().coroutine_captures_by_ref_ty
+    }
+
+    pub fn coroutine_witness_ty(self) -> I::Ty {
+        self.split().coroutine_witness_ty
+    }
+
+    pub fn has_self_borrows(&self) -> bool {
+        match self.coroutine_captures_by_ref_ty().kind() {
+            ty::FnPtr(sig) => sig
+                .skip_binder()
+                .visit_with(&mut HasRegionsBoundAt { binder: ty::INNERMOST })
+                .is_break(),
+            ty::Error(_) => true,
+            _ => panic!(),
+        }
+    }
+}
+
+/// Unlike `has_escaping_bound_vars` or `outermost_exclusive_binder`, this will
+/// detect only regions bound *at* the debruijn index.
+struct HasRegionsBoundAt {
+    binder: ty::DebruijnIndex,
+}
+// FIXME: Could be optimized to not walk into components with no escaping bound vars.
+impl<I: Interner> TypeVisitor<I> for HasRegionsBoundAt {
+    type Result = ControlFlow<()>;
+    fn visit_binder<T: TypeVisitable<I>>(&mut self, t: &ty::Binder<I, T>) -> Self::Result {
+        self.binder.shift_in(1);
+        t.super_visit_with(self)?;
+        self.binder.shift_out(1);
+        ControlFlow::Continue(())
+    }
+
+    fn visit_region(&mut self, r: I::Region) -> Self::Result {
+        if matches!(r.kind(), ty::ReBound(binder, _) if self.binder == binder) {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    }
+}
+
+#[derive(derivative::Derivative)]
+#[derivative(
+    Clone(bound = ""),
+    Copy(bound = ""),
+    Hash(bound = ""),
+    PartialEq(bound = ""),
+    Eq(bound = ""),
+    Debug(bound = "")
+)]
+#[derive(TypeVisitable_Generic, TypeFoldable_Generic)]
+pub struct CoroutineClosureSignature<I: Interner> {
+    pub interior: I::Ty,
+    pub tupled_inputs_ty: I::Ty,
+    pub resume_ty: I::Ty,
+    pub yield_ty: I::Ty,
+    pub return_ty: I::Ty,
+
+    // Like the `fn_sig_as_fn_ptr_ty` of a regular closure, these types
+    // never actually differ. But we save them rather than recreating them
+    // from scratch just for good measure.
+    /// Always false
+    pub c_variadic: bool,
+    /// Always `Normal` (safe)
+    pub safety: I::Safety,
+    /// Always `RustCall`
+    pub abi: I::Abi,
+}
+
+impl<I: Interner> CoroutineClosureSignature<I> {
+    /// Construct a coroutine from the closure signature. Since a coroutine signature
+    /// is agnostic to the type of generator that is returned (by-ref/by-move),
+    /// the caller must specify what "flavor" of generator that they'd like to
+    /// create. Additionally, they must manually compute the upvars of the closure.
+    ///
+    /// This helper is not really meant to be used directly except for early on
+    /// during typeck, when we want to put inference vars into the kind and upvars tys.
+    /// When the kind and upvars are known, use the other helper functions.
+    pub fn to_coroutine(
+        self,
+        tcx: I,
+        parent_args: I::GenericArgsSlice,
+        coroutine_kind_ty: I::Ty,
+        coroutine_def_id: I::DefId,
+        tupled_upvars_ty: I::Ty,
+    ) -> I::Ty {
+        let coroutine_args = ty::CoroutineArgs::new(
+            tcx,
+            ty::CoroutineArgsParts {
+                parent_args,
+                kind_ty: coroutine_kind_ty,
+                resume_ty: self.resume_ty,
+                yield_ty: self.yield_ty,
+                return_ty: self.return_ty,
+                witness: self.interior,
+                tupled_upvars_ty,
+            },
+        );
+
+        Ty::new_coroutine(tcx, coroutine_def_id, coroutine_args.args)
+    }
+
+    /// Given known upvars and a [`ClosureKind`](ty::ClosureKind), compute the coroutine
+    /// returned by that corresponding async fn trait.
+    ///
+    /// This function expects the upvars to have been computed already, and doesn't check
+    /// that the `ClosureKind` is actually supported by the coroutine-closure.
+    pub fn to_coroutine_given_kind_and_upvars(
+        self,
+        tcx: I,
+        parent_args: I::GenericArgsSlice,
+        coroutine_def_id: I::DefId,
+        goal_kind: ty::ClosureKind,
+        env_region: I::Region,
+        closure_tupled_upvars_ty: I::Ty,
+        coroutine_captures_by_ref_ty: I::Ty,
+    ) -> I::Ty {
+        let tupled_upvars_ty = Self::tupled_upvars_by_closure_kind(
+            tcx,
+            goal_kind,
+            self.tupled_inputs_ty,
+            closure_tupled_upvars_ty,
+            coroutine_captures_by_ref_ty,
+            env_region,
+        );
+
+        self.to_coroutine(
+            tcx,
+            parent_args,
+            Ty::from_coroutine_closure_kind(tcx, goal_kind),
+            coroutine_def_id,
+            tupled_upvars_ty,
+        )
+    }
+
+    /// Compute the tupled upvars that a coroutine-closure's output coroutine
+    /// would return for the given `ClosureKind`.
+    ///
+    /// When `ClosureKind` is `FnMut`/`Fn`, then this will use the "captures by ref"
+    /// to return a set of upvars which are borrowed with the given `env_region`.
+    ///
+    /// This ensures that the `AsyncFn::call` will return a coroutine whose upvars'
+    /// lifetimes are related to the lifetime of the borrow on the closure made for
+    /// the call. This allows borrowck to enforce the self-borrows correctly.
+    pub fn tupled_upvars_by_closure_kind(
+        tcx: I,
+        kind: ty::ClosureKind,
+        tupled_inputs_ty: I::Ty,
+        closure_tupled_upvars_ty: I::Ty,
+        coroutine_captures_by_ref_ty: I::Ty,
+        env_region: I::Region,
+    ) -> I::Ty {
+        match kind {
+            ty::ClosureKind::Fn | ty::ClosureKind::FnMut => {
+                let ty::FnPtr(sig) = coroutine_captures_by_ref_ty.kind() else {
+                    panic!();
+                };
+                let coroutine_captures_by_ref_ty =
+                    sig.output().skip_binder().fold_with(&mut FoldEscapingRegions {
+                        interner: tcx,
+                        region: env_region,
+                        debruijn: ty::INNERMOST,
+                    });
+                Ty::new_tup_from_iter(
+                    tcx,
+                    tupled_inputs_ty
+                        .tuple_fields()
+                        .into_iter()
+                        .chain(coroutine_captures_by_ref_ty.tuple_fields()),
+                )
+            }
+            ty::ClosureKind::FnOnce => Ty::new_tup_from_iter(
+                tcx,
+                tupled_inputs_ty
+                    .tuple_fields()
+                    .into_iter()
+                    .chain(closure_tupled_upvars_ty.tuple_fields()),
+            ),
+        }
+    }
+}
+
+/// Instantiates a `for<'env> ...` binder with a specific region.
+// FIXME(async_closures): Get rid of this in favor of `BoundVarReplacerDelegate`
+// when that is uplifted.
+struct FoldEscapingRegions<I: Interner> {
+    interner: I,
+    debruijn: ty::DebruijnIndex,
+    region: I::Region,
+}
+
+impl<I: Interner> TypeFolder<I> for FoldEscapingRegions<I> {
+    fn interner(&self) -> I {
+        self.interner
+    }
+
+    fn fold_binder<T>(&mut self, t: ty::Binder<I, T>) -> ty::Binder<I, T>
+    where
+        T: TypeFoldable<I>,
+    {
+        self.debruijn.shift_in(1);
+        let result = t.super_fold_with(self);
+        self.debruijn.shift_out(1);
+        result
+    }
+
+    fn fold_region(&mut self, r: <I as Interner>::Region) -> <I as Interner>::Region {
+        if let ty::ReBound(debruijn, _) = r.kind() {
+            assert!(
+                debruijn <= self.debruijn,
+                "cannot instantiate binder with escaping bound vars"
+            );
+            if self.debruijn == debruijn {
+                shift_region(self.interner, self.region, self.debruijn.as_u32())
+            } else {
+                r
+            }
+        } else {
+            r
+        }
+    }
+}
+
+#[derive(derivative::Derivative)]
+#[derivative(
+    Clone(bound = ""),
+    Copy(bound = ""),
+    Hash(bound = ""),
+    PartialEq(bound = ""),
+    Eq(bound = ""),
+    Debug(bound = "")
+)]
+#[derive(TypeVisitable_Generic, TypeFoldable_Generic)]
+pub struct GenSig<I: Interner> {
+    pub resume_ty: I::Ty,
+    pub yield_ty: I::Ty,
+    pub return_ty: I::Ty,
+}
+
+/// Similar to `ClosureArgs`; see the above documentation for more.
+#[derive(derivative::Derivative)]
+#[derivative(
+    Clone(bound = ""),
+    Copy(bound = ""),
+    Hash(bound = ""),
+    PartialEq(bound = ""),
+    Eq(bound = ""),
+    Debug(bound = "")
+)]
+#[derive(TypeVisitable_Generic, TypeFoldable_Generic, Lift_Generic)]
+pub struct CoroutineArgs<I: Interner> {
+    pub args: I::GenericArgs,
+}
+
+pub struct CoroutineArgsParts<I: Interner> {
+    /// This is the args of the typeck root.
+    pub parent_args: I::GenericArgsSlice,
+
+    /// The coroutines returned by a coroutine-closure's `AsyncFnOnce`/`AsyncFnMut`
+    /// implementations must be distinguished since the former takes the closure's
+    /// upvars by move, and the latter takes the closure's upvars by ref.
+    ///
+    /// This field distinguishes these fields so that codegen can select the right
+    /// body for the coroutine. This has the same type representation as the closure
+    /// kind: `i8`/`i16`/`i32`.
+    ///
+    /// For regular coroutines, this field will always just be `()`.
+    pub kind_ty: I::Ty,
+
+    pub resume_ty: I::Ty,
+    pub yield_ty: I::Ty,
+    pub return_ty: I::Ty,
+
+    /// The interior type of the coroutine.
+    /// Represents all types that are stored in locals
+    /// in the coroutine's body.
+    pub witness: I::Ty,
+
+    /// The upvars captured by the closure. Remains an inference variable
+    /// until the upvar analysis, which happens late in HIR typeck.
+    pub tupled_upvars_ty: I::Ty,
+}
+
+impl<I: Interner> CoroutineArgs<I> {
+    /// Construct `CoroutineArgs` from `CoroutineArgsParts`, containing `Args`
+    /// for the coroutine parent, alongside additional coroutine-specific components.
+    pub fn new(tcx: I, parts: CoroutineArgsParts<I>) -> CoroutineArgs<I> {
+        CoroutineArgs {
+            args: tcx.mk_args_from_iter(parts.parent_args.iter().copied().chain([
+                parts.kind_ty.into(),
+                parts.resume_ty.into(),
+                parts.yield_ty.into(),
+                parts.return_ty.into(),
+                parts.witness.into(),
+                parts.tupled_upvars_ty.into(),
+            ])),
+        }
+    }
+
+    /// Divides the coroutine args into their respective components.
+    /// The ordering assumed here must match that used by `CoroutineArgs::new` above.
+    fn split(self) -> CoroutineArgsParts<I> {
+        self.args.split_coroutine_args()
+    }
+
+    /// Returns the generic parameters of the coroutine's parent.
+    pub fn parent_args(self) -> I::GenericArgsSlice {
+        self.split().parent_args
+    }
+
+    // Returns the kind of the coroutine. See docs on the `kind_ty` field.
+    pub fn kind_ty(self) -> I::Ty {
+        self.split().kind_ty
+    }
+
+    /// This describes the types that can be contained in a coroutine.
+    /// It will be a type variable initially and unified in the last stages of typeck of a body.
+    /// It contains a tuple of all the types that could end up on a coroutine frame.
+    /// The state transformation MIR pass may only produce layouts which mention types
+    /// in this tuple. Upvars are not counted here.
+    pub fn witness(self) -> I::Ty {
+        self.split().witness
+    }
+
+    /// Returns an iterator over the list of types of captured paths by the coroutine.
+    /// In case there was a type error in figuring out the types of the captured path, an
+    /// empty iterator is returned.
+    #[inline]
+    pub fn upvar_tys(self) -> I::Tys {
+        match self.tupled_upvars_ty().kind() {
+            ty::Error(_) => Default::default(),
+            ty::Tuple(tys) => tys,
+            ty::Infer(_) => panic!("upvar_tys called before capture types are inferred"),
+            ty => panic!("Unexpected representation of upvar types tuple {:?}", ty),
+        }
+    }
+
+    /// Returns the tuple type representing the upvars for this coroutine.
+    #[inline]
+    pub fn tupled_upvars_ty(self) -> I::Ty {
+        self.split().tupled_upvars_ty
+    }
+
+    /// Returns the type representing the resume type of the coroutine.
+    pub fn resume_ty(self) -> I::Ty {
+        self.split().resume_ty
+    }
+
+    /// Returns the type representing the yield type of the coroutine.
+    pub fn yield_ty(self) -> I::Ty {
+        self.split().yield_ty
+    }
+
+    /// Returns the type representing the return type of the coroutine.
+    pub fn return_ty(self) -> I::Ty {
+        self.split().return_ty
+    }
+
+    /// Returns the "coroutine signature", which consists of its resume, yield
+    /// and return types.
+    pub fn sig(self) -> GenSig<I> {
+        let parts = self.split();
+        GenSig { resume_ty: parts.resume_ty, yield_ty: parts.yield_ty, return_ty: parts.return_ty }
+    }
+}

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1093,9 +1093,12 @@ macro_rules! uint_impl {
         pub const fn checked_ilog(self, base: Self) -> Option<u32> {
             if self <= 0 || base <= 1 {
                 None
+            } else if self < base {
+                Some(0)
             } else {
-                let mut n = 0;
-                let mut r = 1;
+                // Since base >= self, n >= 1
+                let mut n = 1;
+                let mut r = base;
 
                 // Optimization for 128 bit wide integers.
                 if Self::BITS == 128 {

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -469,7 +469,8 @@ impl Build {
 
             // Make sure we update these before gathering metadata so we don't get an error about missing
             // Cargo.toml files.
-            let rust_submodules = ["src/tools/cargo", "library/backtrace", "library/stdarch"];
+            let rust_submodules =
+                ["src/tools/cargo", "src/doc/book", "library/backtrace", "library/stdarch"];
             for s in rust_submodules {
                 build.update_submodule(Path::new(s));
             }

--- a/src/tools/clippy/clippy_lints/src/eta_reduction.rs
+++ b/src/tools/clippy/clippy_lints/src/eta_reduction.rs
@@ -10,7 +10,7 @@ use rustc_infer::infer::TyCtxtInferExt;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{
     self, Binder, ClosureArgs, ClosureKind, FnSig, GenericArg, GenericArgKind, List, Region, RegionKind, Ty,
-    TypeVisitableExt, TypeckResults,
+    TypeVisitableExt, TypeckResults, TyCtxt,
 };
 use rustc_session::declare_lint_pass;
 use rustc_span::symbol::sym;
@@ -240,7 +240,7 @@ fn check_inputs(
         })
 }
 
-fn check_sig<'tcx>(cx: &LateContext<'tcx>, closure: ClosureArgs<'tcx>, call_sig: FnSig<'_>) -> bool {
+fn check_sig<'tcx>(cx: &LateContext<'tcx>, closure: ClosureArgs<TyCtxt<'tcx>>, call_sig: FnSig<'_>) -> bool {
     call_sig.safety == Safety::Safe
         && !has_late_bound_to_non_late_bound_regions(
             cx.tcx.signature_unclosure(closure.sig(), Safety::Safe).skip_binder(),

--- a/tests/codegen/checked_ilog.rs
+++ b/tests/codegen/checked_ilog.rs
@@ -1,0 +1,20 @@
+//@ compile-flags: -O
+
+#![crate_type = "lib"]
+
+// Ensure that when val < base, we do not divide or multiply.
+
+// CHECK-LABEL: @checked_ilog
+// CHECK-SAME: (i16 noundef %val, i16 noundef %base)
+#[no_mangle]
+pub fn checked_ilog(val: u16, base: u16) -> Option<u32> {
+    // CHECK-NOT: udiv
+    // CHECK-NOT: mul
+    // CHECK: %[[IS_LESS:.+]] = icmp ult i16 %val, %base
+    // CHECK-NEXT: br i1 %[[IS_LESS]], label %[[TRUE:.+]], label %[[FALSE:.+]]
+    // CHECK: [[TRUE]]:
+    // CHECK-NOT: udiv
+    // CHECK-NOT: mul
+    // CHECK: ret { i32, i32 }
+    val.checked_ilog(base)
+}


### PR DESCRIPTION
Successful merges:

 - #124294 (Unroll first iteration of checked_ilog loop)
 - #125562 (Weekly `cargo update`)
 - #125775 (Uplift `{Closure,Coroutine,CoroutineClosure}Args` and friends to `rustc_type_ir`)
 - #125822 (Refactor `--print=check-cfg` test)
 - #125856 (include missing submodule on bootstrap)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=124294,125562,125775,125822,125856)
<!-- homu-ignore:end -->