### PR TITLE
Reject `CVarArgs` in `parse_ty_for_where_clause`

### DIFF
--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -194,7 +194,7 @@ impl<'a> Parser<'a> {
     pub(super) fn parse_ty_for_where_clause(&mut self) -> PResult<'a, P<Ty>> {
         self.parse_ty_common(
             AllowPlus::Yes,
-            AllowCVariadic::Yes,
+            AllowCVariadic::No,
             RecoverQPath::Yes,
             RecoverReturnSign::OnlyFatArrow,
             None,
@@ -344,8 +344,9 @@ impl<'a> Parser<'a> {
             match allow_c_variadic {
                 AllowCVariadic::Yes => TyKind::CVarArgs,
                 AllowCVariadic::No => {
-                    // FIXME(Centril): Should we just allow `...` syntactically
+                    // FIXME(c_variadic): Should we just allow `...` syntactically
                     // anywhere in a type and use semantic restrictions instead?
+                    // NOTE: This may regress certain MBE calls if done incorrectly.
                     let guar = self
                         .dcx()
                         .emit_err(NestedCVariadicType { span: lo.to(self.prev_token.span) });

--- a/tests/ui/parser/macro/mbe-dotdotdot-may-not-begin-a-type.rs
+++ b/tests/ui/parser/macro/mbe-dotdotdot-may-not-begin-a-type.rs
@@ -1,0 +1,11 @@
+// A bare `...` represents `CVarArgs` (`VaListImpl<'_>`) in function argument type
+// position without being a proper type syntactically.
+// This test ensures that we do not regress certain MBE calls would we ever promote
+// `...` to a proper type syntactically.
+
+//@ check-pass
+
+macro_rules! ck { ($ty:ty) => { compile_error!(""); }; (...) => {}; }
+ck!(...);
+
+fn main() {}

--- a/tests/ui/parser/variadic-ffi-nested-syntactic-fail.rs
+++ b/tests/ui/parser/variadic-ffi-nested-syntactic-fail.rs
@@ -4,6 +4,10 @@ fn f1<'a>(x: u8, y: &'a ...) {}
 fn f2<'a>(x: u8, y: Vec<&'a ...>) {}
 //~^ ERROR C-variadic type `...` may not be nested inside another type
 
+// Regression test for issue #125847.
+fn f3() where for<> ...: {}
+//~^ ERROR C-variadic type `...` may not be nested inside another type
+
 fn main() {
     let _recovery_witness: () = 0;
     //~^ ERROR: mismatched types

--- a/tests/ui/parser/variadic-ffi-nested-syntactic-fail.stderr
+++ b/tests/ui/parser/variadic-ffi-nested-syntactic-fail.stderr
@@ -10,15 +10,21 @@ error[E0743]: C-variadic type `...` may not be nested inside another type
 LL | fn f2<'a>(x: u8, y: Vec<&'a ...>) {}
    |                             ^^^
 
+error[E0743]: C-variadic type `...` may not be nested inside another type
+  --> $DIR/variadic-ffi-nested-syntactic-fail.rs:8:21
+   |
+LL | fn f3() where for<> ...: {}
+   |                     ^^^
+
 error[E0308]: mismatched types
-  --> $DIR/variadic-ffi-nested-syntactic-fail.rs:8:33
+  --> $DIR/variadic-ffi-nested-syntactic-fail.rs:12:33
    |
 LL |     let _recovery_witness: () = 0;
    |                            --   ^ expected `()`, found integer
    |                            |
    |                            expected due to this
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0308, E0743.
 For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #125847. This regressed in #77035 where the `parse_ty` inside `parse_ty_where_predicate` was replaced with the at the time new `parse_ty_for_where_clause` which incorrectly stated it would permit CVarArgs (maybe a copy/paste error).

r? parser