### PR TITLE
Add `target_env = "p1"` to the `wasm32-wasip1` target

### DIFF
--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1.rs
@@ -18,6 +18,7 @@ pub fn target() -> Target {
     let mut options = base::wasm::options();
 
     options.os = "wasi".into();
+    options.env = "p1".into();
     options.add_pre_link_args(LinkerFlavor::WasmLld(Cc::Yes), &["--target=wasm32-wasi"]);
 
     options.pre_link_objects_self_contained = crt_objects::pre_wasi_self_contained();

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
@@ -13,6 +13,7 @@ pub fn target() -> Target {
     let mut options = base::wasm::options();
 
     options.os = "wasi".into();
+    options.env = "p1".into();
 
     options.add_pre_link_args(
         LinkerFlavor::WasmLld(Cc::No),

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
@@ -155,7 +155,7 @@ or another engine that supports `wasi-threads` is installed and can be found in 
 
 It's recommended to conditionally compile code for this target with:
 
-```
+```text
 #[cfg(all(target_os = "wasi", target_env = "p1", target_feature = "atomics"))]
 ```
 

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
@@ -150,3 +150,15 @@ or another engine that supports `wasi-threads` is installed and can be found in 
 5. Apply such [a change](https://github.com/g0djan/rust/compare/godjan/wasi-threads...g0djan:rust:godjan/wasi-run-ui-tests?expand=1) with an engine from the step 1.
 6. Run `./x.py test --target wasm32-wasip1-threads tests/ui` and save the list of failed tests.
 7. For both lists of failed tests run `cat list | sort > sorted_list` and compare it with `diff sorted_list1 sorted_list2`.
+
+## Conditionally compiling code
+
+It's recommended to conditionally compile code for this target with:
+
+```
+#[cfg(all(target_os = "wasi", target_env = "p1", target_feature = "atomics"))]
+```
+
+Prior to Rust 1.80 the `target_env = "p1"` key was not set. Currently the
+`target_feature = "atomics"` is Nightly-only. Note that the precise `#[cfg]`
+necessary to detect this target may change as the target becomes more stable.

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1.md
@@ -126,7 +126,7 @@ can be tested locally, for example, with:
 
 It's recommended to conditionally compile code for this target with:
 
-```
+```text
 #[cfg(all(target_os = "wasi", target_env = "p1"))]
 ```
 

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1.md
@@ -121,3 +121,14 @@ can be tested locally, for example, with:
 ```text
 ./x.py test --target wasm32-wasip1 tests/ui
 ```
+
+## Conditionally compiling code
+
+It's recommended to conditionally compile code for this target with:
+
+```
+#[cfg(all(target_os = "wasi", target_env = "p1"))]
+```
+
+Note that the `target_env = "p1"` condition first appeared in Rust 1.80. Prior
+to Rust 1.80 the `target_env` condition was not set.

--- a/src/doc/rustc/src/platform-support/wasm32-wasip2.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip2.md
@@ -53,3 +53,11 @@ This target is not tested in CI at this time. Locally it can be tested with a
 ```text
 ./x.py test --target wasm32-wasip2 tests/ui
 ```
+
+## Conditionally compiling code
+
+It's recommended to conditionally compile code for this target with:
+
+```
+#[cfg(all(target_os = "wasi", target_env = "p2"))]
+```

--- a/src/doc/rustc/src/platform-support/wasm32-wasip2.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip2.md
@@ -58,6 +58,6 @@ This target is not tested in CI at this time. Locally it can be tested with a
 
 It's recommended to conditionally compile code for this target with:
 
-```
+```text
 #[cfg(all(target_os = "wasi", target_env = "p2"))]
 ```

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -147,7 +147,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_env = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_env` are: ``, `gnu`, `msvc`, `musl`, `newlib`, `nto70`, `nto71`, `ohos`, `p2`, `psx`, `relibc`, `sgx`, and `uclibc`
+   = note: expected values for `target_env` are: ``, `gnu`, `msvc`, `musl`, `newlib`, `nto70`, `nto71`, `ohos`, `p1`, `p2`, `psx`, `relibc`, `sgx`, and `uclibc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`


### PR DESCRIPTION
This commit sets the `target_env` key for the
`wasm32-wasi{,p1,p1-threads}` targets to the string `"p1"`. This mirrors how the `wasm32-wasip2` target has `target_env = "p2"`. The intention of this is to more easily detect each target in downstream crates to enable adding custom code per-target.

cc #125803

<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->