### PR TITLE
Add migration lint for 2024 prelude additions

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -91,6 +91,7 @@ declare_lint_pass! {
         RUST_2021_PREFIXES_INCOMPATIBLE_SYNTAX,
         RUST_2021_PRELUDE_COLLISIONS,
         RUST_2024_INCOMPATIBLE_PAT,
+        RUST_2024_PRELUDE_COLLISIONS,
         SELF_CONSTRUCTOR_FROM_OUTER_ITEM,
         SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
         SINGLE_USE_LIFETIMES,
@@ -3747,6 +3748,46 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
         reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>",
+    };
+}
+
+declare_lint! {
+    /// The `rust_2024_prelude_collisions` lint detects the usage of trait methods which are ambiguous
+    /// with traits added to the prelude in future editions.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,edition2021,compile_fail
+    /// #![deny(rust_2024_prelude_collisions)]
+    /// trait Meow {
+    ///     fn poll(&self) {}
+    /// }
+    /// impl<T> Meow for T {}
+    ///
+    /// fn main() {
+    ///     core::pin::pin!(async {}).poll();
+    ///     //                        ^^^^^^
+    ///     // This call to try_into matches both Future::poll and Meow::poll as
+    ///     // `Future` has been added to the Rust prelude in 2024 edition.
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Rust 2024, introduces two new additions to the standard library's prelude:
+    /// `Future` and `IntoFuture`. This results in an ambiguity as to which method/function
+    /// to call when an existing `poll`/`into_future` method is called via dot-call syntax or
+    /// a `poll`/`into_future` associated function is called directly on a type.
+    ///
+    pub RUST_2024_PRELUDE_COLLISIONS,
+    Allow,
+    "detects the usage of trait methods which are ambiguous with traits added to the \
+        prelude in future editions",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>",
     };
 }
 

--- a/tests/ui/rust-2024/prelude-migration/future-poll-already-future.rs
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-already-future.rs
@@ -1,0 +1,17 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//@ check-pass
+
+#![deny(rust_2024_prelude_collisions)]
+
+use std::future::Future;
+
+fn main() {
+    core::pin::pin!(async {}).poll(&mut context());
+}
+
+fn context() -> core::task::Context<'static> {
+    loop {}
+}

--- a/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.fixed
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.fixed
@@ -1,0 +1,21 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2021] run-rustfix
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//@[e2024] check-pass
+
+#![deny(rust_2024_prelude_collisions)]
+trait Meow {
+    fn poll(&self, _ctx: &mut core::task::Context<'_>) {}
+}
+impl<T> Meow for T {}
+fn main() {
+    Meow::poll(&core::pin::pin!(async {}), &mut context());
+    //[e2021]~^ ERROR trait method `poll` will become ambiguous in Rust 2024
+    //[e2021]~| WARN this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+}
+
+fn context() -> core::task::Context<'static> {
+    loop {}
+}

--- a/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.stderr
@@ -1,0 +1,16 @@
+error: trait method `poll` will become ambiguous in Rust 2024
+  --> $DIR/future-poll-async-block.rs:14:5
+   |
+LL |     core::pin::pin!(async {}).poll(&mut context());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::poll(&core::pin::pin!(async {}), &mut context())`
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+note: the lint level is defined here
+  --> $DIR/future-poll-async-block.rs:8:9
+   |
+LL | #![deny(rust_2024_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rust-2024/prelude-migration/future-poll-async-block.rs
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-async-block.rs
@@ -1,0 +1,21 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2021] run-rustfix
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//@[e2024] check-pass
+
+#![deny(rust_2024_prelude_collisions)]
+trait Meow {
+    fn poll(&self, _ctx: &mut core::task::Context<'_>) {}
+}
+impl<T> Meow for T {}
+fn main() {
+    core::pin::pin!(async {}).poll(&mut context());
+    //[e2021]~^ ERROR trait method `poll` will become ambiguous in Rust 2024
+    //[e2021]~| WARN this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+}
+
+fn context() -> core::task::Context<'static> {
+    loop {}
+}

--- a/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.fixed
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.fixed
@@ -1,0 +1,21 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2021] run-rustfix
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//@[e2024] check-pass
+
+#![deny(rust_2024_prelude_collisions)]
+trait Meow {
+    fn poll(&self) {}
+}
+impl<T> Meow for T {}
+fn main() {
+    // This is a deliberate false positive.
+    // While `()` does not implement `Future` and can therefore not be ambiguous, we
+    // do not check that in the lint, as that introduces additional complexities.
+    // Just checking whether the self type is `Pin<&mut _>` is enough.
+    Meow::poll(&core::pin::pin!(()));
+    //[e2021]~^ ERROR trait method `poll` will become ambiguous in Rust 2024
+    //[e2021]~| WARN this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+}

--- a/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.stderr
@@ -1,0 +1,16 @@
+error: trait method `poll` will become ambiguous in Rust 2024
+  --> $DIR/future-poll-not-future-pinned.rs:18:5
+   |
+LL |     core::pin::pin!(()).poll();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::poll(&core::pin::pin!(()))`
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+note: the lint level is defined here
+  --> $DIR/future-poll-not-future-pinned.rs:8:9
+   |
+LL | #![deny(rust_2024_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.rs
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.rs
@@ -1,0 +1,21 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2021] run-rustfix
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//@[e2024] check-pass
+
+#![deny(rust_2024_prelude_collisions)]
+trait Meow {
+    fn poll(&self) {}
+}
+impl<T> Meow for T {}
+fn main() {
+    // This is a deliberate false positive.
+    // While `()` does not implement `Future` and can therefore not be ambiguous, we
+    // do not check that in the lint, as that introduces additional complexities.
+    // Just checking whether the self type is `Pin<&mut _>` is enough.
+    core::pin::pin!(()).poll();
+    //[e2021]~^ ERROR trait method `poll` will become ambiguous in Rust 2024
+    //[e2021]~| WARN this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+}

--- a/tests/ui/rust-2024/prelude-migration/future-poll-not-future.rs
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-not-future.rs
@@ -1,0 +1,15 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//@ check-pass
+
+#![deny(rust_2024_prelude_collisions)]
+trait Meow {
+    fn poll(&self) {}
+}
+impl<T> Meow for T {}
+fn main() {
+    // As the self type here is not `Pin<&mut _>`, the lint does not fire.
+    ().poll();
+}

--- a/tests/ui/rust-2024/prelude-migration/in_2024_compatibility.rs
+++ b/tests/ui/rust-2024/prelude-migration/in_2024_compatibility.rs
@@ -1,0 +1,17 @@
+//@ edition: 2021
+
+#![deny(rust_2024_compatibility)]
+
+trait Meow {
+    fn poll(&self, _ctx: &mut core::task::Context<'_>) {}
+}
+impl<T> Meow for T {}
+fn main() {
+    core::pin::pin!(async {}).poll(&mut context());
+    //~^ ERROR trait method `poll` will become ambiguous in Rust 2024
+    //~| WARN this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+}
+
+fn context() -> core::task::Context<'static> {
+    loop {}
+}

--- a/tests/ui/rust-2024/prelude-migration/in_2024_compatibility.stderr
+++ b/tests/ui/rust-2024/prelude-migration/in_2024_compatibility.stderr
@@ -1,0 +1,17 @@
+error: trait method `poll` will become ambiguous in Rust 2024
+  --> $DIR/in_2024_compatibility.rs:10:5
+   |
+LL |     core::pin::pin!(async {}).poll(&mut context());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::poll(&core::pin::pin!(async {}), &mut context())`
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+note: the lint level is defined here
+  --> $DIR/in_2024_compatibility.rs:3:9
+   |
+LL | #![deny(rust_2024_compatibility)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(rust_2024_prelude_collisions)]` implied by `#[deny(rust_2024_compatibility)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.fixed
+++ b/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.fixed
@@ -1,0 +1,29 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2021] run-rustfix
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//@[e2024] check-pass
+
+#![deny(rust_2024_prelude_collisions)]
+trait Meow {
+    fn into_future(&self) {}
+}
+impl Meow for Cat {}
+
+struct Cat;
+
+impl core::future::IntoFuture for Cat {
+    type Output = ();
+    type IntoFuture = core::future::Ready<()>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        core::future::ready(())
+    }
+}
+
+fn main() {
+    Meow::into_future(&Cat);
+    //[e2021]~^ ERROR trait method `into_future` will become ambiguous in Rust 2024
+    //[e2021]~| WARN this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+}

--- a/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.stderr
@@ -1,0 +1,16 @@
+error: trait method `into_future` will become ambiguous in Rust 2024
+  --> $DIR/into-future-adt.rs:26:5
+   |
+LL |     Cat.into_future();
+   |     ^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::into_future(&Cat)`
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+note: the lint level is defined here
+  --> $DIR/into-future-adt.rs:8:9
+   |
+LL | #![deny(rust_2024_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rust-2024/prelude-migration/into-future-adt.rs
+++ b/tests/ui/rust-2024/prelude-migration/into-future-adt.rs
@@ -1,0 +1,29 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2021] run-rustfix
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//@[e2024] check-pass
+
+#![deny(rust_2024_prelude_collisions)]
+trait Meow {
+    fn into_future(&self) {}
+}
+impl Meow for Cat {}
+
+struct Cat;
+
+impl core::future::IntoFuture for Cat {
+    type Output = ();
+    type IntoFuture = core::future::Ready<()>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        core::future::ready(())
+    }
+}
+
+fn main() {
+    Cat.into_future();
+    //[e2021]~^ ERROR trait method `into_future` will become ambiguous in Rust 2024
+    //[e2021]~| WARN this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+}

--- a/tests/ui/rust-2024/prelude-migration/into-future-already-into-future.rs
+++ b/tests/ui/rust-2024/prelude-migration/into-future-already-into-future.rs
@@ -1,0 +1,24 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//@ check-pass
+
+#![deny(rust_2024_prelude_collisions)]
+
+use core::future::IntoFuture;
+
+struct Cat;
+
+impl IntoFuture for Cat {
+    type Output = ();
+    type IntoFuture = core::future::Ready<()>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        core::future::ready(())
+    }
+}
+
+fn main() {
+    let _ = Cat.into_future();
+}

--- a/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.fixed
+++ b/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.fixed
@@ -1,0 +1,23 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2021] run-rustfix
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//@[e2024] check-pass
+
+#![deny(rust_2024_prelude_collisions)]
+trait Meow {
+    fn into_future(&self) {}
+}
+impl Meow for Cat {}
+
+struct Cat;
+
+fn main() {
+    // This is a false positive, but it should be rare enough to not matter, and checking whether
+    // it implements the trait can have other nontrivial consequences, so it was decided to accept
+    // this.
+    Meow::into_future(&Cat);
+    //[e2021]~^ ERROR trait method `into_future` will become ambiguous in Rust 2024
+    //[e2021]~| WARN this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+}

--- a/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.stderr
@@ -1,0 +1,16 @@
+error: trait method `into_future` will become ambiguous in Rust 2024
+  --> $DIR/into-future-not-into-future.rs:20:5
+   |
+LL |     Cat.into_future();
+   |     ^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::into_future(&Cat)`
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+note: the lint level is defined here
+  --> $DIR/into-future-not-into-future.rs:8:9
+   |
+LL | #![deny(rust_2024_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.rs
+++ b/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.rs
@@ -1,0 +1,23 @@
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2021] run-rustfix
+//@[e2024] edition: 2024
+//@[e2024] compile-flags: -Zunstable-options
+//@[e2024] check-pass
+
+#![deny(rust_2024_prelude_collisions)]
+trait Meow {
+    fn into_future(&self) {}
+}
+impl Meow for Cat {}
+
+struct Cat;
+
+fn main() {
+    // This is a false positive, but it should be rare enough to not matter, and checking whether
+    // it implements the trait can have other nontrivial consequences, so it was decided to accept
+    // this.
+    Cat.into_future();
+    //[e2021]~^ ERROR trait method `into_future` will become ambiguous in Rust 2024
+    //[e2021]~| WARN this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+}


### PR DESCRIPTION
This adds the migration lint for the newly ambiguous methods `poll` and `into_future`. When these methods are used on types implementing the respective traits, it will be ambiguous in the future, which can lead to hard errors or behavior changes depending on the exact circumstances.

tracked by #121042

<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
r? compiler-errors as the method prober