### PR TITLE
compiletest: fix outdated rmake.rs comment

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3435,13 +3435,13 @@ impl<'test> TestCx<'test> {
         // ```
         // base_dir/
         //     rmake.exe
-        //     scratch/
+        //     rmake_out/
         // ```
-        // having the executable separate from the scratch directory allows the recipes to
-        // `remove_dir_all(scratch)` without running into permission denied issues because
-        // the executable is not under the `scratch/` directory.
+        // having the executable separate from the output artifacts directory allows the recipes to
+        // `remove_dir_all($TMPDIR)` without running into permission denied issues because
+        // the executable is not under the `rmake_out/` directory.
         //
-        // This setup diverges from legacy Makefile run-make tests.
+        // This setup intentionally diverges from legacy Makefile run-make tests.
         let base_dir = cwd.join(self.output_base_name());
         if base_dir.exists() {
             self.aggressive_rm_rf(&base_dir).unwrap();


### PR DESCRIPTION
Noticed in https://github.com/rust-lang/rust/pull/125827#discussion_r1623420820. I fixed the PR description but forgot to update the comment.