### PR TITLE
rustdoc: add a regression test for a former blanket impl synthesis ICE

### DIFF
--- a/tests/rustdoc-ui/ice-blanket-impl-119792.rs
+++ b/tests/rustdoc-ui/ice-blanket-impl-119792.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+// https://github.com/rust-lang/rust/issues/119792
+
+struct Wrapper<T>(T);
+
+trait Div<Rhs> {}
+trait Mul<Rhs> {
+    type Output;
+}
+
+impl<T> Mul<T> for Wrapper<T> {
+    type Output = ();
+}
+
+impl<T> Div<Self> for Wrapper<T> {}
+
+pub trait NumOps<Rhs> {}
+
+impl<T, Rhs> NumOps<Rhs> for T where T: Mul<Rhs, Output = ()> + Div<Rhs> {}


### PR DESCRIPTION
Fixes #119792 (also passes in #125907 in case you were wondering).

r? rustdoc