### PR TITLE
Create `run-make` `env_var` and `env_var_os` helpers

### DIFF
--- a/src/tools/run-make-support/src/cc.rs
+++ b/src/tools/run-make-support/src/cc.rs
@@ -1,8 +1,9 @@
-use std::env;
 use std::path::Path;
 use std::process::Command;
 
-use crate::{bin_name, cygpath_windows, handle_failed_output, is_msvc, is_windows, tmp_dir, uname};
+use crate::{
+    bin_name, cygpath_windows, env_var, handle_failed_output, is_msvc, is_windows, tmp_dir, uname,
+};
 
 /// Construct a new platform-specific C compiler invocation.
 ///
@@ -27,11 +28,11 @@ impl Cc {
     /// WARNING: This means that what flags are accepted by the underlying C compile is
     /// platform- AND compiler-specific. Consult the relevant docs for `gcc`, `clang` and `mvsc`.
     pub fn new() -> Self {
-        let compiler = env::var("CC").unwrap();
+        let compiler = env_var("CC");
 
         let mut cmd = Command::new(compiler);
 
-        let default_cflags = env::var("CC_DEFAULT_FLAGS").unwrap();
+        let default_cflags = env_var("CC_DEFAULT_FLAGS");
         for flag in default_cflags.split(char::is_whitespace) {
             cmd.arg(flag);
         }

--- a/src/tools/run-make-support/src/clang.rs
+++ b/src/tools/run-make-support/src/clang.rs
@@ -1,8 +1,7 @@
-use std::env;
 use std::path::Path;
 use std::process::Command;
 
-use crate::{bin_name, handle_failed_output, tmp_dir};
+use crate::{bin_name, env_var, handle_failed_output, tmp_dir};
 
 /// Construct a new `clang` invocation. `clang` is not always available for all targets.
 pub fn clang() -> Clang {
@@ -20,8 +19,7 @@ crate::impl_common_helpers!(Clang);
 impl Clang {
     /// Construct a new `clang` invocation. `clang` is not always available for all targets.
     pub fn new() -> Self {
-        let clang =
-            env::var("CLANG").expect("`CLANG` not specified, but this is required to find `clang`");
+        let clang = env_var("CLANG");
         let cmd = Command::new(clang);
         Self { cmd }
     }

--- a/src/tools/run-make-support/src/llvm_readobj.rs
+++ b/src/tools/run-make-support/src/llvm_readobj.rs
@@ -1,8 +1,7 @@
-use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::handle_failed_output;
+use crate::{env_var, handle_failed_output};
 
 /// Construct a new `llvm-readobj` invocation. This assumes that `llvm-readobj` is available
 /// at `$LLVM_BIN_DIR/llvm-readobj`.
@@ -22,8 +21,7 @@ impl LlvmReadobj {
     /// Construct a new `llvm-readobj` invocation. This assumes that `llvm-readobj` is available
     /// at `$LLVM_BIN_DIR/llvm-readobj`.
     pub fn new() -> Self {
-        let llvm_bin_dir = env::var("LLVM_BIN_DIR")
-            .expect("`LLVM_BIN_DIR` not specified, but this is required to find `llvm-readobj`");
+        let llvm_bin_dir = env_var("LLVM_BIN_DIR");
         let llvm_bin_dir = PathBuf::from(llvm_bin_dir);
         let llvm_readobj = llvm_bin_dir.join("llvm-readobj");
         let cmd = Command::new(llvm_readobj);

--- a/src/tools/run-make-support/src/run.rs
+++ b/src/tools/run-make-support/src/run.rs
@@ -2,23 +2,23 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-use crate::is_windows;
+use crate::{env_var, is_windows};
 
 use super::handle_failed_output;
 
 fn run_common(name: &str) -> (Command, Output) {
     let mut bin_path = PathBuf::new();
-    bin_path.push(env::var("TMPDIR").unwrap());
+    bin_path.push(env_var("TMPDIR"));
     bin_path.push(name);
-    let ld_lib_path_envvar = env::var("LD_LIB_PATH_ENVVAR").unwrap();
+    let ld_lib_path_envvar = env_var("LD_LIB_PATH_ENVVAR");
     let mut cmd = Command::new(bin_path);
     cmd.env(&ld_lib_path_envvar, {
         let mut paths = vec![];
-        paths.push(PathBuf::from(env::var("TMPDIR").unwrap()));
-        for p in env::split_paths(&env::var("TARGET_RPATH_ENV").unwrap()) {
+        paths.push(PathBuf::from(env_var("TMPDIR")));
+        for p in env::split_paths(&env_var("TARGET_RPATH_ENV")) {
             paths.push(p.to_path_buf());
         }
-        for p in env::split_paths(&env::var(&ld_lib_path_envvar).unwrap()) {
+        for p in env::split_paths(&env_var(&ld_lib_path_envvar)) {
             paths.push(p.to_path_buf());
         }
         env::join_paths(paths.iter()).unwrap()
@@ -29,7 +29,7 @@ fn run_common(name: &str) -> (Command, Output) {
         for p in env::split_paths(&std::env::var("PATH").unwrap_or(String::new())) {
             paths.push(p.to_path_buf());
         }
-        paths.push(Path::new(&std::env::var("TARGET_RPATH_DIR").unwrap()).to_path_buf());
+        paths.push(Path::new(&env_var("TARGET_RPATH_DIR")).to_path_buf());
         cmd.env("PATH", env::join_paths(paths.iter()).unwrap());
     }
 

--- a/src/tools/run-make-support/src/rustc.rs
+++ b/src/tools/run-make-support/src/rustc.rs
@@ -1,10 +1,9 @@
-use std::env;
 use std::ffi::{OsStr, OsString};
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
-use crate::{handle_failed_output, set_host_rpath, tmp_dir};
+use crate::{env_var, handle_failed_output, set_host_rpath, tmp_dir};
 
 /// Construct a new `rustc` invocation.
 pub fn rustc() -> Rustc {
@@ -26,7 +25,7 @@ pub struct Rustc {
 crate::impl_common_helpers!(Rustc);
 
 fn setup_common() -> Command {
-    let rustc = env::var("RUSTC").unwrap();
+    let rustc = env_var("RUSTC");
     let mut cmd = Command::new(rustc);
     set_host_rpath(&mut cmd);
     cmd.arg("--out-dir").arg(tmp_dir()).arg("-L").arg(tmp_dir());

--- a/src/tools/run-make-support/src/rustdoc.rs
+++ b/src/tools/run-make-support/src/rustdoc.rs
@@ -1,10 +1,9 @@
-use std::env;
 use std::ffi::OsStr;
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
-use crate::{handle_failed_output, set_host_rpath};
+use crate::{env_var, env_var_os, handle_failed_output, set_host_rpath};
 
 /// Construct a plain `rustdoc` invocation with no flags set.
 pub fn bare_rustdoc() -> Rustdoc {
@@ -25,7 +24,7 @@ pub struct Rustdoc {
 crate::impl_common_helpers!(Rustdoc);
 
 fn setup_common() -> Command {
-    let rustdoc = env::var("RUSTDOC").unwrap();
+    let rustdoc = env_var("RUSTDOC");
     let mut cmd = Command::new(rustdoc);
     set_host_rpath(&mut cmd);
     cmd
@@ -41,7 +40,7 @@ impl Rustdoc {
     /// Construct a `rustdoc` invocation with `-L $(TARGET_RPATH_DIR)` set.
     pub fn new() -> Self {
         let mut cmd = setup_common();
-        let target_rpath_dir = env::var_os("TARGET_RPATH_DIR").unwrap();
+        let target_rpath_dir = env_var_os("TARGET_RPATH_DIR");
         cmd.arg(format!("-L{}", target_rpath_dir.to_string_lossy()));
         Self { cmd, stdin: None }
     }

--- a/tests/run-make/compiler-builtins/rmake.rs
+++ b/tests/run-make/compiler-builtins/rmake.rs
@@ -14,7 +14,6 @@
 
 #![deny(warnings)]
 
-use run_make_support::object;
 use run_make_support::object::read::archive::ArchiveFile;
 use run_make_support::object::read::Object;
 use run_make_support::object::ObjectSection;
@@ -22,6 +21,7 @@ use run_make_support::object::ObjectSymbol;
 use run_make_support::object::RelocationTarget;
 use run_make_support::set_host_rpath;
 use run_make_support::tmp_dir;
+use run_make_support::{env_var, object};
 use std::collections::HashSet;
 
 const MANIFEST: &str = r#"
@@ -35,7 +35,7 @@ path = "lib.rs""#;
 
 fn main() {
     let target_dir = tmp_dir().join("target");
-    let target = std::env::var("TARGET").unwrap();
+    let target = env_var("TARGET");
 
     println!("Testing compiler_builtins for {}", target);
 
@@ -44,9 +44,9 @@ fn main() {
     std::fs::write(&manifest_path, MANIFEST.as_bytes()).unwrap();
     std::fs::write(tmp_dir().join("lib.rs"), b"#![no_std]").unwrap();
 
-    let path = std::env::var("PATH").unwrap();
-    let rustc = std::env::var("RUSTC").unwrap();
-    let bootstrap_cargo = std::env::var("BOOTSTRAP_CARGO").unwrap();
+    let path = env_var("PATH");
+    let rustc = env_var("RUSTC");
+    let bootstrap_cargo = env_var("BOOTSTRAP_CARGO");
     let mut cmd = std::process::Command::new(bootstrap_cargo);
     cmd.args([
         "build",

--- a/tests/run-make/windows-binary-no-external-deps/rmake.rs
+++ b/tests/run-make/windows-binary-no-external-deps/rmake.rs
@@ -2,15 +2,14 @@
 //! a "hello world" application by setting `PATH` to `C:\Windows\System32`.
 //@ only-windows
 
-use run_make_support::{rustc, tmp_dir};
-use std::env;
+use run_make_support::{env_var, rustc, tmp_dir};
 use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
     rustc().input("hello.rs").run();
 
-    let windows_dir = env::var("SystemRoot").unwrap();
+    let windows_dir = env_var("SystemRoot");
     let system32: PathBuf = [&windows_dir, "System32"].iter().collect();
     // Note: This does not use the support wrappers so that we can precisely control the PATH
     let exe = tmp_dir().join("hello.exe");


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/rust/pull/125886. It's quite useful to know which environment variable failed, so better provide a helper helping with that.

r? @jieyouxu 