### PR TITLE
Ignore `vec_deque_alloc_error::test_shrink_to_unwind` test on non-unwind targets

### DIFF
--- a/library/alloc/tests/vec_deque_alloc_error.rs
+++ b/library/alloc/tests/vec_deque_alloc_error.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 #[test]
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_shrink_to_unwind() {
     // This tests that `shrink_to` leaves the deque in a consistent state when
     // the call to `RawVec::shrink_to_fit` unwinds. The code is adapted from #123369


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/123803 added this test which requires unwinding to succeed. This conditionally ignores the test on non-unwind targets (as is the case with other tests using `catch_unwind`).