### PR TITLE
Update fuchsia maintainers

### DIFF
--- a/src/doc/rustc/src/platform-support/fuchsia.md
+++ b/src/doc/rustc/src/platform-support/fuchsia.md
@@ -10,9 +10,9 @@ updatable, and performant.
 The [Fuchsia team]:
 
 - Tyler Mandry ([@tmandry](https://github.com/tmandry))
-- Dan Johnson ([@computerdruid](https://github.com/computerdruid))
 - David Koloski ([@djkoloski](https://github.com/djkoloski))
-- Joseph Ryan ([@P1n3appl3](https://github.com/P1n3appl3))
+- Julia Ryan ([@P1n3appl3](https://github.com/P1n3appl3))
+- Erick Tryzelaar ([@erickt](https://github.com/erickt))
 
 As the team evolves over time, the specific members listed here may differ from
 the members reported by the API. The API should be considered to be


### PR DESCRIPTION
This makes the maintainers list in the docs line up with the current [fuchsia team](https://github.com/rust-lang/team/blob/master/teams/fuchsia.toml).