### PR TITLE
Revert "tidy: validate LLVM component names in tests"

### DIFF
--- a/src/tools/tidy/src/target_specific_tests.rs
+++ b/src/tools/tidy/src/target_specific_tests.rs
@@ -10,26 +10,6 @@ use crate::walk::filter_not_rust;
 const LLVM_COMPONENTS_HEADER: &str = "needs-llvm-components:";
 const COMPILE_FLAGS_HEADER: &str = "compile-flags:";
 
-const KNOWN_LLVM_COMPONENTS: &[&str] = &[
-    "aarch64",
-    "arm",
-    "avr",
-    "bpf",
-    "csky",
-    "hexagon",
-    "loongarch",
-    "m68k",
-    "mips",
-    "msp430",
-    "nvptx",
-    "powerpc",
-    "riscv",
-    "sparc",
-    "systemz",
-    "webassembly",
-    "x86",
-];
-
 #[derive(Default, Debug)]
 struct RevisionInfo<'a> {
     target_arch: Option<&'a str>,
@@ -86,20 +66,6 @@ pub fn check(path: &Path, bad: &mut bool) {
                 (Some(_), Some(_)) => {
                     // FIXME: check specified components against the target architectures we
                     // gathered.
-                }
-            }
-            if let Some(llvm_components) = llvm_components {
-                for component in llvm_components {
-                    // Ensure the given component even exists.
-                    // This is somewhat redundant with COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS,
-                    // but helps detect such problems earlier (PR CI rather than bors CI).
-                    if !KNOWN_LLVM_COMPONENTS.contains(component) {
-                        eprintln!(
-                            "{}: revision {} specifies unknown LLVM component `{}`",
-                            file, rev, component
-                        );
-                        *bad = true;
-                    }
                 }
             }
         }


### PR DESCRIPTION
This reverts #125472.

This has already caused a [bit](https://github.com/rust-lang/rust/pull/125702) of [trouble](https://github.com/rust-lang/rust/pull/125710), and I was mistaken about the original motivation--incorrect component names [_will_](https://github.com/rust-lang/rust/pull/125702#issuecomment-2137030731) be detected by a full CI run.

I no longer think it pulls its weight.

r? @workingjubilee