### PR TITLE
Store the types of `ty::Expr` arguments in the `ty::Expr`

### DIFF
--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -24,7 +24,7 @@ pub type ConstKind<'tcx> = ir::ConstKind<TyCtxt<'tcx>>;
 pub type UnevaluatedConst<'tcx> = ir::UnevaluatedConst<TyCtxt<'tcx>>;
 
 #[cfg(target_pointer_width = "64")]
-rustc_data_structures::static_assert_size!(ConstKind<'_>, 32);
+rustc_data_structures::static_assert_size!(ConstKind<'_>, 24);
 
 /// Use this rather than `ConstData`, whenever possible.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, HashStable)]
@@ -58,7 +58,7 @@ pub struct ConstData<'tcx> {
 }
 
 #[cfg(target_pointer_width = "64")]
-rustc_data_structures::static_assert_size!(ConstData<'_>, 40);
+rustc_data_structures::static_assert_size!(ConstData<'_>, 32);
 
 impl<'tcx> Const<'tcx> {
     #[inline]

--- a/compiler/rustc_middle/src/ty/consts/kind.rs
+++ b/compiler/rustc_middle/src/ty/consts/kind.rs
@@ -1,7 +1,7 @@
 use super::Const;
 use crate::mir;
 use crate::ty::abstract_const::CastKind;
-use crate::ty::{self, visit::TypeVisitableExt as _, List, Ty, TyCtxt};
+use crate::ty::{self, visit::TypeVisitableExt as _, Ty, TyCtxt};
 use rustc_macros::{extension, HashStable, TyDecodable, TyEncodable, TypeFoldable, TypeVisitable};
 
 #[extension(pub(crate) trait UnevaluatedConstEvalExt<'tcx>)]
@@ -40,14 +40,125 @@ impl<'tcx> ty::UnevaluatedConst<'tcx> {
     }
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(HashStable, TyEncodable, TyDecodable, TypeVisitable, TypeFoldable)]
+pub enum ExprKind {
+    Binop(mir::BinOp),
+    UnOp(mir::UnOp),
+    FunctionCall,
+    Cast(CastKind),
+}
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 #[derive(HashStable, TyEncodable, TyDecodable, TypeVisitable, TypeFoldable)]
-pub enum Expr<'tcx> {
-    Binop(mir::BinOp, Const<'tcx>, Const<'tcx>),
-    UnOp(mir::UnOp, Const<'tcx>),
-    FunctionCall(Const<'tcx>, &'tcx List<Const<'tcx>>),
-    Cast(CastKind, Const<'tcx>, Ty<'tcx>),
+pub struct Expr<'tcx> {
+    pub kind: ExprKind,
+    args: ty::GenericArgsRef<'tcx>,
+}
+impl<'tcx> Expr<'tcx> {
+    pub fn new_binop(
+        tcx: TyCtxt<'tcx>,
+        binop: mir::BinOp,
+        lhs_ty: Ty<'tcx>,
+        rhs_ty: Ty<'tcx>,
+        lhs_ct: Const<'tcx>,
+        rhs_ct: Const<'tcx>,
+    ) -> Self {
+        let args = tcx.mk_args_from_iter::<_, ty::GenericArg<'tcx>>(
+            [lhs_ty.into(), rhs_ty.into(), lhs_ct.into(), rhs_ct.into()].into_iter(),
+        );
+
+        Self { kind: ExprKind::Binop(binop), args }
+    }
+
+    pub fn binop_args(self) -> (Ty<'tcx>, Ty<'tcx>, Const<'tcx>, Const<'tcx>) {
+        assert!(matches!(self.kind, ExprKind::Binop(_)));
+
+        match self.args().as_slice() {
+            [lhs_ty, rhs_ty, lhs_ct, rhs_ct] => (
+                lhs_ty.expect_ty(),
+                rhs_ty.expect_ty(),
+                lhs_ct.expect_const(),
+                rhs_ct.expect_const(),
+            ),
+            _ => bug!("Invalid args for `Binop` expr {self:?}"),
+        }
+    }
+
+    pub fn new_unop(tcx: TyCtxt<'tcx>, unop: mir::UnOp, ty: Ty<'tcx>, ct: Const<'tcx>) -> Self {
+        let args =
+            tcx.mk_args_from_iter::<_, ty::GenericArg<'tcx>>([ty.into(), ct.into()].into_iter());
+
+        Self { kind: ExprKind::UnOp(unop), args }
+    }
+
+    pub fn unop_args(self) -> (Ty<'tcx>, Const<'tcx>) {
+        assert!(matches!(self.kind, ExprKind::UnOp(_)));
+
+        match self.args().as_slice() {
+            [ty, ct] => (ty.expect_ty(), ct.expect_const()),
+            _ => bug!("Invalid args for `UnOp` expr {self:?}"),
+        }
+    }
+
+    pub fn new_call(
+        tcx: TyCtxt<'tcx>,
+        func_ty: Ty<'tcx>,
+        func_expr: Const<'tcx>,
+        arguments: impl Iterator<Item = Const<'tcx>>,
+    ) -> Self {
+        let args = tcx.mk_args_from_iter::<_, ty::GenericArg<'tcx>>(
+            [func_ty.into(), func_expr.into()].into_iter().chain(arguments.map(|ct| ct.into())),
+        );
+
+        Self { kind: ExprKind::FunctionCall, args }
+    }
+
+    pub fn call_args(self) -> (Ty<'tcx>, Const<'tcx>, impl Iterator<Item = Const<'tcx>>) {
+        assert!(matches!(self.kind, ExprKind::FunctionCall));
+
+        match self.args().as_slice() {
+            [func_ty, func, rest @ ..] => (
+                func_ty.expect_ty(),
+                func.expect_const(),
+                rest.iter().map(|arg| arg.expect_const()),
+            ),
+            _ => bug!("Invalid args for `Call` expr {self:?}"),
+        }
+    }
+
+    pub fn new_cast(
+        tcx: TyCtxt<'tcx>,
+        cast: CastKind,
+        value_ty: Ty<'tcx>,
+        value: Const<'tcx>,
+        to_ty: Ty<'tcx>,
+    ) -> Self {
+        let args = tcx.mk_args_from_iter::<_, ty::GenericArg<'tcx>>(
+            [value_ty.into(), value.into(), to_ty.into()].into_iter(),
+        );
+
+        Self { kind: ExprKind::Cast(cast), args }
+    }
+
+    pub fn cast_args(self) -> (Ty<'tcx>, Const<'tcx>, Ty<'tcx>) {
+        assert!(matches!(self.kind, ExprKind::Cast(_)));
+
+        match self.args().as_slice() {
+            [value_ty, value, to_ty] => {
+                (value_ty.expect_ty(), value.expect_const(), to_ty.expect_ty())
+            }
+            _ => bug!("Invalid args for `Cast` expr {self:?}"),
+        }
+    }
+
+    pub fn new(kind: ExprKind, args: ty::GenericArgsRef<'tcx>) -> Self {
+        Self { kind, args }
+    }
+
+    pub fn args(&self) -> ty::GenericArgsRef<'tcx> {
+        self.args
+    }
 }
 
 #[cfg(target_pointer_width = "64")]
-rustc_data_structures::static_assert_size!(Expr<'_>, 24);
+rustc_data_structures::static_assert_size!(Expr<'_>, 16);

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -374,26 +374,7 @@ impl FlagComputation {
                 self.add_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
             }
             ty::ConstKind::Value(_) => {}
-            ty::ConstKind::Expr(e) => {
-                use ty::Expr;
-                match e {
-                    Expr::Binop(_, l, r) => {
-                        self.add_const(l);
-                        self.add_const(r);
-                    }
-                    Expr::UnOp(_, v) => self.add_const(v),
-                    Expr::FunctionCall(f, args) => {
-                        self.add_const(f);
-                        for arg in args {
-                            self.add_const(arg);
-                        }
-                    }
-                    Expr::Cast(_, c, t) => {
-                        self.add_ty(t);
-                        self.add_const(c);
-                    }
-                }
-            }
+            ty::ConstKind::Expr(e) => self.add_args(e.args()),
             ty::ConstKind::Error(_) => self.add_flags(TypeFlags::HAS_ERROR),
         }
     }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -87,7 +87,7 @@ pub use self::closure::{
     CAPTURE_STRUCT_LOCAL,
 };
 pub use self::consts::{
-    Const, ConstData, ConstInt, ConstKind, Expr, ScalarInt, UnevaluatedConst, ValTree,
+    Const, ConstData, ConstInt, ConstKind, Expr, ExprKind, ScalarInt, UnevaluatedConst, ValTree,
 };
 pub use self::context::{
     tls, CtxtInterners, CurrentGcx, DeducedParamAttrs, Feed, FreeRegionInfo, GlobalCtxt, Lift,

--- a/compiler/rustc_middle/src/ty/walk.rs
+++ b/compiler/rustc_middle/src/ty/walk.rs
@@ -222,24 +222,7 @@ fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>)
                 | ty::ConstKind::Value(_)
                 | ty::ConstKind::Error(_) => {}
 
-                ty::ConstKind::Expr(expr) => match expr {
-                    ty::Expr::UnOp(_, v) => push_inner(stack, v.into()),
-                    ty::Expr::Binop(_, l, r) => {
-                        push_inner(stack, r.into());
-                        push_inner(stack, l.into())
-                    }
-                    ty::Expr::FunctionCall(func, args) => {
-                        for a in args.iter().rev() {
-                            push_inner(stack, a.into());
-                        }
-                        push_inner(stack, func.into());
-                    }
-                    ty::Expr::Cast(_, c, t) => {
-                        push_inner(stack, t.into());
-                        push_inner(stack, c.into());
-                    }
-                },
-
+                ty::ConstKind::Expr(expr) => stack.extend(expr.args().iter().rev()),
                 ty::ConstKind::Unevaluated(ct) => {
                     stack.extend(ct.args.iter().rev());
                 }

--- a/tests/ui/const-generics/generic_const_exprs/eval-privacy.rs
+++ b/tests/ui/const-generics/generic_const_exprs/eval-privacy.rs
@@ -15,6 +15,7 @@ where
 {
     type AssocTy = Const<{ my_const_fn(U) }>;
     //~^ ERROR private type
+    //~| ERROR private type
     fn assoc_fn() -> Self::AssocTy {
         Const
     }

--- a/tests/ui/const-generics/generic_const_exprs/eval-privacy.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/eval-privacy.stderr
@@ -7,6 +7,17 @@ LL |     type AssocTy = Const<{ my_const_fn(U) }>;
 LL | const fn my_const_fn(val: u8) -> u8 {
    | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
 
-error: aborting due to 1 previous error
+error[E0446]: private type `fn(u8) -> u8 {my_const_fn}` in public interface
+  --> $DIR/eval-privacy.rs:16:5
+   |
+LL |     type AssocTy = Const<{ my_const_fn(U) }>;
+   |     ^^^^^^^^^^^^ can't leak private type
+...
+LL | const fn my_const_fn(val: u8) -> u8 {
+   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0446`.

--- a/tests/ui/privacy/where-priv-type.rs
+++ b/tests/ui/privacy/where-priv-type.rs
@@ -74,6 +74,7 @@ where
 {
     type AssocTy = Const<{ my_const_fn(U) }>;
     //~^ ERROR private type
+    //~| ERROR private type
     fn assoc_fn() -> Self::AssocTy {
         Const
     }

--- a/tests/ui/privacy/where-priv-type.stderr
+++ b/tests/ui/privacy/where-priv-type.stderr
@@ -77,6 +77,17 @@ LL |     type AssocTy = Const<{ my_const_fn(U) }>;
 LL | const fn my_const_fn(val: u8) -> u8 {
    | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
 
-error: aborting due to 1 previous error; 5 warnings emitted
+error[E0446]: private type `fn(u8) -> u8 {my_const_fn}` in public interface
+  --> $DIR/where-priv-type.rs:75:5
+   |
+LL |     type AssocTy = Const<{ my_const_fn(U) }>;
+   |     ^^^^^^^^^^^^ can't leak private type
+...
+LL | const fn my_const_fn(val: u8) -> u8 {
+   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors; 5 warnings emitted
 
 For more information about this error, try `rustc --explain E0446`.


### PR DESCRIPTION
Part of #125958

In attempting to remove the `ty` field on `Const` it will become necessary to store the `Ty<'tcx>` inside of `Expr<'tcx>`. In order to do this without blowing up the size of `ConstKind`, we start storing the type/const args as `GenericArgs`

r? @oli-obk 