### PR TITLE
When `derive`ing, account for HRTB on `BareFn` fields

### DIFF
--- a/tests/ui/derives/derive-hrtb-for-bare-fn-field-with-lifetime.rs
+++ b/tests/ui/derives/derive-hrtb-for-bare-fn-field-with-lifetime.rs
@@ -1,0 +1,13 @@
+//@ run-pass
+// Issue #122622: `#[derive(Clone)]` should work for HRTB function type taking an associated type
+#![allow(dead_code)]
+trait SomeTrait {
+    type SomeType<'a>;
+}
+
+#[derive(Clone)]
+struct Foo<T: SomeTrait> {
+    x: for<'a> fn(T::SomeType<'a>)
+}
+
+fn main() {}


### PR DESCRIPTION
When given

```rust
trait SomeTrait {
    type SomeType<'a>;
}

#[derive(Clone)]
struct Foo<T: SomeTrait> {
    x: for<'a> fn(T::SomeType<'a>)
}
```

expand to

```rust
impl<T: ::core::clone::Clone + SomeTrait> ::core::clone::Clone for Foo<T>
    where for<'a> T::SomeType<'a>: ::core::clone::Clone {
    #[inline]
    fn clone(&self) -> Foo<T> {
        Foo { x: ::core::clone::Clone::clone(&self.x) }
    }
}
```

instead of the previous invalid

```
impl<T: ::core::clone::Clone + SomeTrait> ::core::clone::Clone for Foo<T>
    where T::SomeType<'a>: ::core::clone::Clone {
    #[inline]
    fn clone(&self) -> Foo<T> {
        Foo { x: ::core::clone::Clone::clone(&self.x) }
    }
}
```

Fix #122622.

<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->