### PR TITLE
Rename `deprecated_safe` lint to `deprecated_safe_2024`

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -322,6 +322,8 @@ fn register_builtins(store: &mut LintStore) {
         REFINING_IMPL_TRAIT_INTERNAL
     );
 
+    add_lint_group!("deprecated_safe", DEPRECATED_SAFE_2024);
+
     // Register renamed and removed lints.
     store.register_renamed("single_use_lifetime", "single_use_lifetimes");
     store.register_renamed("elided_lifetime_in_path", "elided_lifetimes_in_paths");

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -37,7 +37,7 @@ declare_lint_pass! {
         DEPRECATED,
         DEPRECATED_CFG_ATTR_CRATE_TYPE_NAME,
         DEPRECATED_IN_FUTURE,
-        DEPRECATED_SAFE,
+        DEPRECATED_SAFE_2024,
         DEPRECATED_WHERE_CLAUSE_LOCATION,
         DUPLICATE_MACRO_ATTRIBUTES,
         ELIDED_LIFETIMES_IN_ASSOCIATED_CONSTANT,
@@ -4812,8 +4812,8 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `deprecated_safe` lint detects unsafe functions being used as safe
-    /// functions.
+    /// The `deprecated_safe_2024` lint detects unsafe functions being used as
+    /// safe functions.
     ///
     /// ### Example
     ///
@@ -4832,8 +4832,8 @@ declare_lint! {
     ///
     /// Rust [editions] allow the language to evolve without breaking backward
     /// compatibility. This lint catches code that uses `unsafe` functions that
-    /// were declared as safe (non-`unsafe`) in earlier editions. If you switch
-    /// the compiler to a new edition without updating the code, then it
+    /// were declared as safe (non-`unsafe`) in editions prior to Rust 2024. If
+    /// you switch the compiler to Rust 2024 without updating the code, then it
     /// will fail to compile if you are using a function previously marked as
     /// safe.
     ///
@@ -4850,7 +4850,7 @@ declare_lint! {
     /// future.
     ///
     /// [editions]: https://doc.rust-lang.org/edition-guide/
-    pub DEPRECATED_SAFE,
+    pub DEPRECATED_SAFE_2024,
     Allow,
     "detects unsafe functions being used as safe functions",
     @future_incompatible = FutureIncompatibleInfo {

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -10,7 +10,7 @@ use rustc_middle::thir::visit::Visitor;
 use rustc_middle::thir::*;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, ParamEnv, Ty, TyCtxt};
-use rustc_session::lint::builtin::{DEPRECATED_SAFE, UNSAFE_OP_IN_UNSAFE_FN, UNUSED_UNSAFE};
+use rustc_session::lint::builtin::{DEPRECATED_SAFE_2024, UNSAFE_OP_IN_UNSAFE_FN, UNUSED_UNSAFE};
 use rustc_session::lint::Level;
 use rustc_span::def_id::{DefId, LocalDefId};
 use rustc_span::symbol::Symbol;
@@ -99,7 +99,7 @@ impl<'tcx> UnsafetyVisitor<'_, 'tcx> {
             {
                 let sm = self.tcx.sess.source_map();
                 self.tcx.emit_node_span_lint(
-                    DEPRECATED_SAFE,
+                    DEPRECATED_SAFE_2024,
                     self.hir_context,
                     span,
                     CallToDeprecatedSafeFnRequiresUnsafe {

--- a/src/tools/lint-docs/src/groups.rs
+++ b/src/tools/lint-docs/src/groups.rs
@@ -24,6 +24,7 @@ static GROUP_DESCRIPTIONS: &[(&str, &str)] = &[
         "keyword-idents",
         "Lints that detect identifiers which will be come keywords in later editions",
     ),
+    ("deprecated-safe", "Lints for functions which were erroneously marked as safe in the past"),
 ];
 
 type LintGroups = BTreeMap<String, BTreeSet<String>>;

--- a/tests/ui/rust-2024/unsafe-env-suggestion.fixed
+++ b/tests/ui/rust-2024/unsafe-env-suggestion.fixed
@@ -1,6 +1,6 @@
 //@ run-rustfix
 
-#![deny(deprecated_safe)]
+#![deny(deprecated_safe_2024)]
 
 use std::env;
 

--- a/tests/ui/rust-2024/unsafe-env-suggestion.rs
+++ b/tests/ui/rust-2024/unsafe-env-suggestion.rs
@@ -1,6 +1,6 @@
 //@ run-rustfix
 
-#![deny(deprecated_safe)]
+#![deny(deprecated_safe_2024)]
 
 use std::env;
 

--- a/tests/ui/rust-2024/unsafe-env-suggestion.stderr
+++ b/tests/ui/rust-2024/unsafe-env-suggestion.stderr
@@ -9,8 +9,8 @@ LL |     env::set_var("FOO", "BAR");
 note: the lint level is defined here
   --> $DIR/unsafe-env-suggestion.rs:3:9
    |
-LL | #![deny(deprecated_safe)]
-   |         ^^^^^^^^^^^^^^^
+LL | #![deny(deprecated_safe_2024)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 help: you can wrap the call in an `unsafe` block if you can guarantee the code is only ever called from single-threaded code
    |
 LL +     // TODO: Audit that the environment access only happens in single-threaded code.


### PR DESCRIPTION
Create a lint group `deprecated_safe` that includes `deprecated_safe_2024`.

Addresses https://github.com/rust-lang/rust/issues/124866#issuecomment-2142814375.

r? @ehuss 