### PR TITLE
Add a co-maintainer for the two ARMv4T targets

### DIFF
--- a/src/doc/rustc/src/platform-support/armv4t-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv4t-none-eabi.md
@@ -12,6 +12,7 @@ overall performance.
 ## Target Maintainers
 
 * [@Lokathor](https://github.com/lokathor)
+* [@corwinkuiper](https://github.com/corwinkuiper)
 
 ## Testing
 


### PR DESCRIPTION
This adds a second maintainer to the `armv4t-none-eabi` and `thumbv4t-none-eabi` targets, a necessary step on the path to Tier 2