### PR TITLE
Port `tests/run-make-fulldeps/issue-19371` to ui-fulldeps

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1267,6 +1267,8 @@ fn expand_variables(mut value: String, config: &Config) -> String {
     const CWD: &str = "{{cwd}}";
     const SRC_BASE: &str = "{{src-base}}";
     const BUILD_BASE: &str = "{{build-base}}";
+    const SYSROOT_BASE: &str = "{{sysroot-base}}";
+    const TARGET_LINKER: &str = "{{target-linker}}";
 
     if value.contains(CWD) {
         let cwd = env::current_dir().unwrap();
@@ -1279,6 +1281,14 @@ fn expand_variables(mut value: String, config: &Config) -> String {
 
     if value.contains(BUILD_BASE) {
         value = value.replace(BUILD_BASE, &config.build_base.to_string_lossy());
+    }
+
+    if value.contains(SYSROOT_BASE) {
+        value = value.replace(SYSROOT_BASE, &config.sysroot_base.to_string_lossy());
+    }
+
+    if value.contains(TARGET_LINKER) {
+        value = value.replace(TARGET_LINKER, config.target_linker.as_deref().unwrap_or(""));
     }
 
     value

--- a/tests/run-make-fulldeps/issue-19371/Makefile
+++ b/tests/run-make-fulldeps/issue-19371/Makefile
@@ -1,9 +1,0 @@
-include ../../run-make/tools.mk
-
-# This test ensures that rustc compile_input can be called twice in one task
-# without causing a panic.
-# The program needs the path to rustc to get sysroot.
-
-all:
-	$(RUSTC) foo.rs
-	$(call RUN,foo $(TMPDIR) $(RUSTC))


### PR DESCRIPTION
This test can run as an ordinary `tests/ui-fulldeps` test, with the help of some additional header variable substitutions to supply a sysroot and linker.

---

Unlike #125973, this test appears to be testing something vaguely useful and breakable, which is why I didn't just delete it.