### PR TITLE
Do not use global caches if opaque types can be defined

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1498,7 +1498,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             return false;
         }
 
-        // Avoid using the master cache during coherence and just rely
+        // Avoid using the global cache during coherence and just rely
         // on the local cache. This effectively disables caching
         // during coherence. It is really just a simplification to
         // avoid us having to fear that coherence results "pollute"
@@ -1506,6 +1506,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // it's not worth going to more trouble to increase the
         // hit-rate, I don't think.
         if self.is_intercrate() {
+            return false;
+        }
+
+        // Avoid using the global cache when we're defining opaque types
+        // as their hidden type may impact the result of candidate selection.
+        if !self.infcx.defining_opaque_types().is_empty() {
             return false;
         }
 

--- a/tests/ui/auto-traits/opaque_type_candidate_selection.rs
+++ b/tests/ui/auto-traits/opaque_type_candidate_selection.rs
@@ -1,4 +1,7 @@
-//@ known-bug: #119272
+//! used to ICE: #119272
+
+//@ check-pass
+
 #![feature(type_alias_impl_trait)]
 mod defining_scope {
     use super::*;


### PR DESCRIPTION
fixes #119272

r? @lcnr

This is certainly a crude way to make the cache sound wrt opaque types, but since perf lets us get away with this, let's do it in the old solver and let the new solver fix this correctly once and for all.

cc https://github.com/rust-lang/rust/pull/122192#issuecomment-2149252655