### PR TITLE
Improve unconstrained impl diagnostic (fixes #107295)

### DIFF
--- a/compiler/rustc_hir_analysis/src/impl_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check.rs
@@ -11,7 +11,7 @@
 use crate::constrained_generic_params as cgp;
 use min_specialization::check_min_specialization;
 
-use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{codes::*, struct_span_code_err};
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
@@ -96,6 +96,28 @@ fn enforce_impl_params_are_constrained(
         &mut constrained_parameters,
     );
 
+    // Reasons each generic is unconstrained, or Other if not present
+    let mut unconstrained_reasons = FxHashMap::default();
+    for (clause, _) in impl_predicates.predicates {
+        if let Some(projection) = clause.as_projection_clause() {
+            let mentioned_params = cgp::parameters_for(tcx, projection.term().skip_binder(), true);
+            let is_clause_circular =
+                Some(projection.required_poly_trait_ref(tcx).skip_binder()) == impl_trait_ref;
+
+            for param in mentioned_params {
+                if is_clause_circular {
+                    // Potentially override BoundToUnconstrainedProjection
+                    unconstrained_reasons.insert(param, UnconstrainedReason::BoundCircularly);
+                } else {
+                    // Don't override BoundCircularly
+                    unconstrained_reasons
+                        .entry(param)
+                        .or_insert(UnconstrainedReason::BoundToUnconstrainedProjection);
+                }
+            }
+        }
+    }
+
     // Disallow unconstrained lifetimes, but only if they appear in assoc types.
     let lifetimes_in_associated_types: FxHashSet<_> = tcx
         .associated_item_def_ids(impl_def_id)
@@ -123,6 +145,9 @@ fn enforce_impl_params_are_constrained(
     let mut res = Ok(());
     for param in &impl_generics.own_params {
         let cgp_param = cgp::Parameter(param.index);
+        let unconstrained_reason =
+            unconstrained_reasons.get(&cgp_param).copied().unwrap_or_default();
+
         match param.kind {
             // Disallow ANY unconstrained type parameters.
             ty::GenericParamDefKind::Type { .. } => {
@@ -134,6 +159,7 @@ fn enforce_impl_params_are_constrained(
                         "type",
                         param_ty.name,
                         impl_kind,
+                        unconstrained_reason,
                     ));
                 }
             }
@@ -147,6 +173,7 @@ fn enforce_impl_params_are_constrained(
                         "lifetime",
                         param.name,
                         impl_kind,
+                        unconstrained_reason,
                     ));
                 }
             }
@@ -159,6 +186,7 @@ fn enforce_impl_params_are_constrained(
                         "const",
                         param_ct.name,
                         impl_kind,
+                        unconstrained_reason,
                     ));
                 }
             }
@@ -192,12 +220,24 @@ enum ImplKind {
     InherentImpl,
 }
 
+#[derive(Copy, Clone, Default)]
+enum UnconstrainedReason {
+    /// Not used in the impl trait, self type, nor bound to any projection
+    #[default]
+    Other,
+    /// Bound to a projection, but the LHS was not constrained
+    BoundToUnconstrainedProjection,
+    /// Bound to a projection, but the LHS is the trait being implemented
+    BoundCircularly,
+}
+
 fn report_unused_parameter(
     tcx: TyCtxt<'_>,
     span: Span,
     kind: &str,
     name: Symbol,
     impl_kind: ImplKind,
+    unconstrained_reason: UnconstrainedReason,
 ) -> ErrorGuaranteed {
     let mut err = struct_span_code_err!(
         tcx.dcx(),
@@ -225,6 +265,22 @@ fn report_unused_parameter(
         }
     }
 
+    match unconstrained_reason {
+        UnconstrainedReason::BoundToUnconstrainedProjection => {
+            err.note(format!(
+                "`{name}` is bound to an associated type, \
+                but the reference to the associated type itself uses unconstrained generic parameters"
+            ));
+        }
+        UnconstrainedReason::BoundCircularly => {
+            err.note(format!(
+                "`{name}` is bound to an associated type, \
+                but the associated type is circularly defined in this impl"
+            ));
+        }
+        UnconstrainedReason::Other => {}
+    }
+
     if kind == "const" {
         err.note(
             "expressions using a const parameter must map each value to a distinct output value",
@@ -233,5 +289,6 @@ fn report_unused_parameter(
             "proving the result of expressions other than the parameter are unique is not supported",
         );
     }
+
     err.emit()
 }

--- a/tests/rustdoc-ui/not-wf-ambiguous-normalization.stderr
+++ b/tests/rustdoc-ui/not-wf-ambiguous-normalization.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T> Allocator for DefaultAllocator {
    |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/synthetic-auto-trait-impls/unconstrained-param-in-impl-ambiguity.stderr
+++ b/tests/rustdoc-ui/synthetic-auto-trait-impls/unconstrained-param-in-impl-ambiguity.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `Q` is not constrained by the impl trait, self 
    |
 LL | unsafe impl<Q: Trait> Send for Inner {}
    |             ^ unconstrained type parameter
+   |
+   = note: to constrain `Q`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/issue-26262.stderr
+++ b/tests/ui/associated-types/issue-26262.stderr
@@ -3,12 +3,16 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T: Tr> S<T::Assoc> {
    |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the self type, or in an equality with an associated type
 
 error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
   --> $DIR/issue-26262.rs:17:6
    |
 LL | impl<'a,T: Trait2<'a>> Trait1<<T as Trait2<'a>>::Foo> for T {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/in-trait/unconstrained-impl-region.stderr
+++ b/tests/ui/async-await/in-trait/unconstrained-impl-region.stderr
@@ -19,6 +19,8 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a> Actor for () {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/issues/issue-78654.full.stderr
+++ b/tests/ui/async-await/issues/issue-78654.full.stderr
@@ -10,6 +10,7 @@ error[E0207]: the const parameter `H` is not constrained by the impl trait, self
 LL | impl<const H: feature> Foo {
    |      ^^^^^^^^^^^^^^^^ unconstrained const parameter
    |
+   = note: to constrain `H`, use it in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/async-await/issues/issue-78654.min.stderr
+++ b/tests/ui/async-await/issues/issue-78654.min.stderr
@@ -10,6 +10,7 @@ error[E0207]: the const parameter `H` is not constrained by the impl trait, self
 LL | impl<const H: feature> Foo {
    |      ^^^^^^^^^^^^^^^^ unconstrained const parameter
    |
+   = note: to constrain `H`, use it in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/const-generics/ice-unexpected-inference-var-122549.stderr
+++ b/tests/ui/const-generics/ice-unexpected-inference-var-122549.stderr
@@ -52,6 +52,7 @@ error[E0207]: the const parameter `N` is not constrained by the impl trait, self
 LL | impl<'a, T, const N: usize> Iterator for ConstChunksExact<'a, T, {}> {
    |             ^^^^^^^^^^^^^^ unconstrained const parameter
    |
+   = note: to constrain `N`, use it in the implemented trait, in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/const-generics/issues/issue-68366.full.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.full.stderr
@@ -16,6 +16,7 @@ error[E0207]: the const parameter `N` is not constrained by the impl trait, self
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
    |       ^^^^^^^^^^^^^^ unconstrained const parameter
    |
+   = note: to constrain `N`, use it in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
@@ -25,6 +26,7 @@ error[E0207]: the const parameter `N` is not constrained by the impl trait, self
 LL | impl<const N: usize> Foo {}
    |      ^^^^^^^^^^^^^^ unconstrained const parameter
    |
+   = note: to constrain `N`, use it in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/const-generics/issues/issue-68366.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.min.stderr
@@ -25,6 +25,7 @@ error[E0207]: the const parameter `N` is not constrained by the impl trait, self
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
    |       ^^^^^^^^^^^^^^ unconstrained const parameter
    |
+   = note: to constrain `N`, use it in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
@@ -34,6 +35,7 @@ error[E0207]: the const parameter `N` is not constrained by the impl trait, self
 LL | impl<const N: usize> Foo {}
    |      ^^^^^^^^^^^^^^ unconstrained const parameter
    |
+   = note: to constrain `N`, use it in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/consts/rustc-impl-const-stability.stderr
+++ b/tests/ui/consts/rustc-impl-const-stability.stderr
@@ -13,6 +13,7 @@ error[E0207]: the const parameter `host` is not constrained by the impl trait, s
 LL | impl const Default for Data {
    |      ^^^^^ unconstrained const parameter
    |
+   = note: to constrain `host`, use it in the implemented trait, in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/error-codes/E0207.stderr
+++ b/tests/ui/error-codes/E0207.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T: Default> Foo {
    |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the self type, or in an equality with an associated type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generic-associated-types/bugs/issue-87735.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-87735.stderr
@@ -3,6 +3,9 @@ error[E0207]: the type parameter `U` is not constrained by the impl trait, self 
    |
 LL | impl<'b, T, U> AsRef2 for Foo<T>
    |             ^ unconstrained type parameter
+   |
+   = note: to constrain `U`, use it in the implemented trait, in the self type, or in an equality with an associated type
+   = note: `U` is bound to an associated type, but the reference to the associated type itself uses unconstrained generic parameters
 
 error[E0309]: the parameter type `U` may not live long enough
   --> $DIR/issue-87735.rs:34:21

--- a/tests/ui/generic-associated-types/bugs/issue-88526.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-88526.stderr
@@ -3,6 +3,9 @@ error[E0207]: the type parameter `I` is not constrained by the impl trait, self 
    |
 LL | impl<'q, Q, I, F> A for TestB<Q, F>
    |             ^ unconstrained type parameter
+   |
+   = note: to constrain `I`, use it in the implemented trait, in the self type, or in an equality with an associated type
+   = note: `I` is bound to an associated type, but the reference to the associated type itself uses unconstrained generic parameters
 
 error[E0309]: the parameter type `F` may not live long enough
   --> $DIR/issue-88526.rs:16:18

--- a/tests/ui/generic-associated-types/gat-trait-path-generic-type-arg.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-generic-type-arg.stderr
@@ -18,6 +18,8 @@ error[E0207]: the type parameter `T1` is not constrained by the impl trait, self
    |
 LL | impl <T, T1> Foo for T {
    |          ^^ unconstrained type parameter
+   |
+   = note: to constrain `T1`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/in-trait/unconstrained-lt.stderr
+++ b/tests/ui/impl-trait/in-trait/unconstrained-lt.stderr
@@ -3,6 +3,8 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a, T> Foo for T {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/issues/issue-87340.stderr
+++ b/tests/ui/impl-trait/issues/issue-87340.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T> X for () {
    |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0282]: type annotations needed
   --> $DIR/issue-87340.rs:11:23

--- a/tests/ui/impl-unused-rps-in-assoc-type.stderr
+++ b/tests/ui/impl-unused-rps-in-assoc-type.stderr
@@ -3,6 +3,8 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a> Fun for Holder {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-unused-tps-inherent.stderr
+++ b/tests/ui/impl-unused-tps-inherent.stderr
@@ -3,12 +3,16 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T> MyType {
    |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the self type, or in an equality with an associated type
 
 error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
   --> $DIR/impl-unused-tps-inherent.rs:17:8
    |
 LL | impl<T,U> MyType1<T> {
    |        ^ unconstrained type parameter
+   |
+   = note: to constrain `U`, use it in the self type, or in an equality with an associated type
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-unused-tps.stderr
+++ b/tests/ui/impl-unused-tps.stderr
@@ -25,30 +25,42 @@ error[E0207]: the type parameter `U` is not constrained by the impl trait, self 
    |
 LL | impl<T,U> Foo<T> for [isize;1] {
    |        ^ unconstrained type parameter
+   |
+   = note: to constrain `U`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
   --> $DIR/impl-unused-tps.rs:31:8
    |
 LL | impl<T,U> Bar for T {
    |        ^ unconstrained type parameter
+   |
+   = note: to constrain `U`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
   --> $DIR/impl-unused-tps.rs:39:8
    |
 LL | impl<T,U> Bar for T
    |        ^ unconstrained type parameter
+   |
+   = note: to constrain `U`, use it in the implemented trait, in the self type, or in an equality with an associated type
+   = note: `U` is bound to an associated type, but the associated type is circularly defined in this impl
 
 error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
   --> $DIR/impl-unused-tps.rs:47:8
    |
 LL | impl<T,U,V> Foo<T> for T
    |        ^ unconstrained type parameter
+   |
+   = note: to constrain `U`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0207]: the type parameter `V` is not constrained by the impl trait, self type, or predicates
   --> $DIR/impl-unused-tps.rs:47:10
    |
 LL | impl<T,U,V> Foo<T> for T
    |          ^ unconstrained type parameter
+   |
+   = note: to constrain `V`, use it in the implemented trait, in the self type, or in an equality with an associated type
+   = note: `V` is bound to an associated type, but the reference to the associated type itself uses unconstrained generic parameters
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/issues/issue-16562.stderr
+++ b/tests/ui/issues/issue-16562.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T, M: MatrixShape> Collection for Col<M, usize> {
    |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-22886.stderr
+++ b/tests/ui/issues/issue-22886.stderr
@@ -3,6 +3,8 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a> Iterator for Newtype {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-29861.stderr
+++ b/tests/ui/issues/issue-29861.stderr
@@ -3,6 +3,8 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a, T: 'a> MakeRef2 for T {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-29861.rs:16:43

--- a/tests/ui/issues/issue-35139.stderr
+++ b/tests/ui/issues/issue-35139.stderr
@@ -3,6 +3,8 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a> MethodType for MTFn {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.stderr
+++ b/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T> Loop<T> {}
    |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the self type, or in an equality with an associated type
 
 error[E0275]: overflow normalizing the type alias `Loop<T>`
   --> $DIR/unconstrained-params-in-impl-due-to-overflow.rs:6:16

--- a/tests/ui/lazy-type-alias/unconstrained-params-in-impl.stderr
+++ b/tests/ui/lazy-type-alias/unconstrained-params-in-impl.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T> NotInjective<T> {}
    |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the self type, or in an equality with an associated type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-impl-requires-const-trait.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-impl-requires-const-trait.stderr
@@ -16,6 +16,7 @@ error[E0207]: the const parameter `host` is not constrained by the impl trait, s
 LL | impl const A for () {}
    |      ^^^^^ unconstrained const parameter
    |
+   = note: to constrain `host`, use it in the implemented trait, in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-non-const-type.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-non-const-type.stderr
@@ -10,6 +10,7 @@ LL | #[derive_const(Default)]
 
 error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
    |
+   = note: to constrain `host`, use it in the implemented trait, in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-use.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-use.stderr
@@ -19,6 +19,7 @@ error[E0207]: the const parameter `host` is not constrained by the impl trait, s
 LL | impl const Default for A {
    |      ^^^^^ unconstrained const parameter
    |
+   = note: to constrain `host`, use it in the implemented trait, in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
@@ -34,6 +35,7 @@ LL | #[derive_const(Default, PartialEq)]
 
 error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
    |
+   = note: to constrain `host`, use it in the implemented trait, in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/span-bug-issue-121418.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/span-bug-issue-121418.stderr
@@ -14,6 +14,7 @@ error[E0207]: the const parameter `host` is not constrained by the impl trait, s
 LL | impl const dyn T {
    |      ^^^^^ unconstrained const parameter
    |
+   = note: to constrain `host`, use it in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/spec-effectvar-ice.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/spec-effectvar-ice.stderr
@@ -34,6 +34,7 @@ error[E0207]: the const parameter `host` is not constrained by the impl trait, s
 LL | impl<T> const Foo for T {}
    |         ^^^^^ unconstrained const parameter
    |
+   = note: to constrain `host`, use it in the implemented trait, in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
@@ -43,6 +44,7 @@ error[E0207]: the const parameter `host` is not constrained by the impl trait, s
 LL | impl<T> const Foo for T where T: const Specialize {}
    |         ^^^^^ unconstrained const parameter
    |
+   = note: to constrain `host`, use it in the implemented trait, in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/trait-default-body-stability.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/trait-default-body-stability.stderr
@@ -22,6 +22,7 @@ error[E0207]: the const parameter `host` is not constrained by the impl trait, s
 LL | impl const Try for T {
    |      ^^^^^ unconstrained const parameter
    |
+   = note: to constrain `host`, use it in the implemented trait, in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
@@ -31,6 +32,7 @@ error[E0207]: the const parameter `host` is not constrained by the impl trait, s
 LL | impl const FromResidual for T {
    |      ^^^^^ unconstrained const parameter
    |
+   = note: to constrain `host`, use it in the implemented trait, in the self type, or in an equality with an associated type
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 

--- a/tests/ui/specialization/min_specialization/ice-const-not-fully-resolved-113045.stderr
+++ b/tests/ui/specialization/min_specialization/ice-const-not-fully-resolved-113045.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `Unconstrained` is not constrained by the impl 
    |
 LL | impl<'a, Unconstrained> X for [(); 0] {}
    |          ^^^^^^^^^^^^^ unconstrained type parameter
+   |
+   = note: to constrain `Unconstrained`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: specialization impl does not specialize any associated items
   --> $DIR/ice-const-not-fully-resolved-113045.rs:11:1

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `S` is not constrained by the impl trait, self 
    |
 LL | impl<T, S> Trait<T> for i32 {
    |         ^ unconstrained type parameter
+   |
+   = note: to constrain `S`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:15:12

--- a/tests/ui/type-alias-impl-trait/assoc-type-lifetime-unconstrained.stderr
+++ b/tests/ui/type-alias-impl-trait/assoc-type-lifetime-unconstrained.stderr
@@ -3,6 +3,8 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a, I> UnwrapItemsExt for I {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0792]: expected generic lifetime parameter, found `'_`
   --> $DIR/assoc-type-lifetime-unconstrained.rs:22:9

--- a/tests/ui/type-alias-impl-trait/ice-failed-to-resolve-instance-for-110696.stderr
+++ b/tests/ui/type-alias-impl-trait/ice-failed-to-resolve-instance-for-110696.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T: MyFrom<Phantom2<DummyT<U>>>, U> MyIndex<DummyT<T>> for Scope<U> {
    |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/impl-with-unconstrained-param.stderr
+++ b/tests/ui/type-alias-impl-trait/impl-with-unconstrained-param.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T> X for () {
    |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0282]: type annotations needed
   --> $DIR/impl-with-unconstrained-param.rs:14:23

--- a/tests/ui/type-alias-impl-trait/issue-74244.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-74244.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T> Allocator for DefaultAllocator {
    |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0282]: type annotations needed
   --> $DIR/issue-74244.rs:16:13

--- a/tests/ui/type-alias-impl-trait/issue-74761-2.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-74761-2.stderr
@@ -3,12 +3,16 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a, 'b> A for () {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0207]: the lifetime parameter `'b` is not constrained by the impl trait, self type, or predicates
   --> $DIR/issue-74761-2.rs:7:10
    |
 LL | impl<'a, 'b> A for () {
    |          ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'b`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0792]: expected generic lifetime parameter, found `'_`
   --> $DIR/issue-74761-2.rs:12:28

--- a/tests/ui/type-alias-impl-trait/issue-74761.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-74761.stderr
@@ -3,12 +3,16 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a, 'b> A for () {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0207]: the lifetime parameter `'b` is not constrained by the impl trait, self type, or predicates
   --> $DIR/issue-74761.rs:7:10
    |
 LL | impl<'a, 'b> A for () {
    |          ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'b`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0792]: expected generic lifetime parameter, found `'_`
   --> $DIR/issue-74761.rs:12:28

--- a/tests/ui/type-alias-impl-trait/type-alias-impl-trait-unconstrained-lifetime.stderr
+++ b/tests/ui/type-alias-impl-trait/type-alias-impl-trait-unconstrained-lifetime.stderr
@@ -3,6 +3,8 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a, I: Iterator<Item = i32>> Trait for (i32, I) {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0792]: expected generic lifetime parameter, found `'_`
   --> $DIR/type-alias-impl-trait-unconstrained-lifetime.rs:14:9

--- a/tests/ui/type-alias-impl-trait/unconstrained-impl-param.stderr
+++ b/tests/ui/type-alias-impl-trait/unconstrained-impl-param.stderr
@@ -3,6 +3,8 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a> Trait for Opaque<&'a str> {
    |      ^^ unconstrained lifetime parameter
+   |
+   = note: to constrain `'a`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-13853-5.stderr
+++ b/tests/ui/typeck/issue-13853-5.stderr
@@ -3,6 +3,8 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<'a, T: Deserializable> Deserializable for &'a str {
    |          ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the implemented trait, in the self type, or in an equality with an associated type
 
 error[E0308]: mismatched types
   --> $DIR/issue-13853-5.rs:9:70

--- a/tests/ui/unconstrained-generic-parameters/mentioned-but-unconstrained-const-generic.rs
+++ b/tests/ui/unconstrained-generic-parameters/mentioned-but-unconstrained-const-generic.rs
@@ -1,0 +1,17 @@
+trait Foo1 {}
+
+trait Foo2 {
+    type Bar;
+}
+
+impl<const N: usize> Foo1 for u32 where [u32; N]: Clone {}
+//~^ ERROR: the const parameter `N` is not constrained
+
+impl<T, const N: usize> Foo1 for String where T: Iterator<Item = [u32; N]> {}
+//~^ ERROR: the type parameter `T` is not constrained
+//~| ERROR: the const parameter `N` is not constrained
+
+impl<T, const N: usize> Foo2 for T where T: Foo2<Bar = [u32; N]> { type Bar = [u32; N]; }
+//~^ ERROR: the const parameter `N` is not constrained
+
+fn main() {}

--- a/tests/ui/unconstrained-generic-parameters/mentioned-but-unconstrained-const-generic.stderr
+++ b/tests/ui/unconstrained-generic-parameters/mentioned-but-unconstrained-const-generic.stderr
@@ -1,0 +1,43 @@
+error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/mentioned-but-unconstrained-const-generic.rs:7:6
+   |
+LL | impl<const N: usize> Foo1 for u32 where [u32; N]: Clone {}
+   |      ^^^^^^^^^^^^^^ unconstrained const parameter
+   |
+   = note: to constrain `N`, use it in the implemented trait, in the self type, or in an equality with an associated type
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/mentioned-but-unconstrained-const-generic.rs:10:6
+   |
+LL | impl<T, const N: usize> Foo1 for String where T: Iterator<Item = [u32; N]> {}
+   |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the implemented trait, in the self type, or in an equality with an associated type
+
+error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/mentioned-but-unconstrained-const-generic.rs:10:9
+   |
+LL | impl<T, const N: usize> Foo1 for String where T: Iterator<Item = [u32; N]> {}
+   |         ^^^^^^^^^^^^^^ unconstrained const parameter
+   |
+   = note: to constrain `N`, use it in the implemented trait, in the self type, or in an equality with an associated type
+   = note: `N` is bound to an associated type, but the reference to the associated type itself uses unconstrained generic parameters
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/mentioned-but-unconstrained-const-generic.rs:14:9
+   |
+LL | impl<T, const N: usize> Foo2 for T where T: Foo2<Bar = [u32; N]> { type Bar = [u32; N]; }
+   |         ^^^^^^^^^^^^^^ unconstrained const parameter
+   |
+   = note: to constrain `N`, use it in the implemented trait, in the self type, or in an equality with an associated type
+   = note: `N` is bound to an associated type, but the associated type is circularly defined in this impl
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/unconstrained-generic-parameters/mentioned-but-unconstrained-type.rs
+++ b/tests/ui/unconstrained-generic-parameters/mentioned-but-unconstrained-type.rs
@@ -1,0 +1,24 @@
+trait Foo1 {}
+
+trait Foo2 {
+    type Bar;
+}
+
+trait Foo3 {
+    type Bar;
+}
+
+impl<T> Foo1 for u32 where T: Clone {}
+//~^ ERROR: the type parameter `T` is not constrained
+
+impl<T, U> Foo1 for String where T: Iterator<Item = U> {}
+//~^ ERROR: the type parameter `T` is not constrained
+//~| ERROR: the type parameter `U` is not constrained
+
+impl<T, U> Foo2 for T where T: Foo2<Bar = U> { type Bar = U; }
+//~^ ERROR: the type parameter `U` is not constrained
+
+impl<T, U> Foo3 for T where T: Foo3<Bar = Option<U>> { type Bar = Option<U>; }
+//~^ ERROR: the type parameter `U` is not constrained
+
+fn main() {}

--- a/tests/ui/unconstrained-generic-parameters/mentioned-but-unconstrained-type.stderr
+++ b/tests/ui/unconstrained-generic-parameters/mentioned-but-unconstrained-type.stderr
@@ -1,0 +1,46 @@
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/mentioned-but-unconstrained-type.rs:11:6
+   |
+LL | impl<T> Foo1 for u32 where T: Clone {}
+   |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the implemented trait, in the self type, or in an equality with an associated type
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/mentioned-but-unconstrained-type.rs:14:6
+   |
+LL | impl<T, U> Foo1 for String where T: Iterator<Item = U> {}
+   |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the implemented trait, in the self type, or in an equality with an associated type
+
+error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/mentioned-but-unconstrained-type.rs:14:9
+   |
+LL | impl<T, U> Foo1 for String where T: Iterator<Item = U> {}
+   |         ^ unconstrained type parameter
+   |
+   = note: to constrain `U`, use it in the implemented trait, in the self type, or in an equality with an associated type
+   = note: `U` is bound to an associated type, but the reference to the associated type itself uses unconstrained generic parameters
+
+error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/mentioned-but-unconstrained-type.rs:18:9
+   |
+LL | impl<T, U> Foo2 for T where T: Foo2<Bar = U> { type Bar = U; }
+   |         ^ unconstrained type parameter
+   |
+   = note: to constrain `U`, use it in the implemented trait, in the self type, or in an equality with an associated type
+   = note: `U` is bound to an associated type, but the associated type is circularly defined in this impl
+
+error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/mentioned-but-unconstrained-type.rs:21:9
+   |
+LL | impl<T, U> Foo3 for T where T: Foo3<Bar = Option<U>> { type Bar = Option<U>; }
+   |         ^ unconstrained type parameter
+   |
+   = note: to constrain `U`, use it in the implemented trait, in the self type, or in an equality with an associated type
+   = note: `U` is bound to an associated type, but the associated type is circularly defined in this impl
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/unconstrained-generic-parameters/unused-const-generic.rs
+++ b/tests/ui/unconstrained-generic-parameters/unused-const-generic.rs
@@ -1,0 +1,14 @@
+struct Foo;
+
+impl<const N: usize> Foo {}
+//~^ ERROR: the const parameter `N` is not constrained
+
+impl<const N: usize> Default for Foo {
+    //~^ ERROR: the const parameter `N` is not constrained
+    fn default() -> Self { Foo }
+}
+
+// This one isn't an error
+fn foo<const N: usize>() {}
+
+fn main() {}

--- a/tests/ui/unconstrained-generic-parameters/unused-const-generic.stderr
+++ b/tests/ui/unconstrained-generic-parameters/unused-const-generic.stderr
@@ -1,0 +1,23 @@
+error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unused-const-generic.rs:3:6
+   |
+LL | impl<const N: usize> Foo {}
+   |      ^^^^^^^^^^^^^^ unconstrained const parameter
+   |
+   = note: to constrain `N`, use it in the self type, or in an equality with an associated type
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unused-const-generic.rs:6:6
+   |
+LL | impl<const N: usize> Default for Foo {
+   |      ^^^^^^^^^^^^^^ unconstrained const parameter
+   |
+   = note: to constrain `N`, use it in the implemented trait, in the self type, or in an equality with an associated type
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/unconstrained-generic-parameters/unused-type-generic.rs
+++ b/tests/ui/unconstrained-generic-parameters/unused-type-generic.rs
@@ -1,0 +1,14 @@
+struct Foo;
+
+impl<T> Foo {}
+//~^ ERROR: the type parameter `T` is not constrained
+
+impl<T> Default for Foo {
+    //~^ ERROR: the type parameter `T` is not constrained
+    fn default() -> Self { Foo }
+}
+
+// This one isn't an error
+fn foo<T>() {}
+
+fn main() {}

--- a/tests/ui/unconstrained-generic-parameters/unused-type-generic.stderr
+++ b/tests/ui/unconstrained-generic-parameters/unused-type-generic.stderr
@@ -1,0 +1,19 @@
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unused-type-generic.rs:3:6
+   |
+LL | impl<T> Foo {}
+   |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the self type, or in an equality with an associated type
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unused-type-generic.rs:6:6
+   |
+LL | impl<T> Default for Foo {
+   |      ^ unconstrained type parameter
+   |
+   = note: to constrain `T`, use it in the implemented trait, in the self type, or in an equality with an associated type
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/107295

### Problem

When a type/lifetime/const generic param is unconstrained ([as defined by the rules in this RFC](https://github.com/rust-lang/rfcs/blob/master/text/0447-no-unused-impl-parameters.md)) the current diagnostic isn't very helpful - it just tells you the param wasn't constrained. It isn't obvious (without having read the RFC) what can be done to *make* the param constrained.

### Solution

We add some additional notes to the existing diagnostic:
* In all cases, this PR adds an extra note which tells the user under what circumstances a generic is constrained. This message is slightly different depending on whether this is an impl trait or an inherent impl. The message slightly oversimplifies things to be more understandable, but the edge cases it misses are covered by the special messages below:
  * If the LHS was the thing being implemented (i.e. circular), then we use an extra message to explain that circularity isn't allowed
  * Otherwise, if the unconstrained param was mentioned in the RHS of an equality w/ a projection/associated-type then we add a message saying that this must mean the LHS of the equality has an unconstrained param

I added a few UI tests which probably explain these messages better than I have here :)

After looking at the RFC I linked, AFAICT there are no more edge cases where the dot points above could be incorrect, but I'm not an expert, so please correct me if there are.

<hr />

Also as a side note - the `enforce_impl_params_are_constrained` function is getting a bit long, lmk if you want me to split it up.