### PR TITLE
Use #[track_caller] for no_threads.rs for Mutex

### DIFF
--- a/library/std/src/sys/sync/mutex/no_threads.rs
+++ b/library/std/src/sys/sync/mutex/no_threads.rs
@@ -16,6 +16,7 @@ impl Mutex {
     }
 
     #[inline]
+    #[track_caller]
     pub fn lock(&self) {
         assert_eq!(self.locked.replace(true), false, "cannot recursively acquire mutex");
     }


### PR DESCRIPTION
Sorry for the lack of context, but I'm experiencing a terrible issue which is made significantly harder in browser WASM to debug as a result of this not being marked as `#[tracked_caller]`.

![2024-06-05 Manifest at 06 10PM@2x](https://github.com/rust-lang/rust/assets/2925395/3f7f11cf-aaca-48bd-9ecc-bea63eaf6e92)


<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->