### PR TITLE
`E0229`: Suggest Moving Type Constraints to Type Parameter Declaration

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2456,6 +2456,15 @@ pub enum AssocItemConstraintKind<'hir> {
     Bound { bounds: &'hir [GenericBound<'hir>] },
 }
 
+impl<'hir> AssocItemConstraintKind<'hir> {
+    pub fn descr(&self) -> &'static str {
+        match self {
+            AssocItemConstraintKind::Equality { .. } => "binding",
+            AssocItemConstraintKind::Bound { .. } => "constraint",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, HashStable_Generic)]
 pub struct Ty<'hir> {
     pub hir_id: HirId,
@@ -3730,6 +3739,21 @@ impl<'hir> Node<'hir> {
             Node::Expr(Expr { kind: ExprKind::Closure(Closure { fn_decl, .. }), .. })
             | Node::ForeignItem(ForeignItem { kind: ForeignItemKind::Fn(fn_decl, _, _), .. }) => {
                 Some(fn_decl)
+            }
+            _ => None,
+        }
+    }
+
+    /// Get a `hir::Impl` if the node is an impl block for the given `trait_def_id`.
+    pub fn impl_block_of_trait(self, trait_def_id: DefId) -> Option<&'hir Impl<'hir>> {
+        match self {
+            Node::Item(Item { kind: ItemKind::Impl(impl_block), .. })
+                if impl_block
+                    .of_trait
+                    .and_then(|trait_ref| trait_ref.trait_def_id())
+                    .is_some_and(|trait_id| trait_id == trait_def_id) =>
+            {
+                Some(impl_block)
             }
             _ => None,
         }

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -531,6 +531,7 @@ pub(crate) fn check_generic_arg_count(
 
         let num_default_params = expected_max - expected_min;
 
+        let mut all_params_are_binded = false;
         let gen_args_info = if provided > expected_max {
             invalid_args.extend((expected_max..provided).map(|i| i + args_offset));
             let num_redundant_args = provided - expected_max;
@@ -546,6 +547,20 @@ pub(crate) fn check_generic_arg_count(
             }
         } else {
             let num_missing_args = expected_max - provided;
+
+            let constraint_names: Vec<_> =
+                gen_args.constraints.iter().map(|b| b.ident.name).collect();
+            let param_names: Vec<_> = gen_params
+                .own_params
+                .iter()
+                .filter(|param| !has_self || param.index != 0) // Assumes `Self` will always be the first parameter
+                .map(|param| param.name)
+                .collect();
+            if constraint_names == param_names {
+                // We set this to true and delay emitting `WrongNumberOfGenericArgs`
+                // to provide a succinct error for cases like issue #113073
+                all_params_are_binded = true;
+            };
 
             GenericArgsInfo::MissingTypesOrConsts {
                 num_missing_args,
@@ -567,7 +582,7 @@ pub(crate) fn check_generic_arg_count(
                 def_id,
             )
             .diagnostic()
-            .emit()
+            .emit_unless(all_params_are_binded)
         });
 
         Err(reported)

--- a/tests/ui/associated-type-bounds/no-gat-position.rs
+++ b/tests/ui/associated-type-bounds/no-gat-position.rs
@@ -5,6 +5,7 @@ pub trait Iter {
 
     fn next<'a>(&'a mut self) -> Option<Self::Item<'a, As1: Copy>>;
     //~^ ERROR associated item constraints are not allowed here
+    //~| HELP consider removing this associated item binding
 }
 
 impl Iter for () {

--- a/tests/ui/associated-type-bounds/no-gat-position.rs
+++ b/tests/ui/associated-type-bounds/no-gat-position.rs
@@ -5,7 +5,7 @@ pub trait Iter {
 
     fn next<'a>(&'a mut self) -> Option<Self::Item<'a, As1: Copy>>;
     //~^ ERROR associated item constraints are not allowed here
-    //~| HELP consider removing this associated item binding
+    //~| HELP consider removing this associated item constraint
 }
 
 impl Iter for () {

--- a/tests/ui/associated-type-bounds/no-gat-position.stderr
+++ b/tests/ui/associated-type-bounds/no-gat-position.stderr
@@ -3,6 +3,11 @@ error[E0229]: associated item constraints are not allowed here
    |
 LL |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a, As1: Copy>>;
    |                                                        ^^^^^^^^^ associated item constraint not allowed here
+   |
+help: consider removing this associated item binding
+   |
+LL |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a, As1: Copy>>;
+   |                                                      ~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-type-bounds/no-gat-position.stderr
+++ b/tests/ui/associated-type-bounds/no-gat-position.stderr
@@ -4,7 +4,7 @@ error[E0229]: associated item constraints are not allowed here
 LL |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a, As1: Copy>>;
    |                                                        ^^^^^^^^^ associated item constraint not allowed here
    |
-help: consider removing this associated item binding
+help: consider removing this associated item constraint
    |
 LL |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a, As1: Copy>>;
    |                                                      ~~~~~~~~~~~

--- a/tests/ui/associated-types/associated-types-eq-2.rs
+++ b/tests/ui/associated-types/associated-types-eq-2.rs
@@ -76,7 +76,6 @@ trait Tr3<const N: i32, T2, T3> {
 impl Tr3<N
 //~^ ERROR associated item constraints are not allowed here
 //~| ERROR associated const equality is incomplete
-//~| ERROR trait takes 3 generic arguments but 0 generic arguments were supplied
 = 42, T2 = Qux, T3 = usize> for Bar {
 }
 
@@ -92,7 +91,6 @@ impl Tr3<n = 42, T2 = Qux, T3 = usize> for Qux {
 // matches the const param ident but the constraint is a type arg
 impl Tr3<N = u32, T2 = Qux, T3 = usize> for Bar {
 //~^ ERROR associated item constraints are not allowed here
-//~| ERROR trait takes 3 generic arguments but 0 generic arguments were supplied
 }
 
 // Test for when equality constraint's ident

--- a/tests/ui/associated-types/associated-types-eq-2.stderr
+++ b/tests/ui/associated-types/associated-types-eq-2.stderr
@@ -5,7 +5,6 @@ LL |   impl Tr3<N
    |  __________^
 LL | |
 LL | |
-LL | |
 LL | | = 42, T2 = Qux, T3 = usize> for Bar {
    | |____^
    |
@@ -14,7 +13,7 @@ LL | | = 42, T2 = Qux, T3 = usize> for Bar {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
-  --> $DIR/associated-types-eq-2.rs:85:10
+  --> $DIR/associated-types-eq-2.rs:84:10
    |
 LL | impl Tr3<n = 42, T2 = Qux, T3 = usize> for Qux {
    |          ^^^^^^
@@ -24,7 +23,7 @@ LL | impl Tr3<n = 42, T2 = Qux, T3 = usize> for Qux {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
-  --> $DIR/associated-types-eq-2.rs:100:14
+  --> $DIR/associated-types-eq-2.rs:98:14
    |
 LL | impl Tr3<42, T2 = 42, T3 = usize> for Bar {
    |              ^^^^^^^
@@ -34,7 +33,7 @@ LL | impl Tr3<42, T2 = 42, T3 = usize> for Bar {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
-  --> $DIR/associated-types-eq-2.rs:108:10
+  --> $DIR/associated-types-eq-2.rs:106:10
    |
 LL | impl Tr3<X = 42, Y = Qux, Z = usize> for Bar {
    |          ^^^^^^
@@ -190,28 +189,11 @@ help: to use `GenericTerm<i32>` as a generic argument specify it directly
 LL | impl Tr2<i32, Qux, GenericTerm<i32>> for Bar {
    |                    ~~~~~~~~~~~~~~~~
 
-error[E0107]: trait takes 3 generic arguments but 0 generic arguments were supplied
-  --> $DIR/associated-types-eq-2.rs:76:6
-   |
-LL | impl Tr3<N
-   |      ^^^ expected 3 generic arguments
-   |
-note: trait defined here, with 3 generic parameters: `N`, `T2`, `T3`
-  --> $DIR/associated-types-eq-2.rs:69:7
-   |
-LL | trait Tr3<const N: i32, T2, T3> {
-   |       ^^^ ------------  --  --
-help: add missing generic arguments
-   |
-LL | impl Tr3<N, T2, T3, N
-   |          ++++++++++
-
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/associated-types-eq-2.rs:76:10
    |
 LL |   impl Tr3<N
    |  __________^
-LL | |
 LL | |
 LL | |
 LL | | = 42, T2 = Qux, T3 = usize> for Bar {
@@ -223,7 +205,7 @@ LL | impl Tr3<42, T2 = Qux, T3 = usize> for Bar {
    |          ~~
 
 error[E0107]: trait takes 3 generic arguments but 0 generic arguments were supplied
-  --> $DIR/associated-types-eq-2.rs:85:6
+  --> $DIR/associated-types-eq-2.rs:84:6
    |
 LL | impl Tr3<n = 42, T2 = Qux, T3 = usize> for Qux {
    |      ^^^ expected 3 generic arguments
@@ -239,7 +221,7 @@ LL | impl Tr3<N, T2, T3, n = 42, T2 = Qux, T3 = usize> for Qux {
    |          ++++++++++
 
 error[E0229]: associated item constraints are not allowed here
-  --> $DIR/associated-types-eq-2.rs:85:10
+  --> $DIR/associated-types-eq-2.rs:84:10
    |
 LL | impl Tr3<n = 42, T2 = Qux, T3 = usize> for Qux {
    |          ^^^^^^ associated item constraint not allowed here
@@ -249,24 +231,8 @@ help: consider removing this associated item binding
 LL | impl Tr3<n = 42, T2 = Qux, T3 = usize> for Qux {
    |          ~~~~~~~
 
-error[E0107]: trait takes 3 generic arguments but 0 generic arguments were supplied
-  --> $DIR/associated-types-eq-2.rs:93:6
-   |
-LL | impl Tr3<N = u32, T2 = Qux, T3 = usize> for Bar {
-   |      ^^^ expected 3 generic arguments
-   |
-note: trait defined here, with 3 generic parameters: `N`, `T2`, `T3`
-  --> $DIR/associated-types-eq-2.rs:69:7
-   |
-LL | trait Tr3<const N: i32, T2, T3> {
-   |       ^^^ ------------  --  --
-help: add missing generic arguments
-   |
-LL | impl Tr3<N, T2, T3, N = u32, T2 = Qux, T3 = usize> for Bar {
-   |          ++++++++++
-
 error[E0229]: associated item constraints are not allowed here
-  --> $DIR/associated-types-eq-2.rs:93:10
+  --> $DIR/associated-types-eq-2.rs:92:10
    |
 LL | impl Tr3<N = u32, T2 = Qux, T3 = usize> for Bar {
    |          ^^^^^^^ associated item constraint not allowed here
@@ -277,7 +243,7 @@ LL | impl Tr3<N = u32, T2 = Qux, T3 = usize> for Bar {
    |          ~~~~~~~~
 
 error[E0107]: trait takes 3 generic arguments but 1 generic argument was supplied
-  --> $DIR/associated-types-eq-2.rs:100:6
+  --> $DIR/associated-types-eq-2.rs:98:6
    |
 LL | impl Tr3<42, T2 = 42, T3 = usize> for Bar {
    |      ^^^ -- supplied 1 generic argument
@@ -295,7 +261,7 @@ LL | impl Tr3<42, T2, T3, T2 = 42, T3 = usize> for Bar {
    |            ++++++++
 
 error[E0229]: associated item constraints are not allowed here
-  --> $DIR/associated-types-eq-2.rs:100:14
+  --> $DIR/associated-types-eq-2.rs:98:14
    |
 LL | impl Tr3<42, T2 = 42, T3 = usize> for Bar {
    |              ^^^^^^^ associated item constraint not allowed here
@@ -306,7 +272,7 @@ LL | impl Tr3<42, T2 = 42, T3 = usize> for Bar {
    |            ~~~~~~~~~
 
 error[E0107]: trait takes 3 generic arguments but 0 generic arguments were supplied
-  --> $DIR/associated-types-eq-2.rs:108:6
+  --> $DIR/associated-types-eq-2.rs:106:6
    |
 LL | impl Tr3<X = 42, Y = Qux, Z = usize> for Bar {
    |      ^^^ expected 3 generic arguments
@@ -322,7 +288,7 @@ LL | impl Tr3<N, T2, T3, X = 42, Y = Qux, Z = usize> for Bar {
    |          ++++++++++
 
 error[E0229]: associated item constraints are not allowed here
-  --> $DIR/associated-types-eq-2.rs:108:10
+  --> $DIR/associated-types-eq-2.rs:106:10
    |
 LL | impl Tr3<X = 42, Y = Qux, Z = usize> for Bar {
    |          ^^^^^^ associated item constraint not allowed here
@@ -333,13 +299,13 @@ LL | impl Tr3<X = 42, Y = Qux, Z = usize> for Bar {
    |          ~~~~~~~
 
 error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/associated-types-eq-2.rs:119:13
+  --> $DIR/associated-types-eq-2.rs:117:13
    |
 LL | impl<'a, T> St<'a , T = Qux> {
    |             ^^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
-  --> $DIR/associated-types-eq-2.rs:117:8
+  --> $DIR/associated-types-eq-2.rs:115:8
    |
 LL | struct St<'a, T> { v: &'a T }
    |        ^^     -
@@ -349,7 +315,7 @@ LL | impl<'a, T> St<'a, T , T = Qux> {
    |                  +++
 
 error[E0229]: associated item constraints are not allowed here
-  --> $DIR/associated-types-eq-2.rs:119:21
+  --> $DIR/associated-types-eq-2.rs:117:21
    |
 LL | impl<'a, T> St<'a , T = Qux> {
    |                     ^^^^^^^ associated item constraint not allowed here
@@ -359,7 +325,7 @@ help: to use `Qux` as a generic argument specify it directly
 LL | impl<'a, T> St<'a , Qux> {
    |                     ~~~
 
-error: aborting due to 27 previous errors
+error: aborting due to 25 previous errors
 
 Some errors have detailed explanations: E0046, E0107, E0229, E0658.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
+++ b/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
@@ -12,6 +12,11 @@ error[E0229]: associated item constraints are not allowed here
    |
 LL | impl Super1<'_, bar(): Send> for () {}
    |                 ^^^^^^^^^^^ associated item constraint not allowed here
+   |
+help: consider removing this associated item binding
+   |
+LL | impl Super1<'_, bar(): Send> for () {}
+   |               ~~~~~~~~~~~~~
 
 error[E0046]: not all trait items implemented, missing: `bar`
   --> $DIR/rtn-in-impl-signature.rs:10:1

--- a/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
+++ b/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
@@ -13,7 +13,7 @@ error[E0229]: associated item constraints are not allowed here
 LL | impl Super1<'_, bar(): Send> for () {}
    |                 ^^^^^^^^^^^ associated item constraint not allowed here
    |
-help: consider removing this associated item binding
+help: consider removing this associated item constraint
    |
 LL | impl Super1<'_, bar(): Send> for () {}
    |               ~~~~~~~~~~~~~

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.rs
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.rs
@@ -7,8 +7,7 @@ struct Bar;
 const T: usize = 42;
 
 impl Foo<N = 3> for Bar {
-//~^ ERROR trait takes 1 generic argument but 0 generic arguments were supplied
-//~| ERROR associated item constraints are not allowed here
+//~^ ERROR associated item constraints are not allowed here
 //~| ERROR associated const equality is incomplete
     fn do_x(&self) -> [u8; 3] {
         [0u8; 3]

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
@@ -8,22 +8,6 @@ LL | impl Foo<N = 3> for Bar {
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/issue-89013-no-kw.rs:9:6
-   |
-LL | impl Foo<N = 3> for Bar {
-   |      ^^^ expected 1 generic argument
-   |
-note: trait defined here, with 1 generic parameter: `N`
-  --> $DIR/issue-89013-no-kw.rs:1:7
-   |
-LL | trait Foo<const N: usize> {
-   |       ^^^ --------------
-help: add missing generic argument
-   |
-LL | impl Foo<N, N = 3> for Bar {
-   |          ++
-
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/issue-89013-no-kw.rs:9:10
    |
@@ -35,7 +19,7 @@ help: to use `3` as a generic argument specify it directly
 LL | impl Foo<3> for Bar {
    |          ~
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0107, E0229, E0658.
-For more information about an error, try `rustc --explain E0107`.
+Some errors have detailed explanations: E0229, E0658.
+For more information about an error, try `rustc --explain E0229`.

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013.rs
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013.rs
@@ -8,7 +8,6 @@ const T: usize = 42;
 
 impl Foo<N = const 3> for Bar {
 //~^ ERROR expected lifetime, type, or constant, found keyword `const`
-//~| ERROR trait takes 1 generic
 //~| ERROR associated item constraints are not allowed here
 //~| ERROR associated const equality is incomplete
     fn do_x(&self) -> [u8; 3] {

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013.stderr
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013.stderr
@@ -20,22 +20,6 @@ LL | impl Foo<N = const 3> for Bar {
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/issue-89013.rs:9:6
-   |
-LL | impl Foo<N = const 3> for Bar {
-   |      ^^^ expected 1 generic argument
-   |
-note: trait defined here, with 1 generic parameter: `N`
-  --> $DIR/issue-89013.rs:1:7
-   |
-LL | trait Foo<const N: usize> {
-   |       ^^^ --------------
-help: add missing generic argument
-   |
-LL | impl Foo<N, N = const 3> for Bar {
-   |          ++
-
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/issue-89013.rs:9:10
    |
@@ -47,7 +31,7 @@ help: to use `3` as a generic argument specify it directly
 LL | impl Foo<3> for Bar {
    |          ~
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0107, E0229, E0658.
-For more information about an error, try `rustc --explain E0107`.
+Some errors have detailed explanations: E0229, E0658.
+For more information about an error, try `rustc --explain E0229`.

--- a/tests/ui/generics/impl-block-params-declared-in-wrong-spot-issue-113073.rs
+++ b/tests/ui/generics/impl-block-params-declared-in-wrong-spot-issue-113073.rs
@@ -1,0 +1,33 @@
+trait Foo<T> {}
+
+impl Foo<T: Default> for String {}
+//~^ ERROR associated item constraints are not allowed here
+//~| HELP declare the type parameter right after the `impl` keyword
+
+impl Foo<T: 'a + Default> for u8 {}
+//~^ ERROR associated item constraints are not allowed here
+//~| HELP declare the type parameter right after the `impl` keyword
+//~| ERROR use of undeclared lifetime name `'a`
+//~| HELP consider introducing lifetime `'a` here
+
+impl<T> Foo<T: Default> for u16 {}
+//~^ ERROR associated item constraints are not allowed here
+//~| HELP declare the type parameter right after the `impl` keyword
+
+impl<'a> Foo<T: 'a + Default> for u32 {}
+//~^ ERROR associated item constraints are not allowed here
+//~| HELP declare the type parameter right after the `impl` keyword
+
+trait Bar<T, K> {}
+
+impl Bar<T: Default, K: Default> for String {}
+//~^ ERROR associated item constraints are not allowed here
+//~| HELP declare the type parameter right after the `impl` keyword
+
+impl<T> Bar<T, K: Default> for u8 {}
+//~^ ERROR trait takes 2 generic arguments but 1 generic argument was supplied
+//~| HELP add missing generic argument
+//~| ERROR associated item constraints are not allowed here
+//~| HELP declare the type parameter right after the `impl` keyword
+
+fn main() {}

--- a/tests/ui/generics/impl-block-params-declared-in-wrong-spot-issue-113073.stderr
+++ b/tests/ui/generics/impl-block-params-declared-in-wrong-spot-issue-113073.stderr
@@ -1,0 +1,96 @@
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:7:13
+   |
+LL | impl Foo<T: 'a + Default> for u8 {}
+   |     -       ^^ undeclared lifetime
+   |     |
+   |     help: consider introducing lifetime `'a` here: `<'a>`
+
+error[E0229]: associated item constraints are not allowed here
+  --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:3:10
+   |
+LL | impl Foo<T: Default> for String {}
+   |          ^^^^^^^^^^ associated item constraint not allowed here
+   |
+help: declare the type parameter right after the `impl` keyword
+   |
+LL | impl<T: Default> Foo<T> for String {}
+   |     ++++++++++++     ~
+
+error[E0229]: associated item constraints are not allowed here
+  --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:7:10
+   |
+LL | impl Foo<T: 'a + Default> for u8 {}
+   |          ^^^^^^^^^^^^^^^ associated item constraint not allowed here
+   |
+help: declare the type parameter right after the `impl` keyword
+   |
+LL | impl<'a, T: 'a + Default> Foo<T> for u8 {}
+   |     +++++++++++++++++++++     ~
+
+error[E0229]: associated item constraints are not allowed here
+  --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:13:13
+   |
+LL | impl<T> Foo<T: Default> for u16 {}
+   |             ^^^^^^^^^^ associated item constraint not allowed here
+   |
+help: declare the type parameter right after the `impl` keyword
+   |
+LL | impl<T, T: Default> Foo<T> for u16 {}
+   |       ++++++++++++      ~
+
+error[E0229]: associated item constraints are not allowed here
+  --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:17:14
+   |
+LL | impl<'a> Foo<T: 'a + Default> for u32 {}
+   |              ^^^^^^^^^^^^^^^ associated item constraint not allowed here
+   |
+help: declare the type parameter right after the `impl` keyword
+   |
+LL | impl<'a, 'a, T: 'a + Default> Foo<T> for u32 {}
+   |        +++++++++++++++++++++      ~
+
+error[E0229]: associated item constraints are not allowed here
+  --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:23:10
+   |
+LL | impl Bar<T: Default, K: Default> for String {}
+   |          ^^^^^^^^^^ associated item constraint not allowed here
+   |
+help: declare the type parameter right after the `impl` keyword
+   |
+LL | impl<T: Default> Bar<T, K: Default> for String {}
+   |     ++++++++++++     ~
+
+error[E0107]: trait takes 2 generic arguments but 1 generic argument was supplied
+  --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:27:9
+   |
+LL | impl<T> Bar<T, K: Default> for u8 {}
+   |         ^^^ - supplied 1 generic argument
+   |         |
+   |         expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `K`
+  --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:21:7
+   |
+LL | trait Bar<T, K> {}
+   |       ^^^ -  -
+help: add missing generic argument
+   |
+LL | impl<T> Bar<T, K, K: Default> for u8 {}
+   |              +++
+
+error[E0229]: associated item constraints are not allowed here
+  --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:27:16
+   |
+LL | impl<T> Bar<T, K: Default> for u8 {}
+   |                ^^^^^^^^^^ associated item constraint not allowed here
+   |
+help: declare the type parameter right after the `impl` keyword
+   |
+LL | impl<T, K: Default> Bar<T, K> for u8 {}
+   |       ++++++++++++         ~
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0107, E0229, E0261.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
Fixes #113073

This PR suggests  `impl<T: Bound> Trait<T> for Foo` when finding `impl Trait<T: Bound> for Foo`. Tangentially, it also improves a handful of other error messages.

It accomplishes this in two steps:
1. Check if constrained arguments and parameter names appear in the same order and delay emitting "incorrect number of generic arguments" error because it can be confusing for the programmer to see `0 generic arguments provided` when there are `n` constrained generic arguments.

2. Inside `E0229`, suggest declaring the type parameter right after the `impl` keyword by finding the relevant impl block's span for type parameter declaration. This also handles lifetime declarations correctly.

Also, the multi part suggestion doesn't use the fluent error mechanism because translating all the errors to fluent style feels outside the scope of this PR. I will handle it in a separate PR if this gets approved.

