### PR TITLE
Expand list of trait implementers in E0277 when calling rustc with --verbose

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2082,12 +2082,16 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 })
                 .collect();
 
-            let end = if candidates.len() <= 9 { candidates.len() } else { 8 };
+            let end = if candidates.len() <= 9 || self.tcx.sess.opts.verbose {
+                candidates.len()
+            } else {
+                8
+            };
             err.help(format!(
                 "the following {other}types implement trait `{}`:{}{}",
                 trait_ref.print_trait_sugared(),
                 candidates[..end].join(""),
-                if candidates.len() > 9 {
+                if candidates.len() > 9 && !self.tcx.sess.opts.verbose {
                     format!("\nand {} others", candidates.len() - 8)
                 } else {
                     String::new()


### PR DESCRIPTION
Fixes: https://github.com/rust-lang/rust/issues/125984

- Build `rustc` use `./x build`. 
- Test result
<img width="634" alt="image" src="https://github.com/rust-lang/rust/assets/15009201/89377059-2316-492b-a38a-fa33adfc9793">

- vim test.rs
```rust
trait Reconcile {
    fn reconcile(&self);
}

// Implementing the trait for some types
impl Reconcile for bool {
    fn reconcile(&self) {
        println!("Reconciling bool");
    }
}

impl Reconcile for i8 {
    fn reconcile(&self) {
        println!("Reconciling i8");
    }
}

impl Reconcile for i16 {
    fn reconcile(&self) {
        println!("Reconciling i16");
    }
}

impl Reconcile for i32 {
    fn reconcile(&self) {
        println!("Reconciling i32");
    }
}

impl Reconcile for i64 {
    fn reconcile(&self) {
        println!("Reconciling i64");
    }
}

impl Reconcile for u8 {
    fn reconcile(&self) {
        println!("Reconciling u8");
    }
}

impl Reconcile for u16 {
    fn reconcile(&self) {
        println!("Reconciling u16");
    }
}

impl Reconcile for u32 {
    fn reconcile(&self) {
        println!("Reconciling u32");
    }
}

impl Reconcile for i128 {
    fn reconcile(&self) {
        println!("Reconciling u32");
    }
}

impl Reconcile for u128 {
    fn reconcile(&self) {
        println!("Reconciling u32");
    }
}

fn process<T: Reconcile>(item: T) {
    item.reconcile();
}

fn main() {
    let value = String::from("This will cause an error");
    process(value); // This line will cause a compilation error
}
```
