### PR TITLE
mark binding undetermined if target name exist and not obtained

### DIFF
--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -998,14 +998,14 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             let Some(module) = single_import.imported_module.get() else {
                 return Err((Undetermined, Weak::No));
             };
-            let ImportKind::Single { source: ident, source_bindings, .. } = &single_import.kind
+            let ImportKind::Single { source: ident, target, target_bindings, .. } =
+                &single_import.kind
             else {
                 unreachable!();
             };
-            if binding.map_or(false, |binding| binding.module().is_some())
-                && source_bindings.iter().all(|binding| matches!(binding.get(), Err(Undetermined)))
-            {
-                // This branch allows the binding to be defined or updated later,
+            if (ident != target) && target_bindings.iter().all(|binding| binding.get().is_none()) {
+                // This branch allows the binding to be defined or updated later if the target name
+                // can hide the source but these bindings are not obtained.
                 // avoiding module inconsistency between the resolve process and the finalize process.
                 // See more details in #124840
                 return Err((Undetermined, Weak::No));

--- a/tests/ui/imports/cycle-import-in-std-1.rs
+++ b/tests/ui/imports/cycle-import-in-std-1.rs
@@ -1,0 +1,9 @@
+//@ edition: 2018
+
+// https://github.com/rust-lang/rust/issues/124490
+
+use ops::{self as std};
+//~^ ERROR: unresolved import `ops`
+use std::collections::{self as ops};
+
+fn main() {}

--- a/tests/ui/imports/cycle-import-in-std-1.stderr
+++ b/tests/ui/imports/cycle-import-in-std-1.stderr
@@ -1,0 +1,13 @@
+error[E0432]: unresolved import `ops`
+  --> $DIR/cycle-import-in-std-1.rs:5:11
+   |
+LL | use ops::{self as std};
+   |           ^^^^^^^^^^^ no external crate `ops`
+   |
+   = help: consider importing one of these items instead:
+           core::ops
+           std::ops
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/imports/cycle-import-in-std-2.rs
+++ b/tests/ui/imports/cycle-import-in-std-2.rs
@@ -1,0 +1,9 @@
+//@ edition: 2018
+
+// https://github.com/rust-lang/rust/issues/125013
+
+use ops::{self as std};
+//~^ ERROR: unresolved import `ops`
+use std::ops::Deref::{self as ops};
+
+fn main() {}

--- a/tests/ui/imports/cycle-import-in-std-2.stderr
+++ b/tests/ui/imports/cycle-import-in-std-2.stderr
@@ -1,0 +1,13 @@
+error[E0432]: unresolved import `ops`
+  --> $DIR/cycle-import-in-std-2.rs:5:11
+   |
+LL | use ops::{self as std};
+   |           ^^^^^^^^^^^ no external crate `ops`
+   |
+   = help: consider importing one of these items instead:
+           core::ops
+           std::ops
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0432`.


### PR DESCRIPTION
- Fixes #124490
- Fixes #125013

Following up on #124840, I think handling only ﻿`target_bindings` is sufficient.

r? @petrochenkov 