### PR TITLE
Change the return type of `Ty::kind` from `&TyKind` to `TyKind`.

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -435,7 +435,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                     && let hir::ExprKind::Call(call, args) = parent_expr.kind
                     && let ty::FnDef(def_id, _) = typeck.node_type(call.hir_id).kind()
                 {
-                    (Some(*def_id), args, 0)
+                    (Some(def_id), args, 0)
                 } else {
                     (None, &[][..], 0)
                 };
@@ -498,7 +498,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                                     .contains(&Some(predicate.def_id()))
                                     && let ty::Param(param) = predicate.self_ty().kind()
                                     && let generics = self.infcx.tcx.generics_of(def_id)
-                                    && let param = generics.type_param(*param, self.infcx.tcx)
+                                    && let param = generics.type_param(param, self.infcx.tcx)
                                     && param.def_id == param_def_id
                                 {
                                     if [
@@ -870,7 +870,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
         // borrowing the type, since `&mut F: FnMut` iff `F: FnMut` and similarly for `Fn`.
         // These types seem reasonably opaque enough that they could be instantiated with their
         // borrowed variants in a function body when we see a move error.
-        let borrow_level = match *ty.kind() {
+        let borrow_level = match ty.kind() {
             ty::Param(_) => tcx
                 .explicit_predicates_of(self.mir_def_id().to_def_id())
                 .predicates
@@ -1263,7 +1263,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
         } else if let ty::Param(param) = ty.kind()
             && let Some(_clone_trait_def) = self.infcx.tcx.lang_items().clone_trait()
             && let generics = self.infcx.tcx.generics_of(self.mir_def_id())
-            && let generic_param = generics.type_param(*param, self.infcx.tcx)
+            && let generic_param = generics.type_param(param, self.infcx.tcx)
             && let param_span = self.infcx.tcx.def_span(generic_param.def_id)
             && if let Some(UseSpans::FnSelfUse { kind, .. }) = use_spans
                 && let CallKind::FnCall { fn_trait_id, self_ty } = kind
@@ -1436,7 +1436,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
             .into_iter()
             .map(|err| match err.obligation.predicate.kind().skip_binder() {
                 PredicateKind::Clause(ty::ClauseKind::Trait(predicate)) => {
-                    match *predicate.self_ty().kind() {
+                    match predicate.self_ty().kind() {
                         ty::Param(param_ty) => Ok((
                             generics.type_param(param_ty, tcx),
                             predicate.trait_ref.print_trait_sugared().to_string(),

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -112,7 +112,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
             ..
         } = &terminator.kind
         {
-            if let ty::FnDef(id, _) = *const_.ty().kind() {
+            if let ty::FnDef(id, _) = const_.ty().kind() {
                 debug!("add_moved_or_invoked_closure_note: id={:?}", id);
                 if self.infcx.tcx.is_lang_item(self.infcx.tcx.parent(id), LangItem::FnOnce) {
                     let closure = match args.first() {
@@ -348,7 +348,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
             // If the type is a box, the field is described from the boxed type
             self.describe_field_from_ty(ty.boxed_ty(), field, variant_index, including_tuple_field)
         } else {
-            match *ty.kind() {
+            match ty.kind() {
                 ty::Adt(def, _) => {
                     let variant = if let Some(idx) = variant_index {
                         assert!(def.is_enum());
@@ -459,7 +459,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
         // this by hooking into the pretty printer and telling it to label the
         // lifetimes without names with the value `'0`.
         if let ty::Ref(region, ..) = ty.kind() {
-            match **region {
+            match *region {
                 ty::ReBound(_, ty::BoundRegion { kind: br, .. })
                 | ty::RePlaceholder(ty::PlaceholderRegion {
                     bound: ty::BoundRegion { kind: br, .. },
@@ -479,7 +479,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
         let mut printer = ty::print::FmtPrinter::new(self.infcx.tcx, Namespace::TypeNS);
 
         let region = if let ty::Ref(region, ..) = ty.kind() {
-            match **region {
+            match *region {
                 ty::ReBound(_, ty::BoundRegion { kind: br, .. })
                 | ty::RePlaceholder(ty::PlaceholderRegion {
                     bound: ty::BoundRegion { kind: br, .. },
@@ -740,7 +740,7 @@ impl<'tcx> BorrowedContentSource<'tcx> {
     }
 
     fn from_call(func: Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Option<Self> {
-        match *func.kind() {
+        match func.kind() {
             ty::FnDef(def_id, args) => {
                 let trait_id = tcx.trait_of_item(def_id)?;
 
@@ -1048,7 +1048,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                     // LL | blk();
                     //    | ----- this value implements `FnOnce`, which causes it to be moved when called
                     // ```
-                    if let ty::Param(param_ty) = *self_ty.kind()
+                    if let ty::Param(param_ty) = self_ty.kind()
                         && let generics = self.infcx.tcx.generics_of(self.mir_def_id())
                         && let param = generics.type_param(param_ty, self.infcx.tcx)
                         && let Some(hir_generics) = self

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -377,7 +377,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                 if suggest {
                     self.construct_mut_suggestion_for_local_binding_patterns(&mut err, local);
                     let tcx = self.infcx.tcx;
-                    if let ty::Closure(id, _) = *the_place_err.ty(self.body, tcx).ty.kind() {
+                    if let ty::Closure(id, _) = the_place_err.ty(self.body, tcx).ty.kind() {
                         self.show_mutating_upvar(tcx, id.expect_local(), the_place_err, &mut err);
                     }
                 }
@@ -431,7 +431,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
 
                 let tcx = self.infcx.tcx;
                 if let ty::Ref(_, ty, Mutability::Mut) = the_place_err.ty(self.body, tcx).ty.kind()
-                    && let ty::Closure(id, _) = *ty.kind()
+                    && let ty::Closure(id, _) = ty.kind()
                 {
                     self.show_mutating_upvar(tcx, id.expect_local(), the_place_err, &mut err);
                 }
@@ -953,7 +953,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                     if let Some(ty::FnDef(def_id, _)) =
                         typeck_results.node_type_opt(expr.hir_id).as_ref().map(|ty| ty.kind())
                     {
-                        Some((*def_id, expr.span, *args))
+                        Some((def_id, expr.span, *args))
                     } else {
                         None
                     }

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -523,7 +523,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, '_, 'tcx> {
                     }
 
                     // Otherwise, let's descend into the referent types.
-                    search_stack.push((*referent_ty, referent_hir_ty.ty));
+                    search_stack.push((referent_ty, referent_hir_ty.ty));
                 }
 
                 // Match up something like `Foo<'1>`
@@ -552,17 +552,17 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, '_, 'tcx> {
                 // The following cases don't have lifetimes, so we
                 // just worry about trying to match up the rustc type
                 // with the HIR types:
-                (&ty::Tuple(elem_tys), hir::TyKind::Tup(elem_hir_tys)) => {
+                (ty::Tuple(elem_tys), hir::TyKind::Tup(elem_hir_tys)) => {
                     search_stack.extend(iter::zip(elem_tys, *elem_hir_tys));
                 }
 
                 (ty::Slice(elem_ty), hir::TyKind::Slice(elem_hir_ty))
                 | (ty::Array(elem_ty, _), hir::TyKind::Array(elem_hir_ty, _)) => {
-                    search_stack.push((*elem_ty, elem_hir_ty));
+                    search_stack.push((elem_ty, elem_hir_ty));
                 }
 
                 (ty::RawPtr(mut_ty, _), hir::TyKind::Ptr(mut_hir_ty)) => {
-                    search_stack.push((*mut_ty, mut_hir_ty.ty));
+                    search_stack.push((mut_ty, mut_hir_ty.ty));
                 }
 
                 _ => {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -265,7 +265,7 @@ fn do_mir_borrowck<'tcx>(
         // The first argument is the coroutine type passed by value
         if let Some(local) = body.local_decls.raw.get(1)
         // Get the interior types and args which typeck computed
-        && let ty::Coroutine(def_id, _) = *local.ty.kind()
+        && let ty::Coroutine(def_id, _) = local.ty.kind()
         && tcx.coroutine_movability(def_id) == hir::Movability::Movable
     {
         true

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1067,7 +1067,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
                 use ty::TypeSuperFoldable as _;
                 let tcx = self.tcx;
-                let &ty::Alias(ty::Opaque, ty::AliasTy { args, def_id, .. }) = t.kind() else {
+                let ty::Alias(ty::Opaque, ty::AliasTy { args, def_id, .. }) = t.kind() else {
                     return t.super_fold_with(self);
                 };
                 let args = std::iter::zip(args, tcx.variances_of(def_id)).map(|(arg, v)| {

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -592,7 +592,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
                 let defining_ty =
                     self.infcx.replace_free_regions_with_nll_infer_vars(FR, defining_ty);
 
-                match *defining_ty.kind() {
+                match defining_ty.kind() {
                     ty::Closure(def_id, args) => DefiningTy::Closure(def_id, args),
                     ty::Coroutine(def_id, args) => DefiningTy::Coroutine(def_id, args),
                     ty::CoroutineClosure(def_id, args) => {
@@ -715,7 +715,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
                 let (&output, tuplized_inputs) =
                     inputs_and_output.skip_binder().split_last().unwrap();
                 assert_eq!(tuplized_inputs.len(), 1, "multiple closure inputs");
-                let &ty::Tuple(inputs) = tuplized_inputs[0].kind() else {
+                let ty::Tuple(inputs) = tuplized_inputs[0].kind() else {
                     bug!("closure inputs not a tuple: {:?}", tuplized_inputs[0]);
                 };
 

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -249,7 +249,7 @@ pub(crate) fn codegen_fn_prelude<'tcx>(fx: &mut FunctionCx<'_, '_, 'tcx>, start_
                 // individual function arguments.
 
                 let tupled_arg_tys = match arg_ty.kind() {
-                    ty::Tuple(ref tys) => tys,
+                    ty::Tuple(tys) => tys,
                     _ => bug!("spread argument isn't a tuple?! but {:?}", arg_ty),
                 };
 
@@ -370,7 +370,7 @@ pub(crate) fn codegen_terminator_call<'tcx>(
     let ret_place = codegen_place(fx, destination);
 
     // Handle special calls like intrinsics and empty drop glue.
-    let instance = if let ty::FnDef(def_id, fn_args) = *func.layout().ty.kind() {
+    let instance = if let ty::FnDef(def_id, fn_args) = func.layout().ty.kind() {
         let instance = ty::Instance::expect_resolve(
             fx.tcx,
             ty::ParamEnv::reveal_all(),
@@ -466,7 +466,7 @@ pub(crate) fn codegen_terminator_call<'tcx>(
         };
 
         let tupled_arguments = match pack_arg.value.layout().ty.kind() {
-            ty::Tuple(ref tupled_arguments) => tupled_arguments,
+            ty::Tuple(tupled_arguments) => tupled_arguments,
             _ => bug!("argument to function with \"rust-call\" ABI is not a tuple"),
         };
 

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -657,7 +657,7 @@ fn codegen_stmt<'tcx>(
                 ) => {
                     let from_ty = fx.monomorphize(operand.ty(&fx.mir.local_decls, fx.tcx));
                     let to_layout = fx.layout_of(fx.monomorphize(to_ty));
-                    match *from_ty.kind() {
+                    match from_ty.kind() {
                         ty::FnDef(def_id, args) => {
                             let func_ref = fx.get_function_ref(
                                 Instance::resolve_for_fn_ptr(
@@ -745,7 +745,7 @@ fn codegen_stmt<'tcx>(
                     _to_ty,
                 ) => {
                     let operand = codegen_operand(fx, operand);
-                    match *operand.layout().ty.kind() {
+                    match operand.layout().ty.kind() {
                         ty::Closure(def_id, args) => {
                             let instance = Instance::resolve_closure(
                                 fx.tcx,
@@ -941,7 +941,7 @@ fn codegen_stmt<'tcx>(
 }
 
 fn codegen_array_len<'tcx>(fx: &mut FunctionCx<'_, '_, 'tcx>, place: CPlace<'tcx>) -> Value {
-    match *place.layout().ty.kind() {
+    match place.layout().ty.kind() {
         ty::Array(_elem_ty, len) => {
             let len = fx.monomorphize(len).eval_target_usize(fx.tcx, ParamEnv::reveal_all()) as i64;
             fx.bcx.ins().iconst(fx.pointer_type, len)
@@ -991,16 +991,16 @@ pub(crate) fn codegen_place<'tcx>(
                 match cplace.layout().ty.kind() {
                     ty::Array(elem_ty, _len) => {
                         assert!(!from_end, "array subslices are never `from_end`");
-                        let elem_layout = fx.layout_of(*elem_ty);
+                        let elem_layout = fx.layout_of(elem_ty);
                         let ptr = cplace.to_ptr();
                         cplace = CPlace::for_ptr(
                             ptr.offset_i64(fx, elem_layout.size.bytes() as i64 * (from as i64)),
-                            fx.layout_of(Ty::new_array(fx.tcx, *elem_ty, to - from)),
+                            fx.layout_of(Ty::new_array(fx.tcx, elem_ty, to - from)),
                         );
                     }
                     ty::Slice(elem_ty) => {
                         assert!(from_end, "slice subslices should be `from_end`");
-                        let elem_layout = fx.layout_of(*elem_ty);
+                        let elem_layout = fx.layout_of(elem_ty);
                         let (ptr, len) = cplace.to_ptr_unsized();
                         cplace = CPlace::for_ptr_with_extra(
                             ptr.offset_i64(fx, elem_layout.size.bytes() as i64 * (from as i64)),

--- a/compiler/rustc_codegen_cranelift/src/common.rs
+++ b/compiler/rustc_codegen_cranelift/src/common.rs
@@ -71,7 +71,7 @@ fn clif_type_from_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<types::Typ
         },
         ty::FnPtr(..) => pointer_ty(tcx),
         ty::RawPtr(pointee_ty, _) | ty::Ref(_, pointee_ty, _) => {
-            if has_ptr_meta(tcx, *pointee_ty) {
+            if has_ptr_meta(tcx, pointee_ty) {
                 return None;
             } else {
                 pointer_ty(tcx)
@@ -91,7 +91,7 @@ fn clif_pair_type_from_ty<'tcx>(
             (clif_type_from_ty(tcx, types[0])?, clif_type_from_ty(tcx, types[1])?)
         }
         ty::RawPtr(pointee_ty, _) | ty::Ref(_, pointee_ty, _) => {
-            if has_ptr_meta(tcx, *pointee_ty) {
+            if has_ptr_meta(tcx, pointee_ty) {
                 (pointer_ty(tcx), pointer_ty(tcx))
             } else {
                 return None;

--- a/compiler/rustc_codegen_cranelift/src/debuginfo/types.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/types.rs
@@ -43,20 +43,20 @@ impl DebugContext {
                 tcx,
                 type_dbg,
                 ty,
-                *elem_ty,
+                elem_ty,
                 len.eval_target_usize(tcx, ty::ParamEnv::reveal_all()),
             ),
             // ty::Slice(_) | ty::Str
             // ty::Dynamic
             // ty::Foreign
             ty::RawPtr(pointee_type, _) | ty::Ref(_, pointee_type, _) => {
-                self.pointer_type(tcx, type_dbg, ty, *pointee_type)
+                self.pointer_type(tcx, type_dbg, ty, pointee_type)
             }
             // ty::Adt(def, args) if def.is_box() && args.get(1).map_or(true, |arg| cx.layout_of(arg.expect_ty()).is_1zst())
             // ty::FnDef(..) | ty::FnPtr(..)
             // ty::Closure(..)
             // ty::Adt(def, ..)
-            ty::Tuple(components) => self.tuple_type(tcx, type_dbg, ty, *components),
+            ty::Tuple(components) => self.tuple_type(tcx, type_dbg, ty, components),
             // ty::Param(_)
             // FIXME implement remaining types and add unreachable!() to the fallback branch
             _ => self.placeholder_for_type(tcx, type_dbg, ty),

--- a/compiler/rustc_codegen_cranelift/src/global_asm.rs
+++ b/compiler/rustc_codegen_cranelift/src/global_asm.rs
@@ -65,7 +65,7 @@ pub(crate) fn codegen_global_asm_item(tcx: TyCtxt<'_>, global_asm: &mut String, 
 
                             let ty = tcx.typeck_body(anon_const.body).node_type(anon_const.hir_id);
                             let instance = match ty.kind() {
-                                &ty::FnDef(def_id, args) => Instance::new(def_id, args),
+                                ty::FnDef(def_id, args) => Instance::new(def_id, args),
                                 _ => span_bug!(op_sp, "asm sym is not a function"),
                             };
                             let symbol = tcx.symbol_name(instance);

--- a/compiler/rustc_codegen_cranelift/src/inline_asm.rs
+++ b/compiler/rustc_codegen_cranelift/src/inline_asm.rs
@@ -89,7 +89,7 @@ pub(crate) fn codegen_inline_asm_terminator<'tcx>(
                 }
 
                 let const_ = fx.monomorphize(value.const_);
-                if let ty::FnDef(def_id, args) = *const_.ty().kind() {
+                if let ty::FnDef(def_id, args) = const_.ty().kind() {
                     let instance = ty::Instance::resolve_for_fn_ptr(
                         fx.tcx,
                         ty::ParamEnv::reveal_all(),
@@ -253,7 +253,7 @@ pub(crate) fn codegen_naked_asm<'tcx>(
                     ty::ParamEnv::reveal_all(),
                     ty::EarlyBinder::bind(value.const_),
                 );
-                if let ty::FnDef(def_id, args) = *const_.ty().kind() {
+                if let ty::FnDef(def_id, args) = const_.ty().kind() {
                     let instance = ty::Instance::resolve_for_fn_ptr(
                         tcx,
                         ty::ParamEnv::reveal_all(),

--- a/compiler/rustc_codegen_cranelift/src/unsize.rs
+++ b/compiler/rustc_codegen_cranelift/src/unsize.rs
@@ -67,11 +67,11 @@ fn unsize_ptr<'tcx>(
     dst_layout: TyAndLayout<'tcx>,
     old_info: Option<Value>,
 ) -> (Value, Value) {
-    match (&src_layout.ty.kind(), &dst_layout.ty.kind()) {
-        (&ty::Ref(_, a, _), &ty::Ref(_, b, _))
-        | (&ty::Ref(_, a, _), &ty::RawPtr(b, _))
-        | (&ty::RawPtr(a, _), &ty::RawPtr(b, _)) => (src, unsized_info(fx, *a, *b, old_info)),
-        (&ty::Adt(def_a, _), &ty::Adt(def_b, _)) => {
+    match (src_layout.ty.kind(), dst_layout.ty.kind()) {
+        (ty::Ref(_, a, _), ty::Ref(_, b, _))
+        | (ty::Ref(_, a, _), ty::RawPtr(b, _))
+        | (ty::RawPtr(a, _), ty::RawPtr(b, _)) => (src, unsized_info(fx, a, b, old_info)),
+        (ty::Adt(def_a, _), ty::Adt(def_b, _)) => {
             assert_eq!(def_a, def_b);
 
             if src_layout == dst_layout {

--- a/compiler/rustc_codegen_gcc/src/int.rs
+++ b/compiler/rustc_codegen_gcc/src/int.rs
@@ -265,7 +265,7 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
         use rustc_middle::ty::UintTy::*;
         use rustc_middle::ty::{Int, Uint};
 
-        let new_kind = match *typ.kind() {
+        let new_kind = match typ.kind() {
             Int(t @ Isize) => Int(t.normalize(self.tcx.sess.target.pointer_width)),
             Uint(t @ Usize) => Uint(t.normalize(self.tcx.sess.target.pointer_width)),
             t @ (Uint(_) | Int(_)) => t,

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -106,7 +106,7 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
         let tcx = self.tcx;
         let callee_ty = instance.ty(tcx, ty::ParamEnv::reveal_all());
 
-        let (def_id, fn_args) = match *callee_ty.kind() {
+        let (def_id, fn_args) = match callee_ty.kind() {
             ty::FnDef(def_id, fn_args) => (def_id, fn_args),
             _ => bug!("expected fn item type, found {}", callee_ty),
         };
@@ -599,7 +599,7 @@ fn int_type_width_signed<'gcc, 'tcx>(
     ty: Ty<'tcx>,
     cx: &CodegenCx<'gcc, 'tcx>,
 ) -> Option<(u64, bool)> {
-    match *ty.kind() {
+    match ty.kind() {
         ty::Int(t) => Some((
             match t {
                 rustc_middle::ty::IntTy::Isize => u64::from(cx.tcx.sess.target.pointer_width),

--- a/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
@@ -71,11 +71,11 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
         let expected_bytes = len / 8 + ((len % 8 > 0) as u64);
 
         let mask_ty = arg_tys[0];
-        let mut mask = match *mask_ty.kind() {
+        let mut mask = match mask_ty.kind() {
             ty::Int(i) if i.bit_width() == Some(expected_int_bits) => args[0].immediate(),
             ty::Uint(i) if i.bit_width() == Some(expected_int_bits) => args[0].immediate(),
             ty::Array(elem, len)
-                if matches!(*elem.kind(), ty::Uint(ty::UintTy::U8))
+                if matches!(elem.kind(), ty::Uint(ty::UintTy::U8))
                     && len.try_eval_target_usize(bx.tcx, ty::ParamEnv::reveal_all())
                         == Some(expected_bytes) =>
             {
@@ -355,8 +355,8 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
     if name == sym::simd_shuffle {
         // Make sure this is actually an array, since typeck only checks the length-suffixed
         // version of this intrinsic.
-        let n: u64 = match *args[2].layout.ty.kind() {
-            ty::Array(ty, len) if matches!(*ty.kind(), ty::Uint(ty::UintTy::U32)) => {
+        let n: u64 = match args[2].layout.ty.kind() {
+            ty::Array(ty, len) if matches!(ty.kind(), ty::Uint(ty::UintTy::U32)) => {
                 len.try_eval_target_usize(bx.cx.tcx, ty::ParamEnv::reveal_all()).unwrap_or_else(
                     || span_bug!(span, "could not evaluate shuffle index array length"),
                 )
@@ -429,7 +429,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
             m_len == v_len,
             InvalidMonomorphization::MismatchedLengths { span, name, m_len, v_len }
         );
-        match *m_elem_ty.kind() {
+        match m_elem_ty.kind() {
             ty::Int(_) => {}
             _ => return_error!(InvalidMonomorphization::MaskType { span, name, ty: m_elem_ty }),
         }
@@ -452,7 +452,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
             }
         );
 
-        match *in_elem.kind() {
+        match in_elem.kind() {
             ty::RawPtr(p_ty, _) => {
                 let metadata = p_ty.ptr_metadata_ty(bx.tcx, |ty| {
                     bx.tcx.normalize_erasing_regions(ty::ParamEnv::reveal_all(), ty)
@@ -466,7 +466,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
                 return_error!(InvalidMonomorphization::ExpectedPointer { span, name, ty: in_elem })
             }
         }
-        match *out_elem.kind() {
+        match out_elem.kind() {
             ty::RawPtr(p_ty, _) => {
                 let metadata = p_ty.ptr_metadata_ty(bx.tcx, |ty| {
                     bx.tcx.normalize_erasing_regions(ty::ParamEnv::reveal_all(), ty)
@@ -509,13 +509,13 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
             }
         );
 
-        match *in_elem.kind() {
+        match in_elem.kind() {
             ty::RawPtr(_, _) => {}
             _ => {
                 return_error!(InvalidMonomorphization::ExpectedPointer { span, name, ty: in_elem })
             }
         }
-        match *out_elem.kind() {
+        match out_elem.kind() {
             ty::Uint(ty::UintTy::Usize) => {}
             _ => return_error!(InvalidMonomorphization::ExpectedUsize { span, name, ty: out_elem }),
         }
@@ -548,11 +548,11 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
             }
         );
 
-        match *in_elem.kind() {
+        match in_elem.kind() {
             ty::Uint(ty::UintTy::Usize) => {}
             _ => return_error!(InvalidMonomorphization::ExpectedUsize { span, name, ty: in_elem }),
         }
-        match *out_elem.kind() {
+        match out_elem.kind() {
             ty::RawPtr(_, _) => {}
             _ => {
                 return_error!(InvalidMonomorphization::ExpectedPointer { span, name, ty: out_elem })
@@ -597,13 +597,13 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
             Unsupported,
         }
 
-        let in_style = match *in_elem.kind() {
+        let in_style = match in_elem.kind() {
             ty::Int(_) | ty::Uint(_) => Style::Int,
             ty::Float(_) => Style::Float,
             _ => Style::Unsupported,
         };
 
-        let out_style = match *out_elem.kind() {
+        let out_style = match out_elem.kind() {
             ty::Int(_) | ty::Uint(_) => Style::Int,
             ty::Float(_) => Style::Float,
             _ => Style::Unsupported,
@@ -630,7 +630,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
     macro_rules! arith_binary {
         ($($name: ident: $($($p: ident),* => $call: ident),*;)*) => {
             $(if name == sym::$name {
-                match *in_elem.kind() {
+                match in_elem.kind() {
                     $($(ty::$p(_))|* => {
                         return Ok(bx.$call(args[0].immediate(), args[1].immediate()))
                     })*
@@ -678,13 +678,13 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
                     << bx.context.new_rvalue_from_int(result_type, i as i32));
         }
 
-        match *ret_ty.kind() {
+        match ret_ty.kind() {
             ty::Uint(i) if i.bit_width() == Some(expected_int_bits) => {
                 // Zero-extend iN to the bitmask type:
                 return Ok(result);
             }
             ty::Array(elem, len)
-                if matches!(*elem.kind(), ty::Uint(ty::UintTy::U8))
+                if matches!(elem.kind(), ty::Uint(ty::UintTy::U8))
                     && len.try_eval_target_usize(bx.tcx, ty::ParamEnv::reveal_all())
                         == Some(expected_bytes) =>
             {
@@ -723,8 +723,8 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
                 return Err(());
             }};
         }
-        let (elem_ty_str, elem_ty) = if let ty::Float(ref f) = *in_elem.kind() {
-            let elem_ty = bx.cx.type_float_from_ty(*f);
+        let (elem_ty_str, elem_ty) = if let ty::Float(f) = in_elem.kind() {
+            let elem_ty = bx.cx.type_float_from_ty(f);
             match f.bit_width() {
                 32 => ("f", elem_ty),
                 64 => ("", elem_ty),
@@ -732,7 +732,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
                     return_error!(InvalidMonomorphization::FloatingPointVector {
                         span,
                         name,
-                        f_ty: *f,
+                        f_ty: f,
                         in_ty
                     });
                 }
@@ -819,7 +819,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
         vec_len: u64,
     ) -> Type<'gcc> {
         // FIXME: use cx.layout_of(ty).llvm_type() ?
-        let elem_ty = match *elem_ty.kind() {
+        let elem_ty = match elem_ty.kind() {
             ty::Int(v) => cx.type_int_from_ty(v),
             ty::Uint(v) => cx.type_uint_from_ty(v),
             ty::Float(v) => cx.type_float_from_ty(v),
@@ -930,7 +930,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
 
         // This counts how many pointers
         fn ptr_count(t: Ty<'_>) -> usize {
-            match *t.kind() {
+            match t.kind() {
                 ty::RawPtr(p_ty, _) => 1 + ptr_count(p_ty),
                 _ => 0,
             }
@@ -938,7 +938,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
 
         // Non-ptr type
         fn non_ptr(t: Ty<'_>) -> Ty<'_> {
-            match *t.kind() {
+            match t.kind() {
                 ty::RawPtr(p_ty, _) => non_ptr(p_ty),
                 _ => t,
             }
@@ -948,7 +948,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
         // to the element type of the first argument
         let (_, element_ty0) = arg_tys[0].simd_size_and_type(bx.tcx());
         let (_, element_ty1) = arg_tys[1].simd_size_and_type(bx.tcx());
-        let (pointer_count, underlying_ty) = match *element_ty1.kind() {
+        let (pointer_count, underlying_ty) = match element_ty1.kind() {
             ty::RawPtr(p_ty, _) if p_ty == in_elem => {
                 (ptr_count(element_ty1), non_ptr(element_ty1))
             }
@@ -974,7 +974,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
 
         // The element type of the third argument must be a signed integer type of any width:
         let (_, element_ty2) = arg_tys[2].simd_size_and_type(bx.tcx());
-        match *element_ty2.kind() {
+        match element_ty2.kind() {
             ty::Int(_) => (),
             _ => {
                 require!(
@@ -1046,7 +1046,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
 
         // This counts how many pointers
         fn ptr_count(t: Ty<'_>) -> usize {
-            match *t.kind() {
+            match t.kind() {
                 ty::RawPtr(p_ty, _) => 1 + ptr_count(p_ty),
                 _ => 0,
             }
@@ -1054,7 +1054,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
 
         // Non-ptr type
         fn non_ptr(t: Ty<'_>) -> Ty<'_> {
-            match *t.kind() {
+            match t.kind() {
                 ty::RawPtr(p_ty, _) => non_ptr(p_ty),
                 _ => t,
             }
@@ -1065,7 +1065,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
         let (_, element_ty0) = arg_tys[0].simd_size_and_type(bx.tcx());
         let (_, element_ty1) = arg_tys[1].simd_size_and_type(bx.tcx());
         let (_, element_ty2) = arg_tys[2].simd_size_and_type(bx.tcx());
-        let (pointer_count, underlying_ty) = match *element_ty1.kind() {
+        let (pointer_count, underlying_ty) = match element_ty1.kind() {
             ty::RawPtr(p_ty, mutbl) if p_ty == in_elem && mutbl == hir::Mutability::Mut => {
                 (ptr_count(element_ty1), non_ptr(element_ty1))
             }
@@ -1090,7 +1090,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
         assert_eq!(underlying_ty, non_ptr(element_ty0));
 
         // The element type of the third argument must be a signed integer type of any width:
-        match *element_ty2.kind() {
+        match element_ty2.kind() {
             ty::Int(_) => (),
             _ => {
                 require!(
@@ -1148,7 +1148,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
     macro_rules! arith_unary {
         ($($name: ident: $($($p: ident),* => $call: ident),*;)*) => {
             $(if name == sym::$name {
-                match *in_elem.kind() {
+                match in_elem.kind() {
                     $($(ty::$p(_))|* => {
                         return Ok(bx.$call(args[0].immediate()))
                     })*
@@ -1169,7 +1169,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
         let rhs = args[1].immediate();
         let is_add = name == sym::simd_saturating_add;
         let ptr_bits = bx.tcx().data_layout.pointer_size.bits() as _;
-        let (signed, elem_width, elem_ty) = match *in_elem.kind() {
+        let (signed, elem_width, elem_ty) = match in_elem.kind() {
             ty::Int(i) => (true, i.bit_width().unwrap_or(ptr_bits) / 8, bx.cx.type_int_from_ty(i)),
             ty::Uint(i) => {
                 (false, i.bit_width().unwrap_or(ptr_bits) / 8, bx.cx.type_uint_from_ty(i))
@@ -1272,7 +1272,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
                     ret_ty == in_elem,
                     InvalidMonomorphization::ReturnType { span, name, in_elem, in_ty, ret_ty }
                 );
-                return match *in_elem.kind() {
+                return match in_elem.kind() {
                     ty::Int(_) | ty::Uint(_) => {
                         let r = bx.vector_reduce_op(args[0].immediate(), $vec_op);
                         if $ordered {
@@ -1341,7 +1341,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
                     ret_ty == in_elem,
                     InvalidMonomorphization::ReturnType { span, name, in_elem, in_ty, ret_ty }
                 );
-                return match *in_elem.kind() {
+                return match in_elem.kind() {
                     ty::Int(_) | ty::Uint(_) => Ok(bx.$int_red(args[0].immediate())),
                     ty::Float(_) => Ok(bx.$float_red(args[0].immediate())),
                     _ => return_error!(InvalidMonomorphization::UnsupportedSymbol {
@@ -1370,7 +1370,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
                     );
                     args[0].immediate()
                 } else {
-                    match *in_elem.kind() {
+                    match in_elem.kind() {
                         ty::Int(_) | ty::Uint(_) => {}
                         _ => return_error!(InvalidMonomorphization::UnsupportedSymbol {
                             span,
@@ -1384,7 +1384,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
 
                     args[0].immediate()
                 };
-                return match *in_elem.kind() {
+                return match in_elem.kind() {
                     ty::Int(_) | ty::Uint(_) => {
                         let r = bx.vector_reduce_op(input, $op);
                         Ok(if !$boolean {

--- a/compiler/rustc_codegen_gcc/src/type_of.rs
+++ b/compiler/rustc_codegen_gcc/src/type_of.rs
@@ -84,7 +84,7 @@ fn uncached_gcc_type<'gcc, 'tcx>(
         Abi::Uninhabited | Abi::Aggregate { .. } => {}
     }
 
-    let name = match *layout.ty.kind() {
+    let name = match layout.ty.kind() {
         // FIXME(eddyb) producing readable type names for trait objects can result
         // in problematically distinct types due to HRTB and subtyping (see #47638).
         // ty::Dynamic(..) |
@@ -97,14 +97,14 @@ fn uncached_gcc_type<'gcc, 'tcx>(
             if !cx.sess().fewer_names() =>
         {
             let mut name = with_no_trimmed_paths!(layout.ty.to_string());
-            if let (&ty::Adt(def, _), &Variants::Single { index }) =
+            if let (ty::Adt(def, _), &Variants::Single { index }) =
                 (layout.ty.kind(), &layout.variants)
             {
                 if def.is_enum() && !def.variants().is_empty() {
                     write!(&mut name, "::{}", def.variant(index).name).unwrap();
                 }
             }
-            if let (&ty::Coroutine(_, _), &Variants::Single { index }) =
+            if let (ty::Coroutine(_, _), &Variants::Single { index }) =
                 (layout.ty.kind(), &layout.variants)
             {
                 write!(&mut name, "::{}", ty::CoroutineArgs::variant_name(index)).unwrap();
@@ -209,7 +209,7 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
             if let Some(&ty) = cx.scalar_types.borrow().get(&self.ty) {
                 return ty;
             }
-            let ty = match *self.ty.kind() {
+            let ty = match self.ty.kind() {
                 // NOTE: we cannot remove this match like in the LLVM codegen because the call
                 // to fn_ptr_backend_type handle the on-stack attribute.
                 // TODO(antoyo): find a less hackish way to hande the on-stack attribute.

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -399,7 +399,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         let new_kind = match ty.kind() {
             Int(t @ Isize) => Int(t.normalize(self.tcx.sess.target.pointer_width)),
             Uint(t @ Usize) => Uint(t.normalize(self.tcx.sess.target.pointer_width)),
-            t @ (Uint(_) | Int(_)) => *t,
+            t @ (Uint(_) | Int(_)) => t,
             _ => panic!("tried to get overflow intrinsic for op applied to non-int type"),
         };
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -119,7 +119,7 @@ fn build_fixed_size_array_di_node<'ll, 'tcx>(
         bug!("build_fixed_size_array_di_node() called with non-ty::Array type `{:?}`", array_type)
     };
 
-    let element_type_di_node = type_di_node(cx, *element_type);
+    let element_type_di_node = type_di_node(cx, element_type);
 
     return_if_di_node_created_in_meantime!(cx, unique_type_id);
 
@@ -406,7 +406,7 @@ fn build_slice_type_di_node<'ll, 'tcx>(
     unique_type_id: UniqueTypeId<'tcx>,
 ) -> DINodeCreationResult<'ll> {
     let element_type = match slice_type.kind() {
-        ty::Slice(element_type) => *element_type,
+        ty::Slice(element_type) => element_type,
         ty::Str => cx.tcx.types.u8,
         _ => {
             bug!(
@@ -435,7 +435,7 @@ pub fn type_di_node<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>) -> &'ll D
 
     debug!("type_di_node: {:?} kind: {:?}", t, t.kind());
 
-    let DINodeCreationResult { di_node, already_stored_in_typemap } = match *t.kind() {
+    let DINodeCreationResult { di_node, already_stored_in_typemap } = match t.kind() {
         ty::Never | ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) => {
             build_basic_type_di_node(cx, t)
         }
@@ -816,7 +816,7 @@ fn build_foreign_type_di_node<'ll, 'tcx>(
 ) -> DINodeCreationResult<'ll> {
     debug!("build_foreign_type_di_node: {:?}", t);
 
-    let &ty::Foreign(def_id) = unique_type_id.expect_ty().kind() else {
+    let ty::Foreign(def_id) = unique_type_id.expect_ty().kind() else {
         bug!(
             "build_foreign_type_di_node() called with unexpected type: {:?}",
             unique_type_id.expect_ty()
@@ -1109,7 +1109,7 @@ fn build_upvar_field_di_nodes<'ll, 'tcx>(
     closure_or_coroutine_ty: Ty<'tcx>,
     closure_or_coroutine_di_node: &'ll DIType,
 ) -> SmallVec<&'ll DIType> {
-    let (&def_id, up_var_tys) = match closure_or_coroutine_ty.kind() {
+    let (def_id, up_var_tys) = match closure_or_coroutine_ty.kind() {
         ty::Coroutine(def_id, args) => (def_id, args.as_coroutine().prefix_tys()),
         ty::Closure(def_id, args) => (def_id, args.as_closure().upvar_tys()),
         ty::CoroutineClosure(def_id, args) => (def_id, args.as_coroutine_closure().upvar_tys()),
@@ -1152,7 +1152,7 @@ fn build_tuple_type_di_node<'ll, 'tcx>(
     unique_type_id: UniqueTypeId<'tcx>,
 ) -> DINodeCreationResult<'ll> {
     let tuple_type = unique_type_id.expect_ty();
-    let &ty::Tuple(component_types) = tuple_type.kind() else {
+    let ty::Tuple(component_types) = tuple_type.kind() else {
         bug!("build_tuple_type_di_node() called with non-tuple-type: {:?}", tuple_type)
     };
 
@@ -1198,8 +1198,7 @@ fn build_closure_env_di_node<'ll, 'tcx>(
     unique_type_id: UniqueTypeId<'tcx>,
 ) -> DINodeCreationResult<'ll> {
     let closure_env_type = unique_type_id.expect_ty();
-    let &(ty::Closure(def_id, _) | ty::CoroutineClosure(def_id, _)) = closure_env_type.kind()
-    else {
+    let (ty::Closure(def_id, _) | ty::CoroutineClosure(def_id, _)) = closure_env_type.kind() else {
         bug!("build_closure_env_di_node() called with non-closure-type: {:?}", closure_env_type)
     };
     let containing_scope = get_namespace_for_item(cx, def_id);
@@ -1277,7 +1276,7 @@ fn build_generic_type_param_di_nodes<'ll, 'tcx>(
     cx: &CodegenCx<'ll, 'tcx>,
     ty: Ty<'tcx>,
 ) -> SmallVec<&'ll DIType> {
-    if let ty::Adt(def, args) = *ty.kind() {
+    if let ty::Adt(def, args) = ty.kind() {
         if args.types().next().is_some() {
             let generics = cx.tcx.generics_of(def.did());
             let names = get_parameter_names(cx, generics);

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/cpp_like.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/cpp_like.rs
@@ -183,7 +183,7 @@ pub(super) fn build_enum_type_di_node<'ll, 'tcx>(
     unique_type_id: UniqueTypeId<'tcx>,
 ) -> DINodeCreationResult<'ll> {
     let enum_type = unique_type_id.expect_ty();
-    let &ty::Adt(enum_adt_def, _) = enum_type.kind() else {
+    let ty::Adt(enum_adt_def, _) = enum_type.kind() else {
         bug!("build_enum_type_di_node() called with non-enum type: `{:?}`", enum_type)
     };
 
@@ -665,7 +665,7 @@ fn build_union_fields_for_direct_tag_coroutine<'ll, 'tcx>(
     };
 
     let (coroutine_def_id, coroutine_args) = match coroutine_type_and_layout.ty.kind() {
-        &ty::Coroutine(def_id, args) => (def_id, args.as_coroutine()),
+        ty::Coroutine(def_id, args) => (def_id, args.as_coroutine()),
         _ => unreachable!(),
     };
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/mod.rs
@@ -33,7 +33,7 @@ pub(super) fn build_enum_type_di_node<'ll, 'tcx>(
     unique_type_id: UniqueTypeId<'tcx>,
 ) -> DINodeCreationResult<'ll> {
     let enum_type = unique_type_id.expect_ty();
-    let &ty::Adt(enum_adt_def, _) = enum_type.kind() else {
+    let ty::Adt(enum_adt_def, _) = enum_type.kind() else {
         bug!("build_enum_type_di_node() called with non-enum type: `{:?}`", enum_type)
     };
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/native.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/native.rs
@@ -44,7 +44,7 @@ pub(super) fn build_enum_type_di_node<'ll, 'tcx>(
     unique_type_id: UniqueTypeId<'tcx>,
 ) -> DINodeCreationResult<'ll> {
     let enum_type = unique_type_id.expect_ty();
-    let &ty::Adt(enum_adt_def, _) = enum_type.kind() else {
+    let ty::Adt(enum_adt_def, _) = enum_type.kind() else {
         bug!("build_enum_type_di_node() called with non-enum type: `{:?}`", enum_type)
     };
 
@@ -124,7 +124,7 @@ pub(super) fn build_coroutine_di_node<'ll, 'tcx>(
     unique_type_id: UniqueTypeId<'tcx>,
 ) -> DINodeCreationResult<'ll> {
     let coroutine_type = unique_type_id.expect_ty();
-    let &ty::Coroutine(coroutine_def_id, coroutine_args) = coroutine_type.kind() else {
+    let ty::Coroutine(coroutine_def_id, coroutine_args) = coroutine_type.kind() else {
         bug!("build_coroutine_di_node() called with non-coroutine type: `{:?}`", coroutine_type)
     };
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -450,9 +450,9 @@ impl<'ll, 'tcx> DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                     let t = arg.layout.ty;
                     let t = match t.kind() {
                         ty::Array(ct, _)
-                            if (*ct == cx.tcx.types.u8) || cx.layout_of(*ct).is_zst() =>
+                            if (ct == cx.tcx.types.u8) || cx.layout_of(ct).is_zst() =>
                         {
-                            Ty::new_imm_ptr(cx.tcx, *ct)
+                            Ty::new_imm_ptr(cx.tcx, ct)
                         }
                         _ => t,
                     };

--- a/compiler/rustc_codegen_llvm/src/debuginfo/utils.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/utils.rs
@@ -75,7 +75,7 @@ pub(crate) fn fat_pointer_kind<'ll, 'tcx>(
         return None;
     }
 
-    match *pointee_tail_ty.kind() {
+    match pointee_tail_ty.kind() {
         ty::Str | ty::Slice(_) => Some(FatPtrKind::Slice),
         ty::Dynamic(..) => Some(FatPtrKind::Dyn),
         ty::Foreign(_) => {

--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -34,14 +34,14 @@ fn uncached_llvm_type<'a, 'tcx>(
             if !cx.sess().fewer_names() =>
         {
             let mut name = with_no_visible_paths!(with_no_trimmed_paths!(layout.ty.to_string()));
-            if let (&ty::Adt(def, _), &Variants::Single { index }) =
+            if let (ty::Adt(def, _), &Variants::Single { index }) =
                 (layout.ty.kind(), &layout.variants)
             {
                 if def.is_enum() && !def.variants().is_empty() {
                     write!(&mut name, "::{}", def.variant(index).name).unwrap();
                 }
             }
-            if let (&ty::Coroutine(_, _), &Variants::Single { index }) =
+            if let (ty::Coroutine(_, _), &Variants::Single { index }) =
                 (layout.ty.kind(), &layout.variants)
             {
                 write!(&mut name, "::{}", ty::CoroutineArgs::variant_name(index)).unwrap();

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -145,10 +145,10 @@ pub fn unsized_info<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     let (source, target) =
         cx.tcx().struct_lockstep_tails_for_codegen(source, target, bx.param_env());
     match (source.kind(), target.kind()) {
-        (&ty::Array(_, len), &ty::Slice(_)) => {
+        (ty::Array(_, len), ty::Slice(_)) => {
             cx.const_usize(len.eval_target_usize(cx.tcx(), ty::ParamEnv::reveal_all()))
         }
-        (&ty::Dynamic(data_a, _, src_dyn_kind), &ty::Dynamic(data_b, _, target_dyn_kind))
+        (ty::Dynamic(data_a, _, src_dyn_kind), ty::Dynamic(data_b, _, target_dyn_kind))
             if src_dyn_kind == target_dyn_kind =>
         {
             let old_info =
@@ -191,12 +191,12 @@ pub fn unsize_ptr<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 ) -> (Bx::Value, Bx::Value) {
     debug!("unsize_ptr: {:?} => {:?}", src_ty, dst_ty);
     match (src_ty.kind(), dst_ty.kind()) {
-        (&ty::Ref(_, a, _), &ty::Ref(_, b, _) | &ty::RawPtr(b, _))
-        | (&ty::RawPtr(a, _), &ty::RawPtr(b, _)) => {
+        (ty::Ref(_, a, _), ty::Ref(_, b, _) | ty::RawPtr(b, _))
+        | (ty::RawPtr(a, _), ty::RawPtr(b, _)) => {
             assert_eq!(bx.cx().type_is_sized(a), old_info.is_none());
             (src, unsized_info(bx, a, b, old_info))
         }
-        (&ty::Adt(def_a, _), &ty::Adt(def_b, _)) => {
+        (ty::Adt(def_a, _), ty::Adt(def_b, _)) => {
             assert_eq!(def_a, def_b); // implies same number of fields
             let src_layout = bx.cx().layout_of(src_ty);
             let dst_layout = bx.cx().layout_of(dst_ty);
@@ -258,7 +258,7 @@ pub fn coerce_unsized_into<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     let src_ty = src.layout.ty;
     let dst_ty = dst.layout.ty;
     match (src_ty.kind(), dst_ty.kind()) {
-        (&ty::Ref(..), &ty::Ref(..) | &ty::RawPtr(..)) | (&ty::RawPtr(..), &ty::RawPtr(..)) => {
+        (ty::Ref(..), ty::Ref(..) | ty::RawPtr(..)) | (ty::RawPtr(..), ty::RawPtr(..)) => {
             let (base, info) = match bx.load_operand(src).val {
                 OperandValue::Pair(base, info) => unsize_ptr(bx, base, src_ty, dst_ty, Some(info)),
                 OperandValue::Immediate(base) => unsize_ptr(bx, base, src_ty, dst_ty, None),
@@ -267,7 +267,7 @@ pub fn coerce_unsized_into<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             OperandValue::Pair(base, info).store(bx, dst);
         }
 
-        (&ty::Adt(def_a, _), &ty::Adt(def_b, _)) => {
+        (ty::Adt(def_a, _), ty::Adt(def_b, _)) => {
             assert_eq!(def_a, def_b); // implies same number of fields
 
             for i in def_a.variant(FIRST_VARIANT).fields.indices() {

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -59,7 +59,7 @@ fn push_debuginfo_type_name<'tcx>(
     // .natvis visualizers (and perhaps other existing native debuggers?)
     let cpp_like_debuginfo = cpp_like_debuginfo(tcx);
 
-    match *t.kind() {
+    match t.kind() {
         ty::Bool => output.push_str("bool"),
         ty::Char => output.push_str("char"),
         ty::Str => {
@@ -700,7 +700,7 @@ fn push_const_param<'tcx>(tcx: TyCtxt<'tcx>, ct: ty::Const<'tcx>, output: &mut S
                     // FIXME: directly extract the bits from a valtree instead of evaluating an
                     // alreay evaluated `Const` in order to get the bits.
                     let bits = ct.eval_bits(tcx, ty::ParamEnv::reveal_all());
-                    let val = Integer::from_int_ty(&tcx, *ity).size().sign_extend(bits) as i128;
+                    let val = Integer::from_int_ty(&tcx, ity).size().sign_extend(bits) as i128;
                     write!(output, "{val}")
                 }
                 ty::Uint(_) => {

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -832,7 +832,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         // Create the callee. This is a fn ptr or zero-sized and hence a kind of scalar.
         let callee = self.codegen_operand(bx, func);
 
-        let (instance, mut llfn) = match *callee.layout.ty.kind() {
+        let (instance, mut llfn) = match callee.layout.ty.kind() {
             ty::FnDef(def_id, args) => (
                 Some(
                     ty::Instance::expect_resolve(
@@ -1197,7 +1197,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 }
                 mir::InlineAsmOperand::SymFn { ref value } => {
                     let const_ = self.monomorphize(value.const_);
-                    if let ty::FnDef(def_id, args) = *const_.ty().kind() {
+                    if let ty::FnDef(def_id, args) = const_.ty().kind() {
                         let instance = ty::Instance::resolve_for_fn_ptr(
                             bx.tcx(),
                             ty::ParamEnv::reveal_all(),

--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -61,7 +61,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     ) -> Result<(), ty::Instance<'tcx>> {
         let callee_ty = instance.ty(bx.tcx(), ty::ParamEnv::reveal_all());
 
-        let ty::FnDef(def_id, fn_args) = *callee_ty.kind() else {
+        let ty::FnDef(def_id, fn_args) = callee_ty.kind() else {
             bug!("expected fn item type, found {}", callee_ty);
         };
 

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -465,7 +465,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         OperandValue::Immediate(lladdr)
                     }
                     mir::CastKind::PointerCoercion(PointerCoercion::ReifyFnPointer) => {
-                        match *operand.layout.ty.kind() {
+                        match operand.layout.ty.kind() {
                             ty::FnDef(def_id, args) => {
                                 let instance = ty::Instance::resolve_for_fn_ptr(
                                     bx.tcx(),
@@ -481,7 +481,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         }
                     }
                     mir::CastKind::PointerCoercion(PointerCoercion::ClosureFnPointer(_)) => {
-                        match *operand.layout.ty.kind() {
+                        match operand.layout.ty.kind() {
                             ty::Closure(def_id, args) => {
                                 let instance = Instance::resolve_closure(
                                     bx.cx().tcx(),

--- a/compiler/rustc_codegen_ssa/src/mono_item.rs
+++ b/compiler/rustc_codegen_ssa/src/mono_item.rs
@@ -76,7 +76,7 @@ impl<'a, 'tcx: 'a> MonoItemExt<'a, 'tcx> for MonoItem<'tcx> {
                                     .typeck_body(anon_const.body)
                                     .node_type(anon_const.hir_id);
                                 let instance = match ty.kind() {
-                                    &ty::FnDef(def_id, args) => Instance::new(def_id, args),
+                                    ty::FnDef(def_id, args) => Instance::new(def_id, args),
                                     _ => span_bug!(*op_sp, "asm sym is not a function"),
                                 };
 

--- a/compiler/rustc_const_eval/src/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/check_consts/check.rs
@@ -723,7 +723,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
 
                 let fn_ty = func.ty(body, tcx);
 
-                let (mut callee, mut fn_args) = match *fn_ty.kind() {
+                let (mut callee, mut fn_args) = match fn_ty.kind() {
                     ty::FnDef(def_id, fn_args) => (def_id, fn_args),
 
                     ty::FnPtr(..) => {

--- a/compiler/rustc_const_eval/src/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/check_consts/ops.rs
@@ -188,8 +188,8 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
             CallKind::FnCall { fn_trait_id, self_ty } => {
                 let note = match self_ty.kind() {
                     FnDef(def_id, ..) => {
-                        let span = tcx.def_span(*def_id);
-                        if ccx.tcx.is_const_fn_raw(*def_id) {
+                        let span = tcx.def_span(def_id);
+                        if ccx.tcx.is_const_fn_raw(def_id) {
                             span_bug!(span, "calling const FnDef errored when it shouldn't");
                         }
 
@@ -230,7 +230,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
                                 let mut tmp_ty = self_ty;
                                 while let rustc_middle::ty::Ref(_, inner_ty, _) = tmp_ty.kind() {
                                     num_refs += 1;
-                                    tmp_ty = *inner_ty;
+                                    tmp_ty = inner_ty;
                                 }
                                 let deref = "*".repeat(num_refs);
 

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -715,7 +715,7 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
         // If it's a frozen shared reference that's not already immutable, make it immutable.
         // (Do nothing on `None` provenance, that cannot store immutability anyway.)
         if let ty::Ref(_, ty, mutbl) = val.layout.ty.kind()
-            && *mutbl == Mutability::Not
+            && mutbl == Mutability::Not
             && val.to_scalar_and_meta().0.to_pointer(ecx)?.provenance.is_some_and(|p| !p.immutable())
             // That next check is expensive, that's why we have all the guards above.
             && ty.is_freeze(*ecx.tcx, ecx.param_env)

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -104,7 +104,7 @@ fn const_to_valtree_inner<'tcx>(
             // The valtree of the base type is the same as the valtree of the pattern type.
             // Since the returned valtree does not contain the type or layout, we can just
             // switch to the base type.
-            place.layout = ecx.layout_of(*base).unwrap();
+            place.layout = ecx.layout_of(base).unwrap();
             ensure_sufficient_stack(|| const_to_valtree_inner(ecx, &place, num_nodes))
         },
 
@@ -284,7 +284,7 @@ pub fn valtree_to_const_value<'tcx>(
 
     let (param_env, ty) = param_env_ty.into_parts();
 
-    match *ty.kind() {
+    match ty.kind() {
         ty::FnDef(..) => {
             assert!(valtree.unwrap_branch().is_empty());
             mir::ConstValue::ZeroSized
@@ -397,7 +397,7 @@ fn valtree_into_mplace<'tcx>(
             ecx.write_immediate(Immediate::Scalar(scalar_int.into()), place).unwrap();
         }
         ty::Ref(_, inner_ty, _) => {
-            let imm = valtree_to_ref(ecx, valtree, *inner_ty);
+            let imm = valtree_to_ref(ecx, valtree, inner_ty);
             debug!(?imm);
             ecx.write_immediate(imm, place).unwrap();
         }

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -77,7 +77,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
 
                 // The src operand does not matter, just its type
-                match *src.layout.ty.kind() {
+                match src.layout.ty.kind() {
                     ty::FnDef(def_id, args) => {
                         let instance = ty::Instance::resolve_for_fn_ptr(
                             *self.tcx,
@@ -110,7 +110,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
 
                 // The src operand does not matter, just its type
-                match *src.layout.ty.kind() {
+                match src.layout.ty.kind() {
                     ty::Closure(def_id, args) => {
                         let instance = ty::Instance::resolve_closure(
                             *self.tcx,
@@ -279,10 +279,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             _ => span_bug!(self.cur_span(), "invalid int-like cast from {}", src_layout.ty),
         };
 
-        Ok(match *cast_ty.kind() {
+        Ok(match cast_ty.kind() {
             // int -> int
             Int(_) | Uint(_) => {
-                let size = match *cast_ty.kind() {
+                let size = match cast_ty.kind() {
                     Int(t) => Integer::from_int_ty(self, t).size(),
                     Uint(t) => Integer::from_uint_ty(self, t).size(),
                     _ => bug!(),
@@ -342,7 +342,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             if f2.is_nan() { M::generate_nan(ecx, &[f1]) } else { f2 }
         }
 
-        match *dest_ty.kind() {
+        match dest_ty.kind() {
             // float -> uint
             Uint(t) => {
                 let size = Integer::from_uint_ty(self, t).size();
@@ -480,7 +480,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         trace!("Unsizing {:?} of type {} into {}", *src, src.layout.ty, cast_ty.ty);
         match (&src.layout.ty.kind(), &cast_ty.ty.kind()) {
             (&ty::Ref(_, s, _), &ty::Ref(_, c, _) | &ty::RawPtr(c, _))
-            | (&ty::RawPtr(s, _), &ty::RawPtr(c, _)) => self.unsize_into_ptr(src, dest, *s, *c),
+            | (&ty::RawPtr(s, _), &ty::RawPtr(c, _)) => self.unsize_into_ptr(src, dest, s, c),
             (&ty::Adt(def_a, _), &ty::Adt(def_b, _)) => {
                 assert_eq!(def_a, def_b); // implies same number of fields
 

--- a/compiler/rustc_const_eval/src/interpret/discriminant.rs
+++ b/compiler/rustc_const_eval/src/interpret/discriminant.rs
@@ -130,7 +130,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 let discr_val = self.int_to_int_or_float(&tag_val, discr_layout).unwrap();
                 let discr_bits = discr_val.to_scalar().to_bits(discr_layout.size)?;
                 // Convert discriminant to variant index, and catch invalid discriminants.
-                let index = match *ty.kind() {
+                let index = match ty.kind() {
                     ty::Adt(adt, _) => {
                         adt.discriminants(*self.tcx).find(|(_, var)| var.val == discr_bits)
                     }

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -64,7 +64,7 @@ pub(crate) fn eval_nullary_intrinsic<'tcx>(
             ty::Alias(..) | ty::Param(_) | ty::Placeholder(_) | ty::Infer(_) => {
                 throw_inval!(TooGeneric)
             }
-            ty::Pat(_, pat) => match **pat {
+            ty::Pat(_, pat) => match *pat {
                 ty::PatternKind::Range { .. } => ConstValue::from_target_usize(0u64, &tcx),
                 // Future pattern kinds may have more variants
             },

--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -324,7 +324,7 @@ where
             // It is not nice to match on the type, but that seems to be the only way to
             // implement this.
             ty::Array(inner, _) => {
-                (MemPlaceMeta::None, Ty::new_array(self.tcx.tcx, *inner, inner_len))
+                (MemPlaceMeta::None, Ty::new_array(self.tcx.tcx, inner, inner_len))
             }
             ty::Slice(..) => {
                 let len = Scalar::from_target_usize(inner_len, self);

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -500,7 +500,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
                 ty::Tuple(tys) => tys.last().is_none_or(|ty| is_very_trivially_sized(*ty)),
 
-                ty::Pat(ty, ..) => is_very_trivially_sized(*ty),
+                ty::Pat(ty, ..) => is_very_trivially_sized(ty),
 
                 // We don't want to do any queries, so there is not much we can do with ADTs.
                 ty::Adt(..) => false,

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -423,7 +423,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let extra_args =
             self.tcx.mk_type_list_from_iter(extra_args.iter().map(|arg| arg.layout().ty));
 
-        let (callee, fn_abi, with_caller_location) = match *func.layout.ty.kind() {
+        let (callee, fn_abi, with_caller_location) = match func.layout.ty.kind() {
             ty::FnPtr(..) => {
                 let fn_ptr = self.read_pointer(&func)?;
                 let fn_val = self.get_ptr_fn(fn_ptr)?;

--- a/compiler/rustc_const_eval/src/interpret/util.rs
+++ b/compiler/rustc_const_eval/src/interpret/util.rs
@@ -39,7 +39,7 @@ where
                 return ControlFlow::Continue(());
             }
 
-            match *ty.kind() {
+            match ty.kind() {
                 ty::Param(_) => ControlFlow::Break(FoundParam),
                 ty::Closure(def_id, args)
                 | ty::CoroutineClosure(def_id, args, ..)

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -613,7 +613,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                 Ok(true)
             }
             ty::Ref(_, _ty, mutbl) => {
-                self.check_safe_pointer(value, PointerKind::Ref(*mutbl))?;
+                self.check_safe_pointer(value, PointerKind::Ref(mutbl))?;
                 Ok(true)
             }
             ty::FnPtr(..) => {
@@ -903,7 +903,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                 // This is the length of the array/slice.
                 let len = op.len(self.ecx)?;
                 // This is the element type size.
-                let layout = self.ecx.layout_of(*tys)?;
+                let layout = self.ecx.layout_of(tys)?;
                 // This is the size in bytes of the whole array. (This checks for overflow.)
                 let size = layout.size * len;
                 // If the size is 0, there is nothing to check.
@@ -962,7 +962,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
             // Fast path for arrays and slices of ZSTs. We only need to check a single ZST element
             // of an array and not all of them, because there's only a single value of a specific
             // ZST type, so either validation fails for all elements or none.
-            ty::Array(tys, ..) | ty::Slice(tys) if self.ecx.layout_of(*tys)?.is_zst() => {
+            ty::Array(tys, ..) | ty::Slice(tys) if self.ecx.layout_of(tys)?.is_zst() => {
                 // Validate just the first element (if any).
                 if op.len(self.ecx)? > 0 {
                     self.visit_field(op, 0, &self.ecx.project_index(op, 0)?)?;

--- a/compiler/rustc_const_eval/src/interpret/visitor.rs
+++ b/compiler/rustc_const_eval/src/interpret/visitor.rs
@@ -86,7 +86,7 @@ pub trait ValueVisitor<'tcx, M: Machine<'tcx>>: Sized {
         trace!("walk_value: type: {ty}");
 
         // Special treatment for special types, where the (static) layout is not sufficient.
-        match *ty.kind() {
+        match ty.kind() {
             // If it is a trait object, switch to the real type that was used to create it.
             ty::Dynamic(data, _, ty::Dyn) => {
                 // Dyn types. This is unsized, and the actual dynamic type of the data is given by the

--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -22,7 +22,7 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
     }
 
     fn print_type(&mut self, ty: Ty<'tcx>) -> Result<(), PrintError> {
-        match *ty.kind() {
+        match ty.kind() {
             // Types without identity.
             ty::Bool
             | ty::Char

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -162,7 +162,7 @@ fn check_union_fields(tcx: TyCtxt<'_>, span: Span, item_def_id: LocalDefId) -> b
                 }
                 ty::Array(elem, _len) => {
                     // Like `Copy`, we do *not* special-case length 0.
-                    allowed_union_field(*elem, tcx, param_env)
+                    allowed_union_field(elem, tcx, param_env)
                 }
                 _ => {
                     // Fallback case: allow `ManuallyDrop` and things that are `Copy`,
@@ -656,7 +656,7 @@ fn check_static_linkage(tcx: TyCtxt<'_>, def_id: LocalDefId) {
     if tcx.codegen_fn_attrs(def_id).import_linkage.is_some() {
         if match tcx.type_of(def_id).instantiate_identity().kind() {
             ty::RawPtr(_, _) => false,
-            ty::Adt(adt_def, args) => !is_enum_of_nonnullable_ptr(tcx, *adt_def, *args),
+            ty::Adt(adt_def, args) => !is_enum_of_nonnullable_ptr(tcx, adt_def, args),
             _ => true,
         } {
             tcx.dcx().emit_err(errors::LinkageType { span: tcx.def_span(def_id) });
@@ -1257,7 +1257,7 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
         ) -> ControlFlow<(&'static str, DefId, GenericArgsRef<'tcx>, bool)> {
             match t.kind() {
                 ty::Tuple(list) => list.iter().try_for_each(|t| check_non_exhaustive(tcx, t)),
-                ty::Array(ty, _) => check_non_exhaustive(tcx, *ty),
+                ty::Array(ty, _) => check_non_exhaustive(tcx, ty),
                 ty::Adt(def, args) => {
                     if !def.did().is_local() {
                         let non_exhaustive = def.is_variant_list_non_exhaustive()
@@ -1639,7 +1639,7 @@ fn opaque_type_cycle_error(
                 }
                 impl<'tcx> ty::visit::TypeVisitor<TyCtxt<'tcx>> for OpaqueTypeCollector {
                     fn visit_ty(&mut self, t: Ty<'tcx>) {
-                        match *t.kind() {
+                        match t.kind() {
                             ty::Alias(ty::Opaque, ty::AliasTy { def_id: def, .. }) => {
                                 self.opaques.push(def);
                             }
@@ -1676,7 +1676,7 @@ fn opaque_type_cycle_error(
                                 && let ty::Alias(
                                     ty::Opaque,
                                     ty::AliasTy { def_id: captured_def_id, .. },
-                                ) = *ty.kind()
+                                ) = ty.kind()
                                 && captured_def_id == opaque_def_id.to_def_id()
                             {
                                 err.span_label(

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -860,7 +860,7 @@ impl<'tcx> ty::FallibleTypeFolder<TyCtxt<'tcx>> for RemapHiddenTyRegions<'tcx> {
     }
 
     fn try_fold_ty(&mut self, t: Ty<'tcx>) -> Result<Ty<'tcx>, Self::Error> {
-        if let ty::Alias(ty::Opaque, ty::AliasTy { args, def_id, .. }) = *t.kind() {
+        if let ty::Alias(ty::Opaque, ty::AliasTy { args, def_id, .. }) = t.kind() {
             let mut mapped_args = Vec::with_capacity(args.len());
             for (arg, v) in std::iter::zip(args, self.tcx.variances_of(def_id)) {
                 mapped_args.push(match (arg.unpack(), v) {
@@ -2264,7 +2264,7 @@ fn try_report_async_mismatch<'tcx>(
     }
 
     let ty::Alias(ty::Projection, ty::AliasTy { def_id: async_future_def_id, .. }) =
-        *tcx.fn_sig(trait_m.def_id).skip_binder().skip_binder().output().kind()
+        tcx.fn_sig(trait_m.def_id).skip_binder().skip_binder().output().kind()
     else {
         bug!("expected `async fn` to return an RPITIT");
     };

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
@@ -76,7 +76,7 @@ pub(super) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
         let hidden_ty = hidden_tys[&trait_projection.def_id].instantiate(tcx, impl_opaque_args);
 
         // If the hidden type is not an opaque, then we have "refined" the trait signature.
-        let ty::Alias(ty::Opaque, impl_opaque) = *hidden_ty.kind() else {
+        let ty::Alias(ty::Opaque, impl_opaque) = hidden_ty.kind() else {
             report_mismatched_rpitit_signature(
                 tcx,
                 trait_m_sig_with_self_for_diag,
@@ -212,7 +212,7 @@ struct ImplTraitInTraitCollector<'tcx> {
 
 impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitCollector<'tcx> {
     fn visit_ty(&mut self, ty: Ty<'tcx>) {
-        if let ty::Alias(ty::Projection, proj) = *ty.kind()
+        if let ty::Alias(ty::Projection, proj) = ty.kind()
             && self.tcx.is_impl_trait_in_trait(proj.def_id)
         {
             if self.types.insert(proj) {
@@ -304,7 +304,7 @@ fn report_mismatched_rpitit_signature<'tcx>(
 }
 
 fn type_visibility<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<ty::Visibility<DefId>> {
-    match *ty.kind() {
+    match ty.kind() {
         ty::Ref(_, ty, _) => type_visibility(tcx, ty),
         ty::Adt(def, args) => {
             if def.is_fundamental() {

--- a/compiler/rustc_hir_analysis/src/check/intrinsicck.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsicck.rs
@@ -57,7 +57,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
             width => bug!("unsupported pointer width: {width}"),
         };
 
-        match *ty.kind() {
+        match ty.kind() {
             ty::Int(IntTy::I8) | ty::Uint(UintTy::U8) => Some(InlineAsmType::I8),
             ty::Int(IntTy::I16) | ty::Uint(UintTy::U16) => Some(InlineAsmType::I16),
             ty::Int(IntTy::I32) | ty::Uint(UintTy::U32) => Some(InlineAsmType::I32),
@@ -79,7 +79,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                         if let Some(len) =
                             len.try_eval_target_usize(self.tcx, self.tcx.param_env(adt.did()))
                         {
-                            (len, *ty)
+                            (len, ty)
                         } else {
                             return None;
                         }
@@ -136,7 +136,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
             bug!("inference variable in asm operand ty: {:?} {:?}", expr, ty);
         }
 
-        let asm_ty = match *ty.kind() {
+        let asm_ty = match ty.kind() {
             // `!` is allowed for input but not for output (issue #87802)
             ty::Never if is_input => return None,
             _ if ty.references_error() => return None,

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -460,7 +460,7 @@ fn fn_sig_suggestion<'tcx>(
     let mut output = sig.output();
 
     let asyncness = if tcx.asyncness(assoc.def_id).is_async() {
-        output = if let ty::Alias(_, alias_ty) = *output.kind() {
+        output = if let ty::Alias(_, alias_ty) = output.kind() {
             tcx.explicit_item_super_predicates(alias_ty.def_id)
                 .iter_instantiated_copied(tcx, alias_ty.args)
                 .find_map(|(bound, _)| {

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -147,13 +147,13 @@ where
         for ty in assumed_wf_types.iter() {
             match ty.kind() {
                 ty::Adt(def, _) => {
-                    if is_bevy_paramset(*def) {
+                    if is_bevy_paramset(def) {
                         break 'is_bevy true;
                     }
                 }
                 ty::Ref(_, ty, _) => match ty.kind() {
                     ty::Adt(def, _) => {
-                        if is_bevy_paramset(*def) {
+                        if is_bevy_paramset(def) {
                             break 'is_bevy true;
                         }
                     }
@@ -998,11 +998,11 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) -> Result<(), 
                             match ty.kind() {
                                 ty::Adt(adt_def, ..) => adt_def.did().is_local(),
                                 // Arrays and slices use the inner type's `ConstParamTy`.
-                                ty::Array(ty, ..) => ty_is_local(*ty),
-                                ty::Slice(ty) => ty_is_local(*ty),
+                                ty::Array(ty, ..) => ty_is_local(ty),
+                                ty::Slice(ty) => ty_is_local(ty),
                                 // `&` references use the inner type's `ConstParamTy`.
                                 // `&mut` are not supported.
-                                ty::Ref(_, ty, ast::Mutability::Not) => ty_is_local(*ty),
+                                ty::Ref(_, ty, ast::Mutability::Not) => ty_is_local(ty),
                                 // Say that a tuple is local if any of its components are local.
                                 // This is not strictly correct, but it's likely that the user can fix the local component.
                                 ty::Tuple(tys) => tys.iter().any(|ty| ty_is_local(ty)),

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -225,11 +225,9 @@ fn visit_implementation_of_dispatch_from_dyn(checker: &Checker<'_>) -> Result<()
     // even if they do not carry that attribute.
     use rustc_type_ir::TyKind::*;
     match (source.kind(), target.kind()) {
-        (&Ref(r_a, _, mutbl_a), Ref(r_b, _, mutbl_b)) if r_a == *r_b && mutbl_a == *mutbl_b => {
-            Ok(())
-        }
-        (&RawPtr(_, a_mutbl), &RawPtr(_, b_mutbl)) if a_mutbl == b_mutbl => Ok(()),
-        (&Adt(def_a, args_a), &Adt(def_b, args_b)) if def_a.is_struct() && def_b.is_struct() => {
+        (Ref(r_a, _, mutbl_a), Ref(r_b, _, mutbl_b)) if r_a == r_b && mutbl_a == mutbl_b => Ok(()),
+        (RawPtr(_, a_mutbl), RawPtr(_, b_mutbl)) if a_mutbl == b_mutbl => Ok(()),
+        (Adt(def_a, args_a), Adt(def_b, args_b)) if def_a.is_struct() && def_b.is_struct() => {
             if def_a != def_b {
                 let source_path = tcx.def_path_str(def_a.did());
                 let target_path = tcx.def_path_str(def_b.did());
@@ -373,26 +371,26 @@ pub fn coerce_unsized_info<'tcx>(
         (mt_a.ty, mt_b.ty, unsize_trait, None)
     };
     let (source, target, trait_def_id, kind) = match (source.kind(), target.kind()) {
-        (&ty::Ref(r_a, ty_a, mutbl_a), &ty::Ref(r_b, ty_b, mutbl_b)) => {
+        (ty::Ref(r_a, ty_a, mutbl_a), ty::Ref(r_b, ty_b, mutbl_b)) => {
             infcx.sub_regions(infer::RelateObjectBound(span), r_b, r_a);
             let mt_a = ty::TypeAndMut { ty: ty_a, mutbl: mutbl_a };
             let mt_b = ty::TypeAndMut { ty: ty_b, mutbl: mutbl_b };
             check_mutbl(mt_a, mt_b, &|ty| Ty::new_imm_ref(tcx, r_b, ty))
         }
 
-        (&ty::Ref(_, ty_a, mutbl_a), &ty::RawPtr(ty_b, mutbl_b)) => check_mutbl(
+        (ty::Ref(_, ty_a, mutbl_a), ty::RawPtr(ty_b, mutbl_b)) => check_mutbl(
             ty::TypeAndMut { ty: ty_a, mutbl: mutbl_a },
             ty::TypeAndMut { ty: ty_b, mutbl: mutbl_b },
             &|ty| Ty::new_imm_ptr(tcx, ty),
         ),
 
-        (&ty::RawPtr(ty_a, mutbl_a), &ty::RawPtr(ty_b, mutbl_b)) => check_mutbl(
+        (ty::RawPtr(ty_a, mutbl_a), ty::RawPtr(ty_b, mutbl_b)) => check_mutbl(
             ty::TypeAndMut { ty: ty_a, mutbl: mutbl_a },
             ty::TypeAndMut { ty: ty_b, mutbl: mutbl_b },
             &|ty| Ty::new_imm_ptr(tcx, ty),
         ),
 
-        (&ty::Adt(def_a, args_a), &ty::Adt(def_b, args_b))
+        (ty::Adt(def_a, args_a), ty::Adt(def_b, args_b))
             if def_a.is_struct() && def_b.is_struct() =>
         {
             if def_a != def_b {

--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
@@ -123,7 +123,7 @@ impl<'tcx> InherentCollect<'tcx> {
                 let span = self.tcx.def_span(impl_def_id);
                 let mut note = None;
                 if let ty::Ref(_, subty, _) = ty.kind() {
-                    note = Some(errors::InherentPrimitiveTyNote { subty: *subty });
+                    note = Some(errors::InherentPrimitiveTyNote { subty });
                 }
                 return Err(self.tcx.dcx().emit_err(errors::InherentPrimitiveTy { span, note }));
             }
@@ -148,10 +148,10 @@ impl<'tcx> InherentCollect<'tcx> {
         let mut self_ty = self.tcx.peel_off_weak_alias_tys(self_ty);
         // We allow impls on pattern types exactly when we allow impls on the base type.
         // FIXME(pattern_types): Figure out the exact coherence rules we want here.
-        while let ty::Pat(base, _) = *self_ty.kind() {
+        while let ty::Pat(base, _) = self_ty.kind() {
             self_ty = base;
         }
-        match *self_ty.kind() {
+        match self_ty.kind() {
             ty::Adt(def, _) => self.check_def_id(id, self_ty, def.did()),
             ty::Foreign(did) => self.check_def_id(id, self_ty, did),
             ty::Dynamic(data, ..) if data.principal_def_id().is_some() => {

--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -401,7 +401,7 @@ fn emit_orphan_check_error<'tcx>(
                 let is_foreign =
                     !trait_ref.def_id.is_local() && matches!(is_target_ty, IsFirstInputType::No);
 
-                match *ty.kind() {
+                match ty.kind() {
                     ty::Slice(_) => {
                         if is_foreign {
                             diag.subdiagnostic(errors::OnlyCurrentTraitsForeign { span });
@@ -519,7 +519,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for UncoveredTyParamCollector<'_, 'tcx> {
         if !ty.has_type_flags(ty::TypeFlags::HAS_TY_INFER) {
             return;
         }
-        let ty::Infer(ty::TyVar(vid)) = *ty.kind() else {
+        let ty::Infer(ty::TyVar(vid)) = ty.kind() else {
             return ty.super_visit_with(self);
         };
         let origin = self.infcx.type_var_origin(vid);
@@ -549,7 +549,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for TyVarReplacer<'cx, 'tcx> {
         if !ty.has_type_flags(ty::TypeFlags::HAS_TY_INFER) {
             return ty;
         }
-        let ty::Infer(ty::TyVar(vid)) = *ty.kind() else {
+        let ty::Infer(ty::TyVar(vid)) = ty.kind() else {
             return ty.super_fold_with(self);
         };
         let origin = self.infcx.type_var_origin(vid);

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1015,7 +1015,7 @@ impl<'tcx> FieldUniquenessCheckContext<'tcx> {
                 // Here we don't care about the generic parameters, so `instantiate_identity` is enough.
                 match self.tcx.type_of(field.did).instantiate_identity().kind() {
                     ty::Adt(adt_def, _) => {
-                        self.check_field_in_nested_adt(*adt_def, unnamed_field_span);
+                        self.check_field_in_nested_adt(adt_def, unnamed_field_span);
                     }
                     ty_kind => span_bug!(
                         self.tcx.def_span(field.did),
@@ -1596,7 +1596,7 @@ pub fn suggest_impl_trait<'tcx>(
          item_ty: Ty<'tcx>| {
             let trait_name = tcx.item_name(trait_def_id);
             let args_tuple = args.type_at(1);
-            let ty::Tuple(types) = *args_tuple.kind() else {
+            let ty::Tuple(types) = args_tuple.kind() else {
                 return None;
             };
             let types = types.make_suggestable(tcx, false, None)?;

--- a/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
+++ b/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
@@ -62,7 +62,7 @@ struct ParameterCollector {
 
 impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ParameterCollector {
     fn visit_ty(&mut self, t: Ty<'tcx>) {
-        match *t.kind() {
+        match t.kind() {
             // Projections are not injective in general.
             ty::Alias(ty::Projection | ty::Inherent | ty::Opaque, _)
                 if !self.include_nonconstraining =>

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -377,7 +377,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             // Next, we need to check that the return-type notation is being used on
             // an RPITIT (return-position impl trait in trait) or AFIT (async fn in trait).
             let output = tcx.fn_sig(assoc_item.def_id).skip_binder().output();
-            let output = if let ty::Alias(ty::Projection, alias_ty) = *output.skip_binder().kind()
+            let output = if let ty::Alias(ty::Projection, alias_ty) = output.skip_binder().kind()
                 && tcx.is_impl_trait_in_trait(alias_ty.def_id)
             {
                 alias_ty.into()
@@ -635,7 +635,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for GenericParamAndBoundVarCollector<'_, 't
             ty::Param(param) => {
                 self.params.insert(param.index);
             }
-            ty::Bound(db, bt) if *db >= self.depth => {
+            ty::Bound(db, bt) if db >= self.depth => {
                 self.vars.insert(match bt.kind {
                     ty::BoundTyKind::Param(def_id, name) => (def_id, name),
                     ty::BoundTyKind::Anon => {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -1575,7 +1575,7 @@ fn generics_args_err_extend<'a>(
         GenericsArgsErrExtend::SelfTyAlias { def_id, span } => {
             let ty = tcx.at(span).type_of(def_id).instantiate_identity();
             let span_of_impl = tcx.span_of_impl(def_id);
-            let def_id = match *ty.kind() {
+            let def_id = match ty.kind() {
                 ty::Adt(self_def, _) => self_def.did(),
                 _ => return,
             };

--- a/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
@@ -113,7 +113,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
             GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => continue,
         };
 
-        match *leaf_ty.kind() {
+        match leaf_ty.kind() {
             ty::Ref(region, rty, _) => {
                 // The type is `&'a T` which means that we will have
                 // a predicate requirement of `T: 'a` (`T` outlives `'a`).

--- a/compiler/rustc_hir_analysis/src/variance/constraints.rs
+++ b/compiler/rustc_hir_analysis/src/variance/constraints.rs
@@ -223,7 +223,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
     ) {
         debug!("add_constraints_from_ty(ty={:?}, variance={:?})", ty, variance);
 
-        match *ty.kind() {
+        match ty.kind() {
             ty::Bool
             | ty::Char
             | ty::Int(_)

--- a/compiler/rustc_hir_analysis/src/variance/mod.rs
+++ b/compiler/rustc_hir_analysis/src/variance/mod.rs
@@ -115,9 +115,9 @@ fn variance_of_opaque(tcx: TyCtxt<'_>, item_def_id: LocalDefId) -> &[ty::Varianc
         fn visit_ty(&mut self, t: Ty<'tcx>) {
             match t.kind() {
                 ty::Alias(_, ty::AliasTy { def_id, args, .. })
-                    if matches!(self.tcx.def_kind(*def_id), DefKind::OpaqueTy) =>
+                    if matches!(self.tcx.def_kind(def_id), DefKind::OpaqueTy) =>
                 {
-                    self.visit_opaque(*def_id, args);
+                    self.visit_opaque(def_id, args);
                 }
                 _ => t.super_visit_with(self),
             }

--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -589,7 +589,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expectation: Expectation<'tcx>,
     ) -> Option<LocalDefId> {
         let expected_ty = expectation.to_option(self)?;
-        let (def_id, args) = match *expected_ty.kind() {
+        let (def_id, args) = match expected_ty.kind() {
             // FIXME: Could also check that the RPIT is not defined
             ty::Alias(ty::Opaque, alias_ty) => (alias_ty.def_id.as_local()?, alias_ty.args),
             // FIXME(-Znext-solver): Remove this branch once `replace_opaque_types_with_infer` is gone.

--- a/compiler/rustc_hir_typeck/src/autoderef.rs
+++ b/compiler/rustc_hir_typeck/src/autoderef.rs
@@ -49,7 +49,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.try_overloaded_deref(autoderef.span(), source).and_then(
                         |InferOk { value: method, obligations: o }| {
                             obligations.extend(o);
-                            if let ty::Ref(region, _, mutbl) = *method.sig.output().kind() {
+                            if let ty::Ref(region, _, mutbl) = method.sig.output().kind() {
                                 Some(OverloadedDeref { region, mutbl, span: autoderef.span() })
                             } else {
                                 None

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -136,7 +136,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.structurally_resolve_type(autoderef.span(), autoderef.final_ty(false));
 
         // If the callee is a bare function or a closure, then we're all set.
-        match *adjusted_ty.kind() {
+        match adjusted_ty.kind() {
             ty::FnDef(..) | ty::FnPtr(..) => {
                 let adjustments = self.adjust_steps(autoderef);
                 self.apply_adjustments(callee_expr, adjustments);
@@ -319,10 +319,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // For initial two-phase borrow
                     // deployment, conservatively omit
                     // overloaded function call ops.
-                    let mutbl = AutoBorrowMutability::new(*mutbl, AllowTwoPhase::No);
+                    let mutbl = AutoBorrowMutability::new(mutbl, AllowTwoPhase::No);
 
                     autoref = Some(Adjustment {
-                        kind: Adjust::Borrow(AutoBorrow::Ref(*region, mutbl)),
+                        kind: Adjust::Borrow(AutoBorrow::Ref(region, mutbl)),
                         target: method.sig.inputs()[0],
                     });
                 }
@@ -433,7 +433,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         arg_exprs: &'tcx [hir::Expr<'tcx>],
         expected: Expectation<'tcx>,
     ) -> Ty<'tcx> {
-        let (fn_sig, def_id) = match *callee_ty.kind() {
+        let (fn_sig, def_id) = match callee_ty.kind() {
             ty::FnDef(def_id, args) => {
                 self.enforce_context_effects(call_expr.span, def_id, args);
                 let fn_sig = self.tcx.fn_sig(def_id).instantiate(self.tcx, args);
@@ -547,7 +547,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // in the function signature (`F: FnOnce<ARG>`), so I did not bother to add another check here.
                 //
                 // This check is here because there is currently no way to express a trait bound for `FnDef` types only.
-                if let ty::FnDef(def_id, _args) = *arg_ty.kind() {
+                if let ty::FnDef(def_id, _args) = arg_ty.kind() {
                     let fn_once_def_id =
                         self.tcx.require_lang_item(hir::LangItem::FnOnce, Some(span));
                     let fn_once_output_def_id =

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -99,7 +99,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let t = self.try_structurally_resolve_type(span, t);
 
-        Ok(match *t.kind() {
+        Ok(match t.kind() {
             ty::Slice(_) | ty::Str => Some(PointerKind::Length),
             ty::Dynamic(tty, _, ty::Dyn) => Some(PointerKind::VTable(tty)),
             ty::Adt(def, args) if def.is_struct() => match def.non_enum_variant().tail_opt() {
@@ -363,15 +363,15 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 );
                 let mut sugg = None;
                 let mut sugg_mutref = false;
-                if let ty::Ref(reg, cast_ty, mutbl) = *self.cast_ty.kind() {
-                    if let ty::RawPtr(expr_ty, _) = *self.expr_ty.kind()
+                if let ty::Ref(reg, cast_ty, mutbl) = self.cast_ty.kind() {
+                    if let ty::RawPtr(expr_ty, _) = self.expr_ty.kind()
                         && fcx.can_coerce(
                             Ty::new_ref(fcx.tcx, fcx.tcx.lifetimes.re_erased, expr_ty, mutbl),
                             self.cast_ty,
                         )
                     {
                         sugg = Some((format!("&{}*", mutbl.prefix_str()), cast_ty == expr_ty));
-                    } else if let ty::Ref(expr_reg, expr_ty, expr_mutbl) = *self.expr_ty.kind()
+                    } else if let ty::Ref(expr_reg, expr_ty, expr_mutbl) = self.expr_ty.kind()
                         && expr_mutbl == Mutability::Not
                         && mutbl == Mutability::Mut
                         && fcx.can_coerce(Ty::new_mut_ref(fcx.tcx, expr_reg, expr_ty), self.cast_ty)
@@ -388,7 +388,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     {
                         sugg = Some((format!("&{}", mutbl.prefix_str()), false));
                     }
-                } else if let ty::RawPtr(_, mutbl) = *self.cast_ty.kind()
+                } else if let ty::RawPtr(_, mutbl) = self.cast_ty.kind()
                     && fcx.can_coerce(
                         Ty::new_ref(fcx.tcx, fcx.tcx.lifetimes.re_erased, self.expr_ty, mutbl),
                         self.cast_ty,
@@ -682,7 +682,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             (Some(t_from), Some(t_cast)) => (t_from, t_cast),
             // Function item types may need to be reified before casts.
             (None, Some(t_cast)) => {
-                match *self.expr_ty.kind() {
+                match self.expr_ty.kind() {
                     ty::FnDef(..) => {
                         // Attempt a coercion to a fn pointer type.
                         let f = fcx.normalize(self.expr_span, self.expr_ty.fn_sig(fcx.tcx));
@@ -707,7 +707,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     // a cast.
                     ty::Ref(_, inner_ty, mutbl) => {
                         return match t_cast {
-                            Int(_) | Float => match *inner_ty.kind() {
+                            Int(_) | Float => match inner_ty.kind() {
                                 ty::Int(_)
                                 | ty::Uint(_)
                                 | ty::Float(_)
@@ -731,7 +731,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             }
             _ => return Err(CastError::NonScalar),
         };
-        if let ty::Adt(adt_def, _) = *self.expr_ty.kind() {
+        if let ty::Adt(adt_def, _) = self.expr_ty.kind() {
             if adt_def.did().krate != LOCAL_CRATE {
                 if adt_def.variants().iter().any(VariantDef::is_field_list_non_exhaustive) {
                     return Err(CastError::ForeignNonExhaustiveAdt);
@@ -979,7 +979,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     });
 
                 // this will report a type mismatch if needed
-                fcx.demand_eqtype(self.span, *ety, m_cast.ty);
+                fcx.demand_eqtype(self.span, ety, m_cast.ty);
                 return Ok(CastKind::ArrayPtrCast);
             }
         }

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -309,7 +309,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected_ty: Ty<'tcx>,
         closure_kind: hir::ClosureKind,
     ) -> (Option<ExpectedSig<'tcx>>, Option<ty::ClosureKind>) {
-        match *expected_ty.kind() {
+        match expected_ty.kind() {
             ty::Alias(ty::Opaque, ty::AliasTy { def_id, args, .. }) => self
                 .deduce_closure_signature_from_predicates(
                     expected_ty,
@@ -502,7 +502,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let arg_param_ty = projection.skip_binder().projection_term.args.type_at(1);
         debug!(?arg_param_ty);
 
-        let ty::Tuple(input_tys) = *arg_param_ty.kind() else {
+        let ty::Tuple(input_tys) = arg_param_ty.kind() else {
             return None;
         };
 
@@ -549,7 +549,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let arg_param_ty = projection.skip_binder().projection_term.args.type_at(1);
         debug!(?arg_param_ty);
 
-        let ty::Tuple(input_tys) = *arg_param_ty.kind() else {
+        let ty::Tuple(input_tys) = arg_param_ty.kind() else {
             return None;
         };
 
@@ -558,7 +558,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // but none of them would be useful, since async closures return
         // concrete anonymous future types, and their futures are not coerced
         // into any other type within the body of the async closure.
-        let ty::Infer(ty::TyVar(return_vid)) = *projection.skip_binder().term.expect_type().kind()
+        let ty::Infer(ty::TyVar(return_vid)) = projection.skip_binder().term.expect_type().kind()
         else {
             return None;
         };
@@ -954,7 +954,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         };
 
-        let output_ty = match *ret_ty.kind() {
+        let output_ty = match ret_ty.kind() {
             ty::Infer(ty::TyVar(ret_vid)) => {
                 self.obligations_for_self_ty(ret_vid).into_iter().find_map(|obligation| {
                     get_future_output(obligation.predicate, obligation.cause.span)

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -1472,7 +1472,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
         let base_ty = self.expr_ty_adjusted(base)?;
 
         let ty::Ref(region, _, mutbl) =
-            *self.cx.try_structurally_resolve_type(base.span, base_ty).kind()
+            self.cx.try_structurally_resolve_type(base.span, base_ty).kind()
         else {
             span_bug!(expr.span, "cat_overloaded_place: base is not a reference");
         };

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
@@ -49,7 +49,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             predicate_args.iter().find_map(|arg| {
                 arg.walk().find_map(|arg| {
                     if let ty::GenericArgKind::Type(ty) = arg.unpack()
-                        && let ty::Param(param_ty) = *ty.kind()
+                        && let ty::Param(param_ty) = ty.kind()
                         && matches(ty::ParamTerm::Ty(param_ty))
                     {
                         Some(arg)
@@ -340,7 +340,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for FindAmbiguousParameter<'_, 'tcx> {
             type Result = ControlFlow<ty::GenericArg<'tcx>>;
             fn visit_ty(&mut self, ty: Ty<'tcx>) -> Self::Result {
-                if let ty::Infer(ty::TyVar(vid)) = *ty.kind()
+                if let ty::Infer(ty::TyVar(vid)) = ty.kind()
                     && let Some(def_id) = self.0.type_var_origin(vid).param_def_id
                     && let generics = self.0.tcx.generics_of(self.1)
                     && let Some(index) = generics.param_def_id_to_index(self.0.tcx, def_id)
@@ -366,7 +366,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         )) = error.code
             && let ty::Closure(def_id, _) | ty::Coroutine(def_id, ..) =
                 expected_trait_ref.self_ty().kind()
-            && span.overlaps(self.tcx.def_span(*def_id))
+            && span.overlaps(self.tcx.def_span(def_id))
         {
             true
         } else {
@@ -650,7 +650,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return self.blame_specific_part_of_expr_corresponding_to_generic_param(
                 param,
                 borrowed_expr,
-                (*ty_ref_type).into(),
+                ty_ref_type.into(),
             );
         }
 
@@ -884,7 +884,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .variant_with_id(variant_def_id)
                     .fields
                     .iter()
-                    .map(|field| field.ty(self.tcx, *in_ty_adt_generic_args))
+                    .map(|field| field.ty(self.tcx, in_ty_adt_generic_args))
                     .enumerate()
                     .filter(|(_index, field_type)| find_param_in_ty((*field_type).into(), param)),
             ) else {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1601,7 +1601,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             Ok((variant, ty.normalized))
         } else {
-            Err(match *ty.normalized.kind() {
+            Err(match ty.normalized.kind() {
                 ty::Error(guar) => {
                     // E0071 might be caused by a spelling error, which will have
                     // already caused an error message and probably a suggestion
@@ -2204,7 +2204,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             && let Some(callee_ty) = callee_ty
         {
             let callee_ty = callee_ty.peel_refs();
-            match *callee_ty.kind() {
+            match callee_ty.kind() {
                 ty::Param(param) => {
                     let param = self.tcx.generics_of(self.body_id).type_param(param, self.tcx);
                     if param.kind.is_synthetic() {
@@ -2453,7 +2453,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     if rcvr.hir_id.owner == typeck.hir_owner
                         && let Some(rcvr_ty) = typeck.node_type_opt(rcvr.hir_id)
                         && let ty::Closure(call_def_id, _) = rcvr_ty.kind()
-                        && def_id == *call_def_id
+                        && def_id == call_def_id
                         && let Some(idx) = expected_idx
                         && let Some(arg) = args.get(idx)
                         && let Some(arg_ty) = typeck.node_type_opt(arg.hir_id)

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
@@ -63,7 +63,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let ty = self.shallow_resolve(ty);
         debug!(?ty);
 
-        match *ty.kind() {
+        match ty.kind() {
             ty::Infer(ty::TyVar(found_vid)) => {
                 self.root_var(expected_vid) == self.root_var(found_vid)
             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -307,7 +307,7 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
 
     fn probe_adt(&self, span: Span, ty: Ty<'tcx>) -> Option<ty::AdtDef<'tcx>> {
         match ty.kind() {
-            ty::Adt(adt_def, _) => Some(*adt_def),
+            ty::Adt(adt_def, _) => Some(adt_def),
             // FIXME(#104767): Should we handle bound regions here?
             ty::Alias(ty::Projection | ty::Inherent | ty::Weak, _)
                 if !ty.has_escaping_bound_vars() =>
@@ -328,7 +328,7 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
             if let ty::Alias(ty::Projection | ty::Weak, ty::AliasTy { args, def_id, .. }) =
                 ty.kind()
             {
-                self.add_required_obligations_for_hir(span, *def_id, args, hir_id);
+                self.add_required_obligations_for_hir(span, def_id, args, hir_id);
             }
 
             self.normalize(span, ty)

--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -13,7 +13,7 @@ use super::FnCtxt;
 /// If the type is `Option<T>`, it will return `T`, otherwise
 /// the type itself. Works on most `Option`-like types.
 fn unpack_option_like<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Ty<'tcx> {
-    let ty::Adt(def, args) = *ty.kind() else { return ty };
+    let ty::Adt(def, args) = ty.kind() else { return ty };
 
     if def.variants().len() == 2 && !def.repr().c() && def.repr().int.is_none() {
         let data_idx;
@@ -74,7 +74,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Special-case transmuting from `typeof(function)` and
             // `Option<typeof(function)>` to present a clearer error.
             let from = unpack_option_like(tcx, from);
-            if let (&ty::FnDef(..), SizeSkeleton::Known(size_to, _)) = (from.kind(), sk_to)
+            if let (ty::FnDef(..), SizeSkeleton::Known(size_to, _)) = (from.kind(), sk_to)
                 && size_to == Pointer(dl.instruction_address_space).size(&tcx)
             {
                 struct_span_code_err!(self.dcx(), span, E0591, "can't transmute zero-sized type")

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -206,7 +206,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
 
                 if unsize {
                     let unsized_ty = if let ty::Array(elem_ty, _) = base_ty.kind() {
-                        Ty::new_slice(self.tcx, *elem_ty)
+                        Ty::new_slice(self.tcx, elem_ty)
                     } else {
                         bug!(
                             "AutorefOrPtrAdjustment's unsize flag should only be set for array ty, found {}",
@@ -222,7 +222,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             }
             Some(probe::AutorefOrPtrAdjustment::ToConstPtr) => {
                 target = match target.kind() {
-                    &ty::RawPtr(ty, mutbl) => {
+                    ty::RawPtr(ty, mutbl) => {
                         assert!(mutbl.is_mut());
                         Ty::new_imm_ptr(self.tcx, ty)
                     }

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -207,7 +207,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if let Some(span) = result.illegal_sized_bound {
             let mut needs_mut = false;
             if let ty::Ref(region, t_type, mutability) = self_ty.kind() {
-                let trait_type = Ty::new_ref(self.tcx, *region, *t_type, mutability.invert());
+                let trait_type = Ty::new_ref(self.tcx, region, t_type, mutability.invert());
                 // We probe again to see if there might be a borrow mutability discrepancy.
                 match self.lookup_probe(
                     segment.ident,

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -425,7 +425,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .probe_instantiate_query_response(span, &orig_values, ty)
                     .unwrap_or_else(|_| span_bug!(span, "instantiating {:?} failed?", ty));
                 let ty = self.resolve_vars_if_possible(ty.value);
-                let guar = match *ty.kind() {
+                let guar = match ty.kind() {
                     ty::Infer(ty::TyVar(_)) => {
                         let raw_ptr_call =
                             bad_ty.reached_raw_pointer && !self.tcx.features().arbitrary_self_types;
@@ -554,7 +554,7 @@ fn method_autoderef_steps<'tcx>(
             steps.push(CandidateStep {
                 self_ty: infcx.make_query_response_ignoring_pending_obligations(
                     inference_vars,
-                    Ty::new_slice(infcx.tcx, *elem_ty),
+                    Ty::new_slice(infcx.tcx, elem_ty),
                 ),
                 autoderefs: dereferences,
                 // this could be from an unsafe deref if we had
@@ -653,7 +653,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     #[instrument(level = "debug", skip(self))]
     fn assemble_probe(&mut self, self_ty: &Canonical<'tcx, QueryResponse<'tcx, Ty<'tcx>>>) {
         let raw_self_ty = self_ty.value.value;
-        match *raw_self_ty.kind() {
+        match raw_self_ty.kind() {
             ty::Dynamic(data, ..) if let Some(p) = data.principal() => {
                 // Subtle: we can't use `instantiate_query_response` here: using it will
                 // commit to all of the type equalities assumed by inference going through
@@ -795,7 +795,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             let bound_predicate = predicate.kind();
             match bound_predicate.skip_binder() {
                 ty::ClauseKind::Trait(trait_predicate) => {
-                    match *trait_predicate.trait_ref.self_ty().kind() {
+                    match trait_predicate.trait_ref.self_ty().kind() {
                         ty::Param(p) if p == param_ty => {
                             Some(bound_predicate.rebind(trait_predicate.trait_ref))
                         }
@@ -1123,7 +1123,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                 pick.autoderefs = step.autoderefs;
 
                 // Insert a `&*` or `&mut *` if this is a reference type:
-                if let ty::Ref(_, _, mutbl) = *step.self_ty.value.value.kind() {
+                if let ty::Ref(_, _, mutbl) = step.self_ty.value.value.kind() {
                     pick.autoderefs += 1;
                     pick.autoref_or_ptr_adjustment = Some(AutorefOrPtrAdjustment::Autoref {
                         mutbl,
@@ -1173,7 +1173,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             return None;
         }
 
-        let &ty::RawPtr(ty, hir::Mutability::Mut) = self_ty.kind() else {
+        let ty::RawPtr(ty, hir::Mutability::Mut) = self_ty.kind() else {
             return None;
         };
 

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -118,7 +118,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let Some(arg_ty) = args[0].as_type() else {
                     return false;
                 };
-                let ty::Param(param) = *arg_ty.kind() else {
+                let ty::Param(param) = arg_ty.kind() else {
                     return false;
                 };
                 // Is `generic_param` the same as the arg for this trait predicate?
@@ -149,7 +149,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return false;
         }
 
-        match *ty.peel_refs().kind() {
+        match ty.peel_refs().kind() {
             ty::Param(param) => {
                 let generics = self.tcx.generics_of(self.body_id);
                 let generic_param = generics.type_param(param, self.tcx);
@@ -351,8 +351,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
                 if let ty::Ref(region, t_type, mutability) = rcvr_ty.kind() {
                     if needs_mut {
-                        let trait_type =
-                            Ty::new_ref(self.tcx, *region, *t_type, mutability.invert());
+                        let trait_type = Ty::new_ref(self.tcx, region, t_type, mutability.invert());
                         let msg = format!("you need `{trait_type}` instead of `{rcvr_ty}`");
                         let mut kind = &self_expr.kind;
                         while let hir::ExprKind::AddrOf(_, _, expr)
@@ -779,7 +778,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // on pointers, check if the method would exist on a reference
         if let SelfSource::MethodCall(rcvr_expr) = source
-            && let ty::RawPtr(ty, ptr_mutbl) = *rcvr_ty.kind()
+            && let ty::RawPtr(ty, ptr_mutbl) = rcvr_ty.kind()
             && let Ok(pick) = self.lookup_probe_for_diagnostic(
                 item_name,
                 Ty::new_ref(tcx, ty::Region::new_error_misc(tcx), ty, ptr_mutbl),
@@ -787,7 +786,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ProbeScope::TraitsInScope,
                 None,
             )
-            && let ty::Ref(_, _, sugg_mutbl) = *pick.self_ty.kind()
+            && let ty::Ref(_, _, sugg_mutbl) = pick.self_ty.kind()
             && (sugg_mutbl.is_not() || ptr_mutbl.is_mut())
         {
             let (method, method_anchor) = match sugg_mutbl {
@@ -1385,7 +1384,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             )),
                             _ => arg,
                         }));
-                    let rcvr_ty = Ty::new_adt(tcx, *def, new_args);
+                    let rcvr_ty = Ty::new_adt(tcx, def, new_args);
                     if let Ok(method) = self.lookup_method_for_diagnostic(
                         rcvr_ty,
                         &item_segment,
@@ -2843,7 +2842,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Target wrapper types - types that wrap or pretend to wrap another type,
             // perhaps this inner type is meant to be called?
             ty::AdtKind::Struct | ty::AdtKind::Union => {
-                let [first] = ***args else {
+                let [first] = **args else {
                     return;
                 };
                 let ty::GenericArgKind::Type(ty) = first.unpack() else {
@@ -3776,9 +3775,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .sort_by_key(|&info| (!info.def_id.is_local(), self.tcx.def_path_str(info.def_id)));
             candidates.dedup();
 
-            let param_type = match *rcvr_ty.kind() {
+            let param_type = match rcvr_ty.kind() {
                 ty::Param(param) => Some(param),
-                ty::Ref(_, ty, _) => match *ty.kind() {
+                ty::Ref(_, ty, _) => match ty.kind() {
                     ty::Param(param) => Some(param),
                     _ => None,
                 },

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -256,9 +256,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let by_ref_binop = !op.node.is_by_value();
                 if is_assign == IsAssign::Yes || by_ref_binop {
                     if let ty::Ref(region, _, mutbl) = method.sig.inputs()[0].kind() {
-                        let mutbl = AutoBorrowMutability::new(*mutbl, AllowTwoPhase::Yes);
+                        let mutbl = AutoBorrowMutability::new(mutbl, AllowTwoPhase::Yes);
                         let autoref = Adjustment {
-                            kind: Adjust::Borrow(AutoBorrow::Ref(*region, mutbl)),
+                            kind: Adjust::Borrow(AutoBorrow::Ref(region, mutbl)),
                             target: method.sig.inputs()[0],
                         };
                         self.apply_adjustments(lhs_expr, vec![autoref]);
@@ -268,10 +268,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     if let ty::Ref(region, _, mutbl) = method.sig.inputs()[1].kind() {
                         // Allow two-phase borrows for binops in initial deployment
                         // since they desugar to methods
-                        let mutbl = AutoBorrowMutability::new(*mutbl, AllowTwoPhase::Yes);
+                        let mutbl = AutoBorrowMutability::new(mutbl, AllowTwoPhase::Yes);
 
                         let autoref = Adjustment {
-                            kind: Adjust::Borrow(AutoBorrow::Ref(*region, mutbl)),
+                            kind: Adjust::Borrow(AutoBorrow::Ref(region, mutbl)),
                             target: method.sig.inputs()[1],
                         };
                         // HACK(eddyb) Bypass checks due to reborrows being in
@@ -507,12 +507,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 } else if is_assign == IsAssign::No
                     && let Ref(region, lhs_deref_ty, mutbl) = lhs_ty.kind()
                 {
-                    if self.type_is_copy_modulo_regions(self.param_env, *lhs_deref_ty) {
-                        suggest_deref_binop(&mut err, *lhs_deref_ty);
+                    if self.type_is_copy_modulo_regions(self.param_env, lhs_deref_ty) {
+                        suggest_deref_binop(&mut err, lhs_deref_ty);
                     } else {
                         let lhs_inv_mutbl = mutbl.invert();
                         let lhs_inv_mutbl_ty =
-                            Ty::new_ref(self.tcx, *region, *lhs_deref_ty, lhs_inv_mutbl);
+                            Ty::new_ref(self.tcx, region, lhs_deref_ty, lhs_inv_mutbl);
 
                         suggest_different_borrow(
                             &mut err,
@@ -525,7 +525,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         if let Ref(region, rhs_deref_ty, mutbl) = rhs_ty.kind() {
                             let rhs_inv_mutbl = mutbl.invert();
                             let rhs_inv_mutbl_ty =
-                                Ty::new_ref(self.tcx, *region, *rhs_deref_ty, rhs_inv_mutbl);
+                                Ty::new_ref(self.tcx, region, rhs_deref_ty, rhs_inv_mutbl);
 
                             suggest_different_borrow(
                                 &mut err,
@@ -704,12 +704,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             |ty: Ty<'tcx>| ty.ty_adt_def().is_some_and(|ty_def| Some(ty_def.did()) == string_type);
 
         match (lhs_ty.kind(), rhs_ty.kind()) {
-            (&Ref(_, l_ty, _), &Ref(_, r_ty, _)) // &str or &String + &str, &String or &&str
-                if (*l_ty.kind() == Str || is_std_string(l_ty))
-                    && (*r_ty.kind() == Str
+            (Ref(_, l_ty, _), Ref(_, r_ty, _)) // &str or &String + &str, &String or &&str
+                if (l_ty.kind() == Str || is_std_string(l_ty))
+                    && (r_ty.kind() == Str
                         || is_std_string(r_ty)
                         || matches!(
-                            r_ty.kind(), Ref(_, inner_ty, _) if *inner_ty.kind() == Str
+                            r_ty.kind(), Ref(_, inner_ty, _) if inner_ty.kind() == Str
                         )) =>
             {
                 if let IsAssign::No = is_assign { // Do not supply this message if `&str += &str`
@@ -733,8 +733,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
                 true
             }
-            (&Ref(_, l_ty, _), &Adt(..)) // Handle `&str` & `&String` + `String`
-                if (*l_ty.kind() == Str || is_std_string(l_ty)) && is_std_string(rhs_ty) =>
+            (Ref(_, l_ty, _), Adt(..)) // Handle `&str` & `&String` + `String`
+                if (l_ty.kind() == Str || is_std_string(l_ty)) && is_std_string(rhs_ty) =>
             {
                 err.span_label(
                     op.span,
@@ -858,7 +858,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 }
                             }
                             Str | Never | Char | Tuple(_) | Array(_, _) => {}
-                            Ref(_, lty, _) if *lty.kind() == Str => {}
+                            Ref(_, lty, _) if lty.kind() == Str => {}
                             _ => {
                                 self.note_unmet_impls_on_type(&mut err, errors, true);
                             }
@@ -1071,7 +1071,7 @@ enum Op {
 /// Dereferences a single level of immutable referencing.
 fn deref_ty_if_possible(ty: Ty<'_>) -> Ty<'_> {
     match ty.kind() {
-        ty::Ref(_, ty, hir::Mutability::Not) => *ty,
+        ty::Ref(_, ty, hir::Mutability::Not) => ty,
         _ => ty,
     }
 }

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -421,7 +421,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         //
         // See the examples in `ui/match-defbm*.rs`.
         let mut pat_adjustments = vec![];
-        while let ty::Ref(_, inner_ty, inner_mutability) = *expected.kind() {
+        while let ty::Ref(_, inner_ty, inner_mutability) = expected.kind() {
             debug!("inspecting {:?}", expected);
 
             debug!("current discriminant is Ref, inserting implicit deref");
@@ -476,7 +476,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut pat_ty = ty;
         if let hir::ExprKind::Lit(Spanned { node: ast::LitKind::ByteStr(..), .. }) = lt.kind {
             let expected = self.structurally_resolve_type(span, expected);
-            if let ty::Ref(_, inner_ty, _) = *expected.kind()
+            if let ty::Ref(_, inner_ty, _) = expected.kind()
                 && self.try_structurally_resolve_type(span, inner_ty).is_slice()
             {
                 let tcx = self.tcx;
@@ -809,7 +809,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         match (expected.kind(), actual.kind(), ba) {
             (ty::Ref(_, inner_ty, _), _, BindingMode::NONE)
-                if self.can_eq(self.param_env, *inner_ty, actual) =>
+                if self.can_eq(self.param_env, inner_ty, actual) =>
             {
                 err.span_suggestion_verbose(
                     span.shrink_to_lo(),
@@ -819,7 +819,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 );
             }
             (_, ty::Ref(_, inner_ty, _), BindingMode::REF)
-                if self.can_eq(self.param_env, expected, *inner_ty) =>
+                if self.can_eq(self.param_env, expected, inner_ty) =>
             {
                 err.span_suggestion_verbose(
                     span.with_hi(span.lo() + BytePos(4)),
@@ -1030,7 +1030,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 return Ty::new_error(tcx, e);
             }
             Res::SelfCtor(def_id) => {
-                if let ty::Adt(adt_def, _) = *tcx.type_of(def_id).skip_binder().kind()
+                if let ty::Adt(adt_def, _) = tcx.type_of(def_id).skip_binder().kind()
                     && adt_def.is_struct()
                     && let Some((CtorKind::Const, _)) = adt_def.non_enum_variant().ctor
                 {
@@ -2162,7 +2162,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected = self.try_structurally_resolve_type(pat.span, expected);
         if new_match_ergonomics {
             if let ByRef::Yes(inh_mut) = pat_info.binding_mode {
-                if !ref_pat_eat_one_layer_2024 && let ty::Ref(_, _, r_mutbl) = *expected.kind() {
+                if !ref_pat_eat_one_layer_2024 && let ty::Ref(_, _, r_mutbl) = expected.kind() {
                     // Don't attempt to consume inherited reference
                     pat_info.binding_mode = pat_info.binding_mode.cap_ref_mutability(r_mutbl);
                 } else {
@@ -2225,7 +2225,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // to avoid creating needless variables. This also helps with
                 // the bad interactions of the given hack detailed in (note_1).
                 debug!("check_pat_ref: expected={:?}", expected);
-                match *expected.kind() {
+                match expected.kind() {
                     ty::Ref(_, r_ty, r_mutbl)
                         if (no_ref_mut_behind_and && r_mutbl >= pat_mutbl)
                             || r_mutbl == pat_mutbl =>
@@ -2362,7 +2362,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let expected = self.structurally_resolve_type(span, expected);
         debug!(?expected);
 
-        let (element_ty, opt_slice_ty, inferred) = match *expected.kind() {
+        let (element_ty, opt_slice_ty, inferred) = match expected.kind() {
             // An array, so we might have something like `let [a, b, c] = [0, 1, 2];`.
             ty::Array(element_ty, len) => {
                 let min = before.len() as u64 + after.len() as u64;
@@ -2574,7 +2574,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ty::Adt(adt_def, _) if self.tcx.is_diagnostic_item(sym::Vec, adt_def.did()) => {
                 (true, ty)
             }
-            ty::Ref(_, ty, _) => self.is_slice_or_array_or_vector(*ty),
+            ty::Ref(_, ty, _) => self.is_slice_or_array_or_vector(ty),
             ty::Slice(..) | ty::Array(..) => (true, ty),
             _ => (false, ty),
         }

--- a/compiler/rustc_hir_typeck/src/place_op.rs
+++ b/compiler/rustc_hir_typeck/src/place_op.rs
@@ -32,7 +32,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.apply_adjustments(
                 oprnd_expr,
                 vec![Adjustment {
-                    kind: Adjust::Borrow(AutoBorrow::Ref(*region, AutoBorrowMutability::Not)),
+                    kind: Adjust::Borrow(AutoBorrow::Ref(region, AutoBorrowMutability::Not)),
                     target: method.sig.inputs()[0],
                 }],
             );
@@ -140,7 +140,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if unsize {
                 // We only unsize arrays here.
                 if let ty::Array(element_ty, _) = adjusted_ty.kind() {
-                    self_ty = Ty::new_slice(self.tcx, *element_ty);
+                    self_ty = Ty::new_slice(self.tcx, element_ty);
                 } else {
                     continue;
                 }
@@ -160,8 +160,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let mut adjustments = self.adjust_steps(autoderef);
                 if let ty::Ref(region, _, hir::Mutability::Not) = method.sig.inputs()[0].kind() {
                     adjustments.push(Adjustment {
-                        kind: Adjust::Borrow(AutoBorrow::Ref(*region, AutoBorrowMutability::Not)),
-                        target: Ty::new_imm_ref(self.tcx, *region, adjusted_ty),
+                        kind: Adjust::Borrow(AutoBorrow::Ref(region, AutoBorrowMutability::Not)),
+                        target: Ty::new_imm_ref(self.tcx, region, adjusted_ty),
                     });
                 } else {
                     span_bug!(expr.span, "input to index is not a ref?");
@@ -291,7 +291,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         )
                     {
                         let method = self.register_infer_ok_obligations(ok);
-                        if let ty::Ref(region, _, mutbl) = *method.sig.output().kind() {
+                        if let ty::Ref(region, _, mutbl) = method.sig.output().kind() {
                             *deref = OverloadedDeref { region, mutbl, span: deref.span };
                         }
                         // If this is a union field, also throw an error for `DerefMut` of `ManuallyDrop` (see RFC 2514).
@@ -393,8 +393,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         // not the case today.
                         allow_two_phase_borrow: AllowTwoPhase::No,
                     };
-                    adjustment.kind = Adjust::Borrow(AutoBorrow::Ref(*region, mutbl));
-                    adjustment.target = Ty::new_ref(self.tcx, *region, source, mutbl.into());
+                    adjustment.kind = Adjust::Borrow(AutoBorrow::Ref(region, mutbl));
+                    adjustment.target = Ty::new_ref(self.tcx, region, source, mutbl.into());
                 }
                 source = adjustment.target;
             }

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -171,7 +171,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         // Extract the type of the closure.
         let ty = self.node_ty(closure_hir_id);
-        let (closure_def_id, args, infer_kind) = match *ty.kind() {
+        let (closure_def_id, args, infer_kind) = match ty.kind() {
             ty::Closure(def_id, args) => {
                 (def_id, UpvarArgs::Closure(args), self.closure_kind(ty).is_none())
             }
@@ -457,7 +457,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // for the inner coroutine may actually be more restrictive.
             if infer_kind {
                 let ty::Coroutine(_, coroutine_args) =
-                    *self.typeck_results.borrow().expr_ty(body.value).kind()
+                    self.typeck_results.borrow().expr_ty(body.value).kind()
                 else {
                     bug!();
                 };

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -219,7 +219,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
         if let hir::ExprKind::Index(ref base, ref index, _) = e.kind {
             // All valid indexing looks like this; might encounter non-valid indexes at this point.
             let base_ty = self.typeck_results.expr_ty_adjusted(base);
-            if let ty::Ref(_, base_ty_inner, _) = *base_ty.kind() {
+            if let ty::Ref(_, base_ty_inner, _) = base_ty.kind() {
                 let index_ty = self.typeck_results.expr_ty_adjusted(index);
                 if self.is_builtin_index(e, base_ty_inner, index_ty) {
                     // Remove the method call record

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -340,7 +340,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
     }
 
     fn fold_ty(&mut self, mut t: Ty<'tcx>) -> Ty<'tcx> {
-        match *t.kind() {
+        match t.kind() {
             ty::Infer(ty::TyVar(mut vid)) => {
                 // We need to canonicalize the *root* of our ty var.
                 // This is so that our canonical response correctly reflects

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -432,7 +432,7 @@ impl<'tcx> InferCtxt<'tcx> {
             match result_value.unpack() {
                 GenericArgKind::Type(result_value) => {
                     // e.g., here `result_value` might be `?0` in the example above...
-                    if let ty::Bound(debruijn, b) = *result_value.kind() {
+                    if let ty::Bound(debruijn, b) = result_value.kind() {
                         // ...in which case we would set `canonical_vars[0]` to `Some(?U)`.
 
                         // We only allow a `ty::INNERMOST` index in generic parameters.

--- a/compiler/rustc_infer/src/infer/freshen.rs
+++ b/compiler/rustc_infer/src/infer/freshen.rs
@@ -129,7 +129,7 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for TypeFreshener<'a, 'tcx> {
         if !t.has_infer() && !t.has_erasable_regions() {
             t
         } else {
-            match *t.kind() {
+            match t.kind() {
                 ty::Infer(v) => self.fold_infer_ty(v).unwrap_or(t),
 
                 // This code is hot enough that a non-debug assertion here makes a noticeable

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -837,7 +837,7 @@ impl<'tcx> InferCtxt<'tcx> {
         let r_a = self.shallow_resolve(predicate.skip_binder().a);
         let r_b = self.shallow_resolve(predicate.skip_binder().b);
         match (r_a.kind(), r_b.kind()) {
-            (&ty::Infer(ty::TyVar(a_vid)), &ty::Infer(ty::TyVar(b_vid))) => {
+            (ty::Infer(ty::TyVar(a_vid)), ty::Infer(ty::TyVar(b_vid))) => {
                 return Err((a_vid, b_vid));
             }
             _ => {}
@@ -1121,7 +1121,7 @@ impl<'tcx> InferCtxt<'tcx> {
     }
 
     pub fn shallow_resolve(&self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        if let ty::Infer(v) = *ty.kind() {
+        if let ty::Infer(v) = ty.kind() {
             match v {
                 ty::TyVar(v) => {
                     // Not entirely obvious: if `typ` is a type variable,
@@ -1371,7 +1371,7 @@ impl<'tcx> InferCtxt<'tcx> {
     /// closure in the current function, in which case its
     /// `ClosureKind` may not yet be known.
     pub fn closure_kind(&self, closure_ty: Ty<'tcx>) -> Option<ty::ClosureKind> {
-        let unresolved_kind_ty = match *closure_ty.kind() {
+        let unresolved_kind_ty = match closure_ty.kind() {
             ty::Closure(_, args) => args.as_closure().kind_ty(),
             ty::CoroutineClosure(_, args) => args.as_coroutine_closure().kind_ty(),
             _ => bug!("unexpected type {closure_ty}"),
@@ -1594,7 +1594,7 @@ impl<'tcx> TyOrConstInferVar {
     /// Tries to extract an inference variable from a type, returns `None`
     /// for types other than `ty::Infer(_)` (or `InferTy::Fresh*`).
     fn maybe_from_ty(ty: Ty<'tcx>) -> Option<Self> {
-        match *ty.kind() {
+        match ty.kind() {
             ty::Infer(ty::TyVar(v)) => Some(TyOrConstInferVar::Ty(v)),
             ty::Infer(ty::IntVar(v)) => Some(TyOrConstInferVar::TyInt(v)),
             ty::Infer(ty::FloatVar(v)) => Some(TyOrConstInferVar::TyFloat(v)),

--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -58,7 +58,7 @@ impl<'tcx> InferCtxt<'tcx> {
             tcx: self.tcx,
             lt_op: |lt| lt,
             ct_op: |ct| ct,
-            ty_op: |ty| match *ty.kind() {
+            ty_op: |ty| match ty.kind() {
                 ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. })
                     if self.can_define_opaque_ty(def_id) && !ty.has_escaping_bound_vars() =>
                 {
@@ -97,7 +97,7 @@ impl<'tcx> InferCtxt<'tcx> {
         span: Span,
         param_env: ty::ParamEnv<'tcx>,
     ) -> Result<Vec<Goal<'tcx, ty::Predicate<'tcx>>>, TypeError<'tcx>> {
-        let process = |a: Ty<'tcx>, b: Ty<'tcx>| match *a.kind() {
+        let process = |a: Ty<'tcx>, b: Ty<'tcx>| match a.kind() {
             ty::Alias(ty::Opaque, ty::AliasTy { def_id, args, .. }) if def_id.is_local() => {
                 let def_id = def_id.expect_local();
                 if self.intercrate {
@@ -147,7 +147,7 @@ impl<'tcx> InferCtxt<'tcx> {
                     return None;
                 }
 
-                if let ty::Alias(ty::Opaque, ty::AliasTy { def_id: b_def_id, .. }) = *b.kind() {
+                if let ty::Alias(ty::Opaque, ty::AliasTy { def_id: b_def_id, .. }) = b.kind() {
                     // We could accept this, but there are various ways to handle this situation, and we don't
                     // want to make a decision on it right now. Likely this case is so super rare anyway, that
                     // no one encounters it in practice.
@@ -438,7 +438,7 @@ where
 
             ty::Alias(ty::Opaque, ty::AliasTy { def_id, args, .. }) => {
                 // Skip lifetime parameters that are not captures.
-                let variances = self.tcx.variances_of(*def_id);
+                let variances = self.tcx.variances_of(def_id);
 
                 for (v, s) in std::iter::zip(variances, args.iter()) {
                     if *v != ty::Bivariant {
@@ -577,7 +577,7 @@ impl<'tcx> InferCtxt<'tcx> {
         for (predicate, _) in item_bounds.iter_instantiated_copied(tcx, args) {
             let predicate = predicate.fold_with(&mut BottomUpFolder {
                 tcx,
-                ty_op: |ty| match *ty.kind() {
+                ty_op: |ty| match ty.kind() {
                     // We can't normalize associated types from `rustc_infer`,
                     // but we can eagerly register inference variables for them.
                     // FIXME(RPITIT): Don't replace RPITITs with inference vars.

--- a/compiler/rustc_infer/src/infer/outlives/for_liveness.rs
+++ b/compiler/rustc_infer/src/infer/outlives/for_liveness.rs
@@ -97,7 +97,7 @@ where
                 } else {
                     // Skip lifetime parameters that are not captures.
                     let variances = match kind {
-                        ty::Opaque => Some(self.tcx.variances_of(*def_id)),
+                        ty::Opaque => Some(self.tcx.variances_of(def_id)),
                         _ => None,
                     };
 

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -406,7 +406,7 @@ where
             // will be invoked with `['b => ^1]` and so we will get `^1` returned.
             let bound = bound_outlives.skip_binder();
             let ty::Alias(_, alias_ty) = bound.0.kind() else { bug!("expected AliasTy") };
-            self.verify_bound.declared_bounds_from_definition(*alias_ty).all(|r| r != bound.1)
+            self.verify_bound.declared_bounds_from_definition(alias_ty).all(|r| r != bound.1)
         });
 
         // If declared bounds list is empty, the only applicable rule is

--- a/compiler/rustc_infer/src/infer/outlives/verify.rs
+++ b/compiler/rustc_infer/src/infer/outlives/verify.rs
@@ -230,7 +230,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
                     (r, p)
                 );
                 // Fast path for the common case.
-                match (&p, erased_ty.kind()) {
+                match (p, erased_ty.kind()) {
                     // In outlive routines, all types are expected to be fully normalized.
                     // And therefore we can safely use structural equality for alias types.
                     (GenericKind::Param(p1), ty::Param(p2)) if p1 == p2 => {}

--- a/compiler/rustc_infer/src/infer/relate/combine.rs
+++ b/compiler/rustc_infer/src/infer/relate/combine.rs
@@ -82,37 +82,37 @@ impl<'tcx> InferCtxt<'tcx> {
 
         match (a.kind(), b.kind()) {
             // Relate integral variables to other types
-            (&ty::Infer(ty::IntVar(a_id)), &ty::Infer(ty::IntVar(b_id))) => {
+            (ty::Infer(ty::IntVar(a_id)), ty::Infer(ty::IntVar(b_id))) => {
                 self.inner.borrow_mut().int_unification_table().union(a_id, b_id);
                 Ok(a)
             }
-            (&ty::Infer(ty::IntVar(v_id)), &ty::Int(v)) => {
+            (ty::Infer(ty::IntVar(v_id)), ty::Int(v)) => {
                 self.unify_integral_variable(v_id, IntType(v));
                 Ok(b)
             }
-            (&ty::Int(v), &ty::Infer(ty::IntVar(v_id))) => {
+            (ty::Int(v), ty::Infer(ty::IntVar(v_id))) => {
                 self.unify_integral_variable(v_id, IntType(v));
                 Ok(a)
             }
-            (&ty::Infer(ty::IntVar(v_id)), &ty::Uint(v)) => {
+            (ty::Infer(ty::IntVar(v_id)), ty::Uint(v)) => {
                 self.unify_integral_variable(v_id, UintType(v));
                 Ok(b)
             }
-            (&ty::Uint(v), &ty::Infer(ty::IntVar(v_id))) => {
+            (ty::Uint(v), ty::Infer(ty::IntVar(v_id))) => {
                 self.unify_integral_variable(v_id, UintType(v));
                 Ok(a)
             }
 
             // Relate floating-point variables to other types
-            (&ty::Infer(ty::FloatVar(a_id)), &ty::Infer(ty::FloatVar(b_id))) => {
+            (ty::Infer(ty::FloatVar(a_id)), ty::Infer(ty::FloatVar(b_id))) => {
                 self.inner.borrow_mut().float_unification_table().union(a_id, b_id);
                 Ok(a)
             }
-            (&ty::Infer(ty::FloatVar(v_id)), &ty::Float(v)) => {
+            (ty::Infer(ty::FloatVar(v_id)), ty::Float(v)) => {
                 self.unify_float_variable(v_id, ty::FloatVarValue::Known(v));
                 Ok(b)
             }
-            (&ty::Float(v), &ty::Infer(ty::FloatVar(v_id))) => {
+            (ty::Float(v), ty::Infer(ty::FloatVar(v_id))) => {
                 self.unify_float_variable(v_id, ty::FloatVarValue::Known(v));
                 Ok(a)
             }
@@ -146,7 +146,7 @@ impl<'tcx> InferCtxt<'tcx> {
             }
 
             // All other cases of inference are errors
-            (&ty::Infer(_), _) | (_, &ty::Infer(_)) => {
+            (ty::Infer(_), _) | (_, ty::Infer(_)) => {
                 Err(TypeError::Sorts(ExpectedFound::new(true, a, b)))
             }
 
@@ -154,7 +154,7 @@ impl<'tcx> InferCtxt<'tcx> {
             // equal to any other type (except for possibly itself). This is an
             // extremely heavy hammer, but can be relaxed in a fowards-compatible
             // way later.
-            (&ty::Alias(ty::Opaque, _), _) | (_, &ty::Alias(ty::Opaque, _)) if self.intercrate => {
+            (ty::Alias(ty::Opaque, _), _) | (_, ty::Alias(ty::Opaque, _)) if self.intercrate => {
                 relation.register_predicates([ty::Binder::dummy(ty::PredicateKind::Ambiguous)]);
                 Ok(a)
             }

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -60,7 +60,7 @@ impl<'tcx> InferCtxt<'tcx> {
             )?;
 
         // Constrain `b_vid` to the generalized type `generalized_ty`.
-        if let &ty::Infer(ty::TyVar(generalized_vid)) = generalized_ty.kind() {
+        if let ty::Infer(ty::TyVar(generalized_vid)) = generalized_ty.kind() {
             self.inner.borrow_mut().type_variables().equate(target_vid, generalized_vid);
         } else {
             self.inner.borrow_mut().type_variables().instantiate(target_vid, generalized_ty);
@@ -100,7 +100,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 relation.register_predicates([ty::PredicateKind::AliasRelate(lhs, rhs, direction)]);
             } else {
                 match source_ty.kind() {
-                    &ty::Alias(ty::Projection, data) => {
+                    ty::Alias(ty::Projection, data) => {
                         // FIXME: This does not handle subtyping correctly, we could
                         // instead create a new inference variable `?normalized_source`, emitting
                         // `Projection(normalized_source, ?ty_normalized)` and `?normalized_source <: generalized_ty`.
@@ -458,7 +458,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Generalizer<'_, 'tcx> {
         // any other type variable related to `vid` via
         // subtyping. This is basically our "occurs check", preventing
         // us from creating infinitely sized types.
-        let g = match *t.kind() {
+        let g = match t.kind() {
             ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
                 bug!("unexpected infer type: {t}")
             }

--- a/compiler/rustc_infer/src/infer/relate/lattice.rs
+++ b/compiler/rustc_infer/src/infer/relate/lattice.rs
@@ -83,24 +83,24 @@ where
         // is (e.g.) `Box<i32>`. A more obvious solution might be to
         // iterate on the subtype obligations that are returned, but I
         // think this suffices. -nmatsakis
-        (&ty::Infer(TyVar(..)), _) => {
+        (ty::Infer(TyVar(..)), _) => {
             let v = infcx.next_ty_var(this.cause().span);
             this.relate_bound(v, b, a)?;
             Ok(v)
         }
-        (_, &ty::Infer(TyVar(..))) => {
+        (_, ty::Infer(TyVar(..))) => {
             let v = infcx.next_ty_var(this.cause().span);
             this.relate_bound(v, a, b)?;
             Ok(v)
         }
 
         (
-            &ty::Alias(ty::Opaque, ty::AliasTy { def_id: a_def_id, .. }),
-            &ty::Alias(ty::Opaque, ty::AliasTy { def_id: b_def_id, .. }),
+            ty::Alias(ty::Opaque, ty::AliasTy { def_id: a_def_id, .. }),
+            ty::Alias(ty::Opaque, ty::AliasTy { def_id: b_def_id, .. }),
         ) if a_def_id == b_def_id => infcx.super_combine_tys(this, a, b),
 
-        (&ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }), _)
-        | (_, &ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }))
+        (ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }), _)
+        | (_, ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }))
             if this.define_opaque_types() == DefineOpaqueTypes::Yes
                 && def_id.is_local()
                 && !this.infcx().next_trait_solver() =>

--- a/compiler/rustc_infer/src/infer/relate/type_relating.rs
+++ b/compiler/rustc_infer/src/infer/relate/type_relating.rs
@@ -78,7 +78,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for TypeRelating<'_, '_, 'tcx> {
         let b = infcx.shallow_resolve(b);
 
         match (a.kind(), b.kind()) {
-            (&ty::Infer(TyVar(a_id)), &ty::Infer(TyVar(b_id))) => {
+            (ty::Infer(TyVar(a_id)), ty::Infer(TyVar(b_id))) => {
                 match self.ambient_variance {
                     ty::Covariant => {
                         // can't make progress on `A <: B` if both A and B are
@@ -115,10 +115,10 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for TypeRelating<'_, '_, 'tcx> {
                 }
             }
 
-            (&ty::Infer(TyVar(a_vid)), _) => {
+            (ty::Infer(TyVar(a_vid)), _) => {
                 infcx.instantiate_ty_var(self, true, a_vid, self.ambient_variance, b)?;
             }
-            (_, &ty::Infer(TyVar(b_vid))) => {
+            (_, ty::Infer(TyVar(b_vid))) => {
                 infcx.instantiate_ty_var(
                     self,
                     false,
@@ -128,20 +128,20 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for TypeRelating<'_, '_, 'tcx> {
                 )?;
             }
 
-            (&ty::Error(e), _) | (_, &ty::Error(e)) => {
+            (ty::Error(e), _) | (_, ty::Error(e)) => {
                 infcx.set_tainted_by_errors(e);
                 return Ok(Ty::new_error(self.cx(), e));
             }
 
             (
-                &ty::Alias(ty::Opaque, ty::AliasTy { def_id: a_def_id, .. }),
-                &ty::Alias(ty::Opaque, ty::AliasTy { def_id: b_def_id, .. }),
+                ty::Alias(ty::Opaque, ty::AliasTy { def_id: a_def_id, .. }),
+                ty::Alias(ty::Opaque, ty::AliasTy { def_id: b_def_id, .. }),
             ) if a_def_id == b_def_id => {
                 infcx.super_combine_tys(self, a, b)?;
             }
 
-            (&ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }), _)
-            | (_, &ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }))
+            (ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }), _)
+            | (_, ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }))
                 if self.fields.define_opaque_types == DefineOpaqueTypes::Yes
                     && def_id.is_local()
                     && !infcx.next_trait_solver() =>

--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -131,7 +131,7 @@ impl<'a, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for FullTypeResolver<'a, 'tcx> {
             Ok(t) // micro-optimize -- if there is nothing in this type that this fold affects...
         } else {
             let t = self.infcx.shallow_resolve(t);
-            match *t.kind() {
+            match t.kind() {
                 ty::Infer(ty::TyVar(vid)) => Err(FixupError::UnresolvedTy(vid)),
                 ty::Infer(ty::IntVar(vid)) => Err(FixupError::UnresolvedIntTy(vid)),
                 ty::Infer(ty::FloatVar(vid)) => Err(FixupError::UnresolvedFloatTy(vid)),

--- a/compiler/rustc_infer/src/infer/snapshot/fudge.rs
+++ b/compiler/rustc_infer/src/infer/snapshot/fudge.rs
@@ -185,7 +185,7 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for InferenceFudger<'a, 'tcx> {
     }
 
     fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        match *ty.kind() {
+        match ty.kind() {
             ty::Infer(ty::InferTy::TyVar(vid)) => {
                 if self.type_vars.0.contains(&vid) {
                     // This variable was created during the fudging.

--- a/compiler/rustc_infer/src/infer/type_variable.rs
+++ b/compiler/rustc_infer/src/infer/type_variable.rs
@@ -186,7 +186,7 @@ impl<'tcx> TypeVariableTable<'_, 'tcx> {
     /// instantiated, then return the with which it was
     /// instantiated. Otherwise, returns `t`.
     pub fn replace_if_possible(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
-        match *t.kind() {
+        match t.kind() {
             ty::Infer(ty::TyVar(v)) => match self.probe(v) {
                 TypeVariableValue::Unknown { .. } => t,
                 TypeVariableValue::Known { value } => value,

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -492,7 +492,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
                 let impl_ty = cx.tcx.type_of(parent).instantiate_identity();
                 let outerdef = match impl_ty.kind() {
                     ty::Adt(def, _) => Some(def.did()),
-                    ty::Foreign(def_id) => Some(*def_id),
+                    ty::Foreign(def_id) => Some(def_id),
                     _ => None,
                 };
                 let is_hidden = match outerdef {
@@ -1131,7 +1131,7 @@ declare_lint_pass!(MutableTransmutes => [MUTABLE_TRANSMUTES]);
 
 impl<'tcx> LateLintPass<'tcx> for MutableTransmutes {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &hir::Expr<'_>) {
-        if let Some((&ty::Ref(_, _, from_mutbl), &ty::Ref(_, _, to_mutbl))) =
+        if let Some((ty::Ref(_, _, from_mutbl), ty::Ref(_, _, to_mutbl))) =
             get_transmute_from_to(cx, expr).map(|(ty1, ty2)| (ty1.kind(), ty2.kind()))
         {
             if from_mutbl < to_mutbl {
@@ -2564,7 +2564,7 @@ impl<'tcx> LateLintPass<'tcx> for InvalidValue {
                     let span = cx.tcx.def_span(adt_def.did());
                     let mut potential_variants = adt_def.variants().iter().filter_map(|variant| {
                         let definitely_inhabited = match variant
-                            .inhabited_predicate(cx.tcx, *adt_def)
+                            .inhabited_predicate(cx.tcx, adt_def)
                             .instantiate(cx.tcx, args)
                             .apply_any_module(cx.tcx, cx.param_env)
                         {
@@ -2621,7 +2621,7 @@ impl<'tcx> LateLintPass<'tcx> for InvalidValue {
                 Array(ty, len) => {
                     if matches!(len.try_eval_target_usize(cx.tcx, cx.param_env), Some(v) if v > 0) {
                         // Array length known at array non-empty -- recurse.
-                        ty_find_init_error(cx, *ty, init)
+                        ty_find_init_error(cx, ty, init)
                     } else {
                         // Empty array or size unknown.
                         None

--- a/compiler/rustc_lint/src/for_loops_over_fallibles.rs
+++ b/compiler/rustc_lint/src/for_loops_over_fallibles.rs
@@ -52,9 +52,9 @@ impl<'tcx> LateLintPass<'tcx> for ForLoopsOverFallibles {
         let ty = cx.typeck_results().expr_ty(arg);
 
         let (adt, args, ref_mutability) = match ty.kind() {
-            &ty::Adt(adt, args) => (adt, args, None),
-            &ty::Ref(_, ty, mutability) => match ty.kind() {
-                &ty::Adt(adt, args) => (adt, args, Some(mutability)),
+            ty::Adt(adt, args) => (adt, args, None),
+            ty::Ref(_, ty, mutability) => match ty.kind() {
+                ty::Adt(adt, args) => (adt, args, Some(mutability)),
                 _ => return,
             },
             _ => return,

--- a/compiler/rustc_lint/src/foreign_modules.rs
+++ b/compiler/rustc_lint/src/foreign_modules.rs
@@ -229,7 +229,7 @@ fn structurally_same_type_impl<'tcx>(
     // type unless the newtype makes the type non-null.
     let non_transparent_ty = |mut ty: Ty<'tcx>| -> Ty<'tcx> {
         loop {
-            if let ty::Adt(def, args) = *ty.kind() {
+            if let ty::Adt(def, args) = ty.kind() {
                 let is_transparent = def.repr().transparent();
                 let is_non_null = types::nonnull_optimization_guaranteed(tcx, def);
                 debug!(
@@ -283,7 +283,7 @@ fn structurally_same_type_impl<'tcx>(
 
         #[allow(rustc::usage_of_ty_tykind)]
         let is_primitive_or_pointer =
-            |kind: &ty::TyKind<'_>| kind.is_primitive() || matches!(kind, RawPtr(..) | Ref(..));
+            |kind: ty::TyKind<'_>| kind.is_primitive() || matches!(kind, RawPtr(..) | Ref(..));
 
         ensure_sufficient_stack(|| {
             match (a_kind, b_kind) {
@@ -318,23 +318,23 @@ fn structurally_same_type_impl<'tcx>(
                     // For arrays, we also check the constness of the type.
                     a_const.kind() == b_const.kind()
                         && structurally_same_type_impl(
-                            seen_types, tcx, param_env, *a_ty, *b_ty, ckind,
+                            seen_types, tcx, param_env, a_ty, b_ty, ckind,
                         )
                 }
                 (Slice(a_ty), Slice(b_ty)) => {
-                    structurally_same_type_impl(seen_types, tcx, param_env, *a_ty, *b_ty, ckind)
+                    structurally_same_type_impl(seen_types, tcx, param_env, a_ty, b_ty, ckind)
                 }
                 (RawPtr(a_ty, a_mutbl), RawPtr(b_ty, b_mutbl)) => {
                     a_mutbl == b_mutbl
                         && structurally_same_type_impl(
-                            seen_types, tcx, param_env, *a_ty, *b_ty, ckind,
+                            seen_types, tcx, param_env, a_ty, b_ty, ckind,
                         )
                 }
                 (Ref(_a_region, a_ty, a_mut), Ref(_b_region, b_ty, b_mut)) => {
                     // For structural sameness, we don't need the region to be same.
                     a_mut == b_mut
                         && structurally_same_type_impl(
-                            seen_types, tcx, param_env, *a_ty, *b_ty, ckind,
+                            seen_types, tcx, param_env, a_ty, b_ty, ckind,
                         )
                 }
                 (FnDef(..), FnDef(..)) => {

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -192,7 +192,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for VisitOpaqueTypes<'tcx> {
             return;
         }
 
-        if let ty::Alias(ty::Projection, opaque_ty) = *t.kind()
+        if let ty::Alias(ty::Projection, opaque_ty) = t.kind()
             && self.tcx.is_impl_trait_in_trait(opaque_ty.def_id)
         {
             // visit the opaque of the RPITIT
@@ -200,7 +200,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for VisitOpaqueTypes<'tcx> {
                 .type_of(opaque_ty.def_id)
                 .instantiate(self.tcx, opaque_ty.args)
                 .visit_with(self)
-        } else if let ty::Alias(ty::Opaque, opaque_ty) = *t.kind()
+        } else if let ty::Alias(ty::Opaque, opaque_ty) = t.kind()
             && let Some(opaque_def_id) = opaque_ty.def_id.as_local()
             // Don't recurse infinitely on an opaque
             && self.seen.insert(opaque_def_id)
@@ -402,7 +402,7 @@ fn extract_def_id_from_arg<'tcx>(
             _ => unreachable!(),
         },
         ty::GenericArgKind::Type(ty) => {
-            let ty::Param(param_ty) = *ty.kind() else {
+            let ty::Param(param_ty) = ty.kind() else {
                 bug!();
             };
             generics.type_param(param_ty, tcx).def_id

--- a/compiler/rustc_lint/src/internal.rs
+++ b/compiler/rustc_lint/src/internal.rs
@@ -69,7 +69,7 @@ fn typeck_results_of_method_fn<'tcx>(
             Some((segment.ident.span, def_id, cx.typeck_results().node_args(expr.hir_id)))
         }
         _ => match cx.typeck_results().node_type(expr.hir_id).kind() {
-            &ty::FnDef(def_id, args) => Some((expr.span, def_id, args)),
+            ty::FnDef(def_id, args) => Some((expr.span, def_id, args)),
             _ => None,
         },
     }
@@ -419,7 +419,7 @@ impl LateLintPass<'_> for Diagnostics {
         let (span, def_id, fn_gen_args, call_tys) = match expr.kind {
             ExprKind::Call(callee, args) => {
                 match cx.typeck_results().node_type(callee.hir_id).kind() {
-                    &ty::FnDef(def_id, fn_gen_args) => {
+                    ty::FnDef(def_id, fn_gen_args) => {
                         let call_tys: Vec<_> =
                             args.iter().map(|arg| cx.typeck_results().expr_ty(arg)).collect();
                         (callee.span, def_id, fn_gen_args, call_tys)

--- a/compiler/rustc_lint/src/map_unit_fn.rs
+++ b/compiler/rustc_lint/src/map_unit_fn.rs
@@ -64,10 +64,7 @@ impl<'tcx> LateLintPass<'tcx> for MapUnitFn {
                                 MAP_UNIT_FN,
                                 span,
                                 MappingToUnit {
-                                    function_label: cx
-                                        .tcx
-                                        .span_of_impl(*id)
-                                        .unwrap_or(default_span),
+                                    function_label: cx.tcx.span_of_impl(id).unwrap_or(default_span),
                                     argument_label: args[0].span,
                                     map_label: arg_ty.default_span(cx.tcx),
                                     suggestion: path.ident.span,
@@ -83,10 +80,7 @@ impl<'tcx> LateLintPass<'tcx> for MapUnitFn {
                                 MAP_UNIT_FN,
                                 span,
                                 MappingToUnit {
-                                    function_label: cx
-                                        .tcx
-                                        .span_of_impl(*id)
-                                        .unwrap_or(default_span),
+                                    function_label: cx.tcx.span_of_impl(id).unwrap_or(default_span),
                                     argument_label: args[0].span,
                                     map_label: arg_ty.default_span(cx.tcx),
                                     suggestion: path.ident.span,

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -51,7 +51,7 @@ declare_lint_pass!(NonPanicFmt => [NON_FMT_PANICS]);
 impl<'tcx> LateLintPass<'tcx> for NonPanicFmt {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
         if let hir::ExprKind::Call(f, [arg]) = &expr.kind {
-            if let &ty::FnDef(def_id, _) = cx.typeck_results().expr_ty(f).kind() {
+            if let ty::FnDef(def_id, _) = cx.typeck_results().expr_ty(f).kind() {
                 let f_diagnostic_name = cx.tcx.get_diagnostic_name(def_id);
 
                 if cx.tcx.is_lang_item(def_id, LangItem::BeginPanic)

--- a/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
+++ b/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
@@ -87,7 +87,7 @@ impl<'tcx> LateLintPass<'tcx> for OpaqueHiddenInferredBound {
                 let Some(proj_term) = proj.term.as_type() else { return };
 
                 // HACK: `impl Trait<Assoc = impl Trait2>` from an RPIT is "ok"...
-                if let ty::Alias(ty::Opaque, opaque_ty) = *proj_term.kind()
+                if let ty::Alias(ty::Opaque, opaque_ty) = proj_term.kind()
                     && cx.tcx.parent(opaque_ty.def_id) == def_id
                     && matches!(
                         opaque.origin,
@@ -100,7 +100,7 @@ impl<'tcx> LateLintPass<'tcx> for OpaqueHiddenInferredBound {
                 // HACK: `async fn() -> Self` in traits is "ok"...
                 // This is not really that great, but it's similar to why the `-> Self`
                 // return type is well-formed in traits even when `Self` isn't sized.
-                if let ty::Param(param_ty) = *proj_term.kind()
+                if let ty::Param(param_ty) = proj_term.kind()
                     && param_ty.name == kw::SelfUpper
                     && matches!(opaque.origin, hir::OpaqueTyOrigin::AsyncFn(_))
                     && opaque.in_trait
@@ -158,7 +158,7 @@ impl<'tcx> LateLintPass<'tcx> for OpaqueHiddenInferredBound {
                                 ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }),
                                 ty::ClauseKind::Trait(trait_pred),
                             ) => Some(AddBound {
-                                suggest_span: cx.tcx.def_span(*def_id).shrink_to_hi(),
+                                suggest_span: cx.tcx.def_span(def_id).shrink_to_hi(),
                                 trait_ref: trait_pred.print_modifiers_and_trait_path(),
                             }),
                             _ => None,

--- a/compiler/rustc_lint/src/reference_casting.rs
+++ b/compiler/rustc_lint/src/reference_casting.rs
@@ -218,7 +218,7 @@ fn is_cast_to_bigger_memory_layout<'tcx>(
         return None;
     }
 
-    let from_layout = cx.layout_of(*inner_start_ty).ok()?;
+    let from_layout = cx.layout_of(inner_start_ty).ok()?;
 
     // if the type isn't sized, we bail out, instead of potentially giving
     // the user a meaningless warning.
@@ -227,7 +227,7 @@ fn is_cast_to_bigger_memory_layout<'tcx>(
     }
 
     let alloc_layout = cx.layout_of(alloc_ty).ok()?;
-    let to_layout = cx.layout_of(*inner_end_ty).ok()?;
+    let to_layout = cx.layout_of(inner_end_ty).ok()?;
 
     if to_layout.layout.size() > from_layout.layout.size()
         && to_layout.layout.size() > alloc_layout.layout.size()

--- a/compiler/rustc_lint/src/shadowed_into_iter.rs
+++ b/compiler/rustc_lint/src/shadowed_into_iter.rs
@@ -92,13 +92,13 @@ impl<'tcx> LateLintPass<'tcx> for ShadowedIntoIter {
             [receiver_ty].into_iter().chain(adjustments.iter().map(|adj| adj.target)).collect();
 
         fn is_ref_to_array(ty: Ty<'_>) -> bool {
-            if let ty::Ref(_, pointee_ty, _) = *ty.kind() { pointee_ty.is_array() } else { false }
+            if let ty::Ref(_, pointee_ty, _) = ty.kind() { pointee_ty.is_array() } else { false }
         }
         fn is_boxed_slice(ty: Ty<'_>) -> bool {
             ty.is_box() && ty.boxed_ty().is_slice()
         }
         fn is_ref_to_boxed_slice(ty: Ty<'_>) -> bool {
-            if let ty::Ref(_, pointee_ty, _) = *ty.kind() {
+            if let ty::Ref(_, pointee_ty, _) = ty.kind() {
                 is_boxed_slice(pointee_ty)
             } else {
                 false

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -116,7 +116,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
             && let ty = cx.typeck_results().expr_ty(await_expr)
             && let ty::Alias(ty::Opaque, ty::AliasTy { def_id: future_def_id, .. }) = ty.kind()
             && cx.tcx.ty_is_opaque_future(ty)
-            && let async_fn_def_id = cx.tcx.parent(*future_def_id)
+            && let async_fn_def_id = cx.tcx.parent(future_def_id)
             && matches!(cx.tcx.def_kind(async_fn_def_id), DefKind::Fn | DefKind::AssocFn)
             // Check that this `impl Future` actually comes from an `async fn`
             && cx.tcx.asyncness(async_fn_def_id).is_async()
@@ -282,7 +282,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
                 return Some(MustUsePath::Suppressed);
             }
 
-            match *ty.kind() {
+            match ty.kind() {
                 ty::Adt(..) if ty.is_box() => {
                     let boxed_ty = ty.boxed_ty();
                     is_ty_must_use(cx, boxed_ty, expr, span)

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -1299,7 +1299,7 @@ impl<'tcx> ExtraComments<'tcx> {
 }
 
 fn use_verbose(ty: Ty<'_>, fn_def: bool) -> bool {
-    match *ty.kind() {
+    match ty.kind() {
         ty::Int(_) | ty::Uint(_) | ty::Bool | ty::Char | ty::Float(_) => false,
         // Unit type
         ty::Tuple(g_args) if g_args.is_empty() => false,
@@ -1768,13 +1768,13 @@ fn pretty_print_const_value_tcx<'tcx>(
                 return Ok(());
             }
         }
-        (_, ty::Ref(_, inner_ty, _)) if matches!(inner_ty.kind(), ty::Slice(t) if *t == u8_type) => {
+        (_, ty::Ref(_, inner_ty, _)) if matches!(inner_ty.kind(), ty::Slice(t) if t == u8_type) => {
             if let Some(data) = ct.try_get_slice_bytes_for_diagnostics(tcx) {
                 pretty_print_byte_str(fmt, data)?;
                 return Ok(());
             }
         }
-        (ConstValue::Indirect { alloc_id, offset }, ty::Array(t, n)) if *t == u8_type => {
+        (ConstValue::Indirect { alloc_id, offset }, ty::Array(t, n)) if t == u8_type => {
             let n = n.try_to_target_usize(tcx).unwrap();
             let alloc = tcx.global_alloc(alloc_id).unwrap_memory();
             // cast is ok because we already checked for pointer size (32 or 64 bit) above
@@ -1796,7 +1796,7 @@ fn pretty_print_const_value_tcx<'tcx>(
             let ty = tcx.lift(ty).unwrap();
             if let Some(contents) = tcx.try_destructure_mir_constant_for_user_output(ct, ty) {
                 let fields: Vec<(ConstValue<'_>, Ty<'_>)> = contents.fields.to_vec();
-                match *ty.kind() {
+                match ty.kind() {
                     ty::Array(..) => {
                         fmt.write_str("[")?;
                         comma_sep(tcx, fmt, fields)?;
@@ -1863,7 +1863,7 @@ fn pretty_print_const_value_tcx<'tcx>(
         (ConstValue::ZeroSized, ty::FnDef(d, s)) => {
             let mut cx = FmtPrinter::new(tcx, Namespace::ValueNS);
             cx.print_alloc_ids = true;
-            cx.print_value_path(*d, s)?;
+            cx.print_value_path(d, s)?;
             fmt.write_str(&cx.into_buffer())?;
             return Ok(());
         }

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -381,7 +381,7 @@ impl<'tcx> Operand<'tcx> {
     /// find as the `func` in a [`TerminatorKind::Call`].
     pub fn const_fn_def(&self) -> Option<(DefId, GenericArgsRef<'tcx>)> {
         let const_ty = self.constant()?.const_.ty();
-        if let ty::FnDef(def_id, args) = *const_ty.kind() { Some((def_id, args)) } else { None }
+        if let ty::FnDef(def_id, args) = const_ty.kind() { Some((def_id, args)) } else { None }
     }
 }
 

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -91,11 +91,11 @@ impl<'tcx> PlaceTy<'tcx> {
             ProjectionElem::Subslice { from, to, from_end } => {
                 PlaceTy::from_ty(match self.ty.kind() {
                     ty::Slice(..) => self.ty,
-                    ty::Array(inner, _) if !from_end => Ty::new_array(tcx, *inner, to - from),
+                    ty::Array(inner, _) if !from_end => Ty::new_array(tcx, inner, to - from),
                     ty::Array(inner, size) if from_end => {
                         let size = size.eval_target_usize(tcx, param_env);
                         let len = size - from - to;
-                        Ty::new_array(tcx, *inner, len)
+                        Ty::new_array(tcx, inner, len)
                     }
                     _ => bug!("cannot subslice non-array type: `{:?}`", self),
                 })

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -415,7 +415,7 @@ impl<'tcx> Key for Ty<'tcx> {
     }
 
     fn ty_def_id(&self) -> Option<DefId> {
-        match *self.kind() {
+        match self.kind() {
             ty::Adt(adt, _) => Some(adt.did()),
             ty::Coroutine(def_id, ..) => Some(def_id),
             _ => None,

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -848,7 +848,7 @@ impl<'tcx> PatRange<'tcx> {
     /// Whether this range covers the full extent of possible values (best-effort, we ignore floats).
     #[inline]
     pub fn is_full_range(&self, tcx: TyCtxt<'tcx>) -> Option<bool> {
-        let (min, max, size, bias) = match *self.ty.kind() {
+        let (min, max, size, bias) = match self.ty.kind() {
             ty::Char => (0, std::char::MAX as u128, Size::from_bits(32), 0),
             ty::Int(ity) => {
                 let size = Integer::from_int_ty(&tcx, ity).size();
@@ -1058,7 +1058,7 @@ impl<'tcx> PatRangeBoundary<'tcx> {
                 a.partial_cmp(&b)
             }
             ty::Int(ity) => {
-                let size = rustc_target::abi::Integer::from_int_ty(&tcx, *ity).size();
+                let size = rustc_target::abi::Integer::from_int_ty(&tcx, ity).size();
                 let a = size.sign_extend(a) as i128;
                 let b = size.sign_extend(b) as i128;
                 Some(a.cmp(&b))

--- a/compiler/rustc_middle/src/ty/cast.rs
+++ b/compiler/rustc_middle/src/ty/cast.rs
@@ -60,7 +60,7 @@ impl<'tcx> CastTy<'tcx> {
     /// Returns `Some` for integral/pointer casts.
     /// Casts like unsizing casts will return `None`.
     pub fn from_ty(t: Ty<'tcx>) -> Option<CastTy<'tcx>> {
-        match *t.kind() {
+        match t.kind() {
             ty::Bool => Some(CastTy::Int(IntTy::Bool)),
             ty::Char => Some(CastTy::Int(IntTy::Char)),
             ty::Int(_) => Some(CastTy::Int(IntTy::I)),

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -32,7 +32,7 @@ pub const SHORTHAND_OFFSET: usize = 0x80;
 
 pub trait EncodableWithShorthand<E: TyEncoder>: Copy + Eq + Hash {
     type Variant: Encodable<E>;
-    fn variant(&self) -> &Self::Variant;
+    fn variant(&self) -> Self::Variant; // njn: removed `&`
 }
 
 #[allow(rustc::usage_of_ty_tykind)]
@@ -40,7 +40,7 @@ impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> EncodableWithShorthand<E> for Ty<'tcx
     type Variant = ty::TyKind<'tcx>;
 
     #[inline]
-    fn variant(&self) -> &Self::Variant {
+    fn variant(&self) -> Self::Variant {
         self.kind()
     }
 }
@@ -49,8 +49,8 @@ impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> EncodableWithShorthand<E> for ty::Pre
     type Variant = ty::PredicateKind<'tcx>;
 
     #[inline]
-    fn variant(&self) -> &Self::Variant {
-        self
+    fn variant(&self) -> Self::Variant {
+        *self // njn: added `*`
     }
 }
 
@@ -91,7 +91,7 @@ where
 
     // The shorthand encoding uses the same usize as the
     // discriminant, with an offset so they can't conflict.
-    let discriminant = intrinsics::discriminant_value(variant);
+    let discriminant = intrinsics::discriminant_value(&variant);
     assert!(SHORTHAND_OFFSET > discriminant as usize);
 
     let shorthand = start + SHORTHAND_OFFSET;

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -91,12 +91,12 @@ impl<'tcx> ValTree<'tcx> {
                 // `&str` can be interpreted as raw bytes
                 ty::Str => {}
                 // `&[u8]` can be interpreted as raw bytes
-                ty::Slice(slice_ty) if *slice_ty == tcx.types.u8 => {}
+                ty::Slice(slice_ty) if slice_ty == tcx.types.u8 => {}
                 // other `&_` can't be interpreted as raw bytes
                 _ => return None,
             },
             // `[u8; N]` can be interpreted as raw bytes
-            ty::Array(array_ty, _) if *array_ty == tcx.types.u8 => {}
+            ty::Array(array_ty, _) if array_ty == tcx.types.u8 => {}
             // Otherwise, type cannot be interpreted as raw bytes
             _ => return None,
         }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2523,7 +2523,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn signature_unclosure(self, sig: PolyFnSig<'tcx>, safety: hir::Safety) -> PolyFnSig<'tcx> {
         sig.map_bound(|s| {
             let params = match s.inputs()[0].kind() {
-                ty::Tuple(params) => *params,
+                ty::Tuple(params) => params,
                 _ => bug!(),
             };
             self.mk_fn_sig(params, s.output(), s.c_variadic, safety, abi::Abi::Rust)

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -542,7 +542,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for IsSuggestableVisitor<'tcx> {
     type Result = ControlFlow<()>;
 
     fn visit_ty(&mut self, t: Ty<'tcx>) -> Self::Result {
-        match *t.kind() {
+        match t.kind() {
             Infer(InferTy::TyVar(_)) if self.infer_suggestable => {}
 
             FnDef(..)
@@ -561,7 +561,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for IsSuggestableVisitor<'tcx> {
                 let parent_ty = self.tcx.type_of(parent).instantiate_identity();
                 if let DefKind::TyAlias | DefKind::AssocTy = self.tcx.def_kind(parent)
                     && let Alias(Opaque, AliasTy { def_id: parent_opaque_def_id, .. }) =
-                        *parent_ty.kind()
+                        parent_ty.kind()
                     && parent_opaque_def_id == def_id
                 {
                     // Okay
@@ -627,7 +627,7 @@ impl<'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for MakeSuggestableFolder<'tcx> {
     }
 
     fn try_fold_ty(&mut self, t: Ty<'tcx>) -> Result<Ty<'tcx>, Self::Error> {
-        let t = match *t.kind() {
+        let t = match t.kind() {
             Infer(InferTy::TyVar(_)) if self.infer_suggestable => t,
 
             FnDef(def_id, args) if self.placeholder.is_none() => {
@@ -656,7 +656,7 @@ impl<'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for MakeSuggestableFolder<'tcx> {
                 if let hir::def::DefKind::TyAlias | hir::def::DefKind::AssocTy =
                     self.tcx.def_kind(parent)
                     && let Alias(Opaque, AliasTy { def_id: parent_opaque_def_id, .. }) =
-                        *parent_ty.kind()
+                        parent_ty.kind()
                     && parent_opaque_def_id == def_id
                 {
                     t

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -123,7 +123,7 @@ impl<'tcx> TypeError<'tcx> {
 
 impl<'tcx> Ty<'tcx> {
     pub fn sort_string(self, tcx: TyCtxt<'tcx>) -> Cow<'static, str> {
-        match *self.kind() {
+        match self.kind() {
             ty::Foreign(def_id) => format!("extern type `{}`", tcx.def_path_str(def_id)).into(),
             ty::FnDef(def_id, ..) => match tcx.def_kind(def_id) {
                 DefKind::Ctor(CtorOf::Struct, _) => "struct constructor".into(),
@@ -167,7 +167,7 @@ impl<'tcx> Ty<'tcx> {
     }
 
     pub fn prefix_string(self, tcx: TyCtxt<'_>) -> Cow<'static, str> {
-        match *self.kind() {
+        match self.kind() {
             ty::Infer(_)
             | ty::Error(_)
             | ty::Bool

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -191,7 +191,7 @@ where
     }
 
     fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
-        match *t.kind() {
+        match t.kind() {
             ty::Bound(debruijn, bound_ty) if debruijn == self.current_index => {
                 let ty = self.delegate.replace_ty(bound_ty);
                 debug_assert!(!ty.has_vars_bound_above(ty::INNERMOST));

--- a/compiler/rustc_middle/src/ty/inhabitedness/mod.rs
+++ b/compiler/rustc_middle/src/ty/inhabitedness/mod.rs
@@ -202,7 +202,7 @@ impl<'tcx> Ty<'tcx> {
 
 /// N.B. this query should only be called through `Ty::inhabited_predicate`
 fn inhabited_predicate_type<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> InhabitedPredicate<'tcx> {
-    match *ty.kind() {
+    match ty.kind() {
         Adt(adt, args) => tcx.inhabited_predicate_adt(adt.did()).instantiate(tcx, args),
 
         Tuple(tys) => {

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -808,7 +808,7 @@ impl<'tcx> Instance<'tcx> {
         trait_id: DefId,
         rcvr_args: ty::GenericArgsRef<'tcx>,
     ) -> Option<Instance<'tcx>> {
-        let ty::Coroutine(coroutine_def_id, args) = *rcvr_args.type_at(0).kind() else {
+        let ty::Coroutine(coroutine_def_id, args) = rcvr_args.type_at(0).kind() else {
             return None;
         };
         let coroutine_kind = tcx.coroutine_kind(coroutine_def_id).unwrap();
@@ -839,7 +839,7 @@ impl<'tcx> Instance<'tcx> {
         };
 
         if tcx.is_lang_item(trait_item_id, coroutine_callable_item) {
-            let ty::Coroutine(_, id_args) = *tcx.type_of(coroutine_def_id).skip_binder().kind()
+            let ty::Coroutine(_, id_args) = tcx.type_of(coroutine_def_id).skip_binder().kind()
             else {
                 bug!()
             };
@@ -984,7 +984,7 @@ fn polymorphize<'tcx>(
 
         fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
             debug!("fold_ty: ty={:?}", ty);
-            match *ty.kind() {
+            match ty.kind() {
                 ty::Closure(def_id, args) => {
                     let polymorphized_args =
                         polymorphize(self.tcx, ty::InstanceKind::Item(def_id), args);

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -358,7 +358,7 @@ impl<'tcx> SizeSkeleton<'tcx> {
             ) => return Err(e),
         };
 
-        match *ty.kind() {
+        match ty.kind() {
             ty::Ref(_, pointee, _) | ty::RawPtr(pointee, _) => {
                 let non_zero = !ty.is_unsafe_ptr();
 
@@ -385,7 +385,7 @@ impl<'tcx> SizeSkeleton<'tcx> {
                     }
                     ty::Error(guar) => {
                         // Fixes ICE #124031
-                        return Err(tcx.arena.alloc(LayoutError::ReferencesError(*guar)));
+                        return Err(tcx.arena.alloc(LayoutError::ReferencesError(guar)));
                     }
                     _ => bug!(
                         "SizeSkeleton::compute({ty}): layout errored ({err:?}), yet \
@@ -795,7 +795,7 @@ where
                 }
             };
 
-            match *this.ty.kind() {
+            match this.ty.kind() {
                 ty::Bool
                 | ty::Char
                 | ty::Int(_)
@@ -978,7 +978,7 @@ where
         let tcx = cx.tcx();
         let param_env = cx.param_env();
 
-        let pointee_info = match *this.ty.kind() {
+        let pointee_info = match this.ty.kind() {
             ty::RawPtr(p_ty, _) if offset.bytes() == 0 => {
                 tcx.layout_of(param_env.and(p_ty)).ok().map(|layout| PointeeInfo {
                     size: layout.size,
@@ -1104,7 +1104,7 @@ where
     }
 
     fn is_never(this: TyAndLayout<'tcx>) -> bool {
-        this.ty.kind() == &ty::Never
+        this.ty.kind() == ty::Never
     }
 
     fn is_tuple(this: TyAndLayout<'tcx>) -> bool {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -443,7 +443,7 @@ impl<'tcx> rustc_type_ir::inherent::IntoKind for Ty<'tcx> {
     type Kind = TyKind<'tcx>;
 
     fn kind(self) -> TyKind<'tcx> {
-        *self.kind()
+        self.kind()
     }
 }
 
@@ -615,7 +615,7 @@ impl<'tcx> Term<'tcx> {
 
     pub fn to_alias_term(self) -> Option<AliasTerm<'tcx>> {
         match self.unpack() {
-            TermKind::Ty(ty) => match *ty.kind() {
+            TermKind::Ty(ty) => match ty.kind() {
                 ty::Alias(_kind, alias_ty) => Some(alias_ty.into()),
                 _ => None,
             },
@@ -1859,7 +1859,7 @@ impl<'tcx> TyCtxt<'tcx> {
             // If we have a `Coroutine` that comes from an coroutine-closure,
             // then it may be a by-move or by-ref body.
             let ty::Coroutine(_, identity_args) =
-                *self.type_of(def_id).instantiate_identity().kind()
+                self.type_of(def_id).instantiate_identity().kind()
             else {
                 unreachable!();
             };

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -150,7 +150,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ReverseMapper<'tcx> {
     }
 
     fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        match *ty.kind() {
+        match ty.kind() {
             ty::Closure(def_id, args) => {
                 let args = self.fold_closure_args(def_id, args);
                 Ty::new_closure(self.tcx, def_id, args)

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -258,7 +258,7 @@ fn characteristic_def_id_of_type_cached<'a>(
     ty: Ty<'a>,
     visited: &mut SsoHashSet<Ty<'a>>,
 ) -> Option<DefId> {
-    match *ty.kind() {
+    match ty.kind() {
         ty::Adt(adt_def, _) => Some(adt_def.did()),
 
         ty::Dynamic(data, ..) => data.principal_def_id(),

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -660,7 +660,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     fn pretty_print_type(&mut self, ty: Ty<'tcx>) -> Result<(), PrintError> {
         define_scoped_cx!(self);
 
-        match *ty.kind() {
+        match ty.kind() {
             ty::Bool => p!("bool"),
             ty::Char => p!("char"),
             ty::Int(t) => p!(write("{}", t.name_str())),
@@ -775,7 +775,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                         // NOTE: I know we should check for NO_QUERIES here, but it's alright.
                         // `type_of` on a type alias or assoc type should never cause a cycle.
                         if let ty::Alias(ty::Opaque, ty::AliasTy { def_id: d, .. }) =
-                            *self.tcx().type_of(parent).instantiate_identity().kind()
+                            self.tcx().type_of(parent).instantiate_identity().kind()
                         {
                             if d == def_id {
                                 // If the type alias directly starts with the `impl` of the
@@ -1812,7 +1812,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         let u8_type = self.tcx().types.u8;
         match (valtree, ty.kind()) {
             (ty::ValTree::Branch(_), ty::Ref(_, inner_ty, _)) => match inner_ty.kind() {
-                ty::Slice(t) if *t == u8_type => {
+                ty::Slice(t) if t == u8_type => {
                     let bytes = valtree.try_to_raw_bytes(self.tcx(), ty).unwrap_or_else(|| {
                         bug!(
                             "expected to convert valtree {:?} to raw bytes for type {:?}",
@@ -1831,11 +1831,11 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 }
                 _ => {
                     p!("&");
-                    p!(pretty_print_const_valtree(valtree, *inner_ty, print_ty));
+                    p!(pretty_print_const_valtree(valtree, inner_ty, print_ty));
                     return Ok(());
                 }
             },
-            (ty::ValTree::Branch(_), ty::Array(t, _)) if *t == u8_type => {
+            (ty::ValTree::Branch(_), ty::Array(t, _)) if t == u8_type => {
                 let bytes = valtree.try_to_raw_bytes(self.tcx(), ty).unwrap_or_else(|| {
                     bug!("expected to convert valtree to raw bytes for type {:?}", t)
                 });
@@ -1848,7 +1848,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 let contents =
                     self.tcx().destructure_const(ty::Const::new_value(self.tcx(), valtree, ty));
                 let fields = contents.fields.iter().copied();
-                match *ty.kind() {
+                match ty.kind() {
                     ty::Array(..) => {
                         p!("[", comma_sep(fields), "]");
                     }
@@ -1899,7 +1899,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             }
             (ty::ValTree::Leaf(leaf), ty::Ref(_, inner_ty, _)) => {
                 p!(write("&"));
-                return self.pretty_print_const_scalar_int(leaf, *inner_ty, print_ty);
+                return self.pretty_print_const_scalar_int(leaf, inner_ty, print_ty);
             }
             (ty::ValTree::Leaf(leaf), _) => {
                 return self.pretty_print_const_scalar_int(leaf, ty, print_ty);
@@ -2550,7 +2550,7 @@ impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for RegionFolder<'a, 'tcx> {
     }
 
     fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
-        match *t.kind() {
+        match t.kind() {
             _ if t.has_vars_bound_at_or_above(self.current_index) || t.has_placeholders() => {
                 return t.super_fold_with(self);
             }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -83,7 +83,7 @@ impl fmt::Debug for ty::LateParamRegion {
 
 impl<'tcx> fmt::Debug for Ty<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        with_no_trimmed_paths!(fmt::Debug::fmt(self.kind(), f))
+        with_no_trimmed_paths!(fmt::Debug::fmt(&self.kind(), f)) // njn: added `&`
     }
 }
 
@@ -362,7 +362,7 @@ impl<'tcx> TypeSuperFoldable<TyCtxt<'tcx>> for Ty<'tcx> {
         self,
         folder: &mut F,
     ) -> Result<Self, F::Error> {
-        let kind = match *self.kind() {
+        let kind = match self.kind() {
             ty::RawPtr(ty, mutbl) => ty::RawPtr(ty.try_fold_with(folder)?, mutbl),
             ty::Array(typ, sz) => ty::Array(typ.try_fold_with(folder)?, sz.try_fold_with(folder)?),
             ty::Slice(typ) => ty::Slice(typ.try_fold_with(folder)?),
@@ -404,7 +404,7 @@ impl<'tcx> TypeSuperFoldable<TyCtxt<'tcx>> for Ty<'tcx> {
             | ty::Foreign(..) => return Ok(self),
         };
 
-        Ok(if *self.kind() == kind { self } else { folder.cx().mk_ty_from_kind(kind) })
+        Ok(if self.kind() == kind { self } else { folder.cx().mk_ty_from_kind(kind) })
     }
 }
 

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -751,7 +751,7 @@ impl<'tcx> IsIdentity for CanonicalUserType<'tcx> {
                         GenericArgKind::Type(ty) => match ty.kind() {
                             ty::Bound(debruijn, b) => {
                                 // We only allow a `ty::INNERMOST` index in generic parameters.
-                                assert_eq!(*debruijn, ty::INNERMOST);
+                                assert_eq!(debruijn, ty::INNERMOST);
                                 cvar == b.var
                             }
                             _ => false,

--- a/compiler/rustc_middle/src/ty/walk.rs
+++ b/compiler/rustc_middle/src/ty/walk.rs
@@ -120,7 +120,7 @@ impl<'tcx> ty::Const<'tcx> {
 /// types as they are written).
 fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>) {
     match parent.unpack() {
-        GenericArgKind::Type(parent_ty) => match *parent_ty.kind() {
+        GenericArgKind::Type(parent_ty) => match parent_ty.kind() {
             ty::Bool
             | ty::Char
             | ty::Int(_)

--- a/compiler/rustc_middle/src/util/find_self_call.rs
+++ b/compiler/rustc_middle/src/util/find_self_call.rs
@@ -20,7 +20,7 @@ pub fn find_self_call<'tcx>(
     {
         debug!("find_self_call: func={:?}", func);
         if let Operand::Constant(box ConstOperand { const_, .. }) = func {
-            if let ty::FnDef(def_id, fn_args) = *const_.ty().kind() {
+            if let ty::FnDef(def_id, fn_args) = const_.ty().kind() {
                 if let Some(ty::AssocItem { fn_has_self_parameter: true, .. }) =
                     tcx.opt_associated_item(def_id)
                 {

--- a/compiler/rustc_mir_build/src/build/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse.rs
@@ -46,7 +46,7 @@ macro_rules! parse_by_kind {
                 ExprKind::Call { ty, fun: _, args: $args, .. } if {
                     match ty.kind() {
                         ty::FnDef(did, _) => {
-                            $self.tcx.is_diagnostic_item(rustc_span::sym::$name, *did)
+                            $self.tcx.is_diagnostic_item(rustc_span::sym::$name, did)
                         }
                         _ => false,
                     }

--- a/compiler/rustc_mir_build/src/build/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_place.rs
@@ -435,7 +435,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     unpack!(block = this.expr_as_place(block, lhs, mutability, fake_borrow_temps,));
                 if let ty::Adt(adt_def, _) = lhs_expr.ty.kind() {
                     if adt_def.is_enum() {
-                        place_builder = place_builder.downcast(*adt_def, variant_index);
+                        place_builder = place_builder.downcast(adt_def, variant_index);
                     }
                 }
                 block.and(place_builder.field(name, expr.ty))

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -407,7 +407,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             (Some((region, elem_ty, _)), _) | (None, Some((region, elem_ty, _))) => {
                 let tcx = self.tcx;
                 // make both a slice
-                ty = Ty::new_imm_ref(tcx, *region, Ty::new_slice(tcx, *elem_ty));
+                ty = Ty::new_imm_ref(tcx, region, Ty::new_slice(tcx, elem_ty));
                 if opt_ref_ty.is_some() {
                     let temp = self.temp(ty, source_info.span);
                     self.cfg.push_assign(
@@ -446,7 +446,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // which have their comparison defined in `core`.
         // (Interestingly this means that exhaustiveness analysis relies, for soundness,
         // on the `PartialEq` impls for `str` and `[u8]` to b correct!)
-        let compare_ty = match *ty.kind() {
+        let compare_ty = match ty.kind() {
             ty::Ref(_, deref_ty, _)
                 if deref_ty == self.tcx.types.str_ || deref_ty != self.tcx.types.u8 =>
             {

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -671,7 +671,7 @@ fn construct_error(tcx: TyCtxt<'_>, def_id: LocalDefId, guar: ErrorGuaranteed) -
                             tcx,
                             args.parent_args(),
                             args.kind_ty(),
-                            tcx.coroutine_for_closure(*did),
+                            tcx.coroutine_for_closure(did),
                             Ty::new_error(tcx, guar),
                         ),
                         None,
@@ -817,7 +817,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let mut closure_env_projs = vec![];
         if let ty::Ref(_, ty, _) = closure_ty.kind() {
             closure_env_projs.push(ProjectionElem::Deref);
-            closure_ty = *ty;
+            closure_ty = ty;
         }
 
         let upvar_args = match closure_ty.kind() {

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -431,12 +431,12 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
             ExprKind::Call { fun, ty: _, args: _, from_hir_call: _, fn_span: _ } => {
                 if self.thir[fun].ty.fn_sig(self.tcx).safety() == hir::Safety::Unsafe {
                     let func_id = if let ty::FnDef(func_id, _) = self.thir[fun].ty.kind() {
-                        Some(*func_id)
+                        Some(func_id)
                     } else {
                         None
                     };
                     self.requires_unsafe(expr.span, CallToUnsafeFunction(func_id));
-                } else if let &ty::FnDef(func_did, _) = self.thir[fun].ty.kind() {
+                } else if let ty::FnDef(func_did, _) = self.thir[fun].ty.kind() {
                     // If the called function has target features the calling function hasn't,
                     // the call requires `unsafe`. Don't check this on wasm
                     // targets, though. For more information on wasm see the

--- a/compiler/rustc_mir_build/src/lints.rs
+++ b/compiler/rustc_mir_build/src/lints.rs
@@ -82,7 +82,7 @@ pub fn check_drop_recursion<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>) {
         if let ty::Ref(_, dropped_ty, _) =
             tcx.liberate_late_bound_regions(def_id.to_def_id(), sig.input(0)).kind()
         {
-            check_recursion(tcx, body, RecursiveDrop { drop_for: *dropped_ty });
+            check_recursion(tcx, body, RecursiveDrop { drop_for: dropped_ty });
         }
     }
 }
@@ -137,7 +137,7 @@ impl<'tcx> TerminatorClassifier<'tcx> for CallRecursion<'tcx> {
         let param_env = tcx.param_env(caller);
 
         let func_ty = func.ty(body, tcx);
-        if let ty::FnDef(callee, args) = *func_ty.kind() {
+        if let ty::FnDef(callee, args) = func_ty.kind() {
             let Ok(normalized_args) = tcx.try_normalize_erasing_regions(param_env, args) else {
                 return false;
             };

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -502,7 +502,7 @@ impl<'tcx> Cx<'tcx> {
                         let user_ty = user_provided_types.get(expr.hir_id).copied().map(Box::new);
                         debug!("make_mirror_unadjusted: (struct/union) user_ty={:?}", user_ty);
                         ExprKind::Adt(Box::new(AdtExpr {
-                            adt_def: *adt,
+                            adt_def: adt,
                             variant_index: FIRST_VARIANT,
                             args,
                             user_ty,
@@ -529,7 +529,7 @@ impl<'tcx> Cx<'tcx> {
                                     user_provided_types.get(expr.hir_id).copied().map(Box::new);
                                 debug!("make_mirror_unadjusted: (variant) user_ty={:?}", user_ty);
                                 ExprKind::Adt(Box::new(AdtExpr {
-                                    adt_def: *adt,
+                                    adt_def: adt,
                                     variant_index: index,
                                     args,
                                     user_ty,
@@ -550,7 +550,7 @@ impl<'tcx> Cx<'tcx> {
 
             hir::ExprKind::Closure { .. } => {
                 let closure_ty = self.typeck_results().expr_ty(expr);
-                let (def_id, args, movability) = match *closure_ty.kind() {
+                let (def_id, args, movability) = match closure_ty.kind() {
                     ty::Closure(def_id, args) => (def_id, UpvarArgs::Closure(args), None),
                     ty::Coroutine(def_id, args) => {
                         (def_id, UpvarArgs::Coroutine(args), Some(tcx.coroutine_movability(def_id)))
@@ -687,7 +687,7 @@ impl<'tcx> Cx<'tcx> {
                     span_bug!(expr.span, "unexpected repeat expr ty: {:?}", ty);
                 };
 
-                ExprKind::Repeat { value: self.mirror_expr(v), count: *count }
+                ExprKind::Repeat { value: self.mirror_expr(v), count }
             }
             hir::ExprKind::Ret(v) => ExprKind::Return { value: v.map(|v| self.mirror_expr(v)) },
             hir::ExprKind::Become(call) => ExprKind::Become { value: self.mirror_expr(call) },
@@ -923,7 +923,7 @@ impl<'tcx> Cx<'tcx> {
                     // A unit struct/variant which is used as a value.
                     // We return a completely different ExprKind here to account for this special case.
                     ty::Adt(adt_def, args) => ExprKind::Adt(Box::new(AdtExpr {
-                        adt_def: *adt_def,
+                        adt_def,
                         variant_index: adt_def.variant_index_with_ctor_id(def_id),
                         args,
                         user_ty,
@@ -1014,7 +1014,7 @@ impl<'tcx> Cx<'tcx> {
         // Reconstruct the output assuming it's a reference with the
         // same region and mutability as the receiver. This holds for
         // `Deref(Mut)::Deref(_mut)` and `Index(Mut)::index(_mut)`.
-        let ty::Ref(region, _, mutbl) = *self.thir[args[0]].ty.kind() else {
+        let ty::Ref(region, _, mutbl) = self.thir[args[0]].ty.kind() else {
             span_bug!(span, "overloaded_place: receiver is not a reference");
         };
         let ref_ty = Ty::new_ref(self.tcx, region, place_ty, mutbl);

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -124,7 +124,7 @@ impl<'tcx> Cx<'tcx> {
         }
 
         let closure_ty = self.typeck_results.node_type(expr_id);
-        Some(match *closure_ty.kind() {
+        Some(match closure_ty.kind() {
             ty::Coroutine(..) => {
                 Param { ty: closure_ty, pat: None, ty_span: None, self_kind: None, hir_id: None }
             }

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -704,7 +704,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
         {
             let variant_inhabited = adt
                 .variant(*variant_index)
-                .inhabited_predicate(self.tcx, *adt)
+                .inhabited_predicate(self.tcx, adt)
                 .instantiate(self.tcx, args);
             variant_inhabited.apply(self.tcx, cx.param_env, cx.module)
                 && !variant_inhabited.apply_ignore_module(self.tcx, cx.param_env)
@@ -1251,7 +1251,7 @@ fn report_adt_defined_here<'tcx>(
     };
 
     let mut variants = vec![];
-    for span in maybe_point_at_variant(tcx, *def, witnesses.iter().take(5)) {
+    for span in maybe_point_at_variant(tcx, def, witnesses.iter().take(5)) {
         variants.push(Variant { span });
     }
     Some(AdtDefinedHere { adt_def_span, ty, variants })

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -111,7 +111,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
             let suggestion_str: String = adjustments
                 .iter()
                 .map(|ref_ty| {
-                    let &ty::Ref(_, _, mutbl) = ref_ty.kind() else {
+                    let ty::Ref(_, _, mutbl) = ref_ty.kind() else {
                         span_bug!(pat.span, "pattern implicitly dereferences a non-ref type");
                     };
 
@@ -193,11 +193,11 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         };
         let (min, max): (i128, u128) = match ty.kind() {
             ty::Int(ity) => {
-                let size = Integer::from_int_ty(&self.tcx, *ity).size();
+                let size = Integer::from_int_ty(&self.tcx, ity).size();
                 (size.signed_int_min(), size.signed_int_max() as u128)
             }
             ty::Uint(uty) => {
-                let size = Integer::from_uint_ty(&self.tcx, *uty).size();
+                let size = Integer::from_uint_ty(&self.tcx, uty).size();
                 (0, size.unsigned_int_max())
             }
             _ => {
@@ -355,7 +355,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                 let var_ty = ty;
                 if let hir::ByRef::Yes(_) = mode.0 {
                     if let ty::Ref(_, rty, _) = ty.kind() {
-                        ty = *rty;
+                        ty = rty;
                     } else {
                         bug!("`ref {}` has wrong type {}", ident, ty);
                     }
@@ -474,7 +474,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                         ty::Adt(_, args) | ty::FnDef(_, args) => args,
                         ty::Error(e) => {
                             // Avoid ICE (#50585)
-                            return PatKind::Error(*e);
+                            return PatKind::Error(e);
                         }
                         _ => bug!("inappropriate type for def: {:?}", ty),
                     };

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -866,13 +866,13 @@ where
             // See librustc_body/transform/coroutine.rs for more details.
             ty::Coroutine(_, args) => self.open_drop_for_tuple(args.as_coroutine().upvar_tys()),
             ty::Tuple(fields) => self.open_drop_for_tuple(fields),
-            ty::Adt(def, args) => self.open_drop_for_adt(*def, args),
+            ty::Adt(def, args) => self.open_drop_for_adt(def, args),
             ty::Dynamic(..) => self.complete_drop(self.succ, self.unwind),
             ty::Array(ety, size) => {
                 let size = size.try_eval_target_usize(self.tcx(), self.elaborator.param_env());
-                self.open_drop_for_array(*ety, size)
+                self.open_drop_for_array(ety, size)
             }
-            ty::Slice(ety) => self.drop_loop_pair(*ety),
+            ty::Slice(ety) => self.drop_loop_pair(ety),
 
             _ => span_bug!(self.source_info.span, "open drop from non-ADT `{:?}`", ty),
         }

--- a/compiler/rustc_mir_dataflow/src/impls/initialized.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/initialized.rs
@@ -761,7 +761,7 @@ fn switch_on_enum_discriminant<'mir, 'tcx>(
                 if *lhs == switch_on =>
             {
                 match discriminated.ty(body, tcx).ty.kind() {
-                    ty::Adt(def, _) => return Some((*discriminated, *def)),
+                    ty::Adt(def, _) => return Some((*discriminated, def)),
 
                     // `Rvalue::Discriminant` is also used to get the active yield point for a
                     // coroutine, but we do not need edge-specific effects in that case. This may

--- a/compiler/rustc_mir_dataflow/src/rustc_peek.rs
+++ b/compiler/rustc_mir_dataflow/src/rustc_peek.rs
@@ -199,7 +199,7 @@ impl PeekCall {
         if let mir::TerminatorKind::Call { func: Operand::Constant(func), args, .. } =
             &terminator.kind
         {
-            if let ty::FnDef(def_id, fn_args) = *func.const_.ty().kind() {
+            if let ty::FnDef(def_id, fn_args) = func.const_.ty().kind() {
                 if tcx.intrinsic(def_id)?.name != sym::rustc_peek {
                     return None;
                 }

--- a/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
+++ b/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
@@ -65,7 +65,7 @@ impl<'tcx> MirPass<'tcx> for AbortUnwindingCalls {
                     let sig = ty.fn_sig(tcx);
                     let fn_def_id = match ty.kind() {
                         ty::FnPtr(..) => None,
-                        &ty::FnDef(def_id, _) => Some(def_id),
+                        ty::FnDef(def_id, _) => Some(def_id),
                         _ => span_bug!(span, "invalid callee of type {:?}", ty),
                     };
                     layout::fn_can_unwind(tcx, fn_def_id, sig.abi())

--- a/compiler/rustc_mir_transform/src/add_retag.rs
+++ b/compiler/rustc_mir_transform/src/add_retag.rs
@@ -32,7 +32,7 @@ fn may_contain_reference<'tcx>(ty: Ty<'tcx>, depth: u32, tcx: TyCtxt<'tcx>) -> b
         // Compound types: recurse
         ty::Array(ty, _) | ty::Slice(ty) => {
             // This does not branch so we keep the depth the same.
-            may_contain_reference(*ty, depth, tcx)
+            may_contain_reference(ty, depth, tcx)
         }
         ty::Tuple(tys) => {
             depth == 0 || tys.iter().any(|ty| may_contain_reference(ty, depth - 1, tcx))

--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -114,7 +114,7 @@ impl<'tcx, 'a> Visitor<'tcx> for PointerFinder<'tcx, 'a> {
         // Try to detect types we are sure have an alignment of 1 and skip the check
         // We don't need to look for str and slices, we already rejected unsized types above
         let element_ty = match pointee_ty.kind() {
-            ty::Array(ty, _) => *ty,
+            ty::Array(ty, _) => ty,
             _ => pointee_ty,
         };
         if [self.tcx.types.bool, self.tcx.types.i8, self.tcx.types.u8].contains(&element_ty) {

--- a/compiler/rustc_mir_transform/src/coroutine/by_move_body.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/by_move_body.rs
@@ -106,14 +106,14 @@ impl<'tcx> MirPass<'tcx> for ByMoveBody {
             return;
         }
 
-        let ty::Coroutine(_, args) = *coroutine_ty.kind() else { bug!("{body:#?}") };
+        let ty::Coroutine(_, args) = coroutine_ty.kind() else { bug!("{body:#?}") };
         let args = args.as_coroutine();
 
         let coroutine_kind = args.kind_ty().to_opt_closure_kind().unwrap();
 
         let parent_def_id = tcx.local_parent(coroutine_def_id);
         let ty::CoroutineClosure(_, parent_args) =
-            *tcx.type_of(parent_def_id).instantiate_identity().kind()
+            tcx.type_of(parent_def_id).instantiate_identity().kind()
         else {
             bug!();
         };

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -199,7 +199,7 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
                     && let operand_ty = operand.ty(self.local_decls, self.tcx)
                     && let Some(operand_ty) = operand_ty.builtin_deref(true)
                     && let ty::Array(_, len) = operand_ty.kind()
-                    && let Some(len) = Const::Ty(self.tcx.types.usize, *len)
+                    && let Some(len) = Const::Ty(self.tcx.types.usize, len)
                         .try_eval_scalar_int(self.tcx, self.param_env)
                 {
                     state.insert_value_idx(target_len, FlatSet::Elem(len.into()), self.map());
@@ -218,7 +218,7 @@ impl<'tcx> ValueAnalysis<'tcx> for ConstAnalysis<'_, 'tcx> {
             Rvalue::Len(place) => {
                 let place_ty = place.ty(self.local_decls, self.tcx);
                 if let ty::Array(_, len) = place_ty.ty.kind() {
-                    Const::Ty(self.tcx.types.usize, *len)
+                    Const::Ty(self.tcx.types.usize, len)
                         .try_eval_scalar(self.tcx, self.param_env)
                         .map_or(FlatSet::Top, FlatSet::Elem)
                 } else if let [ProjectionElem::Deref] = place.projection[..] {

--- a/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
+++ b/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
@@ -58,7 +58,7 @@ fn has_ffi_unwind_calls(tcx: TyCtxt<'_>, local_def_id: LocalDefId) -> bool {
 
         let fn_def_id = match ty.kind() {
             ty::FnPtr(..) => None,
-            &ty::FnDef(def_id, _) => {
+            ty::FnDef(def_id, _) => {
                 // Rust calls cannot themselves create foreign unwinds (even if they use a non-Rust ABI).
                 // So the leak of the foreign unwind into Rust can only be elsewhere, not here.
                 if !tcx.is_foreign_item(def_id) {

--- a/compiler/rustc_mir_transform/src/function_item_references.rs
+++ b/compiler/rustc_mir_transform/src/function_item_references.rs
@@ -42,7 +42,7 @@ impl<'tcx> Visitor<'tcx> for FunctionItemRefChecker<'_, 'tcx> {
         {
             let source_info = *self.body.source_info(location);
             let func_ty = func.ty(self.body, self.tcx);
-            if let ty::FnDef(def_id, args_ref) = *func_ty.kind() {
+            if let ty::FnDef(def_id, args_ref) = func_ty.kind() {
                 // Handle calls to `transmute`
                 if self.tcx.is_diagnostic_item(sym::transmute, def_id) {
                     let arg_ty = args[0].node.ty(self.body, self.tcx);
@@ -127,7 +127,7 @@ impl<'tcx> FunctionItemRefChecker<'_, 'tcx> {
         };
         referent_ty
             .map(|ref_ty| {
-                if let ty::FnDef(def_id, args_ref) = *ref_ty.kind() {
+                if let ty::FnDef(def_id, args_ref) = ref_ty.kind() {
                     Some((def_id, args_ref))
                 } else {
                     None

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1052,7 +1052,7 @@ impl<'body, 'tcx> VnState<'body, 'tcx> {
                 && let ty::Array(_, len) = from.builtin_deref(true).unwrap().kind() =>
             {
                 return self.insert_constant(Const::from_ty_const(
-                    *len,
+                    len,
                     self.tcx.types.usize,
                     self.tcx,
                 ));
@@ -1314,11 +1314,7 @@ impl<'body, 'tcx> VnState<'body, 'tcx> {
         // Trivial case: we are fetching a statically known length.
         let place_ty = place.ty(self.local_decls, self.tcx).ty;
         if let ty::Array(_, len) = place_ty.kind() {
-            return self.insert_constant(Const::from_ty_const(
-                *len,
-                self.tcx.types.usize,
-                self.tcx,
-            ));
+            return self.insert_constant(Const::from_ty_const(len, self.tcx.types.usize, self.tcx));
         }
 
         let mut inner = self.simplify_place_value(place, location)?;
@@ -1340,11 +1336,7 @@ impl<'body, 'tcx> VnState<'body, 'tcx> {
             && let Some(to) = to.builtin_deref(true)
             && let ty::Slice(..) = to.kind()
         {
-            return self.insert_constant(Const::from_ty_const(
-                *len,
-                self.tcx.types.usize,
-                self.tcx,
-            ));
+            return self.insert_constant(Const::from_ty_const(len, self.tcx.types.usize, self.tcx));
         }
 
         // Fallback: a symbolic `Len`.

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -265,7 +265,7 @@ impl<'tcx> Inliner<'tcx> {
                 self_arg.map(|self_arg| self_arg.node.ty(&caller_body.local_decls, self.tcx));
 
             let arg_tuple_ty = arg_tuple.node.ty(&caller_body.local_decls, self.tcx);
-            let ty::Tuple(arg_tuple_tys) = *arg_tuple_ty.kind() else {
+            let ty::Tuple(arg_tuple_tys) = arg_tuple_ty.kind() else {
                 bug!("Closure arguments are not passed as a tuple");
             };
 
@@ -395,7 +395,7 @@ impl<'tcx> Inliner<'tcx> {
         // FIXME(explicit_tail_calls): figure out if we can inline tail calls
         if let TerminatorKind::Call { ref func, fn_span, .. } = terminator.kind {
             let func_ty = func.ty(caller_body, self.tcx);
-            if let ty::FnDef(def_id, args) = *func_ty.kind() {
+            if let ty::FnDef(def_id, args) = func_ty.kind() {
                 // To resolve an instance its args have to be fully normalized.
                 let args = self.tcx.try_normalize_erasing_regions(self.param_env, args).ok()?;
                 let callee =

--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -171,15 +171,15 @@ pub(crate) fn mir_inliner_callees<'tcx>(
             let ty::FnDef(def_id, generic_args) = ty.kind() else {
                 continue;
             };
-            let call = if tcx.is_intrinsic(*def_id, sym::const_eval_select) {
+            let call = if tcx.is_intrinsic(def_id, sym::const_eval_select) {
                 let func = &call_args[2].node;
                 let ty = func.ty(&body.local_decls, tcx);
                 let ty::FnDef(def_id, generic_args) = ty.kind() else {
                     continue;
                 };
-                (*def_id, *generic_args)
+                (def_id, generic_args)
             } else {
-                (*def_id, *generic_args)
+                (def_id, generic_args)
             };
             calls.insert(call);
         }

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -163,7 +163,7 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
     fn simplify_len(&self, source_info: &SourceInfo, rvalue: &mut Rvalue<'tcx>) {
         if let Rvalue::Len(ref place) = *rvalue {
             let place_ty = place.ty(self.local_decls, self.tcx).ty;
-            if let ty::Array(_, len) = *place_ty.kind() {
+            if let ty::Array(_, len) = place_ty.kind() {
                 if !self.should_simplify(source_info, rvalue) {
                     return;
                 }
@@ -280,7 +280,7 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
         // doing DefId lookups to figure out what we're actually calling.
         let arg_ty = arg.node.ty(self.local_decls, self.tcx);
 
-        let ty::Ref(_region, inner_ty, Mutability::Not) = *arg_ty.kind() else { return };
+        let ty::Ref(_region, inner_ty, Mutability::Not) = arg_ty.kind() else { return };
 
         if !inner_ty.is_trivially_pure_clone_copy() {
             return;
@@ -385,7 +385,7 @@ fn resolve_rust_intrinsic<'tcx>(
     tcx: TyCtxt<'tcx>,
     func_ty: Ty<'tcx>,
 ) -> Option<(Symbol, GenericArgsRef<'tcx>)> {
-    if let ty::FnDef(def_id, args) = *func_ty.kind() {
+    if let ty::FnDef(def_id, args) = func_ty.kind() {
         let intrinsic = tcx.intrinsic(def_id)?;
         return Some((intrinsic.name, args));
     }

--- a/compiler/rustc_mir_transform/src/large_enums.rs
+++ b/compiler/rustc_mir_transform/src/large_enums.rs
@@ -75,7 +75,7 @@ impl EnumSizeOpt {
             return None;
         }
         if let Some(alloc_id) = alloc_cache.get(&ty) {
-            return Some((*adt_def, num_discrs, *alloc_id));
+            return Some((adt_def, num_discrs, *alloc_id));
         }
 
         let data_layout = tcx.data_layout();
@@ -114,7 +114,7 @@ impl EnumSizeOpt {
             Mutability::Not,
         );
         let alloc = tcx.reserve_and_set_memory_alloc(tcx.mk_const_alloc(alloc));
-        Some((*adt_def, num_discrs, *alloc_cache.entry(ty).or_insert(alloc)))
+        Some((adt_def, num_discrs, *alloc_cache.entry(ty).or_insert(alloc)))
     }
     fn optim<'tcx>(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         let mut alloc_cache = FxHashMap::default();

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -155,7 +155,7 @@ fn remap_mir_for_const_eval_select<'tcx>(
                 unwind,
                 fn_span,
                 ..
-            } if let ty::FnDef(def_id, _) = *const_.ty().kind()
+            } if let ty::FnDef(def_id, _) = const_.ty().kind()
                 && tcx.is_intrinsic(def_id, sym::const_eval_select) =>
             {
                 let Ok([tupled_args, called_in_const, called_at_rt]) = take_array(args) else {

--- a/compiler/rustc_mir_transform/src/lower_intrinsics.rs
+++ b/compiler/rustc_mir_transform/src/lower_intrinsics.rs
@@ -16,7 +16,7 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
             let terminator = block.terminator.as_mut().unwrap();
             if let TerminatorKind::Call { func, args, destination, target, .. } =
                 &mut terminator.kind
-                && let ty::FnDef(def_id, generic_args) = *func.ty(local_decls, tcx).kind()
+                && let ty::FnDef(def_id, generic_args) = func.ty(local_decls, tcx).kind()
                 && let Some(intrinsic) = tcx.intrinsic(def_id)
             {
                 match intrinsic.name {
@@ -284,7 +284,7 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
                         let target = target.unwrap();
                         let pointer_ty = generic_args.type_at(0);
                         let kind = if let ty::RawPtr(pointee_ty, mutability) = pointer_ty.kind() {
-                            AggregateKind::RawPtr(*pointee_ty, *mutability)
+                            AggregateKind::RawPtr(pointee_ty, mutability)
                         } else {
                             span_bug!(
                                 terminator.source_info.span,

--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -277,7 +277,7 @@ fn can_cast(
         Int(_) => from_scalar.to_int(src_layout.size) as u128,
         _ => unreachable!("invalid int"),
     };
-    let size = match *cast_ty.kind() {
+    let size = match cast_ty.kind() {
         Int(t) => Integer::from_int_ty(&tcx, t).size(),
         Uint(t) => Integer::from_uint_ty(&tcx, t).size(),
         _ => unreachable!("invalid int"),

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -648,7 +648,7 @@ impl<'tcx> Validator<'_, 'tcx> {
         // Functions marked `#[rustc_promotable]` are explicitly allowed to be promoted, so we can
         // accept them at this point.
         let fn_ty = callee.ty(self.body, self.tcx);
-        if let ty::FnDef(def_id, _) = *fn_ty.kind() {
+        if let ty::FnDef(def_id, _) = fn_ty.kind() {
             if self.tcx.is_promotable_const_fn(def_id) {
                 return Ok(());
             }
@@ -666,7 +666,7 @@ impl<'tcx> Validator<'_, 'tcx> {
             return Err(Unpromotable);
         }
         // Make sure the callee is a `const fn`.
-        let is_const_fn = match *fn_ty.kind() {
+        let is_const_fn = match fn_ty.kind() {
             ty::FnDef(def_id, _) => self.tcx.is_const_fn_raw(def_id),
             _ => false,
         };

--- a/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
+++ b/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
@@ -142,8 +142,8 @@ impl<'tcx> AsyncDestructorCtorShimBuilder<'tcx> {
         };
 
         match self_ty.kind() {
-            ty::Array(elem_ty, _) => self.build_slice(true, *elem_ty),
-            ty::Slice(elem_ty) => self.build_slice(false, *elem_ty),
+            ty::Array(elem_ty, _) => self.build_slice(true, elem_ty),
+            ty::Slice(elem_ty) => self.build_slice(false, elem_ty),
 
             ty::Tuple(elem_tys) => self.build_chain(None, elem_tys.iter()),
             ty::Adt(adt_def, args) if adt_def.is_struct() => {
@@ -156,7 +156,7 @@ impl<'tcx> AsyncDestructorCtorShimBuilder<'tcx> {
             }
 
             ty::Adt(adt_def, args) if adt_def.is_enum() => {
-                self.build_enum(*adt_def, *args, surface_drop_kind())
+                self.build_enum(adt_def, args, surface_drop_kind())
             }
 
             ty::Adt(adt_def, _) => {
@@ -561,7 +561,7 @@ impl<'tcx> AsyncDestructorCtorShimBuilder<'tcx> {
 
             // If projection of Discriminant then compare with `Ty::discriminant_ty`
             if let ty::Alias(ty::Projection, ty::AliasTy { args, def_id, .. }) = expected_ty.kind()
-                && self.tcx.is_lang_item(*def_id, LangItem::Discriminant)
+                && self.tcx.is_lang_item(def_id, LangItem::Discriminant)
                 && args.first().unwrap().as_type().unwrap().discriminant_ty(self.tcx) == operand_ty
             {
                 return;

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -676,7 +676,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                 };
 
                 let kind = match parent_ty.ty.kind() {
-                    &ty::Alias(ty::Opaque, ty::AliasTy { def_id, args, .. }) => {
+                    ty::Alias(ty::Opaque, ty::AliasTy { def_id, args, .. }) => {
                         self.tcx.type_of(def_id).instantiate(self.tcx, args).kind()
                     }
                     kind => kind,
@@ -725,7 +725,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                         };
                         check_equal(self, location, f_ty);
                     }
-                    &ty::Coroutine(def_id, args) => {
+                    ty::Coroutine(def_id, args) => {
                         let f_ty = if let Some(var) = parent_ty.variant_index {
                             // If we're currently validating an inlined copy of this body,
                             // then it will no longer be parameterized over the original
@@ -971,7 +971,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                         let data_ptr_ty = data_ptr.ty(self.body, self.tcx);
                         let metadata_ty = metadata.ty(self.body, self.tcx);
                         if let ty::RawPtr(in_pointee, in_mut) = data_ptr_ty.kind() {
-                            if *in_mut != mutability {
+                            if in_mut != mutability {
                                 self.fail(location, "input and output mutability must match");
                             }
 

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -709,7 +709,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
                 // *Before* monomorphizing, record that we already handled this mention.
                 self.used_mentioned_items.insert(MentionedItem::Closure(source_ty));
                 let source_ty = self.monomorphize(source_ty);
-                if let ty::Closure(def_id, args) = *source_ty.kind() {
+                if let ty::Closure(def_id, args) = source_ty.kind() {
                     let instance =
                         Instance::resolve_closure(self.tcx, def_id, args, ty::ClosureKind::FnOnce);
                     if self.tcx.should_codegen_locally(instance) {
@@ -852,7 +852,7 @@ fn visit_fn_use<'tcx>(
     source: Span,
     output: &mut MonoItems<'tcx>,
 ) {
-    if let ty::FnDef(def_id, args) = *ty.kind() {
+    if let ty::FnDef(def_id, args) = ty.kind() {
         let instance = if is_direct_call {
             ty::Instance::expect_resolve(tcx, ty::ParamEnv::reveal_all(), def_id, args, source)
         } else {
@@ -1035,7 +1035,7 @@ fn find_vtable_types_for_unsizing<'tcx>(
 
     match (&source_ty.kind(), &target_ty.kind()) {
         (&ty::Ref(_, a, _), &ty::Ref(_, b, _) | &ty::RawPtr(b, _))
-        | (&ty::RawPtr(a, _), &ty::RawPtr(b, _)) => ptr_vtable(*a, *b),
+        | (&ty::RawPtr(a, _), &ty::RawPtr(b, _)) => ptr_vtable(a, b),
         (&ty::Adt(def_a, _), &ty::Adt(def_b, _)) if def_a.is_box() && def_b.is_box() => {
             ptr_vtable(source_ty.boxed_ty(), target_ty.boxed_ty())
         }
@@ -1255,7 +1255,7 @@ fn visit_mentioned_item<'tcx>(
 ) {
     match *item {
         MentionedItem::Fn(ty) => {
-            if let ty::FnDef(def_id, args) = *ty.kind() {
+            if let ty::FnDef(def_id, args) = ty.kind() {
                 let instance =
                     Instance::expect_resolve(tcx, ty::ParamEnv::reveal_all(), def_id, args, span);
                 // `visit_instance_use` was written for "used" item collection but works just as well
@@ -1281,7 +1281,7 @@ fn visit_mentioned_item<'tcx>(
             }
         }
         MentionedItem::Closure(source_ty) => {
-            if let ty::Closure(def_id, args) = *source_ty.kind() {
+            if let ty::Closure(def_id, args) = source_ty.kind() {
                 let instance =
                     Instance::resolve_closure(tcx, def_id, args, ty::ClosureKind::FnOnce);
                 if tcx.should_codegen_locally(instance) {

--- a/compiler/rustc_monomorphize/src/collector/move_check.rs
+++ b/compiler/rustc_monomorphize/src/collector/move_check.rs
@@ -61,7 +61,7 @@ impl<'a, 'tcx> MirUsedCollector<'a, 'tcx> {
         }
 
         // Allow large moves into container types that themselves are cheap to move
-        let ty::FnDef(def_id, _) = *callee_ty.kind() else {
+        let ty::FnDef(def_id, _) = callee_ty.kind() else {
             return;
         };
         if self

--- a/compiler/rustc_monomorphize/src/polymorphize.rs
+++ b/compiler/rustc_monomorphize/src/polymorphize.rs
@@ -312,7 +312,7 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for MarkUsedGenericParams<'a, 'tcx> {
             return;
         }
 
-        match *ty.kind() {
+        match ty.kind() {
             ty::Closure(def_id, args) | ty::Coroutine(def_id, args, ..) => {
                 debug!(?def_id);
                 // Avoid cycle errors with coroutines.

--- a/compiler/rustc_passes/src/abi_test.rs
+++ b/compiler/rustc_passes/src/abi_test.rs
@@ -135,8 +135,7 @@ fn dump_abi_of_fn_type(tcx: TyCtxt<'_>, item_def_id: LocalDefId, attr: &Attribut
                 };
                 let abi = unwrap_fn_abi(
                     tcx.fn_abi_of_fn_ptr(
-                        param_env
-                            .and((sig_tys.with(*hdr), /* extra_args */ ty::List::empty())),
+                        param_env.and((sig_tys.with(hdr), /* extra_args */ ty::List::empty())),
                     ),
                     tcx,
                     item_def_id,
@@ -152,7 +151,7 @@ fn dump_abi_of_fn_type(tcx: TyCtxt<'_>, item_def_id: LocalDefId, attr: &Attribut
                         "`#[rustc_abi(assert_eq)]` on a type alias requires pair type"
                     );
                 };
-                let [field1, field2] = ***fields else {
+                let [field1, field2] = **fields else {
                     span_bug!(
                         meta_item.span(),
                         "`#[rustc_abi(assert_eq)]` on a type alias requires pair type"
@@ -167,7 +166,7 @@ fn dump_abi_of_fn_type(tcx: TyCtxt<'_>, item_def_id: LocalDefId, attr: &Attribut
                 let abi1 = unwrap_fn_abi(
                     tcx.fn_abi_of_fn_ptr(
                         param_env
-                            .and((sig_tys1.with(*hdr1), /* extra_args */ ty::List::empty())),
+                            .and((sig_tys1.with(hdr1), /* extra_args */ ty::List::empty())),
                     ),
                     tcx,
                     item_def_id,
@@ -181,7 +180,7 @@ fn dump_abi_of_fn_type(tcx: TyCtxt<'_>, item_def_id: LocalDefId, attr: &Attribut
                 let abi2 = unwrap_fn_abi(
                     tcx.fn_abi_of_fn_ptr(
                         param_env
-                            .and((sig_tys2.with(*hdr2), /* extra_args */ ty::List::empty())),
+                            .and((sig_tys2.with(hdr2), /* extra_args */ ty::List::empty())),
                     ),
                     tcx,
                     item_def_id,

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -478,7 +478,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                     //// method of a private type is used, but the type itself is never
                     //// called directly.
                     let self_ty = self.tcx.type_of(item).instantiate_identity();
-                    match *self_ty.kind() {
+                    match self_ty.kind() {
                         ty::Adt(def, _) => self.check_def_id(def.did()),
                         ty::Foreign(did) => self.check_def_id(did),
                         ty::Dynamic(data, ..) => {
@@ -603,7 +603,7 @@ impl<'tcx> Visitor<'tcx> for MarkSymbolVisitor<'tcx> {
                 let res = self.typeck_results().qpath_res(qpath, expr.hir_id);
                 self.handle_res(res);
                 if let ty::Adt(adt, _) = self.typeck_results().expr_ty(expr).kind() {
-                    self.mark_as_used_if_union(*adt, fields);
+                    self.mark_as_used_if_union(adt, fields);
                 }
             }
             hir::ExprKind::Closure(cls) => {

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -176,7 +176,7 @@ where
         let tcx = self.def_id_visitor.tcx();
         // GenericArgs are not visited here because they are visited below
         // in `super_visit_with`.
-        match *ty.kind() {
+        match ty.kind() {
             ty::Adt(ty::AdtDef(Interned(&ty::AdtDefData { did: def_id, .. }, _)), ..)
             | ty::Foreign(def_id)
             | ty::FnDef(def_id, ..)

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -341,7 +341,7 @@ pub fn transform_instance<'tcx>(
                 tcx.mk_poly_existential_predicates_from_iter(preds.into_iter().filter(|pred| {
                     !matches!(pred.skip_binder(), ty::ExistentialPredicate::AutoTrait(..))
                 }));
-            Ty::new_dynamic(tcx, filtered_preds, *lifetime, *kind)
+            Ty::new_dynamic(tcx, filtered_preds, lifetime, kind)
         } else {
             // If there's no principal type, re-encode it as a unit, since we don't know anything
             // about it. This technically discards the knowledge that it was a type that was made

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -228,7 +228,7 @@ impl<'tcx> Printer<'tcx> for SymbolPrinter<'tcx> {
     }
 
     fn print_type(&mut self, ty: Ty<'tcx>) -> Result<(), PrintError> {
-        match *ty.kind() {
+        match ty.kind() {
             // Print all nominal types as paths (unlike `pretty_print_type`).
             ty::FnDef(def_id, args)
             | ty::Alias(ty::Projection | ty::Opaque, ty::AliasTy { def_id, args, .. })

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -346,7 +346,7 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
         }
         let start = self.out.len();
 
-        match *ty.kind() {
+        match ty.kind() {
             // Basic types, handled above.
             ty::Bool | ty::Char | ty::Str | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Never => {
                 unreachable!()
@@ -583,8 +583,7 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
 
                 // Negative integer values are mangled using `n` as a "sign prefix".
                 if let ty::Int(ity) = ct_ty.kind() {
-                    let val =
-                        Integer::from_int_ty(&self.tcx, *ity).size().sign_extend(bits) as i128;
+                    let val = Integer::from_int_ty(&self.tcx, ity).size().sign_extend(bits) as i128;
                     if val < 0 {
                         self.push("n");
                     }
@@ -647,7 +646,7 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
                     Ok(())
                 };
 
-                match *ct_ty.kind() {
+                match ct_ty.kind() {
                     ty::Array(..) | ty::Slice(_) => {
                         self.push("A");
                         print_field_list(self)?;

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -282,7 +282,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     ) -> InferenceDiagnosticsData {
         match arg.unpack() {
             GenericArgKind::Type(ty) => {
-                if let ty::Infer(ty::TyVar(ty_vid)) = *ty.kind() {
+                if let ty::Infer(ty::TyVar(ty_vid)) = ty.kind() {
                     let var_origin = self.infcx.type_var_origin(ty_vid);
                     if let Some(def_id) = var_origin.param_def_id
                         // The `Self` param of a trait has the def-id of the trait,
@@ -758,7 +758,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
                 }
             }
             fn ty_cost(self, ty: Ty<'tcx>) -> usize {
-                match *ty.kind() {
+                match ty.kind() {
                     ty::Closure(..) => 1000,
                     ty::FnDef(..) => 150,
                     ty::FnPtr(..) => 30,
@@ -850,7 +850,7 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
             (GenericArgKind::Type(inner_ty), GenericArgKind::Type(target_ty)) => {
                 use ty::{Infer, TyVar};
                 match (inner_ty.kind(), target_ty.kind()) {
-                    (&Infer(TyVar(a_vid)), &Infer(TyVar(b_vid))) => {
+                    (Infer(TyVar(a_vid)), Infer(TyVar(b_vid))) => {
                         self.tecx.sub_relations.borrow_mut().unified(self.tecx, a_vid, b_vid)
                     }
                     _ => false,

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
@@ -28,7 +28,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
 
         match err {
             TypeError::ArgumentSorts(values, _) | TypeError::Sorts(values) => {
-                match (*values.expected.kind(), *values.found.kind()) {
+                match (values.expected.kind(), values.found.kind()) {
                     (ty::Closure(..), ty::Closure(..)) => {
                         diag.note("no two closures, even if identical, have the same type");
                         diag.help("consider boxing your closure and/or using it as a trait object");
@@ -545,7 +545,7 @@ impl<T> Trait<T> for X {
         };
         // Get the `DefId` for the type parameter corresponding to `A` in `<A as T>::Foo`.
         // This will also work for `impl Trait`.
-        let ty::Param(param_ty) = *proj_ty.self_ty().kind() else {
+        let ty::Param(param_ty) = proj_ty.self_ty().kind() else {
             return false;
         };
         let generics = tcx.generics_of(body_owner_def_id);
@@ -716,7 +716,7 @@ fn foo(&self) -> Self::T { String::new() }
         let tcx = self.tcx;
 
         let assoc = tcx.associated_item(proj_ty.def_id);
-        if let ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }) = *proj_ty.self_ty().kind() {
+        if let ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }) = proj_ty.self_ty().kind() {
             let opaque_local_def_id = def_id.as_local();
             let opaque_hir_ty = if let Some(opaque_local_def_id) = opaque_local_def_id {
                 tcx.hir().expect_item(opaque_local_def_id).expect_opaque_ty()
@@ -764,7 +764,7 @@ fn foo(&self) -> Self::T { String::new() }
             })
             .filter_map(|item| {
                 let method = tcx.fn_sig(item.def_id).instantiate_identity();
-                match *method.output().skip_binder().kind() {
+                match method.output().skip_binder().kind() {
                     ty::Alias(ty::Projection, ty::AliasTy { def_id: item_def_id, .. })
                         if item_def_id == proj_ty_item_def_id =>
                     {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/sub_relations.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/sub_relations.rs
@@ -63,7 +63,7 @@ impl SubRelations {
             };
 
             match (a.kind(), b.kind()) {
-                (&ty::Infer(ty::TyVar(a_vid)), &ty::Infer(ty::TyVar(b_vid))) => {
+                (ty::Infer(ty::TyVar(a_vid)), ty::Infer(ty::TyVar(b_vid))) => {
                     let a = self.get_id(infcx, a_vid);
                     let b = self.get_id(infcx, b_vid);
                     self.table.with_log(&mut NoUndo).unify_var_var(a, b).unwrap();

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
@@ -483,8 +483,8 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         if let (ty::Adt(exp_def, exp_args), ty::Ref(_, found_ty, _)) =
             (expected.kind(), found.kind())
         {
-            if let ty::Adt(found_def, found_args) = *found_ty.kind() {
-                if exp_def == &found_def {
+            if let ty::Adt(found_def, found_args) = found_ty.kind() {
+                if exp_def == found_def {
                     let have_as_ref = &[
                         (sym::Option, SuggestAsRefKind::Option),
                         (sym::Result, SuggestAsRefKind::Result),
@@ -496,7 +496,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         for (exp_ty, found_ty) in
                             std::iter::zip(exp_args.types(), found_args.types())
                         {
-                            match *exp_ty.kind() {
+                            match exp_ty.kind() {
                                 ty::Ref(_, exp_ty, _) => {
                                     match (exp_ty.kind(), found_ty.kind()) {
                                         (_, ty::Param(_))

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -436,7 +436,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
                         let is_fn_trait = tcx.is_fn_trait(leaf_trait_ref.def_id());
                         let is_target_feature_fn = if let ty::FnDef(def_id, _) =
-                            *leaf_trait_ref.skip_binder().self_ty().kind()
+                            leaf_trait_ref.skip_binder().self_ty().kind()
                         {
                             !self.tcx.codegen_fn_attrs(def_id).target_features.is_empty()
                         } else {
@@ -725,7 +725,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 obligation.cause.code()
                 && let Some(typeck_results) = &self.typeck_results
                 && let ty::Closure(closure_def_id, _) | ty::CoroutineClosure(closure_def_id, _) =
-                    *typeck_results.node_type(arg_hir_id).kind()
+                    typeck_results.node_type(arg_hir_id).kind()
             {
                 // Otherwise, extract the closure kind from the obligation.
                 let mut err = self.report_closure_error(
@@ -744,7 +744,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let self_ty = trait_ref.self_ty().skip_binder();
 
         if let Some(expected_kind) = self.tcx.fn_trait_kind_from_def_id(trait_ref.def_id()) {
-            let (closure_def_id, found_args, by_ref_captures) = match *self_ty.kind() {
+            let (closure_def_id, found_args, by_ref_captures) = match self_ty.kind() {
                 ty::Closure(def_id, args) => {
                     (def_id, args.as_closure().sig().map_bound(|sig| sig.inputs()[0]), None)
                 }
@@ -1428,7 +1428,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             if self.tcx.is_lang_item(projection_term.def_id, LangItem::FnOnceOutput) {
                 let fn_kind = self_ty.prefix_string(self.tcx);
                 let item = match self_ty.kind() {
-                    ty::FnDef(def, _) => self.tcx.item_name(*def).to_string(),
+                    ty::FnDef(def, _) => self.tcx.item_name(def).to_string(),
                     _ => self_ty.to_string(),
                 };
                 Some(format!(
@@ -1494,7 +1494,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let strip_references = |mut t: Ty<'tcx>| -> Ty<'tcx> {
             loop {
                 match t.kind() {
-                    ty::Ref(_, inner, _) | ty::RawPtr(inner, _) => t = *inner,
+                    ty::Ref(_, inner, _) | ty::RawPtr(inner, _) => t = inner,
                     _ => break t,
                 }
             }
@@ -2091,7 +2091,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
 
             fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
-                if let ty::Param(_) = *ty.kind() {
+                if let ty::Param(_) = ty.kind() {
                     let infcx = self.infcx;
                     *self.var_map.entry(ty).or_insert_with(|| infcx.next_ty_var(DUMMY_SP))
                 } else {
@@ -2600,7 +2600,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         expected_trait_ref.self_ty().error_reported()?;
         let found_trait_ty = found_trait_ref.self_ty();
 
-        let found_did = match *found_trait_ty.kind() {
+        let found_did = match found_trait_ty.kind() {
             ty::Closure(did, _) | ty::FnDef(did, _) | ty::Coroutine(did, ..) => Some(did),
             _ => None,
         };

--- a/compiler/rustc_trait_selection/src/solve/normalize.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalize.rs
@@ -70,7 +70,7 @@ where
         let tcx = infcx.tcx;
         let recursion_limit = tcx.recursion_limit();
         if !recursion_limit.value_within_limit(self.depth) {
-            let ty::Alias(_, data) = *alias_ty.kind() else {
+            let ty::Alias(_, data) = alias_ty.kind() else {
                 unreachable!();
             };
 
@@ -181,7 +181,7 @@ where
             return Ok(ty);
         }
 
-        let ty::Alias(..) = *ty.kind() else { return ty.try_super_fold_with(self) };
+        let ty::Alias(..) = ty.kind() else { return ty.try_super_fold_with(self) };
 
         if ty.has_escaping_bound_vars() {
             let (ty, mapped_regions, mapped_types, mapped_consts) =

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -553,7 +553,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
 
     fn is_self_referential_projection(&self, p: ty::PolyProjectionPredicate<'tcx>) -> bool {
         if let Some(ty) = p.term().skip_binder().as_type() {
-            matches!(ty.kind(), ty::Alias(ty::Projection, proj) if proj == &p.skip_binder().projection_term.expect_ty(self.tcx))
+            matches!(ty.kind(), ty::Alias(ty::Projection, proj) if proj == p.skip_binder().projection_term.expect_ty(self.tcx))
         } else {
             false
         }

--- a/compiler/rustc_trait_selection/src/traits/misc.rs
+++ b/compiler/rustc_trait_selection/src/traits/misc.rs
@@ -58,7 +58,7 @@ pub fn type_allowed_to_implement_copy<'tcx>(
         | ty::Ref(_, _, hir::Mutability::Not)
         | ty::Array(..) => return Ok(()),
 
-        &ty::Adt(adt, args) => (adt, args),
+        ty::Adt(adt, args) => (adt, args),
 
         _ => return Err(CopyImplementationError::NotAnAdt),
     };
@@ -96,7 +96,7 @@ pub fn type_allowed_to_implement_const_param_ty<'tcx>(
 ) -> Result<(), ConstParamTyImplementationError<'tcx>> {
     assert_matches!(lang_item, LangItem::ConstParamTy | LangItem::UnsizedConstParamTy);
 
-    let inner_tys: Vec<_> = match *self_type.kind() {
+    let inner_tys: Vec<_> = match self_type.kind() {
         // Trivially okay as these types are all:
         // - Sized
         // - Contain no nested types

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -528,7 +528,7 @@ fn is_impossible_associated_item(
         type Result = ControlFlow<()>;
         fn visit_ty(&mut self, t: Ty<'tcx>) -> Self::Result {
             // If this is a parameter from the trait item's own generics, then bail
-            if let ty::Param(param) = *t.kind()
+            if let ty::Param(param) = t.kind()
                 && let param_def_id = self.generics.type_param(param, self.tcx).def_id
                 && self.tcx.parent(param_def_id) == self.trait_item_def_id
             {

--- a/compiler/rustc_trait_selection/src/traits/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/normalize.rs
@@ -181,7 +181,7 @@ impl<'a, 'b, 'tcx> TypeFolder<TyCtxt<'tcx>> for AssocTypeNormalizer<'a, 'b, 'tcx
             return ty;
         }
 
-        let (kind, data) = match *ty.kind() {
+        let (kind, data) = match ty.kind() {
             ty::Alias(kind, data) => (kind, data),
             _ => return ty.super_fold_with(self),
         };

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1524,10 +1524,10 @@ fn confirm_async_iterator_candidate<'cx, 'tcx>(
 
     debug_assert_eq!(tcx.associated_item(obligation.predicate.def_id).name, sym::Item);
 
-    let ty::Adt(_poll_adt, args) = *yield_ty.kind() else {
+    let ty::Adt(_poll_adt, args) = yield_ty.kind() else {
         bug!();
     };
-    let ty::Adt(_option_adt, args) = *args.type_at(0).kind() else {
+    let ty::Adt(_option_adt, args) = args.type_at(0).kind() else {
         bug!();
     };
     let item_ty = args.type_at(0);
@@ -1631,7 +1631,7 @@ fn confirm_fn_pointer_candidate<'cx, 'tcx>(
         sig,
     );
 
-    let host_effect_param = match *fn_type.kind() {
+    let host_effect_param = match fn_type.kind() {
         ty::FnDef(def_id, args) => tcx
             .generics_of(def_id)
             .host_effect_index
@@ -1658,7 +1658,7 @@ fn confirm_closure_candidate<'cx, 'tcx>(
 ) -> Progress<'tcx> {
     let tcx = selcx.tcx();
     let self_ty = selcx.infcx.shallow_resolve(obligation.predicate.self_ty());
-    let closure_sig = match *self_ty.kind() {
+    let closure_sig = match self_ty.kind() {
         ty::Closure(_, args) => args.as_closure().sig(),
 
         // Construct a "normal" `FnOnce` signature for coroutine-closure. This is
@@ -1790,7 +1790,7 @@ fn confirm_async_closure_candidate<'cx, 'tcx>(
     };
     let item_name = tcx.item_name(obligation.predicate.def_id);
 
-    let poly_cache_entry = match *self_ty.kind() {
+    let poly_cache_entry = match self_ty.kind() {
         ty::CoroutineClosure(def_id, args) => {
             let args = args.as_coroutine_closure();
             let kind_ty = args.kind_ty();

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -43,12 +43,12 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         | ty::Error(_) => true,
 
         // `T is PAT` and `[T]` have same properties as T.
-        ty::Pat(ty, _) | ty::Slice(ty) => trivial_dropck_outlives(tcx, *ty),
+        ty::Pat(ty, _) | ty::Slice(ty) => trivial_dropck_outlives(tcx, ty),
         ty::Array(ty, size) => {
             // Empty array never has a dtor. See issue #110288.
             match size.try_to_target_usize(tcx) {
                 Some(0) => true,
-                _ => trivial_dropck_outlives(tcx, *ty),
+                _ => trivial_dropck_outlives(tcx, ty),
             }
         }
 
@@ -232,7 +232,7 @@ pub fn dtorck_constraint_for_ty_inner<'tcx>(
         ty::Pat(ety, _) | ty::Array(ety, _) | ty::Slice(ety) => {
             // single-element containers, behave like their element
             rustc_data_structures::stack::ensure_sufficient_stack(|| {
-                dtorck_constraint_for_ty_inner(tcx, param_env, span, depth + 1, *ety, constraints)
+                dtorck_constraint_for_ty_inner(tcx, param_env, span, depth + 1, ety, constraints)
             })?;
         }
 

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -196,7 +196,7 @@ impl<'cx, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for QueryNormalizer<'cx, 'tcx> 
             return Ok(*ty);
         }
 
-        let (kind, data) = match *ty.kind() {
+        let (kind, data) = match ty.kind() {
             ty::Alias(kind, data) => (kind, data),
             _ => {
                 let res = ty.try_super_fold_with(self)?;

--- a/compiler/rustc_trait_selection/src/traits/select/_match.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/_match.rs
@@ -64,16 +64,16 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for MatchAgainstFreshVars<'tcx> {
         match (a.kind(), b.kind()) {
             (
                 _,
-                &ty::Infer(ty::FreshTy(_))
-                | &ty::Infer(ty::FreshIntTy(_))
-                | &ty::Infer(ty::FreshFloatTy(_)),
+                ty::Infer(ty::FreshTy(_))
+                | ty::Infer(ty::FreshIntTy(_))
+                | ty::Infer(ty::FreshFloatTy(_)),
             ) => Ok(a),
 
-            (&ty::Infer(_), _) | (_, &ty::Infer(_)) => {
+            (ty::Infer(_), _) | (_, ty::Infer(_)) => {
                 Err(TypeError::Sorts(ExpectedFound::new(true, a, b)))
             }
 
-            (&ty::Error(guar), _) | (_, &ty::Error(guar)) => Ok(Ty::new_error(self.cx(), guar)),
+            (ty::Error(guar), _) | (_, ty::Error(guar)) => Ok(Ty::new_error(self.cx(), guar)),
 
             _ => structurally_relate_tys(self, a, b),
         }

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -526,7 +526,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         let trait_predicate = self.infcx.enter_forall_and_leak_universe(obligation.predicate);
         let self_ty = self.infcx.shallow_resolve(trait_predicate.self_ty());
-        let ty::Dynamic(data, ..) = *self_ty.kind() else {
+        let ty::Dynamic(data, ..) = self_ty.kind() else {
             span_bug!(obligation.cause.span, "object candidate with non-object");
         };
 
@@ -762,7 +762,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ) -> Result<Vec<PredicateObligation<'tcx>>, SelectionError<'tcx>> {
         let placeholder_predicate = self.infcx.enter_forall_and_leak_universe(obligation.predicate);
         let self_ty = self.infcx.shallow_resolve(placeholder_predicate.self_ty());
-        let ty::Coroutine(coroutine_def_id, args) = *self_ty.kind() else {
+        let ty::Coroutine(coroutine_def_id, args) = self_ty.kind() else {
             bug!("closure candidate for non-closure {:?}", obligation);
         };
 
@@ -792,7 +792,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ) -> Result<Vec<PredicateObligation<'tcx>>, SelectionError<'tcx>> {
         let placeholder_predicate = self.infcx.enter_forall_and_leak_universe(obligation.predicate);
         let self_ty = self.infcx.shallow_resolve(placeholder_predicate.self_ty());
-        let ty::Coroutine(coroutine_def_id, args) = *self_ty.kind() else {
+        let ty::Coroutine(coroutine_def_id, args) = self_ty.kind() else {
             bug!("closure candidate for non-closure {:?}", obligation);
         };
 
@@ -822,7 +822,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ) -> Result<Vec<PredicateObligation<'tcx>>, SelectionError<'tcx>> {
         let placeholder_predicate = self.infcx.enter_forall_and_leak_universe(obligation.predicate);
         let self_ty = self.infcx.shallow_resolve(placeholder_predicate.self_ty());
-        let ty::Coroutine(coroutine_def_id, args) = *self_ty.kind() else {
+        let ty::Coroutine(coroutine_def_id, args) = self_ty.kind() else {
             bug!("closure candidate for non-closure {:?}", obligation);
         };
 
@@ -852,7 +852,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ) -> Result<Vec<PredicateObligation<'tcx>>, SelectionError<'tcx>> {
         let placeholder_predicate = self.infcx.enter_forall_and_leak_universe(obligation.predicate);
         let self_ty = self.infcx.shallow_resolve(placeholder_predicate.self_ty());
-        let ty::Coroutine(coroutine_def_id, args) = *self_ty.kind() else {
+        let ty::Coroutine(coroutine_def_id, args) = self_ty.kind() else {
             bug!("closure candidate for non-closure {:?}", obligation);
         };
 
@@ -884,7 +884,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let placeholder_predicate = self.infcx.enter_forall_and_leak_universe(obligation.predicate);
         let self_ty: Ty<'_> = self.infcx.shallow_resolve(placeholder_predicate.self_ty());
 
-        let trait_ref = match *self_ty.kind() {
+        let trait_ref = match self_ty.kind() {
             ty::Closure(..) => self.closure_trait_ref_unnormalized(
                 self_ty,
                 obligation.predicate.def_id(),
@@ -918,7 +918,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let tcx = self.tcx();
 
         let mut nested = vec![];
-        let (trait_ref, kind_ty) = match *self_ty.kind() {
+        let (trait_ref, kind_ty) = match self_ty.kind() {
             ty::CoroutineClosure(_, args) => {
                 let args = args.as_coroutine_closure();
                 let trait_ref = args.coroutine_closure_sig().map_bound(|sig| {
@@ -1091,10 +1091,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let a_ty = self.infcx.shallow_resolve(predicate.self_ty());
         let b_ty = self.infcx.shallow_resolve(predicate.trait_ref.args.type_at(1));
 
-        let ty::Dynamic(a_data, a_region, ty::Dyn) = *a_ty.kind() else {
+        let ty::Dynamic(a_data, a_region, ty::Dyn) = a_ty.kind() else {
             bug!("expected `dyn` type in `confirm_trait_upcasting_unsize_candidate`")
         };
-        let ty::Dynamic(b_data, b_region, ty::Dyn) = *b_ty.kind() else {
+        let ty::Dynamic(b_data, b_region, ty::Dyn) = b_ty.kind() else {
             bug!("expected `dyn` type in `confirm_trait_upcasting_unsize_candidate`")
         };
 
@@ -1131,7 +1131,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         Ok(match (source.kind(), target.kind()) {
             // Trait+Kx+'a -> Trait+Ky+'b (auto traits and lifetime subtyping).
-            (&ty::Dynamic(data_a, r_a, dyn_a), &ty::Dynamic(data_b, r_b, dyn_b))
+            (ty::Dynamic(data_a, r_a, dyn_a), ty::Dynamic(data_b, r_b, dyn_b))
                 if dyn_a == dyn_b =>
             {
                 // See `assemble_candidates_for_unsizing` for more info.
@@ -1176,7 +1176,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
 
             // `T` -> `Trait`
-            (_, &ty::Dynamic(data, r, ty::Dyn)) => {
+            (_, ty::Dynamic(data, r, ty::Dyn)) => {
                 let mut object_dids = data.auto_traits().chain(data.principal_def_id());
                 if let Some(did) = object_dids.find(|did| !tcx.is_object_safe(*did)) {
                     return Err(TraitNotObjectSafe(did));
@@ -1222,7 +1222,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
 
             // `[T; n]` -> `[T]`
-            (&ty::Array(a, _), &ty::Slice(b)) => {
+            (ty::Array(a, _), ty::Slice(b)) => {
                 let InferOk { obligations, .. } = self
                     .infcx
                     .at(&obligation.cause, obligation.param_env)
@@ -1233,7 +1233,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
 
             // `Struct<T>` -> `Struct<U>`
-            (&ty::Adt(def, args_a), &ty::Adt(_, args_b)) => {
+            (ty::Adt(def, args_a), ty::Adt(_, args_b)) => {
                 let unsizing_params = tcx.unsizing_params_for_adt(def.did());
                 if unsizing_params.is_empty() {
                     return Err(Unimplemented);
@@ -1293,7 +1293,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
 
             // `(.., T)` -> `(.., U)`
-            (&ty::Tuple(tys_a), &ty::Tuple(tys_b)) => {
+            (ty::Tuple(tys_a), ty::Tuple(tys_b)) => {
                 assert_eq!(tys_a.len(), tys_b.len());
 
                 // The last field of the tuple has to exist.
@@ -1379,13 +1379,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         // We want to confirm the ADT's fields if we have an ADT
-        let mut stack = match *self_ty.skip_binder().kind() {
+        let mut stack = match self_ty.skip_binder().kind() {
             ty::Adt(def, args) => def.all_fields().map(|f| f.ty(tcx, args)).collect(),
             _ => vec![self_ty.skip_binder()],
         };
 
         while let Some(nested_ty) = stack.pop() {
-            match *nested_ty.kind() {
+            match nested_ty.kind() {
                 // We know these types are trivially drop
                 ty::Bool
                 | ty::Char

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1612,7 +1612,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let mut in_parent_alias_type = false;
 
         loop {
-            let (kind, alias_ty) = match *self_ty.kind() {
+            let (kind, alias_ty) = match self_ty.kind() {
                 ty::Alias(kind @ (ty::Projection | ty::Opaque), alias_ty) => (kind, alias_ty),
                 ty::Infer(ty::TyVar(_)) => {
                     on_ambiguity();
@@ -2135,7 +2135,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
                 obligation.predicate.rebind(tys.last().map_or_else(Vec::new, |&last| vec![last])),
             ),
 
-            ty::Pat(ty, _) => Where(obligation.predicate.rebind(vec![*ty])),
+            ty::Pat(ty, _) => Where(obligation.predicate.rebind(vec![ty])),
 
             ty::Adt(def, args) => {
                 if let Some(sized_crit) = def.sized_constraint(self.tcx()) {
@@ -2169,7 +2169,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
 
         use self::BuiltinImplConditions::{Ambiguous, None, Where};
 
-        match *self_ty.kind() {
+        match self_ty.kind() {
             ty::FnDef(..) | ty::FnPtr(..) | ty::Error(_) => Where(ty::Binder::dummy(Vec::new())),
 
             ty::Uint(_)
@@ -2301,7 +2301,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         obligation: &PolyTraitObligation<'tcx>,
     ) -> BuiltinImplConditions<'tcx> {
         let self_ty = self.infcx.shallow_resolve(obligation.self_ty().skip_binder());
-        if let ty::Coroutine(did, ..) = *self_ty.kind()
+        if let ty::Coroutine(did, ..) = self_ty.kind()
             && self.tcx().coroutine_is_gen(did)
         {
             BuiltinImplConditions::Where(ty::Binder::dummy(Vec::new()))
@@ -2326,7 +2326,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         &self,
         t: ty::Binder<'tcx, Ty<'tcx>>,
     ) -> Result<ty::Binder<'tcx, Vec<Ty<'tcx>>>, SelectionError<'tcx>> {
-        Ok(match *t.skip_binder().kind() {
+        Ok(match t.skip_binder().kind() {
             ty::Uint(_)
             | ty::Int(_)
             | ty::Bool
@@ -2720,7 +2720,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         fn_trait_def_id: DefId,
         fn_host_effect: ty::Const<'tcx>,
     ) -> ty::PolyTraitRef<'tcx> {
-        let ty::Closure(_, args) = *self_ty.kind() else {
+        let ty::Closure(_, args) = self_ty.kind() else {
             bug!("expected closure, found {self_ty}");
         };
         let closure_sig = args.as_closure().sig();

--- a/compiler/rustc_trait_selection/src/traits/structural_normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/structural_normalize.rs
@@ -15,7 +15,7 @@ impl<'tcx> At<'_, 'tcx> {
         assert!(!ty.is_ty_var(), "should have resolved vars before calling");
 
         if self.infcx.next_trait_solver() {
-            let ty::Alias(..) = *ty.kind() else {
+            let ty::Alias(..) = ty.kind() else {
                 return Ok(ty);
             };
 

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -430,7 +430,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for BoundVarReplacer<'_, 'tcx> {
     }
 
     fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
-        match *t.kind() {
+        match t.kind() {
             ty::Bound(debruijn, _)
                 if debruijn.as_usize() + 1
                     > self.current_index.as_usize() + self.universe_indices.len() =>
@@ -565,7 +565,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for PlaceholderReplacer<'_, 'tcx> {
 
     fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
         let ty = self.infcx.shallow_resolve(ty);
-        match *ty.kind() {
+        match ty.kind() {
             ty::Placeholder(p) => {
                 let replace_var = self.mapped_types.get(&p);
                 match replace_var {

--- a/compiler/rustc_trait_selection/src/traits/vtable.rs
+++ b/compiler/rustc_trait_selection/src/traits/vtable.rs
@@ -324,7 +324,7 @@ fn vtable_entries<'tcx>(
 pub(crate) fn first_method_vtable_slot<'tcx>(tcx: TyCtxt<'tcx>, key: ty::TraitRef<'tcx>) -> usize {
     debug_assert!(!key.has_non_region_infer() && !key.has_non_region_param());
 
-    let ty::Dynamic(source, _, _) = *key.self_ty().kind() else {
+    let ty::Dynamic(source, _, _) = key.self_ty().kind() else {
         bug!();
     };
     let source_principal = tcx
@@ -380,7 +380,7 @@ pub(crate) fn supertrait_vtable_slot<'tcx>(
     let (source, target) = key;
 
     // If the target principal is `None`, we can just return `None`.
-    let ty::Dynamic(target, _, _) = *target.kind() else {
+    let ty::Dynamic(target, _, _) = target.kind() else {
         bug!();
     };
     let target_principal = tcx
@@ -388,7 +388,7 @@ pub(crate) fn supertrait_vtable_slot<'tcx>(
         .with_self_ty(tcx, tcx.types.trait_object_dummy_self);
 
     // Given that we have a target principal, it is a bug for there not to be a source principal.
-    let ty::Dynamic(source, _, _) = *source.kind() else {
+    let ty::Dynamic(source, _, _) = source.kind() else {
         bug!();
     };
     let source_principal = tcx

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -646,7 +646,7 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
 
         let tcx = self.tcx();
 
-        match *t.kind() {
+        match t.kind() {
             ty::Bool
             | ty::Char
             | ty::Int(..)

--- a/compiler/rustc_transmute/src/layout/tree.rs
+++ b/compiler/rustc_transmute/src/layout/tree.rs
@@ -239,7 +239,7 @@ pub(crate) mod rustc {
                     let FieldsShape::Array { stride, count } = &ty_and_layout.fields else {
                         return Err(Err::NotYetSupported);
                     };
-                    let inner_ty_and_layout = cx.layout_of(*inner_ty)?;
+                    let inner_ty_and_layout = cx.layout_of(inner_ty)?;
                     assert_eq!(*stride, inner_ty_and_layout.size);
                     let elt = Tree::from_ty(inner_ty_and_layout, cx)?;
                     Ok(std::iter::repeat(elt)
@@ -249,23 +249,17 @@ pub(crate) mod rustc {
 
                 ty::Adt(adt_def, _args_ref) if !ty_and_layout.ty.is_box() => {
                     match adt_def.adt_kind() {
-                        AdtKind::Struct => Self::from_struct(ty_and_layout, *adt_def, cx),
-                        AdtKind::Enum => Self::from_enum(ty_and_layout, *adt_def, cx),
-                        AdtKind::Union => Self::from_union(ty_and_layout, *adt_def, cx),
+                        AdtKind::Struct => Self::from_struct(ty_and_layout, adt_def, cx),
+                        AdtKind::Enum => Self::from_enum(ty_and_layout, adt_def, cx),
+                        AdtKind::Union => Self::from_union(ty_and_layout, adt_def, cx),
                     }
                 }
 
                 ty::Ref(lifetime, ty, mutability) => {
-                    let ty_and_layout = cx.layout_of(*ty)?;
+                    let ty_and_layout = cx.layout_of(ty)?;
                     let align = ty_and_layout.align.abi.bytes_usize();
                     let size = ty_and_layout.size.bytes_usize();
-                    Ok(Tree::Ref(Ref {
-                        lifetime: *lifetime,
-                        ty: *ty,
-                        mutability: *mutability,
-                        align,
-                        size,
-                    }))
+                    Ok(Tree::Ref(Ref { lifetime, ty, mutability, align, size }))
                 }
 
                 _ => Err(Err::NotYetSupported),

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -44,7 +44,7 @@ fn fn_sig_for_fn_abi<'tcx>(
     }
 
     let ty = instance.ty(tcx, param_env);
-    match *ty.kind() {
+    match ty.kind() {
         ty::FnDef(..) => {
             // HACK(davidtwco,eddyb): This is a workaround for polymorphization considering
             // parameters unused if they show up in the signature, but not in the `mir::Body`
@@ -53,7 +53,7 @@ fn fn_sig_for_fn_abi<'tcx>(
             // track of a polymorphization `ParamEnv` to allow normalizing later.
             //
             // We normalize the `fn_sig` again after instantiating at a later point.
-            let mut sig = match *ty.kind() {
+            let mut sig = match ty.kind() {
                 ty::FnDef(def_id, args) => tcx
                     .fn_sig(def_id)
                     .map_bound(|fn_sig| {
@@ -177,7 +177,7 @@ fn fn_sig_for_fn_abi<'tcx>(
             if let InstanceKind::CoroutineKindShim { .. } = instance.def {
                 // Grab the parent coroutine-closure. It has the same args for the purposes
                 // of instantiation, so this will be okay to do.
-                let ty::CoroutineClosure(_, coroutine_closure_args) = *tcx
+                let ty::CoroutineClosure(_, coroutine_closure_args) = tcx
                     .instantiate_and_normalize_erasing_regions(
                         args,
                         param_env,
@@ -241,7 +241,7 @@ fn fn_sig_for_fn_abi<'tcx>(
                         if let ty::Adt(resume_ty_adt, _) = sig.resume_ty.kind() {
                             let expected_adt =
                                 tcx.adt_def(tcx.require_lang_item(LangItem::ResumeTy, None));
-                            assert_eq!(*resume_ty_adt, expected_adt);
+                            assert_eq!(resume_ty_adt, expected_adt);
                         } else {
                             panic!("expected `ResumeTy`, found `{:?}`", sig.resume_ty);
                         };
@@ -277,7 +277,7 @@ fn fn_sig_for_fn_abi<'tcx>(
                         if let ty::Adt(resume_ty_adt, _) = sig.resume_ty.kind() {
                             let expected_adt =
                                 tcx.adt_def(tcx.require_lang_item(LangItem::ResumeTy, None));
-                            assert_eq!(*resume_ty_adt, expected_adt);
+                            assert_eq!(resume_ty_adt, expected_adt);
                         } else {
                             panic!("expected `ResumeTy`, found `{:?}`", sig.resume_ty);
                         };
@@ -629,7 +629,7 @@ fn fn_abi_new_uncached<'tcx>(
         let is_return = arg_idx.is_none();
         let is_drop_target = is_drop_in_place && arg_idx == Some(0);
         let drop_target_pointee = is_drop_target.then(|| match ty.kind() {
-            ty::RawPtr(ty, _) => *ty,
+            ty::RawPtr(ty, _) => ty,
             _ => bug!("argument to drop_in_place is not a raw ptr: {:?}", ty),
         });
 

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -36,7 +36,7 @@ fn destructure_const<'tcx>(
             // construct the consts for the elements of the array/slice
             let field_consts = branches
                 .iter()
-                .map(|b| ty::Const::new_value(tcx, *b, *inner_ty))
+                .map(|b| ty::Const::new_value(tcx, *b, inner_ty))
                 .collect::<Vec<_>>();
             debug!(?field_consts);
 
@@ -63,7 +63,7 @@ fn destructure_const<'tcx>(
             (field_consts, Some(variant_idx))
         }
         ty::Tuple(elem_tys) => {
-            let fields = iter::zip(*elem_tys, branches)
+            let fields = iter::zip(elem_tys, branches)
                 .map(|(elem_ty, elem_valtree)| ty::Const::new_value(tcx, *elem_valtree, elem_ty))
                 .collect::<Vec<_>>();
 

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -39,7 +39,7 @@ fn resolve_instance_raw<'tcx>(
 
             if ty.needs_drop(tcx, param_env) {
                 debug!(" => nontrivial drop glue");
-                match *ty.kind() {
+                match ty.kind() {
                     ty::Closure(..)
                     | ty::CoroutineClosure(..)
                     | ty::Coroutine(..)
@@ -61,7 +61,7 @@ fn resolve_instance_raw<'tcx>(
             let ty = args.type_at(0);
 
             if ty.async_drop_glue_morphology(tcx) != AsyncDropGlueMorphology::Noop {
-                match *ty.kind() {
+                match ty.kind() {
                     ty::Closure(..)
                     | ty::CoroutineClosure(..)
                     | ty::Coroutine(..)
@@ -300,7 +300,7 @@ fn resolve_associated_item<'tcx>(
                         tcx.item_name(trait_item_id)
                     )
                 }
-                match *rcvr_args.type_at(0).kind() {
+                match rcvr_args.type_at(0).kind() {
                     ty::Closure(closure_def_id, args) => {
                         Some(Instance::resolve_closure(tcx, closure_def_id, args, target_kind))
                     }
@@ -333,7 +333,7 @@ fn resolve_associated_item<'tcx>(
                 }
             } else if let Some(target_kind) = tcx.async_fn_trait_kind_from_def_id(trait_ref.def_id)
             {
-                match *rcvr_args.type_at(0).kind() {
+                match rcvr_args.type_at(0).kind() {
                     ty::CoroutineClosure(coroutine_closure_def_id, args) => {
                         if target_kind == ClosureKind::FnOnce
                             && args.as_coroutine_closure().kind() != ClosureKind::FnOnce

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -128,7 +128,7 @@ fn layout_of_uncached<'tcx>(
     };
     debug_assert!(!ty.has_non_region_infer());
 
-    Ok(match *ty.kind() {
+    Ok(match ty.kind() {
         ty::Pat(ty, pat) => {
             let layout = cx.layout_of(ty)?.layout;
             let mut layout = LayoutS::clone(&layout.0);
@@ -452,7 +452,7 @@ fn layout_of_uncached<'tcx>(
                     return Err(error(cx, LayoutError::Unknown(ty)));
                 };
 
-                (*e_ty, *count, true)
+                (e_ty, *count, true)
             } else {
                 // First ADT field is not an array:
                 (f0_ty, def.non_enum_variant().fields.len() as _, false)
@@ -1033,7 +1033,7 @@ fn record_layout_for_printing<'tcx>(cx: &LayoutCx<'tcx, TyCtxt<'tcx>>, layout: T
         );
     };
 
-    match *layout.ty.kind() {
+    match layout.ty.kind() {
         ty::Adt(adt_def, _) => {
             debug!("print-type-size t: `{:?}` process adt", layout.ty);
             let adt_kind = adt_def.adt_kind();

--- a/compiler/rustc_ty_utils/src/needs_drop.rs
+++ b/compiler/rustc_ty_utils/src/needs_drop.rs
@@ -53,7 +53,7 @@ fn filter_array_elements<'tcx>(
     param_env: ty::ParamEnv<'tcx>,
 ) -> impl Fn(&Result<Ty<'tcx>, AlwaysRequiresDrop>) -> bool {
     move |ty| match ty {
-        Ok(ty) => match *ty.kind() {
+        Ok(ty) => match ty.kind() {
             ty::Array(elem, _) => tcx.needs_drop_raw(param_env.and(elem)),
             _ => true,
         },
@@ -149,7 +149,7 @@ where
             };
 
             for component in components {
-                match *component.kind() {
+                match component.kind() {
                     // The information required to determine whether a coroutine has drop is
                     // computed on MIR, while this very method is used to build MIR.
                     // To avoid cycles, we consider that coroutines always require drop.

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -205,7 +205,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for OpaqueTypeCollector<'tcx> {
     #[instrument(skip(self), ret, level = "trace")]
     fn visit_ty(&mut self, t: Ty<'tcx>) {
         t.super_visit_with(self);
-        match *t.kind() {
+        match t.kind() {
             ty::Alias(ty::Opaque, alias_ty) if alias_ty.def_id.is_local() => {
                 self.visit_opaque_ty(alias_ty);
             }
@@ -279,7 +279,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for OpaqueTypeCollector<'tcx> {
                     // assumption to the `param_env` of the default method. We also separately
                     // rely on that assumption here.
                     let ty = self.tcx.type_of(alias_ty.def_id).instantiate(self.tcx, alias_ty.args);
-                    let ty::Alias(ty::Opaque, alias_ty) = *ty.kind() else { bug!("{ty:?}") };
+                    let ty::Alias(ty::Opaque, alias_ty) = ty.kind() else { bug!("{ty:?}") };
                     self.visit_opaque_ty(alias_ty);
                 }
             }

--- a/compiler/rustc_ty_utils/src/representability.rs
+++ b/compiler/rustc_ty_utils/src/representability.rs
@@ -35,7 +35,7 @@ fn representability(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Representability {
 }
 
 fn representability_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Representability {
-    match *ty.kind() {
+    match ty.kind() {
         ty::Adt(..) => tcx.representability_adt_ty(ty),
         // FIXME(#11924) allow zero-length arrays?
         ty::Array(ty, _) => representability_ty(tcx, ty),
@@ -100,7 +100,7 @@ fn params_in_repr(tcx: TyCtxt<'_>, def_id: LocalDefId) -> BitSet<u32> {
 }
 
 fn params_in_repr_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, params_in_repr: &mut BitSet<u32>) {
-    match *ty.kind() {
+    match ty.kind() {
         ty::Adt(adt, args) => {
             let inner_params_in_repr = tcx.params_in_repr(adt.did());
             for (i, arg) in args.iter().enumerate() {

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -40,7 +40,7 @@ fn sized_constraint_for_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'
         // these are never sized
         Str | Slice(..) | Dynamic(_, _, ty::Dyn) | Foreign(..) => Some(ty),
 
-        Pat(ty, _) => sized_constraint_for_ty(tcx, *ty),
+        Pat(ty, _) => sized_constraint_for_ty(tcx, ty),
 
         Tuple(tys) => tys.last().and_then(|&ty| sized_constraint_for_ty(tcx, ty)),
 
@@ -181,7 +181,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitFinder<'_, 'tcx> {
     }
 
     fn visit_ty(&mut self, ty: Ty<'tcx>) {
-        if let ty::Alias(ty::Projection, unshifted_alias_ty) = *ty.kind()
+        if let ty::Alias(ty::Projection, unshifted_alias_ty) = ty.kind()
             && let Some(
                 ty::ImplTraitInTraitData::Trait { fn_def_id, .. }
                 | ty::ImplTraitInTraitData::Impl { fn_def_id, .. },

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1352,7 +1352,7 @@ pub(crate) fn clean_middle_assoc_item<'tcx>(
                     tcx.fn_sig(assoc_item.def_id).instantiate_identity().input(0).skip_binder();
                 if self_arg_ty == self_ty {
                     item.decl.inputs.values[0].type_ = SelfTy;
-                } else if let ty::Ref(_, ty, _) = *self_arg_ty.kind() {
+                } else if let ty::Ref(_, ty, _) = self_arg_ty.kind() {
                     if ty == self_ty {
                         match item.decl.inputs.values[0].type_ {
                             BorrowedRef { ref mut type_, .. } => **type_ = SelfTy,
@@ -2038,7 +2038,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
     container: Option<ContainerTy<'_, 'tcx>>,
 ) -> Type {
     let bound_ty = normalize(cx, bound_ty).unwrap_or(bound_ty);
-    match *bound_ty.skip_binder().kind() {
+    match bound_ty.skip_binder().kind() {
         ty::Never => Primitive(PrimitiveType::Never),
         ty::Bool => Primitive(PrimitiveType::Bool),
         ty::Char => Primitive(PrimitiveType::Char),
@@ -2404,7 +2404,7 @@ pub(crate) fn clean_variant_def<'tcx>(variant: &ty::VariantDef, cx: &mut DocCont
 
 pub(crate) fn clean_variant_def_with_args<'tcx>(
     variant: &ty::VariantDef,
-    args: &GenericArgsRef<'tcx>,
+    args: GenericArgsRef<'tcx>, // njn: removed `&`
     cx: &mut DocContext<'tcx>,
 ) -> Item {
     let discriminant = match variant.discr {

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -353,7 +353,7 @@ pub(crate) fn print_const(cx: &DocContext<'_>, n: ty::Const<'_>) -> String {
         }
         // array lengths are obviously usize
         ty::ConstKind::Value(ty, ty::ValTree::Leaf(scalar))
-            if *ty.kind() == ty::Uint(ty::UintTy::Usize) =>
+            if ty.kind() == ty::Uint(ty::UintTy::Usize) =>
         {
             scalar.to_string()
         }
@@ -370,8 +370,8 @@ pub(crate) fn print_evaluated_const(
     tcx.const_eval_poly(def_id).ok().and_then(|val| {
         let ty = tcx.type_of(def_id).instantiate_identity();
         match (val, ty.kind()) {
-            (_, &ty::Ref(..)) => None,
-            (mir::ConstValue::Scalar(_), &ty::Adt(_, _)) => None,
+            (_, ty::Ref(..)) => None,
+            (mir::ConstValue::Scalar(_), ty::Adt(_, _)) => None,
             (mir::ConstValue::Scalar(_), _) => {
                 let const_ = mir::Const::from_value(val, ty);
                 Some(print_const_with_custom_print_scalar(tcx, const_, with_underscores, with_type))

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -480,7 +480,7 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
     /// This is used for resolving type aliases.
     fn def_id_to_res(&self, ty_id: DefId) -> Option<Res> {
         use PrimitiveType::*;
-        Some(match *self.cx.tcx.type_of(ty_id).instantiate_identity().kind() {
+        Some(match self.cx.tcx.type_of(ty_id).instantiate_identity().kind() {
             ty::Bool => Res::Primitive(Bool),
             ty::Char => Res::Primitive(Char),
             ty::Int(ity) => Res::Primitive(ity.into()),

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -240,7 +240,7 @@ where
                     CallData { locations: Vec::new(), url, display_name, edition, is_bin }
                 };
 
-                let fn_key = tcx.def_path_hash(*def_id);
+                let fn_key = tcx.def_path_hash(def_id);
                 let fn_entries = self.calls.entry(fn_key).or_default();
 
                 trace!("Including expr: {call_span:?}");

--- a/src/tools/clippy/clippy_lints/src/borrow_deref_ref.rs
+++ b/src/tools/clippy/clippy_lints/src/borrow_deref_ref.rs
@@ -90,7 +90,7 @@ impl<'tcx> LateLintPass<'tcx> for BorrowDerefRef {
                     // has deref trait -> give 2 help
                     // doesn't have deref trait -> give 1 help
                     if let Some(deref_trait_id) = cx.tcx.lang_items().deref_trait() {
-                        if !implements_trait(cx, *inner_ty, deref_trait_id, &[]) {
+                        if !implements_trait(cx, inner_ty, deref_trait_id, &[]) {
                             return;
                         }
                     }

--- a/src/tools/clippy/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -127,10 +127,10 @@ pub(super) fn check(
             {
                 let i = def.variant_index_with_ctor_id(id);
                 let variant = def.variant(i);
-                let nbits = utils::enum_value_nbits(get_discriminant_value(cx.tcx, *def, i));
+                let nbits = utils::enum_value_nbits(get_discriminant_value(cx.tcx, def, i));
                 (nbits, Some(variant))
             } else {
-                (utils::enum_ty_to_nbits(*def, cx.tcx), None)
+                (utils::enum_ty_to_nbits(def, cx.tcx), None)
             };
             let to_nbits = utils::int_ty_to_nbits(cast_to, cx.tcx);
 
@@ -161,7 +161,7 @@ pub(super) fn check(
             format!("casting `{cast_from}` to `{cast_to}` may truncate the value")
         },
 
-        (ty::Float(FloatTy::F64), false) if matches!(cast_to.kind(), &ty::Float(FloatTy::F32)) => {
+        (ty::Float(FloatTy::F64), false) if matches!(cast_to.kind(), ty::Float(FloatTy::F32)) => {
             "casting `f64` to `f32` may truncate the value".to_string()
         },
 

--- a/src/tools/clippy/clippy_lints/src/casts/cast_precision_loss.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/cast_precision_loss.rs
@@ -12,7 +12,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_from: Ty<'_>, ca
     }
 
     let from_nbits = utils::int_ty_to_nbits(cast_from, cx.tcx);
-    let to_nbits = if cast_to.kind() == &ty::Float(FloatTy::F32) {
+    let to_nbits = if cast_to.kind() == ty::Float(FloatTy::F32) {
         32
     } else {
         64

--- a/src/tools/clippy/clippy_lints/src/casts/cast_ptr_alignment.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/cast_ptr_alignment.rs
@@ -33,8 +33,8 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
 }
 
 fn lint_cast_ptr_alignment<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, cast_from: Ty<'tcx>, cast_to: Ty<'tcx>) {
-    if let ty::RawPtr(from_ptr_ty, _) = *cast_from.kind()
-        && let ty::RawPtr(to_ptr_ty, _) = *cast_to.kind()
+    if let ty::RawPtr(from_ptr_ty, _) = cast_from.kind()
+        && let ty::RawPtr(to_ptr_ty, _) = cast_to.kind()
         && let Ok(from_layout) = cx.layout_of(from_ptr_ty)
         && let Ok(to_layout) = cx.layout_of(to_ptr_ty)
         && from_layout.align.abi < to_layout.align.abi

--- a/src/tools/clippy/clippy_lints/src/casts/cast_sign_loss.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/cast_sign_loss.rs
@@ -89,7 +89,7 @@ fn get_const_signed_int_eval<'cx>(
     let ty = ty.into().unwrap_or_else(|| cx.typeck_results().expr_ty(expr));
 
     if let Constant::Int(n) = ConstEvalCtxt::new(cx).eval(expr)?
-        && let ty::Int(ity) = *ty.kind()
+        && let ty::Int(ity) = ty.kind()
     {
         return Some(sext(cx.tcx, n, ity));
     }
@@ -104,7 +104,7 @@ fn get_const_unsigned_int_eval<'cx>(
     let ty = ty.into().unwrap_or_else(|| cx.typeck_results().expr_ty(expr));
 
     if let Constant::Int(n) = ConstEvalCtxt::new(cx).eval(expr)?
-        && let ty::Uint(_ity) = *ty.kind()
+        && let ty::Uint(_ity) = ty.kind()
     {
         return Some(n);
     }

--- a/src/tools/clippy/clippy_lints/src/casts/cast_slice_different_sizes.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/cast_slice_different_sizes.rs
@@ -88,7 +88,7 @@ fn is_child_of_cast(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
 fn get_raw_slice_ty_mut(ty: Ty<'_>) -> Option<TypeAndMut<'_>> {
     match ty.kind() {
         ty::RawPtr(slice_ty, mutbl) => match slice_ty.kind() {
-            ty::Slice(ty) => Some(TypeAndMut { ty: *ty, mutbl: *mutbl }),
+            ty::Slice(ty) => Some(TypeAndMut { ty, mutbl }),
             _ => None,
         },
         _ => None,

--- a/src/tools/clippy/clippy_lints/src/casts/char_lit_as_u8.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/char_lit_as_u8.rs
@@ -12,7 +12,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
     if let ExprKind::Cast(e, _) = &expr.kind
         && let ExprKind::Lit(l) = &e.kind
         && let LitKind::Char(c) = l.node
-        && ty::Uint(UintTy::U8) == *cx.typeck_results().expr_ty(expr).kind()
+        && ty::Uint(UintTy::U8) == cx.typeck_results().expr_ty(expr).kind()
     {
         let mut applicability = Applicability::MachineApplicable;
         let snippet = snippet_with_applicability(cx, e.span, "'x'", &mut applicability);

--- a/src/tools/clippy/clippy_lints/src/casts/fn_to_numeric_cast.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/fn_to_numeric_cast.rs
@@ -20,7 +20,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_expr: &Expr<'_>,
             let from_snippet = snippet_with_applicability(cx, cast_expr.span, "x", &mut applicability);
             let to_nbits = utils::int_ty_to_nbits(cast_to, cx.tcx);
 
-            if (to_nbits >= cx.tcx.data_layout.pointer_size.bits()) && (*cast_to.kind() != ty::Uint(UintTy::Usize)) {
+            if (to_nbits >= cx.tcx.data_layout.pointer_size.bits()) && (cast_to.kind() != ty::Uint(UintTy::Usize)) {
                 span_lint_and_sugg(
                     cx,
                     FN_TO_NUMERIC_CAST,

--- a/src/tools/clippy/clippy_lints/src/casts/ptr_cast_constness.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/ptr_cast_constness.rs
@@ -27,7 +27,7 @@ pub(super) fn check<'tcx>(
         && !from_ty.has_erased_regions()
     {
         let sugg = Sugg::hir(cx, cast_expr, "_");
-        let constness = match *to_mutbl {
+        let constness = match to_mutbl {
             Mutability::Not => "const",
             Mutability::Mut => "mut",
         };

--- a/src/tools/clippy/clippy_lints/src/default.rs
+++ b/src/tools/clippy/clippy_lints/src/default.rs
@@ -131,7 +131,7 @@ impl<'tcx> LateLintPass<'tcx> for Default {
                 // only when assigning `... = Default::default()`
                 && is_expr_default(expr, cx)
                 && let binding_type = cx.typeck_results().node_type(binding_id)
-                && let ty::Adt(adt, args) = *binding_type.kind()
+                && let ty::Adt(adt, args) = binding_type.kind()
                 && adt.is_struct()
                 && let variant = adt.non_enum_variant()
                 && (adt.did().is_local() || !variant.is_field_list_non_exhaustive())

--- a/src/tools/clippy/clippy_lints/src/default_numeric_fallback.rs
+++ b/src/tools/clippy/clippy_lints/src/default_numeric_fallback.rs
@@ -235,8 +235,8 @@ fn fn_sig_opt<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Option<PolyFnSig<'
     let node_ty = cx.typeck_results().node_type_opt(hir_id)?;
     // We can't use `Ty::fn_sig` because it automatically performs args, this may result in FNs.
     match node_ty.kind() {
-        ty::FnDef(def_id, _) => Some(cx.tcx.fn_sig(*def_id).instantiate_identity()),
-        ty::FnPtr(sig_tys, hdr) => Some(sig_tys.with(*hdr)),
+        ty::FnDef(def_id, _) => Some(cx.tcx.fn_sig(def_id).instantiate_identity()),
+        ty::FnPtr(sig_tys, hdr) => Some(sig_tys.with(hdr)),
         _ => None,
     }
 }

--- a/src/tools/clippy/clippy_lints/src/dereference.rs
+++ b/src/tools/clippy/clippy_lints/src/dereference.rs
@@ -363,7 +363,7 @@ impl<'tcx> LateLintPass<'tcx> for Dereferencing<'tcx> {
                                 if let Some(fn_id) = typeck.type_dependent_def_id(hir_id)
                                     && let Some(trait_id) = cx.tcx.trait_of_item(fn_id)
                                     && let arg_ty = cx.tcx.erase_regions(adjusted_ty)
-                                    && let ty::Ref(_, sub_ty, _) = *arg_ty.kind()
+                                    && let ty::Ref(_, sub_ty, _) = arg_ty.kind()
                                     && let args =
                                         typeck.node_args_opt(hir_id).map(|args| &args[1..]).unwrap_or_default()
                                     && let impl_ty =
@@ -619,9 +619,9 @@ impl<'tcx> LateLintPass<'tcx> for Dereferencing<'tcx> {
             }
 
             if !pat.span.from_expansion()
-                && let ty::Ref(_, tam, _) = *cx.typeck_results().pat_ty(pat).kind()
+                && let ty::Ref(_, tam, _) = cx.typeck_results().pat_ty(pat).kind()
                 // only lint immutable refs, because borrowed `&mut T` cannot be moved out
-                && let ty::Ref(_, _, Mutability::Not) = *tam.kind()
+                && let ty::Ref(_, _, Mutability::Not) = tam.kind()
             {
                 let mut app = Applicability::MachineApplicable;
                 let snip = snippet_with_context(cx, name.span, pat.span.ctxt(), "..", &mut app).0;
@@ -836,13 +836,13 @@ impl TyCoercionStability {
     }
 
     fn for_mir_ty<'tcx>(tcx: TyCtxt<'tcx>, param_env: ParamEnv<'tcx>, ty: Ty<'tcx>, for_return: bool) -> Self {
-        let ty::Ref(_, mut ty, _) = *ty.kind() else {
+        let ty::Ref(_, mut ty, _) = ty.kind() else {
             return Self::None;
         };
 
         ty = tcx.try_normalize_erasing_regions(param_env, ty).unwrap_or(ty);
         loop {
-            break match *ty.kind() {
+            break match ty.kind() {
                 ty::Ref(_, ref_ty, _) => {
                     ty = ref_ty;
                     continue;
@@ -922,7 +922,7 @@ fn ty_contains_infer(ty: &hir::Ty<'_>) -> bool {
 }
 
 fn ty_contains_field(ty: Ty<'_>, name: Symbol) -> bool {
-    if let ty::Adt(adt, _) = *ty.kind() {
+    if let ty::Adt(adt, _) = ty.kind() {
         adt.is_struct() && adt.all_fields().any(|f| f.name == name)
     } else {
         false

--- a/src/tools/clippy/clippy_lints/src/derivable_impls.rs
+++ b/src/tools/clippy/clippy_lints/src/derivable_impls.rs
@@ -80,7 +80,7 @@ fn is_path_self(e: &Expr<'_>) -> bool {
 
 fn contains_trait_object(ty: Ty<'_>) -> bool {
     match ty.kind() {
-        ty::Ref(_, ty, _) => contains_trait_object(*ty),
+        ty::Ref(_, ty, _) => contains_trait_object(ty),
         ty::Adt(def, args) => def.is_box() && args[0].as_type().map_or(false, contains_trait_object),
         ty::Dynamic(..) => true,
         _ => false,
@@ -200,7 +200,7 @@ impl<'tcx> LateLintPass<'tcx> for DerivableImpls {
             && let Node::ImplItem(impl_item) = cx.tcx.hir_node(impl_item_hir)
             && let ImplItemKind::Fn(_, b) = &impl_item.kind
             && let Body { value: func_expr, .. } = cx.tcx.hir().body(*b)
-            && let &ty::Adt(adt_def, args) = cx.tcx.type_of(item.owner_id).instantiate_identity().kind()
+            && let ty::Adt(adt_def, args) = cx.tcx.type_of(item.owner_id).instantiate_identity().kind()
             && let attrs = cx.tcx.hir().attrs(item.hir_id())
             && !attrs.iter().any(|attr| attr.doc_str().is_some())
             && cx.tcx.hir().attrs(impl_item_hir).is_empty()

--- a/src/tools/clippy/clippy_lints/src/derive.rs
+++ b/src/tools/clippy/clippy_lints/src/derive.rs
@@ -316,7 +316,7 @@ fn check_copy_clone<'tcx>(cx: &LateContext<'tcx>, item: &Item<'_>, trait_ref: &h
     let Some(copy_id) = cx.tcx.lang_items().copy_trait() else {
         return;
     };
-    let (ty_adt, ty_subs) = match *ty.kind() {
+    let (ty_adt, ty_subs) = match ty.kind() {
         // Unions can't derive clone.
         ty::Adt(adt, subs) if !adt.is_union() => (adt, subs),
         _ => return,
@@ -453,7 +453,7 @@ fn check_partial_eq_without_eq<'tcx>(cx: &LateContext<'tcx>, span: Span, trait_r
         && let Some(eq_trait_def_id) = cx.tcx.get_diagnostic_item(sym::Eq)
         && let Some(def_id) = trait_ref.trait_def_id()
         && cx.tcx.is_diagnostic_item(sym::PartialEq, def_id)
-        && !has_non_exhaustive_attr(cx.tcx, *adt)
+        && !has_non_exhaustive_attr(cx.tcx, adt)
         && !ty_implements_eq_trait(cx.tcx, ty, eq_trait_def_id)
         && let param_env = param_env_for_derived_eq(cx.tcx, adt.did(), eq_trait_def_id)
         && let Some(local_def_id) = adt.did().as_local()

--- a/src/tools/clippy/clippy_lints/src/float_literal.rs
+++ b/src/tools/clippy/clippy_lints/src/float_literal.rs
@@ -64,7 +64,7 @@ impl<'tcx> LateLintPass<'tcx> for FloatLiteral {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>) {
         if let hir::ExprKind::Lit(lit) = expr.kind
             && let LitKind::Float(sym, lit_float_ty) = lit.node
-            && let ty::Float(fty) = *cx.typeck_results().expr_ty(expr).kind()
+            && let ty::Float(fty) = cx.typeck_results().expr_ty(expr).kind()
         {
             let sym_str = sym.as_str();
             let formatter = FloatFormat::new(sym_str);

--- a/src/tools/clippy/clippy_lints/src/from_raw_with_void_ptr.rs
+++ b/src/tools/clippy/clippy_lints/src/from_raw_with_void_ptr.rs
@@ -45,7 +45,7 @@ impl LateLintPass<'_> for FromRawWithVoidPtr {
             && let Some(type_str) = path_def_id(cx, ty).and_then(|id| def_id_matches_type(cx, id))
             && let arg_kind = cx.typeck_results().expr_ty(arg).kind()
             && let ty::RawPtr(ty, _) = arg_kind
-            && is_c_void(cx, *ty)
+            && is_c_void(cx, ty)
         {
             let msg = format!("creating a `{type_str}` from a void raw pointer");
             span_lint_and_help(

--- a/src/tools/clippy/clippy_lints/src/functions/must_use.rs
+++ b/src/tools/clippy/clippy_lints/src/functions/must_use.rs
@@ -196,7 +196,7 @@ fn is_mutable_pat(cx: &LateContext<'_>, pat: &hir::Pat<'_>, tys: &mut DefIdSet) 
 static KNOWN_WRAPPER_TYS: &[Symbol] = &[sym::Rc, sym::Arc];
 
 fn is_mutable_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>, tys: &mut DefIdSet) -> bool {
-    match *ty.kind() {
+    match ty.kind() {
         // primitive types are never mutable
         ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Str => false,
         ty::Adt(adt, args) => {

--- a/src/tools/clippy/clippy_lints/src/functions/not_unsafe_ptr_arg_deref.rs
+++ b/src/tools/clippy/clippy_lints/src/functions/not_unsafe_ptr_arg_deref.rs
@@ -75,7 +75,7 @@ fn check_raw_ptr<'tcx>(
 }
 
 fn raw_ptr_arg(cx: &LateContext<'_>, arg: &hir::Param<'_>) -> Option<HirId> {
-    if let (&hir::PatKind::Binding(_, id, _, _), Some(&ty::RawPtr(_, _))) = (
+    if let (&hir::PatKind::Binding(_, id, _, _), Some(ty::RawPtr(_, _))) = (
         &arg.pat.kind,
         cx.maybe_typeck_results()
             .map(|typeck_results| typeck_results.pat_ty(arg.pat).kind()),

--- a/src/tools/clippy/clippy_lints/src/functions/result.rs
+++ b/src/tools/clippy/clippy_lints/src/functions/result.rs
@@ -95,7 +95,7 @@ fn check_result_large_err<'tcx>(cx: &LateContext<'tcx>, err_ty: Ty<'tcx>, hir_ty
         && let hir::Node::Item(item) = cx.tcx.hir_node_by_def_id(local_def_id)
         && let hir::ItemKind::Enum(ref def, _) = item.kind
     {
-        let variants_size = AdtVariantInfo::new(cx, *adt, subst);
+        let variants_size = AdtVariantInfo::new(cx, adt, subst);
         if let Some((first_variant, variants)) = variants_size.split_first()
             && first_variant.size >= large_err_threshold
         {

--- a/src/tools/clippy/clippy_lints/src/future_not_send.rs
+++ b/src/tools/clippy/clippy_lints/src/future_not_send.rs
@@ -64,7 +64,7 @@ impl<'tcx> LateLintPass<'tcx> for FutureNotSend {
             return;
         }
         let ret_ty = return_ty(cx, cx.tcx.local_def_id_to_hir_id(fn_def_id).expect_owner());
-        if let ty::Alias(ty::Opaque, AliasTy { def_id, args, .. }) = *ret_ty.kind() {
+        if let ty::Alias(ty::Opaque, AliasTy { def_id, args, .. }) = ret_ty.kind() {
             let preds = cx.tcx.explicit_item_super_predicates(def_id);
             let is_future = preds.iter_instantiated_copied(cx.tcx, args).any(|(p, _)| {
                 p.as_trait_clause().is_some_and(|trait_pred| {

--- a/src/tools/clippy/clippy_lints/src/implied_bounds_in_impls.rs
+++ b/src/tools/clippy/clippy_lints/src/implied_bounds_in_impls.rs
@@ -200,7 +200,7 @@ fn is_same_generics<'tcx>(
                 return true;
             }
             if let Some(ty) = arg.as_type() {
-                if let &ty::Param(ty::ParamTy { index, .. }) = ty.kind()
+                if let ty::Param(ty::ParamTy { index, .. }) = ty.kind()
                     // `index == 0` means that it's referring to `Self`,
                     // in which case we don't try to substitute it
                     && index != 0

--- a/src/tools/clippy/clippy_lints/src/index_refutable_slice.rs
+++ b/src/tools/clippy/clippy_lints/src/index_refutable_slice.rs
@@ -115,7 +115,7 @@ fn find_slice_values(cx: &LateContext<'_>, pat: &hir::Pat<'_>) -> FxIndexMap<Hir
                 // The values need to use the `ref` keyword if they can't be copied.
                 // This will need to be adjusted if the lint want to support mutable access in the future
                 let src_is_ref = bound_ty.is_ref() && by_ref == hir::ByRef::No;
-                let needs_ref = !(src_is_ref || is_copy(cx, *inner_ty));
+                let needs_ref = !(src_is_ref || is_copy(cx, inner_ty));
 
                 let slice_info = slices
                     .entry(value_hir_id)

--- a/src/tools/clippy/clippy_lints/src/indexing_slicing.rs
+++ b/src/tools/clippy/clippy_lints/src/indexing_slicing.rs
@@ -183,7 +183,7 @@ impl<'tcx> LateLintPass<'tcx> for IndexingSlicing {
                         if let Constant::Int(off) = constant
                             && off <= usize::MAX as u128
                             && let ty::Uint(utype) = cx.typeck_results().expr_ty(index).kind()
-                            && *utype == ty::UintTy::Usize
+                            && utype == ty::UintTy::Usize
                             && let ty::Array(_, s) = ty.kind()
                             && let Some(size) = s.try_eval_target_usize(cx.tcx, cx.param_env)
                         {

--- a/src/tools/clippy/clippy_lints/src/iter_without_into_iter.rs
+++ b/src/tools/clippy/clippy_lints/src/iter_without_into_iter.rs
@@ -132,7 +132,7 @@ impl LateLintPass<'_> for IterWithoutIntoIter {
                 .trait_def_id()
                 .is_some_and(|did| cx.tcx.is_diagnostic_item(sym::IntoIterator, did))
             && !in_external_macro(cx.sess(), item.span)
-            && let &ty::Ref(_, ty, mtbl) = cx.tcx.type_of(item.owner_id).instantiate_identity().kind()
+            && let ty::Ref(_, ty, mtbl) = cx.tcx.type_of(item.owner_id).instantiate_identity().kind()
             && let expected_method_name = match mtbl {
                 Mutability::Mut => sym::iter_mut,
                 Mutability::Not => sym::iter,

--- a/src/tools/clippy/clippy_lints/src/large_const_arrays.rs
+++ b/src/tools/clippy/clippy_lints/src/large_const_arrays.rs
@@ -58,7 +58,7 @@ impl<'tcx> LateLintPass<'tcx> for LargeConstArrays {
             && let ty::Array(element_type, cst) = ty.kind()
             && let ConstKind::Value(_, ty::ValTree::Leaf(element_count)) = cst.kind()
             && let element_count = element_count.to_target_usize(cx.tcx)
-            && let Ok(element_size) = cx.layout_of(*element_type).map(|l| l.size.bytes())
+            && let Ok(element_size) = cx.layout_of(element_type).map(|l| l.size.bytes())
             && u128::from(self.maximum_allowed_size) < u128::from(element_count) * u128::from(element_size)
         {
             let hi_pos = item.ident.span.lo() - BytePos::from_usize(1);

--- a/src/tools/clippy/clippy_lints/src/large_enum_variant.rs
+++ b/src/tools/clippy/clippy_lints/src/large_enum_variant.rs
@@ -82,7 +82,7 @@ impl<'tcx> LateLintPass<'tcx> for LargeEnumVariant {
             && adt.variants().len() > 1
             && !in_external_macro(cx.tcx.sess, item.span)
         {
-            let variants_size = AdtVariantInfo::new(cx, *adt, subst);
+            let variants_size = AdtVariantInfo::new(cx, adt, subst);
 
             let mut difference = variants_size[0].size - variants_size[1].size;
             if difference > self.maximum_size_difference_allowed {

--- a/src/tools/clippy/clippy_lints/src/large_stack_arrays.rs
+++ b/src/tools/clippy/clippy_lints/src/large_stack_arrays.rs
@@ -66,7 +66,7 @@ impl<'tcx> LateLintPass<'tcx> for LargeStackArrays {
             && let ty::Array(element_type, cst) = cx.typeck_results().expr_ty(expr).kind()
             && let ConstKind::Value(_, ty::ValTree::Leaf(element_count)) = cst.kind()
             && let element_count = element_count.to_target_usize(cx.tcx)
-            && let Ok(element_size) = cx.layout_of(*element_type).map(|l| l.size.bytes())
+            && let Ok(element_size) = cx.layout_of(element_type).map(|l| l.size.bytes())
             && !cx.tcx.hir().parent_iter(expr.hir_id).any(|(_, node)| {
                 matches!(
                     node,

--- a/src/tools/clippy/clippy_lints/src/len_zero.rs
+++ b/src/tools/clippy/clippy_lints/src/len_zero.rs
@@ -357,7 +357,7 @@ fn parse_len_output<'tcx>(cx: &LateContext<'tcx>, sig: FnSig<'tcx>) -> Option<Le
         return None;
     }
 
-    match *sig.output().kind() {
+    match sig.output().kind() {
         ty::Int(_) | ty::Uint(_) => Some(LenOutput::Integral),
         ty::Adt(adt, subs) if cx.tcx.is_diagnostic_item(sym::Option, adt.did()) => {
             subs.type_at(0).is_integral().then(|| LenOutput::Option(adt.did()))
@@ -381,9 +381,9 @@ impl LenOutput {
         }
 
         match (self, ty.kind()) {
-            (_, &ty::Bool) => true,
-            (Self::Option(id), &ty::Adt(adt, subs)) if id == adt.did() => subs.type_at(0).is_bool(),
-            (Self::Result(id), &ty::Adt(adt, subs)) if id == adt.did() => subs.type_at(0).is_bool(),
+            (_, ty::Bool) => true,
+            (Self::Option(id), ty::Adt(adt, subs)) if id == adt.did() => subs.type_at(0).is_bool(),
+            (Self::Result(id), ty::Adt(adt, subs)) if id == adt.did() => subs.type_at(0).is_bool(),
             _ => false,
         }
     }

--- a/src/tools/clippy/clippy_lints/src/loops/explicit_iter_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/explicit_iter_loop.rs
@@ -23,7 +23,7 @@ pub(super) fn check(
     let Some((adjust, ty)) = is_ref_iterable(cx, self_arg, call_expr, enforce_iter_loop_reborrow) else {
         return;
     };
-    if let ty::Array(_, count) = *ty.peel_refs().kind() {
+    if let ty::Array(_, count) = ty.peel_refs().kind() {
         if !ty.is_ref() {
             if !msrv.meets(msrvs::ARRAY_INTO_ITERATOR) {
                 return;
@@ -136,7 +136,7 @@ fn is_ref_iterable<'tcx>(
         let res_ty = cx
             .tcx
             .erase_regions(EarlyBinder::bind(req_res_ty).instantiate(cx.tcx, typeck.node_args(call_expr.hir_id)));
-        let mutbl = if let ty::Ref(_, _, mutbl) = *req_self_ty.kind() {
+        let mutbl = if let ty::Ref(_, _, mutbl) = req_self_ty.kind() {
             Some(mutbl)
         } else {
             None
@@ -153,7 +153,7 @@ fn is_ref_iterable<'tcx>(
                     return Some((AdjustKind::None, self_ty));
                 }
             } else if enforce_iter_loop_reborrow
-                && let ty::Ref(region, ty, Mutability::Mut) = *self_ty.kind()
+                && let ty::Ref(region, ty, Mutability::Mut) = self_ty.kind()
                 && let Some(mutbl) = mutbl
             {
                 // Attempt to reborrow the mutable reference

--- a/src/tools/clippy/clippy_lints/src/loops/for_kv_map.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/for_kv_map.rs
@@ -16,7 +16,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, pat: &'tcx Pat<'_>, arg: &'tcx
     if let PatKind::Tuple(pat, _) = pat.kind {
         if pat.len() == 2 {
             let arg_span = arg.span;
-            let (new_pat_span, kind, ty, mutbl) = match *cx.typeck_results().expr_ty(arg).kind() {
+            let (new_pat_span, kind, ty, mutbl) = match cx.typeck_results().expr_ty(arg).kind() {
                 ty::Ref(_, ty, mutbl) => match (&pat[0].kind, &pat[1].kind) {
                     (key, _) if pat_is_wild(cx, key, body) => (pat[1].span, "value", ty, mutbl),
                     (_, value) if pat_is_wild(cx, value, body) => (pat[0].span, "key", ty, Mutability::Not),

--- a/src/tools/clippy/clippy_lints/src/loops/manual_memcpy.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/manual_memcpy.rs
@@ -333,8 +333,8 @@ struct Start<'hir> {
 fn get_slice_like_element_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
     match ty.kind() {
         ty::Adt(adt, subs) if cx.tcx.is_diagnostic_item(sym::Vec, adt.did()) => Some(subs.type_at(0)),
-        ty::Ref(_, subty, _) => get_slice_like_element_ty(cx, *subty),
-        ty::Slice(ty) | ty::Array(ty, _) => Some(*ty),
+        ty::Ref(_, subty, _) => get_slice_like_element_ty(cx, subty),
+        ty::Slice(ty) | ty::Array(ty, _) => Some(ty),
         _ => None,
     }
 }

--- a/src/tools/clippy/clippy_lints/src/loops/needless_range_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/needless_range_loop.rs
@@ -346,7 +346,7 @@ impl<'a, 'tcx> Visitor<'tcx> for VarVisitor<'a, 'tcx> {
                 for expr in args {
                     let ty = self.cx.typeck_results().expr_ty_adjusted(expr);
                     self.prefer_mutable = false;
-                    if let ty::Ref(_, _, mutbl) = *ty.kind() {
+                    if let ty::Ref(_, _, mutbl) = ty.kind() {
                         if mutbl == Mutability::Mut {
                             self.prefer_mutable = true;
                         }
@@ -361,7 +361,7 @@ impl<'a, 'tcx> Visitor<'tcx> for VarVisitor<'a, 'tcx> {
                     iter::once(receiver).chain(args.iter()),
                 ) {
                     self.prefer_mutable = false;
-                    if let ty::Ref(_, _, mutbl) = *ty.kind() {
+                    if let ty::Ref(_, _, mutbl) = ty.kind() {
                         if mutbl == Mutability::Mut {
                             self.prefer_mutable = true;
                         }

--- a/src/tools/clippy/clippy_lints/src/loops/unused_enumerate_index.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/unused_enumerate_index.rs
@@ -17,7 +17,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, pat: &Pat<'tcx>, arg: &Expr<'_
         && let ExprKind::MethodCall(_method, self_arg, [], _) = arg.kind
         && let ty = cx.typeck_results().expr_ty(arg)
         && pat_is_wild(cx, &index.kind, body)
-        && let ty::Adt(base, _) = *ty.kind()
+        && let ty::Adt(base, _) = ty.kind()
         && cx.tcx.is_diagnostic_item(sym::Enumerate, base.did())
         && let Some((DefKind::AssocFn, call_id)) = cx.typeck_results().type_dependent_def(arg.hir_id)
         && cx.tcx.is_diagnostic_item(sym::enumerate_method, call_id)

--- a/src/tools/clippy/clippy_lints/src/manual_slice_size_calculation.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_slice_size_calculation.rs
@@ -94,7 +94,7 @@ fn simplify_half<'tcx>(
         && cx.tcx.is_diagnostic_item(sym::mem_size_of, def_id)
         && let Some(ty2) = cx.typeck_results().node_args(func.hir_id).types().next()
         // T1 == T2?
-        && *ty1 == ty2
+        && ty1 == ty2
     {
         Some(receiver)
     } else {

--- a/src/tools/clippy/clippy_lints/src/map_unit_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/map_unit_fn.rs
@@ -101,7 +101,7 @@ fn is_unit_type(ty: Ty<'_>) -> bool {
 fn is_unit_function(cx: &LateContext<'_>, expr: &hir::Expr<'_>) -> bool {
     let ty = cx.typeck_results().expr_ty(expr);
 
-    if let ty::FnDef(id, _) = *ty.kind() {
+    if let ty::FnDef(id, _) = ty.kind() {
         if let Some(fn_type) = cx.tcx.fn_sig(id).instantiate_identity().no_bound_vars() {
             return is_unit_type(fn_type.output());
         }

--- a/src/tools/clippy/clippy_lints/src/matches/match_as_ref.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/match_as_ref.rs
@@ -30,7 +30,7 @@ pub(crate) fn check(cx: &LateContext<'_>, ex: &Expr<'_>, arms: &[Arm<'_>], expr:
                 && let input_ty = args.type_at(0)
                 && let ty::Adt(_, args) = output_ty.kind()
                 && let output_ty = args.type_at(0)
-                && let ty::Ref(_, output_ty, _) = *output_ty.kind()
+                && let ty::Ref(_, output_ty, _) = output_ty.kind()
                 && input_ty != output_ty
             {
                 ".map(|x| x as _)"

--- a/src/tools/clippy/clippy_lints/src/matches/match_bool.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/match_bool.rs
@@ -12,7 +12,7 @@ use super::MATCH_BOOL;
 
 pub(crate) fn check(cx: &LateContext<'_>, scrutinee: &Expr<'_>, arms: &[Arm<'_>], expr: &Expr<'_>) {
     // Type of expression is `bool`.
-    if *cx.typeck_results().expr_ty(scrutinee).kind() == ty::Bool {
+    if cx.typeck_results().expr_ty(scrutinee).kind() == ty::Bool {
         span_lint_and_then(
             cx,
             MATCH_BOOL,

--- a/src/tools/clippy/clippy_lints/src/matches/match_str_case_mismatch.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/match_str_case_mismatch.rs
@@ -54,7 +54,7 @@ impl<'a, 'tcx> MatchExprVisitor<'a, 'tcx> {
         if let Some(case_method) = get_case_method(segment_ident) {
             let ty = self.cx.typeck_results().expr_ty(receiver).peel_refs();
 
-            if is_type_lang_item(self.cx, ty, LangItem::String) || ty.kind() == &ty::Str {
+            if is_type_lang_item(self.cx, ty, LangItem::String) || ty.kind() == ty::Str {
                 self.case_method = Some(case_method);
                 return true;
             }

--- a/src/tools/clippy/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
@@ -220,7 +220,7 @@ impl<'a, 'tcx> SigDropChecker<'a, 'tcx> {
                             .any(|ty| self.has_sig_drop_attr_impl(ty)))
             },
             rustc_middle::ty::Tuple(tys) => tys.iter().any(|ty| self.has_sig_drop_attr_impl(ty)),
-            rustc_middle::ty::Array(ty, _) | rustc_middle::ty::Slice(ty) => self.has_sig_drop_attr_impl(*ty),
+            rustc_middle::ty::Array(ty, _) | rustc_middle::ty::Slice(ty) => self.has_sig_drop_attr_impl(ty),
             _ => false,
         };
 
@@ -380,7 +380,7 @@ impl<'a, 'tcx> SigDropHelper<'a, 'tcx> {
         let output_ty = fn_sig.skip_binder().output();
         if let rustc_middle::ty::Ref(output_re, peel_ref_ty, _) = output_ty.kind()
             && input_re == output_re
-            && for_each_top_level_late_bound_region(*peel_ref_ty, contains_input_re).is_continue()
+            && for_each_top_level_late_bound_region(peel_ref_ty, contains_input_re).is_continue()
         {
             // We're lucky! The output type is still a direct reference to the value with significant drop.
             self.sig_drop_holder = SigDropHolder::DirectRef;
@@ -400,7 +400,7 @@ impl<'a, 'tcx> SigDropHelper<'a, 'tcx> {
 fn ty_peel_refs(mut ty: Ty<'_>) -> (Ty<'_>, usize) {
     let mut n = 0;
     while let rustc_middle::ty::Ref(_, new_ty, Mutability::Not) = ty.kind() {
-        ty = *new_ty;
+        ty = new_ty;
         n += 1;
     }
     (ty, n)

--- a/src/tools/clippy/clippy_lints/src/matches/single_match.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/single_match.rs
@@ -56,7 +56,7 @@ pub(crate) fn check<'tcx>(cx: &LateContext<'tcx>, ex: &'tcx Expr<'_>, arms: &'tc
         };
 
         let typeck = cx.typeck_results();
-        if *typeck.expr_ty(ex).peel_refs().kind() != ty::Bool || is_lint_allowed(cx, MATCH_BOOL, ex.hir_id) {
+        if typeck.expr_ty(ex).peel_refs().kind() != ty::Bool || is_lint_allowed(cx, MATCH_BOOL, ex.hir_id) {
             let mut v = PatVisitor {
                 typeck,
                 has_enum: false,
@@ -262,7 +262,7 @@ impl<'a> PatState<'a> {
         single_pat: Option<&'tcx Pat<'tcx>>,
         pats: impl IntoIterator<Item = &'tcx Pat<'tcx>>,
     ) -> bool {
-        let ty::Adt(adt, _) = *cx.typeck.pat_ty(pat).kind() else {
+        let ty::Adt(adt, _) = cx.typeck.pat_ty(pat).kind() else {
             // Should never happen
             *self = Self::Wild;
             return true;
@@ -308,7 +308,7 @@ impl<'a> PatState<'a> {
     fn add_pat<'tcx>(&mut self, cx: &'a PatCtxt<'tcx>, pat: &'tcx Pat<'_>) -> bool {
         match pat.kind {
             PatKind::Path(_)
-                if match *cx.typeck.pat_ty(pat).peel_refs().kind() {
+                if match cx.typeck.pat_ty(pat).peel_refs().kind() {
                     ty::Adt(adt, _) => adt.is_enum() || (adt.is_struct() && !adt.non_enum_variant().fields.is_empty()),
                     ty::Tuple(tys) => !tys.is_empty(),
                     ty::Array(_, len) => len.try_eval_target_usize(cx.tcx, cx.param_env) != Some(1),
@@ -329,7 +329,7 @@ impl<'a> PatState<'a> {
                 self.add_pat(cx, sub_pat)
             },
             PatKind::Slice([sub_pat], _, []) | PatKind::Slice([], _, [sub_pat])
-                if let ty::Array(_, len) = *cx.typeck.pat_ty(pat).kind()
+                if let ty::Array(_, len) = cx.typeck.pat_ty(pat).kind()
                     && len.try_eval_target_usize(cx.tcx, cx.param_env) == Some(1) =>
             {
                 self.add_pat(cx, sub_pat)

--- a/src/tools/clippy/clippy_lints/src/methods/bytecount.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/bytecount.rs
@@ -35,7 +35,7 @@ pub(super) fn check<'tcx>(
         } else {
             return;
         }
-        && ty::Uint(UintTy::U8) == *cx.typeck_results().expr_ty(needle).peel_refs().kind()
+        && ty::Uint(UintTy::U8) == cx.typeck_results().expr_ty(needle).peel_refs().kind()
         && !is_local_used(cx, needle, arg_id)
     {
         let haystack = if let ExprKind::MethodCall(path, receiver, [], _) = filter_recv.kind {

--- a/src/tools/clippy/clippy_lints/src/methods/chars_cmp.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/chars_cmp.rs
@@ -22,7 +22,7 @@ pub(super) fn check(
         let mut applicability = Applicability::MachineApplicable;
         let self_ty = cx.typeck_results().expr_ty_adjusted(args[0].0).peel_refs();
 
-        if *self_ty.kind() != ty::Str {
+        if self_ty.kind() != ty::Str {
             return false;
         }
 

--- a/src/tools/clippy/clippy_lints/src/methods/cloned_instead_of_copied.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/cloned_instead_of_copied.rs
@@ -30,7 +30,7 @@ pub fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, span: Span,
     };
     match inner_ty.kind() {
         // &T where T: Copy
-        ty::Ref(_, ty, _) if is_copy(cx, *ty) => {},
+        ty::Ref(_, ty, _) if is_copy(cx, ty) => {},
         _ => return,
     };
     span_lint_and_sugg(

--- a/src/tools/clippy/clippy_lints/src/methods/iter_overeager_cloned.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/iter_overeager_cloned.rs
@@ -49,7 +49,7 @@ pub(super) fn check<'tcx>(
         && cx.tcx.trait_of_item(method_id) == Some(iter_id)
         && let cloned_recv_ty = typeck.expr_ty_adjusted(cloned_recv)
         && let Some(iter_assoc_ty) = cx.get_associated_type(cloned_recv_ty, iter_id, "Item")
-        && matches!(*iter_assoc_ty.kind(), ty::Ref(_, ty, _) if !is_copy(cx, ty))
+        && matches!(iter_assoc_ty.kind(), ty::Ref(_, ty, _) if !is_copy(cx, ty))
     {
         if needs_into_iter
             && let Some(into_iter_id) = cx.tcx.get_diagnostic_item(sym::IntoIterator)

--- a/src/tools/clippy/clippy_lints/src/methods/map_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/map_clone.rs
@@ -78,7 +78,7 @@ pub(super) fn check(cx: &LateContext<'_>, e: &hir::Expr<'_>, recv: &hir::Expr<'_
                                     let obj_ty = cx.typeck_results().expr_ty(obj);
                                     if let ty::Ref(_, ty, mutability) = obj_ty.kind() {
                                         if matches!(mutability, Mutability::Not) {
-                                            let copy = is_copy(cx, *ty);
+                                            let copy = is_copy(cx, ty);
                                             lint_explicit_closure(cx, e.span, recv.span, copy, msrv);
                                         }
                                     } else {
@@ -123,8 +123,8 @@ fn handle_path(
             && let Some(ty) = args.iter().find_map(|generic_arg| generic_arg.as_type())
             && let ty::Ref(_, ty, Mutability::Not) = ty.kind()
             && let ty::FnDef(_, lst) = cx.typeck_results().expr_ty(arg).kind()
-            && lst.iter().all(|l| l.as_type() == Some(*ty))
-            && !should_call_clone_as_function(cx, *ty)
+            && lst.iter().all(|l| l.as_type() == Some(ty))
+            && !should_call_clone_as_function(cx, ty)
         {
             lint_path(cx, e.span, recv.span, is_copy(cx, ty.peel_refs()));
         }

--- a/src/tools/clippy/clippy_lints/src/methods/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/mod.rs
@@ -5201,7 +5201,7 @@ impl SelfKind {
         }
 
         fn matches_ref<'a>(cx: &LateContext<'a>, mutability: hir::Mutability, parent_ty: Ty<'a>, ty: Ty<'a>) -> bool {
-            if let ty::Ref(_, t, m) = *ty.kind() {
+            if let ty::Ref(_, t, m) = ty.kind() {
                 return m == mutability && t == parent_ty;
             }
 

--- a/src/tools/clippy/clippy_lints/src/methods/needless_character_iteration.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/needless_character_iteration.rs
@@ -34,7 +34,7 @@ fn handle_expr(
                 && method.ident.name.as_str() == "is_ascii"
                 && path_to_local_id(receiver, first_param)
                 && let char_arg_ty = cx.typeck_results().expr_ty_adjusted(receiver).peel_refs()
-                && *char_arg_ty.kind() == ty::Char
+                && char_arg_ty.kind() == ty::Char
                 && let Some(snippet) = snippet_opt(cx, before_chars)
             {
                 span_lint_and_sugg(
@@ -103,7 +103,7 @@ pub(super) fn check(cx: &LateContext<'_>, call_expr: &Expr<'_>, recv: &Expr<'_>,
         && let ExprKind::MethodCall(method, mut recv, [], _) = recv.kind
         && method.ident.name.as_str() == "chars"
         && let str_ty = cx.typeck_results().expr_ty_adjusted(recv).peel_refs()
-        && *str_ty.kind() == ty::Str
+        && str_ty.kind() == ty::Str
     {
         let expr_start = recv.span;
         while let ExprKind::MethodCall(_, new_recv, _, _) = recv.kind {

--- a/src/tools/clippy/clippy_lints/src/methods/needless_collect.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/needless_collect.rs
@@ -223,7 +223,7 @@ fn is_contains_sig(cx: &LateContext<'_>, call_id: HirId, iter_expr: &Expr<'_>) -
         && let sig = cx.tcx.fn_sig(id).instantiate_identity()
         && sig.skip_binder().output().is_bool()
         && let [_, search_ty] = *sig.skip_binder().inputs()
-        && let ty::Ref(_, search_ty, Mutability::Not) = *cx
+        && let ty::Ref(_, search_ty, Mutability::Not) = cx
             .tcx
             .instantiate_bound_regions_with_erased(sig.rebind(search_ty))
             .kind()
@@ -486,14 +486,14 @@ fn get_captured_ids(cx: &LateContext<'_>, ty: Ty<'_>) -> HirIdSet {
     fn get_captured_ids_recursive(cx: &LateContext<'_>, ty: Ty<'_>, set: &mut HirIdSet) {
         match ty.kind() {
             ty::Adt(_, generics) => {
-                for generic in *generics {
+                for generic in generics {
                     if let GenericArgKind::Type(ty) = generic.unpack() {
                         get_captured_ids_recursive(cx, ty, set);
                     }
                 }
             },
             ty::Closure(def_id, _) => {
-                let closure_hir_node = cx.tcx.hir().get_if_local(*def_id).unwrap();
+                let closure_hir_node = cx.tcx.hir().get_if_local(def_id).unwrap();
                 if let Node::Expr(closure_expr) = closure_hir_node {
                     can_move_expr_to_closure(cx, closure_expr)
                         .unwrap()

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_join.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_join.rs
@@ -21,7 +21,7 @@ pub(super) fn check<'tcx>(
     if let ty::Ref(_, ref_type, _) = collect_output_adjusted_type.kind()
         // the turbofish for collect is ::<Vec<String>>
         && let ty::Slice(slice) = ref_type.kind()
-        && is_type_lang_item(cx, *slice, LangItem::String)
+        && is_type_lang_item(cx, slice, LangItem::String)
         // the argument for join is ""
         && let ExprKind::Lit(spanned) = &join_arg.kind
         && let LitKind::Str(symbol, _) = spanned.node

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_min_or_max.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_min_or_max.rs
@@ -80,10 +80,10 @@ fn detect_extrema<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) -> Option<
     let cv = ConstEvalCtxt::new(cx).eval(expr)?;
 
     match (cv.int_value(cx.tcx, ty)?, ty.kind()) {
-        (FullInt::S(i), &ty::Int(ity)) if i == i128::MIN >> (128 - ity.bit_width()?) => Some(Extrema::Minimum),
-        (FullInt::S(i), &ty::Int(ity)) if i == i128::MAX >> (128 - ity.bit_width()?) => Some(Extrema::Maximum),
-        (FullInt::U(i), &ty::Uint(uty)) if i == u128::MAX >> (128 - uty.bit_width()?) => Some(Extrema::Maximum),
-        (FullInt::U(0), &ty::Uint(_)) => Some(Extrema::Minimum),
+        (FullInt::S(i), ty::Int(ity)) if i == i128::MIN >> (128 - ity.bit_width()?) => Some(Extrema::Minimum),
+        (FullInt::S(i), ty::Int(ity)) if i == i128::MAX >> (128 - ity.bit_width()?) => Some(Extrema::Maximum),
+        (FullInt::U(i), ty::Uint(uty)) if i == u128::MAX >> (128 - uty.bit_width()?) => Some(Extrema::Maximum),
+        (FullInt::U(0), ty::Uint(_)) => Some(Extrema::Minimum),
         _ => None,
     }
 }

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
@@ -453,7 +453,7 @@ fn get_callee_generic_args_and_args<'tcx>(
         && let ty::FnDef(callee_def_id, _) = callee_ty.kind()
     {
         let generic_args = cx.typeck_results().node_args(callee.hir_id);
-        return Some((*callee_def_id, generic_args, None, args));
+        return Some((callee_def_id, generic_args, None, args));
     }
     if let ExprKind::MethodCall(_, recv, args, _) = expr.kind
         && let Some(method_def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id)
@@ -524,7 +524,7 @@ fn can_change_type<'a>(cx: &LateContext<'a>, mut expr: &'a Expr<'a>, mut ty: Ty<
                         .chain(call_args)
                         .position(|arg| arg.hir_id == expr.hir_id)
                         && let param_ty = fn_sig.input(arg_index).skip_binder()
-                        && let ty::Param(ParamTy { index: param_index , ..}) = *param_ty.kind()
+                        && let ty::Param(ParamTy { index: param_index , ..}) = param_ty.kind()
                         // https://github.com/rust-lang/rust-clippy/issues/9504 and https://github.com/rust-lang/rust-clippy/issues/10021
                         && (param_index as usize) < call_generic_args.len()
                     {

--- a/src/tools/clippy/clippy_lints/src/methods/utils.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/utils.rs
@@ -19,7 +19,7 @@ pub(super) fn derefs_to_slice<'tcx>(
             ty::Adt(def, _) if def.is_box() => may_slice(cx, ty.boxed_ty()),
             ty::Adt(..) => is_type_diagnostic_item(cx, ty, sym::Vec),
             ty::Array(_, size) => size.try_eval_target_usize(cx.tcx, cx.param_env).is_some(),
-            ty::Ref(_, inner, _) => may_slice(cx, *inner),
+            ty::Ref(_, inner, _) => may_slice(cx, inner),
             _ => false,
         }
     }
@@ -35,7 +35,7 @@ pub(super) fn derefs_to_slice<'tcx>(
             ty::Slice(_) => Some(expr),
             ty::Adt(def, _) if def.is_box() && may_slice(cx, ty.boxed_ty()) => Some(expr),
             ty::Ref(_, inner, _) => {
-                if may_slice(cx, *inner) {
+                if may_slice(cx, inner) {
                     Some(expr)
                 } else {
                     None

--- a/src/tools/clippy/clippy_lints/src/methods/zst_offset.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/zst_offset.rs
@@ -7,7 +7,7 @@ use super::ZST_OFFSET;
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, recv: &hir::Expr<'_>) {
     if let ty::RawPtr(ty, _) = cx.typeck_results().expr_ty(recv).kind()
-        && let Ok(layout) = cx.tcx.layout_of(cx.param_env.and(*ty))
+        && let Ok(layout) = cx.tcx.layout_of(cx.param_env.and(ty))
         && layout.is_zst()
     {
         span_lint(cx, ZST_OFFSET, expr.span, "offset calculation on zero-sized value");

--- a/src/tools/clippy/clippy_lints/src/mixed_read_write_in_expression.rs
+++ b/src/tools/clippy/clippy_lints/src/mixed_read_write_in_expression.rs
@@ -168,7 +168,7 @@ impl<'a, 'tcx> Visitor<'tcx> for DivergenceVisitor<'a, 'tcx> {
                 match typ.kind() {
                     ty::FnDef(..) | ty::FnPtr(..) => {
                         let sig = typ.fn_sig(self.cx.tcx);
-                        if self.cx.tcx.instantiate_bound_regions_with_erased(sig).output().kind() == &ty::Never {
+                        if self.cx.tcx.instantiate_bound_regions_with_erased(sig).output().kind() == ty::Never {
                             self.report_diverging_sub_expr(e);
                         }
                     },

--- a/src/tools/clippy/clippy_lints/src/multiple_unsafe_ops_per_block.rs
+++ b/src/tools/clippy/clippy_lints/src/multiple_unsafe_ops_per_block.rs
@@ -128,7 +128,7 @@ fn collect_unsafe_exprs<'tcx>(
             },
 
             ExprKind::Call(path_expr, _) => {
-                let sig = match *cx.typeck_results().expr_ty(path_expr).kind() {
+                let sig = match cx.typeck_results().expr_ty(path_expr).kind() {
                     ty::FnDef(id, _) => cx.tcx.fn_sig(id).skip_binder(),
                     ty::FnPtr(sig_tys, hdr) => sig_tys.with(hdr),
                     _ => return Continue(Descend::Yes),

--- a/src/tools/clippy/clippy_lints/src/mutex_atomic.rs
+++ b/src/tools/clippy/clippy_lints/src/mutex_atomic.rs
@@ -91,7 +91,7 @@ impl<'tcx> LateLintPass<'tcx> for Mutex {
                         "consider using an `{atomic_name}` instead of a `Mutex` here; if you just want the locking \
                          behavior and not the internal type, consider using `Mutex<()>`"
                     );
-                    match *mutex_param.kind() {
+                    match mutex_param.kind() {
                         ty::Uint(t) if t != UintTy::Usize => span_lint(cx, MUTEX_INTEGER, expr.span, msg),
                         ty::Int(t) if t != IntTy::Isize => span_lint(cx, MUTEX_INTEGER, expr.span, msg),
                         _ => span_lint(cx, MUTEX_ATOMIC, expr.span, msg),

--- a/src/tools/clippy/clippy_lints/src/needless_borrows_for_generic_args.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_borrows_for_generic_args.rs
@@ -86,7 +86,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBorrowsForGenericArgs<'tcx> {
             && !use_cx.is_ty_unified
             && let use_node = use_cx.use_node(cx)
             && let Some(DefinedTy::Mir(ty)) = use_node.defined_ty(cx)
-            && let ty::Param(ty) = *ty.value.skip_binder().kind()
+            && let ty::Param(ty) = ty.value.skip_binder().kind()
             && let Some((hir_id, fn_id, i)) = match use_node {
                 ExprUseNode::MethodArg(_, _, 0) => None,
                 ExprUseNode::MethodArg(hir_id, None, i) => cx
@@ -327,7 +327,7 @@ fn is_mixed_projection_predicate<'tcx>(
         // The inner-most self type is a type parameter from the current function.
         let mut projection_term = projection_predicate.projection_term;
         loop {
-            match *projection_term.self_ty().kind() {
+            match projection_term.self_ty().kind() {
                 ty::Alias(ty::Projection, inner_projection_ty) => {
                     projection_term = inner_projection_ty.into();
                 },
@@ -422,7 +422,7 @@ fn replace_types<'tcx>(
                     if let Ok(projected_ty) = cx.tcx.try_normalize_erasing_regions(cx.param_env, projection)
                         && args[term_param_ty.index as usize] != GenericArg::from(projected_ty)
                     {
-                        deque.push_back((*term_param_ty, projected_ty));
+                        deque.push_back((term_param_ty, projected_ty));
                     }
                 }
             }

--- a/src/tools/clippy/clippy_lints/src/non_copy_const.rs
+++ b/src/tools/clippy/clippy_lints/src/non_copy_const.rs
@@ -193,7 +193,7 @@ impl<'tcx> NonCopyConst<'tcx> {
     }
 
     fn is_value_unfrozen_raw_inner(cx: &LateContext<'tcx>, val: ty::ValTree<'tcx>, ty: Ty<'tcx>) -> bool {
-        match *ty.kind() {
+        match ty.kind() {
             // the fact that we have to dig into every structs to search enums
             // leads us to the point checking `UnsafeCell` directly is the only option.
             ty::Adt(ty_def, ..) if ty_def.is_unsafe_cell() => true,

--- a/src/tools/clippy/clippy_lints/src/non_send_fields_in_send_ty.rs
+++ b/src/tools/clippy/clippy_lints/src/non_send_fields_in_send_ty.rs
@@ -205,7 +205,7 @@ fn ty_allowed_with_raw_pointer_heuristic<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'t
         ty::Tuple(fields) => fields
             .iter()
             .all(|ty| ty_allowed_with_raw_pointer_heuristic(cx, ty, send_trait)),
-        ty::Array(ty, _) | ty::Slice(ty) => ty_allowed_with_raw_pointer_heuristic(cx, *ty, send_trait),
+        ty::Array(ty, _) | ty::Slice(ty) => ty_allowed_with_raw_pointer_heuristic(cx, ty, send_trait),
         ty::Adt(_, args) => {
             if contains_pointer_like(cx, ty) {
                 // descends only if ADT contains any raw pointers

--- a/src/tools/clippy/clippy_lints/src/only_used_in_recursion.rs
+++ b/src/tools/clippy/clippy_lints/src/only_used_in_recursion.rs
@@ -387,7 +387,7 @@ fn has_matching_args(kind: FnKind, args: GenericArgsRef<'_>) -> bool {
         FnKind::Fn => true,
         FnKind::TraitFn => args.iter().enumerate().all(|(idx, subst)| match subst.unpack() {
             GenericArgKind::Lifetime(_) => true,
-            GenericArgKind::Type(ty) => matches!(*ty.kind(), ty::Param(ty) if ty.index as usize == idx),
+            GenericArgKind::Type(ty) => matches!(ty.kind(), ty::Param(ty) if ty.index as usize == idx),
             GenericArgKind::Const(c) => matches!(c.kind(), ConstKind::Param(c) if c.index as usize == idx),
         }),
         FnKind::ImplTraitFn(expected_args) => std::ptr::from_ref(args) as usize == expected_args,

--- a/src/tools/clippy/clippy_lints/src/operators/absurd_extreme_comparisons.rs
+++ b/src/tools/clippy/clippy_lints/src/operators/absurd_extreme_comparisons.rs
@@ -124,16 +124,16 @@ fn detect_extreme_expr<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) -> Op
     let cv = ConstEvalCtxt::new(cx).eval(expr)?;
 
     let which = match (ty.kind(), cv) {
-        (&ty::Bool, Constant::Bool(false)) | (&ty::Uint(_), Constant::Int(0)) => ExtremeType::Minimum,
-        (&ty::Int(ity), Constant::Int(i)) if i == unsext(cx.tcx, i128::MIN >> (128 - int_bits(cx.tcx, ity)), ity) => {
+        (ty::Bool, Constant::Bool(false)) | (ty::Uint(_), Constant::Int(0)) => ExtremeType::Minimum,
+        (ty::Int(ity), Constant::Int(i)) if i == unsext(cx.tcx, i128::MIN >> (128 - int_bits(cx.tcx, ity)), ity) => {
             ExtremeType::Minimum
         },
 
-        (&ty::Bool, Constant::Bool(true)) => ExtremeType::Maximum,
-        (&ty::Int(ity), Constant::Int(i)) if i == unsext(cx.tcx, i128::MAX >> (128 - int_bits(cx.tcx, ity)), ity) => {
+        (ty::Bool, Constant::Bool(true)) => ExtremeType::Maximum,
+        (ty::Int(ity), Constant::Int(i)) if i == unsext(cx.tcx, i128::MAX >> (128 - int_bits(cx.tcx, ity)), ity) => {
             ExtremeType::Maximum
         },
-        (&ty::Uint(uty), Constant::Int(i)) if clip(cx.tcx, u128::MAX, uty) == i => ExtremeType::Maximum,
+        (ty::Uint(uty), Constant::Int(i)) if clip(cx.tcx, u128::MAX, uty) == i => ExtremeType::Maximum,
 
         _ => return None,
     };

--- a/src/tools/clippy/clippy_lints/src/operators/identity_op.rs
+++ b/src/tools/clippy/clippy_lints/src/operators/identity_op.rs
@@ -201,7 +201,7 @@ fn check_remainder(cx: &LateContext<'_>, left: &Expr<'_>, right: &Expr<'_>, span
 
 fn check_op(cx: &LateContext<'_>, e: &Expr<'_>, m: i8, span: Span, arg: Span, parens: Parens, is_erased: bool) -> bool {
     if let Some(Constant::Int(v)) = ConstEvalCtxt::new(cx).eval_simple(e).map(Constant::peel_refs) {
-        let check = match *cx.typeck_results().expr_ty(e).peel_refs().kind() {
+        let check = match cx.typeck_results().expr_ty(e).peel_refs().kind() {
             ty::Int(ity) => unsext(cx.tcx, -1_i128, ity),
             ty::Uint(uty) => clip(cx.tcx, !0, uty),
             _ => return false,

--- a/src/tools/clippy/clippy_lints/src/operators/modulo_arithmetic.rs
+++ b/src/tools/clippy/clippy_lints/src/operators/modulo_arithmetic.rs
@@ -57,7 +57,7 @@ struct OperandInfo {
 
 fn analyze_operand(operand: &Expr<'_>, cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<OperandInfo> {
     match ConstEvalCtxt::new(cx).eval(operand) {
-        Some(Constant::Int(v)) => match *cx.typeck_results().expr_ty(expr).kind() {
+        Some(Constant::Int(v)) => match cx.typeck_results().expr_ty(expr).kind() {
             ty::Int(ity) => {
                 let value = sext(cx.tcx, v, ity);
                 return Some(OperandInfo {

--- a/src/tools/clippy/clippy_lints/src/operators/modulo_one.rs
+++ b/src/tools/clippy/clippy_lints/src/operators/modulo_one.rs
@@ -13,7 +13,7 @@ pub(crate) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, op: BinOpKind, right:
         }
 
         if let ty::Int(ity) = cx.typeck_results().expr_ty(right).kind() {
-            if is_integer_const(cx, right, unsext(cx.tcx, -1, *ity)) {
+            if is_integer_const(cx, right, unsext(cx.tcx, -1, ity)) {
                 span_lint(
                     cx,
                     MODULO_ONE,

--- a/src/tools/clippy/clippy_lints/src/pass_by_ref_or_value.rs
+++ b/src/tools/clippy/clippy_lints/src/pass_by_ref_or_value.rs
@@ -158,7 +158,7 @@ impl<'tcx> PassByRefOrValue {
                 _ => (),
             }
 
-            match *ty.skip_binder().kind() {
+            match ty.skip_binder().kind() {
                 ty::Ref(lt, ty, Mutability::Not) => {
                     match lt.kind() {
                         RegionKind::ReBound(index, region)

--- a/src/tools/clippy/clippy_lints/src/pattern_type_mismatch.rs
+++ b/src/tools/clippy/clippy_lints/src/pattern_type_mismatch.rs
@@ -180,7 +180,7 @@ fn find_first_mismatch(cx: &LateContext<'_>, pat: &Pat<'_>) -> Option<(Span, Mut
         };
         if let Some(adjustments) = cx.typeck_results().pat_adjustments().get(adjust_pat.hir_id) {
             if let [first, ..] = **adjustments {
-                if let ty::Ref(.., mutability) = *first.kind() {
+                if let ty::Ref(.., mutability) = first.kind() {
                     let level = if p.hir_id == pat.hir_id {
                         Level::Top
                     } else {

--- a/src/tools/clippy/clippy_lints/src/ptr.rs
+++ b/src/tools/clippy/clippy_lints/src/ptr.rs
@@ -425,8 +425,8 @@ fn check_fn_args<'cx, 'tcx: 'cx>(
         .zip(hir_tys.iter())
         .enumerate()
         .filter_map(move |(i, (ty, hir_ty))| {
-            if let ty::Ref(_, ty, mutability) = *ty.kind()
-                && let  ty::Adt(adt, args) = *ty.kind()
+            if let ty::Ref(_, ty, mutability) = ty.kind()
+                && let  ty::Adt(adt, args) = ty.kind()
                 && let TyKind::Ref(lt, ref ty) = hir_ty.kind
                 && let TyKind::Path(QPath::Resolved(None, path)) = ty.ty.kind
                 // Check that the name as typed matches the actual name of the type.
@@ -614,7 +614,7 @@ fn check_ptr_arg_usage<'tcx>(cx: &LateContext<'tcx>, body: &Body<'tcx>, args: &[
                     ExprKind::Call(f, expr_args) => {
                         let i = expr_args.iter().position(|arg| arg.hir_id == child_id).unwrap_or(0);
                         if expr_sig(self.cx, f).and_then(|sig| sig.input(i)).map_or(true, |ty| {
-                            match *ty.skip_binder().peel_refs().kind() {
+                            match ty.skip_binder().peel_refs().kind() {
                                 ty::Dynamic(preds, _, _) => !matches_preds(self.cx, args.deref_ty.ty(self.cx), preds),
                                 ty::Param(_) => true,
                                 ty::Adt(def, _) => def.did() == args.ty_did,
@@ -648,7 +648,7 @@ fn check_ptr_arg_usage<'tcx>(cx: &LateContext<'tcx>, body: &Body<'tcx>, args: &[
                             return;
                         };
 
-                        match *self.cx.tcx.fn_sig(id).instantiate_identity().skip_binder().inputs()[i]
+                        match self.cx.tcx.fn_sig(id).instantiate_identity().skip_binder().inputs()[i]
                             .peel_refs()
                             .kind()
                         {

--- a/src/tools/clippy/clippy_lints/src/rc_clone_in_vec_init.rs
+++ b/src/tools/clippy/clippy_lints/src/rc_clone_in_vec_init.rs
@@ -132,7 +132,7 @@ fn ref_init(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<(Symbol, Span)> {
             return Some((symbol, func.span));
         }
 
-        if let ty::Adt(adt, _) = *cx.typeck_results().expr_ty(expr).kind()
+        if let ty::Adt(adt, _) = cx.typeck_results().expr_ty(expr).kind()
             && matches!(cx.tcx.get_diagnostic_name(adt.did()), Some(sym::RcWeak | sym::ArcWeak))
         {
             return Some((Symbol::intern("Weak"), func.span));

--- a/src/tools/clippy/clippy_lints/src/redundant_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_clone.rs
@@ -258,7 +258,7 @@ fn is_call_with_ref_arg<'tcx>(
     } = kind
         && args.len() == 1
         && let mir::Operand::Move(mir::Place { local, .. }) = &args[0].node
-        && let ty::FnDef(def_id, _) = *func.ty(mir, cx.tcx).kind()
+        && let ty::FnDef(def_id, _) = func.ty(mir, cx.tcx).kind()
         && let (inner_ty, 1) = walk_ptrs_ty_depth(args[0].node.ty(mir, cx.tcx))
         && !is_copy(cx, inner_ty)
     {

--- a/src/tools/clippy/clippy_lints/src/significant_drop_tightening.rs
+++ b/src/tools/clippy/clippy_lints/src/significant_drop_tightening.rs
@@ -186,7 +186,7 @@ impl<'cx, 'others, 'tcx> AttrChecker<'cx, 'others, 'tcx> {
                         return true;
                     }
                 }
-                for generic_arg in *b {
+                for generic_arg in b {
                     if let GenericArgKind::Type(ty) = generic_arg.unpack() {
                         if self.has_sig_drop_attr(ty) {
                             return true;
@@ -198,7 +198,7 @@ impl<'cx, 'others, 'tcx> AttrChecker<'cx, 'others, 'tcx> {
             rustc_middle::ty::Array(ty, _)
             | rustc_middle::ty::RawPtr(ty, _)
             | rustc_middle::ty::Ref(_, ty, _)
-            | rustc_middle::ty::Slice(ty) => self.has_sig_drop_attr(*ty),
+            | rustc_middle::ty::Slice(ty) => self.has_sig_drop_attr(ty),
             _ => false,
         }
     }

--- a/src/tools/clippy/clippy_lints/src/size_of_in_element_count.rs
+++ b/src/tools/clippy/clippy_lints/src/size_of_in_element_count.rs
@@ -110,7 +110,7 @@ fn get_pointee_ty_and_count_expr<'tcx>(
         && let ty::RawPtr(pointee_ty, _) =
             cx.typeck_results().expr_ty(ptr_self).kind()
     {
-        return Some((*pointee_ty, count));
+        return Some((pointee_ty, count));
     };
     None
 }

--- a/src/tools/clippy/clippy_lints/src/to_digit_is_some.rs
+++ b/src/tools/clippy/clippy_lints/src/to_digit_is_some.rs
@@ -44,7 +44,7 @@ impl<'tcx> LateLintPass<'tcx> for ToDigitIsSome {
                 hir::ExprKind::MethodCall(to_digits_path, char_arg, [radix_arg], _) => {
                     if to_digits_path.ident.name.as_str() == "to_digit"
                         && let char_arg_ty = cx.typeck_results().expr_ty_adjusted(char_arg)
-                        && *char_arg_ty.kind() == ty::Char
+                        && char_arg_ty.kind() == ty::Char
                     {
                         Some((true, *char_arg, radix_arg))
                     } else {

--- a/src/tools/clippy/clippy_lints/src/transmute/crosspointer_transmute.rs
+++ b/src/tools/clippy/clippy_lints/src/transmute/crosspointer_transmute.rs
@@ -7,7 +7,7 @@ use rustc_middle::ty::{self, Ty};
 /// Checks for `crosspointer_transmute` lint.
 /// Returns `true` if it's triggered, otherwise returns `false`.
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>, from_ty: Ty<'tcx>, to_ty: Ty<'tcx>) -> bool {
-    match (*from_ty.kind(), *to_ty.kind()) {
+    match (from_ty.kind(), to_ty.kind()) {
         (ty::RawPtr(from_ptr_ty, _), _) if from_ptr_ty == to_ty => {
             span_lint(
                 cx,

--- a/src/tools/clippy/clippy_lints/src/transmute/transmute_ref_to_ref.rs
+++ b/src/tools/clippy/clippy_lints/src/transmute/transmute_ref_to_ref.rs
@@ -19,8 +19,8 @@ pub(super) fn check<'tcx>(
 ) -> bool {
     let mut triggered = false;
 
-    if let (ty::Ref(_, ty_from, from_mutbl), ty::Ref(_, ty_to, to_mutbl)) = (*from_ty.kind(), *to_ty.kind()) {
-        if let ty::Slice(slice_ty) = *ty_from.kind()
+    if let (ty::Ref(_, ty_from, from_mutbl), ty::Ref(_, ty_to, to_mutbl)) = (from_ty.kind(), to_ty.kind()) {
+        if let ty::Slice(slice_ty) = ty_from.kind()
             && ty_to.is_str()
             && let ty::Uint(ty::UintTy::U8) = slice_ty.kind()
             && from_mutbl == to_mutbl

--- a/src/tools/clippy/clippy_lints/src/transmute/transmute_undefined_repr.rs
+++ b/src/tools/clippy/clippy_lints/src/transmute/transmute_undefined_repr.rs
@@ -196,21 +196,21 @@ fn reduce_refs<'tcx>(cx: &LateContext<'tcx>, mut from_ty: Ty<'tcx>, mut to_ty: T
     let (from_fat_ptr, to_fat_ptr) = loop {
         break match (from_ty.kind(), to_ty.kind()) {
             (
-                &(ty::Ref(_, from_sub_ty, _) | ty::RawPtr(from_sub_ty, _)),
-                &(ty::Ref(_, to_sub_ty, _) | ty::RawPtr(to_sub_ty, _)),
+                ty::Ref(_, from_sub_ty, _) | ty::RawPtr(from_sub_ty, _),
+                ty::Ref(_, to_sub_ty, _) | ty::RawPtr(to_sub_ty, _),
             ) => {
-                from_raw_ptr = matches!(*from_ty.kind(), ty::RawPtr(_, _));
+                from_raw_ptr = matches!(from_ty.kind(), ty::RawPtr(_, _));
                 from_ty = from_sub_ty;
-                to_raw_ptr = matches!(*to_ty.kind(), ty::RawPtr(_, _));
+                to_raw_ptr = matches!(to_ty.kind(), ty::RawPtr(_, _));
                 to_ty = to_sub_ty;
                 continue;
             },
-            (&(ty::Ref(_, unsized_ty, _) | ty::RawPtr(unsized_ty, _)), _)
+            (ty::Ref(_, unsized_ty, _) | ty::RawPtr(unsized_ty, _), _)
                 if !unsized_ty.is_sized(cx.tcx, cx.param_env) =>
             {
                 (true, false)
             },
-            (_, &(ty::Ref(_, unsized_ty, _) | ty::RawPtr(unsized_ty, _)))
+            (_, ty::Ref(_, unsized_ty, _) | ty::RawPtr(unsized_ty, _))
                 if !unsized_ty.is_sized(cx.tcx, cx.param_env) =>
             {
                 (false, true)
@@ -245,7 +245,7 @@ enum ReducedTy<'tcx> {
 fn reduce_ty<'tcx>(cx: &LateContext<'tcx>, mut ty: Ty<'tcx>) -> ReducedTy<'tcx> {
     loop {
         ty = cx.tcx.try_normalize_erasing_regions(cx.param_env, ty).unwrap_or(ty);
-        return match *ty.kind() {
+        return match ty.kind() {
             ty::Array(sub_ty, _) if matches!(sub_ty.kind(), ty::Int(_) | ty::Uint(_)) => {
                 ReducedTy::TypeErasure { raw_ptr_only: false }
             },
@@ -307,7 +307,7 @@ fn is_zero_sized_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
 }
 
 fn is_size_pair(ty: Ty<'_>) -> bool {
-    if let ty::Tuple(tys) = *ty.kind()
+    if let ty::Tuple(tys) = ty.kind()
         && let [ty1, ty2] = &**tys
     {
         matches!(ty1.kind(), ty::Int(IntTy::Isize) | ty::Uint(UintTy::Usize))

--- a/src/tools/clippy/clippy_lints/src/transmute/useless_transmute.rs
+++ b/src/tools/clippy/clippy_lints/src/transmute/useless_transmute.rs
@@ -15,7 +15,7 @@ pub(super) fn check<'tcx>(
     to_ty: Ty<'tcx>,
     arg: &'tcx Expr<'_>,
 ) -> bool {
-    match (*from_ty.kind(), *to_ty.kind()) {
+    match (from_ty.kind(), to_ty.kind()) {
         _ if from_ty == to_ty && !from_ty.has_erased_regions() => {
             span_lint(
                 cx,

--- a/src/tools/clippy/clippy_lints/src/tuple_array_conversions.rs
+++ b/src/tools/clippy/clippy_lints/src/tuple_array_conversions.rs
@@ -90,7 +90,7 @@ fn check_array<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, elements: &
             ExprKind::Path(_) => Some(elements.iter().collect()),
             _ => None,
         })
-        && all_bindings_are_for_conv(cx, &[*ty], expr, elements, &locals, ToType::Array)
+        && all_bindings_are_for_conv(cx, &[ty], expr, elements, &locals, ToType::Array)
         && !is_from_proc_macro(cx, expr)
     {
         span_lint_and_help(
@@ -191,7 +191,8 @@ fn all_bindings_are_for_conv<'tcx>(
                 },
                 (ToType::Tuple, ty::Array(ty, len)) => {
                     let Some(len) = len.try_eval_target_usize(cx.tcx, cx.param_env) else { return false };
-                    len as usize == elements.len() && final_tys.iter().chain(once(ty)).all_equal()
+                    // njn: added `&`
+                    len as usize == elements.len() && final_tys.iter().chain(once(&ty)).all_equal()
                 },
                 _ => false,
             }

--- a/src/tools/clippy/clippy_lints/src/unconditional_recursion.rs
+++ b/src/tools/clippy/clippy_lints/src/unconditional_recursion.rs
@@ -140,7 +140,7 @@ fn matches_ty<'tcx>(
     expected_left: Ty<'tcx>,
     expected_right: Ty<'tcx>,
 ) -> bool {
-    while let (&ty::Ref(_, lty, _), &ty::Ref(_, rty, _)) = (left.kind(), right.kind()) {
+    while let (ty::Ref(_, lty, _), ty::Ref(_, rty, _)) = (left.kind(), right.kind()) {
         if lty == expected_left && rty == expected_right {
             return true;
         }
@@ -161,8 +161,8 @@ fn check_partial_eq(cx: &LateContext<'_>, method_span: Span, method_def_id: Loca
 
     // That has two arguments.
     if let [self_arg, other_arg] = sig.inputs()
-        && let &ty::Ref(_, self_arg, _) = self_arg.kind()
-        && let &ty::Ref(_, other_arg, _) = other_arg.kind()
+        && let ty::Ref(_, self_arg, _) = self_arg.kind()
+        && let ty::Ref(_, other_arg, _) = other_arg.kind()
         // The two arguments are of the same type.
         && let Some(trait_def_id) = get_impl_trait_def_id(cx, method_def_id)
         // The trait is `PartialEq`.

--- a/src/tools/clippy/clippy_lints/src/unit_types/let_unit_value.rs
+++ b/src/tools/clippy/clippy_lints/src/unit_types/let_unit_value.rs
@@ -218,7 +218,7 @@ fn needs_inferred_result_ty(
         _ => return false,
     };
     let sig = cx.tcx.fn_sig(id).instantiate_identity().skip_binder();
-    if let ty::Param(output_ty) = *sig.output().kind() {
+    if let ty::Param(output_ty) = sig.output().kind() {
         let args: Vec<&Expr<'_>> = if let Some(receiver) = receiver {
             std::iter::once(receiver).chain(args.iter()).collect()
         } else {

--- a/src/tools/clippy/clippy_lints/src/use_self.rs
+++ b/src/tools/clippy/clippy_lints/src/use_self.rs
@@ -350,7 +350,7 @@ fn same_lifetimes<'tcx>(a: MiddleTy<'tcx>, b: MiddleTy<'tcx>) -> bool {
 fn has_no_lifetime(ty: MiddleTy<'_>) -> bool {
     use rustc_middle::ty::{Adt, GenericArgKind};
     match ty.kind() {
-        &Adt(_, args) => !args
+        Adt(_, args) => !args
             .iter()
             // TODO: Handle inferred lifetimes
             .any(|arg| matches!(arg.unpack(), GenericArgKind::Lifetime(..))),

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -1107,7 +1107,7 @@ pub fn capture_local_usage(cx: &LateContext<'_>, e: &Expr<'_>) -> CaptureKind {
             .map_or(&[][..], |x| &**x)
         {
             if let rustc_ty::RawPtr(_, mutability) | rustc_ty::Ref(_, _, mutability) =
-                *adjust.last().map_or(target, |a| a.target).kind()
+                adjust.last().map_or(target, |a| a.target).kind()
             {
                 return CaptureKind::Ref(mutability);
             }
@@ -2371,10 +2371,10 @@ pub fn is_slice_of_primitives(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<S
     let expr_type = cx.typeck_results().expr_ty_adjusted(expr);
     let expr_kind = expr_type.kind();
     let is_primitive = match expr_kind {
-        rustc_ty::Slice(element_type) => is_recursively_primitive_type(*element_type),
-        rustc_ty::Ref(_, inner_ty, _) if matches!(inner_ty.kind(), &rustc_ty::Slice(_)) => {
+        rustc_ty::Slice(element_type) => is_recursively_primitive_type(element_type),
+        rustc_ty::Ref(_, inner_ty, _) if matches!(inner_ty.kind(), rustc_ty::Slice(_)) => {
             if let rustc_ty::Slice(element_type) = inner_ty.kind() {
-                is_recursively_primitive_type(*element_type)
+                is_recursively_primitive_type(element_type)
             } else {
                 unreachable!()
             }
@@ -2525,7 +2525,7 @@ pub fn peel_hir_ty_refs<'a>(mut ty: &'a hir::Ty<'a>) -> (&'a hir::Ty<'a>, usize)
 pub fn peel_middle_ty_refs(mut ty: Ty<'_>) -> (Ty<'_>, usize) {
     let mut count = 0;
     while let rustc_ty::Ref(_, dest_ty, _) = ty.kind() {
-        ty = *dest_ty;
+        ty = dest_ty;
         count += 1;
     }
     (ty, count)

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -71,7 +71,7 @@ fn check_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, span: Span) -> McfResult {
                 return Err((span, "function pointers in const fn are unstable".into()));
             },
             ty::Dynamic(preds, _, _) => {
-                for pred in *preds {
+                for pred in preds {
                     match pred.skip_binder() {
                         ty::ExistentialPredicate::AutoTrait(_) | ty::ExistentialPredicate::Projection(_) => {
                             return Err((
@@ -333,7 +333,7 @@ fn check_terminator<'tcx>(
         }
         | TerminatorKind::TailCall { func, args, fn_span: _ } => {
             let fn_ty = func.ty(body, tcx);
-            if let ty::FnDef(fn_def_id, _) = *fn_ty.kind() {
+            if let ty::FnDef(fn_def_id, _) = fn_ty.kind() {
                 if !is_const_fn(tcx, fn_def_id, msrv) {
                     return Err((
                         span,

--- a/src/tools/clippy/clippy_utils/src/ty.rs
+++ b/src/tools/clippy/clippy_utils/src/ty.rs
@@ -91,7 +91,7 @@ pub fn contains_ty_adt_constructor_opaque<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'
                     return true;
                 }
 
-                if let ty::Alias(ty::Opaque, AliasTy { def_id, .. }) = *inner_ty.kind() {
+                if let ty::Alias(ty::Opaque, AliasTy { def_id, .. }) = inner_ty.kind() {
                     if !seen.insert(def_id) {
                         return false;
                     }
@@ -191,7 +191,7 @@ pub fn has_iter_method(cx: &LateContext<'_>, probably_ref_ty: Ty<'_>) -> Option<
     ];
 
     let ty_to_check = match probably_ref_ty.kind() {
-        ty::Ref(_, ty_to_check, _) => *ty_to_check,
+        ty::Ref(_, ty_to_check, _) => ty_to_check,
         _ => probably_ref_ty,
     };
 
@@ -322,11 +322,11 @@ pub fn has_drop<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
 pub fn is_must_use_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
     match ty.kind() {
         ty::Adt(adt, _) => cx.tcx.has_attr(adt.did(), sym::must_use),
-        ty::Foreign(did) => cx.tcx.has_attr(*did, sym::must_use),
+        ty::Foreign(did) => cx.tcx.has_attr(did, sym::must_use),
         ty::Slice(ty) | ty::Array(ty, _) | ty::RawPtr(ty, _) | ty::Ref(_, ty, _) => {
             // for the Array case we don't need to care for the len == 0 case
             // because we don't want to lint functions returning empty arrays
-            is_must_use_ty(cx, *ty)
+            is_must_use_ty(cx, ty)
         },
         ty::Tuple(args) => args.iter().any(|ty| is_must_use_ty(cx, ty)),
         ty::Alias(ty::Opaque, AliasTy { def_id, .. }) => {
@@ -340,7 +340,7 @@ pub fn is_must_use_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
             false
         },
         ty::Dynamic(binder, _, _) => {
-            for predicate in *binder {
+            for predicate in binder {
                 if let ty::ExistentialPredicate::Trait(ref trait_ref) = predicate.skip_binder() {
                     if cx.tcx.has_attr(trait_ref.def_id, sym::must_use) {
                         return true;
@@ -407,7 +407,7 @@ pub fn is_non_aggregate_primitive_type(ty: Ty<'_>) -> bool {
 /// Returns `true` if the given type is a primitive (a `bool` or `char`, any integer or
 /// floating-point number type, a `str`, or an array, slice, or tuple of those types).
 pub fn is_recursively_primitive_type(ty: Ty<'_>) -> bool {
-    match *ty.kind() {
+    match ty.kind() {
         ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Str => true,
         ty::Ref(_, inner, _) if inner.is_str() => true,
         ty::Array(inner_type, _) | ty::Slice(inner_type) => is_recursively_primitive_type(inner_type),
@@ -510,7 +510,7 @@ pub fn needs_ordered_drop<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
             // Check if any component type has any.
             match ty.kind() {
                 ty::Tuple(fields) => fields.iter().any(|ty| needs_ordered_drop_inner(cx, ty, seen)),
-                ty::Array(ty, _) => needs_ordered_drop_inner(cx, *ty, seen),
+                ty::Array(ty, _) => needs_ordered_drop_inner(cx, ty, seen),
                 ty::Adt(adt, subs) => adt
                     .all_fields()
                     .map(|f| f.ty(cx.tcx, subs))
@@ -530,8 +530,8 @@ pub fn needs_ordered_drop<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
 pub fn peel_mid_ty_refs_is_mutable(ty: Ty<'_>) -> (Ty<'_>, usize, Mutability) {
     fn f(ty: Ty<'_>, count: usize, mutability: Mutability) -> (Ty<'_>, usize, Mutability) {
         match ty.kind() {
-            ty::Ref(_, ty, Mutability::Mut) => f(*ty, count + 1, mutability),
-            ty::Ref(_, ty, Mutability::Not) => f(*ty, count + 1, Mutability::Not),
+            ty::Ref(_, ty, Mutability::Mut) => f(ty, count + 1, mutability),
+            ty::Ref(_, ty, Mutability::Not) => f(ty, count + 1, Mutability::Not),
             _ => (ty, count, mutability),
         }
     }
@@ -559,7 +559,7 @@ pub fn walk_ptrs_hir_ty<'tcx>(ty: &'tcx hir::Ty<'tcx>) -> &'tcx hir::Ty<'tcx> {
 pub fn walk_ptrs_ty_depth(ty: Ty<'_>) -> (Ty<'_>, usize) {
     fn inner(ty: Ty<'_>, depth: usize) -> (Ty<'_>, usize) {
         match ty.kind() {
-            ty::Ref(_, ty, _) => inner(*ty, depth + 1),
+            ty::Ref(_, ty, _) => inner(ty, depth + 1),
             _ => (ty, depth),
         }
     }
@@ -599,7 +599,7 @@ pub fn is_uninit_value_valid_for_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) 
 
 /// A fallback for polymorphic types, which are not supported by `check_validity_requirement`.
 fn is_uninit_value_valid_for_ty_fallback<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
-    match *ty.kind() {
+    match ty.kind() {
         // The array length may be polymorphic, let's try the inner type.
         ty::Array(component, _) => is_uninit_value_valid_for_ty(cx, component),
         // Peek through tuples and try their fallbacks.
@@ -707,7 +707,7 @@ pub fn ty_sig<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<ExprFnSig<'t
     if ty.is_box() {
         return ty_sig(cx, ty.boxed_ty());
     }
-    match *ty.kind() {
+    match ty.kind() {
         ty::Closure(id, subs) => {
             let decl = id
                 .as_local()
@@ -986,7 +986,7 @@ pub fn approx_ty_size<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> u64 {
         (Ok(size), _) => size,
         (Err(_), ty::Tuple(list)) => list.iter().map(|t| approx_ty_size(cx, t)).sum(),
         (Err(_), ty::Array(t, n)) => {
-            n.try_eval_target_usize(cx.tcx, cx.param_env).unwrap_or_default() * approx_ty_size(cx, *t)
+            n.try_eval_target_usize(cx.tcx, cx.param_env).unwrap_or_default() * approx_ty_size(cx, t)
         },
         (Err(_), ty::Adt(def, subst)) if def.is_struct() => def
             .variants()
@@ -1200,7 +1200,7 @@ impl<'tcx> InteriorMut<'tcx> {
             Entry::Vacant(v) => v.insert(None),
         };
 
-        let interior_mut = match *ty.kind() {
+        let interior_mut = match ty.kind() {
             ty::RawPtr(inner_ty, _) if !self.ignore_pointers => self.is_interior_mut_ty(cx, inner_ty),
             ty::Ref(_, inner_ty, _) | ty::Slice(inner_ty) => self.is_interior_mut_ty(cx, inner_ty),
             ty::Array(inner_ty, size) => {
@@ -1329,7 +1329,7 @@ pub fn get_adt_inherent_method<'a>(cx: &'a LateContext<'_>, ty: Ty<'_>, method_n
 
 /// Get's the type of a field by name.
 pub fn get_field_by_name<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, name: Symbol) -> Option<Ty<'tcx>> {
-    match *ty.kind() {
+    match ty.kind() {
         ty::Adt(def, args) if def.is_union() || def.is_struct() => def
             .non_enum_variant()
             .fields

--- a/src/tools/clippy/clippy_utils/src/ty/type_certainty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/type_certainty/mod.rs
@@ -294,7 +294,7 @@ fn type_is_inferable_from_arguments(cx: &LateContext<'_>, expr: &Expr<'_>) -> bo
         ExprKind::Call(callee, _) => {
             let callee_ty = cx.typeck_results().expr_ty(callee);
             if let ty::FnDef(callee_def_id, _) = callee_ty.kind() {
-                Some(*callee_def_id)
+                Some(callee_def_id)
             } else {
                 None
             }

--- a/src/tools/clippy/clippy_utils/src/visitors.rs
+++ b/src/tools/clippy/clippy_utils/src/visitors.rs
@@ -437,7 +437,7 @@ pub fn is_expr_unsafe<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> bool {
                 {
                     self.is_unsafe = true;
                 },
-                ExprKind::Call(func, _) => match *self.cx.typeck_results().expr_ty(func).peel_refs().kind() {
+                ExprKind::Call(func, _) => match self.cx.typeck_results().expr_ty(func).peel_refs().kind() {
                     ty::FnDef(id, _) if self.cx.tcx.fn_sig(id).skip_binder().safety() == Safety::Unsafe => {
                         self.is_unsafe = true;
                     },

--- a/src/tools/miri/src/borrow_tracker/tree_borrows/mod.rs
+++ b/src/tools/miri/src/borrow_tracker/tree_borrows/mod.rs
@@ -383,7 +383,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, ImmTy<'tcx>> {
         let this = self.eval_context_mut();
         let new_perm = match val.layout.ty.kind() {
-            &ty::Ref(_, pointee, mutability) =>
+            ty::Ref(_, pointee, mutability) =>
                 NewPermission::from_ref_ty(pointee, mutability, kind, this),
             _ => None,
         };
@@ -466,7 +466,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 // Check the type of this value to see what to do with it (retag, or recurse).
                 match place.layout.ty.kind() {
-                    &ty::Ref(_, pointee, mutability) => {
+                    ty::Ref(_, pointee, mutability) => {
                         let new_perm =
                             NewPermission::from_ref_ty(pointee, mutability, self.kind, self.ecx);
                         self.retag_ptr_inplace(place, new_perm)?;

--- a/src/tools/miri/src/intrinsics/simd.rs
+++ b/src/tools/miri/src/intrinsics/simd.rs
@@ -468,7 +468,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         assert!(mask.layout.size.bits() >= bitmask_len);
                         this.read_scalar(mask)?.to_bits(mask.layout.size)?.try_into().unwrap()
                     }
-                    ty::Array(elem, _len) if elem == &this.tcx.types.u8 => {
+                    ty::Array(elem, _len) if elem == this.tcx.types.u8 => {
                         // The array must have exactly the right size.
                         assert_eq!(mask.layout.size.bits(), bitmask_len);
                         // Read the raw bytes.
@@ -547,7 +547,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         assert!(dest.layout.size.bits() >= bitmask_len);
                         this.write_int(res, dest)?;
                     }
-                    ty::Array(elem, _len) if elem == &this.tcx.types.u8 => {
+                    ty::Array(elem, _len) if elem == this.tcx.types.u8 => {
                         // The array must have exactly the right size.
                         assert_eq!(dest.layout.size.bits(), bitmask_len);
                         // We have to write the result byte-for-byte.


### PR DESCRIPTION
This is valid because `TyKind` impls `Copy`, and makes `Ty` consistent with `Predicate` and `Region`, both of which have `kind` methods that return a non-reference.

The change removes more than one thousand `&` and `*` sigils, while requiring the addition of just five! It's clearly moving with the grain of the existing code.

Almost all of the removed sigils fit one of the following three patterns.

- Remove the dereference in the match expression:

    `match *ty.kind() { ... }` ->
    `match ty.kind() { ... }`

- Remove the dereference in the match pattern:

    `match ty.kind() { &ty::Foo(foo) => { ... foo ... }` ->
    `match ty.kind() { ty::Foo(foo) => { ... foo ... }`

- Remove the derefernce in the match arm:

    `match ty.kind() { ty::Foo(foo) => { ... *foo ... }` ->
    `match ty.kind() { ty::Foo(foo) => { ... foo ... }`

A couple of other methods had their signatures changed.
- `TypeErrCtxt::cmp_fn_sig`: `&` removed from two args.
- `EncodableWithShorthand::variant`: `&` removed from return type.

r? @ghost