### PR TITLE
privacy: normalize associated types before visiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4244,10 +4244,12 @@ dependencies = [
  "rustc_errors",
  "rustc_fluent_macro",
  "rustc_hir",
+ "rustc_infer",
  "rustc_macros",
  "rustc_middle",
  "rustc_session",
  "rustc_span",
+ "rustc_trait_selection",
  "rustc_ty_utils",
  "tracing",
 ]

--- a/compiler/rustc_privacy/Cargo.toml
+++ b/compiler/rustc_privacy/Cargo.toml
@@ -11,10 +11,12 @@ rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_fluent_macro = { path = "../rustc_fluent_macro" }
 rustc_hir = { path = "../rustc_hir" }
+rustc_infer = { path = "../rustc_infer" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_middle = { path = "../rustc_middle" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
+rustc_trait_selection = { path = "../rustc_trait_selection" }
 rustc_ty_utils = { path = "../rustc_ty_utils" }
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/src/tools/tidy/src/issues.txt
+++ b/src/tools/tidy/src/issues.txt
@@ -623,7 +623,6 @@ ui/const-generics/issues/issue-80062.rs
 ui/const-generics/issues/issue-80375.rs
 ui/const-generics/issues/issue-82956.rs
 ui/const-generics/issues/issue-83249.rs
-ui/const-generics/issues/issue-83288.rs
 ui/const-generics/issues/issue-83466.rs
 ui/const-generics/issues/issue-83765.rs
 ui/const-generics/issues/issue-84659.rs

--- a/tests/crashes/83288.rs
+++ b/tests/crashes/83288.rs
@@ -1,4 +1,4 @@
-//@ build-pass
+//@ known-bug: rust-lang/rust#83288
 
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]

--- a/tests/ui/associated-inherent-types/private-in-public.rs
+++ b/tests/ui/associated-inherent-types/private-in-public.rs
@@ -5,9 +5,9 @@
 #![crate_type = "lib"]
 
 pub type PubAlias0 = PubTy::PrivAssocTy;
-//~^ WARNING associated type `PubTy::PrivAssocTy` is more private than the item `PubAlias0`
+
 pub type PubAlias1 = PrivTy::PubAssocTy;
-//~^ WARNING type `PrivTy` is more private than the item `PubAlias1`
+
 pub type PubAlias2 = PubTy::PubAssocTy<PrivTy>;
 //~^ WARNING type `PrivTy` is more private than the item `PubAlias2`
 

--- a/tests/ui/associated-inherent-types/private-in-public.stderr
+++ b/tests/ui/associated-inherent-types/private-in-public.stderr
@@ -1,28 +1,3 @@
-warning: associated type `PubTy::PrivAssocTy` is more private than the item `PubAlias0`
-  --> $DIR/private-in-public.rs:7:1
-   |
-LL | pub type PubAlias0 = PubTy::PrivAssocTy;
-   | ^^^^^^^^^^^^^^^^^^ type alias `PubAlias0` is reachable at visibility `pub`
-   |
-note: but associated type `PubTy::PrivAssocTy` is only usable at visibility `pub(crate)`
-  --> $DIR/private-in-public.rs:16:5
-   |
-LL |     type PrivAssocTy = ();
-   |     ^^^^^^^^^^^^^^^^
-   = note: `#[warn(private_interfaces)]` on by default
-
-warning: type `PrivTy` is more private than the item `PubAlias1`
-  --> $DIR/private-in-public.rs:9:1
-   |
-LL | pub type PubAlias1 = PrivTy::PubAssocTy;
-   | ^^^^^^^^^^^^^^^^^^ type alias `PubAlias1` is reachable at visibility `pub`
-   |
-note: but type `PrivTy` is only usable at visibility `pub(crate)`
-  --> $DIR/private-in-public.rs:20:1
-   |
-LL | struct PrivTy;
-   | ^^^^^^^^^^^^^
-
 warning: type `PrivTy` is more private than the item `PubAlias2`
   --> $DIR/private-in-public.rs:11:1
    |
@@ -34,6 +9,7 @@ note: but type `PrivTy` is only usable at visibility `pub(crate)`
    |
 LL | struct PrivTy;
    | ^^^^^^^^^^^^^
+   = note: `#[warn(private_interfaces)]` on by default
 
-warning: 3 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/ui/privacy/projections2.rs
+++ b/tests/ui/privacy/projections2.rs
@@ -17,8 +17,7 @@ mod m {
 
     impl Trait4 for u8 {
         type A<T: Trait> = <u8 as Trait3>::A<T>;
-        //~^ ERROR: private associated type `Trait3::A` in public interface
-        //~| ERROR: private trait `Trait3` in public interface
+        //~^ ERROR: private type `Priv` in public interface
     }
 }
 

--- a/tests/ui/privacy/projections2.stderr
+++ b/tests/ui/privacy/projections2.stderr
@@ -11,24 +11,15 @@ LL |     struct Priv;
    |     ^^^^^^^^^^^
    = note: `#[warn(private_interfaces)]` on by default
 
-error[E0446]: private associated type `Trait3::A` in public interface
+error[E0446]: private type `Priv` in public interface
   --> $DIR/projections2.rs:19:9
    |
-LL |         type A<T: Trait>;
-   |         ---------------- `Trait3::A` declared as private
+LL |     struct Priv;
+   |     ----------- `Priv` declared as private
 ...
 LL |         type A<T: Trait> = <u8 as Trait3>::A<T>;
-   |         ^^^^^^^^^^^^^^^^ can't leak private associated type
+   |         ^^^^^^^^^^^^^^^^ can't leak private type
 
-error[E0446]: private trait `Trait3` in public interface
-  --> $DIR/projections2.rs:19:9
-   |
-LL |     trait Trait3 {
-   |     ------------ `Trait3` declared as private
-...
-LL |         type A<T: Trait> = <u8 as Trait3>::A<T>;
-   |         ^^^^^^^^^^^^^^^^ can't leak private trait
-
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0446`.


### PR DESCRIPTION
This permits associated types to reference private types and traits, so long as the normalized type does not itself violate type privacy.

Fixes #45713

<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->