### PR TITLE
Do not use relative paths to Rust source root in run-make tests

### DIFF
--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -83,11 +83,12 @@ pub fn python_command() -> Command {
 
 pub fn htmldocck() -> Command {
     let mut python = python_command();
-    python.arg(source_path().join("src/etc/htmldocck.py"));
+    python.arg(source_root().join("src/etc/htmldocck.py"));
     python
 }
 
-pub fn source_path() -> PathBuf {
+/// Path to the root rust-lang/rust source checkout.
+pub fn source_root() -> PathBuf {
     env_var("S").into()
 }
 

--- a/tests/run-make/alloc-no-oom-handling/rmake.rs
+++ b/tests/run-make/alloc-no-oom-handling/rmake.rs
@@ -2,14 +2,14 @@
 // when the unstable no_global_oom_handling feature is turned on.
 // See https://github.com/rust-lang/rust/pull/84266
 
-use run_make_support::rustc;
+use run_make_support::{rustc, source_root};
 
 fn main() {
     rustc()
         .edition("2021")
         .arg("-Dwarnings")
         .crate_type("rlib")
-        .input("../../../library/alloc/src/lib.rs")
+        .input(source_root().join("library/alloc/src/lib.rs"))
         .cfg("no_global_oom_handling")
         .run();
 }

--- a/tests/run-make/alloc-no-rc/rmake.rs
+++ b/tests/run-make/alloc-no-rc/rmake.rs
@@ -2,14 +2,14 @@
 // when the unstable no_rc feature is turned on.
 // See https://github.com/rust-lang/rust/pull/84266
 
-use run_make_support::rustc;
+use run_make_support::{rustc, source_root};
 
 fn main() {
     rustc()
         .edition("2021")
         .arg("-Dwarnings")
         .crate_type("rlib")
-        .input("../../../library/alloc/src/lib.rs")
+        .input(source_root().join("library/alloc/src/lib.rs"))
         .cfg("no_rc")
         .run();
 }

--- a/tests/run-make/alloc-no-sync/rmake.rs
+++ b/tests/run-make/alloc-no-sync/rmake.rs
@@ -2,14 +2,14 @@
 // when the unstable no_sync feature is turned on.
 // See https://github.com/rust-lang/rust/pull/84266
 
-use run_make_support::rustc;
+use run_make_support::{rustc, source_root};
 
 fn main() {
     rustc()
         .edition("2021")
         .arg("-Dwarnings")
         .crate_type("rlib")
-        .input("../../../library/alloc/src/lib.rs")
+        .input(source_root().join("library/alloc/src/lib.rs"))
         .cfg("no_sync")
         .run();
 }

--- a/tests/run-make/core-no-fp-fmt-parse/rmake.rs
+++ b/tests/run-make/core-no-fp-fmt-parse/rmake.rs
@@ -1,14 +1,14 @@
 // This test checks that the core library of Rust can be compiled without enabling
 // support for formatting and parsing floating-point numbers.
 
-use run_make_support::rustc;
+use run_make_support::{rustc, source_root};
 
 fn main() {
     rustc()
         .edition("2021")
         .arg("-Dwarnings")
         .crate_type("rlib")
-        .input("../../../library/core/src/lib.rs")
+        .input(source_root().join("library/core/src/lib.rs"))
         .cfg("no_fp_fmt_parse")
         .run();
 }

--- a/tests/run-make/core-no-oom-handling/rmake.rs
+++ b/tests/run-make/core-no-oom-handling/rmake.rs
@@ -2,14 +2,14 @@
 // when the no_global_oom_handling feature is turned on.
 // See https://github.com/rust-lang/rust/pull/110649
 
-use run_make_support::{rustc, tmp_dir};
+use run_make_support::{rustc, source_root, tmp_dir};
 
 fn main() {
     rustc()
         .edition("2021")
         .arg("-Dwarnings")
         .crate_type("rlib")
-        .input("../../../library/core/src/lib.rs")
+        .input(source_root().join("library/core/src/lib.rs"))
         .sysroot(tmp_dir().join("fakeroot"))
         .cfg("no_global_oom_handling")
         .run();

--- a/tests/run-make/rustdoc-scrape-examples-remap/scrape.rs
+++ b/tests/run-make/rustdoc-scrape-examples-remap/scrape.rs
@@ -1,4 +1,4 @@
-use run_make_support::{htmldocck, rustc, rustdoc, source_path, tmp_dir};
+use run_make_support::{htmldocck, rustc, rustdoc, source_root, tmp_dir};
 use std::fs::read_dir;
 use std::path::Path;
 

--- a/tests/run-make/rustdoc-themes/rmake.rs
+++ b/tests/run-make/rustdoc-themes/rmake.rs
@@ -1,13 +1,13 @@
 // Test that rustdoc will properly load in a theme file and display it in the theme selector.
 
-use run_make_support::{htmldocck, rustdoc, source_path, tmp_dir};
+use run_make_support::{htmldocck, rustdoc, source_root, tmp_dir};
 
 fn main() {
     let out_dir = tmp_dir().join("rustdoc-themes");
     let test_css = out_dir.join("test.css");
 
     let no_script =
-        std::fs::read_to_string(source_path().join("src/librustdoc/html/static/css/noscript.css"))
+        std::fs::read_to_string(source_root().join("src/librustdoc/html/static/css/noscript.css"))
             .unwrap();
 
     let mut test_content = String::new();


### PR DESCRIPTION
Pre-requisite for https://github.com/rust-lang/rust/issues/126080.

Fixes: https://github.com/rust-lang/rust/issues/126071

r? @jieyouxu