### PR TITLE
use windows compatible executable name for libcxx-version

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -834,7 +834,7 @@ impl Step for LibcxxVersionTool {
         let compiler = builder.cxx(self.target).unwrap();
         let mut cmd = Command::new(compiler);
 
-        let executable = out_dir.join("libcxx-version");
+        let executable = out_dir.join(exe("libcxx-version", self.target));
         cmd.arg("-o").arg(&executable).arg(builder.src.join("src/tools/libcxx-version/main.cpp"));
 
         builder.run_cmd(&mut cmd);


### PR DESCRIPTION
Resolves #https://github.com/rust-lang/rust/pull/125411#discussion_r1629915724