### PR TITLE
linker: Link dylib crates by path

### DIFF
--- a/tests/run-make/dylib-soname/foo.rs
+++ b/tests/run-make/dylib-soname/foo.rs
@@ -1,0 +1,1 @@
+pub fn something() {}

--- a/tests/run-make/dylib-soname/rmake.rs
+++ b/tests/run-make/dylib-soname/rmake.rs
@@ -1,0 +1,19 @@
+// Checks that produced dylibs have a relative SONAME set, so they don't put "unmovable" full paths
+// into DT_NEEDED when used by a full path.
+
+//@ only-linux
+//@ ignore-cross-compile
+
+use run_make_support::regex::Regex;
+use run_make_support::{cmd, run_in_tmpdir, rustc};
+
+fn main() {
+    run_in_tmpdir(|| {
+        rustc().crate_name("foo").crate_type("dylib").input("foo.rs").run();
+        cmd("readelf")
+            .arg("-d")
+            .arg("libfoo.so")
+            .run()
+            .assert_stdout_contains("Library soname: [libfoo.so]");
+    });
+}


### PR DESCRIPTION
Linkers seem to support linking dynamic libraries by path.
Not sure why the previous scheme with splitting the path into a directory (passed with `-L`) and a name (passed with `-l`) was used (upd: likely due to https://github.com/rust-lang/rust/pull/126094#issuecomment-2155063414).

When we split a library path `some/dir/libfoo.so` into `-L some/dir` and `-l foo` we add `some/dir` to search directories for *all* libraries looked up by the linker, not just `foo`, and `foo` is also looked up in *all* search directories not just `some/dir`.
Technically we may find some unintended libraries this way.
Therefore linking dylibs via a full path is both simpler and more reliable.

It also makes the set of search directories more easily reproducible when we need to lookup some native library manually (like in https://github.com/rust-lang/rust/pull/123436).