### PR TITLE
Clean up source root in run-make tests

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3566,7 +3566,7 @@ impl<'test> TestCx<'test> {
             .env(dylib_env_var(), &dylib_env_paths)
             .env("TARGET", &self.config.target)
             .env("PYTHON", &self.config.python)
-            .env("S", &src_root)
+            .env("SOURCE_ROOT", &src_root)
             .env("RUST_BUILD_STAGE", &self.config.stage_id)
             .env("RUSTC", cwd.join(&self.config.rustc_path))
             .env("TMPDIR", &rmake_out_dir)

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3515,7 +3515,6 @@ impl<'test> TestCx<'test> {
             .arg(&self.testpaths.file.join("rmake.rs"))
             .env("TARGET", &self.config.target)
             .env("PYTHON", &self.config.python)
-            .env("S", &src_root)
             .env("RUST_BUILD_STAGE", &self.config.stage_id)
             .env("RUSTC", cwd.join(&self.config.rustc_path))
             .env("TMPDIR", &rmake_out_dir)

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -89,7 +89,7 @@ pub fn htmldocck() -> Command {
 
 /// Path to the root rust-lang/rust source checkout.
 pub fn source_root() -> PathBuf {
-    env_var("S").into()
+    env_var("SOURCE_ROOT").into()
 }
 
 /// Construct the static library name based on the platform.

--- a/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
+++ b/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use run_make_support::{aux_build, rustc};
+use run_make_support::{aux_build, rustc, source_root};
 
 fn main() {
     aux_build().input("stable.rs").emit("metadata").run();
@@ -17,7 +17,7 @@ fn main() {
         rustc().input("main.rs").emit("metadata").extern_("stable", &stable_path).command_output();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let version = include_str!(concat!(env!("S"), "/src/version"));
+    let version = std::fs::read_to_string(source_root().join("src/version")).unwrap();
     let expected_string = format!("stable since {}", version.trim());
     assert!(stderr.contains(&expected_string));
 }


### PR DESCRIPTION
The name `S` isn't exactly the most descriptive, and we also shouldn't need to pass it when building (actually I think that most of the env. vars that we pass to `cargo` here are probably not really needed).

Related issue: https://github.com/rust-lang/rust/issues/126071

r? @jieyouxu