### PR TITLE
CI: use a native `arm64` runner

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -33,7 +33,7 @@ runners:
     <<: *base-job
 
   - &job-aarch64-linux
-    os: [ self-hosted, ARM64, linux ]
+    os: ubuntu-22.04-arm64-8core-32gb
 
 envs:
   env-x86_64-apple-tests: &env-x86_64-apple-tests


### PR DESCRIPTION
Opening to test if we can use a native GitHub ARM runner instead of the self-hosted one.

The CI has finished [successfully](https://github.com/rust-lang/rust/actions/runs/9414573751/job/25933776975?pr=126113). It took 1h 29m, which is longer than the previous duration (~1h 10m). This is expected, since we currently use 8 cores on GitHub, rather than 14 cores which are configured for the self-hosted runner.

try-job: aarch64-gnu