### PR TITLE
CI: remove `Setup Python` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,12 +156,6 @@ jobs:
 
       - name: checkout submodules
         run: src/ci/scripts/checkout-submodules.sh
-      
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-        if: runner.environment == 'github-hosted'
 
       - name: install MinGW
         run: src/ci/scripts/install-mingw.sh


### PR DESCRIPTION
This action was added recently in https://github.com/rust-lang/rust/pull/125590, but it shouldn't really be needed, as our CI was working fine before without it. Our base Ubuntu 20.04 images use Python 3.8, while this action installed Python 3.12, but we don't really need that.

Since this action does not support ARM yet, this blocks https://github.com/rust-lang/rust/pull/126113. See https://github.com/rust-lang/rust/pull/125590#issuecomment-2154438250.

r? @jdno

