### PR TITLE
Add a custom Command wrapper to `run-make-support`

### DIFF
--- a/src/tools/run-make-support/src/cc.rs
+++ b/src/tools/run-make-support/src/cc.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use crate::{bin_name, cygpath_windows, env_var, handle_failed_output, is_msvc, is_windows, uname};
 use crate::command::Command;
+use crate::{bin_name, cygpath_windows, env_var, is_msvc, is_windows, uname};
 
 /// Construct a new platform-specific C compiler invocation.
 ///

--- a/src/tools/run-make-support/src/cc.rs
+++ b/src/tools/run-make-support/src/cc.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
-use std::process::Command;
 
 use crate::{bin_name, cygpath_windows, env_var, handle_failed_output, is_msvc, is_windows, uname};
+use crate::command::Command;
 
 /// Construct a new platform-specific C compiler invocation.
 ///

--- a/src/tools/run-make-support/src/clang.rs
+++ b/src/tools/run-make-support/src/clang.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
-use std::process::Command;
 
 use crate::{bin_name, env_var, handle_failed_output};
+use crate::command::Command;
 
 /// Construct a new `clang` invocation. `clang` is not always available for all targets.
 pub fn clang() -> Clang {
@@ -67,10 +67,5 @@ impl Clang {
     pub fn use_ld(&mut self, ld: &str) -> &mut Self {
         self.cmd.arg(format!("-fuse-ld={ld}"));
         self
-    }
-
-    /// Get the [`Output`][::std::process::Output] of the finished process.
-    pub fn command_output(&mut self) -> ::std::process::Output {
-        self.cmd.output().expect("failed to get output of finished process")
     }
 }

--- a/src/tools/run-make-support/src/clang.rs
+++ b/src/tools/run-make-support/src/clang.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use crate::{bin_name, env_var, handle_failed_output};
 use crate::command::Command;
+use crate::{bin_name, env_var};
 
 /// Construct a new `clang` invocation. `clang` is not always available for all targets.
 pub fn clang() -> Clang {

--- a/src/tools/run-make-support/src/command.rs
+++ b/src/tools/run-make-support/src/command.rs
@@ -1,8 +1,12 @@
+use crate::{assert_not_contains, handle_failed_output};
 use std::ffi::OsStr;
 use std::io::Write;
 use std::ops::{Deref, DerefMut};
 use std::process::{Command as StdCommand, ExitStatus, Output, Stdio};
 
+/// This is a custom command wrapper that simplifies working with commands
+/// and makes it easier to ensure that we check the exit status of executed
+/// processes.
 #[derive(Debug)]
 pub struct Command {
     cmd: StdCommand,
@@ -11,14 +15,37 @@ pub struct Command {
 
 impl Command {
     pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
-        Self {
-            cmd: StdCommand::new(program),
-            stdin: None,
-        }
+        Self { cmd: StdCommand::new(program), stdin: None }
     }
 
     pub fn set_stdin(&mut self, stdin: Box<[u8]>) {
         self.stdin = Some(stdin);
+    }
+
+    /// Run the constructed command and assert that it is successfully run.
+    #[track_caller]
+    pub fn run(&mut self) -> CompletedProcess {
+        let caller_location = std::panic::Location::caller();
+        let caller_line_number = caller_location.line();
+
+        let output = self.command_output();
+        if !output.status().success() {
+            handle_failed_output(&self, output, caller_line_number);
+        }
+        output
+    }
+
+    /// Run the constructed command and assert that it does not successfully run.
+    #[track_caller]
+    pub fn run_fail(&mut self) -> CompletedProcess {
+        let caller_location = std::panic::Location::caller();
+        let caller_line_number = caller_location.line();
+
+        let output = self.command_output();
+        if output.status().success() {
+            handle_failed_output(&self, output, caller_line_number);
+        }
+        output
     }
 
     #[track_caller]
@@ -59,6 +86,8 @@ impl DerefMut for Command {
 }
 
 /// Represents the result of an executed process.
+/// The various `assert_` helper methods should preferably be used for
+/// checking the contents of stdout/stderr.
 pub struct CompletedProcess {
     output: Output,
 }
@@ -76,16 +105,47 @@ impl CompletedProcess {
         self.output.status
     }
 
+    /// Checks that trimmed `stdout` matches trimmed `content`.
     #[track_caller]
-    pub fn assert_exit_code(&self, code: i32) {
+    pub fn assert_stdout_equals<S: AsRef<str>>(self, content: S) -> Self {
+        assert_eq!(self.stdout_utf8().trim(), content.as_ref().trim());
+        self
+    }
+
+    #[track_caller]
+    pub fn assert_stdout_not_contains<S: AsRef<str>>(self, needle: S) -> Self {
+        assert_not_contains(&self.stdout_utf8(), needle.as_ref());
+        self
+    }
+
+    /// Checks that trimmed `stderr` matches trimmed `content`.
+    #[track_caller]
+    pub fn assert_stderr_equals<S: AsRef<str>>(self, content: S) -> Self {
+        assert_eq!(self.stderr_utf8().trim(), content.as_ref().trim());
+        self
+    }
+
+    #[track_caller]
+    pub fn assert_stderr_contains<S: AsRef<str>>(self, needle: S) -> Self {
+        assert!(self.stderr_utf8().contains(needle.as_ref()));
+        self
+    }
+
+    #[track_caller]
+    pub fn assert_stderr_not_contains<S: AsRef<str>>(self, needle: S) -> Self {
+        assert_not_contains(&self.stdout_utf8(), needle.as_ref());
+        self
+    }
+
+    #[track_caller]
+    pub fn assert_exit_code(self, code: i32) -> Self {
         assert!(self.output.status.code() == Some(code));
+        self
     }
 }
 
 impl From<Output> for CompletedProcess {
     fn from(output: Output) -> Self {
-        Self {
-            output
-        }
+        Self { output }
     }
 }

--- a/src/tools/run-make-support/src/command.rs
+++ b/src/tools/run-make-support/src/command.rs
@@ -1,0 +1,91 @@
+use std::ffi::OsStr;
+use std::io::Write;
+use std::ops::{Deref, DerefMut};
+use std::process::{Command as StdCommand, ExitStatus, Output, Stdio};
+
+#[derive(Debug)]
+pub struct Command {
+    cmd: StdCommand,
+    stdin: Option<Box<[u8]>>,
+}
+
+impl Command {
+    pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
+        Self {
+            cmd: StdCommand::new(program),
+            stdin: None,
+        }
+    }
+
+    pub fn set_stdin(&mut self, stdin: Box<[u8]>) {
+        self.stdin = Some(stdin);
+    }
+
+    #[track_caller]
+    pub(crate) fn command_output(&mut self) -> CompletedProcess {
+        // let's make sure we piped all the input and outputs
+        self.cmd.stdin(Stdio::piped());
+        self.cmd.stdout(Stdio::piped());
+        self.cmd.stderr(Stdio::piped());
+
+        let output = if let Some(input) = &self.stdin {
+            let mut child = self.cmd.spawn().unwrap();
+
+            {
+                let mut stdin = child.stdin.take().unwrap();
+                stdin.write_all(input.as_ref()).unwrap();
+            }
+
+            child.wait_with_output().expect("failed to get output of finished process")
+        } else {
+            self.cmd.output().expect("failed to get output of finished process")
+        };
+        output.into()
+    }
+}
+
+impl Deref for Command {
+    type Target = StdCommand;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cmd
+    }
+}
+
+impl DerefMut for Command {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cmd
+    }
+}
+
+/// Represents the result of an executed process.
+pub struct CompletedProcess {
+    output: Output,
+}
+
+impl CompletedProcess {
+    pub fn stdout_utf8(&self) -> String {
+        String::from_utf8(self.output.stdout.clone()).expect("stdout is not valid UTF-8")
+    }
+
+    pub fn stderr_utf8(&self) -> String {
+        String::from_utf8(self.output.stderr.clone()).expect("stderr is not valid UTF-8")
+    }
+
+    pub fn status(&self) -> ExitStatus {
+        self.output.status
+    }
+
+    #[track_caller]
+    pub fn assert_exit_code(&self, code: i32) {
+        assert!(self.output.status.code() == Some(code));
+    }
+}
+
+impl From<Output> for CompletedProcess {
+    fn from(output: Output) -> Self {
+        Self {
+            output
+        }
+    }
+}

--- a/src/tools/run-make-support/src/llvm_readobj.rs
+++ b/src/tools/run-make-support/src/llvm_readobj.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
-use crate::{env_var, handle_failed_output};
 use crate::command::Command;
+use crate::env_var;
 
 /// Construct a new `llvm-readobj` invocation. This assumes that `llvm-readobj` is available
 /// at `$LLVM_BIN_DIR/llvm-readobj`.

--- a/src/tools/run-make-support/src/llvm_readobj.rs
+++ b/src/tools/run-make-support/src/llvm_readobj.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use crate::{env_var, handle_failed_output};
+use crate::command::Command;
 
 /// Construct a new `llvm-readobj` invocation. This assumes that `llvm-readobj` is available
 /// at `$LLVM_BIN_DIR/llvm-readobj`.
@@ -38,11 +38,5 @@ impl LlvmReadobj {
     pub fn file_header(&mut self) -> &mut Self {
         self.cmd.arg("--file-header");
         self
-    }
-
-    /// Get the [`Output`][::std::process::Output] of the finished process.
-    #[track_caller]
-    pub fn command_output(&mut self) -> ::std::process::Output {
-        self.cmd.output().expect("failed to get output of finished process")
     }
 }

--- a/src/tools/run-make-support/src/run.rs
+++ b/src/tools/run-make-support/src/run.rs
@@ -1,12 +1,12 @@
 use std::env;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
 
 use crate::{cwd, env_var, is_windows};
+use crate::command::{Command, CompletedProcess};
 
 use super::handle_failed_output;
 
-fn run_common(name: &str) -> (Command, Output) {
+fn run_common(name: &str) -> (Command, CompletedProcess) {
     let mut bin_path = PathBuf::new();
     bin_path.push(cwd());
     bin_path.push(name);
@@ -33,18 +33,18 @@ fn run_common(name: &str) -> (Command, Output) {
         cmd.env("PATH", env::join_paths(paths.iter()).unwrap());
     }
 
-    let output = cmd.output().unwrap();
+    let output = cmd.command_output();
     (cmd, output)
 }
 
 /// Run a built binary and make sure it succeeds.
 #[track_caller]
-pub fn run(name: &str) -> Output {
+pub fn run(name: &str) -> CompletedProcess {
     let caller_location = std::panic::Location::caller();
     let caller_line_number = caller_location.line();
 
     let (cmd, output) = run_common(name);
-    if !output.status.success() {
+    if !output.status().success() {
         handle_failed_output(&cmd, output, caller_line_number);
     }
     output
@@ -52,12 +52,12 @@ pub fn run(name: &str) -> Output {
 
 /// Run a built binary and make sure it fails.
 #[track_caller]
-pub fn run_fail(name: &str) -> Output {
+pub fn run_fail(name: &str) -> CompletedProcess {
     let caller_location = std::panic::Location::caller();
     let caller_line_number = caller_location.line();
 
     let (cmd, output) = run_common(name);
-    if output.status.success() {
+    if output.status().success() {
         handle_failed_output(&cmd, output, caller_line_number);
     }
     output

--- a/src/tools/run-make-support/src/run.rs
+++ b/src/tools/run-make-support/src/run.rs
@@ -1,8 +1,9 @@
 use std::env;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
-use crate::{cwd, env_var, is_windows};
 use crate::command::{Command, CompletedProcess};
+use crate::{cwd, env_var, is_windows, set_host_rpath};
 
 use super::handle_failed_output;
 
@@ -61,4 +62,12 @@ pub fn run_fail(name: &str) -> CompletedProcess {
         handle_failed_output(&cmd, output, caller_line_number);
     }
     output
+}
+
+/// Create a new custom Command.
+/// This should be preferred to creating `std::process::Command` directly.
+pub fn cmd<S: AsRef<OsStr>>(program: S) -> Command {
+    let mut command = Command::new(program);
+    set_host_rpath(&mut command);
+    command
 }

--- a/src/tools/run-make-support/src/rustc.rs
+++ b/src/tools/run-make-support/src/rustc.rs
@@ -1,8 +1,8 @@
+use command::Command;
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
-use command::Command;
 
-use crate::{command, cwd, env_var, handle_failed_output, set_host_rpath};
+use crate::{command, cwd, env_var, set_host_rpath};
 
 /// Construct a new `rustc` invocation.
 pub fn rustc() -> Rustc {

--- a/src/tools/run-make-support/src/rustc.rs
+++ b/src/tools/run-make-support/src/rustc.rs
@@ -1,9 +1,8 @@
 use std::ffi::{OsStr, OsString};
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Output, Stdio};
+use command::Command;
 
-use crate::{cwd, env_var, handle_failed_output, set_host_rpath};
+use crate::{command, cwd, env_var, handle_failed_output, set_host_rpath};
 
 /// Construct a new `rustc` invocation.
 pub fn rustc() -> Rustc {
@@ -19,7 +18,6 @@ pub fn aux_build() -> Rustc {
 #[derive(Debug)]
 pub struct Rustc {
     cmd: Command,
-    stdin: Option<Box<[u8]>>,
 }
 
 crate::impl_common_helpers!(Rustc);
@@ -38,14 +36,14 @@ impl Rustc {
     /// Construct a new `rustc` invocation.
     pub fn new() -> Self {
         let cmd = setup_common();
-        Self { cmd, stdin: None }
+        Self { cmd }
     }
 
     /// Construct a new `rustc` invocation with `aux_build` preset (setting `--crate-type=lib`).
     pub fn new_aux_build() -> Self {
         let mut cmd = setup_common();
         cmd.arg("--crate-type=lib");
-        Self { cmd, stdin: None }
+        Self { cmd }
     }
 
     // Argument provider methods
@@ -197,7 +195,7 @@ impl Rustc {
 
     /// Specify a stdin input
     pub fn stdin<I: AsRef<[u8]>>(&mut self, input: I) -> &mut Self {
-        self.stdin = Some(input.as_ref().to_vec().into_boxed_slice());
+        self.cmd.set_stdin(input.as_ref().to_vec().into_boxed_slice());
         self
     }
 
@@ -212,39 +210,5 @@ impl Rustc {
     pub fn linker(&mut self, linker: &str) -> &mut Self {
         self.cmd.arg(format!("-Clinker={linker}"));
         self
-    }
-
-    /// Get the [`Output`] of the finished process.
-    #[track_caller]
-    pub fn command_output(&mut self) -> Output {
-        // let's make sure we piped all the input and outputs
-        self.cmd.stdin(Stdio::piped());
-        self.cmd.stdout(Stdio::piped());
-        self.cmd.stderr(Stdio::piped());
-
-        if let Some(input) = &self.stdin {
-            let mut child = self.cmd.spawn().unwrap();
-
-            {
-                let mut stdin = child.stdin.take().unwrap();
-                stdin.write_all(input.as_ref()).unwrap();
-            }
-
-            child.wait_with_output().expect("failed to get output of finished process")
-        } else {
-            self.cmd.output().expect("failed to get output of finished process")
-        }
-    }
-
-    #[track_caller]
-    pub fn run_fail_assert_exit_code(&mut self, code: i32) -> Output {
-        let caller_location = std::panic::Location::caller();
-        let caller_line_number = caller_location.line();
-
-        let output = self.command_output();
-        if output.status.code().unwrap() != code {
-            handle_failed_output(&self.cmd, output, caller_line_number);
-        }
-        output
     }
 }

--- a/src/tools/run-make-support/src/rustdoc.rs
+++ b/src/tools/run-make-support/src/rustdoc.rs
@@ -1,9 +1,8 @@
 use std::ffi::OsStr;
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Output, Stdio};
 
 use crate::{env_var, env_var_os, handle_failed_output, set_host_rpath};
+use crate::command::Command;
 
 /// Construct a plain `rustdoc` invocation with no flags set.
 pub fn bare_rustdoc() -> Rustdoc {
@@ -18,7 +17,6 @@ pub fn rustdoc() -> Rustdoc {
 #[derive(Debug)]
 pub struct Rustdoc {
     cmd: Command,
-    stdin: Option<Box<[u8]>>,
 }
 
 crate::impl_common_helpers!(Rustdoc);
@@ -34,7 +32,7 @@ impl Rustdoc {
     /// Construct a bare `rustdoc` invocation.
     pub fn bare() -> Self {
         let cmd = setup_common();
-        Self { cmd, stdin: None }
+        Self { cmd }
     }
 
     /// Construct a `rustdoc` invocation with `-L $(TARGET_RPATH_DIR)` set.
@@ -42,7 +40,7 @@ impl Rustdoc {
         let mut cmd = setup_common();
         let target_rpath_dir = env_var_os("TARGET_RPATH_DIR");
         cmd.arg(format!("-L{}", target_rpath_dir.to_string_lossy()));
-        Self { cmd, stdin: None }
+        Self { cmd }
     }
 
     /// Specify where an external library is located.
@@ -88,31 +86,8 @@ impl Rustdoc {
 
     /// Specify a stdin input
     pub fn stdin<I: AsRef<[u8]>>(&mut self, input: I) -> &mut Self {
-        self.cmd.stdin(Stdio::piped());
-        self.stdin = Some(input.as_ref().to_vec().into_boxed_slice());
+        self.cmd.set_stdin(input.as_ref().to_vec().into_boxed_slice());
         self
-    }
-
-    /// Get the [`Output`] of the finished process.
-    #[track_caller]
-    pub fn command_output(&mut self) -> ::std::process::Output {
-        // let's make sure we piped all the input and outputs
-        self.cmd.stdin(Stdio::piped());
-        self.cmd.stdout(Stdio::piped());
-        self.cmd.stderr(Stdio::piped());
-
-        if let Some(input) = &self.stdin {
-            let mut child = self.cmd.spawn().unwrap();
-
-            {
-                let mut stdin = child.stdin.take().unwrap();
-                stdin.write_all(input.as_ref()).unwrap();
-            }
-
-            child.wait_with_output().expect("failed to get output of finished process")
-        } else {
-            self.cmd.output().expect("failed to get output of finished process")
-        }
     }
 
     /// Specify the edition year.
@@ -155,17 +130,5 @@ impl Rustdoc {
         self.cmd.arg("--output-format");
         self.cmd.arg(format);
         self
-    }
-
-    #[track_caller]
-    pub fn run_fail_assert_exit_code(&mut self, code: i32) -> Output {
-        let caller_location = std::panic::Location::caller();
-        let caller_line_number = caller_location.line();
-
-        let output = self.command_output();
-        if output.status.code().unwrap() != code {
-            handle_failed_output(&self.cmd, output, caller_line_number);
-        }
-        output
     }
 }

--- a/src/tools/run-make-support/src/rustdoc.rs
+++ b/src/tools/run-make-support/src/rustdoc.rs
@@ -1,8 +1,8 @@
 use std::ffi::OsStr;
 use std::path::Path;
 
-use crate::{env_var, env_var_os, handle_failed_output, set_host_rpath};
 use crate::command::Command;
+use crate::{env_var, env_var_os, set_host_rpath};
 
 /// Construct a plain `rustdoc` invocation with no flags set.
 pub fn bare_rustdoc() -> Rustdoc {

--- a/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
+++ b/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
@@ -10,14 +10,10 @@ use run_make_support::{aux_build, rustc, source_root};
 fn main() {
     aux_build().input("stable.rs").emit("metadata").run();
 
-    let output = rustc()
-        .input("main.rs")
-        .emit("metadata")
-        .extern_("stable", "libstable.rmeta")
-        .command_output();
+    let output =
+        rustc().input("main.rs").emit("metadata").extern_("stable", "libstable.rmeta").run();
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
     let version = std::fs::read_to_string(source_root().join("src/version")).unwrap();
     let expected_string = format!("stable since {}", version.trim());
-    assert!(stderr.contains(&expected_string));
+    output.assert_stderr_contains(expected_string);
 }

--- a/tests/run-make/allow-warnings-cmdline-stability/rmake.rs
+++ b/tests/run-make/allow-warnings-cmdline-stability/rmake.rs
@@ -1,11 +1,13 @@
 // Test that `-Awarnings` suppresses warnings for unstable APIs.
 
-use run_make_support::{assert_not_contains, rustc};
+use run_make_support::rustc;
 
 fn main() {
     rustc().input("bar.rs").run();
-    let output = rustc().input("foo.rs").arg("-Awarnings").run();
-
-    assert_not_contains(&String::from_utf8(output.stdout).unwrap(), "warning");
-    assert_not_contains(&String::from_utf8(output.stderr).unwrap(), "warning");
+    rustc()
+        .input("foo.rs")
+        .arg("-Awarnings")
+        .run()
+        .assert_stdout_not_contains("warning")
+        .assert_stderr_not_contains("warning");
 }

--- a/tests/run-make/compiler-builtins/rmake.rs
+++ b/tests/run-make/compiler-builtins/rmake.rs
@@ -19,8 +19,7 @@ use run_make_support::object::read::Object;
 use run_make_support::object::ObjectSection;
 use run_make_support::object::ObjectSymbol;
 use run_make_support::object::RelocationTarget;
-use run_make_support::set_host_rpath;
-use run_make_support::{env_var, object};
+use run_make_support::{cmd, env_var, object};
 use std::collections::HashSet;
 use std::path::PathBuf;
 
@@ -35,7 +34,7 @@ fn main() {
     let path = env_var("PATH");
     let rustc = env_var("RUSTC");
     let bootstrap_cargo = env_var("BOOTSTRAP_CARGO");
-    let mut cmd = std::process::Command::new(bootstrap_cargo);
+    let mut cmd = cmd(bootstrap_cargo);
     cmd.args([
         "build",
         "--manifest-path",
@@ -52,10 +51,8 @@ fn main() {
     // Visual Studio 2022 requires that the LIB env var be set so it can
     // find the Windows SDK.
     .env("LIB", std::env::var("LIB").unwrap_or_default());
-    set_host_rpath(&mut cmd);
 
-    let status = cmd.status().unwrap();
-    assert!(status.success());
+    cmd.run();
 
     let rlibs_path = target_dir.join(target).join("debug").join("deps");
     let compiler_builtins_rlib = std::fs::read_dir(rlibs_path)

--- a/tests/run-make/const-prop-lint/rmake.rs
+++ b/tests/run-make/const-prop-lint/rmake.rs
@@ -5,7 +5,7 @@ use std::fs;
 use run_make_support::{cwd, rustc};
 
 fn main() {
-    rustc().input("input.rs").run_fail_assert_exit_code(1);
+    rustc().input("input.rs").run_fail().assert_exit_code(1);
 
     for entry in fs::read_dir(cwd()).unwrap() {
         let entry = entry.unwrap();

--- a/tests/run-make/crate-data-smoke/rmake.rs
+++ b/tests/run-make/crate-data-smoke/rmake.rs
@@ -1,22 +1,21 @@
-use std::process::Output;
-
 use run_make_support::{bin_name, rust_lib_name, rustc};
 
-fn compare_stdout<S: AsRef<str>>(output: Output, expected: S) {
-    assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), expected.as_ref());
-}
-
 fn main() {
-    compare_stdout(rustc().print("crate-name").input("crate.rs").run(), "foo");
-    compare_stdout(rustc().print("file-names").input("crate.rs").run(), bin_name("foo"));
-    compare_stdout(
-        rustc().print("file-names").crate_type("lib").arg("--test").input("crate.rs").run(),
-        bin_name("foo"),
-    );
-    compare_stdout(
-        rustc().print("file-names").arg("--test").input("lib.rs").run(),
-        bin_name("mylib"),
-    );
-    compare_stdout(rustc().print("file-names").input("lib.rs").run(), rust_lib_name("mylib"));
-    compare_stdout(rustc().print("file-names").input("rlib.rs").run(), rust_lib_name("mylib"));
+    rustc().print("crate-name").input("crate.rs").run().assert_stdout_equals("foo");
+    rustc().print("file-names").input("crate.rs").run().assert_stdout_equals(bin_name("foo"));
+    rustc()
+        .print("file-names")
+        .crate_type("lib")
+        .arg("--test")
+        .input("crate.rs")
+        .run()
+        .assert_stdout_equals(bin_name("foo"));
+    rustc()
+        .print("file-names")
+        .arg("--test")
+        .input("lib.rs")
+        .run()
+        .assert_stdout_equals(bin_name("mylib"));
+    rustc().print("file-names").input("lib.rs").run().assert_stdout_equals(rust_lib_name("mylib"));
+    rustc().print("file-names").input("rlib.rs").run().assert_stdout_equals(rust_lib_name("mylib"));
 }

--- a/tests/run-make/exit-code/rmake.rs
+++ b/tests/run-make/exit-code/rmake.rs
@@ -5,21 +5,22 @@ use run_make_support::{rustc, rustdoc};
 fn main() {
     rustc().arg("success.rs").run();
 
-    rustc().arg("--invalid-arg-foo").run_fail_assert_exit_code(1);
+    rustc().arg("--invalid-arg-foo").run_fail().assert_exit_code(1);
 
-    rustc().arg("compile-error.rs").run_fail_assert_exit_code(1);
+    rustc().arg("compile-error.rs").run_fail().assert_exit_code(1);
 
     rustc()
         .env("RUSTC_ICE", "0")
         .arg("-Ztreat-err-as-bug")
         .arg("compile-error.rs")
-        .run_fail_assert_exit_code(101);
+        .run_fail()
+        .assert_exit_code(101);
 
     rustdoc().arg("success.rs").output("exit-code").run();
 
-    rustdoc().arg("--invalid-arg-foo").run_fail_assert_exit_code(1);
+    rustdoc().arg("--invalid-arg-foo").run_fail().assert_exit_code(1);
 
-    rustdoc().arg("compile-error.rs").run_fail_assert_exit_code(1);
+    rustdoc().arg("compile-error.rs").run_fail().assert_exit_code(1);
 
-    rustdoc().arg("lint-failure.rs").run_fail_assert_exit_code(1);
+    rustdoc().arg("lint-failure.rs").run_fail().assert_exit_code(1);
 }

--- a/tests/run-make/mixing-formats/rmake.rs
+++ b/tests/run-make/mixing-formats/rmake.rs
@@ -34,8 +34,8 @@ fn main() {
         rustc().crate_type("rlib").input("foo.rs").run();
         rustc().crate_type("dylib").input("bar1.rs").arg("-Cprefer-dynamic").run();
         rustc().crate_type("dylib").input("bar2.rs").arg("-Cprefer-dynamic").run();
-        rustc().crate_type("dylib").input("baz2.rs").run_fail_assert_exit_code(1);
-        rustc().crate_type("bin").input("baz2.rs").run_fail_assert_exit_code(1);
+        rustc().crate_type("dylib").input("baz2.rs").run_fail().assert_exit_code(1);
+        rustc().crate_type("bin").input("baz2.rs").run_fail().assert_exit_code(1);
     });
     run_in_tmpdir(|| {
         rustc().crate_type("rlib").input("foo.rs").run();

--- a/tests/run-make/no-input-file/no-input-file.stderr
+++ b/tests/run-make/no-input-file/no-input-file.stderr
@@ -1,2 +1,0 @@
-error: no input filename given
-

--- a/tests/run-make/no-input-file/rmake.rs
+++ b/tests/run-make/no-input-file/rmake.rs
@@ -1,7 +1,9 @@
-use run_make_support::{diff, rustc};
+use run_make_support::rustc;
 
 fn main() {
-    let output = rustc().print("crate-name").run_fail_assert_exit_code(1);
-
-    diff().expected_file("no-input-file.stderr").actual_text("output", output.stderr).run();
+    rustc()
+        .print("crate-name")
+        .run_fail()
+        .assert_exit_code(1)
+        .assert_stderr_equals("error: no input filename given");
 }

--- a/tests/run-make/non-unicode-env/rmake.rs
+++ b/tests/run-make/non-unicode-env/rmake.rs
@@ -6,7 +6,6 @@ fn main() {
     #[cfg(windows)]
     let non_unicode: std::ffi::OsString = std::os::windows::ffi::OsStringExt::from_wide(&[0xD800]);
     let output = rustc().input("non_unicode_env.rs").env("NON_UNICODE_VAR", non_unicode).run_fail();
-    let actual = std::str::from_utf8(&output.stderr).unwrap();
     let expected = std::fs::read_to_string("non_unicode_env.stderr").unwrap();
-    assert_eq!(actual, expected);
+    output.assert_stderr_equals(expected);
 }

--- a/tests/run-make/notify-all-emit-artifacts/rmake.rs
+++ b/tests/run-make/notify-all-emit-artifacts/rmake.rs
@@ -19,7 +19,7 @@ fn main() {
             .error_format("json")
             .incremental(cwd())
             .run();
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = output.stderr_utf8();
         for file in &["lib.o", "lib.ll", "lib.bc", "lib.s"] {
             assert!(stderr.contains(file), "No {:?} in {:?}", file, stderr);
         }
@@ -35,7 +35,7 @@ fn main() {
             .error_format("json")
             .incremental(cwd())
             .run();
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = output.stderr_utf8();
         for file in &["rcgu.o", "rcgu.ll", "rcgu.bc", "rcgu.s"] {
             assert!(stderr.contains(file), "No {:?} in {:?}", file, stderr);
         }

--- a/tests/run-make/print-cfg/rmake.rs
+++ b/tests/run-make/print-cfg/rmake.rs
@@ -83,8 +83,7 @@ fn check(PrintCfg { target, includes, disallow }: PrintCfg) {
     // --print=cfg
     {
         let output = rustc().target(target).print("cfg").run();
-
-        let stdout = String::from_utf8(output.stdout).unwrap();
+        let stdout = output.stdout_utf8();
 
         check_(&stdout, includes, disallow);
     }
@@ -95,7 +94,7 @@ fn check(PrintCfg { target, includes, disallow }: PrintCfg) {
         let mut print_arg = OsString::from("--print=cfg=");
         print_arg.push(tmp_path.as_os_str());
 
-        let output = rustc().target(target).arg(print_arg).run();
+        rustc().target(target).arg(print_arg).run();
 
         let output = std::fs::read_to_string(&tmp_path).unwrap();
 

--- a/tests/run-make/print-check-cfg/rmake.rs
+++ b/tests/run-make/print-check-cfg/rmake.rs
@@ -93,7 +93,7 @@ fn check(CheckCfg { args, contains }: CheckCfg) {
         .args(&*args)
         .run();
 
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = output.stdout_utf8();
 
     let mut found = HashSet::<String>::new();
 

--- a/tests/run-make/print-native-static-libs/rmake.rs
+++ b/tests/run-make/print-native-static-libs/rmake.rs
@@ -30,9 +30,7 @@ fn main() {
         .run();
 
     let mut found_note = false;
-    for l in output.stderr.lines() {
-        let l = l.expect("utf-8 string");
-
+    for l in output.stderr_utf8().lines() {
         let Some(args) = l.strip_prefix("note: native-static-libs:") else {
             continue;
         };

--- a/tests/run-make/print-to-output/rmake.rs
+++ b/tests/run-make/print-to-output/rmake.rs
@@ -39,11 +39,7 @@ fn check(args: Option) {
     }
 
     // --print={option}
-    let stdout = {
-        let output = rustc().target(args.target).print(args.option).run();
-
-        String::from_utf8(output.stdout).unwrap()
-    };
+    let stdout = rustc().target(args.target).print(args.option).run().stdout_utf8();
 
     // --print={option}=PATH
     let output = {
@@ -51,7 +47,7 @@ fn check(args: Option) {
         let mut print_arg = OsString::from(format!("--print={}=", args.option));
         print_arg.push(tmp_path.as_os_str());
 
-        let _output = rustc().target(args.target).arg(print_arg).run();
+        rustc().target(args.target).arg(print_arg).run();
 
         std::fs::read_to_string(&tmp_path).unwrap()
     };

--- a/tests/run-make/rust-lld-by-default/rmake.rs
+++ b/tests/run-make/rust-lld-by-default/rmake.rs
@@ -17,9 +17,9 @@ fn main() {
         .input("main.rs")
         .run();
     assert!(
-        find_lld_version_in_logs(&output),
+        find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should be present in the output logs:\n{}",
-        std::str::from_utf8(&output.stderr).unwrap()
+        output.stderr_utf8()
     );
 
     // But it can still be disabled by turning the linker feature off.
@@ -30,14 +30,13 @@ fn main() {
         .input("main.rs")
         .run();
     assert!(
-        !find_lld_version_in_logs(&output),
+        !find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should not be present in the output logs:\n{}",
-        std::str::from_utf8(&output.stderr).unwrap()
+        output.stderr_utf8()
     );
 }
 
-fn find_lld_version_in_logs(output: &Output) -> bool {
+fn find_lld_version_in_logs(stderr: String) -> bool {
     let lld_version_re = Regex::new(r"^LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
-    let stderr = std::str::from_utf8(&output.stderr).unwrap();
     stderr.lines().any(|line| lld_version_re.is_match(line.trim()))
 }

--- a/tests/run-make/rust-lld-custom-target/rmake.rs
+++ b/tests/run-make/rust-lld-custom-target/rmake.rs
@@ -23,9 +23,9 @@ fn main() {
         .input("lib.rs")
         .run();
     assert!(
-        find_lld_version_in_logs(&output),
+        find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should be present in the output logs:\n{}",
-        std::str::from_utf8(&output.stderr).unwrap()
+        output.stderr_utf8()
     );
 
     // But it can also be disabled via linker features.
@@ -38,14 +38,13 @@ fn main() {
         .input("lib.rs")
         .run();
     assert!(
-        !find_lld_version_in_logs(&output),
+        !find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should not be present in the output logs:\n{}",
-        std::str::from_utf8(&output.stderr).unwrap()
+        output.stderr_utf8()
     );
 }
 
-fn find_lld_version_in_logs(output: &Output) -> bool {
+fn find_lld_version_in_logs(stderr: String) -> bool {
     let lld_version_re = Regex::new(r"^LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
-    let stderr = std::str::from_utf8(&output.stderr).unwrap();
     stderr.lines().any(|line| lld_version_re.is_match(line.trim()))
 }

--- a/tests/run-make/rust-lld/rmake.rs
+++ b/tests/run-make/rust-lld/rmake.rs
@@ -21,9 +21,9 @@ fn main() {
         .input("main.rs")
         .run();
     assert!(
-        find_lld_version_in_logs(&output),
+        find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should be present in the output logs:\n{}",
-        std::str::from_utf8(&output.stderr).unwrap()
+        output.stderr_utf8()
     );
 
     // It should not be used when we explictly opt-out of lld.
@@ -34,9 +34,9 @@ fn main() {
         .input("main.rs")
         .run();
     assert!(
-        !find_lld_version_in_logs(&output),
+        !find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should not be present in the output logs:\n{}",
-        std::str::from_utf8(&output.stderr).unwrap()
+        output.stderr_utf8()
     );
 
     // While we're here, also check that the last linker feature flag "wins" when passed multiple
@@ -52,14 +52,13 @@ fn main() {
         .input("main.rs")
         .run();
     assert!(
-        find_lld_version_in_logs(&output),
+        find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should be present in the output logs:\n{}",
-        std::str::from_utf8(&output.stderr).unwrap()
+        output.stderr_utf8()
     );
 }
 
-fn find_lld_version_in_logs(output: &Output) -> bool {
+fn find_lld_version_in_logs(stderr: String) -> bool {
     let lld_version_re = Regex::new(r"^LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
-    let stderr = std::str::from_utf8(&output.stderr).unwrap();
     stderr.lines().any(|line| lld_version_re.is_match(line.trim()))
 }

--- a/tests/run-make/rustdoc-error-lines/rmake.rs
+++ b/tests/run-make/rustdoc-error-lines/rmake.rs
@@ -4,9 +4,7 @@
 use run_make_support::rustdoc;
 
 fn main() {
-    let output =
-        String::from_utf8(rustdoc().input("input.rs").arg("--test").command_output().stdout)
-            .unwrap();
+    let output = rustdoc().input("input.rs").arg("--test").run_fail().stdout_utf8();
 
     let should_contain = &[
         "input.rs - foo (line 5)",

--- a/tests/run-make/rustdoc-scrape-examples-macros/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-macros/rmake.rs
@@ -8,17 +8,14 @@ fn main() {
     let proc_crate_name = "foobar_macro";
     let crate_name = "foobar";
 
-    let dylib_name = String::from_utf8(
-        rustc()
-            .crate_name(proc_crate_name)
-            .crate_type("dylib")
-            .arg("--print")
-            .arg("file-names")
-            .arg("-")
-            .command_output()
-            .stdout,
-    )
-    .unwrap();
+    let dylib_name = rustc()
+        .crate_name(proc_crate_name)
+        .crate_type("dylib")
+        .arg("--print")
+        .arg("file-names")
+        .arg("-")
+        .run()
+        .stdout_utf8();
 
     rustc()
         .input("src/proc.rs")

--- a/tests/run-make/rustdoc-shared-flags/rmake.rs
+++ b/tests/run-make/rustdoc-shared-flags/rmake.rs
@@ -1,8 +1,8 @@
 use run_make_support::{rustc, rustdoc, Diff};
 
 fn compare_outputs(args: &[&str]) {
-    let rustc_output = String::from_utf8(rustc().args(args).command_output().stdout).unwrap();
-    let rustdoc_output = String::from_utf8(rustdoc().args(args).command_output().stdout).unwrap();
+    let rustc_output = rustc().args(args).run().stdout_utf8();
+    let rustdoc_output = rustdoc().args(args).run().stdout_utf8();
 
     Diff::new().expected_text("rustc", rustc_output).actual_text("rustdoc", rustdoc_output).run();
 }

--- a/tests/run-make/stdin-rustc/rmake.rs
+++ b/tests/run-make/stdin-rustc/rmake.rs
@@ -21,7 +21,7 @@ fn main() {
     );
 
     // echo $NOT_UTF8 | rustc -
-    let output = rustc().arg("-").stdin(NOT_UTF8).run_fail();
-    let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("error: couldn't read from stdin, as it did not contain valid UTF-8"));
+    rustc().arg("-").stdin(NOT_UTF8).run_fail().assert_stderr_contains(
+        "error: couldn't read from stdin, as it did not contain valid UTF-8",
+    );
 }


### PR DESCRIPTION
This should make it easier to make sure that we check process exit codes, and it should also make checking of stdout/stderr less verbose and more explicit in run-make tests. I prefer the `run()/run_fail().assert(...)` style to something like `run_fail_assert_exit_code`, because the former is more composable.

Regarding https://github.com/rust-lang/rust/issues/125747, I'm not sure if we really need a custom trait, I think that we can get far enough with just `Deref` on the `Cc/Clang/Rustc/Rustdoc/...` structs. But now that these structs don't even need `command_output` anymore, I think that they are fine-ish as they are with the macro.

Related issues: https://github.com/rust-lang/rust/issues/125617, https://github.com/rust-lang/rust/issues/125747

Fixes: https://github.com/rust-lang/rust/issues/125617 (because `command_output` is no longer a public method)

r? @jieyouxu