### PR TITLE
tests: Add ui/higher-ranked/trait-bounds/normalize-generic-arg.rs

### DIFF
--- a/tests/ui/higher-ranked/trait-bounds/rigid-equate-projections-in-higher-ranked-fn-signature.next.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/rigid-equate-projections-in-higher-ranked-fn-signature.next.stderr
@@ -1,0 +1,9 @@
+error[E0284]: type annotations needed: cannot satisfy `for<'a> <_ as Trait<'a>>::Assoc <: <T as Trait<'_>>::Assoc`
+  --> $DIR/rigid-equate-projections-in-higher-ranked-fn-signature.rs:27:50
+   |
+LL |     let _: for<'a> fn(<_ as Trait<'a>>::Assoc) = foo::<T>();
+   |                                                  ^^^^^^^^^^ cannot satisfy `for<'a> <_ as Trait<'a>>::Assoc <: <T as Trait<'_>>::Assoc`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/higher-ranked/trait-bounds/rigid-equate-projections-in-higher-ranked-fn-signature.rs
+++ b/tests/ui/higher-ranked/trait-bounds/rigid-equate-projections-in-higher-ranked-fn-signature.rs
@@ -1,0 +1,30 @@
+//@ revisions: current next
+//@[current] check-pass
+//@[next] compile-flags: -Znext-solver
+//@[next] check-fail
+//@ ignore-compare-mode-next-solver (explicit revisions)
+
+/// This triggers an ICE with (and without) `--emit metadata` using the old
+/// trait solver:
+/// ```
+/// rustc +nightly-2023-01-09 \
+///   tests/ui/higher-ranked/trait-bounds/rigid-equate-projections-in-higher-ranked-fn-signature.rs
+/// ```
+/// The ICE was unknowingly fixed by
+/// <https://github.com/rust-lang/rust/pull/101947> in `nightly-2023-01-10`.
+/// This is a regression test for that fixed ICE. For the next solver we simply
+/// make sure there is a compiler error.
+
+trait Trait<'a> {
+    type Assoc;
+}
+
+fn foo<T: for<'a> Trait<'a>>() -> for<'a> fn(<T as Trait<'a>>::Assoc) {
+    todo!()
+}
+
+fn bar<T: for<'a> Trait<'a>>() {
+    let _: for<'a> fn(<_ as Trait<'a>>::Assoc) = foo::<T>(); //[next]~ ERROR type annotations needed
+}
+
+fn main() {}


### PR DESCRIPTION
This adds a regression test for an ICE "accidentally" fixed by https://github.com/rust-lang/rust/pull/101947 that does not add a test for this particular case.

Closes #107564.

I have confirmed the added test code fails with `nightly-2023-01-09` (and passes with `nightly-2023-01-10` and of course recent `nightly`).

