### PR TITLE
resolve rustdoc incompatibility with `rust.download-rustc=true` + `rust.channel= beta/stable`

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1038,14 +1038,26 @@ impl<'a> Builder<'a> {
     }
 
     pub fn doc_rust_lang_org_channel(&self) -> String {
-        let channel = match &*self.config.channel {
-            "stable" => &self.version,
-            "beta" => "beta",
-            "nightly" | "dev" => "nightly",
-            // custom build of rustdoc maybe? link to the latest stable docs just in case
-            _ => "stable",
+        // When using precompiled compiler from CI, we need to use CI rustc's channel and
+        // ignore `rust.channel` from the configuration. Otherwise most of the rustdoc tests
+        // will fail due to incompatible `DOC_RUST_LANG_ORG_CHANNEL`.
+        let channel = if let Some(commit) = self.config.download_rustc_commit() {
+            self.config
+                .read_file_by_commit(&PathBuf::from("src/ci/channel"), commit)
+                .trim()
+                .to_owned()
+        } else {
+            match &*self.config.channel {
+                "stable" => &self.version,
+                "beta" => "beta",
+                "nightly" | "dev" => "nightly",
+                // custom build of rustdoc maybe? link to the latest stable docs just in case
+                _ => "stable",
+            }
+            .to_owned()
         };
-        "https://doc.rust-lang.org/".to_owned() + channel
+
+        format!("https://doc.rust-lang.org/{channel}")
     }
 
     fn run_step_descriptions(&self, v: &[StepDescription], paths: &[PathBuf]) {

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1608,19 +1608,8 @@ impl Config {
             set(&mut config.channel, channel);
 
             config.download_rustc_commit = config.download_ci_rustc_commit(download_rustc);
-            // This list is incomplete, please help by expanding it!
-            if config.download_rustc_commit.is_some() {
-                // We need the channel used by the downloaded compiler to match the one we set for rustdoc;
-                // otherwise rustdoc-ui tests break.
-                if config.channel != ci_channel
-                    && !(config.channel == "dev" && ci_channel == "nightly")
-                {
-                    panic!(
-                        "setting rust.channel={} is incompatible with download-rustc",
-                        config.channel
-                    );
-                }
-            }
+
+            // FIXME: handle download-rustc incompatible options.
 
             debug = debug_toml;
             debug_assertions = debug_assertions_toml;

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2134,17 +2134,29 @@ impl Config {
         args
     }
 
+    /// Returns the content of the given file at a specific commit.
+    pub(crate) fn read_file_by_commit(&self, file: &Path, commit: &str) -> String {
+        assert!(
+            self.rust_info.is_managed_git_subrepository(),
+            "`Config::read_file_by_commit` is not supported in non-git sources."
+        );
+
+        let mut git = self.git();
+        git.arg("show").arg(format!("{commit}:{}", file.to_str().unwrap()));
+        output(&mut git)
+    }
+
     /// Bootstrap embeds a version number into the name of shared libraries it uploads in CI.
     /// Return the version it would have used for the given commit.
     pub(crate) fn artifact_version_part(&self, commit: &str) -> String {
         let (channel, version) = if self.rust_info.is_managed_git_subrepository() {
-            let mut channel = self.git();
-            channel.arg("show").arg(format!("{commit}:src/ci/channel"));
-            let channel = output(&mut channel);
-            let mut version = self.git();
-            version.arg("show").arg(format!("{commit}:src/version"));
-            let version = output(&mut version);
-            (channel.trim().to_owned(), version.trim().to_owned())
+            let channel = self
+                .read_file_by_commit(&PathBuf::from("src/ci/channel"), commit)
+                .trim()
+                .to_owned();
+            let version =
+                self.read_file_by_commit(&PathBuf::from("src/version"), commit).trim().to_owned();
+            (channel, version)
         } else {
             let channel = fs::read_to_string(self.src.join("src/ci/channel"));
             let version = fs::read_to_string(self.src.join("src/version"));


### PR DESCRIPTION
Previously, we were unable to use `rust.download-rustc` with the beta or stable
channel settings through `rust.channel` due to breaking rustdoc UI tests.
This was because when using a precompiled nightly compiler from CI, we must use the
channel of precompiled compiler and ignore `rust.channel` from the configuration.

This change addresses that issue in `Builder::doc_rust_lang_org_channel` and allows rustdoc
UI tests to work with the precompiled compiler even if the channel specified in config.toml is
"beta" or "stable".

Blocker for https://github.com/rust-lang/rust/pull/122709