### PR TITLE
add missing Scalar::from_i128

### DIFF
--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -197,6 +197,11 @@ impl<Prov> Scalar<Prov> {
     }
 
     #[inline]
+    pub fn from_i128(i: i128) -> Self {
+        Self::from_int(i, Size::from_bits(128))
+    }
+
+    #[inline]
     pub fn from_target_isize(i: i64, cx: &impl HasDataLayout) -> Self {
         Self::from_int(i, cx.data_layout().pointer_size)
     }


### PR DESCRIPTION
We seem to have `from` methods for all primitive types except `i128`... let's complete the set of methods. (This came up in https://github.com/rust-lang/miri/pull/3622.)