### PR TITLE
Disallow setting some built-in cfg via the command-line

### DIFF
--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -555,7 +555,7 @@ fn make_format_args(
             };
             let arg_name = args.explicit_args()[index].kind.ident().unwrap();
             ecx.buffered_early_lint.push(BufferedEarlyLint {
-                span: arg_name.span.into(),
+                span: Some(arg_name.span.into()),
                 node_id: rustc_ast::CRATE_NODE_ID,
                 lint_id: LintId::of(NAMED_ARGUMENTS_USED_POSITIONALLY),
                 diagnostic: BuiltinLintDiag::NamedArgumentUsedPositionally {

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -775,6 +775,10 @@ lint_undropped_manually_drops = calls to `std::mem::drop` with `std::mem::Manual
     .label = argument has type `{$arg_ty}`
     .suggestion = use `std::mem::ManuallyDrop::into_inner` to get the inner value
 
+lint_unexpected_builtin_cfg = unexpected `--cfg {$cfg}` flag
+    .controlled_by = config `{$cfg_name}` is only supposed to be controlled by `{$controlled_by}`
+    .incoherent = manually setting a built-in cfg can and does create incoherent behaviors
+
 lint_unexpected_cfg_add_build_rs_println = or consider adding `{$build_rs_println}` to the top of the `build.rs`
 lint_unexpected_cfg_add_cargo_feature = consider using a Cargo feature instead
 lint_unexpected_cfg_add_cargo_toml_lint_cfg = or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:{$cargo_toml_lint_cfg}

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -533,7 +533,7 @@ pub struct EarlyContext<'a> {
 }
 
 impl EarlyContext<'_> {
-    /// Emit a lint at the appropriate level, with an optional associated span and an existing
+    /// Emit a lint at the appropriate level, with an associated span and an existing
     /// diagnostic.
     ///
     /// [`lint_level`]: rustc_middle::lint::lint_level#decorate-signature
@@ -544,7 +544,21 @@ impl EarlyContext<'_> {
         span: MultiSpan,
         diagnostic: BuiltinLintDiag,
     ) {
-        self.opt_span_lint(lint, Some(span), |diag| {
+        self.opt_span_lint_with_diagnostics(lint, Some(span), diagnostic);
+    }
+
+    /// Emit a lint at the appropriate level, with an optional associated span and an existing
+    /// diagnostic.
+    ///
+    /// [`lint_level`]: rustc_middle::lint::lint_level#decorate-signature
+    #[rustc_lint_diagnostics]
+    pub fn opt_span_lint_with_diagnostics(
+        &self,
+        lint: &'static Lint,
+        span: Option<MultiSpan>,
+        diagnostic: BuiltinLintDiag,
+    ) {
+        self.opt_span_lint(lint, span, |diag| {
             diagnostics::decorate_lint(self.sess(), diagnostic, diag);
         });
     }

--- a/compiler/rustc_lint/src/context/diagnostics.rs
+++ b/compiler/rustc_lint/src/context/diagnostics.rs
@@ -438,5 +438,8 @@ pub(super) fn decorate_lint(sess: &Session, diagnostic: BuiltinLintDiag, diag: &
         BuiltinLintDiag::OutOfScopeMacroCalls { path } => {
             lints::OutOfScopeMacroCalls { path }.decorate_lint(diag)
         }
+        BuiltinLintDiag::UnexpectedBuiltinCfg { cfg, cfg_name, controlled_by } => {
+            lints::UnexpectedBuiltinCfg { cfg, cfg_name, controlled_by }.decorate_lint(diag)
+        }
     }
 }

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -47,7 +47,7 @@ impl<'a, T: EarlyLintPass> EarlyContextAndPass<'a, T> {
     fn inlined_check_id(&mut self, id: ast::NodeId) {
         for early_lint in self.context.buffered.take(id) {
             let BufferedEarlyLint { span, node_id: _, lint_id, diagnostic } = early_lint;
-            self.context.span_lint_with_diagnostics(lint_id.lint, span, diagnostic);
+            self.context.opt_span_lint_with_diagnostics(lint_id.lint, span, diagnostic);
         }
     }
 

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2380,6 +2380,16 @@ pub mod unexpected_cfg_value {
 }
 
 #[derive(LintDiagnostic)]
+#[diag(lint_unexpected_builtin_cfg)]
+#[note(lint_controlled_by)]
+#[note(lint_incoherent)]
+pub struct UnexpectedBuiltinCfg {
+    pub(crate) cfg: String,
+    pub(crate) cfg_name: Symbol,
+    pub(crate) controlled_by: &'static str,
+}
+
+#[derive(LintDiagnostic)]
 #[diag(lint_macro_use_deprecated)]
 #[help]
 pub struct MacroUseDeprecated;

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -42,6 +42,7 @@ declare_lint_pass! {
         DUPLICATE_MACRO_ATTRIBUTES,
         ELIDED_LIFETIMES_IN_ASSOCIATED_CONSTANT,
         ELIDED_LIFETIMES_IN_PATHS,
+        EXPLICIT_BUILTIN_CFGS_IN_FLAGS,
         EXPORTED_PRIVATE_DEPENDENCIES,
         FFI_UNWIND_CALLS,
         FORBIDDEN_LINT_GROUPS,
@@ -3286,6 +3287,39 @@ declare_lint! {
     pub UNEXPECTED_CFGS,
     Warn,
     "detects unexpected names and values in `#[cfg]` conditions",
+}
+
+declare_lint! {
+    /// The `explicit_builtin_cfgs_in_flags` lint detects builtin cfgs set via the `--cfg` flag.
+    ///
+    /// ### Example
+    ///
+    /// ```text
+    /// rustc --cfg unix
+    /// ```
+    ///
+    /// ```rust,ignore (needs command line option)
+    /// fn main() {}
+    /// ```
+    ///
+    /// This will produce:
+    ///
+    /// ```text
+    /// error: unexpected `--cfg unix` flag
+    ///   |
+    ///   = note: config `unix` is only supposed to be controlled by `--target`
+    ///   = note: manually setting a built-in cfg can and does create incoherent behaviors
+    ///   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+    /// ```
+    ///
+    /// ### Explanation
+    ///
+    /// Setting builtin cfgs can and does produce incoherent behavior, it's better to the use
+    /// the appropriate `rustc` flag that controls the config. For example setting the `windows`
+    /// cfg but on Linux based target.
+    pub EXPLICIT_BUILTIN_CFGS_IN_FLAGS,
+    Deny,
+    "detects builtin cfgs set via the `--cfg`"
 }
 
 declare_lint! {

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -746,6 +746,11 @@ pub enum BuiltinLintDiag {
     OutOfScopeMacroCalls {
         path: String,
     },
+    UnexpectedBuiltinCfg {
+        cfg: String,
+        cfg_name: Symbol,
+        controlled_by: &'static str,
+    },
 }
 
 /// Lints that are buffered up early on in the `Session` before the

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -753,7 +753,7 @@ pub enum BuiltinLintDiag {
 #[derive(Debug)]
 pub struct BufferedEarlyLint {
     /// The span of code that we are linting on.
-    pub span: MultiSpan,
+    pub span: Option<MultiSpan>,
 
     /// The `NodeId` of the AST node that generated the lint.
     pub node_id: NodeId,
@@ -791,7 +791,7 @@ impl LintBuffer {
         self.add_early_lint(BufferedEarlyLint {
             lint_id: LintId::of(lint),
             node_id,
-            span: span.into(),
+            span: Some(span.into()),
             diagnostic,
         });
     }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1304,7 +1304,10 @@ pub(crate) const fn default_lib_output() -> CrateType {
 }
 
 pub fn build_configuration(sess: &Session, mut user_cfg: Cfg) -> Cfg {
-    // Combine the configuration requested by the session (command line) with
+    // First disallow some configuration given on the command line
+    cfg::disallow_cfgs(sess, &user_cfg);
+
+    // Then combine the configuration requested by the session (command line) with
     // some default and generated configuration items.
     user_cfg.extend(cfg::default_configuration(sess));
     user_cfg

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -17,12 +17,16 @@
 //!  - Add the activation logic in [`default_configuration`]
 //!  - Add the cfg to [`CheckCfg::fill_well_known`] (and related files),
 //!    so that the compiler can know the cfg is expected
+//!  - Add the cfg in [`disallow_cfgs`] to disallow users from setting it via `--cfg`
 //!  - Add the feature gating in `compiler/rustc_feature/src/builtin_attrs.rs`
 
 use std::hash::Hash;
 use std::iter;
 
+use rustc_ast::ast;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexSet};
+use rustc_lint_defs::builtin::EXPLICIT_BUILTIN_CFGS_IN_FLAGS;
+use rustc_lint_defs::BuiltinLintDiag;
 use rustc_span::symbol::{sym, Symbol};
 use rustc_target::abi::Align;
 use rustc_target::spec::{PanicStrategy, RelocModel, SanitizerSet, Target, TargetTriple, TARGETS};
@@ -78,6 +82,67 @@ impl<'a, T: Eq + Hash + Copy + 'a> Extend<&'a T> for ExpectedValues<T> {
         match self {
             ExpectedValues::Some(expecteds) => expecteds.extend(iter.into_iter().map(|a| Some(*a))),
             ExpectedValues::Any => {}
+        }
+    }
+}
+
+/// Disallow builtin cfgs from the CLI.
+pub(crate) fn disallow_cfgs(sess: &Session, user_cfgs: &Cfg) {
+    let disallow = |cfg: &(Symbol, Option<Symbol>), controlled_by| {
+        let cfg_name = cfg.0;
+        let cfg = if let Some(value) = cfg.1 {
+            format!(r#"{}="{}""#, cfg_name, value)
+        } else {
+            format!("{}", cfg_name)
+        };
+        sess.psess.opt_span_buffer_lint(
+            EXPLICIT_BUILTIN_CFGS_IN_FLAGS,
+            None,
+            ast::CRATE_NODE_ID,
+            BuiltinLintDiag::UnexpectedBuiltinCfg { cfg, cfg_name, controlled_by },
+        )
+    };
+
+    // We want to restrict setting builtin cfgs that will produce incoherent behavior
+    // between the cfg and the rustc cli flag that sets it.
+    //
+    // The tests are in tests/ui/cfg/disallowed-cli-cfgs.rs.
+
+    // By-default all builtin cfgs are disallowed, only those are allowed:
+    //  - test: as it makes sense to the have the `test` cfg active without the builtin
+    //          test harness. See Cargo `harness = false` config.
+    //
+    // Cargo `--cfg test`: https://github.com/rust-lang/cargo/blob/bc89bffa5987d4af8f71011c7557119b39e44a65/src/cargo/core/compiler/mod.rs#L1124
+
+    for cfg in user_cfgs {
+        match cfg {
+            (sym::overflow_checks, None) => disallow(cfg, "-C overflow-checks"),
+            (sym::debug_assertions, None) => disallow(cfg, "-C debug-assertions"),
+            (sym::ub_checks, None) => disallow(cfg, "-Z ub-checks"),
+            (sym::sanitize, None | Some(_)) => disallow(cfg, "-Z sanitizer"),
+            (
+                sym::sanitizer_cfi_generalize_pointers | sym::sanitizer_cfi_normalize_integers,
+                None | Some(_),
+            ) => disallow(cfg, "-Z sanitizer=cfi"),
+            (sym::proc_macro, None) => disallow(cfg, "--crate-type proc-macro"),
+            (sym::panic, Some(sym::abort | sym::unwind)) => disallow(cfg, "-C panic"),
+            (sym::target_feature, Some(_)) => disallow(cfg, "-C target-feature"),
+            (sym::unix, None)
+            | (sym::windows, None)
+            | (sym::relocation_model, Some(_))
+            | (sym::target_abi, None | Some(_))
+            | (sym::target_arch, Some(_))
+            | (sym::target_endian, Some(_))
+            | (sym::target_env, None | Some(_))
+            | (sym::target_family, Some(_))
+            | (sym::target_os, Some(_))
+            | (sym::target_pointer_width, Some(_))
+            | (sym::target_vendor, None | Some(_))
+            | (sym::target_has_atomic, Some(_))
+            | (sym::target_has_atomic_equal_alignment, Some(_))
+            | (sym::target_has_atomic_load_store, Some(_))
+            | (sym::target_thread_local, None) => disallow(cfg, "--target"),
+            _ => {}
         }
     }
 }

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -307,9 +307,19 @@ impl ParseSess {
         node_id: NodeId,
         diagnostic: BuiltinLintDiag,
     ) {
+        self.opt_span_buffer_lint(lint, Some(span.into()), node_id, diagnostic)
+    }
+
+    pub fn opt_span_buffer_lint(
+        &self,
+        lint: &'static Lint,
+        span: Option<MultiSpan>,
+        node_id: NodeId,
+        diagnostic: BuiltinLintDiag,
+    ) {
         self.buffered_lints.with_lock(|buffered_lints| {
             buffered_lints.push(BufferedEarlyLint {
-                span: span.into(),
+                span,
                 node_id,
                 lint_id: LintId::of(lint),
                 diagnostic,

--- a/tests/assembly/x86-return-float.rs
+++ b/tests/assembly/x86-return-float.rs
@@ -8,9 +8,9 @@
 // Force frame pointers to make ASM more consistent between targets
 //@ compile-flags: -O -C force-frame-pointers
 //@ filecheck-flags: --implicit-check-not fld --implicit-check-not fst
-//@ revisions: unix windows
-//@[unix] ignore-windows
-//@[windows] only-windows
+//@ revisions: normal win
+//@[normal] ignore-windows
+//@[win] only-windows
 
 #![crate_type = "lib"]
 #![feature(f16, f128)]
@@ -190,10 +190,10 @@ pub unsafe fn call_f64_f64(x: &mut (f64, f64)) {
     }
     // CHECK: movl {{.*}}(%ebp), %[[PTR:.*]]
     // CHECK: calll {{()|_}}get_f64_f64
-    // unix: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
-    // unix-NEXT: movsd [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
-    // windows: movsd (%esp), %[[VAL1:.*]]
-    // windows-NEXT: movsd 8(%esp), %[[VAL2:.*]]
+    // normal: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
+    // normal-NEXT: movsd [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
+    // win: movsd (%esp), %[[VAL1:.*]]
+    // win-NEXT: movsd 8(%esp), %[[VAL2:.*]]
     // CHECK-NEXT: movsd %[[VAL1]], (%[[PTR]])
     // CHECK-NEXT: movsd %[[VAL2]], 8(%[[PTR]])
     *x = get_f64_f64();
@@ -207,13 +207,13 @@ pub unsafe fn call_f32_f64(x: &mut (f32, f64)) {
     }
     // CHECK: movl {{.*}}(%ebp), %[[PTR:.*]]
     // CHECK: calll {{()|_}}get_f32_f64
-    // unix: movss [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
-    // unix-NEXT: movsd [[#%d,OFFSET+4]](%ebp), %[[VAL2:.*]]
-    // windows: movss (%esp), %[[VAL1:.*]]
-    // windows-NEXT: movsd 8(%esp), %[[VAL2:.*]]
+    // normal: movss [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
+    // normal-NEXT: movsd [[#%d,OFFSET+4]](%ebp), %[[VAL2:.*]]
+    // win: movss (%esp), %[[VAL1:.*]]
+    // win-NEXT: movsd 8(%esp), %[[VAL2:.*]]
     // CHECK-NEXT: movss %[[VAL1]], (%[[PTR]])
-    // unix-NEXT: movsd %[[VAL2]], 4(%[[PTR]])
-    // windows-NEXT: movsd %[[VAL2]], 8(%[[PTR]])
+    // normal-NEXT: movsd %[[VAL2]], 4(%[[PTR]])
+    // win-NEXT: movsd %[[VAL2]], 8(%[[PTR]])
     *x = get_f32_f64();
 }
 
@@ -225,10 +225,10 @@ pub unsafe fn call_f64_f32(x: &mut (f64, f32)) {
     }
     // CHECK: movl {{.*}}(%ebp), %[[PTR:.*]]
     // CHECK: calll {{()|_}}get_f64_f32
-    // unix: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
-    // unix-NEXT: movss [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
-    // windows: movsd (%esp), %[[VAL1:.*]]
-    // windows-NEXT: movss 8(%esp), %[[VAL2:.*]]
+    // normal: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
+    // normal-NEXT: movss [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
+    // win: movsd (%esp), %[[VAL1:.*]]
+    // win-NEXT: movss 8(%esp), %[[VAL2:.*]]
     // CHECK-NEXT: movsd %[[VAL1]], (%[[PTR]])
     // CHECK-NEXT: movss %[[VAL2]], 8(%[[PTR]])
     *x = get_f64_f32();
@@ -257,10 +257,10 @@ pub unsafe fn call_f64_other(x: &mut (f64, usize)) {
     }
     // CHECK: movl {{.*}}(%ebp), %[[PTR:.*]]
     // CHECK: calll {{()|_}}get_f64_other
-    // unix: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
-    // unix-NEXT: movl [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
-    // windows: movsd (%esp), %[[VAL1:.*]]
-    // windows-NEXT: movl 8(%esp), %[[VAL2:.*]]
+    // normal: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
+    // normal-NEXT: movl [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
+    // win: movsd (%esp), %[[VAL1:.*]]
+    // win-NEXT: movl 8(%esp), %[[VAL2:.*]]
     // CHECK-NEXT: movsd %[[VAL1]], (%[[PTR]])
     // CHECK-NEXT: movl %[[VAL2]], 8(%[[PTR]])
     *x = get_f64_other();
@@ -289,13 +289,13 @@ pub unsafe fn call_other_f64(x: &mut (usize, f64)) {
     }
     // CHECK: movl {{.*}}(%ebp), %[[PTR:.*]]
     // CHECK: calll {{()|_}}get_other_f64
-    // unix: movl [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
-    // unix-NEXT: movsd [[#%d,OFFSET+4]](%ebp), %[[VAL2:.*]]
-    // windows: movl (%esp), %[[VAL1:.*]]
-    // windows-NEXT: movsd 8(%esp), %[[VAL2:.*]]
+    // normal: movl [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
+    // normal-NEXT: movsd [[#%d,OFFSET+4]](%ebp), %[[VAL2:.*]]
+    // win: movl (%esp), %[[VAL1:.*]]
+    // win-NEXT: movsd 8(%esp), %[[VAL2:.*]]
     // CHECK-NEXT: movl %[[VAL1]], (%[[PTR]])
-    // unix-NEXT: movsd %[[VAL2]], 4(%[[PTR]])
-    // windows-NEXT: movsd %[[VAL2]], 8(%[[PTR]])
+    // normal-NEXT: movsd %[[VAL2]], 4(%[[PTR]])
+    // win-NEXT: movsd %[[VAL2]], 8(%[[PTR]])
     *x = get_other_f64();
 }
 

--- a/tests/codegen/aarch64-struct-align-128.rs
+++ b/tests/codegen/aarch64-struct-align-128.rs
@@ -1,12 +1,12 @@
 // Test that structs aligned to 128 bits are passed with the correct ABI on aarch64.
 
-//@ revisions:linux darwin windows
+//@ revisions: linux darwin win
 //@[linux] compile-flags: --target aarch64-unknown-linux-gnu
 //@[darwin] compile-flags: --target aarch64-apple-darwin
-//@[windows] compile-flags: --target aarch64-pc-windows-msvc
+//@[win] compile-flags: --target aarch64-pc-windows-msvc
 //@[linux] needs-llvm-components: aarch64
 //@[darwin] needs-llvm-components: aarch64
-//@[windows] needs-llvm-components: aarch64
+//@[win] needs-llvm-components: aarch64
 
 #![feature(no_core, lang_items)]
 #![crate_type = "lib"]
@@ -39,9 +39,9 @@ pub struct Wrapped8 {
 }
 
 extern "C" {
-    // linux:   declare void @test_8([2 x i64], [2 x i64], [2 x i64])
-    // darwin:  declare void @test_8([2 x i64], [2 x i64], [2 x i64])
-    // windows: declare void @test_8([2 x i64], [2 x i64], [2 x i64])
+    // linux:  declare void @test_8([2 x i64], [2 x i64], [2 x i64])
+    // darwin: declare void @test_8([2 x i64], [2 x i64], [2 x i64])
+    // win:    declare void @test_8([2 x i64], [2 x i64], [2 x i64])
     fn test_8(a: Align8, b: Transparent8, c: Wrapped8);
 }
 
@@ -69,9 +69,9 @@ pub struct Wrapped16 {
 }
 
 extern "C" {
-    // linux:   declare void @test_16([2 x i64], [2 x i64], i128)
-    // darwin:  declare void @test_16(i128, i128, i128)
-    // windows: declare void @test_16(i128, i128, i128)
+    // linux:  declare void @test_16([2 x i64], [2 x i64], i128)
+    // darwin: declare void @test_16(i128, i128, i128)
+    // win:    declare void @test_16(i128, i128, i128)
     fn test_16(a: Align16, b: Transparent16, c: Wrapped16);
 }
 
@@ -94,9 +94,9 @@ pub struct WrappedI128 {
 }
 
 extern "C" {
-    // linux:   declare void @test_i128(i128, i128, i128)
-    // darwin:  declare void @test_i128(i128, i128, i128)
-    // windows: declare void @test_i128(i128, i128, i128)
+    // linux:  declare void @test_i128(i128, i128, i128)
+    // darwin: declare void @test_i128(i128, i128, i128)
+    // win:    declare void @test_i128(i128, i128, i128)
     fn test_i128(a: I128, b: TransparentI128, c: WrappedI128);
 }
 
@@ -121,9 +121,9 @@ pub struct WrappedPacked {
 }
 
 extern "C" {
-    // linux:   declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
-    // darwin:  declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
-    // windows: declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
+    // linux:  declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
+    // darwin: declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
+    // win:    declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
     fn test_packed(a: Packed, b: TransparentPacked, c: WrappedPacked);
 }
 

--- a/tests/codegen/cold-call-declare-and-call.rs
+++ b/tests/codegen/cold-call-declare-and-call.rs
@@ -1,8 +1,8 @@
-//@ revisions: NORMAL WINDOWS
+//@ revisions: NORMAL WIN
 //@ compile-flags: -C no-prepopulate-passes
 //@[NORMAL] ignore-windows
-//@[WINDOWS] only-windows
-//@[WINDOWS] only-x86_64
+//@[WIN] only-windows
+//@[WIN] only-x86_64
 
 #![crate_type = "lib"]
 #![feature(rust_cold_cc)]
@@ -14,8 +14,8 @@
 
 // See the comment in `Target::adjust_abi` for why this differs
 
-// WINDOWS: define void @this_should_never_happen(i16
-// WINDOWS: call void @this_should_never_happen(i16
+// WIN: define void @this_should_never_happen(i16
+// WIN: call void @this_should_never_happen(i16
 
 #[no_mangle]
 pub extern "rust-cold" fn this_should_never_happen(x: u16) {}

--- a/tests/codegen/default-requires-uwtable.rs
+++ b/tests/codegen/default-requires-uwtable.rs
@@ -1,9 +1,9 @@
-//@ revisions: WINDOWS ANDROID
+//@ revisions: WINDOWS_ ANDROID_
 //@ compile-flags: -C panic=abort -Copt-level=0
-//@ [WINDOWS] compile-flags: --target=x86_64-pc-windows-msvc
-//@ [WINDOWS] needs-llvm-components: x86
-//@ [ANDROID] compile-flags: --target=armv7-linux-androideabi
-//@ [ANDROID] needs-llvm-components: arm
+//@ [WINDOWS_] compile-flags: --target=x86_64-pc-windows-msvc
+//@ [WINDOWS_] needs-llvm-components: x86
+//@ [ANDROID_] compile-flags: --target=armv7-linux-androideabi
+//@ [ANDROID_] needs-llvm-components: arm
 
 #![feature(no_core, lang_items)]
 #![crate_type = "lib"]

--- a/tests/codegen/instrument-coverage/testprog.rs
+++ b/tests/codegen/instrument-coverage/testprog.rs
@@ -1,7 +1,7 @@
 //@ edition: 2021
 //@ compile-flags: -Zno-profiler-runtime
 //@ compile-flags: -Cinstrument-coverage -Copt-level=0
-//@ revisions: LINUX DARWIN WINDOWS
+//@ revisions: LINUX DARWIN WIN
 
 //@ [LINUX] only-linux
 //@ [LINUX] filecheck-flags: -DINSTR_PROF_DATA=__llvm_prf_data
@@ -19,13 +19,13 @@
 //@ [DARWIN] filecheck-flags: -DINSTR_PROF_COVFUN=__LLVM_COV,__llvm_covfun
 //@ [DARWIN] filecheck-flags: -DCOMDAT_IF_SUPPORTED=
 
-//@ [WINDOWS] only-windows
-//@ [WINDOWS] filecheck-flags: -DINSTR_PROF_DATA=.lprfd$M
-//@ [WINDOWS] filecheck-flags: -DINSTR_PROF_NAME=.lprfn$M
-//@ [WINDOWS] filecheck-flags: -DINSTR_PROF_CNTS=.lprfc$M
-//@ [WINDOWS] filecheck-flags: -DINSTR_PROF_COVMAP=.lcovmap$M
-//@ [WINDOWS] filecheck-flags: -DINSTR_PROF_COVFUN=.lcovfun$M
-//@ [WINDOWS] filecheck-flags: '-DCOMDAT_IF_SUPPORTED=, comdat'
+//@ [WIN] only-windows
+//@ [WIN] filecheck-flags: -DINSTR_PROF_DATA=.lprfd$M
+//@ [WIN] filecheck-flags: -DINSTR_PROF_NAME=.lprfn$M
+//@ [WIN] filecheck-flags: -DINSTR_PROF_CNTS=.lprfc$M
+//@ [WIN] filecheck-flags: -DINSTR_PROF_COVMAP=.lcovmap$M
+//@ [WIN] filecheck-flags: -DINSTR_PROF_COVFUN=.lcovfun$M
+//@ [WIN] filecheck-flags: '-DCOMDAT_IF_SUPPORTED=, comdat'
 
 // ignore-tidy-linelength
 
@@ -71,7 +71,7 @@ fn main() {
 // Check for metadata, variables, declarations, and function definitions injected
 // into LLVM IR when compiling with -Cinstrument-coverage.
 
-// WINDOWS:      $__llvm_profile_runtime_user = comdat any
+// WIN:          $__llvm_profile_runtime_user = comdat any
 
 // CHECK:        @__llvm_coverage_mapping = private constant
 // CHECK-SAME:   section "[[INSTR_PROF_COVMAP]]", align 8
@@ -79,7 +79,7 @@ fn main() {
 // CHECK:        @__covrec_{{[A-F0-9]+}}u = linkonce_odr hidden constant
 // CHECK-SAME:   section "[[INSTR_PROF_COVFUN]]"[[COMDAT_IF_SUPPORTED]], align 8
 
-// WINDOWS:      @__llvm_profile_runtime = external{{.*}}global i32
+// WIN:          @__llvm_profile_runtime = external{{.*}}global i32
 
 // CHECK:        @__profc__R{{[a-zA-Z0-9_]+}}testprog14will_be_called = {{private|internal}} global
 // CHECK-SAME:   section "[[INSTR_PROF_CNTS]]"{{.*}}, align 8
@@ -111,10 +111,10 @@ fn main() {
 
 // CHECK:        declare void @llvm.instrprof.increment(ptr, i64, i32, i32) #[[LLVM_INSTRPROF_INCREMENT_ATTR:[0-9]+]]
 
-// WINDOWS:      define linkonce_odr hidden i32 @__llvm_profile_runtime_user() #[[LLVM_PROFILE_RUNTIME_USER_ATTR:[0-9]+]] comdat {
-// WINDOWS-NEXT: %1 = load i32, ptr @__llvm_profile_runtime
-// WINDOWS-NEXT: ret i32 %1
-// WINDOWS-NEXT: }
+// WIN:          define linkonce_odr hidden i32 @__llvm_profile_runtime_user() #[[LLVM_PROFILE_RUNTIME_USER_ATTR:[0-9]+]] comdat {
+// WIN-NEXT:     %1 = load i32, ptr @__llvm_profile_runtime
+// WIN-NEXT:     ret i32 %1
+// WIN-NEXT:     }
 
 // CHECK:        attributes #[[LLVM_INSTRPROF_INCREMENT_ATTR]] = { nounwind }
-// WINDOWS:      attributes #[[LLVM_PROFILE_RUNTIME_USER_ATTR]] = { noinline }
+// WIN:          attributes #[[LLVM_PROFILE_RUNTIME_USER_ATTR]] = { noinline }

--- a/tests/codegen/repr/transparent-sysv64.rs
+++ b/tests/codegen/repr/transparent-sysv64.rs
@@ -1,12 +1,12 @@
-//@ revisions: linux apple windows
+//@ revisions: linux apple win
 //@ compile-flags: -O -C no-prepopulate-passes
 
 //@[linux] compile-flags: --target x86_64-unknown-linux-gnu
 //@[linux] needs-llvm-components: x86
 //@[apple] compile-flags: --target x86_64-apple-darwin
 //@[apple] needs-llvm-components: x86
-//@[windows] compile-flags: --target x86_64-pc-windows-msvc
-//@[windows] needs-llvm-components: x86
+//@[win] compile-flags: --target x86_64-pc-windows-msvc
+//@[win] needs-llvm-components: x86
 
 #![feature(no_core, lang_items)]
 #![crate_type = "lib"]

--- a/tests/debuginfo/thread-names.rs
+++ b/tests/debuginfo/thread-names.rs
@@ -1,8 +1,8 @@
 //@ compile-flags:-g
-//@ revisions: macos windows
+//@ revisions: macos win
 // We can't set the main thread name on Linux because it renames the process (#97191)
 //@[macos] only-macos
-//@[windows] only-windows
+//@[win] only-windows
 //@ ignore-sgx
 //@ ignore-windows-gnu
 

--- a/tests/ui/cfg/disallowed-cli-cfgs-allow.rs
+++ b/tests/ui/cfg/disallowed-cli-cfgs-allow.rs
@@ -1,0 +1,4 @@
+//@ check-pass
+//@ compile-flags: --cfg unix -Aexplicit_builtin_cfgs_in_flags
+
+fn main() {}

--- a/tests/ui/cfg/disallowed-cli-cfgs.debug_assertions_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.debug_assertions_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg debug_assertions` flag
+   |
+   = note: config `debug_assertions` is only supposed to be controlled by `-C debug-assertions`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.overflow_checks_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.overflow_checks_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg overflow_checks` flag
+   |
+   = note: config `overflow_checks` is only supposed to be controlled by `-C overflow-checks`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.panic_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.panic_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg panic="abort"` flag
+   |
+   = note: config `panic` is only supposed to be controlled by `-C panic`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.proc_macro_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.proc_macro_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg proc_macro` flag
+   |
+   = note: config `proc_macro` is only supposed to be controlled by `--crate-type proc-macro`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.relocation_model_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.relocation_model_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg relocation_model="a"` flag
+   |
+   = note: config `relocation_model` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.rs
+++ b/tests/ui/cfg/disallowed-cli-cfgs.rs
@@ -1,0 +1,35 @@
+//@ check-fail
+//@ revisions: overflow_checks_ debug_assertions_ ub_checks_ sanitize_
+//@ revisions: sanitizer_cfi_generalize_pointers_ sanitizer_cfi_normalize_integers_
+//@ revisions: proc_macro_ panic_ target_feature_ unix_ windows_ target_abi_
+//@ revisions: target_arch_ target_endian_ target_env_ target_family_ target_os_
+//@ revisions: target_pointer_width_ target_vendor_ target_has_atomic_
+//@ revisions: target_has_atomic_equal_alignment_ target_has_atomic_load_store_
+//@ revisions: target_thread_local_ relocation_model_
+
+//@ [overflow_checks_]compile-flags: --cfg overflow_checks
+//@ [debug_assertions_]compile-flags: --cfg debug_assertions
+//@ [ub_checks_]compile-flags: --cfg ub_checks
+//@ [sanitize_]compile-flags: --cfg sanitize="cfi"
+//@ [sanitizer_cfi_generalize_pointers_]compile-flags: --cfg sanitizer_cfi_generalize_pointers
+//@ [sanitizer_cfi_normalize_integers_]compile-flags: --cfg sanitizer_cfi_normalize_integers
+//@ [proc_macro_]compile-flags: --cfg proc_macro
+//@ [panic_]compile-flags: --cfg panic="abort"
+//@ [target_feature_]compile-flags: --cfg target_feature="sse3"
+//@ [unix_]compile-flags: --cfg unix
+//@ [windows_]compile-flags: --cfg windows
+//@ [target_abi_]compile-flags: --cfg target_abi="gnu"
+//@ [target_arch_]compile-flags: --cfg target_arch="arm"
+//@ [target_endian_]compile-flags: --cfg target_endian="little"
+//@ [target_env_]compile-flags: --cfg target_env
+//@ [target_family_]compile-flags: --cfg target_family="unix"
+//@ [target_os_]compile-flags: --cfg target_os="linux"
+//@ [target_pointer_width_]compile-flags: --cfg target_pointer_width="32"
+//@ [target_vendor_]compile-flags: --cfg target_vendor
+//@ [target_has_atomic_]compile-flags: --cfg target_has_atomic="32"
+//@ [target_has_atomic_equal_alignment_]compile-flags: --cfg target_has_atomic_equal_alignment="32"
+//@ [target_has_atomic_load_store_]compile-flags: --cfg target_has_atomic_load_store="32"
+//@ [target_thread_local_]compile-flags: --cfg target_thread_local
+//@ [relocation_model_]compile-flags: --cfg relocation_model="a"
+
+fn main() {}

--- a/tests/ui/cfg/disallowed-cli-cfgs.sanitize_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.sanitize_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg sanitize="cfi"` flag
+   |
+   = note: config `sanitize` is only supposed to be controlled by `-Z sanitizer`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.sanitizer_cfi_generalize_pointers_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.sanitizer_cfi_generalize_pointers_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg sanitizer_cfi_generalize_pointers` flag
+   |
+   = note: config `sanitizer_cfi_generalize_pointers` is only supposed to be controlled by `-Z sanitizer=cfi`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.sanitizer_cfi_normalize_integers_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.sanitizer_cfi_normalize_integers_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg sanitizer_cfi_normalize_integers` flag
+   |
+   = note: config `sanitizer_cfi_normalize_integers` is only supposed to be controlled by `-Z sanitizer=cfi`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_abi_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_abi_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_abi="gnu"` flag
+   |
+   = note: config `target_abi` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_arch_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_arch_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_arch="arm"` flag
+   |
+   = note: config `target_arch` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_endian_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_endian_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_endian="little"` flag
+   |
+   = note: config `target_endian` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_env_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_env_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_env` flag
+   |
+   = note: config `target_env` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_family_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_family_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_family="unix"` flag
+   |
+   = note: config `target_family` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_feature_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_feature_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_feature="sse3"` flag
+   |
+   = note: config `target_feature` is only supposed to be controlled by `-C target-feature`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_has_atomic_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_has_atomic_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_has_atomic="32"` flag
+   |
+   = note: config `target_has_atomic` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_has_atomic_equal_alignment_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_has_atomic_equal_alignment_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_has_atomic_equal_alignment="32"` flag
+   |
+   = note: config `target_has_atomic_equal_alignment` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_has_atomic_load_store_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_has_atomic_load_store_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_has_atomic_load_store="32"` flag
+   |
+   = note: config `target_has_atomic_load_store` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_os_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_os_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_os="linux"` flag
+   |
+   = note: config `target_os` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_pointer_width_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_pointer_width_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_pointer_width="32"` flag
+   |
+   = note: config `target_pointer_width` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_thread_local_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_thread_local_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_thread_local` flag
+   |
+   = note: config `target_thread_local` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.target_vendor_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.target_vendor_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_vendor` flag
+   |
+   = note: config `target_vendor` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.test_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.test_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg test` flag
+   |
+   = note: config `test` is only supposed to be controlled by `--test`
+   = note: see <https://github.com/rust-lang/rust/issues/xxxxx> for more information
+   = note: `#[deny(unexpected_builtin_cfgs)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.ub_checks_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.ub_checks_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg ub_checks` flag
+   |
+   = note: config `ub_checks` is only supposed to be controlled by `-Z ub-checks`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.unix_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.unix_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg unix` flag
+   |
+   = note: config `unix` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/disallowed-cli-cfgs.windows_.stderr
+++ b/tests/ui/cfg/disallowed-cli-cfgs.windows_.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg windows` flag
+   |
+   = note: config `windows` is only supposed to be controlled by `--target`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This PR disallow users from setting some built-in cfg via set the command-line in order to prevent incoherent state, eg. `windows` cfg active but target is Linux based.

This implements MCP https://github.com/rust-lang/compiler-team/issues/610, with the caveat that we disallow cfgs no matter if they make sense or not, since I don't think it's useful to allow users to set a cfg that will be set anyway. It also complicates the implementation.

------

The `explicit_builtin_cfgs_in_flags` lint detects builtin cfgs set via the `--cfg` flag.

*(deny-by-default)*

### Example

```text
rustc --cfg unix
```

```rust,ignore (needs command line option)
fn main() {}
```

This will produce:

```text
error: unexpected `--cfg unix` flag
  |
  = note: config `unix` is only supposed to be controlled by `--target`
  = note: manually setting a built-in cfg can and does create incoherent behaviours
  = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
```

### Explanation

Setting builtin cfgs can and does produce incoherent behaviour, it's better to the use the appropriate `rustc` flag that controls the config. For example setting the `windows` cfg but on Linux based target.

-----

r? @petrochenkov
cc @jyn514

try-job: aarch64-apple
try-job: test-various
try-job: armhf-gnu
try-job: x86_64-msvc
try-job: x86_64-mingw
try-job: i686-msvc
try-job: i686-mingw
try-job: x86_64-gnu-llvm-17
try-job: dist-various-1