### PR TITLE
std::unix::thread fix available_parallelism on netbsd/32 bits.

### DIFF
--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -379,29 +379,6 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
                 }
             }
 
-            #[cfg(target_os = "netbsd")]
-            {
-                unsafe {
-                    let set = libc::_cpuset_create();
-                    if !set.is_null() {
-                        let mut count: usize = 0;
-                        if libc::pthread_getaffinity_np(libc::pthread_self(), libc::_cpuset_size(set), set) == 0 {
-                            for i in 0..libc::cpuid_t::MAX {
-                                match libc::_cpuset_isset(i, set) {
-                                    -1 => break,
-                                    0 => continue,
-                                    _ => count = count + 1,
-                                }
-                            }
-                        }
-                        libc::_cpuset_destroy(set);
-                        if let Some(count) = NonZero::new(count) {
-                            return Ok(count);
-                        }
-                    }
-                }
-            }
-
             let mut cpus: libc::c_uint = 0;
             let mut cpus_size = crate::mem::size_of_val(&cpus);
 


### PR DESCRIPTION
when bootstrapping rust, it segfaults in i386, ppc, arm ... there is no cpu attached by default in such early stage.
therefore removing the affinity api and falls back on the always reliable sysctl/HW_NCPU call instead.