### PR TITLE
Use --quiet flag when installing pip dependencies

### DIFF
--- a/src/tools/tidy/src/ext_tool_checks.rs
+++ b/src/tools/tidy/src/ext_tool_checks.rs
@@ -320,7 +320,7 @@ fn install_requirements(
     }
 
     let stat = Command::new(py_path)
-        .args(["-m", "pip", "install", "--require-hashes", "-r"])
+        .args(["-m", "pip", "install", "--quiet", "--require-hashes", "-r"])
         .arg(src_reqs_path)
         .status()?;
     if !stat.success() {


### PR DESCRIPTION
Fixes: https://github.com/rust-lang/rust/issues/126164

This still prints an error if any occurs.