### PR TITLE
rustdoc-search: use lowercase, non-normalized name for type search

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2399,15 +2399,19 @@ function initSearch(rawSearchIndex) {
              * @param {boolean} isAssocType
              */
             function convertNameToId(elem, isAssocType) {
-                if (typeNameIdMap.has(elem.normalizedPathLast) &&
-                    (isAssocType || !typeNameIdMap.get(elem.normalizedPathLast).assocOnly)) {
-                    elem.id = typeNameIdMap.get(elem.normalizedPathLast).id;
+                const loweredName = elem.pathLast.toLowerCase();
+                if (typeNameIdMap.has(loweredName) &&
+                    (isAssocType || !typeNameIdMap.get(loweredName).assocOnly)) {
+                    elem.id = typeNameIdMap.get(loweredName).id;
                 } else if (!parsedQuery.literalSearch) {
                     let match = null;
                     let matchDist = maxEditDistance + 1;
                     let matchName = "";
                     for (const [name, {id, assocOnly}] of typeNameIdMap) {
-                        const dist = editDistance(name, elem.normalizedPathLast, maxEditDistance);
+                        const dist = Math.min(
+                            editDistance(name, loweredName, maxEditDistance),
+                            editDistance(name, elem.normalizedPathLast, maxEditDistance),
+                        );
                         if (dist <= matchDist && dist <= maxEditDistance &&
                             (isAssocType || !assocOnly)) {
                             if (dist === matchDist && matchName > name) {

--- a/tests/rustdoc-js/underscoredtype.js
+++ b/tests/rustdoc-js/underscoredtype.js
@@ -1,0 +1,62 @@
+const EXPECTED = [
+    {
+        'query': 'pid_t',
+        'correction': null,
+        'proposeCorrectionFrom': null,
+        'proposeCorrectionTo': null,
+        'others': [
+            { 'path': 'underscoredtype::unix', 'name': 'pid_t' },
+        ],
+        'returned': [
+            { 'path': 'underscoredtype::unix', 'name': 'set_pid' },
+        ],
+        'returned': [
+            { 'path': 'underscoredtype::unix', 'name': 'get_pid' },
+        ],
+    },
+    {
+        'query': 'pidt',
+        'correction': 'pid_t',
+        'proposeCorrectionFrom': null,
+        'proposeCorrectionTo': null,
+        'others': [
+            { 'path': 'underscoredtype::unix', 'name': 'pid_t' },
+        ],
+        'returned': [
+            { 'path': 'underscoredtype::unix', 'name': 'set_pid' },
+        ],
+        'returned': [
+            { 'path': 'underscoredtype::unix', 'name': 'get_pid' },
+        ],
+    },
+    {
+        'query': 'unix::pid_t',
+        'correction': null,
+        'proposeCorrectionFrom': null,
+        'proposeCorrectionTo': null,
+        'others': [
+            { 'path': 'underscoredtype::unix', 'name': 'pid_t' },
+        ],
+        'returned': [
+            { 'path': 'underscoredtype::unix', 'name': 'set_pid' },
+        ],
+        'returned': [
+            { 'path': 'underscoredtype::unix', 'name': 'get_pid' },
+        ],
+    },
+    {
+        'query': 'unix::pidt',
+        'correction': 'pid_t',
+        'proposeCorrectionFrom': null,
+        'proposeCorrectionTo': null,
+        'others': [
+            { 'path': 'underscoredtype::unix', 'name': 'pid_t' },
+        ],
+        'returned': [
+            { 'path': 'underscoredtype::unix', 'name': 'set_pid' },
+        ],
+        'returned': [
+            { 'path': 'underscoredtype::unix', 'name': 'get_pid' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/underscoredtype.rs
+++ b/tests/rustdoc-js/underscoredtype.rs
@@ -1,0 +1,8 @@
+pub mod unix {
+    #[allow(non_camel_case_types)]
+    pub type pid_t = i32;
+    pub fn get_pid() -> pid_t {
+        0
+    }
+    pub fn set_pid(_: pid_t) {}
+}


### PR DESCRIPTION
The type name ID map has underscores in its names, so the query element should have them, too.

Fixes #125993
