### PR TITLE
Separate core search logic with search ui

### DIFF
--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -427,7 +427,6 @@ function loadSearchJS(doc_folder, resource_suffix) {
             return list[descIndex];
         },
         loadedDescShard: function(crate, shard, data) {
-            //console.log(this.descShards);
             this.descShards.get(crate)[shard].resolve(data.split("\n"));
         },
     };
@@ -436,15 +435,15 @@ function loadSearchJS(doc_folder, resource_suffix) {
     const searchJs = fs.readdirSync(staticFiles).find(f => f.match(/search.*\.js$/));
     const searchModule = require(path.join(staticFiles, searchJs));
     searchModule.initSearch(searchIndex.searchIndex);
-
+    const docSearch = searchModule.docSearch;
     return {
         doSearch: function(queryStr, filterCrate, currentCrate) {
-            return searchModule.execQuery(searchModule.parseQuery(queryStr),
+            return docSearch.execQuery(searchModule.parseQuery(queryStr),
                 filterCrate, currentCrate);
         },
         getCorrections: function(queryStr, filterCrate, currentCrate) {
             const parsedQuery = searchModule.parseQuery(queryStr);
-            searchModule.execQuery(parsedQuery, filterCrate, currentCrate);
+            docSearch.execQuery(parsedQuery, filterCrate, currentCrate);
             return parsedQuery.correction;
         },
         parseQuery: searchModule.parseQuery,


### PR DESCRIPTION
Currenty, the `search.js` mixed with UI/DOM manipulation codes and search logic codes, I propose to extract the search logic to a class for following benefits:

- Clean code. Separation of DOM manipulation and search logic can lead better code maintainability and easy code testings. 
- Easy share the search logic for third party to utilize the search function, such as [Rust Search Extension](https://rust.extension.sh), https://query.rs.
 
This PR added a new class called `DocSearch`, which mainly expose following methods:

```js
class DocSearch {
	// Dependency inject searchIndex, rootPath and searchState
	constructor(rawSearchIndex, rootPath, searchState) {
		// build search index...
	}

	static parseQuery(userQuery) {
	}

	async execQuery(parsedQuery, filterCrates, currentCrate) {
	}
}
```
