### PR TITLE
For E0277 suggest adding `Result` return type for function when using QuestionMark `?` in the body.

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1010,6 +1010,7 @@ pub struct Block<'hir> {
     pub hir_id: HirId,
     /// Distinguishes between `unsafe { ... }` and `{ ... }`.
     pub rules: BlockCheckMode,
+    /// The span includes the curly braces `{` and `}` around the block.
     pub span: Span,
     /// If true, then there may exist `break 'a` values that aim to
     /// break out of this block early.

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -612,6 +612,10 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             &mut err,
                             trait_predicate,
                         );
+                        self.suggest_add_result_as_return_type(&obligation,
+                            &mut err,
+                            trait_ref);
+
                         if self.suggest_add_reference_to_arg(
                             &obligation,
                             &mut err,

--- a/tests/ui/return/return-from-residual-sugg-issue-125997.fixed
+++ b/tests/ui/return/return-from-residual-sugg-issue-125997.fixed
@@ -1,0 +1,42 @@
+//@ run-rustfix
+
+#![allow(unused_imports)]
+#![allow(dead_code)]
+
+use std::fs::File;
+use std::io::prelude::*;
+
+fn test1() -> Result<(), Box<dyn std::error::Error>> {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+
+    Ok(())
+}
+
+fn test2() -> Result<(), Box<dyn std::error::Error>> {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+    println!();
+
+    Ok(())
+}
+
+macro_rules! mac {
+    () => {
+        fn test3() -> Result<(), Box<dyn std::error::Error>> {
+            let mut _file = File::create("foo.txt")?;
+            //~^ ERROR the `?` operator can only be used in a function
+            println!();
+        
+    Ok(())
+}
+    };
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+    mac!();
+
+    Ok(())
+}

--- a/tests/ui/return/return-from-residual-sugg-issue-125997.rs
+++ b/tests/ui/return/return-from-residual-sugg-issue-125997.rs
@@ -1,0 +1,34 @@
+//@ run-rustfix
+
+#![allow(unused_imports)]
+#![allow(dead_code)]
+
+use std::fs::File;
+use std::io::prelude::*;
+
+fn test1() {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+}
+
+fn test2() {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+    println!();
+}
+
+macro_rules! mac {
+    () => {
+        fn test3() {
+            let mut _file = File::create("foo.txt")?;
+            //~^ ERROR the `?` operator can only be used in a function
+            println!();
+        }
+    };
+}
+
+fn main() {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+    mac!();
+}

--- a/tests/ui/return/return-from-residual-sugg-issue-125997.stderr
+++ b/tests/ui/return/return-from-residual-sugg-issue-125997.stderr
@@ -1,0 +1,86 @@
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> $DIR/return-from-residual-sugg-issue-125997.rs:10:44
+   |
+LL | fn test1() {
+   | ---------- this function should return `Result` or `Option` to accept `?`
+LL |     let mut _file = File::create("foo.txt")?;
+   |                                            ^ cannot use the `?` operator in a function that returns `()`
+   |
+   = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+help: consider adding return type
+   |
+LL ~ fn test1() -> Result<(), Box<dyn std::error::Error>> {
+LL |     let mut _file = File::create("foo.txt")?;
+LL |
+LL + 
+LL +     Ok(())
+LL + }
+   |
+
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> $DIR/return-from-residual-sugg-issue-125997.rs:15:44
+   |
+LL | fn test2() {
+   | ---------- this function should return `Result` or `Option` to accept `?`
+LL |     let mut _file = File::create("foo.txt")?;
+   |                                            ^ cannot use the `?` operator in a function that returns `()`
+   |
+   = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+help: consider adding return type
+   |
+LL ~ fn test2() -> Result<(), Box<dyn std::error::Error>> {
+LL |     let mut _file = File::create("foo.txt")?;
+LL |
+LL |     println!();
+LL + 
+LL +     Ok(())
+LL + }
+   |
+
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> $DIR/return-from-residual-sugg-issue-125997.rs:31:44
+   |
+LL | fn main() {
+   | --------- this function should return `Result` or `Option` to accept `?`
+LL |     let mut _file = File::create("foo.txt")?;
+   |                                            ^ cannot use the `?` operator in a function that returns `()`
+   |
+   = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+help: consider adding return type
+   |
+LL ~ fn main() -> Result<(), Box<dyn std::error::Error>> {
+LL |     let mut _file = File::create("foo.txt")?;
+LL |
+LL |     mac!();
+LL + 
+LL +     Ok(())
+LL + }
+   |
+
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> $DIR/return-from-residual-sugg-issue-125997.rs:23:52
+   |
+LL |         fn test3() {
+   |         ---------- this function should return `Result` or `Option` to accept `?`
+LL |             let mut _file = File::create("foo.txt")?;
+   |                                                    ^ cannot use the `?` operator in a function that returns `()`
+...
+LL |     mac!();
+   |     ------ in this macro invocation
+   |
+   = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider adding return type
+   |
+LL ~         fn test3() -> Result<(), Box<dyn std::error::Error>> {
+LL |             let mut _file = File::create("foo.txt")?;
+LL |
+LL |             println!();
+LL ~         
+LL +     Ok(())
+LL + }
+   |
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/try-trait/try-operator-on-main.stderr
+++ b/tests/ui/try-trait/try-operator-on-main.stderr
@@ -8,6 +8,16 @@ LL |     std::fs::File::open("foo")?;
    |                               ^ cannot use the `?` operator in a function that returns `()`
    |
    = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+help: consider adding return type
+   |
+LL ~ fn main() -> Result<(), Box<dyn std::error::Error>> {
+LL |     // error for a `Try` type on a non-`Try` fn
+ ...
+LL |     try_trait_generic::<()>();
+LL + 
+LL +     Ok(())
+LL + }
+   |
 
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
   --> $DIR/try-operator-on-main.rs:10:5


### PR DESCRIPTION
Adding suggestions for following function in E0277.

```rust
fn main() {
    let mut _file = File::create("foo.txt")?;
}
```

to

```rust
fn main() -> Result<(), Box<dyn std::error::Error>> {
    let mut _file = File::create("foo.txt")?;

    return Ok(());
}
```


According to the issue #125997, only the code examples in the issue are targeted, but the issue covers a wider range of situations.

<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->