### PR TITLE
Remove libstdc++ version check error

### DIFF
--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -128,7 +128,6 @@ pub fn check(build: &mut Build) {
                     eprintln!(
                         "Consider upgrading libstdc++ or disabling the `llvm.download-ci-llvm` option."
                     );
-                    crate::exit!(1);
                 }
             }
             tool::LibcxxVersion::Llvm(_) => {


### PR DESCRIPTION
This keeps the error message from https://github.com/rust-lang/rust/pull/125411, but removes the `exit(1)` call.

This PR is mostly a hotfix to unblock bootstrap benchmarks in rustc-perf.

However, I think that it might be better to just print a warning, in general. If the ABI version does not match, the build might or might not work locally (as we can see on rustc-perf, where it works even if the reported ABI is 7).

If it does not work (and **if** we can always recognize this during the LLVM wrapper build, instead of having some silent miscompilations), then the user will have to update their libstdc++ anyway, the error does not help them out on its own. So it should be enough to just provide a better error message, without blocking the build.

But I'm not adamant on that, I just want to unblock bootstrap benchmarks until we can find a way to update libstdc++ on the collector machine.

CC @onur-ozkan

r? @Mark-Simulacrum