### PR TITLE
fix: build on haiku

### DIFF
--- a/library/std/src/sys/pal/unix/os.rs
+++ b/library/std/src/sys/pal/unix/os.rs
@@ -465,9 +465,9 @@ pub fn current_exe() -> io::Result<PathBuf> {
     let mut name = vec![0; libc::PATH_MAX as usize];
     unsafe {
         let result = libc::find_path(
-            std::ptr::null_mut(),
+            crate::ptr::null_mut(),
             libc::path_base_directory::B_FIND_PATH_IMAGE_PATH,
-            std::ptr::null_mut(),
+            crate::ptr::null_mut(),
             name.as_mut_ptr(),
             name.len(),
         );


### PR DESCRIPTION
## What does this PR do

The std is broken on haiku, this PR fixes it.

## To reproduce the issue

```sh
$ cargo +nightly --version
cargo 1.81.0-nightly (b1feb75d0 2024-06-07)

$ cargo new hello
$ cd hello
$ cargo +nightly check -Zbuild-std --target x86_64-unknown-haiku -q
error[E0433]: failed to resolve: use of undeclared crate or module `std`
   --> ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/os.rs:468:13
    |
468 |             std::ptr::null_mut(),
    |             ^^^ use of undeclared crate or module `std`
    |
help: consider importing one of these items
    |
8   + use core::ptr;
    |
8   + use crate::ptr;
    |
help: if you import `ptr`, refer to it directly
    |
468 -             std::ptr::null_mut(),
468 +             ptr::null_mut(),
    |

error[E0433]: failed to resolve: use of undeclared crate or module `std`
   --> ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/os.rs:470:13
    |
470 |             std::ptr::null_mut(),
    |             ^^^ use of undeclared crate or module `std`
    |
help: consider importing one of these items
    |
8   + use core::ptr;
```