### PR TITLE
Add explanatory note to async block type mismatch error

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
@@ -32,6 +32,15 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         diag.note("no two closures, even if identical, have the same type");
                         diag.help("consider boxing your closure and/or using it as a trait object");
                     }
+                    (ty::Coroutine(def_id1, ..), ty::Coroutine(def_id2, ..))
+                        if self.tcx.coroutine_is_async(def_id1)
+                            && self.tcx.coroutine_is_async(def_id2) =>
+                    {
+                        diag.note("no two async blocks, even if identical, have the same type");
+                        diag.help(
+                            "consider pinning your async block and casting it to a trait object",
+                        );
+                    }
                     (ty::Alias(ty::Opaque, ..), ty::Alias(ty::Opaque, ..)) => {
                         // Issue #63167
                         diag.note("distinct uses of `impl Trait` result in different opaque types");

--- a/tests/ui/async-await/coroutine-desc.stderr
+++ b/tests/ui/async-await/coroutine-desc.stderr
@@ -10,6 +10,8 @@ LL |     fun(async {}, async {});
    |
    = note: expected `async` block `{async block@$DIR/coroutine-desc.rs:10:9: 10:17}`
               found `async` block `{async block@$DIR/coroutine-desc.rs:10:19: 10:27}`
+   = note: no two async blocks, even if identical, have the same type
+   = help: consider pinning your async block and casting it to a trait object
 note: function defined here
   --> $DIR/coroutine-desc.rs:8:4
    |
@@ -51,6 +53,8 @@ LL |     fun((async || {})(), (async || {})());
    |
    = note: expected `async` closure body `{async closure body@$DIR/coroutine-desc.rs:14:19: 14:21}`
               found `async` closure body `{async closure body@$DIR/coroutine-desc.rs:14:36: 14:38}`
+   = note: no two async blocks, even if identical, have the same type
+   = help: consider pinning your async block and casting it to a trait object
 note: function defined here
   --> $DIR/coroutine-desc.rs:8:4
    |


### PR DESCRIPTION
The async block type mismatch error might leave the user wondering as to why it occurred. The new note should give them the needed context.

Changes this diagnostic:
```
error[E0308]: mismatched types
 --> src/main.rs:5:23
  |
2 |     let a = async { 1 };
  |             ----------- the expected `async` block
3 |     let b = async { 2 };
  |             ----------- the found `async` block
4 |     
5 |     let bad = vec![a, b];
  |                       ^ expected `async` block, found a different `async` block
  |
  = note: expected `async` block `{async block@src/main.rs:2:13: 2:24}`
             found `async` block `{async block@src/main.rs:3:13: 3:24}`
```

to this:
```
error[E0308]: mismatched types
 --> src/main.rs:5:23
  |
2 |     let a = async { 1 };
  |             ----------- the expected `async` block
3 |     let b = async { 2 };
  |             ----------- the found `async` block
4 |     
5 |     let bad = vec![a, b];
  |                       ^ expected `async` block, found a different `async` block
  |
  = note: expected `async` block `{async block@src/main.rs:2:13: 2:24}`
             found `async` block `{async block@src/main.rs:3:13: 3:24}`
  = note: no two async blocks, even if identical, have the same type
  = help: consider pinning your async block and and casting it to a trait object
```
 
Fixes #125737 
