### PR TITLE
Update `rustc-perf` submodule before running tidy

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1101,6 +1101,8 @@ impl Step for Tidy {
     /// Once tidy passes, this step also runs `fmt --check` if tests are being run
     /// for the `dev` or `nightly` channels.
     fn run(self, builder: &Builder<'_>) {
+        builder.build.update_submodule(Path::new("src/tools/rustc-perf"));
+
         let mut cmd = builder.tool_cmd(Tool::Tidy);
         cmd.arg(&builder.src);
         cmd.arg(&builder.initial_cargo);


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/125465, `tidy` checks `src/tools/rustc-perf`, so we need to have it checked out before running `tidy`.

Fixes: https://github.com/rust-lang/rust/issues/126224

r? @onur-ozkan