### PR TITLE
Provide correct parent for nested anon const

### DIFF
--- a/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.rs
+++ b/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.rs
@@ -1,0 +1,20 @@
+// Given an anon const `a`: `{ N }` and some anon const `b` which references the
+// first anon const: `{ [1; a] }`. `b` should not have any generics as it is not
+// a simple `N` argument nor is it a repeat expr count.
+//
+// On the other hand `b` *is* a repeat expr count and so it should inherit its
+// parents generics as part of the `const_evaluatable_unchecked` fcw (#76200).
+//
+// In this specific case however `b`'s parent should be `a` and so it should wind
+// up not having any generics after all. If `a` were to inherit its generics from
+// the enclosing item then the reference to `a` from `b` would contain generic
+// parameters not usable by `b` which would cause us to ICE.
+
+fn bar<const N: usize>() {}
+
+fn foo<const N: usize>() {
+    bar::<{ [1; N] }>();
+    //~^ ERROR: generic parameters may not be used in const operations
+}
+
+fn main() {}

--- a/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
+++ b/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
@@ -1,0 +1,11 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/repeat_expr_hack_gives_right_generics.rs:16:17
+   |
+LL |     bar::<{ [1; N] }>();
+   |                 ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #126147

99% of this PR is just comments explaining what the issue is.

`tcx.parent(` and `hir().get_parent_item(` give different results as the hir owner for all the hir of anon consts is the enclosing function. I didn't attempt to change that as being a hir owner requires a `DefId` and long term we want to stop creating anon consts' `DefId`s before hir ty lowering.

So i just opted to change `generics_of` to use `tcx.parent` to get the parent for `AnonConst`'s. I'm not entirely sure about this being what we want, it does seem weird that we have two ways of getting the parent of an `AnonConst` and they both give different results.

Alternatively we could just go ahead and make `const_evaluatable_unchecked` a hard error and stop providing generics to repeat exprs. Then this isn't an issue. (The FCW has been around for almost 4 years now)

r? @compiler-errors 