### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -154,7 +154,7 @@ expand_unsupported_key_value =
     key-value macro attributes are not supported
 
 expand_var_still_repeating =
-    variable '{$ident}' is still repeating at this depth
+    variable `{$ident}` is still repeating at this depth
 
 expand_wrong_fragment_kind =
     non-{$kind} macro in {$kind} position: {$name}

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -445,7 +445,8 @@ lint_macro_is_private = macro `{$ident}` is private
 lint_macro_rule_never_used = rule #{$n} of macro `{$name}` is never used
 
 lint_macro_use_deprecated =
-    deprecated `#[macro_use]` attribute used to import macros should be replaced at use sites with a `use` item to import the macro instead
+    applying the `#[macro_use]` attribute to an `extern crate` item is deprecated
+    .help = remove it and import macros at use sites with a `use` item instead
 
 lint_malformed_attribute = malformed lint attribute input
 
@@ -456,7 +457,7 @@ lint_map_unit_fn = `Iterator::map` call that discard the iterator's values
     .map_label = after this call to map, the resulting iterator is `impl Iterator<Item = ()>`, which means the only information carried by the iterator is the number of items
     .suggestion = you might have meant to use `Iterator::for_each`
 
-lint_metavariable_still_repeating = variable '{$name}' is still repeating at this depth
+lint_metavariable_still_repeating = variable `{$name}` is still repeating at this depth
 
 lint_metavariable_wrong_operator = meta-variable repeats with different Kleene operator
 
@@ -632,8 +633,8 @@ lint_pattern_in_bodiless = patterns aren't allowed in functions without bodies
 lint_pattern_in_foreign = patterns aren't allowed in foreign function declarations
     .label = pattern not allowed in foreign function
 
-lint_private_extern_crate_reexport =
-    extern crate `{$ident}` is private, and cannot be re-exported, consider declaring with `pub`
+lint_private_extern_crate_reexport = extern crate `{$ident}` is private and cannot be re-exported
+    .suggestion = consider making the `extern crate` item publicly accessible
 
 lint_proc_macro_back_compat = using an old version of `{$crate_name}`
     .note = older versions of the `{$crate_name}` crate will stop compiling in future versions of Rust; please update to `{$crate_name}` v{$fixed_version}, or switch to one of the `{$crate_name}` alternatives
@@ -847,7 +848,8 @@ lint_unused_coroutine =
     }{$post} that must be used
     .note = coroutines are lazy and do nothing unless resumed
 
-lint_unused_crate_dependency = external crate `{$extern_crate}` unused in `{$local_crate}`: remove the dependency or add `use {$extern_crate} as _;`
+lint_unused_crate_dependency = extern crate `{$extern_crate}` is unused in crate `{$local_crate}`
+    .help = remove the dependency or add `use {$extern_crate} as _;` to the crate root
 
 lint_unused_def = unused {$pre}`{$def}`{$post} that must be used
     .suggestion = use `let _ = ...` to ignore the resulting value

--- a/compiler/rustc_lint/src/context/diagnostics.rs
+++ b/compiler/rustc_lint/src/context/diagnostics.rs
@@ -340,8 +340,9 @@ pub(super) fn decorate_lint(sess: &Session, diagnostic: BuiltinLintDiag, diag: &
             lints::MacroUseDeprecated.decorate_lint(diag);
         }
         BuiltinLintDiag::UnusedMacroUse => lints::UnusedMacroUse.decorate_lint(diag),
-        BuiltinLintDiag::PrivateExternCrateReexport(ident) => {
-            lints::PrivateExternCrateReexport { ident }.decorate_lint(diag);
+        BuiltinLintDiag::PrivateExternCrateReexport { source: ident, extern_crate_span } => {
+            lints::PrivateExternCrateReexport { ident, sugg: extern_crate_span.shrink_to_lo() }
+                .decorate_lint(diag);
         }
         BuiltinLintDiag::UnusedLabel => lints::UnusedLabel.decorate_lint(diag),
         BuiltinLintDiag::MacroIsPrivate(ident) => {

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2313,6 +2313,7 @@ pub mod unexpected_cfg_value {
 
 #[derive(LintDiagnostic)]
 #[diag(lint_macro_use_deprecated)]
+#[help]
 pub struct MacroUseDeprecated;
 
 #[derive(LintDiagnostic)]
@@ -2323,6 +2324,8 @@ pub struct UnusedMacroUse;
 #[diag(lint_private_extern_crate_reexport, code = E0365)]
 pub struct PrivateExternCrateReexport {
     pub ident: Ident,
+    #[suggestion(code = "pub ", style = "verbose", applicability = "maybe-incorrect")]
+    pub sugg: Span,
 }
 
 #[derive(LintDiagnostic)]
@@ -2416,6 +2419,7 @@ pub struct UnknownMacroVariable {
 
 #[derive(LintDiagnostic)]
 #[diag(lint_unused_crate_dependency)]
+#[help]
 pub struct UnusedCrateDependency {
     pub extern_crate: Symbol,
     pub local_crate: Symbol,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -512,8 +512,9 @@ declare_lint! {
     /// This will produce:
     ///
     /// ```text
-    /// error: external crate `regex` unused in `lint_example`: remove the dependency or add `use regex as _;`
+    /// error: extern crate `regex` is unused in crate `lint_example`
     ///   |
+    ///   = help: remove the dependency or add `use regex as _;` to the crate root
     /// note: the lint level is defined here
     ///  --> src/lib.rs:1:9
     ///   |
@@ -2202,8 +2203,7 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `macro_use_extern_crate` lint detects the use of the
-    /// [`macro_use` attribute].
+    /// The `macro_use_extern_crate` lint detects the use of the [`macro_use` attribute].
     ///
     /// ### Example
     ///
@@ -2221,12 +2221,13 @@ declare_lint! {
     /// This will produce:
     ///
     /// ```text
-    /// error: deprecated `#[macro_use]` attribute used to import macros should be replaced at use sites with a `use` item to import the macro instead
+    /// error: applying the `#[macro_use]` attribute to an `extern crate` item is deprecated
     ///  --> src/main.rs:3:1
     ///   |
     /// 3 | #[macro_use]
     ///   | ^^^^^^^^^^^^
     ///   |
+    ///   = help: remove it and import macros at use sites with a `use` item instead
     /// note: the lint level is defined here
     ///  --> src/main.rs:1:9
     ///   |

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -707,7 +707,10 @@ pub enum BuiltinLintDiag {
     },
     MacroUseDeprecated,
     UnusedMacroUse,
-    PrivateExternCrateReexport(Ident),
+    PrivateExternCrateReexport {
+        source: Ident,
+        extern_crate_span: Span,
+    },
     UnusedLabel,
     MacroIsPrivate(Ident),
     UnusedMacroDefinition(Symbol),

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2041,8 +2041,11 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                         ast::AssocItemKind::Fn(..) => AssocSuggestion::AssocFn { called },
                         ast::AssocItemKind::Type(..) => AssocSuggestion::AssocType,
                         ast::AssocItemKind::Delegation(..)
-                            if self.r.delegation_fn_sigs[&self.r.local_def_id(assoc_item.id)]
-                                .has_self =>
+                            if self
+                                .r
+                                .delegation_fn_sigs
+                                .get(&self.r.local_def_id(assoc_item.id))
+                                .map_or(false, |sig| sig.has_self) =>
                         {
                             AssocSuggestion::MethodWithSelf { called }
                         }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2739,18 +2739,15 @@ impl AsInnerMut<fs_imp::DirBuilder> for DirBuilder {
 /// # Examples
 ///
 /// ```no_run
-/// #![feature(fs_try_exists)]
 /// use std::fs;
 ///
-/// assert!(!fs::try_exists("does_not_exist.txt").expect("Can't check existence of file does_not_exist.txt"));
-/// assert!(fs::try_exists("/root/secret_file.txt").is_err());
+/// assert!(!fs::exists("does_not_exist.txt").expect("Can't check existence of file does_not_exist.txt"));
+/// assert!(fs::exists("/root/secret_file.txt").is_err());
 /// ```
 ///
 /// [`Path::exists`]: crate::path::Path::exists
-// FIXME: stabilization should modify documentation of `exists()` to recommend this method
-// instead.
-#[unstable(feature = "fs_try_exists", issue = "83186")]
+#[stable(feature = "fs_try_exists", since = "CURRENT_RUSTC_VERSION")]
 #[inline]
-pub fn try_exists<P: AsRef<Path>>(path: P) -> io::Result<bool> {
-    fs_imp::try_exists(path.as_ref())
+pub fn exists<P: AsRef<Path>>(path: P) -> io::Result<bool> {
+    fs_imp::exists(path.as_ref())
 }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2888,6 +2888,8 @@ impl Path {
     /// prevent time-of-check to time-of-use (TOCTOU) bugs. You should only use it in scenarios
     /// where those bugs are not an issue.
     ///
+    /// This is an alias for [`std::fs::exists`](crate::fs::exists).
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -2900,7 +2902,7 @@ impl Path {
     #[stable(feature = "path_try_exists", since = "1.63.0")]
     #[inline]
     pub fn try_exists(&self) -> io::Result<bool> {
-        fs::try_exists(self)
+        fs::exists(self)
     }
 
     /// Returns `true` if the path exists on disk and is pointing at a regular file.

--- a/library/std/src/sys/pal/unix/fs.rs
+++ b/library/std/src/sys/pal/unix/fs.rs
@@ -101,7 +101,7 @@ use libc::{
 ))]
 use libc::{dirent64, fstat64, ftruncate64, lseek64, lstat64, off64_t, open64, stat64};
 
-pub use crate::sys_common::fs::try_exists;
+pub use crate::sys_common::fs::exists;
 
 pub struct File(FileDesc);
 

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -477,7 +477,7 @@ mod cgroups {
     //!   output and we don't unescape
     use crate::borrow::Cow;
     use crate::ffi::OsString;
-    use crate::fs::{try_exists, File};
+    use crate::fs::{exists, File};
     use crate::io::Read;
     use crate::io::{BufRead, BufReader};
     use crate::os::unix::ffi::OsStringExt;
@@ -555,7 +555,7 @@ mod cgroups {
         path.push("cgroup.controllers");
 
         // skip if we're not looking at cgroup2
-        if matches!(try_exists(&path), Err(_) | Ok(false)) {
+        if matches!(exists(&path), Err(_) | Ok(false)) {
             return usize::MAX;
         };
 
@@ -612,7 +612,7 @@ mod cgroups {
             path.push(&group_path);
 
             // skip if we guessed the mount incorrectly
-            if matches!(try_exists(&path), Err(_) | Ok(false)) {
+            if matches!(exists(&path), Err(_) | Ok(false)) {
                 continue;
             }
 

--- a/library/std/src/sys/pal/unsupported/fs.rs
+++ b/library/std/src/sys/pal/unsupported/fs.rs
@@ -291,7 +291,7 @@ pub fn remove_dir_all(_path: &Path) -> io::Result<()> {
     unsupported()
 }
 
-pub fn try_exists(_path: &Path) -> io::Result<bool> {
+pub fn exists(_path: &Path) -> io::Result<bool> {
     unsupported()
 }
 

--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -1531,7 +1531,7 @@ pub fn junction_point(original: &Path, link: &Path) -> io::Result<()> {
 }
 
 // Try to see if a file exists but, unlike `exists`, report I/O errors.
-pub fn try_exists(path: &Path) -> io::Result<bool> {
+pub fn exists(path: &Path) -> io::Result<bool> {
     // Open the file to ensure any symlinks are followed to their target.
     let mut opts = OpenOptions::new();
     // No read, write, etc access rights are needed.

--- a/library/std/src/sys_common/fs.rs
+++ b/library/std/src/sys_common/fs.rs
@@ -42,7 +42,7 @@ fn remove_dir_all_recursive(path: &Path) -> io::Result<()> {
     fs::remove_dir(path)
 }
 
-pub fn try_exists(path: &Path) -> io::Result<bool> {
+pub fn exists(path: &Path) -> io::Result<bool> {
     match fs::metadata(path) {
         Ok(_) => Ok(true),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),

--- a/tests/crashes/124342.rs
+++ b/tests/crashes/124342.rs
@@ -1,6 +1,0 @@
-//@ known-bug: #124342
-trait Trait2 : Trait {
-   reuse <() as Trait>::async {
-        (async || {}).await;
-    };
-}

--- a/tests/ui/delegation/ice-issue-124342.rs
+++ b/tests/ui/delegation/ice-issue-124342.rs
@@ -1,0 +1,12 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+mod to_reuse {}
+
+trait Trait {
+    reuse to_reuse::foo { foo }
+    //~^ ERROR cannot find function `foo` in module `to_reuse`
+    //~| ERROR cannot find value `foo` in this scope
+}
+
+fn main() {}

--- a/tests/ui/delegation/ice-issue-124342.stderr
+++ b/tests/ui/delegation/ice-issue-124342.stderr
@@ -1,0 +1,20 @@
+error[E0425]: cannot find function `foo` in module `to_reuse`
+  --> $DIR/ice-issue-124342.rs:7:21
+   |
+LL |     reuse to_reuse::foo { foo }
+   |                     ^^^ not found in `to_reuse`
+
+error[E0425]: cannot find value `foo` in this scope
+  --> $DIR/ice-issue-124342.rs:7:27
+   |
+LL |     reuse to_reuse::foo { foo }
+   |                           ^^^
+   |
+help: you might have meant to refer to the associated function
+   |
+LL |     reuse to_reuse::foo { Self::foo }
+   |                           ++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/extern-flag/no-nounused.rs
+++ b/tests/ui/extern-flag/no-nounused.rs
@@ -2,5 +2,5 @@
 //@ compile-flags: -Zunstable-options -Dunused-crate-dependencies
 //@ edition:2018
 
-fn main() { //~ ERROR external crate `somedep` unused in `no_nounused`
+fn main() { //~ ERROR extern crate `somedep` is unused in crate `no_nounused`
 }

--- a/tests/ui/extern-flag/no-nounused.stderr
+++ b/tests/ui/extern-flag/no-nounused.stderr
@@ -1,9 +1,10 @@
-error: external crate `somedep` unused in `no_nounused`: remove the dependency or add `use somedep as _;`
+error: extern crate `somedep` is unused in crate `no_nounused`
   --> $DIR/no-nounused.rs:5:1
    |
 LL | fn main() {
    | ^
    |
+   = help: remove the dependency or add `use somedep as _;` to the crate root
    = note: requested on the command line with `-D unused-crate-dependencies`
 
 error: aborting due to 1 previous error

--- a/tests/ui/macros/issue-61053-missing-repetition.rs
+++ b/tests/ui/macros/issue-61053-missing-repetition.rs
@@ -3,7 +3,7 @@
 macro_rules! foo {
     () => {};
     ($( $i:ident = $($j:ident),+ );*) => { $( $i = $j; )* };
-    //~^ ERROR variable 'j' is still repeating
+    //~^ ERROR variable `j` is still repeating
 }
 
 macro_rules! bar {
@@ -12,12 +12,12 @@ macro_rules! bar {
         macro_rules! nested {
             () => {};
             ($( $i:ident = $($j:ident),+ );*) => { $( $i = $j; )* };
-            //~^ ERROR variable 'j' is still repeating
+            //~^ ERROR variable `j` is still repeating
         }
     };
     ( $( $i:ident = $($j:ident),+ );* ) => {
         $(macro_rules! $i {
-            () => { $j }; //~ ERROR variable 'j' is still repeating
+            () => { $j }; //~ ERROR variable `j` is still repeating
         })*
     };
 }

--- a/tests/ui/macros/issue-61053-missing-repetition.stderr
+++ b/tests/ui/macros/issue-61053-missing-repetition.stderr
@@ -1,4 +1,4 @@
-error: variable 'j' is still repeating at this depth
+error: variable `j` is still repeating at this depth
   --> $DIR/issue-61053-missing-repetition.rs:5:52
    |
 LL |     ($( $i:ident = $($j:ident),+ );*) => { $( $i = $j; )* };
@@ -12,7 +12,7 @@ note: the lint level is defined here
 LL | #![deny(meta_variable_misuse)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: variable 'j' is still repeating at this depth
+error: variable `j` is still repeating at this depth
   --> $DIR/issue-61053-missing-repetition.rs:14:60
    |
 LL |             ($( $i:ident = $($j:ident),+ );*) => { $( $i = $j; )* };
@@ -20,7 +20,7 @@ LL |             ($( $i:ident = $($j:ident),+ );*) => { $( $i = $j; )* };
    |                                        |
    |                                        expected repetition
 
-error: variable 'j' is still repeating at this depth
+error: variable `j` is still repeating at this depth
   --> $DIR/issue-61053-missing-repetition.rs:20:21
    |
 LL |     ( $( $i:ident = $($j:ident),+ );* ) => {

--- a/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.rs
+++ b/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.rs
@@ -35,7 +35,7 @@ macro_rules! no_curly__no_rhs_dollar__no_round {
 #[rustfmt::skip] // autoformatters can break a few of the error traces
 macro_rules! no_curly__rhs_dollar__round {
     ( $( $i:ident ),* ) => { count($i) };
-    //~^ ERROR variable 'i' is still repeating at this depth
+    //~^ ERROR variable `i` is still repeating at this depth
 }
 
 #[rustfmt::skip] // autoformatters can break a few of the error traces

--- a/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
@@ -208,7 +208,7 @@ error: `count` can not be placed inside the inner-most repetition
 LL |     ( $i:ident ) => { ${ count($i) } };
    |                        ^^^^^^^^^^^^^
 
-error: variable 'i' is still repeating at this depth
+error: variable `i` is still repeating at this depth
   --> $DIR/syntax-errors.rs:37:36
    |
 LL |     ( $( $i:ident ),* ) => { count($i) };

--- a/tests/ui/parser/macro/macro-repeat.stderr
+++ b/tests/ui/parser/macro/macro-repeat.stderr
@@ -1,10 +1,10 @@
-error: variable 'v' is still repeating at this depth
+error: variable `v` is still repeating at this depth
   --> $DIR/macro-repeat.rs:3:9
    |
 LL |         $v
    |         ^^
 
-error: variable 'v' is still repeating at this depth
+error: variable `v` is still repeating at this depth
   --> $DIR/macro-repeat.rs:3:9
    |
 LL |         $v

--- a/tests/ui/pub/pub-reexport-priv-extern-crate.rs
+++ b/tests/ui/pub/pub-reexport-priv-extern-crate.rs
@@ -1,5 +1,5 @@
 extern crate core;
-pub use core as reexported_core; //~ ERROR `core` is private, and cannot be re-exported
+pub use core as reexported_core; //~ ERROR `core` is private and cannot be re-exported
                                  //~^ WARN this was previously accepted
 
 mod foo1 {

--- a/tests/ui/pub/pub-reexport-priv-extern-crate.stderr
+++ b/tests/ui/pub/pub-reexport-priv-extern-crate.stderr
@@ -22,7 +22,7 @@ note: the crate import `core` is defined here
 LL |         extern crate core;
    |         ^^^^^^^^^^^^^^^^^^
 
-error[E0365]: extern crate `core` is private, and cannot be re-exported, consider declaring with `pub`
+error[E0365]: extern crate `core` is private and cannot be re-exported
   --> $DIR/pub-reexport-priv-extern-crate.rs:2:9
    |
 LL | pub use core as reexported_core;
@@ -31,6 +31,10 @@ LL | pub use core as reexported_core;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
    = note: `#[deny(pub_use_of_private_extern_crate)]` on by default
+help: consider making the `extern crate` item publicly accessible
+   |
+LL | pub extern crate core;
+   | +++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rust-2018/macro-use-warned-against.rs
+++ b/tests/ui/rust-2018/macro-use-warned-against.rs
@@ -4,7 +4,7 @@
 
 #![warn(macro_use_extern_crate, unused)]
 
-#[macro_use] //~ WARN should be replaced at use sites with a `use` item
+#[macro_use] //~ WARN applying the `#[macro_use]` attribute to an `extern crate` item is deprecated
 extern crate macro_use_warned_against;
 #[macro_use] //~ WARN unused `#[macro_use]`
 extern crate macro_use_warned_against2;

--- a/tests/ui/rust-2018/macro-use-warned-against.stderr
+++ b/tests/ui/rust-2018/macro-use-warned-against.stderr
@@ -1,9 +1,10 @@
-warning: deprecated `#[macro_use]` attribute used to import macros should be replaced at use sites with a `use` item to import the macro instead
+warning: applying the `#[macro_use]` attribute to an `extern crate` item is deprecated
   --> $DIR/macro-use-warned-against.rs:7:1
    |
 LL | #[macro_use]
    | ^^^^^^^^^^^^
    |
+   = help: remove it and import macros at use sites with a `use` item instead
 note: the lint level is defined here
   --> $DIR/macro-use-warned-against.rs:5:9
    |

--- a/tests/ui/unused-crate-deps/deny-attr.rs
+++ b/tests/ui/unused-crate-deps/deny-attr.rs
@@ -4,6 +4,6 @@
 //@ aux-crate:bar=bar.rs
 
 #![deny(unused_crate_dependencies)]
-//~^ ERROR external crate `bar` unused in
+//~^ ERROR extern crate `bar` is unused in
 
 fn main() {}

--- a/tests/ui/unused-crate-deps/deny-attr.stderr
+++ b/tests/ui/unused-crate-deps/deny-attr.stderr
@@ -1,9 +1,10 @@
-error: external crate `bar` unused in `deny_attr`: remove the dependency or add `use bar as _;`
+error: extern crate `bar` is unused in crate `deny_attr`
   --> $DIR/deny-attr.rs:6:1
    |
 LL | #![deny(unused_crate_dependencies)]
    | ^
    |
+   = help: remove the dependency or add `use bar as _;` to the crate root
 note: the lint level is defined here
   --> $DIR/deny-attr.rs:6:9
    |

--- a/tests/ui/unused-crate-deps/deny-cmdline.rs
+++ b/tests/ui/unused-crate-deps/deny-cmdline.rs
@@ -5,4 +5,4 @@
 //@ aux-crate:bar=bar.rs
 
 fn main() {}
-//~^ ERROR external crate `bar` unused in
+//~^ ERROR extern crate `bar` is unused in

--- a/tests/ui/unused-crate-deps/deny-cmdline.stderr
+++ b/tests/ui/unused-crate-deps/deny-cmdline.stderr
@@ -1,9 +1,10 @@
-error: external crate `bar` unused in `deny_cmdline`: remove the dependency or add `use bar as _;`
+error: extern crate `bar` is unused in crate `deny_cmdline`
   --> $DIR/deny-cmdline.rs:7:1
    |
 LL | fn main() {}
    | ^
    |
+   = help: remove the dependency or add `use bar as _;` to the crate root
    = note: requested on the command line with `-D unused-crate-dependencies`
 
 error: aborting due to 1 previous error

--- a/tests/ui/unused-crate-deps/libfib.rs
+++ b/tests/ui/unused-crate-deps/libfib.rs
@@ -5,7 +5,7 @@
 //@ compile-flags:--crate-type lib -Wunused-crate-dependencies
 
 pub fn fib(n: u32) -> Vec<u32> {
-//~^ WARNING external crate `bar` unused in
+//~^ WARNING extern crate `bar` is unused in
 let mut prev = 0;
     let mut cur = 1;
     let mut v = vec![];

--- a/tests/ui/unused-crate-deps/libfib.stderr
+++ b/tests/ui/unused-crate-deps/libfib.stderr
@@ -1,9 +1,10 @@
-warning: external crate `bar` unused in `libfib`: remove the dependency or add `use bar as _;`
+warning: extern crate `bar` is unused in crate `libfib`
   --> $DIR/libfib.rs:7:1
    |
 LL | pub fn fib(n: u32) -> Vec<u32> {
    | ^
    |
+   = help: remove the dependency or add `use bar as _;` to the crate root
    = note: requested on the command line with `-W unused-crate-dependencies`
 
 warning: 1 warning emitted

--- a/tests/ui/unused-crate-deps/unused-aliases.rs
+++ b/tests/ui/unused-crate-deps/unused-aliases.rs
@@ -6,7 +6,7 @@
 //@ aux-crate:barbar=bar.rs
 
 #![warn(unused_crate_dependencies)]
-//~^ WARNING external crate `barbar` unused in
+//~^ WARNING extern crate `barbar` is unused in
 
 use bar as _;
 

--- a/tests/ui/unused-crate-deps/unused-aliases.stderr
+++ b/tests/ui/unused-crate-deps/unused-aliases.stderr
@@ -1,9 +1,10 @@
-warning: external crate `barbar` unused in `unused_aliases`: remove the dependency or add `use barbar as _;`
+warning: extern crate `barbar` is unused in crate `unused_aliases`
   --> $DIR/unused-aliases.rs:8:1
    |
 LL | #![warn(unused_crate_dependencies)]
    | ^
    |
+   = help: remove the dependency or add `use barbar as _;` to the crate root
 note: the lint level is defined here
   --> $DIR/unused-aliases.rs:8:9
    |

--- a/tests/ui/unused-crate-deps/warn-attr.rs
+++ b/tests/ui/unused-crate-deps/warn-attr.rs
@@ -5,6 +5,6 @@
 //@ aux-crate:bar=bar.rs
 
 #![warn(unused_crate_dependencies)]
-//~^ WARNING external crate `bar` unused in
+//~^ WARNING extern crate `bar` is unused in
 
 fn main() {}

--- a/tests/ui/unused-crate-deps/warn-attr.stderr
+++ b/tests/ui/unused-crate-deps/warn-attr.stderr
@@ -1,9 +1,10 @@
-warning: external crate `bar` unused in `warn_attr`: remove the dependency or add `use bar as _;`
+warning: extern crate `bar` is unused in crate `warn_attr`
   --> $DIR/warn-attr.rs:7:1
    |
 LL | #![warn(unused_crate_dependencies)]
    | ^
    |
+   = help: remove the dependency or add `use bar as _;` to the crate root
 note: the lint level is defined here
   --> $DIR/warn-attr.rs:7:9
    |

--- a/tests/ui/unused-crate-deps/warn-cmdline-static.rs
+++ b/tests/ui/unused-crate-deps/warn-cmdline-static.rs
@@ -7,4 +7,4 @@
 //@ no-prefer-dynamic
 
 fn main() {}
-//~^ WARNING external crate `bar` unused in
+//~^ WARNING extern crate `bar` is unused in

--- a/tests/ui/unused-crate-deps/warn-cmdline-static.stderr
+++ b/tests/ui/unused-crate-deps/warn-cmdline-static.stderr
@@ -1,9 +1,10 @@
-warning: external crate `bar` unused in `warn_cmdline_static`: remove the dependency or add `use bar as _;`
+warning: extern crate `bar` is unused in crate `warn_cmdline_static`
   --> $DIR/warn-cmdline-static.rs:9:1
    |
 LL | fn main() {}
    | ^
    |
+   = help: remove the dependency or add `use bar as _;` to the crate root
    = note: requested on the command line with `-W unused-crate-dependencies`
 
 warning: 1 warning emitted

--- a/tests/ui/unused-crate-deps/warn-cmdline.rs
+++ b/tests/ui/unused-crate-deps/warn-cmdline.rs
@@ -6,4 +6,4 @@
 //@ aux-crate:bar=bar.rs
 
 fn main() {}
-//~^ WARNING external crate `bar` unused in
+//~^ WARNING extern crate `bar` is unused in

--- a/tests/ui/unused-crate-deps/warn-cmdline.stderr
+++ b/tests/ui/unused-crate-deps/warn-cmdline.stderr
@@ -1,9 +1,10 @@
-warning: external crate `bar` unused in `warn_cmdline`: remove the dependency or add `use bar as _;`
+warning: extern crate `bar` is unused in crate `warn_cmdline`
   --> $DIR/warn-cmdline.rs:8:1
    |
 LL | fn main() {}
    | ^
    |
+   = help: remove the dependency or add `use bar as _;` to the crate root
    = note: requested on the command line with `-W unused-crate-dependencies`
 
 warning: 1 warning emitted


### PR DESCRIPTION
Successful merges:

 - #125913 (Spruce up the diagnostics of some early lints)
 - #126140 (Rename `std::fs::try_exists` to  `std::fs::exists` and stabilize fs_try_exists)
 - #126234 (Delegation: fix ICE on late diagnostics)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=125913,126140,126234)
<!-- homu-ignore:end -->