### PR TITLE
Simplify assert matchers in `run-make-support`

### DIFF
--- a/src/tools/run-make-support/src/command.rs
+++ b/src/tools/run-make-support/src/command.rs
@@ -107,38 +107,38 @@ impl CompletedProcess {
 
     /// Checks that trimmed `stdout` matches trimmed `content`.
     #[track_caller]
-    pub fn assert_stdout_equals<S: AsRef<str>>(self, content: S) -> Self {
+    pub fn assert_stdout_equals<S: AsRef<str>>(&self, content: S) -> &Self {
         assert_eq!(self.stdout_utf8().trim(), content.as_ref().trim());
         self
     }
 
     #[track_caller]
-    pub fn assert_stdout_not_contains<S: AsRef<str>>(self, needle: S) -> Self {
+    pub fn assert_stdout_not_contains<S: AsRef<str>>(&self, needle: S) -> &Self {
         assert_not_contains(&self.stdout_utf8(), needle.as_ref());
         self
     }
 
     /// Checks that trimmed `stderr` matches trimmed `content`.
     #[track_caller]
-    pub fn assert_stderr_equals<S: AsRef<str>>(self, content: S) -> Self {
+    pub fn assert_stderr_equals<S: AsRef<str>>(&self, content: S) -> &Self {
         assert_eq!(self.stderr_utf8().trim(), content.as_ref().trim());
         self
     }
 
     #[track_caller]
-    pub fn assert_stderr_contains<S: AsRef<str>>(self, needle: S) -> Self {
+    pub fn assert_stderr_contains<S: AsRef<str>>(&self, needle: S) -> &Self {
         assert!(self.stderr_utf8().contains(needle.as_ref()));
         self
     }
 
     #[track_caller]
-    pub fn assert_stderr_not_contains<S: AsRef<str>>(self, needle: S) -> Self {
+    pub fn assert_stderr_not_contains<S: AsRef<str>>(&self, needle: S) -> &Self {
         assert_not_contains(&self.stdout_utf8(), needle.as_ref());
         self
     }
 
     #[track_caller]
-    pub fn assert_exit_code(self, code: i32) -> Self {
+    pub fn assert_exit_code(&self, code: i32) -> &Self {
         assert!(self.output.status.code() == Some(code));
         self
     }


### PR DESCRIPTION
See [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/421156-gsoc/topic/Project.3A.20Rewriting.20Makefile.20Tests.20Using.20Rust/near/443922302) for context. This should make it easier to use the matchers.

r? @jieyouxu