### PR TITLE
Remove ignore-cross-compile directive from ui/macros/proc_macro

### DIFF
--- a/tests/ui/macros/proc_macro.rs
+++ b/tests/ui/macros/proc_macro.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 //@ aux-build:proc_macro_def.rs
-//@ ignore-cross-compile
 
 extern crate proc_macro_def;
 


### PR DESCRIPTION
All the other proc-macro tests don't have this, presumably this was forgotten when the restriction got lifted as it does test just fine

r? @pietroalbini 