### PR TITLE
fix checking git submodules during a commit hook

### DIFF
--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -501,6 +501,16 @@ pub fn git(source_dir: Option<&Path>) -> Command {
 
     if let Some(source_dir) = source_dir {
         git.current_dir(source_dir);
+        // If we are running inside git (e.g. via a hook), `GIT_DIR` is set and takes precedence
+        // over the current dir. Un-set it to make the current dir matter.
+        git.env_remove("GIT_DIR");
+        // Also un-set some other variables, to be on the safe side (based on cargo's
+        // `fetch_with_cli`). In particular un-setting `GIT_INDEX_FILE` is required to fix some odd
+        // misbehavior.
+        git.env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_OBJECT_DIRECTORY")
+            .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES");
     }
 
     git


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/125954
The one thing that still puzzles me is why this only is a problem with worktrees.

r? @onur 