### PR TITLE
Add {{target}} substitution to compiletest

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1281,6 +1281,7 @@ fn expand_variables(mut value: String, config: &Config) -> String {
     const BUILD_BASE: &str = "{{build-base}}";
     const SYSROOT_BASE: &str = "{{sysroot-base}}";
     const TARGET_LINKER: &str = "{{target-linker}}";
+    const TARGET: &str = "{{target}}";
 
     if value.contains(CWD) {
         let cwd = env::current_dir().unwrap();
@@ -1301,6 +1302,10 @@ fn expand_variables(mut value: String, config: &Config) -> String {
 
     if value.contains(TARGET_LINKER) {
         value = value.replace(TARGET_LINKER, config.target_linker.as_deref().unwrap_or(""));
+    }
+
+    if value.contains(TARGET) {
+        value = value.replace(TARGET, &config.target);
     }
 
     value

--- a/src/tools/tidy/src/target_specific_tests.rs
+++ b/src/tools/tidy/src/target_specific_tests.rs
@@ -53,9 +53,9 @@ pub fn check(path: &Path, bad: &mut bool) {
             } else if directive.starts_with(COMPILE_FLAGS_HEADER) {
                 let compile_flags = &directive[COMPILE_FLAGS_HEADER.len()..];
                 if let Some((_, v)) = compile_flags.split_once("--target") {
-                    if let Some((arch, _)) =
-                        v.trim_start_matches(|c| c == ' ' || c == '=').split_once("-")
-                    {
+                    let v = v.trim_start_matches(|c| c == ' ' || c == '=');
+                    let v = if v == "{{target}}" { Some((v, v)) } else { v.split_once("-") };
+                    if let Some((arch, _)) = v {
                         let info = header_map.entry(revision).or_insert(RevisionInfo::default());
                         info.target_arch.replace(arch);
                     } else {


### PR DESCRIPTION
In ferrocene we have ui tests testing the cli interface of the compiler, one of which tests the `--target` flag. To be able to run this on all targets we require a way to specify a valid target in the `compile-flags` directive that is target independent, as otherwise we can only run the test against the one target we choose to supply in the flags. See https://github.com/ferrocene/ferrocene/blob/383cbc80f4e85859a4055f121f15dac329908346/tests/ui/ferrocene/compiler-arguments/target/target.rs

We figured the project might be able to make use of this substitution as well in the future.

try-job: dist-x86_64-msvc
