### PR TITLE
Skip fast path for dec2flt when optimize_for_size

### DIFF
--- a/library/core/src/num/dec2flt/mod.rs
+++ b/library/core/src/num/dec2flt/mod.rs
@@ -250,8 +250,10 @@ pub fn dec2flt<F: RawFloat>(s: &str) -> Result<F, ParseFloatError> {
         None => return Err(pfe_invalid()),
     };
     num.negative = negative;
-    if let Some(value) = num.try_fast_path::<F>() {
-        return Ok(value);
+    if cfg!(not(feature = "optimize_for_size")) {
+        if let Some(value) = num.try_fast_path::<F>() {
+            return Ok(value);
+        }
     }
 
     // If significant digits were truncated, then we can have rounding error

--- a/library/core/src/num/dec2flt/mod.rs
+++ b/library/core/src/num/dec2flt/mod.rs
@@ -250,7 +250,7 @@ pub fn dec2flt<F: RawFloat>(s: &str) -> Result<F, ParseFloatError> {
         None => return Err(pfe_invalid()),
     };
     num.negative = negative;
-    if cfg!(not(feature = "optimize_for_size")) {
+    if !cfg!(feature = "optimize_for_size") {
         if let Some(value) = num.try_fast_path::<F>() {
             return Ok(value);
         }


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/125612

Skip the fast algorithm when optimizing for size.
When compiling for https://github.com/quartiq/stabilizer I get these numbers:

Before
```
   text    data     bss     dec     hex filename
 192192       8   49424  241624   3afd8 dual-iir
```

After
```
   text    data     bss     dec     hex filename
 191632       8   49424  241064   3ada8 dual-iir
```

This saves 560 bytes.