### PR TITLE
Enhance suggestions of `dropping_*` lints

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -689,6 +689,10 @@ lint_redundant_semicolons =
         *[false] this semicolon
     }
 
+lint_remove_entirely_suggestion = remove the whole expression
+
+lint_remove_function_call_suggestion = remove the function call
+
 lint_remove_mut_from_pattern = remove `mut` from the parameter
 
 lint_removed_lint = lint `{$name}` has been removed: {$reason}

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -233,6 +233,9 @@ lint_drop_trait_constraints =
 lint_dropping_copy_types = calls to `std::mem::drop` with a value that implements `Copy` does nothing
     .label = argument has type `{$arg_ty}`
 
+lint_dropping_mutable_references = calls to `std::mem::drop` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
+    .label = argument has type `{$arg_ty}`
+
 lint_dropping_references = calls to `std::mem::drop` with a reference instead of an owned value does nothing
     .label = argument has type `{$arg_ty}`
 
@@ -268,6 +271,9 @@ lint_for_loops_over_fallibles =
     .use_question_mark = consider unwrapping the `Result` with `?` to iterate over its contents
 
 lint_forgetting_copy_types = calls to `std::mem::forget` with a value that implements `Copy` does nothing
+    .label = argument has type `{$arg_ty}`
+
+lint_forgetting_mutable_references = calls to `std::mem::forget` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
     .label = argument has type `{$arg_ty}`
 
 lint_forgetting_references = calls to `std::mem::forget` with a reference instead of an owned value does nothing

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -657,15 +657,39 @@ pub struct ForLoopsOverFalliblesSuggestion<'a> {
 }
 
 #[derive(Subdiagnostic)]
-pub enum UseLetUnderscoreIgnoreSuggestion {
+pub enum IgnoreSuggestion {
+    #[note(lint_remove_entirely_suggestion)]
+    RemoveEntirelyNote,
+    #[multipart_suggestion(
+        lint_remove_entirely_suggestion,
+        style = "verbose",
+        applicability = "maybe-incorrect"
+    )]
+    RemoveEntirelySuggestion {
+        #[suggestion_part(code = "")]
+        span: Span,
+    },
+    #[note(lint_remove_function_call_suggestion)]
+    RemoveFunctionCallNote,
+    #[multipart_suggestion(
+        lint_remove_function_call_suggestion,
+        style = "verbose",
+        applicability = "maybe-incorrect"
+    )]
+    RemoveFunctionCallSuggestion {
+        #[suggestion_part(code = "")]
+        start_span: Span,
+        #[suggestion_part(code = "")]
+        end_span: Span,
+    },
     #[note(lint_use_let_underscore_ignore_suggestion)]
-    Note,
+    UseLetUnderscoreNote,
     #[multipart_suggestion(
         lint_use_let_underscore_ignore_suggestion,
         style = "verbose",
         applicability = "maybe-incorrect"
     )]
-    Suggestion {
+    UseLetUnderscoreSuggestion {
         #[suggestion_part(code = "let _ = ")]
         start_span: Span,
         #[suggestion_part(code = "")]
@@ -681,7 +705,7 @@ pub struct DropRefDiag<'a> {
     #[label]
     pub label: Span,
     #[subdiagnostic]
-    pub sugg: UseLetUnderscoreIgnoreSuggestion,
+    pub sugg: IgnoreSuggestion,
 }
 
 #[derive(LintDiagnostic)]
@@ -691,7 +715,7 @@ pub struct DropMutRefDiag<'a> {
     #[label]
     pub label: Span,
     #[subdiagnostic]
-    pub sugg: UseLetUnderscoreIgnoreSuggestion,
+    pub sugg: IgnoreSuggestion,
 }
 
 #[derive(LintDiagnostic)]
@@ -701,7 +725,7 @@ pub struct DropCopyDiag<'a> {
     #[label]
     pub label: Span,
     #[subdiagnostic]
-    pub sugg: UseLetUnderscoreIgnoreSuggestion,
+    pub sugg: IgnoreSuggestion,
 }
 
 #[derive(LintDiagnostic)]
@@ -711,7 +735,7 @@ pub struct ForgetRefDiag<'a> {
     #[label]
     pub label: Span,
     #[subdiagnostic]
-    pub sugg: UseLetUnderscoreIgnoreSuggestion,
+    pub sugg: IgnoreSuggestion,
 }
 
 #[derive(LintDiagnostic)]
@@ -721,7 +745,7 @@ pub struct ForgetMutRefDiag<'a> {
     #[label]
     pub label: Span,
     #[subdiagnostic]
-    pub sugg: UseLetUnderscoreIgnoreSuggestion,
+    pub sugg: IgnoreSuggestion,
 }
 
 #[derive(LintDiagnostic)]
@@ -731,7 +755,7 @@ pub struct ForgetCopyDiag<'a> {
     #[label]
     pub label: Span,
     #[subdiagnostic]
-    pub sugg: UseLetUnderscoreIgnoreSuggestion,
+    pub sugg: IgnoreSuggestion,
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -685,6 +685,16 @@ pub struct DropRefDiag<'a> {
 }
 
 #[derive(LintDiagnostic)]
+#[diag(lint_dropping_mutable_references)]
+pub struct DropMutRefDiag<'a> {
+    pub arg_ty: Ty<'a>,
+    #[label]
+    pub label: Span,
+    #[subdiagnostic]
+    pub sugg: UseLetUnderscoreIgnoreSuggestion,
+}
+
+#[derive(LintDiagnostic)]
 #[diag(lint_dropping_copy_types)]
 pub struct DropCopyDiag<'a> {
     pub arg_ty: Ty<'a>,
@@ -697,6 +707,16 @@ pub struct DropCopyDiag<'a> {
 #[derive(LintDiagnostic)]
 #[diag(lint_forgetting_references)]
 pub struct ForgetRefDiag<'a> {
+    pub arg_ty: Ty<'a>,
+    #[label]
+    pub label: Span,
+    #[subdiagnostic]
+    pub sugg: UseLetUnderscoreIgnoreSuggestion,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(lint_forgetting_mutable_references)]
+pub struct ForgetMutRefDiag<'a> {
     pub arg_ty: Ty<'a>,
     #[label]
     pub label: Span,

--- a/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.stderr
+++ b/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.stderr
@@ -6,7 +6,7 @@ LL |         0 => drop(y),
    |                   |
    |                   argument has type `i32`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+   = note: remove the whole expression
 note: the lint level is defined here
   --> $DIR/dropping_copy_types-issue-125189-can-not-fixed.rs:3:9
    |
@@ -21,7 +21,7 @@ LL |         1 => drop(z),
    |                   |
    |                   argument has type `i32`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+   = note: remove the whole expression
 
 error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
   --> $DIR/dropping_copy_types-issue-125189-can-not-fixed.rs:11:14

--- a/tests/ui/lint/dropping_copy_types-issue-125189.fixed
+++ b/tests/ui/lint/dropping_copy_types-issue-125189.fixed
@@ -3,8 +3,9 @@
 
 #![deny(dropping_copy_types)]
 
+#[allow(unused_variables)]
 fn main() {
     let y = 1;
     let _ = 3.2; //~ ERROR calls to `std::mem::drop`
-    let _ = y; //~ ERROR calls to `std::mem::drop`
+     //~ ERROR calls to `std::mem::drop`
 }

--- a/tests/ui/lint/dropping_copy_types-issue-125189.rs
+++ b/tests/ui/lint/dropping_copy_types-issue-125189.rs
@@ -3,6 +3,7 @@
 
 #![deny(dropping_copy_types)]
 
+#[allow(unused_variables)]
 fn main() {
     let y = 1;
     drop(3.2); //~ ERROR calls to `std::mem::drop`

--- a/tests/ui/lint/dropping_copy_types-issue-125189.stderr
+++ b/tests/ui/lint/dropping_copy_types-issue-125189.stderr
@@ -1,5 +1,5 @@
 error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
-  --> $DIR/dropping_copy_types-issue-125189.rs:8:5
+  --> $DIR/dropping_copy_types-issue-125189.rs:9:5
    |
 LL |     drop(3.2);
    |     ^^^^^---^
@@ -18,17 +18,17 @@ LL +     let _ = 3.2;
    |
 
 error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
-  --> $DIR/dropping_copy_types-issue-125189.rs:9:5
+  --> $DIR/dropping_copy_types-issue-125189.rs:10:5
    |
 LL |     drop(y);
    |     ^^^^^-^
    |          |
    |          argument has type `i32`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(y);
-LL +     let _ = y;
+LL +
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/lint/dropping_copy_types.rs
+++ b/tests/ui/lint/dropping_copy_types.rs
@@ -51,6 +51,8 @@ fn main() {
     drop(a3);
     drop(a4); //~ WARN calls to `std::mem::drop`
     drop(a5);
+
+    drop(drop(String::new())); //~ WARN calls to `std::mem::drop`
 }
 
 #[allow(unused)]

--- a/tests/ui/lint/dropping_copy_types.stderr
+++ b/tests/ui/lint/dropping_copy_types.stderr
@@ -11,10 +11,10 @@ note: the lint level is defined here
    |
 LL | #![warn(dropping_copy_types)]
    |         ^^^^^^^^^^^^^^^^^^^
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(s1);
-LL +     let _ = s1;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
@@ -25,10 +25,10 @@ LL |     drop(s2);
    |          |
    |          argument has type `SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(s2);
-LL +     let _ = s2;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
@@ -40,10 +40,10 @@ LL |     drop(s3);
    |          argument has type `&SomeStruct`
    |
    = note: `#[warn(dropping_references)]` on by default
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(s3);
-LL +     let _ = s3;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
@@ -54,10 +54,10 @@ LL |     drop(s4);
    |          |
    |          argument has type `SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(s4);
-LL +     let _ = s4;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
@@ -68,10 +68,10 @@ LL |     drop(s5);
    |          |
    |          argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(s5);
-LL +     let _ = s5;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
@@ -82,10 +82,10 @@ LL |     drop(a2);
    |          |
    |          argument has type `&AnotherStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(a2);
-LL +     let _ = a2;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
@@ -96,10 +96,10 @@ LL |     drop(a4);
    |          |
    |          argument has type `&AnotherStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(a4);
-LL +     let _ = a4;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing

--- a/tests/ui/lint/dropping_copy_types.stderr
+++ b/tests/ui/lint/dropping_copy_types.stderr
@@ -103,7 +103,21 @@ LL +
    |
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
-  --> $DIR/dropping_copy_types.rs:71:13
+  --> $DIR/dropping_copy_types.rs:55:5
+   |
+LL |     drop(drop(String::new()));
+   |     ^^^^^-------------------^
+   |          |
+   |          argument has type `()`
+   |
+help: remove the function call
+   |
+LL -     drop(drop(String::new()));
+LL +     drop(String::new());
+   |
+
+warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types.rs:73:13
    |
 LL |             drop(println_and(13));
    |             ^^^^^---------------^
@@ -117,7 +131,7 @@ LL +             let _ = println_and(13);
    |
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
-  --> $DIR/dropping_copy_types.rs:74:14
+  --> $DIR/dropping_copy_types.rs:76:14
    |
 LL |         3 if drop(println_and(14)) == () => (),
    |              ^^^^^---------------^
@@ -127,7 +141,7 @@ LL |         3 if drop(println_and(14)) == () => (),
    = note: use `let _ = ...` to ignore the expression or result
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
-  --> $DIR/dropping_copy_types.rs:76:14
+  --> $DIR/dropping_copy_types.rs:78:14
    |
 LL |         4 => drop(2),
    |              ^^^^^-^
@@ -136,5 +150,5 @@ LL |         4 => drop(2),
    |
    = note: use `let _ = ...` to ignore the expression or result
 
-warning: 10 warnings emitted
+warning: 11 warnings emitted
 

--- a/tests/ui/lint/dropping_references-can-fixed.fixed
+++ b/tests/ui/lint/dropping_references-can-fixed.fixed
@@ -5,27 +5,28 @@
 
 struct SomeStruct;
 
+#[allow(unused_mut, unused_variables)]
 fn main() {
-    let _ = &SomeStruct; //~ ERROR calls to `std::mem::drop`
+     //~ ERROR calls to `std::mem::drop`
 
     let mut owned1 = SomeStruct;
-    let _ = &owned1; //~ ERROR calls to `std::mem::drop`
-    let _ = &&owned1; //~ ERROR calls to `std::mem::drop`
-    let _ = &mut owned1; //~ ERROR calls to `std::mem::drop`
+     //~ ERROR calls to `std::mem::drop`
+     //~ ERROR calls to `std::mem::drop`
+     //~ ERROR calls to `std::mem::drop`
     drop(owned1);
 
     let reference1 = &SomeStruct;
-    let _ = reference1; //~ ERROR calls to `std::mem::drop`
+     //~ ERROR calls to `std::mem::drop`
 
     let reference2 = &mut SomeStruct;
-    let _ = reference2; //~ ERROR calls to `std::mem::drop`
+     //~ ERROR calls to `std::mem::drop`
 
     let ref reference3 = SomeStruct;
-    let _ = reference3; //~ ERROR calls to `std::mem::drop`
+     //~ ERROR calls to `std::mem::drop`
 }
 
 #[allow(dead_code)]
 fn test_generic_fn_drop<T>(val: T) {
-    let _ = &val; //~ ERROR calls to `std::mem::drop`
+     //~ ERROR calls to `std::mem::drop`
     drop(val);
 }

--- a/tests/ui/lint/dropping_references-can-fixed.rs
+++ b/tests/ui/lint/dropping_references-can-fixed.rs
@@ -5,6 +5,7 @@
 
 struct SomeStruct;
 
+#[allow(unused_mut, unused_variables)]
 fn main() {
     drop(&SomeStruct); //~ ERROR calls to `std::mem::drop`
 

--- a/tests/ui/lint/dropping_references-can-fixed.stderr
+++ b/tests/ui/lint/dropping_references-can-fixed.stderr
@@ -45,7 +45,7 @@ LL -     drop(&&owned1);
 LL +     let _ = &&owned1;
    |
 
-error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+error: calls to `std::mem::drop` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
   --> $DIR/dropping_references-can-fixed.rs:14:5
    |
 LL |     drop(&mut owned1);
@@ -73,7 +73,7 @@ LL -     drop(reference1);
 LL +     let _ = reference1;
    |
 
-error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+error: calls to `std::mem::drop` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
   --> $DIR/dropping_references-can-fixed.rs:21:5
    |
 LL |     drop(reference2);

--- a/tests/ui/lint/dropping_references-can-fixed.stderr
+++ b/tests/ui/lint/dropping_references-can-fixed.stderr
@@ -1,5 +1,5 @@
 error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
-  --> $DIR/dropping_references-can-fixed.rs:9:5
+  --> $DIR/dropping_references-can-fixed.rs:10:5
    |
 LL |     drop(&SomeStruct);
    |     ^^^^^-----------^
@@ -11,108 +11,108 @@ note: the lint level is defined here
    |
 LL | #![deny(dropping_references)]
    |         ^^^^^^^^^^^^^^^^^^^
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(&SomeStruct);
-LL +     let _ = &SomeStruct;
+LL +
    |
 
 error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
-  --> $DIR/dropping_references-can-fixed.rs:12:5
+  --> $DIR/dropping_references-can-fixed.rs:13:5
    |
 LL |     drop(&owned1);
    |     ^^^^^-------^
    |          |
    |          argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(&owned1);
-LL +     let _ = &owned1;
+LL +
    |
 
 error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
-  --> $DIR/dropping_references-can-fixed.rs:13:5
+  --> $DIR/dropping_references-can-fixed.rs:14:5
    |
 LL |     drop(&&owned1);
    |     ^^^^^--------^
    |          |
    |          argument has type `&&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(&&owned1);
-LL +     let _ = &&owned1;
+LL +
    |
 
 error: calls to `std::mem::drop` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
-  --> $DIR/dropping_references-can-fixed.rs:14:5
+  --> $DIR/dropping_references-can-fixed.rs:15:5
    |
 LL |     drop(&mut owned1);
    |     ^^^^^-----------^
    |          |
    |          argument has type `&mut SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(&mut owned1);
-LL +     let _ = &mut owned1;
+LL +
    |
 
 error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
-  --> $DIR/dropping_references-can-fixed.rs:18:5
+  --> $DIR/dropping_references-can-fixed.rs:19:5
    |
 LL |     drop(reference1);
    |     ^^^^^----------^
    |          |
    |          argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(reference1);
-LL +     let _ = reference1;
+LL +
    |
 
 error: calls to `std::mem::drop` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
-  --> $DIR/dropping_references-can-fixed.rs:21:5
+  --> $DIR/dropping_references-can-fixed.rs:22:5
    |
 LL |     drop(reference2);
    |     ^^^^^----------^
    |          |
    |          argument has type `&mut SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(reference2);
-LL +     let _ = reference2;
+LL +
    |
 
 error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
-  --> $DIR/dropping_references-can-fixed.rs:24:5
+  --> $DIR/dropping_references-can-fixed.rs:25:5
    |
 LL |     drop(reference3);
    |     ^^^^^----------^
    |          |
    |          argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(reference3);
-LL +     let _ = reference3;
+LL +
    |
 
 error: calls to `std::mem::drop` with a reference instead of an owned value does nothing
-  --> $DIR/dropping_references-can-fixed.rs:29:5
+  --> $DIR/dropping_references-can-fixed.rs:30:5
    |
 LL |     drop(&val);
    |     ^^^^^----^
    |          |
    |          argument has type `&T`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(&val);
-LL +     let _ = &val;
+LL +
    |
 
 error: aborting due to 8 previous errors

--- a/tests/ui/lint/dropping_references.stderr
+++ b/tests/ui/lint/dropping_references.stderr
@@ -11,10 +11,10 @@ note: the lint level is defined here
    |
 LL | #![warn(dropping_references)]
    |         ^^^^^^^^^^^^^^^^^^^
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(&SomeStruct);
-LL +     let _ = &SomeStruct;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
@@ -25,10 +25,10 @@ LL |     drop(&owned1);
    |          |
    |          argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(&owned1);
-LL +     let _ = &owned1;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
@@ -39,10 +39,10 @@ LL |     drop(&&owned1);
    |          |
    |          argument has type `&&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(&&owned1);
-LL +     let _ = &&owned1;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
@@ -53,10 +53,10 @@ LL |     drop(&mut owned1);
    |          |
    |          argument has type `&mut SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(&mut owned1);
-LL +     let _ = &mut owned1;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
@@ -67,10 +67,10 @@ LL |     drop(reference1);
    |          |
    |          argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(reference1);
-LL +     let _ = reference1;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
@@ -81,10 +81,10 @@ LL |     drop(reference2);
    |          |
    |          argument has type `&mut SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(reference2);
-LL +     let _ = reference2;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
@@ -95,10 +95,10 @@ LL |     drop(reference3);
    |          |
    |          argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(reference3);
-LL +     let _ = reference3;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
@@ -109,10 +109,10 @@ LL |     drop(&val);
    |          |
    |          argument has type `&T`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     drop(&val);
-LL +     let _ = &val;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
@@ -123,10 +123,10 @@ LL |     std::mem::drop(&SomeStruct);
    |                    |
    |                    argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     std::mem::drop(&SomeStruct);
-LL +     let _ = &SomeStruct;
+LL +
    |
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing

--- a/tests/ui/lint/dropping_references.stderr
+++ b/tests/ui/lint/dropping_references.stderr
@@ -45,7 +45,7 @@ LL -     drop(&&owned1);
 LL +     let _ = &&owned1;
    |
 
-warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+warning: calls to `std::mem::drop` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
   --> $DIR/dropping_references.rs:13:5
    |
 LL |     drop(&mut owned1);
@@ -73,7 +73,7 @@ LL -     drop(reference1);
 LL +     let _ = reference1;
    |
 
-warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+warning: calls to `std::mem::drop` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
   --> $DIR/dropping_references.rs:20:5
    |
 LL |     drop(reference2);

--- a/tests/ui/lint/forgetting_copy_types-can-fixed.fixed
+++ b/tests/ui/lint/forgetting_copy_types-can-fixed.fixed
@@ -11,12 +11,13 @@ use std::mem::forget;
 #[derive(Copy, Clone)]
 struct SomeStruct;
 
+#[allow(unused_variables)]
 fn main() {
     let s1 = SomeStruct {};
     let s2 = s1;
     let mut s3 = s1;
 
-    let _ = s1; //~ ERROR calls to `std::mem::forget`
-    let _ = s2; //~ ERROR calls to `std::mem::forget`
-    let _ = s3; //~ ERROR calls to `std::mem::forget`
+     //~ ERROR calls to `std::mem::forget`
+     //~ ERROR calls to `std::mem::forget`
+     //~ ERROR calls to `std::mem::forget`
 }

--- a/tests/ui/lint/forgetting_copy_types-can-fixed.rs
+++ b/tests/ui/lint/forgetting_copy_types-can-fixed.rs
@@ -11,6 +11,7 @@ use std::mem::forget;
 #[derive(Copy, Clone)]
 struct SomeStruct;
 
+#[allow(unused_variables)]
 fn main() {
     let s1 = SomeStruct {};
     let s2 = s1;

--- a/tests/ui/lint/forgetting_copy_types-can-fixed.stderr
+++ b/tests/ui/lint/forgetting_copy_types-can-fixed.stderr
@@ -1,5 +1,5 @@
 error: calls to `std::mem::forget` with a value that implements `Copy` does nothing
-  --> $DIR/forgetting_copy_types-can-fixed.rs:19:5
+  --> $DIR/forgetting_copy_types-can-fixed.rs:20:5
    |
 LL |     forget(s1);
    |     ^^^^^^^--^
@@ -11,38 +11,38 @@ note: the lint level is defined here
    |
 LL | #![deny(forgetting_copy_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(s1);
-LL +     let _ = s1;
+LL +
    |
 
 error: calls to `std::mem::forget` with a value that implements `Copy` does nothing
-  --> $DIR/forgetting_copy_types-can-fixed.rs:20:5
+  --> $DIR/forgetting_copy_types-can-fixed.rs:21:5
    |
 LL |     forget(s2);
    |     ^^^^^^^--^
    |            |
    |            argument has type `SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(s2);
-LL +     let _ = s2;
+LL +
    |
 
 error: calls to `std::mem::forget` with a value that implements `Copy` does nothing
-  --> $DIR/forgetting_copy_types-can-fixed.rs:21:5
+  --> $DIR/forgetting_copy_types-can-fixed.rs:22:5
    |
 LL |     forget(s3);
    |     ^^^^^^^--^
    |            |
    |            argument has type `SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(s3);
-LL +     let _ = s3;
+LL +
    |
 
 error: aborting due to 3 previous errors

--- a/tests/ui/lint/forgetting_copy_types.stderr
+++ b/tests/ui/lint/forgetting_copy_types.stderr
@@ -11,10 +11,10 @@ note: the lint level is defined here
    |
 LL | #![warn(forgetting_copy_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(s1);
-LL +     let _ = s1;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a value that implements `Copy` does nothing
@@ -25,10 +25,10 @@ LL |     forget(s2);
    |            |
    |            argument has type `SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(s2);
-LL +     let _ = s2;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
@@ -40,10 +40,10 @@ LL |     forget(s3);
    |            argument has type `&SomeStruct`
    |
    = note: `#[warn(forgetting_references)]` on by default
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(s3);
-LL +     let _ = s3;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a value that implements `Copy` does nothing
@@ -54,10 +54,10 @@ LL |     forget(s4);
    |            |
    |            argument has type `SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(s4);
-LL +     let _ = s4;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
@@ -68,10 +68,10 @@ LL |     forget(s5);
    |            |
    |            argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(s5);
-LL +     let _ = s5;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
@@ -82,10 +82,10 @@ LL |     forget(a2);
    |            |
    |            argument has type `&AnotherStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(a2);
-LL +     let _ = a2;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
@@ -96,10 +96,10 @@ LL |     forget(a3);
    |            |
    |            argument has type `&AnotherStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(a3);
-LL +     let _ = a3;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
@@ -110,10 +110,10 @@ LL |     forget(a4);
    |            |
    |            argument has type `&AnotherStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(a4);
-LL +     let _ = a4;
+LL +
    |
 
 warning: 8 warnings emitted

--- a/tests/ui/lint/forgetting_references-can-fixed.fixed
+++ b/tests/ui/lint/forgetting_references-can-fixed.fixed
@@ -7,28 +7,29 @@ use std::mem::forget;
 
 struct SomeStruct;
 
+#[allow(unused_mut, unused_variables)]
 fn main() {
-    let _ = &SomeStruct; //~ ERROR calls to `std::mem::forget`
+     //~ ERROR calls to `std::mem::forget`
 
     let mut owned = SomeStruct;
-    let _ = &owned; //~ ERROR calls to `std::mem::forget`
-    let _ = &&owned; //~ ERROR calls to `std::mem::forget`
-    let _ = &mut owned; //~ ERROR calls to `std::mem::forget`
+     //~ ERROR calls to `std::mem::forget`
+     //~ ERROR calls to `std::mem::forget`
+     //~ ERROR calls to `std::mem::forget`
     forget(owned);
 
     let reference1 = &SomeStruct;
     let _ = &*reference1; //~ ERROR calls to `std::mem::forget`
 
     let reference2 = &mut SomeStruct;
-    let _ = reference2; //~ ERROR calls to `std::mem::forget`
+     //~ ERROR calls to `std::mem::forget`
 
     let ref reference3 = SomeStruct;
-    let _ = reference3; //~ ERROR calls to `std::mem::forget`
+     //~ ERROR calls to `std::mem::forget`
 }
 
 #[allow(dead_code)]
 fn test_generic_fn_forget<T>(val: T) {
-    let _ = &val; //~ ERROR calls to `std::mem::forget`
+     //~ ERROR calls to `std::mem::forget`
     forget(val);
 }
 
@@ -36,5 +37,5 @@ fn test_generic_fn_forget<T>(val: T) {
 fn test_similarly_named_function() {
     fn forget<T>(_val: T) {}
     forget(&SomeStruct); //OK; call to unrelated function which happens to have the same name
-    let _ = &SomeStruct; //~ ERROR calls to `std::mem::forget`
+     //~ ERROR calls to `std::mem::forget`
 }

--- a/tests/ui/lint/forgetting_references-can-fixed.rs
+++ b/tests/ui/lint/forgetting_references-can-fixed.rs
@@ -7,6 +7,7 @@ use std::mem::forget;
 
 struct SomeStruct;
 
+#[allow(unused_mut, unused_variables)]
 fn main() {
     forget(&SomeStruct); //~ ERROR calls to `std::mem::forget`
 

--- a/tests/ui/lint/forgetting_references-can-fixed.stderr
+++ b/tests/ui/lint/forgetting_references-can-fixed.stderr
@@ -1,5 +1,5 @@
 error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references-can-fixed.rs:11:5
+  --> $DIR/forgetting_references-can-fixed.rs:12:5
    |
 LL |     forget(&SomeStruct);
    |     ^^^^^^^-----------^
@@ -11,56 +11,56 @@ note: the lint level is defined here
    |
 LL | #![deny(forgetting_references)]
    |         ^^^^^^^^^^^^^^^^^^^^^
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(&SomeStruct);
-LL +     let _ = &SomeStruct;
+LL +
    |
 
 error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references-can-fixed.rs:14:5
+  --> $DIR/forgetting_references-can-fixed.rs:15:5
    |
 LL |     forget(&owned);
    |     ^^^^^^^------^
    |            |
    |            argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(&owned);
-LL +     let _ = &owned;
+LL +
    |
 
 error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references-can-fixed.rs:15:5
+  --> $DIR/forgetting_references-can-fixed.rs:16:5
    |
 LL |     forget(&&owned);
    |     ^^^^^^^-------^
    |            |
    |            argument has type `&&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(&&owned);
-LL +     let _ = &&owned;
+LL +
    |
 
 error: calls to `std::mem::forget` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
-  --> $DIR/forgetting_references-can-fixed.rs:16:5
+  --> $DIR/forgetting_references-can-fixed.rs:17:5
    |
 LL |     forget(&mut owned);
    |     ^^^^^^^----------^
    |            |
    |            argument has type `&mut SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(&mut owned);
-LL +     let _ = &mut owned;
+LL +
    |
 
 error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references-can-fixed.rs:20:5
+  --> $DIR/forgetting_references-can-fixed.rs:21:5
    |
 LL |     forget(&*reference1);
    |     ^^^^^^^------------^
@@ -74,59 +74,59 @@ LL +     let _ = &*reference1;
    |
 
 error: calls to `std::mem::forget` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
-  --> $DIR/forgetting_references-can-fixed.rs:23:5
+  --> $DIR/forgetting_references-can-fixed.rs:24:5
    |
 LL |     forget(reference2);
    |     ^^^^^^^----------^
    |            |
    |            argument has type `&mut SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(reference2);
-LL +     let _ = reference2;
+LL +
    |
 
 error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references-can-fixed.rs:26:5
+  --> $DIR/forgetting_references-can-fixed.rs:27:5
    |
 LL |     forget(reference3);
    |     ^^^^^^^----------^
    |            |
    |            argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(reference3);
-LL +     let _ = reference3;
+LL +
    |
 
 error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references-can-fixed.rs:31:5
+  --> $DIR/forgetting_references-can-fixed.rs:32:5
    |
 LL |     forget(&val);
    |     ^^^^^^^----^
    |            |
    |            argument has type `&T`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(&val);
-LL +     let _ = &val;
+LL +
    |
 
 error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
-  --> $DIR/forgetting_references-can-fixed.rs:39:5
+  --> $DIR/forgetting_references-can-fixed.rs:40:5
    |
 LL |     std::mem::forget(&SomeStruct);
    |     ^^^^^^^^^^^^^^^^^-----------^
    |                      |
    |                      argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     std::mem::forget(&SomeStruct);
-LL +     let _ = &SomeStruct;
+LL +
    |
 
 error: aborting due to 9 previous errors

--- a/tests/ui/lint/forgetting_references-can-fixed.stderr
+++ b/tests/ui/lint/forgetting_references-can-fixed.stderr
@@ -45,7 +45,7 @@ LL -     forget(&&owned);
 LL +     let _ = &&owned;
    |
 
-error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+error: calls to `std::mem::forget` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
   --> $DIR/forgetting_references-can-fixed.rs:16:5
    |
 LL |     forget(&mut owned);
@@ -73,7 +73,7 @@ LL -     forget(&*reference1);
 LL +     let _ = &*reference1;
    |
 
-error: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+error: calls to `std::mem::forget` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
   --> $DIR/forgetting_references-can-fixed.rs:23:5
    |
 LL |     forget(reference2);

--- a/tests/ui/lint/forgetting_references.stderr
+++ b/tests/ui/lint/forgetting_references.stderr
@@ -45,7 +45,7 @@ LL -     forget(&&owned);
 LL +     let _ = &&owned;
    |
 
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+warning: calls to `std::mem::forget` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
   --> $DIR/forgetting_references.rs:15:5
    |
 LL |     forget(&mut owned);
@@ -73,7 +73,7 @@ LL -     forget(&*reference1);
 LL +     let _ = &*reference1;
    |
 
-warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
+warning: calls to `std::mem::forget` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
   --> $DIR/forgetting_references.rs:22:5
    |
 LL |     forget(reference2);

--- a/tests/ui/lint/forgetting_references.stderr
+++ b/tests/ui/lint/forgetting_references.stderr
@@ -11,10 +11,10 @@ note: the lint level is defined here
    |
 LL | #![warn(forgetting_references)]
    |         ^^^^^^^^^^^^^^^^^^^^^
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(&SomeStruct);
-LL +     let _ = &SomeStruct;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
@@ -25,10 +25,10 @@ LL |     forget(&owned);
    |            |
    |            argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(&owned);
-LL +     let _ = &owned;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
@@ -39,10 +39,10 @@ LL |     forget(&&owned);
    |            |
    |            argument has type `&&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(&&owned);
-LL +     let _ = &&owned;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a mutable reference instead of an owned value only makes the reference inaccessible, it does not drop the underlying value
@@ -53,10 +53,10 @@ LL |     forget(&mut owned);
    |            |
    |            argument has type `&mut SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(&mut owned);
-LL +     let _ = &mut owned;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
@@ -81,10 +81,10 @@ LL |     forget(reference2);
    |            |
    |            argument has type `&mut SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(reference2);
-LL +     let _ = reference2;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
@@ -95,10 +95,10 @@ LL |     forget(reference3);
    |            |
    |            argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(reference3);
-LL +     let _ = reference3;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
@@ -119,7 +119,7 @@ LL |         2 => forget(reference3),
    |                     |
    |                     argument has type `&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+   = note: remove the whole expression
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
   --> $DIR/forgetting_references.rs:33:14
@@ -129,7 +129,7 @@ LL |         3 => forget(reference4),
    |                     |
    |                     argument has type `&SomeStruct`
    |
-   = note: use `let _ = ...` to ignore the expression or result
+   = note: remove the whole expression
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
   --> $DIR/forgetting_references.rs:40:5
@@ -139,10 +139,10 @@ LL |     forget(&val);
    |            |
    |            argument has type `&T`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     forget(&val);
-LL +     let _ = &val;
+LL +
    |
 
 warning: calls to `std::mem::forget` with a reference instead of an owned value does nothing
@@ -153,10 +153,10 @@ LL |     std::mem::forget(&SomeStruct);
    |                      |
    |                      argument has type `&SomeStruct`
    |
-help: use `let _ = ...` to ignore the expression or result
+help: remove the whole expression
    |
 LL -     std::mem::forget(&SomeStruct);
-LL +     let _ = &SomeStruct;
+LL +
    |
 
 warning: 12 warnings emitted


### PR DESCRIPTION
Distinguish dropping mutable references and add more intelligent suggestions if a reference or copyable type is dropped: E.g. delete the expression if it is trivially side-effect free.

Fixes #125972.