### PR TITLE
Detect pub structs never constructed even though they impl pub trait with assoc constants

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -472,7 +472,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                             && let ItemKind::Impl(impl_ref) =
                                 self.tcx.hir().expect_item(local_impl_id).kind
                         {
-                            if matches!(trait_item.kind, hir::TraitItemKind::Fn(..))
+                            if !matches!(trait_item.kind, hir::TraitItemKind::Type(..))
                                 && !ty_ref_to_pub_struct(self.tcx, impl_ref.self_ty)
                                     .ty_and_all_fields_are_public
                             {
@@ -802,7 +802,7 @@ fn check_item<'tcx>(
             // And we access the Map here to get HirId from LocalDefId
             for local_def_id in local_def_ids {
                 // check the function may construct Self
-                let mut may_construct_self = true;
+                let mut may_construct_self = false;
                 if let Some(fn_sig) =
                     tcx.hir().fn_sig_by_hir_id(tcx.local_def_id_to_hir_id(local_def_id))
                 {

--- a/tests/ui/lint/dead-code/unused-adt-impl-pub-trait-with-assoc-const.rs
+++ b/tests/ui/lint/dead-code/unused-adt-impl-pub-trait-with-assoc-const.rs
@@ -1,0 +1,52 @@
+#![deny(dead_code)]
+
+struct T1; //~ ERROR struct `T1` is never constructed
+pub struct T2(i32); //~ ERROR struct `T2` is never constructed
+struct T3;
+
+trait Trait1 { //~ ERROR trait `Trait1` is never used
+    const UNUSED: i32;
+    fn unused(&self) {}
+    fn construct_self() -> Self;
+}
+
+pub trait Trait2 {
+    const USED: i32;
+    fn used(&self) {}
+}
+
+pub trait Trait3 {
+    const USED: i32;
+    fn construct_self() -> Self;
+}
+
+impl Trait1 for T1 {
+    const UNUSED: i32 = 0;
+    fn construct_self() -> Self {
+        Self
+    }
+}
+
+impl Trait1 for T2 {
+    const UNUSED: i32 = 0;
+    fn construct_self() -> Self {
+        T2(0)
+    }
+}
+
+impl Trait2 for T1 {
+    const USED: i32 = 0;
+}
+
+impl Trait2 for T2 {
+    const USED: i32 = 0;
+}
+
+impl Trait3 for T3 {
+    const USED: i32 = 0;
+    fn construct_self() -> Self {
+        Self
+    }
+}
+
+fn main() {}

--- a/tests/ui/lint/dead-code/unused-adt-impl-pub-trait-with-assoc-const.stderr
+++ b/tests/ui/lint/dead-code/unused-adt-impl-pub-trait-with-assoc-const.stderr
@@ -1,0 +1,26 @@
+error: struct `T1` is never constructed
+  --> $DIR/unused-adt-impl-pub-trait-with-assoc-const.rs:3:8
+   |
+LL | struct T1;
+   |        ^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-adt-impl-pub-trait-with-assoc-const.rs:1:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: struct `T2` is never constructed
+  --> $DIR/unused-adt-impl-pub-trait-with-assoc-const.rs:4:12
+   |
+LL | pub struct T2(i32);
+   |            ^^
+
+error: trait `Trait1` is never used
+  --> $DIR/unused-adt-impl-pub-trait-with-assoc-const.rs:7:7
+   |
+LL | trait Trait1 {
+   |       ^^^^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Extend dead code analysis to impl items of pub assoc constants.

<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->