### PR TITLE
[beta] Ensure self-contained linker is only enabled on dev/nightly

### DIFF
--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -440,10 +440,7 @@ impl<T: Ord> BinaryHeap<T> {
     /// heap.push(4);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(
-        feature = "const_binary_heap_constructor",
-        since = "1.80.0"
-    )]
+    #[rustc_const_stable(feature = "const_binary_heap_constructor", since = "1.80.0")]
     #[must_use]
     pub const fn new() -> BinaryHeap<T> {
         BinaryHeap { data: vec![] }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1137,7 +1137,9 @@ pub fn rustc_cargo_env(
     }
 
     // Enable rustc's env var for `rust-lld` when requested.
-    if builder.config.lld_enabled {
+    if builder.config.lld_enabled
+        && (builder.config.channel == "dev" || builder.config.channel == "nightly")
+    {
         cargo.env("CFG_USE_SELF_CONTAINED_LINKER", "1");
     }
 


### PR DESCRIPTION
It seems the self-contained linker is enabled on beta. Let's fix that.

```console
$ cargo clean && cargo +beta build && readelf -p .comment target/debug/helloworld
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s

String dump of section '.comment':
  [     0]  Linker: LLD 18.1.7
  [    14]  GCC: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
  [    3f]  rustc version 1.80.0-beta.1 (75ac3b633 2024-06-10)
```

I will open a PR to fix it on master as well, right after I test CI's behavior on beta.