### PR TITLE
set_env: State the conclusion upfront

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -323,8 +323,10 @@ impl Error for VarError {
 /// This function is also always safe to call on Windows, in single-threaded
 /// and multi-threaded programs.
 ///
-/// In multi-threaded programs on other operating systems, we strongly suggest
-/// not using `set_var` or `remove_var` at all. The exact requirement is: you
+/// In multi-threaded programs on other operating systems, the only safe option is
+/// to not use `set_var` or `remove_var` at all.
+///
+/// The exact requirement is: you
 /// must ensure that there are no other threads concurrently writing or
 /// *reading*(!) the environment through functions or global variables other
 /// than the ones in this module. The problem is that these operating systems
@@ -390,8 +392,10 @@ unsafe fn _set_var(key: &OsStr, value: &OsStr) {
 /// This function is also always safe to call on Windows, in single-threaded
 /// and multi-threaded programs.
 ///
-/// In multi-threaded programs on other operating systems, we strongly suggest
-/// not using `set_var` or `remove_var` at all. The exact requirement is: you
+/// In multi-threaded programs on other operating systems, the only safe option is
+/// to not use `set_var` or `remove_var` at all.
+///
+/// The exact requirement is: you
 /// must ensure that there are no other threads concurrently writing or
 /// *reading*(!) the environment through functions or global variables other
 /// than the ones in this module. The problem is that these operating systems


### PR DESCRIPTION
People tend to skim or skip over long explanations so we should be very upfront that `set_var` and `remove_var` are being made unsafe for a very good reason.

This is just the conclusion restated almost verbatim but earlier in the docs and separated from the explanation:

https://github.com/rust-lang/rust/blob/0c960618b56f662d933e8b864cd9632a99174e87/library/std/src/env.rs#L338-L339

I think this may help with people who may not be entirely comfortable with #125937 being rejected.