### PR TITLE
Ensure self-contained linker is only enabled on dev/nightly 

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1137,7 +1137,9 @@ pub fn rustc_cargo_env(
     }
 
     // Enable rustc's env var for `rust-lld` when requested.
-    if builder.config.lld_enabled {
+    if builder.config.lld_enabled
+        && (builder.config.channel == "dev" || builder.config.channel == "nightly")
+    {
         cargo.env("CFG_USE_SELF_CONTAINED_LINKER", "1");
     }
 


### PR DESCRIPTION
This is a version of #126278 for the master branch. It should be no-op _here_, compared to beta.

I'll r? @Mark-Simulacrum like the other one.