### PR TITLE
Make `storage-live.rs` robust against rustc internal changes.

### DIFF
--- a/tests/ui/mir/lint/storage-live.rs
+++ b/tests/ui/mir/lint/storage-live.rs
@@ -5,6 +5,7 @@
 //@ normalize-stderr-test "note: .*\n\n" -> ""
 //@ normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
 //@ normalize-stderr-test "storage_live\[....\]" -> "storage_live[HASH]"
+//@ normalize-stderr-test "(delayed at [^:]+):\d+:\d+ - " -> "$1:LL:CC - "
 //@ rustc-env:RUST_BACKTRACE=0
 
 #![feature(custom_mir, core_intrinsics)]

--- a/tests/ui/mir/lint/storage-live.stderr
+++ b/tests/ui/mir/lint/storage-live.stderr
@@ -1,12 +1,12 @@
 error: internal compiler error: broken MIR in Item(DefId(0:8 ~ storage_live[HASH]::multiple_storage)) (after pass CheckPackedRef) at bb0[1]:
                                 StorageLive(_1) which already has storage here
-  --> $DIR/storage-live.rs:22:13
+  --> $DIR/storage-live.rs:23:13
    |
 LL |             StorageLive(a);
    |             ^^^^^^^^^^^^^^
    |
-note: delayed at compiler/rustc_mir_transform/src/lint.rs:97:26 - disabled backtrace
-  --> $DIR/storage-live.rs:22:13
+note: delayed at compiler/rustc_mir_transform/src/lint.rs:LL:CC - disabled backtrace
+  --> $DIR/storage-live.rs:23:13
    |
 LL |             StorageLive(a);
    |             ^^^^^^^^^^^^^^


### PR DESCRIPTION
Currently it can be made to fail by rearranging code within `compiler/rustc_mir_transform/src/lint.rs`.

This is a precursor to #125443.

r? @lqd