### PR TITLE
No uninitalized report in a pre-returned match arm

### DIFF
--- a/tests/ui/borrowck/uninitalized-in-match-arm-issue-126133.rs
+++ b/tests/ui/borrowck/uninitalized-in-match-arm-issue-126133.rs
@@ -1,0 +1,22 @@
+enum E {
+    A,
+    B,
+    C,
+}
+
+fn foo(e: E) {
+    let bar;
+
+    match e {
+        E::A if true => return,
+        E::A => return,
+        E::B => {}
+        E::C => {
+            bar = 5;
+        }
+    }
+
+    let _baz = bar; //~ ERROR E0381
+}
+
+fn main() {}

--- a/tests/ui/borrowck/uninitalized-in-match-arm-issue-126133.stderr
+++ b/tests/ui/borrowck/uninitalized-in-match-arm-issue-126133.stderr
@@ -1,0 +1,15 @@
+error[E0381]: used binding `bar` is possibly-uninitialized
+  --> $DIR/uninitalized-in-match-arm-issue-126133.rs:19:16
+   |
+LL |     let bar;
+   |         --- binding declared here but left uninitialized
+...
+LL |         E::B => {}
+   |         ---- if this pattern is matched, `bar` is not initialized
+...
+LL |     let _baz = bar;
+   |                ^^^ `bar` used here but it is possibly-uninitialized
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0381`.


### PR DESCRIPTION
This is an attemp to address https://github.com/rust-lang/rust/issues/126133



