### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2064,7 +2064,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     if all_traits_equal {
                         format!("\n  {}", c.self_ty())
                     } else {
-                        format!("\n  {c}")
+                        format!("\n  `{}` implements `{}`", c.self_ty(), c.print_only_trait_path())
                     }
                 })
                 .collect();

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -533,11 +533,9 @@ impl<T, const N: usize> [T; N] {
     /// assert_eq!(c, Some(a));
     /// ```
     #[unstable(feature = "array_try_map", issue = "79711")]
-    pub fn try_map<F, R>(self, f: F) -> ChangeOutputType<R, [R::Output; N]>
+    pub fn try_map<R>(self, f: impl FnMut(T) -> R) -> ChangeOutputType<R, [R::Output; N]>
     where
-        F: FnMut(T) -> R,
-        R: Try,
-        R::Residual: Residual<[R::Output; N]>,
+        R: Try<Residual: Residual<[R::Output; N]>>,
     {
         drain_array_with(self, |iter| try_from_trusted_iterator(iter.map(f)))
     }

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -363,7 +363,9 @@ pub trait Residual<O> {
 }
 
 #[unstable(feature = "pub_crate_should_not_need_unstable_attr", issue = "none")]
-pub(crate) type ChangeOutputType<T, V> = <<T as Try>::Residual as Residual<V>>::TryType;
+#[allow(type_alias_bounds)]
+pub(crate) type ChangeOutputType<T: Try<Residual: Residual<V>>, V> =
+    <T::Residual as Residual<V>>::TryType;
 
 /// An adapter for implementing non-try methods via the `Try` implementation.
 ///

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -92,11 +92,13 @@ use crate::ub_checks;
 /// ```
 /// use std::slice;
 ///
+/// /// Sum the elements of an FFI slice.
+/// ///
 /// /// # Safety
 /// ///
 /// /// If ptr is not NULL, it must be correctly aligned and
 /// /// point to `len` initialized items of type `f32`.
-/// unsafe extern "C" fn handle_slice(ptr: *const f32, len: usize) {
+/// unsafe extern "C" fn sum_slice(ptr: *const f32, len: usize) -> f32 {
 ///     let data = if ptr.is_null() {
 ///         // `len` is assumed to be 0.
 ///         &[]
@@ -104,9 +106,14 @@ use crate::ub_checks;
 ///         // SAFETY: see function docstring.
 ///         unsafe { slice::from_raw_parts(ptr, len) }
 ///     };
-///     dbg!(data);
-///     // ...
+///     data.sum()
 /// }
+///
+/// // This could be the result of C++'s std::vector::data():
+/// let ptr = std::ptr::null();
+/// // And this could be std::vector::size():
+/// let len = 0;
+/// assert_eq!(unsafe { sum_slice(ptr, len) }, 0.0);
 /// ```
 ///
 /// [valid]: ptr#safety

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -83,6 +83,27 @@ use crate::ub_checks;
 /// }
 /// ```
 ///
+/// ### FFI: Handling null pointers
+///
+/// In languages such as C++, pointers to empty collections are not guaranteed to be non-null.
+/// When accepting such pointers, they have to be checked for null-ness to avoid undefined
+/// behavior.
+///
+/// ```
+/// use std::slice;
+///
+/// unsafe extern "C" fn handle_slice(ptr: *const f32, len: usize) {
+///     let data = if ptr.is_null() {
+///         // `len` is assumed to be 0.
+///         &[]
+///     } else {
+///         unsafe { slice::from_raw_parts(ptr, len) }
+///     };
+///     dbg!(data);
+///     // ...
+/// }
+/// ```
+///
 /// [valid]: ptr#safety
 /// [`NonNull::dangling()`]: ptr::NonNull::dangling
 #[inline]

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -92,11 +92,16 @@ use crate::ub_checks;
 /// ```
 /// use std::slice;
 ///
+/// /// # Safety
+/// ///
+/// /// If ptr is not NULL, it must be correctly aligned and
+/// /// point to `len` initialized items of type `f32`.
 /// unsafe extern "C" fn handle_slice(ptr: *const f32, len: usize) {
 ///     let data = if ptr.is_null() {
 ///         // `len` is assumed to be 0.
 ///         &[]
 ///     } else {
+///         // SAFETY: see function docstring.
 ///         unsafe { slice::from_raw_parts(ptr, len) }
 ///     };
 ///     dbg!(data);

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -106,7 +106,7 @@ use crate::ub_checks;
 ///         // SAFETY: see function docstring.
 ///         unsafe { slice::from_raw_parts(ptr, len) }
 ///     };
-///     data.sum()
+///     data.into_iter().sum()
 /// }
 ///
 /// // This could be the result of C++'s std::vector::data():

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1281,6 +1281,7 @@ fn expand_variables(mut value: String, config: &Config) -> String {
     const BUILD_BASE: &str = "{{build-base}}";
     const SYSROOT_BASE: &str = "{{sysroot-base}}";
     const TARGET_LINKER: &str = "{{target-linker}}";
+    const TARGET: &str = "{{target}}";
 
     if value.contains(CWD) {
         let cwd = env::current_dir().unwrap();
@@ -1301,6 +1302,10 @@ fn expand_variables(mut value: String, config: &Config) -> String {
 
     if value.contains(TARGET_LINKER) {
         value = value.replace(TARGET_LINKER, config.target_linker.as_deref().unwrap_or(""));
+    }
+
+    if value.contains(TARGET) {
+        value = value.replace(TARGET, &config.target);
     }
 
     value

--- a/src/tools/tidy/src/target_specific_tests.rs
+++ b/src/tools/tidy/src/target_specific_tests.rs
@@ -53,9 +53,9 @@ pub fn check(path: &Path, bad: &mut bool) {
             } else if directive.starts_with(COMPILE_FLAGS_HEADER) {
                 let compile_flags = &directive[COMPILE_FLAGS_HEADER.len()..];
                 if let Some((_, v)) = compile_flags.split_once("--target") {
-                    if let Some((arch, _)) =
-                        v.trim_start_matches(|c| c == ' ' || c == '=').split_once("-")
-                    {
+                    let v = v.trim_start_matches(|c| c == ' ' || c == '=');
+                    let v = if v == "{{target}}" { Some((v, v)) } else { v.split_once("-") };
+                    if let Some((arch, _)) = v {
                         let info = header_map.entry(revision).or_insert(RevisionInfo::default());
                         info.target_arch.replace(arch);
                     } else {

--- a/tests/codegen/issues/issue-122805.rs
+++ b/tests/codegen/issues/issue-122805.rs
@@ -39,17 +39,20 @@
 // OPT3WINX64-NEXT: store <8 x i16>
 // CHECK-NEXT: ret void
 #[no_mangle]
-#[cfg(target_endian = "little")]
 pub fn convert(value: [u16; 8]) -> [u8; 16] {
+    #[cfg(target_endian = "little")]
+    let bswap = u16::to_be;
+    #[cfg(target_endian = "big")]
+    let bswap = u16::to_le;
     let addr16 = [
-        value[0].to_be(),
-        value[1].to_be(),
-        value[2].to_be(),
-        value[3].to_be(),
-        value[4].to_be(),
-        value[5].to_be(),
-        value[6].to_be(),
-        value[7].to_be(),
+        bswap(value[0]),
+        bswap(value[1]),
+        bswap(value[2]),
+        bswap(value[3]),
+        bswap(value[4]),
+        bswap(value[5]),
+        bswap(value[6]),
+        bswap(value[7]),
     ];
     unsafe { core::mem::transmute::<_, [u8; 16]>(addr16) }
 }

--- a/tests/ui/binop/binary-op-suggest-deref.stderr
+++ b/tests/ui/binop/binary-op-suggest-deref.stderr
@@ -303,10 +303,10 @@ LL |     let _ = FOO & (*"Sized".to_string().into_boxed_str());
    |
    = help: the trait `BitAnd<str>` is not implemented for `i32`
    = help: the following other types implement trait `BitAnd<Rhs>`:
-             <&'a i32 as BitAnd<i32>>
-             <&i32 as BitAnd<&i32>>
-             <i32 as BitAnd<&i32>>
-             <i32 as BitAnd>
+             `&'a i32` implements `BitAnd<i32>`
+             `&i32` implements `BitAnd<&i32>`
+             `i32` implements `BitAnd<&i32>`
+             `i32` implements `BitAnd`
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/binary-op-suggest-deref.rs:78:17

--- a/tests/ui/binop/binop-mul-i32-f32.stderr
+++ b/tests/ui/binop/binop-mul-i32-f32.stderr
@@ -6,10 +6,10 @@ LL |     x * y
    |
    = help: the trait `Mul<f32>` is not implemented for `i32`
    = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a i32 as Mul<i32>>
-             <&i32 as Mul<&i32>>
-             <i32 as Mul<&i32>>
-             <i32 as Mul>
+             `&'a i32` implements `Mul<i32>`
+             `&i32` implements `Mul<&i32>`
+             `i32` implements `Mul<&i32>`
+             `i32` implements `Mul`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/binop/shift-various-bad-types.stderr
+++ b/tests/ui/binop/shift-various-bad-types.stderr
@@ -6,14 +6,14 @@ LL |     22 >> p.char;
    |
    = help: the trait `Shr<char>` is not implemented for `{integer}`
    = help: the following other types implement trait `Shr<Rhs>`:
-             <&'a i128 as Shr<i128>>
-             <&'a i128 as Shr<i16>>
-             <&'a i128 as Shr<i32>>
-             <&'a i128 as Shr<i64>>
-             <&'a i128 as Shr<i8>>
-             <&'a i128 as Shr<isize>>
-             <&'a i128 as Shr<u128>>
-             <&'a i128 as Shr<u16>>
+             `&'a i128` implements `Shr<i128>`
+             `&'a i128` implements `Shr<i16>`
+             `&'a i128` implements `Shr<i32>`
+             `&'a i128` implements `Shr<i64>`
+             `&'a i128` implements `Shr<i8>`
+             `&'a i128` implements `Shr<isize>`
+             `&'a i128` implements `Shr<u128>`
+             `&'a i128` implements `Shr<u16>`
            and 568 others
 
 error[E0277]: no implementation for `{integer} >> &str`
@@ -24,14 +24,14 @@ LL |     22 >> p.str;
    |
    = help: the trait `Shr<&str>` is not implemented for `{integer}`
    = help: the following other types implement trait `Shr<Rhs>`:
-             <&'a i128 as Shr<i128>>
-             <&'a i128 as Shr<i16>>
-             <&'a i128 as Shr<i32>>
-             <&'a i128 as Shr<i64>>
-             <&'a i128 as Shr<i8>>
-             <&'a i128 as Shr<isize>>
-             <&'a i128 as Shr<u128>>
-             <&'a i128 as Shr<u16>>
+             `&'a i128` implements `Shr<i128>`
+             `&'a i128` implements `Shr<i16>`
+             `&'a i128` implements `Shr<i32>`
+             `&'a i128` implements `Shr<i64>`
+             `&'a i128` implements `Shr<i8>`
+             `&'a i128` implements `Shr<isize>`
+             `&'a i128` implements `Shr<u128>`
+             `&'a i128` implements `Shr<u16>`
            and 568 others
 
 error[E0277]: no implementation for `{integer} >> &Panolpy`
@@ -42,14 +42,14 @@ LL |     22 >> p;
    |
    = help: the trait `Shr<&Panolpy>` is not implemented for `{integer}`
    = help: the following other types implement trait `Shr<Rhs>`:
-             <&'a i128 as Shr<i128>>
-             <&'a i128 as Shr<i16>>
-             <&'a i128 as Shr<i32>>
-             <&'a i128 as Shr<i64>>
-             <&'a i128 as Shr<i8>>
-             <&'a i128 as Shr<isize>>
-             <&'a i128 as Shr<u128>>
-             <&'a i128 as Shr<u16>>
+             `&'a i128` implements `Shr<i128>`
+             `&'a i128` implements `Shr<i16>`
+             `&'a i128` implements `Shr<i32>`
+             `&'a i128` implements `Shr<i64>`
+             `&'a i128` implements `Shr<i8>`
+             `&'a i128` implements `Shr<isize>`
+             `&'a i128` implements `Shr<u128>`
+             `&'a i128` implements `Shr<u16>`
            and 568 others
 
 error[E0308]: mismatched types

--- a/tests/ui/const-generics/exhaustive-value.stderr
+++ b/tests/ui/const-generics/exhaustive-value.stderr
@@ -5,14 +5,14 @@ LL |     <() as Foo<N>>::test()
    |      ^^ the trait `Foo<N>` is not implemented for `()`
    |
    = help: the following other types implement trait `Foo<N>`:
-             <() as Foo<0>>
-             <() as Foo<100>>
-             <() as Foo<101>>
-             <() as Foo<102>>
-             <() as Foo<103>>
-             <() as Foo<104>>
-             <() as Foo<105>>
-             <() as Foo<106>>
+             `()` implements `Foo<0>`
+             `()` implements `Foo<100>`
+             `()` implements `Foo<101>`
+             `()` implements `Foo<102>`
+             `()` implements `Foo<103>`
+             `()` implements `Foo<104>`
+             `()` implements `Foo<105>`
+             `()` implements `Foo<106>`
            and 248 others
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.rs
+++ b/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.rs
@@ -1,0 +1,20 @@
+// Given an anon const `a`: `{ N }` and some anon const `b` which references the
+// first anon const: `{ [1; a] }`. `b` should not have any generics as it is not
+// a simple `N` argument nor is it a repeat expr count.
+//
+// On the other hand `b` *is* a repeat expr count and so it should inherit its
+// parents generics as part of the `const_evaluatable_unchecked` fcw (#76200).
+//
+// In this specific case however `b`'s parent should be `a` and so it should wind
+// up not having any generics after all. If `a` were to inherit its generics from
+// the enclosing item then the reference to `a` from `b` would contain generic
+// parameters not usable by `b` which would cause us to ICE.
+
+fn bar<const N: usize>() {}
+
+fn foo<const N: usize>() {
+    bar::<{ [1; N] }>();
+    //~^ ERROR: generic parameters may not be used in const operations
+}
+
+fn main() {}

--- a/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
+++ b/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
@@ -1,0 +1,11 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/repeat_expr_hack_gives_right_generics.rs:16:17
+   |
+LL |     bar::<{ [1; N] }>();
+   |                 ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/consts/const-eval/const-eval-overflow-3b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-3b.stderr
@@ -12,10 +12,10 @@ LL |     = [0; (i8::MAX + 1u8) as usize];
    |
    = help: the trait `Add<u8>` is not implemented for `i8`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a i8 as Add<i8>>
-             <&i8 as Add<&i8>>
-             <i8 as Add<&i8>>
-             <i8 as Add>
+             `&'a i8` implements `Add<i8>`
+             `&i8` implements `Add<&i8>`
+             `i8` implements `Add<&i8>`
+             `i8` implements `Add`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
@@ -12,10 +12,10 @@ LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
    |
    = help: the trait `Add<u8>` is not implemented for `i8`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a i8 as Add<i8>>
-             <&i8 as Add<&i8>>
-             <i8 as Add<&i8>>
-             <i8 as Add>
+             `&'a i8` implements `Add<i8>`
+             `&i8` implements `Add<&i8>`
+             `i8` implements `Add<&i8>`
+             `i8` implements `Add`
 
 error[E0604]: only `u8` can be cast as `char`, not `i8`
   --> $DIR/const-eval-overflow-4b.rs:22:13

--- a/tests/ui/consts/too_generic_eval_ice.stderr
+++ b/tests/ui/consts/too_generic_eval_ice.stderr
@@ -22,14 +22,14 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
    |
    = help: the trait `PartialEq<[{integer}; 0]>` is not implemented for `[{integer}; Self::HOST_SIZE]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
-             <&[T] as PartialEq<Vec<U, A>>>
-             <&[T] as PartialEq<[U; N]>>
-             <&mut [T] as PartialEq<Vec<U, A>>>
-             <&mut [T] as PartialEq<[U; N]>>
-             <[T; N] as PartialEq<&[U]>>
-             <[T; N] as PartialEq<&mut [U]>>
-             <[T; N] as PartialEq<[U; N]>>
-             <[T; N] as PartialEq<[U]>>
+             `&[T]` implements `PartialEq<Vec<U, A>>`
+             `&[T]` implements `PartialEq<[U; N]>`
+             `&mut [T]` implements `PartialEq<Vec<U, A>>`
+             `&mut [T]` implements `PartialEq<[U; N]>`
+             `[T; N]` implements `PartialEq<&[U]>`
+             `[T; N]` implements `PartialEq<&mut [U]>`
+             `[T; N]` implements `PartialEq<[U; N]>`
+             `[T; N]` implements `PartialEq<[U]>`
            and 3 others
 
 error: aborting due to 3 previous errors

--- a/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
+++ b/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
@@ -7,8 +7,8 @@ LL |     f1.foo(1usize);
    |        required by a bound introduced by this call
    |
    = help: the following other types implement trait `Foo<A>`:
-             <Bar as Foo<i32>>
-             <Bar as Foo<u8>>
+             `Bar` implements `Foo<i32>`
+             `Bar` implements `Foo<u8>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
+++ b/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
@@ -7,12 +7,12 @@ LL |     f1.foo(1usize);
    |        required by a bound introduced by this call
    |
    = help: the following other types implement trait `Foo<A>`:
-             <Bar as Foo<i16>>
-             <Bar as Foo<i32>>
-             <Bar as Foo<i8>>
-             <Bar as Foo<u16>>
-             <Bar as Foo<u32>>
-             <Bar as Foo<u8>>
+             `Bar` implements `Foo<i16>`
+             `Bar` implements `Foo<i32>`
+             `Bar` implements `Foo<i8>`
+             `Bar` implements `Foo<u16>`
+             `Bar` implements `Foo<u32>`
+             `Bar` implements `Foo<u8>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
+++ b/tests/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
@@ -7,11 +7,11 @@ LL |     Foo::<i32>::bar(&1i8);
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `Foo<B>`:
-             <i8 as Foo<bool>>
-             <i8 as Foo<u16>>
-             <i8 as Foo<u32>>
-             <i8 as Foo<u64>>
-             <i8 as Foo<u8>>
+             `i8` implements `Foo<bool>`
+             `i8` implements `Foo<u16>`
+             `i8` implements `Foo<u32>`
+             `i8` implements `Foo<u64>`
+             `i8` implements `Foo<u8>`
 
 error[E0277]: the trait bound `u8: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:25:21
@@ -22,10 +22,10 @@ LL |     Foo::<i32>::bar(&1u8);
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `Foo<B>`:
-             <u8 as Foo<bool>>
-             <u8 as Foo<u16>>
-             <u8 as Foo<u32>>
-             <u8 as Foo<u64>>
+             `u8` implements `Foo<bool>`
+             `u8` implements `Foo<u16>`
+             `u8` implements `Foo<u32>`
+             `u8` implements `Foo<u64>`
 
 error[E0277]: the trait bound `bool: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:26:21
@@ -36,12 +36,12 @@ LL |     Foo::<i32>::bar(&true);
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `Foo<B>`:
-             <bool as Foo<bool>>
-             <bool as Foo<i8>>
-             <bool as Foo<u16>>
-             <bool as Foo<u32>>
-             <bool as Foo<u64>>
-             <bool as Foo<u8>>
+             `bool` implements `Foo<bool>`
+             `bool` implements `Foo<i8>`
+             `bool` implements `Foo<u16>`
+             `bool` implements `Foo<u32>`
+             `bool` implements `Foo<u64>`
+             `bool` implements `Foo<u8>`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/issues/issue-11771.stderr
+++ b/tests/ui/issues/issue-11771.stderr
@@ -6,14 +6,14 @@ LL |     1 +
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f128 as Add<f128>>
-             <&'a f16 as Add<f16>>
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
+             `&'a f128` implements `Add<f128>`
+             `&'a f16` implements `Add<f16>`
+             `&'a f32` implements `Add<f32>`
+             `&'a f64` implements `Add<f64>`
+             `&'a i128` implements `Add<i128>`
+             `&'a i16` implements `Add<i16>`
+             `&'a i32` implements `Add<i32>`
+             `&'a i64` implements `Add<i64>`
            and 56 others
 
 error[E0277]: cannot add `()` to `{integer}`
@@ -24,14 +24,14 @@ LL |     1 +
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f128 as Add<f128>>
-             <&'a f16 as Add<f16>>
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
+             `&'a f128` implements `Add<f128>`
+             `&'a f16` implements `Add<f16>`
+             `&'a f32` implements `Add<f32>`
+             `&'a f64` implements `Add<f64>`
+             `&'a i128` implements `Add<i128>`
+             `&'a i16` implements `Add<i16>`
+             `&'a i32` implements `Add<i32>`
+             `&'a i64` implements `Add<i64>`
            and 56 others
 
 error: aborting due to 2 previous errors

--- a/tests/ui/issues/issue-24352.stderr
+++ b/tests/ui/issues/issue-24352.stderr
@@ -6,10 +6,10 @@ LL |     1.0f64 - 1
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f64 as Sub<f64>>
-             <&f64 as Sub<&f64>>
-             <f64 as Sub<&f64>>
-             <f64 as Sub>
+             `&'a f64` implements `Sub<f64>`
+             `&f64` implements `Sub<&f64>`
+             `f64` implements `Sub<&f64>`
+             `f64` implements `Sub`
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     1.0f64 - 1.0

--- a/tests/ui/issues/issue-50582.stderr
+++ b/tests/ui/issues/issue-50582.stderr
@@ -16,14 +16,14 @@ LL |     Vec::<[(); 1 + for x in 0..1 {}]>::new();
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f128 as Add<f128>>
-             <&'a f16 as Add<f16>>
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
+             `&'a f128` implements `Add<f128>`
+             `&'a f16` implements `Add<f16>`
+             `&'a f32` implements `Add<f32>`
+             `&'a f64` implements `Add<f64>`
+             `&'a i128` implements `Add<i128>`
+             `&'a i16` implements `Add<i16>`
+             `&'a i32` implements `Add<i32>`
+             `&'a i64` implements `Add<i64>`
            and 56 others
 
 error: aborting due to 2 previous errors

--- a/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
@@ -33,8 +33,8 @@ LL |     println!("{}", scores.sum::<i32>());
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
-             <i32 as Sum>
+             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:14:10
    |
@@ -66,8 +66,8 @@ LL |             .sum::<i32>(),
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
-             <i32 as Sum>
+             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:23:14
    |
@@ -99,8 +99,8 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
-             <i32 as Sum>
+             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:27:38
    |

--- a/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
@@ -8,8 +8,8 @@ LL |     let x = Some(()).iter().map(|()| 1).sum::<f32>();
    |
    = help: the trait `Sum<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Sum<A>`:
-             <f32 as Sum<&'a f32>>
-             <f32 as Sum>
+             `f32` implements `Sum<&'a f32>`
+             `f32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-with-int-infer.rs:2:29
    |

--- a/tests/ui/iterators/invalid-iterator-chain.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain.stderr
@@ -33,8 +33,8 @@ LL |     println!("{}", scores.sum::<i32>());
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
-             <i32 as Sum>
+             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:12:10
    |
@@ -65,8 +65,8 @@ LL |             .sum::<i32>(),
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
-             <i32 as Sum>
+             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:25:14
    |
@@ -104,8 +104,8 @@ LL |             .sum::<i32>(),
    |
    = help: the trait `Sum<f64>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
-             <i32 as Sum>
+             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:33:14
    |
@@ -134,8 +134,8 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
-             <i32 as Sum>
+             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:38:38
    |
@@ -162,8 +162,8 @@ LL |     println!("{}", vec![(), ()].iter().sum::<i32>());
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
-             <i32 as Sum>
+             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:39:33
    |

--- a/tests/ui/lazy-type-alias/trailing-where-clause.stderr
+++ b/tests/ui/lazy-type-alias/trailing-where-clause.stderr
@@ -5,12 +5,12 @@ LL |     let _: Alias<()>;
    |                  ^^ the trait `From<()>` is not implemented for `String`
    |
    = help: the following other types implement trait `From<T>`:
-             <String as From<&String>>
-             <String as From<&mut str>>
-             <String as From<&str>>
-             <String as From<Box<str>>>
-             <String as From<Cow<'a, str>>>
-             <String as From<char>>
+             `String` implements `From<&String>`
+             `String` implements `From<&mut str>`
+             `String` implements `From<&str>`
+             `String` implements `From<Box<str>>`
+             `String` implements `From<Cow<'a, str>>`
+             `String` implements `From<char>`
 note: required by a bound in `Alias`
   --> $DIR/trailing-where-clause.rs:8:13
    |

--- a/tests/ui/mismatched_types/binops.stderr
+++ b/tests/ui/mismatched_types/binops.stderr
@@ -6,14 +6,14 @@ LL |     1 + Some(1);
    |
    = help: the trait `Add<Option<{integer}>>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f128 as Add<f128>>
-             <&'a f16 as Add<f16>>
-             <&'a f32 as Add<f32>>
-             <&'a f64 as Add<f64>>
-             <&'a i128 as Add<i128>>
-             <&'a i16 as Add<i16>>
-             <&'a i32 as Add<i32>>
-             <&'a i64 as Add<i64>>
+             `&'a f128` implements `Add<f128>`
+             `&'a f16` implements `Add<f16>`
+             `&'a f32` implements `Add<f32>`
+             `&'a f64` implements `Add<f64>`
+             `&'a i128` implements `Add<i128>`
+             `&'a i16` implements `Add<i16>`
+             `&'a i32` implements `Add<i32>`
+             `&'a i64` implements `Add<i64>`
            and 56 others
 
 error[E0277]: cannot subtract `Option<{integer}>` from `usize`
@@ -24,10 +24,10 @@ LL |     2 as usize - Some(1);
    |
    = help: the trait `Sub<Option<{integer}>>` is not implemented for `usize`
    = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a usize as Sub<usize>>
-             <&usize as Sub<&usize>>
-             <usize as Sub<&usize>>
-             <usize as Sub>
+             `&'a usize` implements `Sub<usize>`
+             `&usize` implements `Sub<&usize>`
+             `usize` implements `Sub<&usize>`
+             `usize` implements `Sub`
 
 error[E0277]: cannot multiply `{integer}` by `()`
   --> $DIR/binops.rs:4:7
@@ -37,14 +37,14 @@ LL |     3 * ();
    |
    = help: the trait `Mul<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f128 as Mul<f128>>
-             <&'a f16 as Mul<f16>>
-             <&'a f32 as Mul<f32>>
-             <&'a f64 as Mul<f64>>
-             <&'a i128 as Mul<i128>>
-             <&'a i16 as Mul<i16>>
-             <&'a i32 as Mul<i32>>
-             <&'a i64 as Mul<i64>>
+             `&'a f128` implements `Mul<f128>`
+             `&'a f16` implements `Mul<f16>`
+             `&'a f32` implements `Mul<f32>`
+             `&'a f64` implements `Mul<f64>`
+             `&'a i128` implements `Mul<i128>`
+             `&'a i16` implements `Mul<i16>`
+             `&'a i32` implements `Mul<i32>`
+             `&'a i64` implements `Mul<i64>`
            and 57 others
 
 error[E0277]: cannot divide `{integer}` by `&str`
@@ -55,14 +55,14 @@ LL |     4 / "";
    |
    = help: the trait `Div<&str>` is not implemented for `{integer}`
    = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f128 as Div<f128>>
-             <&'a f16 as Div<f16>>
-             <&'a f32 as Div<f32>>
-             <&'a f64 as Div<f64>>
-             <&'a i128 as Div<i128>>
-             <&'a i16 as Div<i16>>
-             <&'a i32 as Div<i32>>
-             <&'a i64 as Div<i64>>
+             `&'a f128` implements `Div<f128>`
+             `&'a f16` implements `Div<f16>`
+             `&'a f32` implements `Div<f32>`
+             `&'a f64` implements `Div<f64>`
+             `&'a i128` implements `Div<i128>`
+             `&'a i16` implements `Div<i16>`
+             `&'a i32` implements `Div<i32>`
+             `&'a i64` implements `Div<i64>`
            and 62 others
 
 error[E0277]: can't compare `{integer}` with `String`

--- a/tests/ui/never_type/issue-13352.stderr
+++ b/tests/ui/never_type/issue-13352.stderr
@@ -6,10 +6,10 @@ LL |     2_usize + (loop {});
    |
    = help: the trait `Add<()>` is not implemented for `usize`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a usize as Add<usize>>
-             <&usize as Add<&usize>>
-             <usize as Add<&usize>>
-             <usize as Add>
+             `&'a usize` implements `Add<usize>`
+             `&usize` implements `Add<&usize>`
+             `usize` implements `Add<&usize>`
+             `usize` implements `Add`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
+++ b/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
@@ -6,10 +6,10 @@ LL |     x + 100.0
    |
    = help: the trait `Add<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a u8 as Add<u8>>
-             <&u8 as Add<&u8>>
-             <u8 as Add<&u8>>
-             <u8 as Add>
+             `&'a u8` implements `Add<u8>`
+             `&u8` implements `Add<&u8>`
+             `u8` implements `Add<&u8>`
+             `u8` implements `Add`
 
 error[E0277]: cannot add `&str` to `f64`
   --> $DIR/not-suggest-float-literal.rs:6:7
@@ -19,10 +19,10 @@ LL |     x + "foo"
    |
    = help: the trait `Add<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f64 as Add<f64>>
-             <&f64 as Add<&f64>>
-             <f64 as Add<&f64>>
-             <f64 as Add>
+             `&'a f64` implements `Add<f64>`
+             `&f64` implements `Add<&f64>`
+             `f64` implements `Add<&f64>`
+             `f64` implements `Add`
 
 error[E0277]: cannot add `{integer}` to `f64`
   --> $DIR/not-suggest-float-literal.rs:11:7
@@ -32,10 +32,10 @@ LL |     x + y
    |
    = help: the trait `Add<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f64 as Add<f64>>
-             <&f64 as Add<&f64>>
-             <f64 as Add<&f64>>
-             <f64 as Add>
+             `&'a f64` implements `Add<f64>`
+             `&f64` implements `Add<&f64>`
+             `f64` implements `Add<&f64>`
+             `f64` implements `Add`
 
 error[E0277]: cannot subtract `{float}` from `u8`
   --> $DIR/not-suggest-float-literal.rs:15:7
@@ -45,10 +45,10 @@ LL |     x - 100.0
    |
    = help: the trait `Sub<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a u8 as Sub<u8>>
-             <&u8 as Sub<&u8>>
-             <u8 as Sub<&u8>>
-             <u8 as Sub>
+             `&'a u8` implements `Sub<u8>`
+             `&u8` implements `Sub<&u8>`
+             `u8` implements `Sub<&u8>`
+             `u8` implements `Sub`
 
 error[E0277]: cannot subtract `&str` from `f64`
   --> $DIR/not-suggest-float-literal.rs:19:7
@@ -58,10 +58,10 @@ LL |     x - "foo"
    |
    = help: the trait `Sub<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f64 as Sub<f64>>
-             <&f64 as Sub<&f64>>
-             <f64 as Sub<&f64>>
-             <f64 as Sub>
+             `&'a f64` implements `Sub<f64>`
+             `&f64` implements `Sub<&f64>`
+             `f64` implements `Sub<&f64>`
+             `f64` implements `Sub`
 
 error[E0277]: cannot subtract `{integer}` from `f64`
   --> $DIR/not-suggest-float-literal.rs:24:7
@@ -71,10 +71,10 @@ LL |     x - y
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f64 as Sub<f64>>
-             <&f64 as Sub<&f64>>
-             <f64 as Sub<&f64>>
-             <f64 as Sub>
+             `&'a f64` implements `Sub<f64>`
+             `&f64` implements `Sub<&f64>`
+             `f64` implements `Sub<&f64>`
+             `f64` implements `Sub`
 
 error[E0277]: cannot multiply `u8` by `{float}`
   --> $DIR/not-suggest-float-literal.rs:28:7
@@ -84,10 +84,10 @@ LL |     x * 100.0
    |
    = help: the trait `Mul<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a u8 as Mul<u8>>
-             <&u8 as Mul<&u8>>
-             <u8 as Mul<&u8>>
-             <u8 as Mul>
+             `&'a u8` implements `Mul<u8>`
+             `&u8` implements `Mul<&u8>`
+             `u8` implements `Mul<&u8>`
+             `u8` implements `Mul`
 
 error[E0277]: cannot multiply `f64` by `&str`
   --> $DIR/not-suggest-float-literal.rs:32:7
@@ -97,10 +97,10 @@ LL |     x * "foo"
    |
    = help: the trait `Mul<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f64 as Mul<f64>>
-             <&f64 as Mul<&f64>>
-             <f64 as Mul<&f64>>
-             <f64 as Mul>
+             `&'a f64` implements `Mul<f64>`
+             `&f64` implements `Mul<&f64>`
+             `f64` implements `Mul<&f64>`
+             `f64` implements `Mul`
 
 error[E0277]: cannot multiply `f64` by `{integer}`
   --> $DIR/not-suggest-float-literal.rs:37:7
@@ -110,10 +110,10 @@ LL |     x * y
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f64 as Mul<f64>>
-             <&f64 as Mul<&f64>>
-             <f64 as Mul<&f64>>
-             <f64 as Mul>
+             `&'a f64` implements `Mul<f64>`
+             `&f64` implements `Mul<&f64>`
+             `f64` implements `Mul<&f64>`
+             `f64` implements `Mul`
 
 error[E0277]: cannot divide `u8` by `{float}`
   --> $DIR/not-suggest-float-literal.rs:41:7
@@ -123,11 +123,11 @@ LL |     x / 100.0
    |
    = help: the trait `Div<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Div<Rhs>`:
-             <&'a u8 as Div<u8>>
-             <&u8 as Div<&u8>>
-             <u8 as Div<&u8>>
-             <u8 as Div<NonZero<u8>>>
-             <u8 as Div>
+             `&'a u8` implements `Div<u8>`
+             `&u8` implements `Div<&u8>`
+             `u8` implements `Div<&u8>`
+             `u8` implements `Div<NonZero<u8>>`
+             `u8` implements `Div`
 
 error[E0277]: cannot divide `f64` by `&str`
   --> $DIR/not-suggest-float-literal.rs:45:7
@@ -137,10 +137,10 @@ LL |     x / "foo"
    |
    = help: the trait `Div<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f64 as Div<f64>>
-             <&f64 as Div<&f64>>
-             <f64 as Div<&f64>>
-             <f64 as Div>
+             `&'a f64` implements `Div<f64>`
+             `&f64` implements `Div<&f64>`
+             `f64` implements `Div<&f64>`
+             `f64` implements `Div`
 
 error[E0277]: cannot divide `f64` by `{integer}`
   --> $DIR/not-suggest-float-literal.rs:50:7
@@ -150,10 +150,10 @@ LL |     x / y
    |
    = help: the trait `Div<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f64 as Div<f64>>
-             <&f64 as Div<&f64>>
-             <f64 as Div<&f64>>
-             <f64 as Div>
+             `&'a f64` implements `Div<f64>`
+             `&f64` implements `Div<&f64>`
+             `f64` implements `Div<&f64>`
+             `f64` implements `Div`
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/numbers-arithmetic/suggest-float-literal.stderr
+++ b/tests/ui/numbers-arithmetic/suggest-float-literal.stderr
@@ -6,10 +6,10 @@ LL |     x + 100
    |
    = help: the trait `Add<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f32 as Add<f32>>
-             <&f32 as Add<&f32>>
-             <f32 as Add<&f32>>
-             <f32 as Add>
+             `&'a f32` implements `Add<f32>`
+             `&f32` implements `Add<&f32>`
+             `f32` implements `Add<&f32>`
+             `f32` implements `Add`
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x + 100.0
@@ -23,10 +23,10 @@ LL |     x + 100
    |
    = help: the trait `Add<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a f64 as Add<f64>>
-             <&f64 as Add<&f64>>
-             <f64 as Add<&f64>>
-             <f64 as Add>
+             `&'a f64` implements `Add<f64>`
+             `&f64` implements `Add<&f64>`
+             `f64` implements `Add<&f64>`
+             `f64` implements `Add`
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x + 100.0
@@ -40,10 +40,10 @@ LL |     x - 100
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f32 as Sub<f32>>
-             <&f32 as Sub<&f32>>
-             <f32 as Sub<&f32>>
-             <f32 as Sub>
+             `&'a f32` implements `Sub<f32>`
+             `&f32` implements `Sub<&f32>`
+             `f32` implements `Sub<&f32>`
+             `f32` implements `Sub`
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x - 100.0
@@ -57,10 +57,10 @@ LL |     x - 100
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
-             <&'a f64 as Sub<f64>>
-             <&f64 as Sub<&f64>>
-             <f64 as Sub<&f64>>
-             <f64 as Sub>
+             `&'a f64` implements `Sub<f64>`
+             `&f64` implements `Sub<&f64>`
+             `f64` implements `Sub<&f64>`
+             `f64` implements `Sub`
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x - 100.0
@@ -74,10 +74,10 @@ LL |     x * 100
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f32 as Mul<f32>>
-             <&f32 as Mul<&f32>>
-             <f32 as Mul<&f32>>
-             <f32 as Mul>
+             `&'a f32` implements `Mul<f32>`
+             `&f32` implements `Mul<&f32>`
+             `f32` implements `Mul<&f32>`
+             `f32` implements `Mul`
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x * 100.0
@@ -91,10 +91,10 @@ LL |     x * 100
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Mul<Rhs>`:
-             <&'a f64 as Mul<f64>>
-             <&f64 as Mul<&f64>>
-             <f64 as Mul<&f64>>
-             <f64 as Mul>
+             `&'a f64` implements `Mul<f64>`
+             `&f64` implements `Mul<&f64>`
+             `f64` implements `Mul<&f64>`
+             `f64` implements `Mul`
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x * 100.0
@@ -108,10 +108,10 @@ LL |     x / 100
    |
    = help: the trait `Div<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f32 as Div<f32>>
-             <&f32 as Div<&f32>>
-             <f32 as Div<&f32>>
-             <f32 as Div>
+             `&'a f32` implements `Div<f32>`
+             `&f32` implements `Div<&f32>`
+             `f32` implements `Div<&f32>`
+             `f32` implements `Div`
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x / 100.0
@@ -125,10 +125,10 @@ LL |     x / 100
    |
    = help: the trait `Div<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Div<Rhs>`:
-             <&'a f64 as Div<f64>>
-             <&f64 as Div<&f64>>
-             <f64 as Div<&f64>>
-             <f64 as Div>
+             `&'a f64` implements `Div<f64>`
+             `&f64` implements `Div<&f64>`
+             `f64` implements `Div<&f64>`
+             `f64` implements `Div`
 help: consider using a floating-point literal by writing it with `.0`
    |
 LL |     x / 100.0

--- a/tests/ui/on-unimplemented/multiple-impls.stderr
+++ b/tests/ui/on-unimplemented/multiple-impls.stderr
@@ -8,8 +8,8 @@ LL |     Index::index(&[] as &[i32], 2u32);
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
+             `[i32]` implements `Index<Bar<usize>>`
+             `[i32]` implements `Index<Foo<usize>>`
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:36:33
@@ -21,8 +21,8 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
+             `[i32]` implements `Index<Bar<usize>>`
+             `[i32]` implements `Index<Foo<usize>>`
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:39:33
@@ -34,8 +34,8 @@ LL |     Index::index(&[] as &[i32], Bar(2u32));
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
+             `[i32]` implements `Index<Bar<usize>>`
+             `[i32]` implements `Index<Foo<usize>>`
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:5
@@ -45,8 +45,8 @@ LL |     Index::index(&[] as &[i32], 2u32);
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
+             `[i32]` implements `Index<Bar<usize>>`
+             `[i32]` implements `Index<Foo<usize>>`
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:36:5
@@ -56,8 +56,8 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
+             `[i32]` implements `Index<Bar<usize>>`
+             `[i32]` implements `Index<Foo<usize>>`
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:39:5
@@ -67,8 +67,8 @@ LL |     Index::index(&[] as &[i32], Bar(2u32));
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
    = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Bar<usize>>>
-             <[i32] as Index<Foo<usize>>>
+             `[i32]` implements `Index<Bar<usize>>`
+             `[i32]` implements `Index<Foo<usize>>`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/on-unimplemented/slice-index.stderr
+++ b/tests/ui/on-unimplemented/slice-index.stderr
@@ -17,8 +17,8 @@ LL |     x[..1i32];
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `RangeTo<i32>`, which is required by `[i32]: Index<_>`
    = help: the following other types implement trait `SliceIndex<T>`:
-             <RangeTo<usize> as SliceIndex<[T]>>
-             <RangeTo<usize> as SliceIndex<str>>
+             `RangeTo<usize>` implements `SliceIndex<[T]>`
+             `RangeTo<usize>` implements `SliceIndex<str>`
    = note: required for `[i32]` to implement `Index<RangeTo<i32>>`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/on-unimplemented/sum.stderr
+++ b/tests/ui/on-unimplemented/sum.stderr
@@ -8,8 +8,8 @@ LL |     vec![(), ()].iter().sum::<i32>();
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             <i32 as Sum<&'a i32>>
-             <i32 as Sum>
+             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/sum.rs:4:18
    |
@@ -30,8 +30,8 @@ LL |     vec![(), ()].iter().product::<i32>();
    |
    = help: the trait `Product<&()>` is not implemented for `i32`
    = help: the following other types implement trait `Product<A>`:
-             <i32 as Product<&'a i32>>
-             <i32 as Product>
+             `i32` implements `Product<&'a i32>`
+             `i32` implements `Product`
 note: the method call chain might not have had the expected associated types
   --> $DIR/sum.rs:7:18
    |

--- a/tests/ui/span/multiline-span-simple.stderr
+++ b/tests/ui/span/multiline-span-simple.stderr
@@ -6,10 +6,10 @@ LL |     foo(1 as u32 +
    |
    = help: the trait `Add<()>` is not implemented for `u32`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a u32 as Add<u32>>
-             <&u32 as Add<&u32>>
-             <u32 as Add<&u32>>
-             <u32 as Add>
+             `&'a u32` implements `Add<u32>`
+             `&u32` implements `Add<&u32>`
+             `u32` implements `Add<&u32>`
+             `u32` implements `Add`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/into-str.stderr
+++ b/tests/ui/suggestions/into-str.stderr
@@ -8,12 +8,12 @@ LL |     foo(String::new());
    |
    = note: to coerce a `String` into a `&str`, use `&*` as a prefix
    = help: the following other types implement trait `From<T>`:
-             <String as From<&String>>
-             <String as From<&mut str>>
-             <String as From<&str>>
-             <String as From<Box<str>>>
-             <String as From<Cow<'a, str>>>
-             <String as From<char>>
+             `String` implements `From<&String>`
+             `String` implements `From<&mut str>`
+             `String` implements `From<&str>`
+             `String` implements `From<Box<str>>`
+             `String` implements `From<Cow<'a, str>>`
+             `String` implements `From<char>`
    = note: required for `String` to implement `Into<&str>`
 note: required by a bound in `foo`
   --> $DIR/into-str.rs:1:31

--- a/tests/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/tests/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -5,14 +5,14 @@ LL |     let _: &[i8] = data.into();
    |                         ^^^^ the trait `From<&[u8]>` is not implemented for `&[i8]`, which is required by `&[u8]: Into<_>`
    |
    = help: the following other types implement trait `From<T>`:
-             <[T; 10] as From<(T, T, T, T, T, T, T, T, T, T)>>
-             <[T; 11] as From<(T, T, T, T, T, T, T, T, T, T, T)>>
-             <[T; 12] as From<(T, T, T, T, T, T, T, T, T, T, T, T)>>
-             <[T; 1] as From<(T,)>>
-             <[T; 2] as From<(T, T)>>
-             <[T; 3] as From<(T, T, T)>>
-             <[T; 4] as From<(T, T, T, T)>>
-             <[T; 5] as From<(T, T, T, T, T)>>
+             `[T; 10]` implements `From<(T, T, T, T, T, T, T, T, T, T)>`
+             `[T; 11]` implements `From<(T, T, T, T, T, T, T, T, T, T, T)>`
+             `[T; 12]` implements `From<(T, T, T, T, T, T, T, T, T, T, T, T)>`
+             `[T; 1]` implements `From<(T,)>`
+             `[T; 2]` implements `From<(T, T)>`
+             `[T; 3]` implements `From<(T, T, T)>`
+             `[T; 4]` implements `From<(T, T, T, T)>`
+             `[T; 5]` implements `From<(T, T, T, T, T)>`
            and 6 others
    = note: required for `&[u8]` to implement `Into<&[i8]>`
 

--- a/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
+++ b/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
@@ -7,8 +7,8 @@ LL |     c.same_as(22)
    |       required by a bound introduced by this call
    |
    = help: the following other types implement trait `CompareTo<T>`:
-             <i64 as CompareTo<i64>>
-             <i64 as CompareTo<u64>>
+             `i64` implements `CompareTo<i64>`
+             `i64` implements `CompareTo<u64>`
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:30:15
@@ -30,8 +30,8 @@ LL |     <dyn CompareToInts>::same_as(c, 22)
    |      ^^^^^^^^^^^^^^^^^ the trait `CompareTo<i32>` is not implemented for `dyn CompareToInts`
    |
    = help: the following other types implement trait `CompareTo<T>`:
-             <i64 as CompareTo<i64>>
-             <i64 as CompareTo<u64>>
+             `i64` implements `CompareTo<i64>`
+             `i64` implements `CompareTo<u64>`
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:38:27
@@ -55,8 +55,8 @@ LL |     assert_eq!(22_i64.same_as(22), true);
    |                       required by a bound introduced by this call
    |
    = help: the following other types implement trait `CompareTo<T>`:
-             <i64 as CompareTo<i64>>
-             <i64 as CompareTo<u64>>
+             `i64` implements `CompareTo<i64>`
+             `i64` implements `CompareTo<u64>`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/traits/next-solver/unevaluated-const-impl-trait-ref.fails.stderr
+++ b/tests/ui/traits/next-solver/unevaluated-const-impl-trait-ref.fails.stderr
@@ -5,8 +5,8 @@ LL |     needs::<1>();
    |             ^ the trait `Trait<1>` is not implemented for `()`
    |
    = help: the following other types implement trait `Trait<N>`:
-             <() as Trait<0>>
-             <() as Trait<2>>
+             `()` implements `Trait<0>`
+             `()` implements `Trait<2>`
 note: required by a bound in `needs`
   --> $DIR/unevaluated-const-impl-trait-ref.rs:10:38
    |

--- a/tests/ui/traits/question-mark-result-err-mismatch.stderr
+++ b/tests/ui/traits/question-mark-result-err-mismatch.stderr
@@ -31,12 +31,12 @@ LL |         .map_err(|_| ())?;
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
-             <String as From<&String>>
-             <String as From<&mut str>>
-             <String as From<&str>>
-             <String as From<Box<str>>>
-             <String as From<Cow<'a, str>>>
-             <String as From<char>>
+             `String` implements `From<&String>`
+             `String` implements `From<&mut str>`
+             `String` implements `From<&str>`
+             `String` implements `From<Box<str>>`
+             `String` implements `From<Cow<'a, str>>`
+             `String` implements `From<char>`
    = note: required for `Result<(), String>` to implement `FromResidual<Result<Infallible, ()>>`
 
 error[E0277]: `?` couldn't convert the error to `String`

--- a/tests/ui/try-trait/bad-interconversion.stderr
+++ b/tests/ui/try-trait/bad-interconversion.stderr
@@ -10,8 +10,8 @@ LL |     Ok(Err(123_i32)?)
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
-             <u8 as From<Char>>
-             <u8 as From<bool>>
+             `u8` implements `From<Char>`
+             `u8` implements `From<bool>`
    = note: required for `Result<u64, u8>` to implement `FromResidual<Result<Infallible, i32>>`
 
 error[E0277]: the `?` operator can only be used on `Result`s, not `Option`s, in a function that returns `Result`
@@ -24,8 +24,8 @@ LL |     Some(3)?;
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<u64, String>`
    = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
-             <Result<T, F> as FromResidual<Yeet<E>>>
+             `Result<T, F>` implements `FromResidual<Result<Infallible, E>>`
+             `Result<T, F>` implements `FromResidual<Yeet<E>>`
 
 error[E0277]: the `?` operator can only be used on `Result`s in a function that returns `Result`
   --> $DIR/bad-interconversion.rs:17:31
@@ -37,8 +37,8 @@ LL |     Ok(ControlFlow::Break(123)?)
    |
    = help: the trait `FromResidual<ControlFlow<{integer}, Infallible>>` is not implemented for `Result<u64, String>`
    = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
-             <Result<T, F> as FromResidual<Yeet<E>>>
+             `Result<T, F>` implements `FromResidual<Result<Infallible, E>>`
+             `Result<T, F>` implements `FromResidual<Yeet<E>>`
 
 error[E0277]: the `?` operator can only be used on `Option`s, not `Result`s, in a function that returns `Option`
   --> $DIR/bad-interconversion.rs:22:22
@@ -50,8 +50,8 @@ LL |     Some(Err("hello")?)
    |
    = help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `Option<u16>`
    = help: the following other types implement trait `FromResidual<R>`:
-             <Option<T> as FromResidual<Yeet<()>>>
-             <Option<T> as FromResidual>
+             `Option<T>` implements `FromResidual<Yeet<()>>`
+             `Option<T>` implements `FromResidual`
 
 error[E0277]: the `?` operator can only be used on `Option`s in a function that returns `Option`
   --> $DIR/bad-interconversion.rs:27:33
@@ -63,8 +63,8 @@ LL |     Some(ControlFlow::Break(123)?)
    |
    = help: the trait `FromResidual<ControlFlow<{integer}, Infallible>>` is not implemented for `Option<u64>`
    = help: the following other types implement trait `FromResidual<R>`:
-             <Option<T> as FromResidual<Yeet<()>>>
-             <Option<T> as FromResidual>
+             `Option<T>` implements `FromResidual<Yeet<()>>`
+             `Option<T>` implements `FromResidual`
 
 error[E0277]: the `?` operator can only be used on `ControlFlow`s in a function that returns `ControlFlow`
   --> $DIR/bad-interconversion.rs:32:39

--- a/tests/ui/try-trait/issue-32709.stderr
+++ b/tests/ui/try-trait/issue-32709.stderr
@@ -10,14 +10,14 @@ LL |     Err(5)?;
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
-             <(T, T) as From<[T; 2]>>
-             <(T, T, T) as From<[T; 3]>>
-             <(T, T, T, T) as From<[T; 4]>>
-             <(T, T, T, T, T) as From<[T; 5]>>
-             <(T, T, T, T, T, T) as From<[T; 6]>>
-             <(T, T, T, T, T, T, T) as From<[T; 7]>>
-             <(T, T, T, T, T, T, T, T) as From<[T; 8]>>
-             <(T, T, T, T, T, T, T, T, T) as From<[T; 9]>>
+             `(T, T)` implements `From<[T; 2]>`
+             `(T, T, T)` implements `From<[T; 3]>`
+             `(T, T, T, T)` implements `From<[T; 4]>`
+             `(T, T, T, T, T)` implements `From<[T; 5]>`
+             `(T, T, T, T, T, T)` implements `From<[T; 6]>`
+             `(T, T, T, T, T, T, T)` implements `From<[T; 7]>`
+             `(T, T, T, T, T, T, T, T)` implements `From<[T; 8]>`
+             `(T, T, T, T, T, T, T, T, T)` implements `From<[T; 9]>`
            and 4 others
    = note: required for `Result<i32, ()>` to implement `FromResidual<Result<Infallible, {integer}>>`
 

--- a/tests/ui/try-trait/option-to-result.stderr
+++ b/tests/ui/try-trait/option-to-result.stderr
@@ -9,8 +9,8 @@ LL |     a?;
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<(), ()>`
    = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
-             <Result<T, F> as FromResidual<Yeet<E>>>
+             `Result<T, F>` implements `FromResidual<Result<Infallible, E>>`
+             `Result<T, F>` implements `FromResidual<Yeet<E>>`
 
 error[E0277]: the `?` operator can only be used on `Option`s, not `Result`s, in a function that returns `Option`
   --> $DIR/option-to-result.rs:11:6
@@ -23,8 +23,8 @@ LL |     a?;
    |
    = help: the trait `FromResidual<Result<Infallible, i32>>` is not implemented for `Option<i32>`
    = help: the following other types implement trait `FromResidual<R>`:
-             <Option<T> as FromResidual<Yeet<()>>>
-             <Option<T> as FromResidual>
+             `Option<T>` implements `FromResidual<Yeet<()>>`
+             `Option<T>` implements `FromResidual`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/try-trait/try-on-option.stderr
+++ b/tests/ui/try-trait/try-on-option.stderr
@@ -9,8 +9,8 @@ LL |     x?;
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<u32, ()>`
    = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
-             <Result<T, F> as FromResidual<Yeet<E>>>
+             `Result<T, F>` implements `FromResidual<Result<Infallible, E>>`
+             `Result<T, F>` implements `FromResidual<Yeet<E>>`
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-on-option.rs:11:6

--- a/tests/ui/type/type-check-defaults.stderr
+++ b/tests/ui/type/type-check-defaults.stderr
@@ -66,10 +66,10 @@ LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
    |
    = help: the trait `Add<u8>` is not implemented for `i32`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a i32 as Add<i32>>
-             <&i32 as Add<&i32>>
-             <i32 as Add<&i32>>
-             <i32 as Add>
+             `&'a i32` implements `Add<i32>`
+             `&i32` implements `Add<&i32>`
+             `i32` implements `Add<&i32>`
+             `i32` implements `Add`
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/typeck/issue-81293.stderr
+++ b/tests/ui/typeck/issue-81293.stderr
@@ -21,10 +21,10 @@ LL |     a = c + b * 5;
    |
    = help: the trait `Add<u16>` is not implemented for `usize`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a usize as Add<usize>>
-             <&usize as Add<&usize>>
-             <usize as Add<&usize>>
-             <usize as Add>
+             `&'a usize` implements `Add<usize>`
+             `&usize` implements `Add<&usize>`
+             `usize` implements `Add<&usize>`
+             `usize` implements `Add`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/issue-90101.stderr
+++ b/tests/ui/typeck/issue-90101.stderr
@@ -7,11 +7,11 @@ LL |     func(Path::new("hello").to_path_buf().to_string_lossy(), "world")
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `From<T>`:
-             <PathBuf as From<&T>>
-             <PathBuf as From<Box<Path>>>
-             <PathBuf as From<Cow<'a, Path>>>
-             <PathBuf as From<OsString>>
-             <PathBuf as From<String>>
+             `PathBuf` implements `From<&T>`
+             `PathBuf` implements `From<Box<Path>>`
+             `PathBuf` implements `From<Cow<'a, Path>>`
+             `PathBuf` implements `From<OsString>`
+             `PathBuf` implements `From<String>`
    = note: required for `Cow<'_, str>` to implement `Into<PathBuf>`
 note: required by a bound in `func`
   --> $DIR/issue-90101.rs:3:20

--- a/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -6,10 +6,10 @@ LL |     <i32 as Add<u32>>::add(1, 2);
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a i32 as Add<i32>>
-             <&i32 as Add<&i32>>
-             <i32 as Add<&i32>>
-             <i32 as Add>
+             `&'a i32` implements `Add<i32>`
+             `&i32` implements `Add<&i32>`
+             `i32` implements `Add<&i32>`
+             `i32` implements `Add`
 
 error[E0277]: cannot add `u32` to `i32`
   --> $DIR/ufcs-qpath-self-mismatch.rs:4:5
@@ -19,10 +19,10 @@ LL |     <i32 as Add<u32>>::add(1, 2);
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
    = help: the following other types implement trait `Add<Rhs>`:
-             <&'a i32 as Add<i32>>
-             <&i32 as Add<&i32>>
-             <i32 as Add<&i32>>
-             <i32 as Add>
+             `&'a i32` implements `Add<i32>`
+             `&i32` implements `Add<&i32>`
+             `i32` implements `Add<&i32>`
+             `i32` implements `Add`
 
 error[E0308]: mismatched types
   --> $DIR/ufcs-qpath-self-mismatch.rs:7:28


### PR DESCRIPTION
Successful merges:

 - #123374 (DOC: Add FFI example for slice::from_raw_parts())
 - #126127 (Spell out other trait diagnostic)
 - #126228 (Provide correct parent for nested anon const)
 - #126249 (Simplify `[T; N]::try_map` signature)
 - #126256 (Add {{target}} substitution to compiletest)
 - #126263 (Make issue-122805.rs big endian compatible)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=123374,126127,126228,126249,126256,126263)
<!-- homu-ignore:end -->