### PR TITLE
Remove superfluous UbChecks from `SliceIndex` methods

### DIFF
--- a/tests/mir-opt/pre-codegen/slice_index.rs
+++ b/tests/mir-opt/pre-codegen/slice_index.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 //@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2 -Z ub-checks=yes
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
@@ -9,21 +8,39 @@ use std::ops::Range;
 
 // EMIT_MIR slice_index.slice_index_usize.PreCodegen.after.mir
 pub fn slice_index_usize(slice: &[u32], index: usize) -> u32 {
+    // CHECK-LABEL: slice_index_usize
+    // CHECK: [[LEN:_[0-9]+]] = Len((*_1))
+    // CHECK: Lt(_2, [[LEN]])
+    // CHECK-NOT: precondition_check
+    // CHECK: _0 = (*_1)[_2];
     slice[index]
 }
 
 // EMIT_MIR slice_index.slice_get_mut_usize.PreCodegen.after.mir
 pub fn slice_get_mut_usize(slice: &mut [u32], index: usize) -> Option<&mut u32> {
+    // CHECK-LABEL: slice_get_mut_usize
+    // CHECK: [[LEN:_[0-9]+]] = Len((*_1))
+    // CHECK: Lt(_2, move [[LEN]])
+    // CHECK-NOT: precondition_check
     slice.get_mut(index)
 }
 
 // EMIT_MIR slice_index.slice_index_range.PreCodegen.after.mir
 pub fn slice_index_range(slice: &[u32], index: Range<usize>) -> &[u32] {
+    // CHECK-LABEL: slice_index_range
     &slice[index]
 }
 
 // EMIT_MIR slice_index.slice_get_unchecked_mut_range.PreCodegen.after.mir
 pub unsafe fn slice_get_unchecked_mut_range(slice: &mut [u32], index: Range<usize>) -> &mut [u32] {
+    // CHECK-LABEL: slice_get_unchecked_mut_range
+    // CHECK: [[START:_[0-9]+]] = move (_2.0: usize);
+    // CHECK: [[END:_[0-9]+]] = move (_2.1: usize);
+    // CHECK: precondition_check
+    // CHECK: [[LEN:_[0-9]+]] = SubUnchecked([[END]], [[START]]);
+    // CHECK: [[PTR:_[0-9]+]] = Offset({{_[0-9]+}}, [[START]]);
+    // CHECK: [[SLICE:_[0-9]+]] = *mut [u32] from ([[PTR]], [[LEN]])
+    // CHECK: _0 = &mut (*[[SLICE]]);
     slice.get_unchecked_mut(index)
 }
 
@@ -32,5 +49,12 @@ pub unsafe fn slice_ptr_get_unchecked_range(
     slice: *const [u32],
     index: Range<usize>,
 ) -> *const [u32] {
+    // CHECK-LABEL: slice_ptr_get_unchecked_range
+    // CHECK: [[START:_[0-9]+]] = move (_2.0: usize);
+    // CHECK: [[END:_[0-9]+]] = move (_2.1: usize);
+    // CHECK: precondition_check
+    // CHECK: [[LEN:_[0-9]+]] = SubUnchecked([[END]], [[START]]);
+    // CHECK: [[PTR:_[0-9]+]] = Offset({{_[0-9]+}}, [[START]]);
+    // CHECK: _0 = *const [u32] from ([[PTR]], [[LEN]])
     slice.get_unchecked(index)
 }

--- a/tests/mir-opt/pre-codegen/slice_index.rs
+++ b/tests/mir-opt/pre-codegen/slice_index.rs
@@ -1,5 +1,5 @@
 // skip-filecheck
-//@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2
+//@ compile-flags: -O -C debuginfo=0 -Zmir-opt-level=2 -Z ub-checks=yes
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 #![crate_type = "lib"]

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-abort.mir
@@ -5,13 +5,54 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
     debug index => _2;
     let mut _0: std::option::Option<&mut u32>;
     scope 1 (inlined core::slice::<impl [u32]>::get_mut::<usize>) {
+        scope 2 (inlined <usize as SliceIndex<[u32]>>::get_mut) {
+            let mut _3: usize;
+            let mut _4: bool;
+            let mut _5: *mut [u32];
+            let mut _7: *mut u32;
+            let mut _8: &mut u32;
+            scope 3 (inlined core::slice::index::get_mut_noubcheck::<u32>) {
+                let _6: *mut u32;
+                scope 4 {
+                }
+            }
+        }
     }
 
     bb0: {
-        _0 = <usize as SliceIndex<[u32]>>::get_mut(move _2, move _1) -> [return: bb1, unwind unreachable];
+        StorageLive(_7);
+        StorageLive(_4);
+        StorageLive(_3);
+        _3 = Len((*_1));
+        _4 = Lt(_2, move _3);
+        switchInt(move _4) -> [0: bb1, otherwise: bb2];
     }
 
     bb1: {
+        StorageDead(_3);
+        _0 = const Option::<&mut u32>::None;
+        goto -> bb3;
+    }
+
+    bb2: {
+        StorageDead(_3);
+        StorageLive(_8);
+        StorageLive(_5);
+        _5 = &raw mut (*_1);
+        StorageLive(_6);
+        _6 = _5 as *mut u32 (PtrToPtr);
+        _7 = Offset(_6, _2);
+        StorageDead(_6);
+        StorageDead(_5);
+        _8 = &mut (*_7);
+        _0 = Option::<&mut u32>::Some(move _8);
+        StorageDead(_8);
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_4);
+        StorageDead(_7);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-unwind.mir
@@ -5,13 +5,54 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
     debug index => _2;
     let mut _0: std::option::Option<&mut u32>;
     scope 1 (inlined core::slice::<impl [u32]>::get_mut::<usize>) {
+        scope 2 (inlined <usize as SliceIndex<[u32]>>::get_mut) {
+            let mut _3: usize;
+            let mut _4: bool;
+            let mut _5: *mut [u32];
+            let mut _7: *mut u32;
+            let mut _8: &mut u32;
+            scope 3 (inlined core::slice::index::get_mut_noubcheck::<u32>) {
+                let _6: *mut u32;
+                scope 4 {
+                }
+            }
+        }
     }
 
     bb0: {
-        _0 = <usize as SliceIndex<[u32]>>::get_mut(move _2, move _1) -> [return: bb1, unwind continue];
+        StorageLive(_7);
+        StorageLive(_4);
+        StorageLive(_3);
+        _3 = Len((*_1));
+        _4 = Lt(_2, move _3);
+        switchInt(move _4) -> [0: bb1, otherwise: bb2];
     }
 
     bb1: {
+        StorageDead(_3);
+        _0 = const Option::<&mut u32>::None;
+        goto -> bb3;
+    }
+
+    bb2: {
+        StorageDead(_3);
+        StorageLive(_8);
+        StorageLive(_5);
+        _5 = &raw mut (*_1);
+        StorageLive(_6);
+        _6 = _5 as *mut u32 (PtrToPtr);
+        _7 = Offset(_6, _2);
+        StorageDead(_6);
+        StorageDead(_5);
+        _8 = &mut (*_7);
+        _0 = Option::<&mut u32>::Some(move _8);
+        StorageDead(_8);
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_4);
+        StorageDead(_7);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
@@ -4,20 +4,62 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     debug slice => _1;
     debug index => _2;
     let mut _0: &mut [u32];
+    let mut _3: usize;
+    let mut _4: usize;
     scope 1 (inlined core::slice::<impl [u32]>::get_unchecked_mut::<std::ops::Range<usize>>) {
-        let mut _3: *mut [u32];
-        let mut _4: *mut [u32];
+        let mut _5: *mut [u32];
+        let mut _12: *mut [u32];
+        scope 2 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) {
+            let mut _7: usize;
+            let _8: ();
+            let _9: usize;
+            scope 3 {
+                scope 6 (inlined core::slice::index::get_offset_len_mut_noubcheck::<u32>) {
+                    let _11: *mut u32;
+                    scope 7 {
+                    }
+                    scope 8 (inlined core::slice::index::get_mut_noubcheck::<u32>) {
+                        let _10: *mut u32;
+                        scope 9 {
+                        }
+                    }
+                }
+            }
+            scope 4 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::len) {
+                let mut _6: *const [u32];
+                scope 5 (inlined std::ptr::metadata::<[u32]>) {
+                }
+            }
+        }
     }
 
     bb0: {
-        StorageLive(_3);
-        _3 = &raw mut (*_1);
-        _4 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut(move _2, move _3) -> [return: bb1, unwind unreachable];
+        _3 = move (_2.0: usize);
+        _4 = move (_2.1: usize);
+        StorageLive(_5);
+        _5 = &raw mut (*_1);
+        StorageLive(_9);
+        StorageLive(_7);
+        StorageLive(_6);
+        _6 = _5 as *const [u32] (PointerCoercion(MutToConstPointer));
+        _7 = PtrMetadata(_6);
+        StorageDead(_6);
+        _8 = <std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked_mut::precondition_check(_3, _4, move _7) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        StorageDead(_3);
-        _0 = &mut (*_4);
+        StorageDead(_7);
+        _9 = SubUnchecked(_4, _3);
+        StorageLive(_11);
+        StorageLive(_10);
+        _10 = _5 as *mut u32 (PtrToPtr);
+        _11 = Offset(_10, _3);
+        StorageDead(_10);
+        _12 = *mut [u32] from (_11, _9);
+        StorageDead(_11);
+        StorageDead(_9);
+        StorageDead(_5);
+        _0 = &mut (*_12);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
@@ -4,20 +4,62 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     debug slice => _1;
     debug index => _2;
     let mut _0: &mut [u32];
+    let mut _3: usize;
+    let mut _4: usize;
     scope 1 (inlined core::slice::<impl [u32]>::get_unchecked_mut::<std::ops::Range<usize>>) {
-        let mut _3: *mut [u32];
-        let mut _4: *mut [u32];
+        let mut _5: *mut [u32];
+        let mut _12: *mut [u32];
+        scope 2 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) {
+            let mut _7: usize;
+            let _8: ();
+            let _9: usize;
+            scope 3 {
+                scope 6 (inlined core::slice::index::get_offset_len_mut_noubcheck::<u32>) {
+                    let _11: *mut u32;
+                    scope 7 {
+                    }
+                    scope 8 (inlined core::slice::index::get_mut_noubcheck::<u32>) {
+                        let _10: *mut u32;
+                        scope 9 {
+                        }
+                    }
+                }
+            }
+            scope 4 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::len) {
+                let mut _6: *const [u32];
+                scope 5 (inlined std::ptr::metadata::<[u32]>) {
+                }
+            }
+        }
     }
 
     bb0: {
-        StorageLive(_3);
-        _3 = &raw mut (*_1);
-        _4 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut(move _2, move _3) -> [return: bb1, unwind continue];
+        _3 = move (_2.0: usize);
+        _4 = move (_2.1: usize);
+        StorageLive(_5);
+        _5 = &raw mut (*_1);
+        StorageLive(_9);
+        StorageLive(_7);
+        StorageLive(_6);
+        _6 = _5 as *const [u32] (PointerCoercion(MutToConstPointer));
+        _7 = PtrMetadata(_6);
+        StorageDead(_6);
+        _8 = <std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked_mut::precondition_check(_3, _4, move _7) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        StorageDead(_3);
-        _0 = &mut (*_4);
+        StorageDead(_7);
+        _9 = SubUnchecked(_4, _3);
+        StorageLive(_11);
+        StorageLive(_10);
+        _10 = _5 as *mut u32 (PtrToPtr);
+        _11 = Offset(_10, _3);
+        StorageDead(_10);
+        _12 = *mut [u32] from (_11, _9);
+        StorageDead(_11);
+        StorageDead(_9);
+        StorageDead(_5);
+        _0 = &mut (*_12);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-abort.mir
@@ -4,14 +4,52 @@ fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -
     debug slice => _1;
     debug index => _2;
     let mut _0: *const [u32];
+    let mut _3: usize;
+    let mut _4: usize;
     scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::get_unchecked::<std::ops::Range<usize>>) {
+        scope 2 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked) {
+            let mut _5: usize;
+            let _6: ();
+            let _7: usize;
+            scope 3 {
+                scope 6 (inlined core::slice::index::get_offset_len_noubcheck::<u32>) {
+                    let _9: *const u32;
+                    scope 7 {
+                    }
+                    scope 8 (inlined core::slice::index::get_noubcheck::<u32>) {
+                        let _8: *const u32;
+                        scope 9 {
+                        }
+                    }
+                }
+            }
+            scope 4 (inlined std::ptr::const_ptr::<impl *const [u32]>::len) {
+                scope 5 (inlined std::ptr::metadata::<[u32]>) {
+                }
+            }
+        }
     }
 
     bb0: {
-        _0 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked(move _2, move _1) -> [return: bb1, unwind unreachable];
+        _3 = move (_2.0: usize);
+        _4 = move (_2.1: usize);
+        StorageLive(_7);
+        StorageLive(_5);
+        _5 = PtrMetadata(_1);
+        _6 = <std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked::precondition_check(_3, _4, move _5) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
+        StorageDead(_5);
+        _7 = SubUnchecked(_4, _3);
+        StorageLive(_9);
+        StorageLive(_8);
+        _8 = _1 as *const u32 (PtrToPtr);
+        _9 = Offset(_8, _3);
+        StorageDead(_8);
+        _0 = *const [u32] from (_9, _7);
+        StorageDead(_9);
+        StorageDead(_7);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_ptr_get_unchecked_range.PreCodegen.after.panic-unwind.mir
@@ -4,14 +4,52 @@ fn slice_ptr_get_unchecked_range(_1: *const [u32], _2: std::ops::Range<usize>) -
     debug slice => _1;
     debug index => _2;
     let mut _0: *const [u32];
+    let mut _3: usize;
+    let mut _4: usize;
     scope 1 (inlined std::ptr::const_ptr::<impl *const [u32]>::get_unchecked::<std::ops::Range<usize>>) {
+        scope 2 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked) {
+            let mut _5: usize;
+            let _6: ();
+            let _7: usize;
+            scope 3 {
+                scope 6 (inlined core::slice::index::get_offset_len_noubcheck::<u32>) {
+                    let _9: *const u32;
+                    scope 7 {
+                    }
+                    scope 8 (inlined core::slice::index::get_noubcheck::<u32>) {
+                        let _8: *const u32;
+                        scope 9 {
+                        }
+                    }
+                }
+            }
+            scope 4 (inlined std::ptr::const_ptr::<impl *const [u32]>::len) {
+                scope 5 (inlined std::ptr::metadata::<[u32]>) {
+                }
+            }
+        }
     }
 
     bb0: {
-        _0 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked(move _2, move _1) -> [return: bb1, unwind continue];
+        _3 = move (_2.0: usize);
+        _4 = move (_2.1: usize);
+        StorageLive(_7);
+        StorageLive(_5);
+        _5 = PtrMetadata(_1);
+        _6 = <std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked::precondition_check(_3, _4, move _5) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
+        StorageDead(_5);
+        _7 = SubUnchecked(_4, _3);
+        StorageLive(_9);
+        StorageLive(_8);
+        _8 = _1 as *const u32 (PtrToPtr);
+        _9 = Offset(_8, _3);
+        StorageDead(_8);
+        _0 = *const [u32] from (_9, _7);
+        StorageDead(_9);
+        StorageDead(_7);
         return;
     }
 }


### PR DESCRIPTION
The current implementation calls the unsafe ones from the safe ones, but that means they end up emitting UbChecks that are impossible to hit, since we just checked those things.

This PR adds some new module-local helpers for the code shared between them, so the safe methods can be small enough to inline by avoiding those extra checks, while the unsafe methods still help catch length mistakes.

r? @saethlin 