### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -533,11 +533,9 @@ impl<T, const N: usize> [T; N] {
     /// assert_eq!(c, Some(a));
     /// ```
     #[unstable(feature = "array_try_map", issue = "79711")]
-    pub fn try_map<F, R>(self, f: F) -> ChangeOutputType<R, [R::Output; N]>
+    pub fn try_map<R>(self, f: impl FnMut(T) -> R) -> ChangeOutputType<R, [R::Output; N]>
     where
-        F: FnMut(T) -> R,
-        R: Try,
-        R::Residual: Residual<[R::Output; N]>,
+        R: Try<Residual: Residual<[R::Output; N]>>,
     {
         drain_array_with(self, |iter| try_from_trusted_iterator(iter.map(f)))
     }

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -363,7 +363,9 @@ pub trait Residual<O> {
 }
 
 #[unstable(feature = "pub_crate_should_not_need_unstable_attr", issue = "none")]
-pub(crate) type ChangeOutputType<T, V> = <<T as Try>::Residual as Residual<V>>::TryType;
+#[allow(type_alias_bounds)]
+pub(crate) type ChangeOutputType<T: Try<Residual: Residual<V>>, V> =
+    <T::Residual as Residual<V>>::TryType;
 
 /// An adapter for implementing non-try methods via the `Try` implementation.
 ///

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -330,7 +330,7 @@ impl<T: ?Sized> *const T {
     ///
     /// unsafe {
     ///     if let Some(val_back) = ptr.as_ref() {
-    ///         println!("We got back the value: {val_back}!");
+    ///         assert_eq!(val_back, &10);
     ///     }
     /// }
     /// ```
@@ -346,7 +346,7 @@ impl<T: ?Sized> *const T {
     ///
     /// unsafe {
     ///     let val_back = &*ptr;
-    ///     println!("We got back the value: {val_back}!");
+    ///     assert_eq!(val_back, &10);
     /// }
     /// ```
     #[stable(feature = "ptr_as_ref", since = "1.9.0")]
@@ -393,7 +393,7 @@ impl<T: ?Sized> *const T {
     /// let ptr: *const u8 = &10u8 as *const u8;
     ///
     /// unsafe {
-    ///     println!("We got back the value: {}!", ptr.as_ref_unchecked());
+    ///     assert_eq!(ptr.as_ref_unchecked(), &10);
     /// }
     /// ```
     // FIXME: mention it in the docs for `as_ref` and `as_uninit_ref` once stabilized.
@@ -439,7 +439,7 @@ impl<T: ?Sized> *const T {
     ///
     /// unsafe {
     ///     if let Some(val_back) = ptr.as_uninit_ref() {
-    ///         println!("We got back the value: {}!", val_back.assume_init());
+    ///         assert_eq!(val_back.assume_init(), 10);
     ///     }
     /// }
     /// ```
@@ -501,8 +501,8 @@ impl<T: ?Sized> *const T {
     /// let ptr: *const u8 = s.as_ptr();
     ///
     /// unsafe {
-    ///     println!("{}", *ptr.offset(1) as char);
-    ///     println!("{}", *ptr.offset(2) as char);
+    ///     assert_eq!(*ptr.offset(1) as char, '2');
+    ///     assert_eq!(*ptr.offset(2) as char, '3');
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -573,19 +573,21 @@ impl<T: ?Sized> *const T {
     /// # Examples
     ///
     /// ```
+    /// # use std::fmt::Write;
     /// // Iterate using a raw pointer in increments of two elements
     /// let data = [1u8, 2, 3, 4, 5];
     /// let mut ptr: *const u8 = data.as_ptr();
     /// let step = 2;
     /// let end_rounded_up = ptr.wrapping_offset(6);
     ///
-    /// // This loop prints "1, 3, 5, "
+    /// let mut out = String::new();
     /// while ptr != end_rounded_up {
     ///     unsafe {
-    ///         print!("{}, ", *ptr);
+    ///         write!(&mut out, "{}, ", *ptr).unwrap();
     ///     }
     ///     ptr = ptr.wrapping_offset(step);
     /// }
+    /// assert_eq!(out.as_str(), "1, 3, 5, ");
     /// ```
     #[stable(feature = "ptr_wrapping_offset", since = "1.16.0")]
     #[must_use = "returns a new pointer rather than modifying its argument"]
@@ -988,8 +990,8 @@ impl<T: ?Sized> *const T {
     /// let ptr: *const u8 = s.as_ptr();
     ///
     /// unsafe {
-    ///     println!("{}", *ptr.add(1) as char);
-    ///     println!("{}", *ptr.add(2) as char);
+    ///     assert_eq!(*ptr.add(1), b'2');
+    ///     assert_eq!(*ptr.add(2), b'3');
     /// }
     /// ```
     #[stable(feature = "pointer_methods", since = "1.26.0")]
@@ -1073,8 +1075,8 @@ impl<T: ?Sized> *const T {
     ///
     /// unsafe {
     ///     let end: *const u8 = s.as_ptr().add(3);
-    ///     println!("{}", *end.sub(1) as char);
-    ///     println!("{}", *end.sub(2) as char);
+    ///     assert_eq!(*end.sub(1), b'3');
+    ///     assert_eq!(*end.sub(2), b'2');
     /// }
     /// ```
     #[stable(feature = "pointer_methods", since = "1.26.0")]
@@ -1155,19 +1157,21 @@ impl<T: ?Sized> *const T {
     /// # Examples
     ///
     /// ```
+    /// # use std::fmt::Write;
     /// // Iterate using a raw pointer in increments of two elements
     /// let data = [1u8, 2, 3, 4, 5];
     /// let mut ptr: *const u8 = data.as_ptr();
     /// let step = 2;
     /// let end_rounded_up = ptr.wrapping_add(6);
     ///
-    /// // This loop prints "1, 3, 5, "
+    /// let mut out = String::new();
     /// while ptr != end_rounded_up {
     ///     unsafe {
-    ///         print!("{}, ", *ptr);
+    ///         write!(&mut out, "{}, ", *ptr).unwrap();
     ///     }
     ///     ptr = ptr.wrapping_add(step);
     /// }
+    /// assert_eq!(out, "1, 3, 5, ");
     /// ```
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[must_use = "returns a new pointer rather than modifying its argument"]
@@ -1234,19 +1238,21 @@ impl<T: ?Sized> *const T {
     /// # Examples
     ///
     /// ```
+    /// # use std::fmt::Write;
     /// // Iterate using a raw pointer in increments of two elements (backwards)
     /// let data = [1u8, 2, 3, 4, 5];
     /// let mut ptr: *const u8 = data.as_ptr();
     /// let start_rounded_down = ptr.wrapping_sub(2);
     /// ptr = ptr.wrapping_add(4);
     /// let step = 2;
-    /// // This loop prints "5, 3, 1, "
+    /// let mut out = String::new();
     /// while ptr != start_rounded_down {
     ///     unsafe {
-    ///         print!("{}, ", *ptr);
+    ///         write!(&mut out, "{}, ", *ptr).unwrap();
     ///     }
     ///     ptr = ptr.wrapping_sub(step);
     /// }
+    /// assert_eq!(out, "5, 3, 1, ");
     /// ```
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[must_use = "returns a new pointer rather than modifying its argument"]

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -92,11 +92,13 @@ use crate::ub_checks;
 /// ```
 /// use std::slice;
 ///
+/// /// Sum the elements of an FFI slice.
+/// ///
 /// /// # Safety
 /// ///
 /// /// If ptr is not NULL, it must be correctly aligned and
 /// /// point to `len` initialized items of type `f32`.
-/// unsafe extern "C" fn handle_slice(ptr: *const f32, len: usize) {
+/// unsafe extern "C" fn sum_slice(ptr: *const f32, len: usize) -> f32 {
 ///     let data = if ptr.is_null() {
 ///         // `len` is assumed to be 0.
 ///         &[]
@@ -104,9 +106,14 @@ use crate::ub_checks;
 ///         // SAFETY: see function docstring.
 ///         unsafe { slice::from_raw_parts(ptr, len) }
 ///     };
-///     dbg!(data);
-///     // ...
+///     data.sum()
 /// }
+///
+/// // This could be the result of C++'s std::vector::data():
+/// let ptr = std::ptr::null();
+/// // And this could be std::vector::size():
+/// let len = 0;
+/// assert_eq!(unsafe { sum_slice(ptr, len) }, 0.0);
 /// ```
 ///
 /// [valid]: ptr#safety

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -83,6 +83,27 @@ use crate::ub_checks;
 /// }
 /// ```
 ///
+/// ### FFI: Handling null pointers
+///
+/// In languages such as C++, pointers to empty collections are not guaranteed to be non-null.
+/// When accepting such pointers, they have to be checked for null-ness to avoid undefined
+/// behavior.
+///
+/// ```
+/// use std::slice;
+///
+/// unsafe extern "C" fn handle_slice(ptr: *const f32, len: usize) {
+///     let data = if ptr.is_null() {
+///         // `len` is assumed to be 0.
+///         &[]
+///     } else {
+///         unsafe { slice::from_raw_parts(ptr, len) }
+///     };
+///     dbg!(data);
+///     // ...
+/// }
+/// ```
+///
 /// [valid]: ptr#safety
 /// [`NonNull::dangling()`]: ptr::NonNull::dangling
 #[inline]

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -92,11 +92,16 @@ use crate::ub_checks;
 /// ```
 /// use std::slice;
 ///
+/// /// # Safety
+/// ///
+/// /// If ptr is not NULL, it must be correctly aligned and
+/// /// point to `len` initialized items of type `f32`.
 /// unsafe extern "C" fn handle_slice(ptr: *const f32, len: usize) {
 ///     let data = if ptr.is_null() {
 ///         // `len` is assumed to be 0.
 ///         &[]
 ///     } else {
+///         // SAFETY: see function docstring.
 ///         unsafe { slice::from_raw_parts(ptr, len) }
 ///     };
 ///     dbg!(data);

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -106,7 +106,7 @@ use crate::ub_checks;
 ///         // SAFETY: see function docstring.
 ///         unsafe { slice::from_raw_parts(ptr, len) }
 ///     };
-///     data.sum()
+///     data.into_iter().sum()
 /// }
 ///
 /// // This could be the result of C++'s std::vector::data():

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1281,6 +1281,7 @@ fn expand_variables(mut value: String, config: &Config) -> String {
     const BUILD_BASE: &str = "{{build-base}}";
     const SYSROOT_BASE: &str = "{{sysroot-base}}";
     const TARGET_LINKER: &str = "{{target-linker}}";
+    const TARGET: &str = "{{target}}";
 
     if value.contains(CWD) {
         let cwd = env::current_dir().unwrap();
@@ -1301,6 +1302,10 @@ fn expand_variables(mut value: String, config: &Config) -> String {
 
     if value.contains(TARGET_LINKER) {
         value = value.replace(TARGET_LINKER, config.target_linker.as_deref().unwrap_or(""));
+    }
+
+    if value.contains(TARGET) {
+        value = value.replace(TARGET, &config.target);
     }
 
     value

--- a/src/tools/tidy/src/target_specific_tests.rs
+++ b/src/tools/tidy/src/target_specific_tests.rs
@@ -53,9 +53,9 @@ pub fn check(path: &Path, bad: &mut bool) {
             } else if directive.starts_with(COMPILE_FLAGS_HEADER) {
                 let compile_flags = &directive[COMPILE_FLAGS_HEADER.len()..];
                 if let Some((_, v)) = compile_flags.split_once("--target") {
-                    if let Some((arch, _)) =
-                        v.trim_start_matches(|c| c == ' ' || c == '=').split_once("-")
-                    {
+                    let v = v.trim_start_matches(|c| c == ' ' || c == '=');
+                    let v = if v == "{{target}}" { Some((v, v)) } else { v.split_once("-") };
+                    if let Some((arch, _)) = v {
                         let info = header_map.entry(revision).or_insert(RevisionInfo::default());
                         info.target_arch.replace(arch);
                     } else {

--- a/tests/codegen/issues/issue-122805.rs
+++ b/tests/codegen/issues/issue-122805.rs
@@ -39,17 +39,20 @@
 // OPT3WINX64-NEXT: store <8 x i16>
 // CHECK-NEXT: ret void
 #[no_mangle]
-#[cfg(target_endian = "little")]
 pub fn convert(value: [u16; 8]) -> [u8; 16] {
+    #[cfg(target_endian = "little")]
+    let bswap = u16::to_be;
+    #[cfg(target_endian = "big")]
+    let bswap = u16::to_le;
     let addr16 = [
-        value[0].to_be(),
-        value[1].to_be(),
-        value[2].to_be(),
-        value[3].to_be(),
-        value[4].to_be(),
-        value[5].to_be(),
-        value[6].to_be(),
-        value[7].to_be(),
+        bswap(value[0]),
+        bswap(value[1]),
+        bswap(value[2]),
+        bswap(value[3]),
+        bswap(value[4]),
+        bswap(value[5]),
+        bswap(value[6]),
+        bswap(value[7]),
     ];
     unsafe { core::mem::transmute::<_, [u8; 16]>(addr16) }
 }

--- a/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.rs
+++ b/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.rs
@@ -1,0 +1,20 @@
+// Given an anon const `a`: `{ N }` and some anon const `b` which references the
+// first anon const: `{ [1; a] }`. `b` should not have any generics as it is not
+// a simple `N` argument nor is it a repeat expr count.
+//
+// On the other hand `b` *is* a repeat expr count and so it should inherit its
+// parents generics as part of the `const_evaluatable_unchecked` fcw (#76200).
+//
+// In this specific case however `b`'s parent should be `a` and so it should wind
+// up not having any generics after all. If `a` were to inherit its generics from
+// the enclosing item then the reference to `a` from `b` would contain generic
+// parameters not usable by `b` which would cause us to ICE.
+
+fn bar<const N: usize>() {}
+
+fn foo<const N: usize>() {
+    bar::<{ [1; N] }>();
+    //~^ ERROR: generic parameters may not be used in const operations
+}
+
+fn main() {}

--- a/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
+++ b/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
@@ -1,0 +1,11 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/repeat_expr_hack_gives_right_generics.rs:16:17
+   |
+LL |     bar::<{ [1; N] }>();
+   |                 ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/mir/lint/storage-live.rs
+++ b/tests/ui/mir/lint/storage-live.rs
@@ -5,6 +5,7 @@
 //@ normalize-stderr-test "note: .*\n\n" -> ""
 //@ normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
 //@ normalize-stderr-test "storage_live\[....\]" -> "storage_live[HASH]"
+//@ normalize-stderr-test "(delayed at [^:]+):\d+:\d+ - " -> "$1:LL:CC - "
 //@ rustc-env:RUST_BACKTRACE=0
 
 #![feature(custom_mir, core_intrinsics)]

--- a/tests/ui/mir/lint/storage-live.stderr
+++ b/tests/ui/mir/lint/storage-live.stderr
@@ -1,12 +1,12 @@
 error: internal compiler error: broken MIR in Item(DefId(0:8 ~ storage_live[HASH]::multiple_storage)) (after pass CheckPackedRef) at bb0[1]:
                                 StorageLive(_1) which already has storage here
-  --> $DIR/storage-live.rs:22:13
+  --> $DIR/storage-live.rs:23:13
    |
 LL |             StorageLive(a);
    |             ^^^^^^^^^^^^^^
    |
-note: delayed at compiler/rustc_mir_transform/src/lint.rs:97:26 - disabled backtrace
-  --> $DIR/storage-live.rs:22:13
+note: delayed at compiler/rustc_mir_transform/src/lint.rs:LL:CC - disabled backtrace
+  --> $DIR/storage-live.rs:23:13
    |
 LL |             StorageLive(a);
    |             ^^^^^^^^^^^^^^


### PR DESCRIPTION
Successful merges:

 - #123374 (DOC: Add FFI example for slice::from_raw_parts())
 - #126210 (docs(core): make more const_ptr doctests assert instead of printing)
 - #126228 (Provide correct parent for nested anon const)
 - #126242 (Simplify provider api to improve llvm ir)
 - #126249 (Simplify `[T; N]::try_map` signature)
 - #126256 (Add {{target}} substitution to compiletest)
 - #126263 (Make issue-122805.rs big endian compatible)
 - #126286 (Make `storage-live.rs` robust against rustc internal changes.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=123374,126210,126228,126242,126249,126256,126263,126286)
<!-- homu-ignore:end -->