### PR TITLE
Make PathBuf less Ok with adding UTF-16 then `into_string`

### DIFF
--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -477,6 +477,9 @@ impl Wtf8Buf {
     /// Part of a hack to make PathBuf::push/pop more efficient.
     #[inline]
     pub(crate) fn as_mut_vec_for_path_buf(&mut self) -> &mut Vec<u8> {
+        // FIXME: this function should not even exist, as it implies violating Wtf8Buf invariants
+        // For now, simply assume that is about to happen.
+        self.is_known_utf8 = false;
         &mut self.bytes
     }
 }

--- a/library/std/tests/windows.rs
+++ b/library/std/tests/windows.rs
@@ -1,0 +1,14 @@
+#![cfg(windows)]
+//! An external tests
+
+use std::{ffi::OsString, os::windows::ffi::OsStringExt, path::PathBuf};
+
+#[test]
+#[should_panic]
+fn os_string_must_know_it_isnt_utf8_issue_126291() {
+    let mut utf8 = PathBuf::from(OsString::from("utf8".to_owned()));
+    let non_utf8: OsString =
+        OsStringExt::from_wide(&[0x6e, 0x6f, 0x6e, 0xd800, 0x75, 0x74, 0x66, 0x38]);
+    utf8.set_extension(&non_utf8);
+    utf8.into_os_string().into_string().unwrap();
+}


### PR DESCRIPTION
Fixes #126291 which is, as far as I can tell, a regression introduced by #96869.

try-job: x86_64-msvc