### PR TITLE
Rollup of 16 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -147,7 +147,7 @@ Language
 - [Split `refining_impl_trait` lint into `_reachable`, `_internal` variants](https://github.com/rust-lang/rust/pull/121720/)
 - [Remove unnecessary type inference when using associated types inside of higher ranked `where`-bounds](https://github.com/rust-lang/rust/pull/119849)
 - [Weaken eager detection of cyclic types during type inference](https://github.com/rust-lang/rust/pull/119989)
-- [`trait Trait: Auto {}`: allow upcasting from `dyn Trait` to `dyn Auto`](https://github.com/rust-lang/rust/pull/119338)
+- [`trait Trait: Auto {}`: allow upcasting from `dyn Trait` to `dyn Trait + Auto`](https://github.com/rust-lang/rust/pull/119338)
 
 <a id="1.78.0-Compiler"></a>
 

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1,7 +1,9 @@
-#![cfg_attr(feature = "nightly", feature(step_trait))]
+// tidy-alphabetical-start
 #![cfg_attr(feature = "nightly", allow(internal_features))]
 #![cfg_attr(feature = "nightly", doc(rust_logo))]
 #![cfg_attr(feature = "nightly", feature(rustdoc_internals))]
+#![cfg_attr(feature = "nightly", feature(step_trait))]
+// tidy-alphabetical-end
 
 use std::fmt;
 use std::num::{NonZeroUsize, ParseIntError};

--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -7,23 +7,25 @@
 //!
 //! This crate implements several kinds of arena.
 
+// tidy-alphabetical-start
+#![allow(clippy::mut_from_ref)] // Arena allocators are one place where this pattern is fine.
+#![allow(internal_features)]
+#![cfg_attr(test, feature(test))]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![doc(
     html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
     test(no_crate_inject, attr(deny(warnings)))
 )]
 #![doc(rust_logo)]
-#![feature(rustdoc_internals)]
 #![feature(core_intrinsics)]
-#![feature(dropck_eyepatch)]
-#![feature(new_uninit)]
-#![feature(maybe_uninit_slice)]
 #![feature(decl_macro)]
+#![feature(dropck_eyepatch)]
+#![feature(maybe_uninit_slice)]
+#![feature(new_uninit)]
 #![feature(rustc_attrs)]
-#![cfg_attr(test, feature(test))]
+#![feature(rustdoc_internals)]
 #![feature(strict_provenance)]
-#![deny(unsafe_op_in_unsafe_fn)]
-#![allow(internal_features)]
-#![allow(clippy::mut_from_ref)] // Arena allocators are one of the places where this pattern is fine.
+// tidy-alphabetical-end
 
 use smallvec::SmallVec;
 

--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -4,20 +4,22 @@
 //!
 //! This API is completely unstable and subject to change.
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![doc(
     html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
     test(attr(deny(warnings)))
 )]
 #![doc(rust_logo)]
-#![allow(internal_features)]
-#![feature(rustdoc_internals)]
 #![feature(associated_type_defaults)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
 #![feature(let_chains)]
-#![feature(never_type)]
 #![feature(negative_impls)]
+#![feature(never_type)]
+#![feature(rustdoc_internals)]
 #![feature(stmt_expr_attributes)]
+// tidy-alphabetical-end
 
 pub mod util {
     pub mod case;

--- a/compiler/rustc_ast_ir/src/lib.rs
+++ b/compiler/rustc_ast_ir/src/lib.rs
@@ -1,6 +1,8 @@
+// tidy-alphabetical-start
+#![cfg_attr(feature = "nightly", allow(internal_features))]
 #![cfg_attr(feature = "nightly", feature(never_type))]
 #![cfg_attr(feature = "nightly", feature(rustc_attrs))]
-#![cfg_attr(feature = "nightly", allow(internal_features))]
+// tidy-alphabetical-end
 
 #[cfg(feature = "nightly")]
 use rustc_macros::{Decodable, Encodable, HashStable_NoContext};

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -30,12 +30,14 @@
 //! get confused if the spans from leaf AST nodes occur in multiple places
 //! in the HIR, especially for multiple identifiers.
 
+// tidy-alphabetical-start
 #![allow(internal_features)]
-#![feature(rustdoc_internals)]
 #![doc(rust_logo)]
 #![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(let_chains)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 use crate::errors::{AssocTyParentheses, AssocTyParenthesesSub, MisplacedImplTrait};
 use rustc_ast::node_id::NodeMap;

--- a/compiler/rustc_ast_passes/src/lib.rs
+++ b/compiler/rustc_ast_passes/src/lib.rs
@@ -4,13 +4,15 @@
 //!
 //! The crate also contains other misc AST visitors, e.g. `node_count` and `show_span`.
 
+// tidy-alphabetical-start
 #![allow(internal_features)]
 #![doc(rust_logo)]
-#![feature(rustdoc_internals)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
 #![feature(iter_is_partitioned)]
 #![feature(let_chains)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 pub mod ast_validation;
 mod errors;

--- a/compiler/rustc_ast_pretty/src/lib.rs
+++ b/compiler/rustc_ast_pretty/src/lib.rs
@@ -1,7 +1,9 @@
+// tidy-alphabetical-start
 #![allow(internal_features)]
-#![feature(rustdoc_internals)]
 #![doc(rust_logo)]
 #![feature(box_patterns)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 mod helpers;
 pub mod pp;

--- a/compiler/rustc_attr/src/lib.rs
+++ b/compiler/rustc_attr/src/lib.rs
@@ -4,10 +4,12 @@
 //! The goal is to move the definition of `MetaItem` and things that don't need to be in `syntax`
 //! to this crate.
 
+// tidy-alphabetical-start
 #![allow(internal_features)]
-#![feature(rustdoc_internals)]
 #![doc(rust_logo)]
 #![feature(let_chains)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 mod builtin;
 mod session_diagnostics;

--- a/compiler/rustc_baked_icu_data/src/lib.rs
+++ b/compiler/rustc_baked_icu_data/src/lib.rs
@@ -20,10 +20,12 @@
 //! --cldr-tag latest --icuexport-tag latest -o src/data
 //! ```
 
-#![allow(internal_features)]
-#![feature(rustdoc_internals)]
-#![doc(rust_logo)]
+// tidy-alphabetical-start
 #![allow(elided_lifetimes_in_paths)]
+#![allow(internal_features)]
+#![doc(rust_logo)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 mod data {
     include!("data/mod.rs");

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1,7 +1,7 @@
 //! This query borrow-checks the MIR to (further) ensure it is not broken.
 
+// tidy-alphabetical-start
 #![allow(internal_features)]
-#![feature(rustdoc_internals)]
 #![doc(rust_logo)]
 #![feature(assert_matches)]
 #![feature(box_patterns)]
@@ -10,8 +10,10 @@
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(rustc_attrs)]
+#![feature(rustdoc_internals)]
 #![feature(stmt_expr_attributes)]
 #![feature(try_blocks)]
+// tidy-alphabetical-end
 
 #[macro_use]
 extern crate tracing;

--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -1,12 +1,12 @@
 //! This crate contains implementations of built-in macros and other code generating facilities
 //! injecting code into the crate before it is lowered to HIR.
 
+// tidy-alphabetical-start
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
-#![feature(rustdoc_internals)]
-#![doc(rust_logo)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![doc(rust_logo)]
 #![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(decl_macro)]
@@ -15,7 +15,9 @@
 #![feature(lint_reasons)]
 #![feature(proc_macro_internals)]
 #![feature(proc_macro_quote)]
+#![feature(rustdoc_internals)]
 #![feature(try_blocks)]
+// tidy-alphabetical-end
 
 extern crate proc_macro;
 

--- a/compiler/rustc_codegen_cranelift/patches/0029-stdlib-rawdylib-processprng.patch
+++ b/compiler/rustc_codegen_cranelift/patches/0029-stdlib-rawdylib-processprng.patch
@@ -12,7 +12,7 @@ diff --git a/library/std/src/sys/pal/windows/c.rs b/library/std/src/sys/pal/wind
 index ad8e01bfa9b..9ca8e4c16ce 100644
 --- a/library/std/src/sys/pal/windows/c.rs
 +++ b/library/std/src/sys/pal/windows/c.rs
-@@ -323,7 +323,7 @@ pub unsafe fn NtWriteFile(
+@@ -312,7 +312,7 @@ pub unsafe fn NtWriteFile(
  
  // Use raw-dylib to import ProcessPrng as we can't rely on there being an import library.
  cfg_if::cfg_if! {
@@ -26,8 +26,8 @@ index e427546222a..f2fe42a4d51 100644
 --- a/library/std/src/sys/pal/windows/rand.rs
 +++ b/library/std/src/sys/pal/windows/rand.rs
 @@ -2,7 +2,7 @@
- use core::mem;
- use core::ptr;
+ 
+ use crate::sys::c;
  
 -#[cfg(not(target_vendor = "win7"))]
 +#[cfg(any())]

--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -1,13 +1,16 @@
-#![cfg_attr(doc, allow(internal_features))]
-#![cfg_attr(doc, feature(rustdoc_internals))]
-#![cfg_attr(doc, doc(rust_logo))]
-#![feature(rustc_private)]
-// Note: please avoid adding other feature gates where possible
+// tidy-alphabetical-start
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
+#![cfg_attr(doc, allow(internal_features))]
+#![cfg_attr(doc, doc(rust_logo))]
+#![cfg_attr(doc, feature(rustdoc_internals))]
+// Note: please avoid adding other feature gates where possible
+#![feature(rustc_private)]
+// Note: please avoid adding other feature gates where possible
 #![warn(rust_2018_idioms)]
-#![warn(unused_lifetimes)]
 #![warn(unreachable_pub)]
+#![warn(unused_lifetimes)]
+// tidy-alphabetical-end
 
 extern crate jobserver;
 #[macro_use]

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -4,16 +4,18 @@
 //!
 //! This API is completely unstable and subject to change.
 
+// tidy-alphabetical-start
 #![allow(internal_features)]
-#![feature(rustdoc_internals)]
-#![doc(rust_logo)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![doc(rust_logo)]
 #![feature(exact_size_is_empty)]
 #![feature(extern_types)]
 #![feature(hash_raw_entry)]
+#![feature(impl_trait_in_assoc_type)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
-#![feature(impl_trait_in_assoc_type)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 use back::owned_target_machine::OwnedTargetMachine;
 use back::write::{create_informational_target_machine, create_target_machine};

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -1,15 +1,17 @@
-#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![doc(rust_logo)]
-#![feature(rustdoc_internals)]
+// tidy-alphabetical-start
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![doc(rust_logo)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
 #![feature(let_chains)]
 #![feature(negative_impls)]
+#![feature(rustdoc_internals)]
 #![feature(strict_provenance)]
 #![feature(try_blocks)]
+// tidy-alphabetical-end
 
 //! This crate contains codegen code that is used by all codegen backends (LLVM and others).
 //! The backend-agnostic functions of this crate use functions defined in various traits that

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -1,18 +1,20 @@
+// tidy-alphabetical-start
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
-#![feature(rustdoc_internals)]
 #![doc(rust_logo)]
 #![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(decl_macro)]
+#![feature(if_let_guard)]
 #![feature(let_chains)]
+#![feature(never_type)]
+#![feature(rustdoc_internals)]
 #![feature(slice_ptr_get)]
 #![feature(strict_provenance)]
-#![feature(never_type)]
 #![feature(trait_alias)]
 #![feature(try_blocks)]
 #![feature(yeet_expr)]
-#![feature(if_let_guard)]
+// tidy-alphabetical-end
 
 pub mod check_consts;
 pub mod const_eval;

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1,8 +1,10 @@
 // This crate is intentionally empty and a re-export of `rustc_driver_impl` to allow the code in
 // `rustc_driver_impl` to be compiled in parallel with other crates.
 
+// tidy-alphabetical-start
 #![allow(internal_features)]
-#![feature(rustdoc_internals)]
 #![doc(rust_logo)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 pub use rustc_driver_impl::*;

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -4,16 +4,18 @@
 //!
 //! This API is completely unstable and subject to change.
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![allow(rustc::untranslatable_diagnostic)] // FIXME: make this translatable
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
-#![feature(rustdoc_internals)]
-#![allow(internal_features)]
 #![feature(decl_macro)]
 #![feature(let_chains)]
 #![feature(panic_backtrace_config)]
 #![feature(panic_update_hook)]
 #![feature(result_flattening)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 use rustc_ast as ast;
 use rustc_codegen_ssa::{traits::CodegenBackend, CodegenErrors, CodegenResults};

--- a/compiler/rustc_error_codes/src/lib.rs
+++ b/compiler/rustc_error_codes/src/lib.rs
@@ -1,10 +1,12 @@
 //! This library is used to gather all error codes into one place, to make
 //! their maintenance easier.
 
+// tidy-alphabetical-start
 #![allow(internal_features)]
-#![feature(rustdoc_internals)]
-#![doc(rust_logo)]
 #![deny(rustdoc::invalid_codeblock_attributes)]
+#![doc(rust_logo)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 // This higher-order macro defines the error codes that are in use. It is used
 // in the `rustc_errors` crate. Removed error codes are listed in the comment

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -1,8 +1,10 @@
-#![doc(rust_logo)]
-#![feature(rustdoc_internals)]
-#![feature(rustc_attrs)]
-#![feature(type_alias_impl_trait)]
+// tidy-alphabetical-start
 #![allow(internal_features)]
+#![doc(rust_logo)]
+#![feature(rustc_attrs)]
+#![feature(rustdoc_internals)]
+#![feature(type_alias_impl_trait)]
+// tidy-alphabetical-end
 
 use fluent_bundle::FluentResource;
 use fluent_syntax::parser::ParserError;

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -11,9 +11,11 @@
 //! even if it is stabilized or removed, *do not remove it*. Instead, move the
 //! symbol to the `accepted` or `removed` modules respectively.
 
+// tidy-alphabetical-start
 #![allow(internal_features)]
-#![feature(rustdoc_internals)]
 #![doc(rust_logo)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 mod accepted;
 mod builtin_attrs;

--- a/compiler/rustc_fluent_macro/src/lib.rs
+++ b/compiler/rustc_fluent_macro/src/lib.rs
@@ -1,10 +1,12 @@
+// tidy-alphabetical-start
+#![allow(internal_features)]
+#![allow(rustc::default_hash_types)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
-#![allow(internal_features)]
-#![feature(rustdoc_internals)]
 #![feature(proc_macro_diagnostic)]
 #![feature(proc_macro_span)]
-#![allow(rustc::default_hash_types)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 use proc_macro::TokenStream;
 

--- a/compiler/rustc_fs_util/src/lib.rs
+++ b/compiler/rustc_fs_util/src/lib.rs
@@ -1,7 +1,9 @@
+// tidy-alphabetical-start
 use std::ffi::CString;
 use std::fs;
 use std::io;
 use std::path::{absolute, Path, PathBuf};
+// tidy-alphabetical-end
 
 // Unfortunately, on windows, it looks like msvcrt.dll is silently translating
 // verbatim paths under the hood to non-verbatim paths! This manifests itself as

--- a/compiler/rustc_graphviz/src/lib.rs
+++ b/compiler/rustc_graphviz/src/lib.rs
@@ -269,13 +269,15 @@
 //!
 //! * [DOT language](https://www.graphviz.org/doc/info/lang.html)
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![doc(
     html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
     test(attr(allow(unused_variables), deny(warnings)))
 )]
-#![feature(rustdoc_internals)]
 #![doc(rust_logo)]
-#![allow(internal_features)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 use LabelText::*;
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1010,6 +1010,7 @@ pub struct Block<'hir> {
     pub hir_id: HirId,
     /// Distinguishes between `unsafe { ... }` and `{ ... }`.
     pub rules: BlockCheckMode,
+    /// The span includes the curly braces `{` and `}` around the block.
     pub span: Span,
     /// If true, then there may exist `break 'a` values that aim to
     /// break out of this block early.

--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -2,13 +2,15 @@
 //!
 //! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/hir.html
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![feature(associated_type_defaults)]
 #![feature(closure_track_caller)]
 #![feature(let_chains)]
 #![feature(never_type)]
 #![feature(rustc_attrs)]
 #![feature(variant_count)]
-#![allow(internal_features)]
+// tidy-alphabetical-end
 
 extern crate self as rustc_hir;
 

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -8,6 +8,10 @@ hir_analysis_assoc_item_constraints_not_allowed_here =
     associated item constraints are not allowed here
     .label = associated item constraint not allowed here
 
+hir_analysis_assoc_item_is_private = {$kind} `{$name}` is private
+    .label = private {$kind}
+    .defined_here_label = the {$kind} is defined here
+
 hir_analysis_assoc_item_not_found = associated {$assoc_kind} `{$assoc_name}` not found for `{$ty_param_name}`
 
 hir_analysis_assoc_item_not_found_found_in_other_trait_label = there is {$identically_named ->

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -56,6 +56,18 @@ pub struct AssocKindMismatchWrapInBracesSugg {
 }
 
 #[derive(Diagnostic)]
+#[diag(hir_analysis_assoc_item_is_private, code = E0624)]
+pub struct AssocItemIsPrivate {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub kind: &'static str,
+    pub name: Ident,
+    #[label(hir_analysis_defined_here_label)]
+    pub defined_here_label: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(hir_analysis_assoc_item_not_found, code = E0220)]
 pub struct AssocItemNotFound<'a> {
     #[primary_span]

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -292,30 +292,15 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             )?
         };
 
-        let (assoc_ident, def_scope) =
-            tcx.adjust_ident_and_get_scope(constraint.ident, candidate.def_id(), hir_ref_id);
-
-        // We have already adjusted the item name above, so compare with `.normalize_to_macros_2_0()`
-        // instead of calling `filter_by_name_and_kind` which would needlessly normalize the
-        // `assoc_ident` again and again.
-        let assoc_item = tcx
-            .associated_items(candidate.def_id())
-            .filter_by_name_unhygienic(assoc_ident.name)
-            .find(|i| i.kind == assoc_kind && i.ident(tcx).normalize_to_macros_2_0() == assoc_ident)
-            .expect("missing associated item");
-
-        if !assoc_item.visibility(tcx).is_accessible_from(def_scope, tcx) {
-            let reported = tcx
-                .dcx()
-                .struct_span_err(
-                    constraint.span,
-                    format!("{} `{}` is private", assoc_item.kind, constraint.ident),
-                )
-                .with_span_label(constraint.span, format!("private {}", assoc_item.kind))
-                .emit();
-            self.set_tainted_by_errors(reported);
-        }
-        tcx.check_stability(assoc_item.def_id, Some(hir_ref_id), constraint.span, None);
+        let assoc_item = self
+            .probe_assoc_item(
+                constraint.ident,
+                assoc_kind,
+                hir_ref_id,
+                constraint.span,
+                candidate.def_id(),
+            )
+            .expect("failed to find associated item");
 
         duplicates
             .entry(assoc_item.def_id)
@@ -406,10 +391,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             // Create the generic arguments for the associated type or constant by joining the
             // parent arguments (the arguments of the trait) and the own arguments (the ones of
             // the associated item itself) and construct an alias type using them.
-            let alias_ty = candidate.map_bound(|trait_ref| {
-                let ident = Ident::new(assoc_item.name, constraint.ident.span);
+            let alias_term = candidate.map_bound(|trait_ref| {
                 let item_segment = hir::PathSegment {
-                    ident,
+                    ident: constraint.ident,
                     hir_id: constraint.hir_id,
                     res: Res::Err,
                     args: Some(constraint.gen_args),
@@ -428,15 +412,15 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             });
 
             // Provide the resolved type of the associated constant to `type_of(AnonConst)`.
-            if let hir::AssocItemConstraintKind::Equality { term: hir::Term::Const(anon_const) } =
-                constraint.kind
-            {
-                let ty = alias_ty.map_bound(|ty| tcx.type_of(ty.def_id).instantiate(tcx, ty.args));
-                let ty = check_assoc_const_binding_type(tcx, assoc_ident, ty, constraint.hir_id);
+            if let Some(anon_const) = constraint.ct() {
+                let ty = alias_term
+                    .map_bound(|alias| tcx.type_of(alias.def_id).instantiate(tcx, alias.args));
+                let ty =
+                    check_assoc_const_binding_type(tcx, constraint.ident, ty, constraint.hir_id);
                 tcx.feed_anon_const_type(anon_const.def_id, ty::EarlyBinder::bind(ty));
             }
 
-            alias_ty
+            alias_term
         };
 
         match constraint.kind {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -1166,8 +1166,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         };
 
         let trait_did = bound.def_id();
-        let assoc_ty_did = self.probe_assoc_ty(assoc_ident, hir_ref_id, span, trait_did).unwrap();
-        let ty = self.lower_assoc_ty(span, assoc_ty_did, assoc_segment, bound);
+        let assoc_ty = self
+            .probe_assoc_item(assoc_ident, ty::AssocKind::Type, hir_ref_id, span, trait_did)
+            .expect("failed to find associated type");
+        let ty = self.lower_assoc_ty(span, assoc_ty.def_id, assoc_segment, bound);
 
         if let Some(variant_def_id) = variant_resolution {
             tcx.node_span_lint(AMBIGUOUS_ASSOCIATED_ITEMS, hir_ref_id, span, |lint| {
@@ -1183,7 +1185,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 };
 
                 could_refer_to(DefKind::Variant, variant_def_id, "");
-                could_refer_to(DefKind::AssocTy, assoc_ty_did, " also");
+                could_refer_to(DefKind::AssocTy, assoc_ty.def_id, " also");
 
                 lint.span_suggestion(
                     span,
@@ -1193,7 +1195,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 );
             });
         }
-        Ok((ty, DefKind::AssocTy, assoc_ty_did))
+        Ok((ty, DefKind::AssocTy, assoc_ty.def_id))
     }
 
     fn probe_inherent_assoc_ty(
@@ -1220,7 +1222,11 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let candidates: Vec<_> = tcx
             .inherent_impls(adt_did)?
             .iter()
-            .filter_map(|&impl_| Some((impl_, self.probe_assoc_ty_unchecked(name, block, impl_)?)))
+            .filter_map(|&impl_| {
+                let (item, scope) =
+                    self.probe_assoc_item_unchecked(name, ty::AssocKind::Type, block, impl_)?;
+                Some((impl_, (item.def_id, scope)))
+            })
             .collect();
 
         if candidates.is_empty() {
@@ -1264,7 +1270,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             },
         )?;
 
-        self.check_assoc_ty(assoc_item, name, def_scope, block, span);
+        self.check_assoc_item(assoc_item, name, def_scope, block, span);
 
         // FIXME(fmease): Currently creating throwaway `parent_args` to please
         // `lower_generic_args_of_assoc_item`. Modify the latter instead (or sth. similar) to
@@ -1351,50 +1357,69 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         }
     }
 
-    fn probe_assoc_ty(&self, name: Ident, block: HirId, span: Span, scope: DefId) -> Option<DefId> {
-        let (item, def_scope) = self.probe_assoc_ty_unchecked(name, block, scope)?;
-        self.check_assoc_ty(item, name, def_scope, block, span);
+    /// Given name and kind search for the assoc item in the provided scope and check if it's accessible[^1].
+    ///
+    /// [^1]: I.e., accessible in the provided scope wrt. visibility and stability.
+    fn probe_assoc_item(
+        &self,
+        ident: Ident,
+        kind: ty::AssocKind,
+        block: HirId,
+        span: Span,
+        scope: DefId,
+    ) -> Option<ty::AssocItem> {
+        let (item, scope) = self.probe_assoc_item_unchecked(ident, kind, block, scope)?;
+        self.check_assoc_item(item.def_id, ident, scope, block, span);
         Some(item)
     }
 
-    fn probe_assoc_ty_unchecked(
+    /// Given name and kind search for the assoc item in the provided scope
+    /// *without* checking if it's accessible[^1].
+    ///
+    /// [^1]: I.e., accessible in the provided scope wrt. visibility and stability.
+    fn probe_assoc_item_unchecked(
         &self,
-        name: Ident,
+        ident: Ident,
+        kind: ty::AssocKind,
         block: HirId,
         scope: DefId,
-    ) -> Option<(DefId, DefId)> {
+    ) -> Option<(ty::AssocItem, /*scope*/ DefId)> {
         let tcx = self.tcx();
-        let (ident, def_scope) = tcx.adjust_ident_and_get_scope(name, scope, block);
 
+        let (ident, def_scope) = tcx.adjust_ident_and_get_scope(ident, scope, block);
         // We have already adjusted the item name above, so compare with `.normalize_to_macros_2_0()`
         // instead of calling `filter_by_name_and_kind` which would needlessly normalize the
         // `ident` again and again.
-        let item = tcx.associated_items(scope).in_definition_order().find(|i| {
-            i.kind.namespace() == Namespace::TypeNS
-                && i.ident(tcx).normalize_to_macros_2_0() == ident
-        })?;
+        let item = tcx
+            .associated_items(scope)
+            .filter_by_name_unhygienic(ident.name)
+            .find(|i| i.kind == kind && i.ident(tcx).normalize_to_macros_2_0() == ident)?;
 
-        Some((item.def_id, def_scope))
+        Some((*item, def_scope))
     }
 
-    fn check_assoc_ty(&self, item: DefId, name: Ident, def_scope: DefId, block: HirId, span: Span) {
+    /// Check if the given assoc item is accessible in the provided scope wrt. visibility and stability.
+    fn check_assoc_item(
+        &self,
+        item_def_id: DefId,
+        ident: Ident,
+        scope: DefId,
+        block: HirId,
+        span: Span,
+    ) {
         let tcx = self.tcx();
-        let kind = DefKind::AssocTy;
 
-        if !tcx.visibility(item).is_accessible_from(def_scope, tcx) {
-            let kind = tcx.def_kind_descr(kind, item);
-            let msg = format!("{kind} `{name}` is private");
-            let def_span = tcx.def_span(item);
-            let reported = tcx
-                .dcx()
-                .struct_span_err(span, msg)
-                .with_code(E0624)
-                .with_span_label(span, format!("private {kind}"))
-                .with_span_label(def_span, format!("{kind} defined here"))
-                .emit();
+        if !tcx.visibility(item_def_id).is_accessible_from(scope, tcx) {
+            let reported = tcx.dcx().emit_err(crate::errors::AssocItemIsPrivate {
+                span,
+                kind: tcx.def_descr(item_def_id),
+                name: ident,
+                defined_here_label: tcx.def_span(item_def_id),
+            });
             self.set_tainted_by_errors(reported);
         }
-        tcx.check_stability(item, Some(block), span, None);
+
+        tcx.check_stability(item_def_id, Some(block), span, None);
     }
 
     fn probe_traits_that_match_assoc_ty(

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -55,21 +55,23 @@ This API is completely unstable and subject to change.
 
 */
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::potential_query_instability)]
 #![allow(rustc::untranslatable_diagnostic)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
-#![feature(rustdoc_internals)]
-#![allow(internal_features)]
 #![feature(control_flow_enum)]
 #![feature(if_let_guard)]
 #![feature(is_sorted)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
 #![feature(never_type)]
+#![feature(rustdoc_internals)]
 #![feature(slice_partition_dedup)]
 #![feature(try_blocks)]
+// tidy-alphabetical-end
 
 #[macro_use]
 extern crate tracing;

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1,7 +1,9 @@
 //! HIR pretty-printing is layered on top of AST pretty-printing. A number of
 //! the definitions in this file have equivalents in `rustc_ast_pretty`.
 
+// tidy-alphabetical-start
 #![recursion_limit = "256"]
+// tidy-alphabetical-end
 
 use rustc_ast as ast;
 use rustc_ast::util::parser::{self, AssocOp, Fixity};

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -1,11 +1,13 @@
+// tidy-alphabetical-start
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
-#![feature(if_let_guard)]
-#![feature(let_chains)]
-#![feature(try_blocks)]
-#![feature(never_type)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
+#![feature(if_let_guard)]
+#![feature(let_chains)]
+#![feature(never_type)]
+#![feature(try_blocks)]
+// tidy-alphabetical-end
 
 #[macro_use]
 extern crate tracing;

--- a/compiler/rustc_incremental/src/lib.rs
+++ b/compiler/rustc_incremental/src/lib.rs
@@ -1,10 +1,12 @@
 //! Support for serializing the dep-graph and reloading it.
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(rustdoc_internals)]
-#![allow(internal_features)]
+// tidy-alphabetical-end
 
 mod assert_dep_graph;
 mod errors;

--- a/compiler/rustc_index/src/lib.rs
+++ b/compiler/rustc_index/src/lib.rs
@@ -1,9 +1,11 @@
+// tidy-alphabetical-start
+#![cfg_attr(all(feature = "nightly", test), feature(stmt_expr_attributes))]
 #![cfg_attr(
     feature = "nightly",
     feature(extend_one, min_specialization, new_uninit, step_trait, test)
 )]
-#![cfg_attr(all(feature = "nightly", test), feature(stmt_expr_attributes))]
 #![cfg_attr(feature = "nightly", allow(internal_features))]
+// tidy-alphabetical-end
 
 pub mod bit_set;
 #[cfg(feature = "nightly")]

--- a/compiler/rustc_index_macros/src/lib.rs
+++ b/compiler/rustc_index_macros/src/lib.rs
@@ -1,5 +1,7 @@
-#![cfg_attr(feature = "nightly", feature(allow_internal_unstable))]
+// tidy-alphabetical-start
 #![cfg_attr(feature = "nightly", allow(internal_features))]
+#![cfg_attr(feature = "nightly", feature(allow_internal_unstable))]
+// tidy-alphabetical-end
 
 use proc_macro::TokenStream;
 

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -12,22 +12,24 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![doc(rust_logo)]
-#![feature(rustdoc_internals)]
+// tidy-alphabetical-start
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![doc(rust_logo)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(extend_one)]
-#![feature(let_chains)]
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]
 #![feature(iterator_try_collect)]
+#![feature(let_chains)]
+#![feature(rustdoc_internals)]
 #![feature(try_blocks)]
 #![feature(yeet_expr)]
 #![recursion_limit = "512"] // For rustdoc
+// tidy-alphabetical-end
 
 #[macro_use]
 extern crate tracing;

--- a/compiler/rustc_interface/src/lib.rs
+++ b/compiler/rustc_interface/src/lib.rs
@@ -1,7 +1,9 @@
+// tidy-alphabetical-start
 #![feature(decl_macro)]
 #![feature(let_chains)]
 #![feature(thread_spawn_unchecked)]
 #![feature(try_blocks)]
+// tidy-alphabetical-end
 
 mod callbacks;
 mod errors;

--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -19,9 +19,11 @@
 //!
 //! [`rustc_parse::lexer`]: ../rustc_parse/lexer/index.html
 
+// tidy-alphabetical-start
 // We want to be able to build this crate with a stable compiler,
 // so no `#![feature]` attributes should be added.
 #![deny(unstable_features)]
+// tidy-alphabetical-end
 
 mod cursor;
 pub mod unescape;

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -25,9 +25,10 @@
 //!
 //! This API is completely unstable and subject to change.
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
-#![feature(rustdoc_internals)]
 #![feature(array_windows)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
@@ -35,9 +36,10 @@
 #![feature(if_let_guard)]
 #![feature(iter_order_by)]
 #![feature(let_chains)]
-#![feature(trait_upcasting)]
 #![feature(rustc_attrs)]
-#![allow(internal_features)]
+#![feature(rustdoc_internals)]
+#![feature(trait_upcasting)]
+// tidy-alphabetical-end
 
 mod async_fn_in_trait;
 pub mod builtin;

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -1,3 +1,4 @@
+// tidy-alphabetical-start
 pub use self::Level::*;
 use rustc_ast::node_id::NodeId;
 use rustc_ast::{AttrId, Attribute};
@@ -14,6 +15,7 @@ use rustc_span::edition::Edition;
 use rustc_span::symbol::MacroRulesNormalizedIdent;
 use rustc_span::{sym, symbol::Ident, Span, Symbol};
 use rustc_target::spec::abi::Abi;
+// tidy-alphabetical-end
 
 use serde::{Deserialize, Serialize};
 

--- a/compiler/rustc_llvm/src/lib.rs
+++ b/compiler/rustc_llvm/src/lib.rs
@@ -1,7 +1,9 @@
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(rustdoc_internals)]
-#![allow(internal_features)]
+// tidy-alphabetical-end
 
 // NOTE: This crate only exists to allow linking on mingw targets.
 

--- a/compiler/rustc_macros/src/lib.rs
+++ b/compiler/rustc_macros/src/lib.rs
@@ -1,3 +1,6 @@
+// tidy-alphabetical-start
+#![allow(internal_features)]
+#![allow(rustc::default_hash_types)]
 #![feature(allow_internal_unstable)]
 #![feature(if_let_guard)]
 #![feature(let_chains)]
@@ -5,8 +8,7 @@
 #![feature(proc_macro_diagnostic)]
 #![feature(proc_macro_span)]
 #![feature(proc_macro_tracked_env)]
-#![allow(rustc::default_hash_types)]
-#![allow(internal_features)]
+// tidy-alphabetical-end
 
 use synstructure::decl_derive;
 

--- a/compiler/rustc_mir_build/src/lib.rs
+++ b/compiler/rustc_mir_build/src/lib.rs
@@ -1,5 +1,6 @@
 //! Construction of MIR from HIR.
 
+// tidy-alphabetical-start
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
 #![feature(assert_matches)]
@@ -7,6 +8,7 @@
 #![feature(if_let_guard)]
 #![feature(let_chains)]
 #![feature(try_blocks)]
+// tidy-alphabetical-end
 
 mod build;
 mod check_unsafety;

--- a/compiler/rustc_mir_dataflow/src/lib.rs
+++ b/compiler/rustc_mir_dataflow/src/lib.rs
@@ -1,8 +1,10 @@
+// tidy-alphabetical-start
 #![feature(associated_type_defaults)]
 #![feature(box_patterns)]
 #![feature(exact_size_is_empty)]
 #![feature(let_chains)]
 #![feature(try_blocks)]
+// tidy-alphabetical-end
 
 use rustc_middle::ty;
 

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -1,8 +1,10 @@
+// tidy-alphabetical-start
 #![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(const_type_name)]
 #![feature(cow_is_borrowed)]
 #![feature(decl_macro)]
+#![feature(if_let_guard)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(is_sorted)]
 #![feature(let_chains)]
@@ -12,7 +14,7 @@
 #![feature(round_char_boundary)]
 #![feature(try_blocks)]
 #![feature(yeet_expr)]
-#![feature(if_let_guard)]
+// tidy-alphabetical-end
 
 #[macro_use]
 extern crate tracing;

--- a/compiler/rustc_monomorphize/src/lib.rs
+++ b/compiler/rustc_monomorphize/src/lib.rs
@@ -1,5 +1,7 @@
+// tidy-alphabetical-start
 #![feature(array_windows)]
 #![feature(is_sorted)]
+// tidy-alphabetical-end
 
 use rustc_hir::lang_items::LangItem;
 use rustc_middle::bug;

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -1,5 +1,6 @@
 //! The main parser interface.
 
+// tidy-alphabetical-start
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
@@ -9,6 +10,7 @@
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
+// tidy-alphabetical-end
 
 use rustc_ast as ast;
 use rustc_ast::token;

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -4,14 +4,16 @@
 //! Parsing does not happen at runtime: structures of `std::fmt::rt` are
 //! generated instead.
 
+// tidy-alphabetical-start
+// We want to be able to build this crate with a stable compiler,
+// so no `#![feature]` attributes should be added.
+#![deny(unstable_features)]
 #![doc(
     html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
     html_playground_url = "https://play.rust-lang.org/",
     test(attr(deny(warnings)))
 )]
-// We want to be able to build this crate with a stable compiler,
-// so no `#![feature]` attributes should be added.
-#![deny(unstable_features)]
+// tidy-alphabetical-end
 
 use rustc_lexer::unescape;
 pub use Alignment::*;

--- a/compiler/rustc_passes/src/lib.rs
+++ b/compiler/rustc_passes/src/lib.rs
@@ -4,13 +4,15 @@
 //!
 //! This API is completely unstable and subject to change.
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
-#![feature(rustdoc_internals)]
-#![allow(internal_features)]
 #![feature(let_chains)]
 #![feature(map_try_insert)]
+#![feature(rustdoc_internals)]
 #![feature(try_blocks)]
+// tidy-alphabetical-end
 
 use rustc_middle::query::Providers;
 

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -1,7 +1,9 @@
 //! Analysis of patterns, notably match exhaustiveness checking.
 
-#![allow(rustc::untranslatable_diagnostic)]
+// tidy-alphabetical-start
 #![allow(rustc::diagnostic_outside_of_impl)]
+#![allow(rustc::untranslatable_diagnostic)]
+// tidy-alphabetical-end
 
 pub mod constructor;
 #[cfg(feature = "rustc")]

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1,10 +1,12 @@
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
-#![feature(rustdoc_internals)]
-#![allow(internal_features)]
 #![feature(associated_type_defaults)]
-#![feature(try_blocks)]
 #![feature(let_chains)]
+#![feature(rustdoc_internals)]
+#![feature(try_blocks)]
+// tidy-alphabetical-end
 
 mod errors;
 

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -1,12 +1,14 @@
 //! Support for serializing the dep-graph and reloading it.
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
+#![allow(rustc::potential_query_instability, unused_parens)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
-#![feature(rustdoc_internals)]
 #![feature(min_specialization)]
 #![feature(rustc_attrs)]
-#![allow(rustc::potential_query_instability, unused_parens)]
-#![allow(internal_features)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 use crate::plumbing::{__rust_begin_short_backtrace, encode_all_query_results, try_mark_green};
 use crate::profiling_support::QueryKeyStringCache;

--- a/compiler/rustc_query_system/src/lib.rs
+++ b/compiler/rustc_query_system/src/lib.rs
@@ -1,9 +1,11 @@
+// tidy-alphabetical-start
+#![allow(rustc::potential_query_instability, internal_features)]
 #![feature(assert_matches)]
 #![feature(core_intrinsics)]
 #![feature(hash_raw_entry)]
-#![feature(min_specialization)]
 #![feature(let_chains)]
-#![allow(rustc::potential_query_instability, internal_features)]
+#![feature(min_specialization)]
+// tidy-alphabetical-end
 
 pub mod cache;
 pub mod dep_graph;

--- a/compiler/rustc_sanitizers/src/lib.rs
+++ b/compiler/rustc_sanitizers/src/lib.rs
@@ -1,7 +1,11 @@
-#![feature(let_chains)]
 //! Sanitizers support for the Rust compiler.
 //!
 //! This crate contains the source code for providing support for the sanitizers to the Rust
 //! compiler.
+
+// tidy-alphabetical-start
+#![feature(let_chains)]
+// tidy-alphabetical-end
+
 pub mod cfi;
 pub mod kcfi;

--- a/compiler/rustc_serialize/src/lib.rs
+++ b/compiler/rustc_serialize/src/lib.rs
@@ -1,20 +1,22 @@
 //! Support code for encoding and decoding types.
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
+#![allow(rustc::internal)]
+#![cfg_attr(test, feature(test))]
 #![doc(
     html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
     html_playground_url = "https://play.rust-lang.org/",
     test(attr(allow(unused_variables), deny(warnings)))
 )]
 #![doc(rust_logo)]
-#![allow(internal_features)]
-#![feature(rustdoc_internals)]
 #![feature(const_option)]
 #![feature(core_intrinsics)]
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(ptr_sub_ptr)]
-#![cfg_attr(test, feature(test))]
-#![allow(rustc::internal)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 pub use self::serialize::{Decodable, Decoder, Encodable, Encoder};
 

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -1,9 +1,11 @@
+// tidy-alphabetical-start
+#![allow(internal_features)]
+#![feature(iter_intersperse)]
 #![feature(let_chains)]
+#![feature(map_many_mut)]
 #![feature(option_get_or_insert_default)]
 #![feature(rustc_attrs)]
-#![feature(map_many_mut)]
-#![feature(iter_intersperse)]
-#![allow(internal_features)]
+// tidy-alphabetical-end
 
 pub mod errors;
 

--- a/compiler/rustc_smir/src/lib.rs
+++ b/compiler/rustc_smir/src/lib.rs
@@ -6,14 +6,16 @@
 //!
 //! This API is still completely unstable and subject to change.
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
+#![allow(rustc::usage_of_ty_tykind)]
 #![doc(
     html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
     test(attr(allow(unused_variables), deny(warnings)))
 )]
 #![doc(rust_logo)]
 #![feature(rustdoc_internals)]
-#![allow(internal_features)]
-#![allow(rustc::usage_of_ty_tykind)]
+// tidy-alphabetical-end
 
 pub mod rustc_internal;
 

--- a/compiler/rustc_symbol_mangling/src/lib.rs
+++ b/compiler/rustc_symbol_mangling/src/lib.rs
@@ -87,11 +87,13 @@
 //! virtually impossible. Thus, symbol hash generation exclusively relies on
 //! DefPaths which are much more robust in the face of changes to the code base.
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
-#![feature(rustdoc_internals)]
 #![feature(let_chains)]
-#![allow(internal_features)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, LOCAL_CRATE};

--- a/compiler/rustc_target/src/abi/call/nvptx64.rs
+++ b/compiler/rustc_target/src/abi/call/nvptx64.rs
@@ -1,20 +1,51 @@
 use crate::abi::call::{ArgAbi, FnAbi, PassMode, Reg, Size, Uniform};
 use crate::abi::{HasDataLayout, TyAbiInterface};
 
+use super::{ArgAttribute, ArgAttributes, ArgExtension, CastTarget};
+
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
-    if ret.layout.is_aggregate() && ret.layout.size.bits() > 64 {
-        ret.make_indirect();
-    } else {
-        // FIXME: this is wrong! Need to decide which ABI we really want here.
-        ret.make_direct_deprecated();
+    if ret.layout.is_aggregate() && ret.layout.is_sized() {
+        classify_aggregate(ret)
+    } else if ret.layout.size.bits() < 32 && ret.layout.is_sized() {
+        ret.extend_integer_width_to(32);
     }
 }
 
 fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
-    if arg.layout.is_aggregate() {
-        arg.make_indirect_byval(None);
-    } else if arg.layout.size.bits() < 32 {
+    if arg.layout.is_aggregate() && arg.layout.is_sized() {
+        classify_aggregate(arg)
+    } else if arg.layout.size.bits() < 32 && arg.layout.is_sized() {
         arg.extend_integer_width_to(32);
+    }
+}
+
+/// the pass mode used for aggregates in arg and ret position
+fn classify_aggregate<Ty>(arg: &mut ArgAbi<'_, Ty>) {
+    let align_bytes = arg.layout.align.abi.bytes();
+    let size = arg.layout.size;
+
+    let reg = match align_bytes {
+        1 => Reg::i8(),
+        2 => Reg::i16(),
+        4 => Reg::i32(),
+        8 => Reg::i64(),
+        16 => Reg::i128(),
+        _ => unreachable!("Align is given as power of 2 no larger than 16 bytes"),
+    };
+
+    if align_bytes == size.bytes() {
+        arg.cast_to(CastTarget {
+            prefix: [Some(reg), None, None, None, None, None, None, None],
+            rest: Uniform::new(Reg::i8(), Size::from_bytes(0)),
+            attrs: ArgAttributes {
+                regular: ArgAttribute::default(),
+                arg_ext: ArgExtension::None,
+                pointee_size: Size::ZERO,
+                pointee_align: None,
+            },
+        });
+    } else {
+        arg.cast_to(Uniform::new(reg, size));
     }
 }
 

--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -10,12 +10,12 @@
 //!
 //! This API is completely unstable and subject to change.
 
-#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![doc(rust_logo)]
-#![feature(rustdoc_internals)]
+// tidy-alphabetical-start
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![doc(rust_logo)]
 #![feature(assert_matches)]
 #![feature(associated_type_defaults)]
 #![feature(box_patterns)]
@@ -24,8 +24,10 @@
 #![feature(if_let_guard)]
 #![feature(let_chains)]
 #![feature(never_type)]
+#![feature(rustdoc_internals)]
 #![feature(type_alias_impl_trait)]
 #![recursion_limit = "512"] // For rustdoc
+// tidy-alphabetical-end
 
 #[macro_use]
 extern crate tracing;

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -612,6 +612,10 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             &mut err,
                             trait_predicate,
                         );
+                        self.suggest_add_result_as_return_type(&obligation,
+                            &mut err,
+                            trait_ref);
+
                         if self.suggest_add_reference_to_arg(
                             &obligation,
                             &mut err,

--- a/compiler/rustc_traits/src/lib.rs
+++ b/compiler/rustc_traits/src/lib.rs
@@ -1,6 +1,8 @@
 //! Queries that are independent from the main solver code.
 
+// tidy-alphabetical-start
 #![recursion_limit = "256"]
+// tidy-alphabetical-end
 
 mod codegen;
 mod dropck_outlives;

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -1,6 +1,8 @@
+// tidy-alphabetical-start
+#![allow(unused_variables)]
 #![feature(alloc_layout_extra)]
 #![feature(never_type)]
-#![allow(unused_variables)]
+// tidy-alphabetical-end
 
 pub(crate) use rustc_data_structures::fx::{FxIndexMap as Map, FxIndexSet as Set};
 

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -4,10 +4,10 @@
 //!
 //! This API is completely unstable and subject to change.
 
+// tidy-alphabetical-start
+#![allow(internal_features)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
-#![feature(rustdoc_internals)]
-#![allow(internal_features)]
 #![feature(assert_matches)]
 #![feature(associated_type_defaults)]
 #![feature(box_patterns)]
@@ -15,6 +15,8 @@
 #![feature(iterator_try_collect)]
 #![feature(let_chains)]
 #![feature(never_type)]
+#![feature(rustdoc_internals)]
+// tidy-alphabetical-end
 
 use rustc_middle::query::Providers;
 

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -1,9 +1,11 @@
+// tidy-alphabetical-start
+#![allow(rustc::usage_of_ty_tykind)]
 #![cfg_attr(
     feature = "nightly",
     feature(associated_type_defaults, min_specialization, never_type, rustc_attrs, negative_impls)
 )]
-#![allow(rustc::usage_of_ty_tykind)]
 #![cfg_attr(feature = "nightly", allow(internal_features))]
+// tidy-alphabetical-end
 
 #[cfg(feature = "nightly")]
 extern crate self as rustc_type_ir;

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -533,11 +533,9 @@ impl<T, const N: usize> [T; N] {
     /// assert_eq!(c, Some(a));
     /// ```
     #[unstable(feature = "array_try_map", issue = "79711")]
-    pub fn try_map<F, R>(self, f: F) -> ChangeOutputType<R, [R::Output; N]>
+    pub fn try_map<R>(self, f: impl FnMut(T) -> R) -> ChangeOutputType<R, [R::Output; N]>
     where
-        F: FnMut(T) -> R,
-        R: Try,
-        R::Residual: Residual<[R::Output; N]>,
+        R: Try<Residual: Residual<[R::Output; N]>>,
     {
         drain_array_with(self, |iter| try_from_trusted_iterator(iter.map(f)))
     }

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -363,7 +363,9 @@ pub trait Residual<O> {
 }
 
 #[unstable(feature = "pub_crate_should_not_need_unstable_attr", issue = "none")]
-pub(crate) type ChangeOutputType<T, V> = <<T as Try>::Residual as Residual<V>>::TryType;
+#[allow(type_alias_bounds)]
+pub(crate) type ChangeOutputType<T: Try<Residual: Residual<V>>, V> =
+    <T::Residual as Residual<V>>::TryType;
 
 /// An adapter for implementing non-try methods via the `Try` implementation.
 ///

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -330,7 +330,7 @@ impl<T: ?Sized> *const T {
     ///
     /// unsafe {
     ///     if let Some(val_back) = ptr.as_ref() {
-    ///         println!("We got back the value: {val_back}!");
+    ///         assert_eq!(val_back, &10);
     ///     }
     /// }
     /// ```
@@ -346,7 +346,7 @@ impl<T: ?Sized> *const T {
     ///
     /// unsafe {
     ///     let val_back = &*ptr;
-    ///     println!("We got back the value: {val_back}!");
+    ///     assert_eq!(val_back, &10);
     /// }
     /// ```
     #[stable(feature = "ptr_as_ref", since = "1.9.0")]
@@ -393,7 +393,7 @@ impl<T: ?Sized> *const T {
     /// let ptr: *const u8 = &10u8 as *const u8;
     ///
     /// unsafe {
-    ///     println!("We got back the value: {}!", ptr.as_ref_unchecked());
+    ///     assert_eq!(ptr.as_ref_unchecked(), &10);
     /// }
     /// ```
     // FIXME: mention it in the docs for `as_ref` and `as_uninit_ref` once stabilized.
@@ -439,7 +439,7 @@ impl<T: ?Sized> *const T {
     ///
     /// unsafe {
     ///     if let Some(val_back) = ptr.as_uninit_ref() {
-    ///         println!("We got back the value: {}!", val_back.assume_init());
+    ///         assert_eq!(val_back.assume_init(), 10);
     ///     }
     /// }
     /// ```
@@ -501,8 +501,8 @@ impl<T: ?Sized> *const T {
     /// let ptr: *const u8 = s.as_ptr();
     ///
     /// unsafe {
-    ///     println!("{}", *ptr.offset(1) as char);
-    ///     println!("{}", *ptr.offset(2) as char);
+    ///     assert_eq!(*ptr.offset(1) as char, '2');
+    ///     assert_eq!(*ptr.offset(2) as char, '3');
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -573,19 +573,21 @@ impl<T: ?Sized> *const T {
     /// # Examples
     ///
     /// ```
+    /// # use std::fmt::Write;
     /// // Iterate using a raw pointer in increments of two elements
     /// let data = [1u8, 2, 3, 4, 5];
     /// let mut ptr: *const u8 = data.as_ptr();
     /// let step = 2;
     /// let end_rounded_up = ptr.wrapping_offset(6);
     ///
-    /// // This loop prints "1, 3, 5, "
+    /// let mut out = String::new();
     /// while ptr != end_rounded_up {
     ///     unsafe {
-    ///         print!("{}, ", *ptr);
+    ///         write!(&mut out, "{}, ", *ptr).unwrap();
     ///     }
     ///     ptr = ptr.wrapping_offset(step);
     /// }
+    /// assert_eq!(out.as_str(), "1, 3, 5, ");
     /// ```
     #[stable(feature = "ptr_wrapping_offset", since = "1.16.0")]
     #[must_use = "returns a new pointer rather than modifying its argument"]
@@ -988,8 +990,8 @@ impl<T: ?Sized> *const T {
     /// let ptr: *const u8 = s.as_ptr();
     ///
     /// unsafe {
-    ///     println!("{}", *ptr.add(1) as char);
-    ///     println!("{}", *ptr.add(2) as char);
+    ///     assert_eq!(*ptr.add(1), b'2');
+    ///     assert_eq!(*ptr.add(2), b'3');
     /// }
     /// ```
     #[stable(feature = "pointer_methods", since = "1.26.0")]
@@ -1073,8 +1075,8 @@ impl<T: ?Sized> *const T {
     ///
     /// unsafe {
     ///     let end: *const u8 = s.as_ptr().add(3);
-    ///     println!("{}", *end.sub(1) as char);
-    ///     println!("{}", *end.sub(2) as char);
+    ///     assert_eq!(*end.sub(1), b'3');
+    ///     assert_eq!(*end.sub(2), b'2');
     /// }
     /// ```
     #[stable(feature = "pointer_methods", since = "1.26.0")]
@@ -1155,19 +1157,21 @@ impl<T: ?Sized> *const T {
     /// # Examples
     ///
     /// ```
+    /// # use std::fmt::Write;
     /// // Iterate using a raw pointer in increments of two elements
     /// let data = [1u8, 2, 3, 4, 5];
     /// let mut ptr: *const u8 = data.as_ptr();
     /// let step = 2;
     /// let end_rounded_up = ptr.wrapping_add(6);
     ///
-    /// // This loop prints "1, 3, 5, "
+    /// let mut out = String::new();
     /// while ptr != end_rounded_up {
     ///     unsafe {
-    ///         print!("{}, ", *ptr);
+    ///         write!(&mut out, "{}, ", *ptr).unwrap();
     ///     }
     ///     ptr = ptr.wrapping_add(step);
     /// }
+    /// assert_eq!(out, "1, 3, 5, ");
     /// ```
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[must_use = "returns a new pointer rather than modifying its argument"]
@@ -1234,19 +1238,21 @@ impl<T: ?Sized> *const T {
     /// # Examples
     ///
     /// ```
+    /// # use std::fmt::Write;
     /// // Iterate using a raw pointer in increments of two elements (backwards)
     /// let data = [1u8, 2, 3, 4, 5];
     /// let mut ptr: *const u8 = data.as_ptr();
     /// let start_rounded_down = ptr.wrapping_sub(2);
     /// ptr = ptr.wrapping_add(4);
     /// let step = 2;
-    /// // This loop prints "5, 3, 1, "
+    /// let mut out = String::new();
     /// while ptr != start_rounded_down {
     ///     unsafe {
-    ///         print!("{}, ", *ptr);
+    ///         write!(&mut out, "{}, ", *ptr).unwrap();
     ///     }
     ///     ptr = ptr.wrapping_sub(step);
     /// }
+    /// assert_eq!(out, "5, 3, 1, ");
     /// ```
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[must_use = "returns a new pointer rather than modifying its argument"]

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -92,11 +92,13 @@ use crate::ub_checks;
 /// ```
 /// use std::slice;
 ///
+/// /// Sum the elements of an FFI slice.
+/// ///
 /// /// # Safety
 /// ///
 /// /// If ptr is not NULL, it must be correctly aligned and
 /// /// point to `len` initialized items of type `f32`.
-/// unsafe extern "C" fn handle_slice(ptr: *const f32, len: usize) {
+/// unsafe extern "C" fn sum_slice(ptr: *const f32, len: usize) -> f32 {
 ///     let data = if ptr.is_null() {
 ///         // `len` is assumed to be 0.
 ///         &[]
@@ -104,9 +106,14 @@ use crate::ub_checks;
 ///         // SAFETY: see function docstring.
 ///         unsafe { slice::from_raw_parts(ptr, len) }
 ///     };
-///     dbg!(data);
-///     // ...
+///     data.sum()
 /// }
+///
+/// // This could be the result of C++'s std::vector::data():
+/// let ptr = std::ptr::null();
+/// // And this could be std::vector::size():
+/// let len = 0;
+/// assert_eq!(unsafe { sum_slice(ptr, len) }, 0.0);
 /// ```
 ///
 /// [valid]: ptr#safety

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -83,6 +83,27 @@ use crate::ub_checks;
 /// }
 /// ```
 ///
+/// ### FFI: Handling null pointers
+///
+/// In languages such as C++, pointers to empty collections are not guaranteed to be non-null.
+/// When accepting such pointers, they have to be checked for null-ness to avoid undefined
+/// behavior.
+///
+/// ```
+/// use std::slice;
+///
+/// unsafe extern "C" fn handle_slice(ptr: *const f32, len: usize) {
+///     let data = if ptr.is_null() {
+///         // `len` is assumed to be 0.
+///         &[]
+///     } else {
+///         unsafe { slice::from_raw_parts(ptr, len) }
+///     };
+///     dbg!(data);
+///     // ...
+/// }
+/// ```
+///
 /// [valid]: ptr#safety
 /// [`NonNull::dangling()`]: ptr::NonNull::dangling
 #[inline]

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -92,11 +92,16 @@ use crate::ub_checks;
 /// ```
 /// use std::slice;
 ///
+/// /// # Safety
+/// ///
+/// /// If ptr is not NULL, it must be correctly aligned and
+/// /// point to `len` initialized items of type `f32`.
 /// unsafe extern "C" fn handle_slice(ptr: *const f32, len: usize) {
 ///     let data = if ptr.is_null() {
 ///         // `len` is assumed to be 0.
 ///         &[]
 ///     } else {
+///         // SAFETY: see function docstring.
 ///         unsafe { slice::from_raw_parts(ptr, len) }
 ///     };
 ///     dbg!(data);

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -106,7 +106,7 @@ use crate::ub_checks;
 ///         // SAFETY: see function docstring.
 ///         unsafe { slice::from_raw_parts(ptr, len) }
 ///     };
-///     data.sum()
+///     data.into_iter().sum()
 /// }
 ///
 /// // This could be the result of C++'s std::vector::data():

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -323,8 +323,10 @@ impl Error for VarError {
 /// This function is also always safe to call on Windows, in single-threaded
 /// and multi-threaded programs.
 ///
-/// In multi-threaded programs on other operating systems, we strongly suggest
-/// not using `set_var` or `remove_var` at all. The exact requirement is: you
+/// In multi-threaded programs on other operating systems, the only safe option is
+/// to not use `set_var` or `remove_var` at all.
+///
+/// The exact requirement is: you
 /// must ensure that there are no other threads concurrently writing or
 /// *reading*(!) the environment through functions or global variables other
 /// than the ones in this module. The problem is that these operating systems
@@ -390,8 +392,10 @@ unsafe fn _set_var(key: &OsStr, value: &OsStr) {
 /// This function is also always safe to call on Windows, in single-threaded
 /// and multi-threaded programs.
 ///
-/// In multi-threaded programs on other operating systems, we strongly suggest
-/// not using `set_var` or `remove_var` at all. The exact requirement is: you
+/// In multi-threaded programs on other operating systems, the only safe option is
+/// to not use `set_var` or `remove_var` at all.
+///
+/// The exact requirement is: you
 /// must ensure that there are no other threads concurrently writing or
 /// *reading*(!) the environment through functions or global variables other
 /// than the ones in this module. The problem is that these operating systems

--- a/library/std/src/sys/pal/windows/rand.rs
+++ b/library/std/src/sys/pal/windows/rand.rs
@@ -1,6 +1,6 @@
+use core::{mem, ptr};
+
 use crate::sys::c;
-use core::mem;
-use core::ptr;
 
 #[cfg(not(target_vendor = "win7"))]
 #[inline]

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -477,6 +477,9 @@ impl Wtf8Buf {
     /// Part of a hack to make PathBuf::push/pop more efficient.
     #[inline]
     pub(crate) fn as_mut_vec_for_path_buf(&mut self) -> &mut Vec<u8> {
+        // FIXME: this function should not even exist, as it implies violating Wtf8Buf invariants
+        // For now, simply assume that is about to happen.
+        self.is_known_utf8 = false;
         &mut self.bytes
     }
 }

--- a/library/std/tests/windows.rs
+++ b/library/std/tests/windows.rs
@@ -1,0 +1,14 @@
+#![cfg(windows)]
+//! An external tests
+
+use std::{ffi::OsString, os::windows::ffi::OsStringExt, path::PathBuf};
+
+#[test]
+#[should_panic]
+fn os_string_must_know_it_isnt_utf8_issue_126291() {
+    let mut utf8 = PathBuf::from(OsString::from("utf8".to_owned()));
+    let non_utf8: OsString =
+        OsStringExt::from_wide(&[0x6e, 0x6f, 0x6e, 0xd800, 0x75, 0x74, 0x66, 0x38]);
+    utf8.set_extension(&non_utf8);
+    utf8.into_os_string().into_string().unwrap();
+}

--- a/src/doc/rustc/src/symbol-mangling/v0.md
+++ b/src/doc/rustc/src/symbol-mangling/v0.md
@@ -150,6 +150,15 @@ the *[disambiguator]* is used to make the name unique across the crate graph.
 > ```
 >
 > Recommended demangling: `mycrate::example`
+>
+> Note: The compiler may re-use the *crate-root* form to express arbitrary
+> unscoped, undisambiguated identifiers, such as for new basic types that have
+> not been added to the grammar yet. To achieve that, it will emit a *crate-root*
+> without an explicit disambiguator, relying on the fact that such an
+> undisambiguated crate name cannot occur in practice. For example, the basic
+> type `f128` would be encode as `C4f128`. For this to have the desired effect,
+> demanglers are expected to never render zero disambiguators of crate roots.
+> I.e. `C4f128` is expected to be displayed as `f128` and not `f128[0]`.
 
 ### Path: Inherent impl
 [inherent-impl]: #path-inherent-impl
@@ -539,6 +548,10 @@ This allows disambiguators that are encoded sequentially to use minimal bytes.
 > **Recommended Demangling**
 >
 > The *disambiguator* may or may not be displayed; see recommendations for rules that use *disambiguator*.
+> Generally, it is recommended that zero disambiguators are never displayed unless their accompanying
+> identifier is empty (like is the case for unnamed items such as closures).
+> When rendering a disambiguator, it can be shortened to a length reasonable for the context,
+> similar to how git commit hashes are rarely displayed in full.
 
 ## Lifetime
 [lifetime]: #lifetime

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1281,6 +1281,7 @@ fn expand_variables(mut value: String, config: &Config) -> String {
     const BUILD_BASE: &str = "{{build-base}}";
     const SYSROOT_BASE: &str = "{{sysroot-base}}";
     const TARGET_LINKER: &str = "{{target-linker}}";
+    const TARGET: &str = "{{target}}";
 
     if value.contains(CWD) {
         let cwd = env::current_dir().unwrap();
@@ -1301,6 +1302,10 @@ fn expand_variables(mut value: String, config: &Config) -> String {
 
     if value.contains(TARGET_LINKER) {
         value = value.replace(TARGET_LINKER, config.target_linker.as_deref().unwrap_or(""));
+    }
+
+    if value.contains(TARGET) {
+        value = value.replace(TARGET, &config.target);
     }
 
     value

--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -175,7 +175,6 @@ run-make/pgo-gen/Makefile
 run-make/pgo-indirect-call-promotion/Makefile
 run-make/pgo-use/Makefile
 run-make/pointer-auth-link-with-c/Makefile
-run-make/prefer-rlib/Makefile
 run-make/pretty-print-to-file/Makefile
 run-make/pretty-print-with-dep-file/Makefile
 run-make/print-calling-conventions/Makefile

--- a/src/tools/tidy/src/target_specific_tests.rs
+++ b/src/tools/tidy/src/target_specific_tests.rs
@@ -53,9 +53,9 @@ pub fn check(path: &Path, bad: &mut bool) {
             } else if directive.starts_with(COMPILE_FLAGS_HEADER) {
                 let compile_flags = &directive[COMPILE_FLAGS_HEADER.len()..];
                 if let Some((_, v)) = compile_flags.split_once("--target") {
-                    if let Some((arch, _)) =
-                        v.trim_start_matches(|c| c == ' ' || c == '=').split_once("-")
-                    {
+                    let v = v.trim_start_matches(|c| c == ' ' || c == '=');
+                    let v = if v == "{{target}}" { Some((v, v)) } else { v.split_once("-") };
+                    if let Some((arch, _)) = v {
                         let info = header_map.entry(revision).or_insert(RevisionInfo::default());
                         info.target_arch.replace(arch);
                     } else {

--- a/tests/assembly/nvptx-c-abi-arg-v7.rs
+++ b/tests/assembly/nvptx-c-abi-arg-v7.rs
@@ -40,6 +40,11 @@ pub struct TripleU16 {
     h: u16,
 }
 #[repr(C)]
+pub struct DoubleI32 {
+    f: i32,
+    g: i32,
+}
+#[repr(C)]
 pub struct TripleU32 {
     f: u32,
     g: u32,
@@ -174,6 +179,11 @@ pub unsafe extern "C" fn f_triple_u16_arg(_a: TripleU16) {}
 // CHECK: .param .align 4 .b8 f_triple_u32_arg_param_0[12]
 #[no_mangle]
 pub unsafe extern "C" fn f_triple_u32_arg(_a: TripleU32) {}
+
+// CHECK: .visible .func f_double_i32_arg(
+// CHECK: .param .align 4 .b8 f_double_i32_arg_param_0[8]
+#[no_mangle]
+pub unsafe extern "C" fn f_double_i32_arg(_a: DoubleI32) {}
 
 // CHECK: .visible .func f_triple_u64_arg(
 // CHECK: .param .align 8 .b8 f_triple_u64_arg_param_0[24]

--- a/tests/assembly/nvptx-c-abi-ret-v7.rs
+++ b/tests/assembly/nvptx-c-abi-ret-v7.rs
@@ -40,6 +40,11 @@ pub struct TripleU16 {
     h: u16,
 }
 #[repr(C)]
+pub struct DoubleI32 {
+    f: i32,
+    g: i32,
+}
+#[repr(C)]
 pub struct TripleU32 {
     f: u32,
     g: u32,
@@ -184,6 +189,12 @@ pub unsafe extern "C" fn f_triple_u8_ret() -> TripleU8 {
 #[no_mangle]
 pub unsafe extern "C" fn f_triple_u16_ret() -> TripleU16 {
     TripleU16 { f: 18, g: 19, h: 20 }
+}
+
+// CHECK: .visible .func (.param .align 4 .b8 func_retval0[8]) f_double_i32_ret(
+#[no_mangle]
+pub unsafe extern "C" fn f_double_i32_ret() -> DoubleI32 {
+    DoubleI32 { f: 1, g: 2 }
 }
 
 // CHECK: .visible .func (.param .align 4 .b8 func_retval0[12]) f_triple_u32_ret(

--- a/tests/assembly/nvptx-c-abi-ret-v7.rs
+++ b/tests/assembly/nvptx-c-abi-ret-v7.rs
@@ -1,7 +1,6 @@
 //@ assembly-output: ptx-linker
 //@ compile-flags: --crate-type cdylib -C target-cpu=sm_86 -Z unstable-options -Clinker-flavor=llbc
 //@ only-nvptx64
-//@ ignore-nvptx64
 
 // The PTX ABI stability is tied to major versions of the PTX ISA
 // These tests assume major version 7

--- a/tests/assembly/nvptx-kernel-abi/nvptx-kernel-args-abi-v7.rs
+++ b/tests/assembly/nvptx-kernel-abi/nvptx-kernel-args-abi-v7.rs
@@ -50,6 +50,11 @@ pub struct TripleU16 {
     h: u16,
 }
 #[repr(C)]
+pub struct DoubleI32 {
+    f: i32,
+    g: i32,
+}
+#[repr(C)]
 pub struct TripleU32 {
     f: u32,
     g: u32,
@@ -179,6 +184,11 @@ pub unsafe extern "ptx-kernel" fn f_triple_u8_arg(_a: TripleU8) {}
 // CHECK: .param .align 2 .b8 f_triple_u16_arg_param_0[6]
 #[no_mangle]
 pub unsafe extern "ptx-kernel" fn f_triple_u16_arg(_a: TripleU16) {}
+
+// CHECK: .visible .entry f_double_i32_arg(
+// CHECK: .param .align 4 .b8 f_double_i32_arg_param_0[8]
+#[no_mangle]
+pub unsafe extern "ptx-kernel" fn f_double_i32_arg(_a: DoubleI32) {}
 
 // CHECK: .visible .entry f_triple_u32_arg(
 // CHECK: .param .align 4 .b8 f_triple_u32_arg_param_0[12]

--- a/tests/codegen/issues/issue-122805.rs
+++ b/tests/codegen/issues/issue-122805.rs
@@ -39,17 +39,20 @@
 // OPT3WINX64-NEXT: store <8 x i16>
 // CHECK-NEXT: ret void
 #[no_mangle]
-#[cfg(target_endian = "little")]
 pub fn convert(value: [u16; 8]) -> [u8; 16] {
+    #[cfg(target_endian = "little")]
+    let bswap = u16::to_be;
+    #[cfg(target_endian = "big")]
+    let bswap = u16::to_le;
     let addr16 = [
-        value[0].to_be(),
-        value[1].to_be(),
-        value[2].to_be(),
-        value[3].to_be(),
-        value[4].to_be(),
-        value[5].to_be(),
-        value[6].to_be(),
-        value[7].to_be(),
+        bswap(value[0]),
+        bswap(value[1]),
+        bswap(value[2]),
+        bswap(value[3]),
+        bswap(value[4]),
+        bswap(value[5]),
+        bswap(value[6]),
+        bswap(value[7]),
     ];
     unsafe { core::mem::transmute::<_, [u8; 16]>(addr16) }
 }

--- a/tests/run-make/prefer-dylib/rmake.rs
+++ b/tests/run-make/prefer-dylib/rmake.rs
@@ -1,7 +1,6 @@
 //@ ignore-cross-compile
 
-use run_make_support::{cwd, dynamic_lib_name, read_dir, run, run_fail, rustc};
-use std::fs::remove_file;
+use run_make_support::{cwd, dynamic_lib_name, fs_wrapper, read_dir, run, run_fail, rustc};
 
 fn main() {
     rustc().input("bar.rs").crate_type("dylib").crate_type("rlib").arg("-Cprefer-dynamic").run();
@@ -9,7 +8,7 @@ fn main() {
 
     run("foo");
 
-    remove_file(dynamic_lib_name("bar")).unwrap();
+    fs_wrapper::remove_file(dynamic_lib_name("bar"));
     // This time the command should fail.
     run_fail("foo");
 }

--- a/tests/run-make/prefer-dylib/rmake.rs
+++ b/tests/run-make/prefer-dylib/rmake.rs
@@ -2,7 +2,6 @@
 
 use run_make_support::{cwd, dynamic_lib_name, read_dir, run, run_fail, rustc};
 use std::fs::remove_file;
-use std::process::Command;
 
 fn main() {
     rustc().input("bar.rs").crate_type("dylib").crate_type("rlib").arg("-Cprefer-dynamic").run();

--- a/tests/run-make/prefer-rlib/Makefile
+++ b/tests/run-make/prefer-rlib/Makefile
@@ -1,9 +1,0 @@
-# ignore-cross-compile
-include ../tools.mk
-
-all:
-	$(RUSTC) bar.rs --crate-type=dylib --crate-type=rlib
-	ls $(TMPDIR)/$(call RLIB_GLOB,bar)
-	$(RUSTC) foo.rs
-	rm $(TMPDIR)/*bar*
-	$(call RUN,foo)

--- a/tests/run-make/prefer-rlib/rmake.rs
+++ b/tests/run-make/prefer-rlib/rmake.rs
@@ -3,14 +3,13 @@
 
 //@ ignore-cross-compile
 
-use run_make_support::{dynamic_lib_name, path, run, rust_lib_name, rustc};
-use std::fs::remove_file;
+use run_make_support::{dynamic_lib_name, fs_wrapper, path, run, rust_lib_name, rustc};
 
 fn main() {
     rustc().input("bar.rs").crate_type("dylib").crate_type("rlib").run();
     assert!(path(rust_lib_name("bar")).exists());
     rustc().input("foo.rs").run();
-    remove_file(rust_lib_name("bar")).unwrap();
-    remove_file(dynamic_lib_name("bar")).unwrap();
+    fs_wrapper::remove_file(rust_lib_name("bar"));
+    fs_wrapper::remove_file(dynamic_lib_name("bar"));
     run("foo");
 }

--- a/tests/run-make/prefer-rlib/rmake.rs
+++ b/tests/run-make/prefer-rlib/rmake.rs
@@ -1,0 +1,16 @@
+// Check that `foo.rs` prefers to link to `bar` statically, and can be executed even if the `bar`
+// library artifacts are removed.
+
+//@ ignore-cross-compile
+
+use run_make_support::{dynamic_lib_name, path, run, rust_lib_name, rustc};
+use std::fs::remove_file;
+
+fn main() {
+    rustc().input("bar.rs").crate_type("dylib").crate_type("rlib").run();
+    assert!(path(rust_lib_name("bar")).exists());
+    rustc().input("foo.rs").run();
+    remove_file(rust_lib_name("bar")).unwrap();
+    remove_file(dynamic_lib_name("bar")).unwrap();
+    run("foo");
+}

--- a/tests/ui/abi/compatibility.rs
+++ b/tests/ui/abi/compatibility.rs
@@ -55,13 +55,9 @@
 //@ revisions: csky
 //@[csky] compile-flags: --target csky-unknown-linux-gnuabiv2
 //@[csky] needs-llvm-components: csky
-
-// FIXME: disabled on nvptx64 since the target ABI fails the sanity check
-// see https://github.com/rust-lang/rust/issues/117480
-/* revisions: nvptx64
-  [nvptx64] compile-flags: --target nvptx64-nvidia-cuda
-  [nvptx64] needs-llvm-components: nvptx
-*/
+//@ revisions: nvptx64
+//@[nvptx64] compile-flags: --target nvptx64-nvidia-cuda
+//@[nvptx64] needs-llvm-components: nvptx
 #![feature(rustc_attrs, unsized_fn_params, transparent_unions)]
 #![cfg_attr(not(host), feature(no_core, lang_items), no_std, no_core)]
 #![allow(unused, improper_ctypes_definitions, internal_features)]

--- a/tests/ui/associated-inherent-types/assoc-inherent-private.stderr
+++ b/tests/ui/associated-inherent-types/assoc-inherent-private.stderr
@@ -2,7 +2,7 @@ error[E0624]: associated type `P` is private
   --> $DIR/assoc-inherent-private.rs:10:10
    |
 LL |         type P = ();
-   |         ------ associated type defined here
+   |         ------ the associated type is defined here
 ...
 LL | type U = m::T::P;
    |          ^^^^^^^ private associated type
@@ -11,7 +11,7 @@ error[E0624]: associated type `P` is private
   --> $DIR/assoc-inherent-private.rs:21:10
    |
 LL |             pub(super) type P = bool;
-   |             ----------------- associated type defined here
+   |             ----------------- the associated type is defined here
 ...
 LL | type V = n::n::T::P;
    |          ^^^^^^^^^^ private associated type

--- a/tests/ui/mir/lint/storage-live.rs
+++ b/tests/ui/mir/lint/storage-live.rs
@@ -5,6 +5,7 @@
 //@ normalize-stderr-test "note: .*\n\n" -> ""
 //@ normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
 //@ normalize-stderr-test "storage_live\[....\]" -> "storage_live[HASH]"
+//@ normalize-stderr-test "(delayed at [^:]+):\d+:\d+ - " -> "$1:LL:CC - "
 //@ rustc-env:RUST_BACKTRACE=0
 
 #![feature(custom_mir, core_intrinsics)]

--- a/tests/ui/mir/lint/storage-live.stderr
+++ b/tests/ui/mir/lint/storage-live.stderr
@@ -1,12 +1,12 @@
 error: internal compiler error: broken MIR in Item(DefId(0:8 ~ storage_live[HASH]::multiple_storage)) (after pass CheckPackedRef) at bb0[1]:
                                 StorageLive(_1) which already has storage here
-  --> $DIR/storage-live.rs:22:13
+  --> $DIR/storage-live.rs:23:13
    |
 LL |             StorageLive(a);
    |             ^^^^^^^^^^^^^^
    |
-note: delayed at compiler/rustc_mir_transform/src/lint.rs:97:26 - disabled backtrace
-  --> $DIR/storage-live.rs:22:13
+note: delayed at compiler/rustc_mir_transform/src/lint.rs:LL:CC - disabled backtrace
+  --> $DIR/storage-live.rs:23:13
    |
 LL |             StorageLive(a);
    |             ^^^^^^^^^^^^^^

--- a/tests/ui/return/return-from-residual-sugg-issue-125997.fixed
+++ b/tests/ui/return/return-from-residual-sugg-issue-125997.fixed
@@ -1,0 +1,42 @@
+//@ run-rustfix
+
+#![allow(unused_imports)]
+#![allow(dead_code)]
+
+use std::fs::File;
+use std::io::prelude::*;
+
+fn test1() -> Result<(), Box<dyn std::error::Error>> {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+
+    Ok(())
+}
+
+fn test2() -> Result<(), Box<dyn std::error::Error>> {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+    println!();
+
+    Ok(())
+}
+
+macro_rules! mac {
+    () => {
+        fn test3() -> Result<(), Box<dyn std::error::Error>> {
+            let mut _file = File::create("foo.txt")?;
+            //~^ ERROR the `?` operator can only be used in a function
+            println!();
+        
+    Ok(())
+}
+    };
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+    mac!();
+
+    Ok(())
+}

--- a/tests/ui/return/return-from-residual-sugg-issue-125997.rs
+++ b/tests/ui/return/return-from-residual-sugg-issue-125997.rs
@@ -1,0 +1,34 @@
+//@ run-rustfix
+
+#![allow(unused_imports)]
+#![allow(dead_code)]
+
+use std::fs::File;
+use std::io::prelude::*;
+
+fn test1() {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+}
+
+fn test2() {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+    println!();
+}
+
+macro_rules! mac {
+    () => {
+        fn test3() {
+            let mut _file = File::create("foo.txt")?;
+            //~^ ERROR the `?` operator can only be used in a function
+            println!();
+        }
+    };
+}
+
+fn main() {
+    let mut _file = File::create("foo.txt")?;
+    //~^ ERROR the `?` operator can only be used in a function
+    mac!();
+}

--- a/tests/ui/return/return-from-residual-sugg-issue-125997.stderr
+++ b/tests/ui/return/return-from-residual-sugg-issue-125997.stderr
@@ -1,0 +1,86 @@
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> $DIR/return-from-residual-sugg-issue-125997.rs:10:44
+   |
+LL | fn test1() {
+   | ---------- this function should return `Result` or `Option` to accept `?`
+LL |     let mut _file = File::create("foo.txt")?;
+   |                                            ^ cannot use the `?` operator in a function that returns `()`
+   |
+   = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+help: consider adding return type
+   |
+LL ~ fn test1() -> Result<(), Box<dyn std::error::Error>> {
+LL |     let mut _file = File::create("foo.txt")?;
+LL |
+LL + 
+LL +     Ok(())
+LL + }
+   |
+
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> $DIR/return-from-residual-sugg-issue-125997.rs:15:44
+   |
+LL | fn test2() {
+   | ---------- this function should return `Result` or `Option` to accept `?`
+LL |     let mut _file = File::create("foo.txt")?;
+   |                                            ^ cannot use the `?` operator in a function that returns `()`
+   |
+   = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+help: consider adding return type
+   |
+LL ~ fn test2() -> Result<(), Box<dyn std::error::Error>> {
+LL |     let mut _file = File::create("foo.txt")?;
+LL |
+LL |     println!();
+LL + 
+LL +     Ok(())
+LL + }
+   |
+
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> $DIR/return-from-residual-sugg-issue-125997.rs:31:44
+   |
+LL | fn main() {
+   | --------- this function should return `Result` or `Option` to accept `?`
+LL |     let mut _file = File::create("foo.txt")?;
+   |                                            ^ cannot use the `?` operator in a function that returns `()`
+   |
+   = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+help: consider adding return type
+   |
+LL ~ fn main() -> Result<(), Box<dyn std::error::Error>> {
+LL |     let mut _file = File::create("foo.txt")?;
+LL |
+LL |     mac!();
+LL + 
+LL +     Ok(())
+LL + }
+   |
+
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> $DIR/return-from-residual-sugg-issue-125997.rs:23:52
+   |
+LL |         fn test3() {
+   |         ---------- this function should return `Result` or `Option` to accept `?`
+LL |             let mut _file = File::create("foo.txt")?;
+   |                                                    ^ cannot use the `?` operator in a function that returns `()`
+...
+LL |     mac!();
+   |     ------ in this macro invocation
+   |
+   = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider adding return type
+   |
+LL ~         fn test3() -> Result<(), Box<dyn std::error::Error>> {
+LL |             let mut _file = File::create("foo.txt")?;
+LL |
+LL |             println!();
+LL ~         
+LL +     Ok(())
+LL + }
+   |
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/item-privacy.stderr
+++ b/tests/ui/traits/item-privacy.stderr
@@ -195,14 +195,17 @@ error[E0624]: associated type `A` is private
   --> $DIR/item-privacy.rs:119:12
    |
 LL |         type A = u8;
-   |         ------ associated type defined here
+   |         ------ the associated type is defined here
 ...
 LL |     let _: T::A;
    |            ^^^^ private associated type
 
-error: associated type `A` is private
+error[E0624]: associated type `A` is private
   --> $DIR/item-privacy.rs:128:9
    |
+LL |         type A = u8;
+   |         ------ the associated type is defined here
+...
 LL |         A = u8,
    |         ^^^^^^ private associated type
 

--- a/tests/ui/try-trait/try-operator-on-main.stderr
+++ b/tests/ui/try-trait/try-operator-on-main.stderr
@@ -8,6 +8,16 @@ LL |     std::fs::File::open("foo")?;
    |                               ^ cannot use the `?` operator in a function that returns `()`
    |
    = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+help: consider adding return type
+   |
+LL ~ fn main() -> Result<(), Box<dyn std::error::Error>> {
+LL |     // error for a `Try` type on a non-`Try` fn
+ ...
+LL |     try_trait_generic::<()>();
+LL + 
+LL +     Ok(())
+LL + }
+   |
 
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
   --> $DIR/try-operator-on-main.rs:10:5


### PR DESCRIPTION
Successful merges:

 - #123374 (DOC: Add FFI example for slice::from_raw_parts())
 - #124514 (Recommend to never display zero disambiguators when demangling v0 symbols)
 - #125978 (Cleanup: HIR ty lowering: Consolidate the places that do assoc item probing & access checking)
 - #125980 (Nvptx remove direct passmode)
 - #126187 (For E0277 suggest adding `Result` return type for function when using QuestionMark `?` in the body.)
 - #126210 (docs(core): make more const_ptr doctests assert instead of printing)
 - #126249 (Simplify `[T; N]::try_map` signature)
 - #126256 (Add {{target}} substitution to compiletest)
 - #126263 (Make issue-122805.rs big endian compatible)
 - #126281 (set_env: State the conclusion upfront)
 - #126286 (Make `storage-live.rs` robust against rustc internal changes.)
 - #126287 (Update a cranelift patch file for formatting changes.)
 - #126301 (Use `tidy` to sort crate attributes for all compiler crates.)
 - #126305 (Make PathBuf less Ok with adding UTF-16 then `into_string`)
 - #126310 (Migrate run make prefer rlib)
 - #126314 (fix RELEASES: we do not support upcasting to auto traits)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=123374,124514,125978,125980,126187,126210,126249,126256,126263,126281,126286,126287,126301,126305,126310,126314)
<!-- homu-ignore:end -->