### PR TITLE
Return opaque type from PanicInfo::message()

### DIFF
--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -12,6 +12,8 @@ use crate::any::Any;
 pub use self::location::Location;
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 pub use self::panic_info::PanicInfo;
+#[unstable(feature = "panic_info_message", issue = "66745")]
+pub use self::panic_info::PanicMessage;
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 pub use self::unwind_safe::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
 


### PR DESCRIPTION
This changes the return type of the (unstable) PanicInfo::message() method to an opaque type (that implements Display). This allows for a bit more flexibility in the future.

See https://github.com/rust-lang/rust/issues/66745