### PR TITLE
Add test for walking order dependent opaque type behaviour

### DIFF
--- a/tests/ui/impl-trait/associated-type-undefine.rs
+++ b/tests/ui/impl-trait/associated-type-undefine.rs
@@ -1,0 +1,28 @@
+#![feature(impl_trait_in_assoc_type)]
+
+trait Foo: Sized {
+    type Bar;
+    type Gat<T: Foo>;
+    fn foo(self) -> (<Self as Foo>::Gat<u32>, <Self as Foo>::Gat<Self>);
+}
+
+impl Foo for u32 {
+    type Bar = ();
+    type Gat<T: Foo> = ();
+    fn foo(self) -> (<Self as Foo>::Gat<u32>, <Self as Foo>::Gat<Self>) {
+        ((), ())
+    }
+}
+
+impl Foo for () {
+    type Bar = impl Sized;
+    type Gat<T: Foo> = <T as Foo>::Bar;
+    // Because we encounter `Gat<u32>` first, we never walk into another `Gat`
+    // again, thus missing the opaque type that we could be defining.
+    fn foo(self) -> (<Self as Foo>::Gat<u32>, <Self as Foo>::Gat<Self>) {
+        ((), ())
+        //~^ ERROR: mismatched types
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/associated-type-undefine.stderr
+++ b/tests/ui/impl-trait/associated-type-undefine.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/associated-type-undefine.rs:23:14
+   |
+LL |     type Bar = impl Sized;
+   |                ---------- the expected opaque type
+...
+LL |         ((), ())
+   |              ^^ expected opaque type, found `()`
+   |
+   = note: expected opaque type `<() as Foo>::Bar`
+                found unit type `()`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
+  --> $DIR/associated-type-undefine.rs:22:8
+   |
+LL |     fn foo(self) -> (<Self as Foo>::Gat<u32>, <Self as Foo>::Gat<Self>) {
+   |        ^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
r? @lcnr 

adding the test for your comment here: https://github.com/rust-lang/rust/pull/122366/files#r1521124754