### PR TITLE
Remove some msys2 utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,6 @@ jobs:
           path-type: inherit
           install: >
             make
-            dos2unix
-            diffutils
 
       - name: disable git crlf conversion
         run: git config --global core.autocrlf false


### PR DESCRIPTION
`dos2unix` should no longer be necessary. I suspect `diffutils` might not be needed either as (I think) only `diff` is used and that seems to be shipped with git bash at least.

try-job: x86_64-msvc
try-job: x86_64-msvc-ext
try-job: dist-x86_64-msvc