### PR TITLE
export std::os::fd module on HermitOS

### DIFF
--- a/library/std/src/os/hermit/io/mod.rs
+++ b/library/std/src/os/hermit/io/mod.rs
@@ -1,13 +1,4 @@
-#![stable(feature = "os_fd", since = "1.66.0")]
+#![stable(feature = "rust1", since = "1.0.0")]
 
-mod net;
-#[path = "../../fd/owned.rs"]
-mod owned;
-#[path = "../../fd/raw.rs"]
-mod raw;
-
-// Export the types and traits for the public API.
-#[stable(feature = "os_fd", since = "1.66.0")]
-pub use owned::*;
-#[stable(feature = "os_fd", since = "1.66.0")]
-pub use raw::*;
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use crate::os::fd::*;

--- a/library/std/src/os/mod.rs
+++ b/library/std/src/os/mod.rs
@@ -160,7 +160,7 @@ pub(crate) mod watchos;
 #[cfg(target_os = "xous")]
 pub mod xous;
 
-#[cfg(any(unix, target_os = "wasi", doc))]
+#[cfg(any(unix, target_os = "hermit", target_os = "wasi", doc))]
 pub mod fd;
 
 #[cfg(any(target_os = "linux", target_os = "android", doc))]


### PR DESCRIPTION
The HermitOS' IO interface is similiar to Unix. Consequently, this PR synchronize the FD implementation between both.

closes #126198