### PR TITLE
Improve error message if dependency installation in tidy fails

### DIFF
--- a/src/tools/tidy/src/ext_tool_checks.rs
+++ b/src/tools/tidy/src/ext_tool_checks.rs
@@ -274,13 +274,18 @@ fn create_venv_at_path(path: &Path) -> Result<(), Error> {
     if out.status.success() {
         return Ok(());
     }
-    let err = if String::from_utf8_lossy(&out.stderr).contains("No module named virtualenv") {
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let err = if stderr.contains("No module named virtualenv") {
         Error::Generic(format!(
             "virtualenv not found: you may need to install it \
                                (`python3 -m pip install venv`)"
         ))
     } else {
-        Error::Generic(format!("failed to create venv at '{}' using {sys_py}", path.display()))
+        Error::Generic(format!(
+            "failed to create venv at '{}' using {sys_py}: {stderr}",
+            path.display()
+        ))
     };
     Err(err)
 }


### PR DESCRIPTION
Should help with easier debugging of issues occuring during [venv installation](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/PR.20CI.20broken) of `tidy` dependencies.