### PR TITLE
docs(rustc): Improve discoverable of Cargo docs

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3256,7 +3256,11 @@ declare_lint! {
     /// See the [Checking Conditional Configurations][check-cfg] section for more
     /// details.
     ///
+    /// See the [Cargo Specifics][unexpected_cfgs_lint_config] section for configuring this lint in
+    /// `Cargo.toml`.
+    ///
     /// [check-cfg]: https://doc.rust-lang.org/nightly/rustc/check-cfg.html
+    /// [unexpected_cfgs_lint_config]: https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html#check-cfg-in-lintsrust-table
     pub UNEXPECTED_CFGS,
     Warn,
     "detects unexpected names and values in `#[cfg]` conditions",

--- a/src/doc/rustc/src/check-cfg.md
+++ b/src/doc/rustc/src/check-cfg.md
@@ -11,9 +11,6 @@ development process.
 In order to accomplish that goal, `rustc` accepts the `--check-cfg` flag, which specifies
 whether to check conditions and how to check them.
 
-> **Note:** No implicit expectation is added when using `--cfg`. Users are expected to
-pass all expected names and values using the _check cfg specification_.
-
 > **Note:** For interacting with this through Cargo,
 see [Cargo Specifics](check-cfg/cargo-specifics.md) page.
 
@@ -25,6 +22,9 @@ breaking change.
 
 To specify expected names and values, the _check cfg specification_ provides the `cfg(...)`
 option which enables specifying for an expected config name and it's expected values.
+
+> **Note:** No implicit expectation is added when using `--cfg`. Users are expected to
+pass all expected names and values using the _check cfg specification_.
 
 It has this basic form:
 

--- a/src/doc/rustc/src/check-cfg.md
+++ b/src/doc/rustc/src/check-cfg.md
@@ -14,6 +14,9 @@ whether to check conditions and how to check them.
 > **Note:** No implicit expectation is added when using `--cfg`. Users are expected to
 pass all expected names and values using the _check cfg specification_.
 
+> **Note:** For interacting with this through Cargo,
+see [Cargo Specifics](check-cfg/cargo-specifics.md) page.
+
 [^reachable]: `rustc` promises to at least check reachable `#[cfg]`, and while non-reachable
 `#[cfg]` are not currently checked, they may well be checked in the future without it being a
 breaking change.


### PR DESCRIPTION
In preparing Cargo's blog post for 1.80, I tried to find the documentation for the lint configuration and I couldn't.  The link is only visible from the lint itself, which isn't where I started, and the side bar, which was collapsed for me.

The first place I went was the docs for `unexpected_cfgs` because this is configuration for that lint.  If using lint configuration were a one off, I could see skipping it here.  However, when we discussed this with at least one T-compiler member, there was interest in using this for other lints in the future.  To that end, it seems like we should be exposing this with the lint itself.

The second place I checked was the `check-cfg` documentation.  This now has a call out for the sub-page.