### PR TITLE
Make `try_from_target_usize` method public

### DIFF
--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -122,7 +122,7 @@ impl TyConst {
     }
 
     /// Creates an interned usize constant.
-    fn try_from_target_usize(val: u64) -> Result<Self, Error> {
+    pub fn try_from_target_usize(val: u64) -> Result<Self, Error> {
         with(|cx| cx.try_new_ty_const_uint(val.into(), UintTy::Usize))
     }
 


### PR DESCRIPTION
There is now no way to create a TyConst from an integer, so I propose making this method public unless there was a reason for keeping it otherwise.