### PR TITLE
Point out failing never obligation for `DEPENDENCY_ON_UNIT_NEVER_TYPE_FALLBACK`

### DIFF
--- a/compiler/rustc_hir_typeck/messages.ftl
+++ b/compiler/rustc_hir_typeck/messages.ftl
@@ -45,6 +45,7 @@ hir_typeck_convert_using_method = try using `{$sugg}` to convert `{$found}` to `
 hir_typeck_ctor_is_private = tuple struct constructor `{$def}` is private
 
 hir_typeck_dependency_on_unit_never_type_fallback = this function depends on never type fallback being `()`
+    .note = in edition 2024, the requirement `{$obligation}` will fail
     .help = specify the types explicitly
 
 hir_typeck_deref_is_empty = this expression `Deref`s to `{$deref_ty}` which implements `is_empty`

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -7,7 +7,7 @@ use rustc_errors::{
     SubdiagMessageOp, Subdiagnostic,
 };
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
-use rustc_middle::ty::Ty;
+use rustc_middle::ty::{self, Ty};
 use rustc_span::{
     edition::{Edition, LATEST_STABLE_EDITION},
     symbol::Ident,
@@ -186,7 +186,11 @@ pub enum NeverTypeFallbackFlowingIntoUnsafe {
 #[derive(LintDiagnostic)]
 #[help]
 #[diag(hir_typeck_dependency_on_unit_never_type_fallback)]
-pub struct DependencyOnUnitNeverTypeFallback {}
+pub struct DependencyOnUnitNeverTypeFallback<'tcx> {
+    #[note]
+    pub obligation_span: Span,
+    pub obligation: ty::Predicate<'tcx>,
+}
 
 #[derive(Subdiagnostic)]
 #[multipart_suggestion(

--- a/tests/ui/delegation/not-supported.stderr
+++ b/tests/ui/delegation/not-supported.stderr
@@ -124,6 +124,11 @@ LL |         fn opaque_ret() -> impl Trait { unimplemented!() }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: opaque::Trait` will fail
+  --> $DIR/not-supported.rs:80:28
+   |
+LL |         fn opaque_ret() -> impl Trait { unimplemented!() }
+   |                            ^^^^^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
 
 error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/not-supported.rs:86:5: 86:24>::{synthetic#0}`
@@ -154,6 +159,11 @@ LL |         pub fn opaque_ret() -> impl Trait { unimplemented!() }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: opaque::Trait` will fail
+  --> $DIR/not-supported.rs:72:32
+   |
+LL |         pub fn opaque_ret() -> impl Trait { unimplemented!() }
+   |                                ^^^^^^^^^^
 
 error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/not-supported.rs:89:5: 89:25>::{synthetic#0}`
   --> $DIR/not-supported.rs:90:24

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -7,6 +7,11 @@ LL | fn m() {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: Default` will fail
+  --> $DIR/never-type-fallback-breaking.rs:19:17
+   |
+LL |         true => Default::default(),
+   |                 ^^^^^^^^^^^^^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
 
 warning: this function depends on never type fallback being `()`
@@ -18,6 +23,11 @@ LL | fn q() -> Option<()> {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: Default` will fail
+  --> $DIR/never-type-fallback-breaking.rs:34:5
+   |
+LL |     deserialize()?;
+   |     ^^^^^^^^^^^^^
 
 warning: 2 warnings emitted
 

--- a/tests/ui/never_type/defaulted-never-note.nofallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.nofallback.stderr
@@ -7,6 +7,11 @@ LL | fn smeg() {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will fail
+  --> $DIR/defaulted-never-note.rs:32:9
+   |
+LL |     foo(_x);
+   |         ^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
+++ b/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
@@ -7,6 +7,11 @@ LL | fn def() {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: Default` will fail
+  --> $DIR/dependency-on-fallback-to-unit.rs:12:19
+   |
+LL |         false => <_>::default(),
+   |                   ^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
 
 warning: this function depends on never type fallback being `()`
@@ -18,6 +23,11 @@ LL | fn question_mark() -> Result<(), ()> {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: Default` will fail
+  --> $DIR/dependency-on-fallback-to-unit.rs:22:5
+   |
+LL |     deserialize()?;
+   |     ^^^^^^^^^^^^^
 
 warning: 2 warnings emitted
 

--- a/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
@@ -7,6 +7,11 @@ LL | fn assignment() {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: UnitDefault` will fail
+  --> $DIR/diverging-fallback-control-flow.rs:36:13
+   |
+LL |         x = UnitDefault::default();
+   |             ^^^^^^^^^^^^^^^^^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
 
 warning: this function depends on never type fallback being `()`
@@ -18,6 +23,11 @@ LL | fn assignment_rev() {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: UnitDefault` will fail
+  --> $DIR/diverging-fallback-control-flow.rs:50:13
+   |
+LL |         x = UnitDefault::default();
+   |             ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: 2 warnings emitted
 

--- a/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
@@ -7,6 +7,11 @@ LL | fn main() {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: Test` will fail
+  --> $DIR/diverging-fallback-no-leak.rs:20:23
+   |
+LL |     unconstrained_arg(return);
+   |                       ^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
@@ -7,6 +7,11 @@ LL | fn main() {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: UnitReturn` will fail
+  --> $DIR/diverging-fallback-unconstrained-return.rs:39:23
+   |
+LL |     let _ = if true { unconstrained_return() } else { panic!() };
+   |                       ^^^^^^^^^^^^^^^^^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
+++ b/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
@@ -7,6 +7,11 @@ LL | fn main() {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: Bar` will fail
+  --> $DIR/fallback-closure-ret.rs:24:5
+   |
+LL |     foo(|| panic!());
+   |     ^^^^^^^^^^^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/never_type/impl_trait_fallback.stderr
+++ b/tests/ui/never_type/impl_trait_fallback.stderr
@@ -7,6 +7,11 @@ LL | fn should_ret_unit() -> impl T {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
+note: in edition 2024, the requirement `!: T` will fail
+  --> $DIR/impl_trait_fallback.rs:8:25
+   |
+LL | fn should_ret_unit() -> impl T {
+   |                         ^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
 
 warning: 1 warning emitted


### PR DESCRIPTION
Based on top of #125289, so just need to look at the last commit.

r? @WaffleLapkin