### PR TITLE
Tweak output of import suggestions

### DIFF
--- a/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
@@ -4,9 +4,7 @@ error[E0412]: cannot find type `PhantomData` in this scope
 LL |     _n: PhantomData,
    |         ^^^^^^^^^^^ not found in this scope
    |
-help: consider importing one of these items
-   |
-LL + use core::marker::PhantomData;
+help: consider importing this struct
    |
 LL + use std::marker::PhantomData;
    |

--- a/tests/ui/const-generics/issues/issue-82956.stderr
+++ b/tests/ui/const-generics/issues/issue-82956.stderr
@@ -4,7 +4,7 @@ error[E0433]: failed to resolve: use of undeclared type `IntoIter`
 LL |         let mut iter = IntoIter::new(self);
    |                        ^^^^^^^^ use of undeclared type `IntoIter`
    |
-help: consider importing one of these items
+help: consider importing one of these structs
    |
 LL + use std::array::IntoIter;
    |

--- a/tests/ui/consts/const_refs_to_static-ice-121413.rs
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.rs
@@ -5,12 +5,16 @@
 // ignore-tidy-linelength
 #![feature(const_refs_to_static)]
 const REF_INTERIOR_MUT: &usize = {
+    //~^ HELP consider importing this struct
     static FOO: Sync = AtomicUsize::new(0);
     //~^ ERROR failed to resolve: use of undeclared type `AtomicUsize`
     //~| WARN trait objects without an explicit `dyn` are deprecated
     //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
     //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+    //~| HELP if this is an object-safe trait, use `dyn`
+    //~| HELP the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+    //~| HELP the trait `Sized` is not implemented for `(dyn Sync + 'static)`
     unsafe { &*(&FOO as *const _ as *const usize) }
 };
 pub fn main() {}

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -1,5 +1,5 @@
 error[E0433]: failed to resolve: use of undeclared type `AtomicUsize`
-  --> $DIR/const_refs_to_static-ice-121413.rs:8:24
+  --> $DIR/const_refs_to_static-ice-121413.rs:9:24
    |
 LL |     static FOO: Sync = AtomicUsize::new(0);
    |                        ^^^^^^^^^^^ use of undeclared type `AtomicUsize`
@@ -10,7 +10,7 @@ LL + use std::sync::atomic::AtomicUsize;
    |
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/const_refs_to_static-ice-121413.rs:8:17
+  --> $DIR/const_refs_to_static-ice-121413.rs:9:17
    |
 LL |     static FOO: Sync = AtomicUsize::new(0);
    |                 ^^^^
@@ -24,7 +24,7 @@ LL |     static FOO: dyn Sync = AtomicUsize::new(0);
    |                 +++
 
 error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
-  --> $DIR/const_refs_to_static-ice-121413.rs:8:17
+  --> $DIR/const_refs_to_static-ice-121413.rs:9:17
    |
 LL |     static FOO: Sync = AtomicUsize::new(0);
    |                 ^^^^ doesn't have a size known at compile-time
@@ -32,7 +32,7 @@ LL |     static FOO: Sync = AtomicUsize::new(0);
    = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
 
 error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
-  --> $DIR/const_refs_to_static-ice-121413.rs:8:24
+  --> $DIR/const_refs_to_static-ice-121413.rs:9:24
    |
 LL |     static FOO: Sync = AtomicUsize::new(0);
    |                        ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/tests/ui/did_you_mean/issue-56028-there-is-an-enum-variant.stderr
+++ b/tests/ui/did_you_mean/issue-56028-there-is-an-enum-variant.stderr
@@ -22,7 +22,7 @@ error[E0425]: cannot find value `Set` in this scope
 LL | fn setup() -> Set { Set }
    |                     ^^^ not found in this scope
    |
-help: consider importing one of these items
+help: consider importing one of these unit variants
    |
 LL + use AffixHeart::Set;
    |

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.stderr
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.stderr
@@ -24,8 +24,7 @@ LL |         fn f() { my_core::mem::drop(0); }
 LL | a!();
    | ---- in this macro invocation
    |
-   = help: consider importing one of these items:
-           core::mem
+   = help: consider importing this module:
            std::mem
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -35,9 +34,7 @@ error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
 LL |     fn f() { my_core::mem::drop(0); }
    |              ^^^^^^^ use of undeclared crate or module `my_core`
    |
-help: consider importing one of these items
-   |
-LL +     use core::mem;
+help: consider importing this module
    |
 LL +     use std::mem;
    |

--- a/tests/ui/imports/cycle-import-in-std-1.stderr
+++ b/tests/ui/imports/cycle-import-in-std-1.stderr
@@ -4,8 +4,7 @@ error[E0432]: unresolved import `ops`
 LL | use ops::{self as std};
    |           ^^^^^^^^^^^ no external crate `ops`
    |
-   = help: consider importing one of these items instead:
-           core::ops
+   = help: consider importing this module instead:
            std::ops
 
 error: aborting due to 1 previous error

--- a/tests/ui/imports/cycle-import-in-std-2.stderr
+++ b/tests/ui/imports/cycle-import-in-std-2.stderr
@@ -4,8 +4,7 @@ error[E0432]: unresolved import `ops`
 LL | use ops::{self as std};
    |           ^^^^^^^^^^^ no external crate `ops`
    |
-   = help: consider importing one of these items instead:
-           core::ops
+   = help: consider importing this module instead:
            std::ops
 
 error: aborting due to 1 previous error

--- a/tests/ui/imports/import-alias-issue-121168.edition2018.stderr
+++ b/tests/ui/imports/import-alias-issue-121168.edition2018.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `Foo` in this scope
 LL |     let _: Foo<i32> = todo!();
    |            ^^^ not found in this scope
    |
-help: consider importing one of these items
+help: consider importing one of these structs
    |
 LL + use crate::nice_crate_name::Foo;
    |

--- a/tests/ui/imports/import-alias-issue-121168.edition2021.stderr
+++ b/tests/ui/imports/import-alias-issue-121168.edition2021.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `Foo` in this scope
 LL |     let _: Foo<i32> = todo!();
    |            ^^^ not found in this scope
    |
-help: consider importing one of these items
+help: consider importing one of these structs
    |
 LL + use crate::nice_crate_name::Foo;
    |

--- a/tests/ui/imports/issue-56125.stderr
+++ b/tests/ui/imports/issue-56125.stderr
@@ -4,16 +4,16 @@ error[E0432]: unresolved import `empty::issue_56125`
 LL |     use empty::issue_56125;
    |         ^^^^^^^^^^^^^^^^^^ no `issue_56125` in `m3::empty`
    |
-help: consider importing one of these items instead
+help: consider importing one of these modules instead
    |
+LL |     use crate::m3::last_segment::issue_56125;
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+LL |     use crate::m3::non_last_segment::non_last_segment::issue_56125;
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 LL |     use ::issue_56125::issue_56125;
    |         ~~~~~~~~~~~~~~~~~~~~~~~~~~
 LL |     use ::issue_56125::last_segment::issue_56125;
    |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-LL |     use ::issue_56125::non_last_segment::non_last_segment::issue_56125;
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-LL |     use crate::m3::last_segment::issue_56125;
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      and 1 other candidate
 
 error[E0659]: `issue_56125` is ambiguous

--- a/tests/ui/lint/use_suggestion_json.stderr
+++ b/tests/ui/lint/use_suggestion_json.stderr
@@ -95,7 +95,7 @@ mod foo {
   ],
   "children": [
     {
-      "message": "consider importing one of these items",
+      "message": "consider importing one of these structs",
       "code": null,
       "level": "help",
       "spans": [
@@ -386,7 +386,7 @@ mod foo {
 \u001b[0m\u001b[1m\u001b[38;5;12mLL\u001b[0m\u001b[0m \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m|\u001b[0m\u001b[0m \u001b[0m\u001b[0m    let x: Iter;\u001b[0m
 \u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m|\u001b[0m\u001b[0m            \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;9m^^^^\u001b[0m\u001b[0m \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;9mnot found in this scope\u001b[0m
 \u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m|\u001b[0m
-\u001b[0m\u001b[1m\u001b[38;5;14mhelp\u001b[0m\u001b[0m: consider importing one of these items\u001b[0m
+\u001b[0m\u001b[1m\u001b[38;5;14mhelp\u001b[0m\u001b[0m: consider importing one of these structs\u001b[0m
 \u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m|\u001b[0m
 \u001b[0m\u001b[1m\u001b[38;5;12mLL\u001b[0m\u001b[0m \u001b[0m\u001b[0m\u001b[38;5;10m+ use std::collections::binary_heap::Iter;\u001b[0m
 \u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m|\u001b[0m

--- a/tests/ui/namespace/namespace-mix.stderr
+++ b/tests/ui/namespace/namespace-mix.stderr
@@ -12,7 +12,7 @@ help: a tuple struct with a similar name exists
    |
 LL |     check(m1::TS);
    |               ~~
-help: consider importing one of these items instead
+help: consider importing one of these constants instead
    |
 LL + use m2::S;
    |
@@ -40,7 +40,7 @@ help: a tuple struct with a similar name exists
    |
 LL |     check(xm1::TS);
    |                ~~
-help: consider importing one of these items instead
+help: consider importing one of these constants instead
    |
 LL + use m2::S;
    |
@@ -66,7 +66,7 @@ help: a tuple variant with a similar name exists
    |
 LL |     check(m7::TV);
    |               ~~
-help: consider importing one of these items instead
+help: consider importing one of these constants instead
    |
 LL + use m8::V;
    |
@@ -94,7 +94,7 @@ help: a tuple variant with a similar name exists
    |
 LL |     check(xm7::TV);
    |                ~~
-help: consider importing one of these items instead
+help: consider importing one of these constants instead
    |
 LL + use m8::V;
    |

--- a/tests/ui/resolve/issue-16058.stderr
+++ b/tests/ui/resolve/issue-16058.stderr
@@ -4,7 +4,7 @@ error[E0574]: expected struct, variant or union type, found enum `Result`
 LL |         Result {
    |         ^^^^^^ not a struct, variant or union type
    |
-help: consider importing one of these items instead
+help: consider importing one of these type aliases instead
    |
 LL + use std::fmt::Result;
    |

--- a/tests/ui/resolve/issue-21221-1.stderr
+++ b/tests/ui/resolve/issue-21221-1.stderr
@@ -4,13 +4,13 @@ error[E0405]: cannot find trait `Mul` in this scope
 LL | impl Mul for Foo {
    |      ^^^ not found in this scope
    |
-help: consider importing one of these items
+help: consider importing one of these traits
+   |
+LL + use std::ops::Mul;
    |
 LL + use mul1::Mul;
    |
 LL + use mul2::Mul;
-   |
-LL + use std::ops::Mul;
    |
 
 error[E0412]: cannot find type `Mul` in this scope
@@ -19,13 +19,13 @@ error[E0412]: cannot find type `Mul` in this scope
 LL | fn getMul() -> Mul {
    |                ^^^ not found in this scope
    |
-help: consider importing one of these items
+help: consider importing one of these traits
+   |
+LL + use std::ops::Mul;
    |
 LL + use mul1::Mul;
    |
 LL + use mul2::Mul;
-   |
-LL + use std::ops::Mul;
    |
 
 error[E0405]: cannot find trait `ThisTraitReallyDoesntExistInAnyModuleReally` in this scope

--- a/tests/ui/resolve/issue-21221-2.stderr
+++ b/tests/ui/resolve/issue-21221-2.stderr
@@ -4,7 +4,7 @@ error[E0405]: cannot find trait `T` in this scope
 LL | impl T for Foo { }
    |      ^ not found in this scope
    |
-help: consider importing one of these items
+help: consider importing one of these traits
    |
 LL + use baz::T;
    |

--- a/tests/ui/resolve/issue-50599.stderr
+++ b/tests/ui/resolve/issue-50599.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find value `LOG10_2` in module `std::f64`
 LL |     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize;
    |                                                ^^^^^^^ not found in `std::f64`
    |
-help: consider importing one of these items
+help: consider importing one of these constants
    |
 LL + use std::f128::consts::LOG10_2;
    |

--- a/tests/ui/resolve/issue-73427.stderr
+++ b/tests/ui/resolve/issue-73427.stderr
@@ -105,7 +105,7 @@ help: the following enum variant is available
    |
 LL |     (E::TupleWithFields(/* fields */)).foo();
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: consider importing one of these items instead
+help: consider importing one of these constants instead
    |
 LL + use std::f128::consts::E;
    |

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -82,7 +82,7 @@ help: a function with a similar name exists
    |
 LL |     let _: E = m::f;
    |                   ~
-help: consider importing one of these items instead
+help: consider importing one of these constants instead
    |
 LL + use std::f128::consts::E;
    |
@@ -123,7 +123,7 @@ help: alternatively, the following enum variant is available
    |
 LL |     let _: E = (E::Fn(/* fields */));
    |                ~~~~~~~~~~~~~~~~~~~~~
-help: consider importing one of these items instead
+help: consider importing one of these constants instead
    |
 LL + use std::f128::consts::E;
    |

--- a/tests/ui/rfcs/rfc-2126-extern-absolute-paths/not-allowed.stderr
+++ b/tests/ui/rfcs/rfc-2126-extern-absolute-paths/not-allowed.stderr
@@ -4,10 +4,8 @@ error[E0432]: unresolved import `alloc`
 LL | use alloc;
    |     ^^^^^ no external crate `alloc`
    |
-help: consider importing one of these items instead
+help: consider importing this module instead
    |
-LL | use core::alloc;
-   |     ~~~~~~~~~~~
 LL | use std::alloc;
    |     ~~~~~~~~~~
 

--- a/tests/ui/rust-2018/issue-52202-use-suggestions.stderr
+++ b/tests/ui/rust-2018/issue-52202-use-suggestions.stderr
@@ -4,7 +4,7 @@ error[E0422]: cannot find struct, variant or union type `Drain` in this scope
 LL |     let _d = Drain {};
    |              ^^^^^ not found in this scope
    |
-help: consider importing one of these items
+help: consider importing one of these structs
    |
 LL + use crate::plumbing::Drain;
    |

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.no_std.fixed
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.no_std.fixed
@@ -7,6 +7,8 @@
 //@ [no_std]compile-flags: --cfg=no_std -C panic=abort
 #![cfg_attr(no_std, no_std)]
 
+use core::num::NonZero;
+
 fn main() {
     //~^ HELP consider importing this struct
     let _x = NonZero::new(5u32).unwrap();

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.no_std.stderr
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.no_std.stderr
@@ -1,14 +1,12 @@
 error[E0433]: failed to resolve: use of undeclared type `NonZero`
-  --> $DIR/core-std-import-order-issue-83564.rs:8:14
+  --> $DIR/core-std-import-order-issue-83564.rs:12:14
    |
 LL |     let _x = NonZero::new(5u32).unwrap();
    |              ^^^^^^^ use of undeclared type `NonZero`
    |
-help: consider importing one of these items
+help: consider importing this struct
    |
 LL + use core::num::NonZero;
-   |
-LL + use std::num::NonZero;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.std.fixed
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.std.fixed
@@ -7,6 +7,8 @@
 //@ [no_std]compile-flags: --cfg=no_std -C panic=abort
 #![cfg_attr(no_std, no_std)]
 
+use std::num::NonZero;
+
 fn main() {
     //~^ HELP consider importing this struct
     let _x = NonZero::new(5u32).unwrap();

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.std.stderr
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.std.stderr
@@ -1,0 +1,14 @@
+error[E0433]: failed to resolve: use of undeclared type `NonZero`
+  --> $DIR/core-std-import-order-issue-83564.rs:12:14
+   |
+LL |     let _x = NonZero::new(5u32).unwrap();
+   |              ^^^^^^^ use of undeclared type `NonZero`
+   |
+help: consider importing this struct
+   |
+LL + use std::num::NonZero;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/suggestions/crate-or-module-typo.stderr
+++ b/tests/ui/suggestions/crate-or-module-typo.stderr
@@ -30,9 +30,7 @@ help: there is a crate or module with a similar name
    |
 LL |     bar: std::cell::Cell<bool>
    |          ~~~
-help: consider importing one of these items
-   |
-LL + use core::cell;
+help: consider importing this module
    |
 LL + use std::cell;
    |

--- a/tests/ui/suggestions/suggest-tryinto-edition-change.rs
+++ b/tests/ui/suggestions/suggest-tryinto-edition-change.rs
@@ -1,5 +1,5 @@
 // Make sure that trying to access `TryInto`, `TryFrom`, `FromIterator` in pre-2021 mentions
-// Edition 2021 change
+// Edition 2021 change.
 //@ edition:2018
 
 fn test() {
@@ -11,19 +11,16 @@ fn test() {
     //~^ ERROR failed to resolve: use of undeclared type
     //~| NOTE use of undeclared type
     //~| NOTE 'std::convert::TryFrom' is included in the prelude starting in Edition 2021
-    //~| NOTE 'core::convert::TryFrom' is included in the prelude starting in Edition 2021
 
     let _i: i16 = TryInto::try_into(0_i32).unwrap();
     //~^ ERROR failed to resolve: use of undeclared type
     //~| NOTE use of undeclared type
     //~| NOTE 'std::convert::TryInto' is included in the prelude starting in Edition 2021
-    //~| NOTE 'core::convert::TryInto' is included in the prelude starting in Edition 2021
 
     let _v: Vec<_> = FromIterator::from_iter(&[1]);
     //~^ ERROR failed to resolve: use of undeclared type
     //~| NOTE use of undeclared type
     //~| NOTE 'std::iter::FromIterator' is included in the prelude starting in Edition 2021
-    //~| NOTE 'core::iter::FromIterator' is included in the prelude starting in Edition 2021
 }
 
 fn main() {

--- a/tests/ui/suggestions/suggest-tryinto-edition-change.stderr
+++ b/tests/ui/suggestions/suggest-tryinto-edition-change.stderr
@@ -4,45 +4,36 @@ error[E0433]: failed to resolve: use of undeclared type `TryFrom`
 LL |     let _i: i16 = TryFrom::try_from(0_i32).unwrap();
    |                   ^^^^^^^ use of undeclared type `TryFrom`
    |
-   = note: 'core::convert::TryFrom' is included in the prelude starting in Edition 2021
    = note: 'std::convert::TryFrom' is included in the prelude starting in Edition 2021
-help: consider importing one of these items
-   |
-LL + use core::convert::TryFrom;
+help: consider importing this trait
    |
 LL + use std::convert::TryFrom;
    |
 
 error[E0433]: failed to resolve: use of undeclared type `TryInto`
-  --> $DIR/suggest-tryinto-edition-change.rs:16:19
+  --> $DIR/suggest-tryinto-edition-change.rs:15:19
    |
 LL |     let _i: i16 = TryInto::try_into(0_i32).unwrap();
    |                   ^^^^^^^ use of undeclared type `TryInto`
    |
-   = note: 'core::convert::TryInto' is included in the prelude starting in Edition 2021
    = note: 'std::convert::TryInto' is included in the prelude starting in Edition 2021
-help: consider importing one of these items
-   |
-LL + use core::convert::TryInto;
+help: consider importing this trait
    |
 LL + use std::convert::TryInto;
    |
 
 error[E0433]: failed to resolve: use of undeclared type `FromIterator`
-  --> $DIR/suggest-tryinto-edition-change.rs:22:22
+  --> $DIR/suggest-tryinto-edition-change.rs:20:22
    |
 LL |     let _v: Vec<_> = FromIterator::from_iter(&[1]);
    |                      ^^^^^^^^^^^^ use of undeclared type `FromIterator`
    |
-   = note: 'core::iter::FromIterator' is included in the prelude starting in Edition 2021
    = note: 'std::iter::FromIterator' is included in the prelude starting in Edition 2021
 help: a trait with a similar name exists
    |
 LL |     let _v: Vec<_> = IntoIterator::from_iter(&[1]);
    |                      ~~~~~~~~~~~~
-help: consider importing one of these items
-   |
-LL + use core::iter::FromIterator;
+help: consider importing this trait
    |
 LL + use std::iter::FromIterator;
    |


### PR DESCRIPTION
When both `std::` and `core::` items are available, only suggest the `std::` ones. We ensure that in `no_std` crates we suggest `core::` items.

Ensure that the list of items suggested to be imported are always in the order of local crate items, `std`/`core` items and finally foreign crate items.

Tweak wording of import suggestion: if there are multiple items but they are all of the same kind, we use the kind name and not the generic "items".

Fix #83564.