### PR TITLE
Do not panic in `ty::consts::Const::try_to_target_usize()` in case of size mismatch

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1402,13 +1402,31 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr: &'tcx hir::Expr<'tcx>,
     ) -> Ty<'tcx> {
         let element_ty = if !args.is_empty() {
+            let mut size_ct = None;
             let coerce_to = expected
                 .to_option(self)
                 .and_then(|uty| match *uty.kind() {
-                    ty::Array(ty, _) | ty::Slice(ty) => Some(ty),
+                    ty::Array(ty, sz_ct) => {
+                        size_ct = Some(sz_ct);
+                        Some(ty)
+                    }
+                    ty::Slice(ty) => Some(ty),
                     _ => None,
                 })
                 .unwrap_or_else(|| self.next_ty_var(expr.span));
+
+            // Check if the expected type of array size is something
+            // other than `usize` which is clearly wrong. Fixes ICE #126359
+            if let Some(size_ct) = size_ct
+                && let ty::ConstKind::Value(size_ty, _) = size_ct.kind()
+                && !matches!(size_ty.kind(), ty::Uint(ty::UintTy::Usize))
+            {
+                let guar = self.dcx().span_delayed_bug(expr.span, "array size type is not `usize`");
+                self.set_tainted_by_errors(guar);
+
+                return Ty::new_error(self.tcx, guar);
+            }
+
             let mut coerce = CoerceMany::with_coercion_sites(coerce_to, args);
             assert_eq!(self.diverges.get(), Diverges::Maybe);
             for e in args {

--- a/tests/crashes/126359.rs
+++ b/tests/crashes/126359.rs
@@ -1,9 +1,0 @@
-//@ known-bug: rust-lang/rust#126359
-
-struct OppOrder<const N: u8 = 3, T = u32> {
-    arr: [T; N],
-}
-
-fn main() {
-    let _ = OppOrder::<3, u32> { arr: [0, 0, 0] };
-}

--- a/tests/ui/consts/ice-const-size-relate-126359.rs
+++ b/tests/ui/consts/ice-const-size-relate-126359.rs
@@ -1,0 +1,14 @@
+// Regression test for ICE #126359
+
+// Tests that there is no ICE when the generic const
+// specifying the size of an array is of a non-usize type
+
+struct OppOrder<const N: u8 = 3, T = u32> {
+    arr: [T; N],
+    //~^ ERROR the constant `N` is not of type `usize`
+}
+
+fn main() {
+    let _ = OppOrder::<3, u32> { arr: [0, 0, 0] };
+    //~^ ERROR the constant `3` is not of type `usize`
+}

--- a/tests/ui/consts/ice-const-size-relate-126359.stderr
+++ b/tests/ui/consts/ice-const-size-relate-126359.stderr
@@ -1,0 +1,14 @@
+error: the constant `N` is not of type `usize`
+  --> $DIR/ice-const-size-relate-126359.rs:7:10
+   |
+LL |     arr: [T; N],
+   |          ^^^^^^ expected `usize`, found `u8`
+
+error: the constant `3` is not of type `usize`
+  --> $DIR/ice-const-size-relate-126359.rs:12:39
+   |
+LL |     let _ = OppOrder::<3, u32> { arr: [0, 0, 0] };
+   |                                       ^^^^^^^^^ expected `usize`, found `u8`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #126359

This is the failing code:
```rust
struct OppOrder<const N: u8 = 3, T = u32> {
    arr: [T; N],
}

fn main() {
    let _ = OppOrder::<3, u32> { arr: [0, 0, 0] };
}
```

The ICE occurred while unifying the type of array `[0, 0, 0]` with `OppOrder::<3, u32>.arr` field. `arr`'s type is malformed because it has `u8` for size instead of `usize`. So when we try to unify `usize` with `u8` a method in `Valtree` panics causing the ICE.

This PR makes `ty::consts::Const::try_to_target_usize`, which calls `Valtree` methods, check for size mismatch and gracefully return `None` instead of calling `Valtree`.

## Edit

Now changed the approach to catch wrongly typed array size in `FnCtxt::check_expr_array` so that we never reach a point where we try to unify `usize` with `u8`.

