### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -22,8 +22,7 @@ use std::fmt::Debug;
 use std::io;
 
 use crate::compiler_interface::with;
-pub use crate::crate_def::CrateDef;
-pub use crate::crate_def::DefId;
+pub use crate::crate_def::{CrateDef, CrateDefType, DefId};
 pub use crate::error::*;
 use crate::mir::Body;
 use crate::mir::Mutability;
@@ -115,12 +114,15 @@ pub enum CtorKind {
 
 pub type Filename = String;
 
-crate_def! {
+crate_def_with_ty! {
     /// Holds information about an item in a crate.
     pub CrateItem;
 }
 
 impl CrateItem {
+    /// This will return the body of an item.
+    ///
+    /// This will panic if no body is available.
     pub fn body(&self) -> mir::Body {
         with(|cx| cx.mir_body(self.0))
     }

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -672,7 +672,7 @@ impl<T> Option<T> {
     /// ```
     #[must_use]
     #[inline]
-    #[unstable(feature = "is_none_or", issue = "none")]
+    #[unstable(feature = "is_none_or", issue = "126383")]
     pub fn is_none_or(self, f: impl FnOnce(T) -> bool) -> bool {
         match self {
             None => true,

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -15,7 +15,7 @@ use crate::errors::{self, Error, ErrorKind};
 use crate::header::TestProps;
 use crate::json;
 use crate::read2::{read2_abbreviated, Truncated};
-use crate::util::{add_dylib_path, copy_dir_all, dylib_env_var, logv, PathBufExt};
+use crate::util::{add_dylib_path, copy_dir_all, dylib_env_var, logv, static_regex, PathBufExt};
 use crate::ColorConfig;
 use colored::Colorize;
 use miropt_test_tools::{files_for_miropt_test, MiroptTest, MiroptTestFile};
@@ -47,14 +47,6 @@ use debugger::DebuggerCommands;
 
 #[cfg(test)]
 mod tests;
-
-macro_rules! static_regex {
-    ($re:literal) => {{
-        static RE: ::std::sync::OnceLock<::regex::Regex> = ::std::sync::OnceLock::new();
-        RE.get_or_init(|| ::regex::Regex::new($re).unwrap())
-    }};
-}
-use static_regex;
 
 const FAKE_SRC_BASE: &str = "fake-test-src-base";
 

--- a/src/tools/compiletest/src/runtest/coverage.rs
+++ b/src/tools/compiletest/src/runtest/coverage.rs
@@ -7,7 +7,8 @@ use std::process::Command;
 use glob::glob;
 
 use crate::common::{UI_COVERAGE, UI_COVERAGE_MAP};
-use crate::runtest::{static_regex, Emit, ProcRes, TestCx, WillExecute};
+use crate::runtest::{Emit, ProcRes, TestCx, WillExecute};
+use crate::util::static_regex;
 
 impl<'test> TestCx<'test> {
     fn coverage_dump_path(&self) -> &Path {

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -90,3 +90,11 @@ pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Re
     }
     Ok(())
 }
+
+macro_rules! static_regex {
+    ($re:literal) => {{
+        static RE: ::std::sync::OnceLock<::regex::Regex> = ::std::sync::OnceLock::new();
+        RE.get_or_init(|| ::regex::Regex::new($re).unwrap())
+    }};
+}
+pub(crate) use static_regex;

--- a/src/tools/tidy/src/ext_tool_checks.rs
+++ b/src/tools/tidy/src/ext_tool_checks.rs
@@ -274,13 +274,18 @@ fn create_venv_at_path(path: &Path) -> Result<(), Error> {
     if out.status.success() {
         return Ok(());
     }
-    let err = if String::from_utf8_lossy(&out.stderr).contains("No module named virtualenv") {
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let err = if stderr.contains("No module named virtualenv") {
         Error::Generic(format!(
             "virtualenv not found: you may need to install it \
                                (`python3 -m pip install venv`)"
         ))
     } else {
-        Error::Generic(format!("failed to create venv at '{}' using {sys_py}", path.display()))
+        Error::Generic(format!(
+            "failed to create venv at '{}' using {sys_py}: {stderr}",
+            path.display()
+        ))
     };
     Err(err)
 }

--- a/tests/ui-fulldeps/stable-mir/check_def_ty.rs
+++ b/tests/ui-fulldeps/stable-mir/check_def_ty.rs
@@ -1,0 +1,114 @@
+//@ run-pass
+//! Test that users are able to use stable mir APIs to retrieve type information from a crate item
+//! definition.
+
+//@ ignore-stage1
+//@ ignore-cross-compile
+//@ ignore-remote
+//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
+//@ edition: 2021
+
+#![feature(rustc_private)]
+#![feature(assert_matches)]
+#![feature(control_flow_enum)]
+
+#[macro_use]
+extern crate rustc_smir;
+extern crate rustc_driver;
+extern crate rustc_interface;
+extern crate stable_mir;
+
+use rustc_smir::rustc_internal;
+use stable_mir::ty::{Ty, ForeignItemKind};
+use stable_mir::*;
+use std::io::Write;
+use std::ops::ControlFlow;
+
+const CRATE_NAME: &str = "crate_def_ty";
+
+/// Test if we can retrieve type information from different definitions.
+fn test_def_tys() -> ControlFlow<()> {
+    let items = stable_mir::all_local_items();
+    for item in &items {
+        // Type from crate items.
+        let ty = item.ty();
+        match item.name().as_str() {
+            "STATIC_STR" => assert!(ty.kind().is_ref()),
+            "CONST_U32" => assert!(ty.kind().is_integral()),
+            "main" => { check_fn_def(ty) }
+            _ => unreachable!("Unexpected item: `{item:?}`")
+        }
+    }
+
+    let foreign_items = stable_mir::local_crate().foreign_modules();
+    for item in foreign_items[0].module().items() {
+        // Type from foreign items.
+        let ty = item.ty();
+        let item_kind = item.kind();
+        let name = item.name();
+        match item_kind {
+            ForeignItemKind::Fn(fn_def) => {
+                assert_eq!(&name, "extern_fn");
+                assert_eq!(ty, fn_def.ty());
+                check_fn_def(ty)
+            }
+            ForeignItemKind::Static(def) => {
+                assert_eq!(&name, "EXT_STATIC");
+                assert_eq!(ty, def.ty());
+                assert!(ty.kind().is_integral())
+            }
+            _ => unreachable!("Unexpected kind: {item_kind:?}")
+        };
+    }
+
+    ControlFlow::Continue(())
+}
+
+fn check_fn_def(ty: Ty) {
+    let kind = ty.kind();
+    let (def, args) = kind.fn_def().expect(&format!("Expected function type, but found: {ty}"));
+    assert!(def.ty().kind().is_fn());
+    assert_eq!(def.ty_with_args(args), ty);
+}
+
+/// This test will generate and analyze a dummy crate using the stable mir.
+/// For that, it will first write the dummy crate into a file.
+/// Then it will create a `StableMir` using custom arguments and then
+/// it will run the compiler.
+fn main() {
+    let path = "defs_ty_input.rs";
+    generate_input(&path).unwrap();
+    let args = vec![
+        "rustc".to_string(),
+        "-Cpanic=abort".to_string(),
+        "--crate-name".to_string(),
+        CRATE_NAME.to_string(),
+        path.to_string(),
+    ];
+    run!(args, test_def_tys).unwrap();
+}
+
+fn generate_input(path: &str) -> std::io::Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    write!(
+        file,
+        r#"
+        // We would like to check intrinsic definition.
+        #![feature(core_intrinsics)]
+        static STATIC_STR: &str = "foo";
+        const CONST_U32: u32 = 0u32;
+
+        fn main() {{
+            let _c = core::char::from_u32(99);
+            let _v = Vec::<u8>::new();
+            let _i = std::intrinsics::size_of::<u8>();
+        }}
+
+        extern "C" {{
+            fn extern_fn(x: i32) -> i32;
+            static EXT_STATIC: i32;
+        }}
+    "#
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
Successful merges:

 - #126347 (Simplify `try_*`'s signature on `Iterator`)
 - #126348 (Improve error message if dependency installation in tidy fails)
 - #126366 (Add a new trait to retrieve StableMir definition Ty)
 - #126370 (compiletest: Stricter parsing of `//@ normalize-*` headers)
 - #126379 (interpret: update doc comment for find_closest_untracked_caller_location)
 - #126384 (add tracking issue for is_none_or)

Failed merges:

 - #126388 (const-eval: make lint scope computation consistent)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=126347,126348,126366,126370,126379,126384)
<!-- homu-ignore:end -->