### PR TITLE
Fix wrong `assert_unsafe_precondition` message for `core::ptr::copy`

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -3043,8 +3043,7 @@ pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     unsafe {
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::copy_nonoverlapping requires that both pointer arguments are aligned and non-null \
-            and the specified memory ranges do not overlap",
+            "ptr::copy requires that both pointer arguments are aligned and non-null",
             (
                 src: *const () = src as *const (),
                 dst: *mut () = dst as *mut (),


### PR DESCRIPTION
A small fix in the `assert_unsafe_precondition` message for `core::ptr::copy` as described by https://github.com/rust-lang/rust/issues/126400 .

fixes #126400
