### PR TITLE
Check that alias-relate terms are WF if reporting an error in alias-relate

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -515,6 +515,30 @@ impl<'tcx> ProofTreeVisitor<'tcx> for BestObligation<'tcx> {
             self.with_derived_obligation(obligation, |this| nested_goal.visit_with(this))?;
         }
 
+        // alias-relate may fail because the lhs or rhs can't be normalized,
+        // and therefore is treated as rigid.
+        if let Some(ty::PredicateKind::AliasRelate(lhs, rhs, _)) = pred_kind.no_bound_vars() {
+            if let Some(obligation) = goal
+                .infcx()
+                .visit_proof_tree(
+                    goal.goal().with(goal.infcx().tcx, ty::ClauseKind::WellFormed(lhs.into())),
+                    self,
+                )
+                .break_value()
+            {
+                return ControlFlow::Break(obligation);
+            } else if let Some(obligation) = goal
+                .infcx()
+                .visit_proof_tree(
+                    goal.goal().with(goal.infcx().tcx, ty::ClauseKind::WellFormed(rhs.into())),
+                    self,
+                )
+                .break_value()
+            {
+                return ControlFlow::Break(obligation);
+            }
+        }
+
         ControlFlow::Break(self.obligation.clone())
     }
 }

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -520,8 +520,9 @@ impl<'tcx> ProofTreeVisitor<'tcx> for BestObligation<'tcx> {
         if let Some(ty::PredicateKind::AliasRelate(lhs, rhs, _)) = pred_kind.no_bound_vars() {
             if let Some(obligation) = goal
                 .infcx()
-                .visit_proof_tree(
+                .visit_proof_tree_at_depth(
                     goal.goal().with(goal.infcx().tcx, ty::ClauseKind::WellFormed(lhs.into())),
+                    goal.depth() + 1,
                     self,
                 )
                 .break_value()
@@ -529,8 +530,9 @@ impl<'tcx> ProofTreeVisitor<'tcx> for BestObligation<'tcx> {
                 return ControlFlow::Break(obligation);
             } else if let Some(obligation) = goal
                 .infcx()
-                .visit_proof_tree(
+                .visit_proof_tree_at_depth(
                     goal.goal().with(goal.infcx().tcx, ty::ClauseKind::WellFormed(rhs.into())),
+                    goal.depth() + 1,
                     self,
                 )
                 .break_value()

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -278,6 +278,10 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
         self.source
     }
 
+    pub fn depth(&self) -> usize {
+        self.depth
+    }
+
     fn candidates_recur(
         &'a self,
         candidates: &mut Vec<InspectCandidate<'a, 'tcx>>,
@@ -436,8 +440,17 @@ impl<'tcx> InferCtxt<'tcx> {
         goal: Goal<'tcx, ty::Predicate<'tcx>>,
         visitor: &mut V,
     ) -> V::Result {
+        self.visit_proof_tree_at_depth(goal, 0, visitor)
+    }
+
+    fn visit_proof_tree_at_depth<V: ProofTreeVisitor<'tcx>>(
+        &self,
+        goal: Goal<'tcx, ty::Predicate<'tcx>>,
+        depth: usize,
+        visitor: &mut V,
+    ) -> V::Result {
         let (_, proof_tree) = self.evaluate_root_goal(goal, GenerateProofTree::Yes);
         let proof_tree = proof_tree.unwrap();
-        visitor.visit_goal(&InspectGoal::new(self, 0, proof_tree, None, GoalSource::Misc))
+        visitor.visit_goal(&InspectGoal::new(self, depth, proof_tree, None, GoalSource::Misc))
     }
 }

--- a/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
@@ -31,18 +31,6 @@ help: consider further restricting `Self`
 LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
    |                            +++++++++++++++++++++++++
 
-error[E0271]: type mismatch resolving `<Self as Deref>::Target == str`
-  --> $DIR/defaults-unsound-62211-1.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ types differ
-   |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:24:31
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                               ^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
-
 error[E0277]: the trait bound `Self: Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:24:96
    |
@@ -50,10 +38,10 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:24:25
+  --> $DIR/defaults-unsound-62211-1.rs:24:31
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
+   |                               ^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + Deref {
@@ -75,7 +63,6 @@ help: consider further restricting `Self`
 LL | trait UncheckedCopy: Sized + Copy {
    |                            ++++++
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0271, E0277.
-For more information about an error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/defaults-unsound-62211-1.rs
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.rs
@@ -26,7 +26,6 @@ trait UncheckedCopy: Sized {
     //~| ERROR the trait bound `Self: Deref` is not satisfied
     //~| ERROR cannot add-assign `&'static str` to `Self`
     //~| ERROR `Self` doesn't implement `std::fmt::Display`
-    //[next]~| ERROR type mismatch resolving `<Self as Deref>::Target == str`
 
     // We said the Output type was Copy, so we can Copy it freely!
     fn unchecked_copy(other: &Self::Output) -> Self::Output {

--- a/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
@@ -31,18 +31,6 @@ help: consider further restricting `Self`
 LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
    |                            +++++++++++++++++++++++++
 
-error[E0271]: type mismatch resolving `<Self as Deref>::Target == str`
-  --> $DIR/defaults-unsound-62211-2.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ types differ
-   |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:24:31
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                               ^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
-
 error[E0277]: the trait bound `Self: Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:24:96
    |
@@ -50,10 +38,10 @@ LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + Fro
    |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:24:25
+  --> $DIR/defaults-unsound-62211-2.rs:24:31
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
+   |                               ^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + Deref {
@@ -75,7 +63,6 @@ help: consider further restricting `Self`
 LL | trait UncheckedCopy: Sized + Copy {
    |                            ++++++
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0271, E0277.
-For more information about an error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/defaults-unsound-62211-2.rs
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.rs
@@ -26,7 +26,6 @@ trait UncheckedCopy: Sized {
     //~| ERROR the trait bound `Self: Deref` is not satisfied
     //~| ERROR cannot add-assign `&'static str` to `Self`
     //~| ERROR `Self` doesn't implement `std::fmt::Display`
-    //[next]~| ERROR type mismatch resolving `<Self as Deref>::Target == str`
 
     // We said the Output type was Copy, so we can Copy it freely!
     fn unchecked_copy(other: &Self::Output) -> Self::Output {

--- a/tests/ui/associated-types/issue-54108.next.stderr
+++ b/tests/ui/associated-types/issue-54108.next.stderr
@@ -1,15 +1,3 @@
-error[E0271]: type mismatch resolving `<<T as SubEncoder>::ActualSize as Add>::Output == <T as SubEncoder>::ActualSize`
-  --> $DIR/issue-54108.rs:23:17
-   |
-LL |     type Size = <Self as SubEncoder>::ActualSize;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ
-   |
-note: required by a bound in `Encoder::Size`
-  --> $DIR/issue-54108.rs:8:20
-   |
-LL |     type Size: Add<Output = Self::Size>;
-   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `Encoder::Size`
-
 error[E0277]: cannot add `<T as SubEncoder>::ActualSize` to `<T as SubEncoder>::ActualSize`
   --> $DIR/issue-54108.rs:23:17
    |
@@ -18,16 +6,15 @@ LL |     type Size = <Self as SubEncoder>::ActualSize;
    |
    = help: the trait `Add` is not implemented for `<T as SubEncoder>::ActualSize`
 note: required by a bound in `Encoder::Size`
-  --> $DIR/issue-54108.rs:8:16
+  --> $DIR/issue-54108.rs:8:20
    |
 LL |     type Size: Add<Output = Self::Size>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Encoder::Size`
+   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `Encoder::Size`
 help: consider further restricting the associated type
    |
 LL |     T: SubEncoder, <T as SubEncoder>::ActualSize: Add
    |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0271, E0277.
-For more information about an error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/issue-54108.rs
+++ b/tests/ui/associated-types/issue-54108.rs
@@ -22,7 +22,6 @@ where
 {
     type Size = <Self as SubEncoder>::ActualSize;
     //~^ ERROR: cannot add `<T as SubEncoder>::ActualSize` to `<T as SubEncoder>::ActualSize`
-    //[next]~| ERROR type mismatch resolving `<<T as SubEncoder>::ActualSize as Add>::Output == <T as SubEncoder>::ActualSize`
 
     fn foo(&self) -> Self::Size {
         self.bar() + self.bar()

--- a/tests/ui/traits/next-solver/coroutine.fail.stderr
+++ b/tests/ui/traits/next-solver/coroutine.fail.stderr
@@ -6,8 +6,6 @@ LL |       needs_coroutine(
 LL |           #[coroutine]
 LL | /         || {
 LL | |
-LL | |
-LL | |
 LL | |             yield ();
 LL | |         },
    | |_________^ the trait `Coroutine<A>` is not implemented for `{coroutine@$DIR/coroutine.rs:20:9: 20:11}`
@@ -18,47 +16,6 @@ note: required by a bound in `needs_coroutine`
 LL | fn needs_coroutine(_: impl Coroutine<A, Yield = B, Return = C>) {}
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `needs_coroutine`
 
-error[E0271]: type mismatch resolving `<{coroutine@$DIR/coroutine.rs:20:9: 20:11} as Coroutine<A>>::Yield == B`
-  --> $DIR/coroutine.rs:20:9
-   |
-LL |       needs_coroutine(
-   |       --------------- required by a bound introduced by this call
-LL |           #[coroutine]
-LL | /         || {
-LL | |
-LL | |
-LL | |
-LL | |             yield ();
-LL | |         },
-   | |_________^ types differ
-   |
-note: required by a bound in `needs_coroutine`
-  --> $DIR/coroutine.rs:14:41
-   |
-LL | fn needs_coroutine(_: impl Coroutine<A, Yield = B, Return = C>) {}
-   |                                         ^^^^^^^^^ required by this bound in `needs_coroutine`
+error: aborting due to 1 previous error
 
-error[E0271]: type mismatch resolving `<{coroutine@$DIR/coroutine.rs:20:9: 20:11} as Coroutine<A>>::Return == C`
-  --> $DIR/coroutine.rs:20:9
-   |
-LL |       needs_coroutine(
-   |       --------------- required by a bound introduced by this call
-LL |           #[coroutine]
-LL | /         || {
-LL | |
-LL | |
-LL | |
-LL | |             yield ();
-LL | |         },
-   | |_________^ types differ
-   |
-note: required by a bound in `needs_coroutine`
-  --> $DIR/coroutine.rs:14:52
-   |
-LL | fn needs_coroutine(_: impl Coroutine<A, Yield = B, Return = C>) {}
-   |                                                    ^^^^^^^^^^ required by this bound in `needs_coroutine`
-
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0271, E0277.
-For more information about an error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/next-solver/coroutine.rs
+++ b/tests/ui/traits/next-solver/coroutine.rs
@@ -19,8 +19,6 @@ fn main() {
         #[coroutine]
         || {
             //[fail]~^ ERROR Coroutine<A>` is not satisfied
-            //[fail]~| ERROR as Coroutine<A>>::Yield == B`
-            //[fail]~| ERROR as Coroutine<A>>::Return == C`
             yield ();
         },
     );

--- a/tests/ui/traits/next-solver/fn-trait.rs
+++ b/tests/ui/traits/next-solver/fn-trait.rs
@@ -19,14 +19,10 @@ fn main() {
     require_fn(f as fn() -> i32);
     require_fn(f as unsafe fn() -> i32);
     //~^ ERROR: expected a `Fn()` closure, found `unsafe fn() -> i32`
-    //~| ERROR: type mismatch resolving `<unsafe fn() -> i32 as FnOnce<()>>::Output == i32`
     require_fn(g);
     //~^ ERROR: expected a `Fn()` closure, found `extern "C" fn() -> i32 {g}`
-    //~| ERROR: type mismatch resolving `<extern "C" fn() -> i32 {g} as FnOnce<()>>::Output == i32`
     require_fn(g as extern "C" fn() -> i32);
     //~^ ERROR: expected a `Fn()` closure, found `extern "C" fn() -> i32`
-    //~| ERROR: type mismatch resolving `<extern "C" fn() -> i32 as FnOnce<()>>::Output == i32`
     require_fn(h);
     //~^ ERROR: expected a `Fn()` closure, found `unsafe fn() -> i32 {h}`
-    //~| ERROR: type mismatch resolving `<unsafe fn() -> i32 {h} as FnOnce<()>>::Output == i32`
 }

--- a/tests/ui/traits/next-solver/fn-trait.stderr
+++ b/tests/ui/traits/next-solver/fn-trait.stderr
@@ -15,22 +15,8 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                       ^^^^^^^^^^^ required by this bound in `require_fn`
 
-error[E0271]: type mismatch resolving `<unsafe fn() -> i32 as FnOnce<()>>::Output == i32`
-  --> $DIR/fn-trait.rs:20:16
-   |
-LL |     require_fn(f as unsafe fn() -> i32);
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^ types differ
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: required by a bound in `require_fn`
-  --> $DIR/fn-trait.rs:3:31
-   |
-LL | fn require_fn(_: impl Fn() -> i32) {}
-   |                               ^^^ required by this bound in `require_fn`
-
 error[E0277]: expected a `Fn()` closure, found `extern "C" fn() -> i32 {g}`
-  --> $DIR/fn-trait.rs:23:16
+  --> $DIR/fn-trait.rs:22:16
    |
 LL |     require_fn(g);
    |     ---------- ^ expected an `Fn()` closure, found `extern "C" fn() -> i32 {g}`
@@ -45,22 +31,8 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                       ^^^^^^^^^^^ required by this bound in `require_fn`
 
-error[E0271]: type mismatch resolving `<extern "C" fn() -> i32 {g} as FnOnce<()>>::Output == i32`
-  --> $DIR/fn-trait.rs:23:16
-   |
-LL |     require_fn(g);
-   |     ---------- ^ types differ
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: required by a bound in `require_fn`
-  --> $DIR/fn-trait.rs:3:31
-   |
-LL | fn require_fn(_: impl Fn() -> i32) {}
-   |                               ^^^ required by this bound in `require_fn`
-
 error[E0277]: expected a `Fn()` closure, found `extern "C" fn() -> i32`
-  --> $DIR/fn-trait.rs:26:16
+  --> $DIR/fn-trait.rs:24:16
    |
 LL |     require_fn(g as extern "C" fn() -> i32);
    |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `Fn()` closure, found `extern "C" fn() -> i32`
@@ -75,22 +47,8 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                       ^^^^^^^^^^^ required by this bound in `require_fn`
 
-error[E0271]: type mismatch resolving `<extern "C" fn() -> i32 as FnOnce<()>>::Output == i32`
-  --> $DIR/fn-trait.rs:26:16
-   |
-LL |     require_fn(g as extern "C" fn() -> i32);
-   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: required by a bound in `require_fn`
-  --> $DIR/fn-trait.rs:3:31
-   |
-LL | fn require_fn(_: impl Fn() -> i32) {}
-   |                               ^^^ required by this bound in `require_fn`
-
 error[E0277]: expected a `Fn()` closure, found `unsafe fn() -> i32 {h}`
-  --> $DIR/fn-trait.rs:29:16
+  --> $DIR/fn-trait.rs:26:16
    |
 LL |     require_fn(h);
    |     ---------- ^ call the function in a closure: `|| unsafe { /* code */ }`
@@ -106,21 +64,6 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                       ^^^^^^^^^^^ required by this bound in `require_fn`
 
-error[E0271]: type mismatch resolving `<unsafe fn() -> i32 {h} as FnOnce<()>>::Output == i32`
-  --> $DIR/fn-trait.rs:29:16
-   |
-LL |     require_fn(h);
-   |     ---------- ^ types differ
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: required by a bound in `require_fn`
-  --> $DIR/fn-trait.rs:3:31
-   |
-LL | fn require_fn(_: impl Fn() -> i32) {}
-   |                               ^^^ required by this bound in `require_fn`
+error: aborting due to 4 previous errors
 
-error: aborting due to 8 previous errors
-
-Some errors have detailed explanations: E0271, E0277.
-For more information about an error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Check that each of the left/right term is WF when deriving a best error obligation for an alias-relate goal. This will make sure that given `<i32 as NotImplemented>::Assoc = ()` will drill down into `i32: NotImplemented` since we currently treat the projection as rigid.

r? lcnr