### PR TITLE
Tier 2 std support must always be known

### DIFF
--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -118,7 +118,7 @@ The `std` column in the table below has the following meanings:
 
 * ✓ indicates the full standard library is available.
 * \* indicates the target only supports [`no_std`] development.
-* ? indicates the standard library support is unknown or a work-in-progress.
+* ? indicates the standard library support is a work-in-progress.
 
 [`no_std`]: https://rust-embedded.github.io/book/intro/no-std.html
 


### PR DESCRIPTION
We should never have a tier 2 target without knowing its support status so I think this line in the tier 2 section is a bit wrong:

> ? indicates the standard library support is unknown or a work-in-progress.

My first inclination was just to drop the "unknown or" part. However, after thinking about it some more, I think we should just use `✓` for this. The only affected targets are UEFI and frankly there are targets with worse std support that are marked with `✓` (e.g. wasm).

I think a `✓` should mean "this supports building with std (and is checked in CI for tier 2+)". The target errata can detail the current limitations or special requirements for doing so.