### PR TITLE
 Also sort `crt-static` in `--print target-features` output

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -394,10 +394,15 @@ fn print_target_features(out: &mut dyn PrintBackendInfo, sess: &Session, tm: &ll
             (*feature, desc)
         })
         .collect::<Vec<_>>();
+
+    // Since we add this at the end ...
     rustc_target_features.extend_from_slice(&[(
         "crt-static",
         "Enables C Run-time Libraries to be statically linked",
     )]);
+    // ... we need to sort the list again.
+    rustc_target_features.sort();
+
     llvm_target_features.retain(|(f, _d)| !known_llvm_target_features.contains(f));
 
     let max_feature_len = llvm_target_features


### PR DESCRIPTION
I didn't find `crt-static` at first (for `x86_64-unknown-linux-gnu`), because it was put at the bottom of the large and otherwise sorted list.

Fully sort the list before we print it.

Note that `llvm_target_features` starts out and remains sorted and does not need to be sorted an extra time.

On my machine the diff is just:

```diff
$ diff -u /tmp/before2.txt /tmp/after2.txt
--- /tmp/before2.txt    2024-06-13 20:40:27.091636592 +0200
+++ /tmp/after2.txt     2024-06-13 20:39:54.584894891 +0200
@@ -20,6 +20,7 @@
     bmi1                            - Support BMI instructions.
     bmi2                            - Support BMI2 instructions.
     cmpxchg16b                      - 64-bit with cmpxchg16b (this is true for most x86-64 chips, but not the first AMD chips).
+    crt-static                      - Enables C Run-time Libraries to be statically linked.
     ermsb                           - REP MOVS/STOS are fast.
     f16c                            - Support 16-bit floating point conversion instructions.
     fma                             - Enable three-operand fused multiple-add.
@@ -49,7 +50,6 @@
     xsavec                          - Support xsavec instructions.
     xsaveopt                        - Support xsaveopt instructions.
     xsaves                          - Support xsaves instructions.
-    crt-static                      - Enables C Run-time Libraries to be statically linked.

 Code-generation features supported by LLVM for this target:
     16bit-mode                      - 16-bit mode (i8086).
```

I couldn't find a ui test that tested this output. Let's see if CI finds a regression tests.
