### PR TITLE
Polish `std::path::absolute` documentation.

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2302,7 +2302,7 @@ pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 ///
 /// This function currently corresponds to the `realpath` function on Unix
 /// and the `CreateFile` and `GetFinalPathNameByHandle` functions on Windows.
-/// Note that, this [may change in the future][changes].
+/// Note that this [may change in the future][changes].
 ///
 /// On Windows, this converts the path to use [extended length path][path]
 /// syntax, which allows your program to use longer path names, but means you


### PR DESCRIPTION
These changes bring it closer to other standard library documentation and, in particular, `std::fs::canonicalize`, which it will often be compared with.

* Add `# Platform-specific behavior` section, with content moved from Examples section.
* Create `# Errors` section.
* Phrase error description to allow future platforms to have new syntactic errors, rather than only emptiness.
* Add missing commas.
* Indent example code 4 spaces.
