### PR TITLE
Optimize libcxx-version for faster bootstrap startups

### DIFF
--- a/src/tools/libcxx-version/main.cpp
+++ b/src/tools/libcxx-version/main.cpp
@@ -5,22 +5,25 @@
 // It's nothing more than specifying the name of the standard library implementation (either libstdc++ or libc++)
 // and its major version.
 
-#include <iostream>
+#include <cstdio>
 
 int main() {
     #ifdef _GLIBCXX_RELEASE
-        std::cout << "libstdc++ version: " << _GLIBCXX_RELEASE << std::endl;
+        #define name "libstdc++"
+        #define version _GLIBCXX_RELEASE
     #elif defined(_LIBCPP_VERSION)
         // _LIBCPP_VERSION follows "XXYYZZ" format (e.g., 170001 for 17.0.1).
         // ref: https://github.com/llvm/llvm-project/blob/f64732195c1030ee2627ff4e4142038e01df1d26/libcxx/include/__config#L51-L54
         //
         // Since we use the major version from _GLIBCXX_RELEASE, we need to extract only the first 2 characters of _LIBCPP_VERSION
         // to provide the major version for consistency.
-        std::cout << "libc++ version: " << std::to_string(_LIBCPP_VERSION).substr(0, 2) << std::endl;
+        #define name "libc++"
+        #define version _LIBCPP_VERSION / 10000
     #else
-        std::cerr << "Coudln't recognize the standard library version." << std::endl;
-        return 1;
+        #error "Couldn't recognize the standard library version."
     #endif
+
+    printf("%s version: %d\n", name, version);
 
     return 0;
 }


### PR DESCRIPTION
Ref: https://github.com/rust-lang/rust/issues/126423

`time (c++ src/tools/libcxx-version/main.cpp && ./a.out && rm ./a.out)` goes from ~180ms to ~50ms on my machine.

I tried doing this at compile time with `#pragma message`, however I couldn't find a way to reliably parse the output across GCC and Clang. Here's how that would've looked like:
```c++
// Include a small standard library header to define the version macros.
#include <cassert>

#define STR(x) XSTR(x)
#define XSTR(x) #x

#ifdef _GLIBCXX_RELEASE
    #pragma message "libstdc++ version: " STR(_GLIBCXX_RELEASE)
#elif defined(_LIBCPP_VERSION)
    #pragma message "libc++ version: " STR(_LIBCPP_VERSION)
#else
    #error "Couldn't recognize the standard library version."
#endif
```

cc @onur-ozkan as implementor in https://github.com/rust-lang/rust/pull/125411