### PR TITLE
build `libcxx-version` only when it doesn't exist

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -823,19 +823,29 @@ impl Step for LibcxxVersionTool {
 
     fn run(self, builder: &Builder<'_>) -> LibcxxVersion {
         let out_dir = builder.out.join(self.target.to_string()).join("libcxx-version");
-        let _ = fs::remove_dir_all(&out_dir);
-        t!(fs::create_dir_all(&out_dir));
-
-        let compiler = builder.cxx(self.target).unwrap();
-        let mut cmd = Command::new(compiler);
-
         let executable = out_dir.join(exe("libcxx-version", self.target));
-        cmd.arg("-o").arg(&executable).arg(builder.src.join("src/tools/libcxx-version/main.cpp"));
 
-        builder.run_cmd(&mut cmd);
-
+        // This is a sanity-check specific step, which means it is frequently called (when using
+        // CI LLVM), and compiling `src/tools/libcxx-version/main.cpp` at the beginning of the bootstrap
+        // invocation adds a fair amount of overhead to the process (see https://github.com/rust-lang/rust/issues/126423).
+        // Therefore, we want to avoid recompiling this file unnecessarily.
         if !executable.exists() {
-            panic!("Something went wrong. {} is not present", executable.display());
+            if !out_dir.exists() {
+                t!(fs::create_dir_all(&out_dir));
+            }
+
+            let compiler = builder.cxx(self.target).unwrap();
+            let mut cmd = Command::new(compiler);
+
+            cmd.arg("-o")
+                .arg(&executable)
+                .arg(builder.src.join("src/tools/libcxx-version/main.cpp"));
+
+            builder.run_cmd(&mut cmd);
+
+            if !executable.exists() {
+                panic!("Something went wrong. {} is not present", executable.display());
+            }
         }
 
         let version_output = output(&mut Command::new(executable));

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -128,6 +128,9 @@ pub fn check(build: &mut Build) {
                     eprintln!(
                         "Consider upgrading libstdc++ or disabling the `llvm.download-ci-llvm` option."
                     );
+                    eprintln!(
+                        "If you choose to upgrade libstdc++, run `x clean` or delete `build/host/libcxx-version` manually after the upgrade."
+                    );
                 }
             }
             tool::LibcxxVersion::Llvm(_) => {


### PR DESCRIPTION
In https://github.com/rust-lang/rust/issues/126423, it seems like c++ parsing takes quite amount of time on bootstrap startups. This PR makes libcxx-version to be compiled only when it doesn't exist.

A simple demonstration on the overhead of buiding `libcxx-version`:

```sh
$ rm -rf build/host/libcxx-version

$ x build
Building bootstrap
    Finished `dev` profile [unoptimized] target(s) in 0.07s

 ----- LIBCXX VERSION CHECK TOOK: 509ms
Building tool rustdoc (stage1 -> stage2, x86_64-unknown-linux-gnu)
    Finished `release` profile [optimized] target(s) in 0.25s
Build completed successfully in 0:00:02

$ x build
Building bootstrap
    Finished `dev` profile [unoptimized] target(s) in 0.07s

 ----- LIBCXX VERSION CHECK TOOK: 2ms
Creating a sysroot for stage2 compiler (use `rustup toolchain link 'name' build/host/stage2`)
Building tool rustdoc (stage1 -> stage2, x86_64-unknown-linux-gnu)
    Finished `release` profile [optimized] target(s) in 0.14s
Build completed successfully in 0:00:01
```