### PR TITLE
Fix running bootstrap tests with a local Rust toolchain as the stage0

### DIFF
--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -138,6 +138,25 @@ class BuildBootstrap(unittest.TestCase):
         if env is None:
             env = {}
 
+        # This test ends up invoking build_bootstrap_cmd, which searches for
+        # the Cargo binary and errors out if it cannot be found. This is not a
+        # problem in most cases, but there is a scenario where it would cause
+        # the test to fail.
+        #
+        # When a custom local Cargo is configured in config.toml (with the
+        # build.cargo setting), no Cargo is downloaded to any location known by
+        # bootstrap, and bootstrap relies on that setting to find it.
+        #
+        # In this test though we are not using the config.toml of the caller:
+        # we are generating a blank one instead. If we don't set build.cargo in
+        # it, the test will have no way to find Cargo, failing the test.
+        cargo_bin = os.environ.get("BOOTSTRAP_TEST_CARGO_BIN")
+        if cargo_bin is not None:
+            configure_args += ["--set", "build.cargo=" + cargo_bin]
+        rustc_bin = os.environ.get("BOOTSTRAP_TEST_RUSTC_BIN")
+        if rustc_bin is not None:
+            configure_args += ["--set", "build.rustc=" + rustc_bin]
+
         env = env.copy()
         env["PATH"] = os.environ["PATH"]
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3040,6 +3040,8 @@ impl Step for Bootstrap {
             .args(["-m", "unittest", "bootstrap_test.py"])
             .env("BUILD_DIR", &builder.out)
             .env("BUILD_PLATFORM", builder.build.build.triple)
+            .env("BOOTSTRAP_TEST_RUSTC_BIN", &builder.initial_rustc)
+            .env("BOOTSTRAP_TEST_CARGO_BIN", &builder.initial_cargo)
             .current_dir(builder.src.join("src/bootstrap/"));
         // NOTE: we intentionally don't pass test_args here because the args for unittest and cargo test are mutually incompatible.
         // Use `python -m unittest` manually if you want to pass arguments.

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1189,7 +1189,19 @@ impl Config {
     pub fn parse(args: &[String]) -> Config {
         #[cfg(test)]
         fn get_toml(_: &Path) -> TomlConfig {
-            TomlConfig::default()
+            let mut default = TomlConfig::default();
+
+            // When configuring bootstrap for tests, make sure to set the rustc and Cargo to the
+            // same ones used to call the tests. If we don't do that, bootstrap will use its own
+            // detection logic to find a suitable rustc and Cargo, which doesn't work when the
+            // caller is specìfying a custom local rustc or Cargo in their config.toml.
+            default.build = Some(Build {
+                rustc: std::env::var_os("RUSTC").map(|v| v.into()),
+                cargo: std::env::var_os("CARGO").map(|v| v.into()),
+                ..Build::default()
+            });
+
+            default
         }
 
         #[cfg(not(test))]

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1451,11 +1451,6 @@ impl Config {
             config.out = crate::utils::helpers::absolute(&config.out);
         }
 
-        // Hacky way to determine the executable suffix for the build target. We cannot use
-        // std::env::consts::EXE_SUFFIX as the build target might not be the target bootstrap was
-        // compiled with.
-        let initial_exe_suffix = if config.build.triple.contains("windows") { ".exe" } else { "" };
-
         config.initial_rustc = if let Some(rustc) = rustc {
             if !flags.skip_stage0_validation {
                 config.check_stage0_version(&rustc, "rustc");
@@ -1468,7 +1463,7 @@ impl Config {
                 .join(config.build.triple)
                 .join("stage0")
                 .join("bin")
-                .join(format!("rustc{initial_exe_suffix}"))
+                .join(exe("rustc", config.build))
         };
 
         config.initial_cargo = if let Some(cargo) = cargo {
@@ -1483,7 +1478,7 @@ impl Config {
                 .join(config.build.triple)
                 .join("stage0")
                 .join("bin")
-                .join(format!("cargo{initial_exe_suffix}"))
+                .join(exe("cargo", config.build))
         };
 
         // NOTE: it's important this comes *after* we set `initial_rustc` just above.

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1452,6 +1452,11 @@ impl Config {
             config.out = crate::utils::helpers::absolute(&config.out);
         }
 
+        // Hacky way to determine the executable suffix for the build target. We cannot use
+        // std::env::consts::EXE_SUFFIX as the build target might not be the target bootstrap was
+        // compiled with.
+        let initial_exe_suffix = if config.build.triple.contains("windows") { ".exe" } else { "" };
+
         config.initial_rustc = if let Some(rustc) = rustc {
             if !flags.skip_stage0_validation {
                 config.check_stage0_version(&rustc, "rustc");
@@ -1459,7 +1464,12 @@ impl Config {
             rustc
         } else {
             config.download_beta_toolchain();
-            config.out.join(config.build.triple).join("stage0/bin/rustc")
+            config
+                .out
+                .join(config.build.triple)
+                .join("stage0")
+                .join("bin")
+                .join(format!("rustc{initial_exe_suffix}"))
         };
 
         config.initial_cargo = if let Some(cargo) = cargo {
@@ -1469,7 +1479,12 @@ impl Config {
             cargo
         } else {
             config.download_beta_toolchain();
-            config.out.join(config.build.triple).join("stage0/bin/cargo")
+            config
+                .out
+                .join(config.build.triple)
+                .join("stage0")
+                .join("bin")
+                .join(format!("cargo{initial_exe_suffix}"))
         };
 
         // NOTE: it's important this comes *after* we set `initial_rustc` just above.


### PR DESCRIPTION
When configuring a local Rust toolchain as the stage0 (with `build.rustc` and `build.cargo` in `config.toml`) we noticed there were test failures (both on the Python and the Rust side) due to bootstrap not being able to find rustc and Cargo.

This was due to those two `config.toml` settings not being propagated in the tests. This PR fixes the issue by ensuring rustc and cargo are always configured in tests, using the parent bootstrap's `initial_rustc` and `initial_cargo`.

try-job: x86_64-msvc
Fixes https://github.com/rust-lang/rust/issues/105766