### PR TITLE
Forbid references to statics in valtrees

### DIFF
--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -310,6 +310,8 @@ const_eval_realloc_or_alloc_with_offset =
 
 const_eval_recursive_static = encountered static that tried to initialize itself with itself
 
+const_eval_ref_to_static = encountered a reference pointing to a static variable in a constant
+
 const_eval_remainder_by_zero =
     calculating the remainder with a divisor of zero
 const_eval_remainder_overflow =
@@ -399,7 +401,6 @@ const_eval_unwind_past_top =
 
 ## The `front_matter`s here refer to either `const_eval_front_matter_invalid_value` or `const_eval_front_matter_invalid_value_with_path`.
 ## (We'd love to sort this differently to make that more clear but tidy won't let us...)
-const_eval_validation_box_to_static = {$front_matter}: encountered a box pointing to a static variable in a constant
 const_eval_validation_box_to_uninhabited = {$front_matter}: encountered a box pointing to uninhabited type {$ty}
 
 const_eval_validation_const_ref_to_extern = {$front_matter}: encountered reference to `extern` static in `const`

--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -454,7 +454,6 @@ const_eval_validation_out_of_range = {$front_matter}: encountered {$value}, but 
 const_eval_validation_partial_pointer = {$front_matter}: encountered a partial pointer or a mix of pointers
 const_eval_validation_pointer_as_int = {$front_matter}: encountered a pointer, but {$expected}
 const_eval_validation_ptr_out_of_range = {$front_matter}: encountered a pointer, but expected something that cannot possibly fail to be {$in_range}
-const_eval_validation_ref_to_static = {$front_matter}: encountered a reference pointing to a static variable in a constant
 const_eval_validation_ref_to_uninhabited = {$front_matter}: encountered a reference pointing to uninhabited type {$ty}
 const_eval_validation_unaligned_box = {$front_matter}: encountered an unaligned box (required {$required_bytes} byte alignment but found {$found_bytes})
 const_eval_validation_unaligned_ref = {$front_matter}: encountered an unaligned reference (required {$required_bytes} byte alignment but found {$found_bytes})

--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -31,6 +31,8 @@ pub(crate) enum ValTreeCreationError {
     NodesOverflow,
     /// Values of this type, or this particular value, are not supported as valtrees.
     NonSupportedType,
+    /// Tried to create a valtree with a reference to a static.
+    StaticRef,
 }
 pub(crate) type ValTreeCreationResult<'tcx> = Result<ty::ValTree<'tcx>, ValTreeCreationError>;
 

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -640,9 +640,6 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
                 const_eval_validation_ref_to_uninhabited
             }
 
-            PtrToStatic { ptr_kind: PointerKind::Box } => const_eval_validation_box_to_static,
-            PtrToStatic { ptr_kind: PointerKind::Ref(_) } => const_eval_validation_ref_to_static,
-
             PointerAsInt { .. } => const_eval_validation_pointer_as_int,
             PartialPointer => const_eval_validation_partial_pointer,
             ConstRefToMutable => const_eval_validation_const_ref_to_mutable,
@@ -807,7 +804,6 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
                 );
             }
             NullPtr { .. }
-            | PtrToStatic { .. }
             | ConstRefToMutable
             | ConstRefToExtern
             | MutableRefToImmutable

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -127,6 +127,13 @@ pub(crate) struct MaxNumNodesInConstErr {
 }
 
 #[derive(Diagnostic)]
+#[diag(const_eval_ref_to_static)]
+pub(crate) struct StaticRefErr {
+    #[primary_span]
+    pub span: Option<Span>,
+}
+
+#[derive(Diagnostic)]
 #[diag(const_eval_unallowed_fn_pointer_call)]
 pub(crate) struct UnallowedFnPointerCall {
     #[primary_span]

--- a/compiler/rustc_const_eval/src/util/caller_location.rs
+++ b/compiler/rustc_const_eval/src/util/caller_location.rs
@@ -7,7 +7,9 @@ use rustc_middle::ty::{self, Mutability};
 use rustc_span::symbol::Symbol;
 use tracing::trace;
 
-use crate::const_eval::{mk_eval_cx_to_read_const_val, CanAccessMutGlobal, CompileTimeInterpCx};
+use crate::const_eval::{
+    mk_eval_cx_to_read_const_val, CompileTimeInterpCx, GlobalAccessPermissions,
+};
 use crate::interpret::*;
 
 /// Allocate a `const core::panic::Location` with the provided filename and line/column numbers.
@@ -62,7 +64,7 @@ pub(crate) fn const_caller_location_provider(
         tcx.tcx,
         tcx.span,
         ty::ParamEnv::reveal_all(),
-        CanAccessMutGlobal::No,
+        GlobalAccessPermissions::Static,
     );
 
     let loc_place = alloc_caller_location(&mut ecx, file, line, col);

--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -3,7 +3,7 @@ use rustc_middle::ty::layout::{LayoutCx, LayoutError, LayoutOf, TyAndLayout, Val
 use rustc_middle::ty::{ParamEnv, ParamEnvAnd, Ty, TyCtxt};
 use rustc_target::abi::{Abi, FieldsShape, Scalar, Variants};
 
-use crate::const_eval::{CanAccessMutGlobal, CheckAlignment, CompileTimeMachine};
+use crate::const_eval::{CheckAlignment, CompileTimeMachine, GlobalAccessPermissions};
 use crate::interpret::{InterpCx, MemoryKind, OpTy};
 
 /// Determines if this type permits "raw" initialization by just transmuting some memory into an
@@ -45,7 +45,7 @@ fn might_permit_raw_init_strict<'tcx>(
     tcx: TyCtxt<'tcx>,
     kind: ValidityRequirement,
 ) -> Result<bool, &'tcx LayoutError<'tcx>> {
-    let machine = CompileTimeMachine::new(CanAccessMutGlobal::No, CheckAlignment::Error);
+    let machine = CompileTimeMachine::new(GlobalAccessPermissions::Static, CheckAlignment::Error);
 
     let mut cx = InterpCx::new(tcx, rustc_span::DUMMY_SP, ParamEnv::reveal_all(), machine);
 

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -438,9 +438,6 @@ pub enum ValidationErrorKind<'tcx> {
         ptr_kind: PointerKind,
         ty: Ty<'tcx>,
     },
-    PtrToStatic {
-        ptr_kind: PointerKind,
-    },
     ConstRefToMutable,
     ConstRefToExtern,
     MutableRefToImmutable,

--- a/tests/ui/consts/const_refs_to_static.rs
+++ b/tests/ui/consts/const_refs_to_static.rs
@@ -14,6 +14,4 @@ const C2: *const i32 = unsafe { std::ptr::addr_of!(S_MUT) };
 fn main() {
     assert_eq!(*C1, 0);
     assert_eq!(unsafe { *C2 }, 0);
-    // Computing this pattern will read from an immutable static. That's fine.
-    assert!(matches!(&0, C1));
 }

--- a/tests/ui/consts/const_refs_to_static_fail_invalid.rs
+++ b/tests/ui/consts/const_refs_to_static_fail_invalid.rs
@@ -48,4 +48,20 @@ fn mutable() {
     }
 }
 
+fn immutable() {
+    static S: i32 = 0;
+
+    const C: &i32 = unsafe { &S };
+    //~^ ERROR: encountered a reference pointing to a static variable in a constant
+
+    // This could be ok, but we'd need to teach valtrees to support
+    // preserving statics, because valtree creation is shared with
+    // const generics, which can't just erase the information about
+    // the static's address.
+    match &42 {
+        C => {} //~ERROR: could not evaluate constant pattern
+        _ => {}
+    }
+}
+
 fn main() {}

--- a/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
+++ b/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
@@ -49,6 +49,18 @@ error: could not evaluate constant pattern
 LL |         C => {}
    |         ^
 
-error: aborting due to 6 previous errors
+error: encountered a reference pointing to a static variable in a constant
+  --> $DIR/const_refs_to_static_fail_invalid.rs:54:5
+   |
+LL |     const C: &i32 = unsafe { &S };
+   |     ^^^^^^^^^^^^^
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refs_to_static_fail_invalid.rs:62:9
+   |
+LL |         C => {}
+   |         ^
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/statics/const_generics.rs
+++ b/tests/ui/statics/const_generics.rs
@@ -1,7 +1,6 @@
 //! check that we lose the information that `BAR` points to `FOO`
 //! when going through a const generic.
 
-//@ run-pass
 // With optimizations, LLVM will deduplicate the constant `X` whose
 // value is `&42` to just be a reference to the static. This is correct,
 // but obscures the issue we're trying to show.
@@ -19,4 +18,5 @@ fn foo<const X: &'static usize>() {
 
 fn main() {
     foo::<BAR>();
+    //~^ ERROR: encountered a reference pointing to a static variable in a constant
 }

--- a/tests/ui/statics/const_generics.rs
+++ b/tests/ui/statics/const_generics.rs
@@ -1,0 +1,22 @@
+//! check that we lose the information that `BAR` points to `FOO`
+//! when going through a const generic.
+
+//@ run-pass
+// With optimizations, LLVM will deduplicate the constant `X` whose
+// value is `&42` to just be a reference to the static. This is correct,
+// but obscures the issue we're trying to show.
+//@ compile-flags: -Copt-level=0
+
+#![feature(const_refs_to_static)]
+#![feature(adt_const_params)]
+#![allow(incomplete_features)]
+
+static FOO: usize = 42;
+const BAR: &usize = &FOO;
+fn foo<const X: &'static usize>() {
+    assert!(!std::ptr::eq(X, &FOO));
+}
+
+fn main() {
+    foo::<BAR>();
+}

--- a/tests/ui/statics/const_generics.stderr
+++ b/tests/ui/statics/const_generics.stderr
@@ -1,0 +1,8 @@
+error: encountered a reference pointing to a static variable in a constant
+  --> $DIR/const_generics.rs:20:11
+   |
+LL |     foo::<BAR>();
+   |           ^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Implements the result of the recent discussions in https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/Refs.20to.20statics.20in.20constants

Basically instead of making a decision on how we want to treatreferences to statics in valtrees (and thus in const generics), we just reject them entirely. In the future we could (behind a separate feature gate) create a new valtree node that preserves the static's identity.

cc https://github.com/rust-lang/rust/issues/119618

Forward compatible with anything we decide in https://github.com/rust-lang/rust/issues/120961

r? @RalfJung 

cc @nikomatsakis 
