### PR TITLE
Disable `llvm-bitcode-linker` in the default bootstrap profiles

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -657,7 +657,7 @@
 # whether to set it as rustc's default linker on `x86_64-unknown-linux-gnu`. This will also only be
 # when *not* building an external LLVM (so only when using `download-ci-llvm` or building LLVM from
 # the in-tree source): setting `llvm-config` in the `[target.x86_64-unknown-linux-gnu]` section will
-# make this default to false. 
+# make this default to false.
 #lld = false in all cases, except on `x86_64-unknown-linux-gnu` as described above, where it is true
 
 # Indicates whether LLD will be used to link Rust crates during bootstrap on
@@ -676,7 +676,7 @@
 #llvm-tools = true
 
 # Indicates whether the `self-contained` llvm-bitcode-linker, will be made available
-# in the sysroot
+# in the sysroot. It is required for running nvptx tests.
 #llvm-bitcode-linker = false
 
 # Whether to deny warnings in crates

--- a/src/bootstrap/defaults/config.compiler.toml
+++ b/src/bootstrap/defaults/config.compiler.toml
@@ -19,8 +19,6 @@ lto = "off"
 # Forces frame pointers to be used with `-Cforce-frame-pointers`.
 # This can be helpful for profiling at a small performance cost.
 frame-pointers = true
-# Build the llvm-bitcode-linker as it is required for running nvptx tests
-llvm-bitcode-linker = true
 
 [llvm]
 # Having this set to true disrupts compiler development workflows for people who use `llvm.download-ci-llvm = true`

--- a/src/bootstrap/defaults/config.dist.toml
+++ b/src/bootstrap/defaults/config.dist.toml
@@ -16,7 +16,7 @@ download-ci-llvm = false
 # Make sure they don't get set when installing from source.
 channel = "nightly"
 download-rustc = false
-# Build the llvm-bitcode-linker as it is required for running nvptx tests
+# Build the llvm-bitcode-linker
 llvm-bitcode-linker = true
 
 [dist]

--- a/src/bootstrap/defaults/config.library.toml
+++ b/src/bootstrap/defaults/config.library.toml
@@ -10,8 +10,6 @@ bench-stage = 0
 incremental = true
 # Make the compiler and standard library faster to build, at the expense of a ~20% runtime slowdown.
 lto = "off"
-# Build the llvm-bitcode-linker as it is required for running nvptx tests
-llvm-bitcode-linker = true
 
 [llvm]
 # Will download LLVM from CI if available on your platform.

--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -12,8 +12,6 @@ incremental = true
 # Using these defaults will download the stage2 compiler (see `download-rustc`
 # setting) and the stage2 toolchain should therefore be used for these defaults.
 download-rustc = "if-unchanged"
-# Build the llvm-bitcode-linker as it is required for running nvptx tests
-llvm-bitcode-linker = true
 
 [build]
 # Document with the in-tree rustdoc by default, since `download-rustc` makes it quick to compile.


### PR DESCRIPTION
I don't think that we really need to enable `llvm-bitcode-linker` in the default bootstrap profiles, since it seems that it is only useful for running `nvptx` tests. It should be enabled on CI, which it is, and that should be enough. People can enable it easily locally, if they want.

The linker causes occasionally some rebuild issues (https://github.com/rust-lang/rust/issues/122491, https://github.com/rust-lang/rust/issues/126464), but more importantly it is just needless work to build it locally.

I kept it enabled for `dist`, because it is distributed as a `rustup` component (for some reason it's not included in `extended`? not sure).

Fixes: https://github.com/rust-lang/rust/issues/126464