### PR TITLE
Add `powerpc-unknown-openbsd` maintenance status

### DIFF
--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -60,6 +60,7 @@
     - [mipsel-sony-psx](platform-support/mipsel-sony-psx.md)
     - [mipsisa\*r6\*-unknown-linux-gnu\*](platform-support/mips-release-6.md)
     - [nvptx64-nvidia-cuda](platform-support/nvptx64-nvidia-cuda.md)
+    - [powerpc-unknown-openbsd](platform-support/powerpc-unknown-openbsd.md)
     - [powerpc64-ibm-aix](platform-support/aix.md)
     - [riscv32im-risc0-zkvm-elf](platform-support/riscv32im-risc0-zkvm-elf.md)
     - [riscv32imac-unknown-xous-elf](platform-support/riscv32imac-unknown-xous-elf.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -329,7 +329,7 @@ target | std | host | notes
 `powerpc-unknown-linux-gnuspe` | ✓ |  | PowerPC SPE Linux
 `powerpc-unknown-linux-musl` | ? |  | PowerPC Linux with musl 1.2.3
 [`powerpc-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | NetBSD 32-bit powerpc systems
-`powerpc-unknown-openbsd` | ? |  |
+[`powerpc-unknown-openbsd`](platform-support/powerpc-unknown-openbsd.md) | * |  |
 `powerpc-wrs-vxworks-spe` | ? |  |
 `powerpc-wrs-vxworks` | ? |  |
 `powerpc64-unknown-freebsd` | ✓ | ✓ | PPC64 FreeBSD (ELFv1 and ELFv2)

--- a/src/doc/rustc/src/platform-support/powerpc-unknown-openbsd.md
+++ b/src/doc/rustc/src/platform-support/powerpc-unknown-openbsd.md
@@ -1,0 +1,3 @@
+## Designated maintainers
+
+`powerpc-unknown-openbsd` is not maintained by OpenBSD developers and there are currently no active rustc maintainers.


### PR DESCRIPTION
As noted in https://github.com/rust-lang/rust/issues/126451#issuecomment-2167211749 `powerpc-unknown-openbsd` is not maintained by the OpenBSD devs. If a maintainer is found this can be updated with their information but we should document the current status and note explicitly that it's different from other OpenBSD targets.