### PR TITLE
Add a little bit of life to `Cell::update`

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -546,14 +546,14 @@ impl<T: Copy> Cell<T> {
     /// use std::cell::Cell;
     ///
     /// let c = Cell::new(5);
-    /// let new = c.update(|x| x + 1);
+    /// let new = c.get_update(|x| x + 1);
     ///
     /// assert_eq!(new, 6);
     /// assert_eq!(c.get(), 6);
     /// ```
     #[inline]
     #[unstable(feature = "cell_update", issue = "50186")]
-    pub fn update<F>(&self, f: F) -> T
+    pub fn get_update<F>(&self, f: F) -> T
     where
         F: FnOnce(T) -> T,
     {
@@ -650,6 +650,35 @@ impl<T: Default> Cell<T> {
     #[stable(feature = "move_cell", since = "1.17.0")]
     pub fn take(&self) -> T {
         self.replace(Default::default())
+    }
+
+    /// Takes and updates the contained value using a function and returns the
+    /// new value, leaving `Default::default()` in its place during the function call.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(cell_update)]
+    ///
+    /// use std::cell::Cell;
+    ///
+    /// let c = Cell::new(5);
+    /// c.take_update(|x| {
+    ///     assert_eq!(c.get(), 0);
+    ///     x + 1
+    /// });
+    ///
+    /// assert_eq!(c.get(), 6);
+    /// ```
+    #[inline]
+    #[unstable(feature = "cell_update", issue = "50186")]
+    pub fn take_update<F>(&self, f: F)
+    where
+        F: FnOnce(T) -> T,
+    {
+        let old = self.take();
+        let new = f(old);
+        self.set(new);
     }
 }
 

--- a/library/core/tests/cell.rs
+++ b/library/core/tests/cell.rs
@@ -47,13 +47,27 @@ fn smoketest_cell() {
 }
 
 #[test]
-fn cell_update() {
+fn cell_get_update() {
     let x = Cell::new(10);
 
-    assert_eq!(x.update(|x| x + 5), 15);
+    assert_eq!(x.get_update(|x| x + 5), 15);
     assert_eq!(x.get(), 15);
 
-    assert_eq!(x.update(|x| x / 3), 5);
+    assert_eq!(x.get_update(|x| x / 3), 5);
+    assert_eq!(x.get(), 5);
+}
+
+#[test]
+fn cell_take_update() {
+    let x = Cell::new(10);
+
+    x.take_update(|x| x + 5);
+    assert_eq!(x.get(), 15);
+
+    x.take_update(|y| {
+        assert_eq!(x.get(), 0);
+        y / 3
+    });
     assert_eq!(x.get(), 5);
 }
 

--- a/src/tools/miri/src/clock.rs
+++ b/src/tools/miri/src/clock.rs
@@ -98,7 +98,7 @@ impl Clock {
                 // Time will pass without us doing anything.
             }
             ClockKind::Virtual { nanoseconds } => {
-                nanoseconds.update(|x| x + NANOSECONDS_PER_BASIC_BLOCK);
+                nanoseconds.get_update(|x| x + NANOSECONDS_PER_BASIC_BLOCK);
             }
         }
     }
@@ -110,7 +110,7 @@ impl Clock {
             ClockKind::Virtual { nanoseconds } => {
                 // Just pretend that we have slept for some time.
                 let nanos: u128 = duration.as_nanos();
-                nanoseconds.update(|x| {
+                nanoseconds.get_update(|x| {
                     x.checked_add(nanos)
                         .expect("Miri's virtual clock cannot represent an execution this long")
                 });


### PR DESCRIPTION
`Cell::update` is open for 6 years now, and [discussion](https://github.com/rust-lang/rust/issues/50186) shows that users are not satisfied with current implementation. That PR implements the most agreed version among proposed ones. Maybe it would be accepted better or new feedback would come in. In any case, it would hopefully get stabilization closer.