### PR TITLE
delegation: Fix hygiene for `self`

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3281,17 +3281,19 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
         }
         self.visit_path(&delegation.path, delegation.id);
         if let Some(body) = &delegation.body {
-            // `PatBoundCtx` is not necessary in this context
-            let mut bindings = smallvec![(PatBoundCtx::Product, Default::default())];
+            self.with_rib(ValueNS, RibKind::FnOrCoroutine, |this| {
+                // `PatBoundCtx` is not necessary in this context
+                let mut bindings = smallvec![(PatBoundCtx::Product, Default::default())];
 
-            let span = delegation.path.segments.last().unwrap().ident.span;
-            self.fresh_binding(
-                Ident::new(kw::SelfLower, span),
-                delegation.id,
-                PatternSource::FnParam,
-                &mut bindings,
-            );
-            self.visit_block(body);
+                let span = delegation.path.segments.last().unwrap().ident.span;
+                this.fresh_binding(
+                    Ident::new(kw::SelfLower, span),
+                    delegation.id,
+                    PatternSource::FnParam,
+                    &mut bindings,
+                );
+                this.visit_block(body);
+            });
         }
     }
 

--- a/tests/ui/delegation/macro-inside-list.rs
+++ b/tests/ui/delegation/macro-inside-list.rs
@@ -14,9 +14,9 @@ struct S(u8);
 
 // Macro expansion works inside delegation items.
 macro_rules! u8 { () => { u8 } }
-macro_rules! self_0 { () => { &self.0 } }
+macro_rules! self_0 { ($self:ident) => { &$self.0 } }
 impl Trait for S {
-    reuse <u8!() as Trait>::{foo, bar} { self_0!() }
+    reuse <u8!() as Trait>::{foo, bar} { self_0!(self) }
 }
 
 fn main() {

--- a/tests/ui/delegation/self-hygiene.rs
+++ b/tests/ui/delegation/self-hygiene.rs
@@ -1,0 +1,20 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+macro_rules! emit_self { () => { self } }
+//~^ ERROR expected value, found module `self`
+//~| ERROR expected value, found module `self`
+
+struct S;
+impl S {
+    fn method(self) {
+        emit_self!();
+    }
+}
+
+fn foo(arg: u8) {}
+reuse foo as bar {
+    emit_self!()
+}
+
+fn main() {}

--- a/tests/ui/delegation/self-hygiene.stderr
+++ b/tests/ui/delegation/self-hygiene.stderr
@@ -1,0 +1,31 @@
+error[E0424]: expected value, found module `self`
+  --> $DIR/self-hygiene.rs:4:34
+   |
+LL |   macro_rules! emit_self { () => { self } }
+   |                                    ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+...
+LL | /     fn method(self) {
+LL | |         emit_self!();
+   | |         ------------ in this macro invocation
+LL | |     }
+   | |_____- this function has a `self` parameter, but a macro invocation can only access identifiers it receives from parameters
+   |
+   = note: this error originates in the macro `emit_self` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0424]: expected value, found module `self`
+  --> $DIR/self-hygiene.rs:4:34
+   |
+LL |   macro_rules! emit_self { () => { self } }
+   |                                    ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+...
+LL | / reuse foo as bar {
+LL | |     emit_self!()
+   | |     ------------ in this macro invocation
+LL | | }
+   | |_- delegation supports a `self` parameter, but a macro invocation can only access identifiers it receives from parameters
+   |
+   = note: this error originates in the macro `emit_self` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0424`.


### PR DESCRIPTION
And fix diagnostics for `self` from a macro.

The missing rib caused `self` to be treated as a generic parameter and ignore `macro_rules` hygiene.

Addresses this comment https://github.com/rust-lang/rust/pull/124135#discussion_r1637492234.