### PR TITLE
make bors ignore comments in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+<!-- homu-ignore:start -->
 <!--
 If this PR is related to an unstable feature or an otherwise tracked effort,
 please link to the relevant tracking issue here. If you don't know of a related
@@ -8,3 +9,4 @@ a specific user to review your work, you can assign it to them by using
 
     r​? <reviewer name>
 -->
+<!-- homu-ignore:end -->


### PR DESCRIPTION
As discussed [here](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/default.20PR.20description.20feedback/near/444794577), the existing PR template is not yet ignored by bors and the html comments show up in git history.

This PR uses markers so the html comments are deleted by the bot.

r? lcnr