### PR TITLE
.mailmap: Associate both my work and my private email with me

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -379,6 +379,7 @@ Markus Westerlind <marwes91@gmail.com> Markus <marwes91@gmail.com>
 Martin Carton <cartonmartin+git@gmail.com>
 Martin Habovštiak <martin.habovstiak@gmail.com>
 Martin Hafskjold Thoresen <martinhath@gmail.com>
+Martin Nordholts <martin.nordholts@codetale.se> <enselic@gmail.com>
 Matej Lach <matej.lach@gmail.com> Matej Ľach <matej.lach@gmail.com>
 Mateusz Mikuła <mati865@gmail.com>
 Mateusz Mikuła <mati865@gmail.com> <mati865@users.noreply.github.com>


### PR DESCRIPTION
Mainly so that 73 + 60 is summed to 133 on the [thanks](https://thanks.rust-lang.org/rust/all-time/) page.