### PR TITLE
Add codegen test for `Request::provide_*`

### DIFF
--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -928,7 +928,7 @@ pub(crate) mod tags {
 /// An `Option` with a type tag `I`.
 ///
 /// Since this struct implements `Erased`, the type can be erased to make a dynamically typed
-/// option. The type can be checked dynamically using `Erased::tag_id` and since this is statically
+/// option. The type can be checked dynamically using `Tagged::tag_id` and since this is statically
 /// checked for the concrete type, there is some degree of type safety.
 #[repr(transparent)]
 pub(crate) struct TaggedOption<'a, I: tags::Type<'a>>(pub Option<I::Reified>);

--- a/tests/codegen/error-provide.rs
+++ b/tests/codegen/error-provide.rs
@@ -36,7 +36,9 @@ impl std::error::Error for MyError {
         // LLVM should be able to optimize multiple .provide_* calls into a switch table
         // and eliminate redundant ones, rather than compare one-by-one.
 
-        // CHECK: switch i64 %{{.*}}, label %{{.*}} [
+        // CHECK-NEXT: start:
+        // CHECK-NEXT: %[[SCRUTINEE:[^ ]+]] = load i64, ptr
+        // CHECK-NEXT: switch i64 %[[SCRUTINEE]], label %{{.*}} [
         // CHECK-COUNT-3: i64 {{.*}}, label %{{.*}}
         // CHECK-NEXT: ]
         request

--- a/tests/codegen/error-provide.rs
+++ b/tests/codegen/error-provide.rs
@@ -1,0 +1,48 @@
+// Codegen test for #126242
+
+//@ compile-flags: -O
+#![crate_type = "lib"]
+#![feature(error_generic_member_access)]
+use std::error::Request;
+use std::fmt;
+
+#[derive(Debug)]
+struct MyBacktrace1 {}
+
+#[derive(Debug)]
+struct MyBacktrace2 {}
+
+#[derive(Debug)]
+struct MyBacktrace3 {}
+
+#[derive(Debug)]
+struct MyError {
+    backtrace1: MyBacktrace1,
+    backtrace2: MyBacktrace2,
+    backtrace3: MyBacktrace3,
+    other: MyBacktrace3,
+}
+
+impl fmt::Display for MyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Example Error")
+    }
+}
+
+impl std::error::Error for MyError {
+    // CHECK-LABEL: @provide
+    #[no_mangle]
+    fn provide<'a>(&'a self, request: &mut Request<'a>) {
+        // LLVM should be able to optimize multiple .provide_* calls into a switch table
+        // and eliminate redundant ones, rather than compare one-by-one.
+
+        // CHECK: switch i64 %{{.*}}, label %{{.*}} [
+        // CHECK-COUNT-3: i64 {{.*}}, label %{{.*}}
+        // CHECK-NEXT: ]
+        request
+            .provide_ref::<MyBacktrace1>(&self.backtrace1)
+            .provide_ref::<MyBacktrace3>(&self.other)
+            .provide_ref::<MyBacktrace2>(&self.backtrace2)
+            .provide_ref::<MyBacktrace3>(&self.backtrace3);
+    }
+}


### PR DESCRIPTION
Codegen before & after https://github.com/rust-lang/rust/pull/126242: https://gist.github.com/slanterns/3789ee36f59ed834e1a6bd4677b68ed4.

Also adjust an outdated comment since `tag_id` is no longer attached to `TaggedOption` via `Erased`, but stored next to it in `Tagged` under the new implementation.

My first time writing FileCheck xD. Correct me if there is anything that should be amended.

r? libs