### PR TITLE
rustc_span: Minor improvements

### DIFF
--- a/compiler/rustc_index_macros/src/newtype.rs
+++ b/compiler/rustc_index_macros/src/newtype.rs
@@ -205,6 +205,21 @@ impl Parse for Newtype {
                     }
                 }
 
+                /// Creates a new index from a given `u16`.
+                ///
+                /// # Panics
+                ///
+                /// Will panic if `value` exceeds `MAX`.
+                #[inline]
+                #vis const fn from_u16(value: u16) -> Self {
+                    let value = value as u32;
+                    assert!(value <= #max);
+                    // SAFETY: We just checked that `value <= max`.
+                    unsafe {
+                        Self::from_u32_unchecked(value)
+                    }
+                }
+
                 /// Creates a new index from a given `u32`.
                 ///
                 /// # Safety

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -881,13 +881,13 @@ impl<'tcx> InferCtxt<'tcx> {
             .collect();
         vars.extend(
             (0..inner.int_unification_table().len())
-                .map(|i| ty::IntVid::from_u32(i as u32))
+                .map(|i| ty::IntVid::from_usize(i))
                 .filter(|&vid| inner.int_unification_table().probe_value(vid).is_unknown())
                 .map(|v| Ty::new_int_var(self.tcx, v)),
         );
         vars.extend(
             (0..inner.float_unification_table().len())
-                .map(|i| ty::FloatVid::from_u32(i as u32))
+                .map(|i| ty::FloatVid::from_usize(i))
                 .filter(|&vid| inner.float_unification_table().probe_value(vid).is_unknown())
                 .map(|v| Ty::new_float_var(self.tcx, v)),
         );

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -539,7 +539,7 @@ impl<'a, 'tcx> SpanDecoder for DecodeContext<'a, 'tcx> {
         } else {
             SpanData::decode(self)
         };
-        Span::new(data.lo, data.hi, data.ctxt, data.parent)
+        data.span()
     }
 
     fn decode_symbol(&mut self) -> Symbol {
@@ -669,7 +669,7 @@ impl<'a, 'tcx> Decodable<DecodeContext<'a, 'tcx>> for SpanData {
         let lo = lo + source_file.translated_source_file.start_pos;
         let hi = hi + source_file.translated_source_file.start_pos;
 
-        // Do not try to decode parent for foreign spans.
+        // Do not try to decode parent for foreign spans (it wasn't encoded in the first place).
         SpanData { lo, hi, ctxt, parent: None }
     }
 }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -691,6 +691,11 @@ impl SyntaxContext {
         SyntaxContext(raw)
     }
 
+    #[inline]
+    pub(crate) const fn from_u16(raw: u16) -> SyntaxContext {
+        SyntaxContext(raw as u32)
+    }
+
     /// Extend a syntax context with a given expansion and transparency.
     pub fn apply_mark(self, expn_id: ExpnId, transparency: Transparency) -> SyntaxContext {
         HygieneData::with(|data| data.apply_mark(self, expn_id, transparency))

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -967,7 +967,7 @@ impl Span {
     /// This span, but in a larger context, may switch to the metavariable span if suitable.
     pub fn with_neighbor(self, neighbor: Span) -> Span {
         match Span::prepare_to_combine(self, neighbor) {
-            Ok((this, ..)) => Span::new(this.lo, this.hi, this.ctxt, this.parent),
+            Ok((this, ..)) => this.span(),
             Err(_) => self,
         }
     }
@@ -1352,7 +1352,7 @@ impl fmt::Debug for Span {
 
 impl fmt::Debug for SpanData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&Span::new(self.lo, self.hi, self.ctxt, self.parent), f)
+        fmt::Debug::fmt(&self.span(), f)
     }
 }
 

--- a/compiler/rustc_span/src/span_encoding.rs
+++ b/compiler/rustc_span/src/span_encoding.rs
@@ -121,7 +121,7 @@ impl InlineCtxt {
         SpanData {
             lo: BytePos(self.lo),
             hi: BytePos(self.lo.debug_strict_add(len)),
-            ctxt: SyntaxContext::from_u32(self.ctxt as u32),
+            ctxt: SyntaxContext::from_u16(self.ctxt),
             parent: None,
         }
     }
@@ -146,7 +146,7 @@ impl InlineParent {
             lo: BytePos(self.lo),
             hi: BytePos(self.lo.debug_strict_add(len)),
             ctxt: SyntaxContext::root(),
-            parent: Some(LocalDefId { local_def_index: DefIndex::from_u32(self.parent as u32) }),
+            parent: Some(LocalDefId { local_def_index: DefIndex::from_u16(self.parent) }),
         }
     }
     #[inline]
@@ -167,7 +167,7 @@ impl PartiallyInterned {
     #[inline]
     fn data(self) -> SpanData {
         SpanData {
-            ctxt: SyntaxContext::from_u32(self.ctxt as u32),
+            ctxt: SyntaxContext::from_u16(self.ctxt),
             ..with_span_interner(|interner| interner.spans[self.index as usize])
         }
     }
@@ -331,8 +331,7 @@ impl Span {
         match_span_kind! {
             self,
             InlineCtxt(span) => {
-                updated_ctxt32 =
-                    update(SyntaxContext::from_u32(span.ctxt as u32)).as_u32();
+                updated_ctxt32 = update(SyntaxContext::from_u16(span.ctxt)).as_u32();
                 // Any small new context including zero will preserve the format.
                 if updated_ctxt32 <= MAX_CTXT {
                     return InlineCtxt::span(span.lo, span.len, updated_ctxt32 as u16);
@@ -349,7 +348,7 @@ impl Span {
                 data = span.data();
             },
             PartiallyInterned(span) => {
-                updated_ctxt32 = update(SyntaxContext::from_u32(span.ctxt as u32)).as_u32();
+                updated_ctxt32 = update(SyntaxContext::from_u16(span.ctxt)).as_u32();
                 // Any small new context excluding zero will preserve the format.
                 // Zero may change the format to `InlineParent` if parent and len are small enough.
                 if updated_ctxt32 <= MAX_CTXT && updated_ctxt32 != 0 {
@@ -373,9 +372,9 @@ impl Span {
     fn inline_ctxt(self) -> Result<SyntaxContext, usize> {
         match_span_kind! {
             self,
-            InlineCtxt(span) => Ok(SyntaxContext::from_u32(span.ctxt as u32)),
+            InlineCtxt(span) => Ok(SyntaxContext::from_u16(span.ctxt)),
             InlineParent(_span) => Ok(SyntaxContext::root()),
-            PartiallyInterned(span) => Ok(SyntaxContext::from_u32(span.ctxt as u32)),
+            PartiallyInterned(span) => Ok(SyntaxContext::from_u16(span.ctxt)),
             Interned(span) => Err(span.index as usize),
         }
     }


### PR DESCRIPTION
Introduce `{IndexNewtype,SyntaxContext}::from_u16` for convenience because small indices are sometimes encoded as `u16`.
Use `SpanData::span` instead of `Span::new` where appropriate.
Add a clarifying comment about decoding span parents.
