### PR TITLE
Reword trait-object compatibility in rustdoc

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -954,13 +954,13 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
     if !t.is_object_safe(cx.tcx()) {
         write_section_heading(
             w,
-            "Object Safety",
+            "Trait-Object Safety",
             "object-safety",
             None,
             &format!(
-                "<div class=\"object-safety-info\">This trait is <b>not</b> \
+                "<div class=\"object-safety-info\">This trait is <strong>not</strong> compatible with \
                 <a href=\"{base}/reference/items/traits.html#object-safety\">\
-                object safe</a>.</div>",
+                <code>dyn Trait</code> types</a>.</div>",
                 base = crate::clean::utils::DOC_RUST_LANG_ORG_CHANNEL
             ),
         );

--- a/tests/rustdoc/trait-object-safe.rs
+++ b/tests/rustdoc/trait-object-safe.rs
@@ -1,14 +1,14 @@
 #![crate_name = "foo"]
 
 // @has 'foo/trait.Unsafe.html'
-// @has - '//*[@class="object-safety-info"]' 'This trait is not object safe.'
+// @has - '//*[@class="object-safety-info"]' 'This trait is not compatible with dyn Trait types.'
 // @has - '//*[@id="object-safety"]' 'Object Safety'
 pub trait Unsafe {
     fn foo() -> Self;
 }
 
 // @has 'foo/trait.Unsafe2.html'
-// @has - '//*[@class="object-safety-info"]' 'This trait is not object safe.'
+// @has - '//*[@class="object-safety-info"]' 'This trait is not compatible with dyn Trait types.'
 // @has - '//*[@id="object-safety"]' 'Object Safety'
 pub trait Unsafe2<T> {
     fn foo(i: T);


### PR DESCRIPTION
"Object Safety" is a difficult to understand jargon. I'm proposing a wording that makes it clearer it's about trait objects, and mentions `dyn Trait` which is the syntax that users are going to be more familiar with.

Related PR: https://github.com/rust-lang/reference/pull/1512

Longer explanation: https://internals.rust-lang.org/t/object-safety-is-a-terrible-term/21025
