### PR TITLE
override user defined channel when using precompiled rustc

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1036,23 +1036,12 @@ impl<'a> Builder<'a> {
     }
 
     pub fn doc_rust_lang_org_channel(&self) -> String {
-        // When using precompiled compiler from CI, we need to use CI rustc's channel and
-        // ignore `rust.channel` from the configuration. Otherwise most of the rustdoc tests
-        // will fail due to incompatible `DOC_RUST_LANG_ORG_CHANNEL`.
-        let channel = if let Some(commit) = self.config.download_rustc_commit() {
-            self.config
-                .read_file_by_commit(&PathBuf::from("src/ci/channel"), commit)
-                .trim()
-                .to_owned()
-        } else {
-            match &*self.config.channel {
-                "stable" => &self.version,
-                "beta" => "beta",
-                "nightly" | "dev" => "nightly",
-                // custom build of rustdoc maybe? link to the latest stable docs just in case
-                _ => "stable",
-            }
-            .to_owned()
+        let channel = match &*self.config.channel {
+            "stable" => &self.version,
+            "beta" => "beta",
+            "nightly" | "dev" => "nightly",
+            // custom build of rustdoc maybe? link to the latest stable docs just in case
+            _ => "stable",
         };
 
         format!("https://doc.rust-lang.org/{channel}")


### PR DESCRIPTION
We need to override `rust.channel` if it's manually specified when using the CI rustc. This is because if the compiler uses a different channel than the one specified in config.toml, tests may fail due to using a different channel than the one used by the compiler during tests.

For more context, see https://github.com/rust-lang/rust/pull/122709#issuecomment-2165246281.