### PR TITLE
Add `run-make/const_fn_mir` missing test annotation

### DIFF
--- a/tests/run-make/const_fn_mir/rmake.rs
+++ b/tests/run-make/const_fn_mir/rmake.rs
@@ -1,5 +1,7 @@
 // The `needs-unwind -Cpanic=abort` gives a different MIR output.
 
+//@ needs-unwind
+
 use run_make_support::{cwd, diff, rustc};
 
 fn main() {


### PR DESCRIPTION
Fixes comment from https://github.com/rust-lang/rust/pull/126270.

r? @bjorn3 