### PR TITLE
Print the tested value in int_log tests

### DIFF
--- a/library/core/tests/num/int_log.rs
+++ b/library/core/tests/num/int_log.rs
@@ -24,15 +24,15 @@ fn checked_ilog() {
 
     #[cfg(not(miri))] // Miri is too slow
     for i in i16::MIN..=0 {
-        assert_eq!(i.checked_ilog(4), None);
+        assert_eq!(i.checked_ilog(4), None, "checking {i}");
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=i16::MAX {
-        assert_eq!(i.checked_ilog(13), Some((i as f32).log(13.0) as u32));
+        assert_eq!(i.checked_ilog(13), Some((i as f32).log(13.0) as u32), "checking {i}");
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=u16::MAX {
-        assert_eq!(i.checked_ilog(13), Some((i as f32).log(13.0) as u32));
+        assert_eq!(i.checked_ilog(13), Some((i as f32).log(13.0) as u32), "checking {i}");
     }
 }
 
@@ -49,30 +49,30 @@ fn checked_ilog2() {
     assert_eq!(0i16.checked_ilog2(), None);
 
     for i in 1..=u8::MAX {
-        assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32));
+        assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32), "checking {i}");
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=u16::MAX {
         // Guard against Android's imprecise f32::ilog2 implementation.
         if i != 8192 && i != 32768 {
-            assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32));
+            assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32), "checking {i}");
         }
     }
     for i in i8::MIN..=0 {
-        assert_eq!(i.checked_ilog2(), None);
+        assert_eq!(i.checked_ilog2(), None, "checking {i}");
     }
     for i in 1..=i8::MAX {
-        assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32));
+        assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32), "checking {i}");
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in i16::MIN..=0 {
-        assert_eq!(i.checked_ilog2(), None);
+        assert_eq!(i.checked_ilog2(), None, "checking {i}");
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=i16::MAX {
         // Guard against Android's imprecise f32::ilog2 implementation.
         if i != 8192 {
-            assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32));
+            assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32), "checking {i}");
         }
     }
 }
@@ -95,19 +95,19 @@ fn checked_ilog10() {
 
     #[cfg(not(miri))] // Miri is too slow
     for i in i16::MIN..=0 {
-        assert_eq!(i.checked_ilog10(), None);
+        assert_eq!(i.checked_ilog10(), None, "checking {i}");
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=i16::MAX {
-        assert_eq!(i.checked_ilog10(), Some((i as f32).log10() as u32));
+        assert_eq!(i.checked_ilog10(), Some((i as f32).log10() as u32), "checking {i}");
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=u16::MAX {
-        assert_eq!(i.checked_ilog10(), Some((i as f32).log10() as u32));
+        assert_eq!(i.checked_ilog10(), Some((i as f32).log10() as u32), "checking {i}");
     }
     #[cfg(not(miri))] // Miri is too slow
     for i in 1..=100_000u32 {
-        assert_eq!(i.checked_ilog10(), Some((i as f32).log10() as u32));
+        assert_eq!(i.checked_ilog10(), Some((i as f32).log10() as u32), "checking {i}");
     }
 }
 


### PR DESCRIPTION
Tiny change - from the failures in https://github.com/rust-lang/rust/pull/125016, it would have been nice to see what the tested values were. Update the assertion messages.