### PR TITLE
Add `rustc-ice*` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ build/
 /src/tools/x/target
 # Created by default with `src/ci/docker/run.sh`
 /obj/
+/rustc-ice*
 
 ## Temporary files
 *~


### PR DESCRIPTION
I am a bit surprised this wasn't already here but there doesn't seem to be any reason not to add it. This will be nice to cut down on `git {add, diff, etc}` noise when debugging crashes.