### PR TITLE
less bootstrap warnings

### DIFF
--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -135,7 +135,7 @@ pub fn symlink_dir(config: &Config, original: &Path, link: &Path) -> io::Result<
     if config.dry_run() {
         return Ok(());
     }
-    let _ = fs::remove_dir(link);
+    let _ = fs::remove_dir_all(link);
     return symlink_dir_inner(original, link);
 
     #[cfg(not(windows))]


### PR DESCRIPTION
This is how the build logs looks like currently:

```sh
$ x build
Building bootstrap
   Compiling bootstrap v0.0.0 (/home/nimda/devspace/onur-ozkan/rust/src/bootstrap)
    Finished `dev` profile [unoptimized] target(s) in 3.43s
WARNING: no codegen-backends config matched the requested path to build a codegen backend. HELP: add backend to codegen-backends in config.toml.
WARNING: creating symbolic link `/home/nimda/devspace/.other/rustc-builds/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/rustc-src/rust` to `/home/nimda/devspace/onur-ozkan/rust` failed with File exists (os
error 17)
Creating a sysroot for stage2 compiler (use `rustup toolchain link 'name' build/host/stage2`)
WARNING: creating symbolic link `/home/nimda/devspace/.other/rustc-builds/build/x86_64-unknown-linux-gnu/ci-rustc-sysroot/lib/rustlib/rustc-src/rust` to `/home/nimda/devspace/onur-ozkan/rust` failed with File e
xists (os error 17)
Building tool rustdoc (stage1 -> stage2, x86_64-unknown-linux-gnu)
   Compiling rustdoc v0.0.0 (/home/nimda/devspace/onur-ozkan/rust/src/librustdoc)
   Compiling rustdoc-tool v0.0.0 (/home/nimda/devspace/onur-ozkan/rust/src/tools/rustdoc)
    Finished `release` profile [optimized + debuginfo] target(s) in 13.57s
Build completed successfully in 0:00:17
```

This PR removes artifact linking warnings and only shows the codegen-backend warning if explicitly called or during Dist or Install steps.