### PR TITLE
Replace all `move||` with `move ||`

### DIFF
--- a/compiler/rustc_hir_typeck/src/typeck_root_ctxt.rs
+++ b/compiler/rustc_hir_typeck/src/typeck_root_ctxt.rs
@@ -22,7 +22,7 @@ use std::ops::Deref;
 /// e.g. closures defined within the function. For example:
 /// ```ignore (illustrative)
 /// fn foo() {
-///     bar(move|| { ... })
+///     bar(move || { ... })
 /// }
 /// ```
 /// Here, the function `foo()` and the closure passed to

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -183,7 +183,7 @@
 //!
 //!     let spinlock_clone = Arc::clone(&spinlock);
 //!
-//!     let thread = thread::spawn(move|| {
+//!     let thread = thread::spawn(move || {
 //!         spinlock_clone.store(0, Ordering::Release);
 //!     });
 //!

--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -20,7 +20,7 @@ use crate::sync::{Condvar, Mutex};
 ///     let c = Arc::clone(&barrier);
 ///     // The same messages will be printed together.
 ///     // You will NOT see any interleaving.
-///     handles.push(thread::spawn(move|| {
+///     handles.push(thread::spawn(move || {
 ///         println!("before wait");
 ///         c.wait();
 ///         println!("after wait");
@@ -115,7 +115,7 @@ impl Barrier {
     ///     let c = Arc::clone(&barrier);
     ///     // The same messages will be printed together.
     ///     // You will NOT see any interleaving.
-    ///     handles.push(thread::spawn(move|| {
+    ///     handles.push(thread::spawn(move || {
     ///         println!("before wait");
     ///         c.wait();
     ///         println!("after wait");

--- a/library/std/src/sync/condvar.rs
+++ b/library/std/src/sync/condvar.rs
@@ -88,7 +88,7 @@ impl WaitTimeoutResult {
 /// let pair2 = Arc::clone(&pair);
 ///
 /// // Inside of our lock, spawn a new thread, and then wait for it to start.
-/// thread::spawn(move|| {
+/// thread::spawn(move || {
 ///     let (lock, cvar) = &*pair2;
 ///     let mut started = lock.lock().unwrap();
 ///     *started = true;
@@ -166,7 +166,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut started = lock.lock().unwrap();
     ///     *started = true;
@@ -221,7 +221,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(true), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut pending = lock.lock().unwrap();
     ///     *pending = false;
@@ -280,7 +280,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut started = lock.lock().unwrap();
     ///     *started = true;
@@ -352,7 +352,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut started = lock.lock().unwrap();
     ///     *started = true;
@@ -420,7 +420,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(true), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut pending = lock.lock().unwrap();
     ///     *pending = false;
@@ -484,7 +484,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut started = lock.lock().unwrap();
     ///     *started = true;
@@ -524,7 +524,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut started = lock.lock().unwrap();
     ///     *started = true;

--- a/library/std/src/sync/mpsc/mod.rs
+++ b/library/std/src/sync/mpsc/mod.rs
@@ -51,7 +51,7 @@
 //!
 //! // Create a simple streaming channel
 //! let (tx, rx) = channel();
-//! thread::spawn(move|| {
+//! thread::spawn(move || {
 //!     tx.send(10).unwrap();
 //! });
 //! assert_eq!(rx.recv().unwrap(), 10);
@@ -69,7 +69,7 @@
 //! let (tx, rx) = channel();
 //! for i in 0..10 {
 //!     let tx = tx.clone();
-//!     thread::spawn(move|| {
+//!     thread::spawn(move || {
 //!         tx.send(i).unwrap();
 //!     });
 //! }
@@ -99,7 +99,7 @@
 //! use std::sync::mpsc::sync_channel;
 //!
 //! let (tx, rx) = sync_channel::<i32>(0);
-//! thread::spawn(move|| {
+//! thread::spawn(move || {
 //!     // This will wait for the parent thread to start receiving
 //!     tx.send(53).unwrap();
 //! });
@@ -510,7 +510,7 @@ pub enum TrySendError<T> {
 /// let (sender, receiver) = channel();
 ///
 /// // Spawn off an expensive computation
-/// thread::spawn(move|| {
+/// thread::spawn(move || {
 /// #   fn expensive_computation() {}
 ///     sender.send(expensive_computation()).unwrap();
 /// });
@@ -561,7 +561,7 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 /// // this returns immediately
 /// sender.send(1).unwrap();
 ///
-/// thread::spawn(move|| {
+/// thread::spawn(move || {
 ///     // this will block until the previous message has been received
 ///     sender.send(2).unwrap();
 /// });

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -62,7 +62,7 @@ use crate::fmt;
 /// FOO.set(2);
 ///
 /// // each thread starts out with the initial value of 1
-/// let t = thread::spawn(move|| {
+/// let t = thread::spawn(move || {
 ///     assert_eq!(FOO.get(), 1);
 ///     FOO.set(3);
 /// });

--- a/tests/ui/array-slice-vec/slice-panic-1.rs
+++ b/tests/ui/array-slice-vec/slice-panic-1.rs
@@ -22,6 +22,6 @@ fn foo() {
 }
 
 fn main() {
-    let _ = thread::spawn(move|| foo()).join();
+    let _ = thread::spawn(move || foo()).join();
     unsafe { assert_eq!(DTOR_COUNT, 2); }
 }

--- a/tests/ui/array-slice-vec/slice-panic-2.rs
+++ b/tests/ui/array-slice-vec/slice-panic-2.rs
@@ -26,6 +26,6 @@ fn foo() {
 }
 
 fn main() {
-    let _ = thread::spawn(move|| foo()).join();
+    let _ = thread::spawn(move || foo()).join();
     unsafe { assert_eq!(DTOR_COUNT, 2); }
 }

--- a/tests/ui/borrowck/borrowck-loan-blocks-move-cc.rs
+++ b/tests/ui/borrowck/borrowck-loan-blocks-move-cc.rs
@@ -11,7 +11,7 @@ fn borrow<F>(v: &isize, f: F) where F: FnOnce(&isize) {
 fn box_imm() {
     let v: Box<_> = Box::new(3);
     let w = &v;
-    thread::spawn(move|| {
+    thread::spawn(move || {
     //~^ ERROR cannot move out of `v` because it is borrowed
         println!("v={}", *v);
     });
@@ -21,7 +21,7 @@ fn box_imm() {
 fn box_imm_explicit() {
     let v: Box<_> = Box::new(3);
     let w = &v;
-    thread::spawn(move|| {
+    thread::spawn(move || {
     //~^ ERROR cannot move
         println!("v={}", *v);
     });

--- a/tests/ui/borrowck/borrowck-loan-blocks-move-cc.stderr
+++ b/tests/ui/borrowck/borrowck-loan-blocks-move-cc.stderr
@@ -5,8 +5,8 @@ LL |     let v: Box<_> = Box::new(3);
    |         - binding `v` declared here
 LL |     let w = &v;
    |             -- borrow of `v` occurs here
-LL |     thread::spawn(move|| {
-   |                   ^^^^^^ move out of `v` occurs here
+LL |     thread::spawn(move || {
+   |                   ^^^^^^^ move out of `v` occurs here
 LL |
 LL |         println!("v={}", *v);
    |                          -- move occurs due to use in closure
@@ -27,8 +27,8 @@ LL |     let v: Box<_> = Box::new(3);
    |         - binding `v` declared here
 LL |     let w = &v;
    |             -- borrow of `v` occurs here
-LL |     thread::spawn(move|| {
-   |                   ^^^^^^ move out of `v` occurs here
+LL |     thread::spawn(move || {
+   |                   ^^^^^^^ move out of `v` occurs here
 LL |
 LL |         println!("v={}", *v);
    |                          -- move occurs due to use in closure

--- a/tests/ui/borrowck/borrowck-move-moved-value-into-closure.rs
+++ b/tests/ui/borrowck/borrowck-move-moved-value-into-closure.rs
@@ -7,6 +7,6 @@ fn call_f<F:FnOnce() -> isize>(f: F) -> isize {
 fn main() {
     let t: Box<_> = Box::new(3);
 
-    call_f(move|| { *t + 1 });
-    call_f(move|| { *t + 1 }); //~ ERROR use of moved value
+    call_f(move || { *t + 1 });
+    call_f(move || { *t + 1 }); //~ ERROR use of moved value
 }

--- a/tests/ui/borrowck/borrowck-move-moved-value-into-closure.stderr
+++ b/tests/ui/borrowck/borrowck-move-moved-value-into-closure.stderr
@@ -4,12 +4,12 @@ error[E0382]: use of moved value: `t`
 LL |     let t: Box<_> = Box::new(3);
    |         - move occurs because `t` has type `Box<isize>`, which does not implement the `Copy` trait
 LL |
-LL |     call_f(move|| { *t + 1 });
-   |            ------   -- variable moved due to use in closure
+LL |     call_f(move || { *t + 1 });
+   |            -------   -- variable moved due to use in closure
    |            |
    |            value moved into closure here
-LL |     call_f(move|| { *t + 1 });
-   |            ^^^^^^   -- use occurs due to use in closure
+LL |     call_f(move || { *t + 1 });
+   |            ^^^^^^^   -- use occurs due to use in closure
    |            |
    |            value used here after move
 

--- a/tests/ui/borrowck/borrowck-multiple-captures.rs
+++ b/tests/ui/borrowck/borrowck-multiple-captures.rs
@@ -9,7 +9,7 @@ fn different_vars_after_borrows() {
     let p1 = &x1;
     let x2: Box<_> = Box::new(2);
     let p2 = &x2;
-    thread::spawn(move|| {
+    thread::spawn(move || {
         //~^ ERROR cannot move out of `x1` because it is borrowed
         //~| ERROR cannot move out of `x2` because it is borrowed
         drop(x1);
@@ -24,7 +24,7 @@ fn different_vars_after_moves() {
     drop(x1);
     let x2: Box<_> = Box::new(2);
     drop(x2);
-    thread::spawn(move|| {
+    thread::spawn(move || {
         //~^ ERROR use of moved value: `x1`
         //~| ERROR use of moved value: `x2`
         drop(x1);
@@ -35,7 +35,7 @@ fn different_vars_after_moves() {
 fn same_var_after_borrow() {
     let x: Box<_> = Box::new(1);
     let p = &x;
-    thread::spawn(move|| {
+    thread::spawn(move || {
         //~^ ERROR cannot move out of `x` because it is borrowed
         drop(x);
         drop(x); //~ ERROR use of moved value: `x`
@@ -46,7 +46,7 @@ fn same_var_after_borrow() {
 fn same_var_after_move() {
     let x: Box<_> = Box::new(1);
     drop(x);
-    thread::spawn(move|| {
+    thread::spawn(move || {
         //~^ ERROR use of moved value: `x`
         drop(x);
         drop(x); //~ ERROR use of moved value: `x`

--- a/tests/ui/borrowck/borrowck-multiple-captures.stderr
+++ b/tests/ui/borrowck/borrowck-multiple-captures.stderr
@@ -6,8 +6,8 @@ LL |     let x1: Box<_> = Box::new(1);
 LL |     let p1 = &x1;
    |              --- borrow of `x1` occurs here
 ...
-LL |     thread::spawn(move|| {
-   |                   ^^^^^^ move out of `x1` occurs here
+LL |     thread::spawn(move || {
+   |                   ^^^^^^^ move out of `x1` occurs here
 ...
 LL |         drop(x1);
    |              -- move occurs due to use in closure
@@ -28,8 +28,8 @@ LL |     let x2: Box<_> = Box::new(2);
    |         -- binding `x2` declared here
 LL |     let p2 = &x2;
    |              --- borrow of `x2` occurs here
-LL |     thread::spawn(move|| {
-   |                   ^^^^^^ move out of `x2` occurs here
+LL |     thread::spawn(move || {
+   |                   ^^^^^^^ move out of `x2` occurs here
 ...
 LL |         drop(x2);
    |              -- move occurs due to use in closure
@@ -51,8 +51,8 @@ LL |     let x1: Box<_> = Box::new(1);
 LL |     drop(x1);
    |          -- value moved here
 ...
-LL |     thread::spawn(move|| {
-   |                   ^^^^^^ value used here after move
+LL |     thread::spawn(move || {
+   |                   ^^^^^^^ value used here after move
 ...
 LL |         drop(x1);
    |              -- use occurs due to use in closure
@@ -69,8 +69,8 @@ LL |     let x2: Box<_> = Box::new(2);
    |         -- move occurs because `x2` has type `Box<i32>`, which does not implement the `Copy` trait
 LL |     drop(x2);
    |          -- value moved here
-LL |     thread::spawn(move|| {
-   |                   ^^^^^^ value used here after move
+LL |     thread::spawn(move || {
+   |                   ^^^^^^^ value used here after move
 ...
 LL |         drop(x2);
    |              -- use occurs due to use in closure
@@ -97,8 +97,8 @@ LL |     let x: Box<_> = Box::new(1);
    |         - binding `x` declared here
 LL |     let p = &x;
    |             -- borrow of `x` occurs here
-LL |     thread::spawn(move|| {
-   |                   ^^^^^^ move out of `x` occurs here
+LL |     thread::spawn(move || {
+   |                   ^^^^^^^ move out of `x` occurs here
 LL |
 LL |         drop(x);
    |              - move occurs due to use in closure
@@ -129,8 +129,8 @@ LL |     let x: Box<_> = Box::new(1);
    |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
 LL |     drop(x);
    |          - value moved here
-LL |     thread::spawn(move|| {
-   |                   ^^^^^^ value used here after move
+LL |     thread::spawn(move || {
+   |                   ^^^^^^^ value used here after move
 LL |
 LL |         drop(x);
    |              - use occurs due to use in closure

--- a/tests/ui/borrowck/kindck-implicit-close-over-mut-var.rs
+++ b/tests/ui/borrowck/kindck-implicit-close-over-mut-var.rs
@@ -10,7 +10,7 @@ fn foo() {
     // Here, i is *copied* into the proc (heap closure).
     // Requires allocation.  The proc's copy is not mutable.
     let mut i = 0;
-    let t = thread::spawn(move|| {
+    let t = thread::spawn(move || {
         user(i);
         println!("spawned {}", i)
     });
@@ -24,7 +24,7 @@ fn bar() {
     // mutable outside of the proc.
     let mut i = 0;
     while i < 10 {
-        let t = thread::spawn(move|| {
+        let t = thread::spawn(move || {
             user(i);
         });
         i += 1;
@@ -36,7 +36,7 @@ fn car() {
     // Here, i must be shadowed in the proc to be mutable.
     let mut i = 0;
     while i < 10 {
-        let t = thread::spawn(move|| {
+        let t = thread::spawn(move || {
             let mut i = i;
             i += 1;
             user(i);

--- a/tests/ui/box/unit/unique-send-2.rs
+++ b/tests/ui/box/unit/unique-send-2.rs
@@ -16,7 +16,7 @@ pub fn main() {
     let ts = (0..n).map(|i| {
         expected += i;
         let tx = tx.clone();
-        thread::spawn(move|| {
+        thread::spawn(move || {
             child(&tx, i)
         })
     }).collect::<Vec<_>>();

--- a/tests/ui/cannot-mutate-captured-non-mut-var.rs
+++ b/tests/ui/cannot-mutate-captured-non-mut-var.rs
@@ -6,10 +6,10 @@ fn to_fn_once<A:std::marker::Tuple,F:FnOnce<A>>(f: F) -> F { f }
 
 fn main() {
     let x = 1;
-    to_fn_once(move|| { x = 2; });
+    to_fn_once(move || { x = 2; });
     //~^ ERROR: cannot assign to `x`, as it is not declared as mutable
 
     let s = std::io::stdin();
-    to_fn_once(move|| { s.read_to_end(&mut Vec::new()); });
+    to_fn_once(move || { s.read_to_end(&mut Vec::new()); });
     //~^ ERROR: cannot borrow `s` as mutable, as it is not declared as mutable
 }

--- a/tests/ui/cannot-mutate-captured-non-mut-var.stderr
+++ b/tests/ui/cannot-mutate-captured-non-mut-var.stderr
@@ -1,18 +1,18 @@
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/cannot-mutate-captured-non-mut-var.rs:9:25
+  --> $DIR/cannot-mutate-captured-non-mut-var.rs:9:26
    |
 LL |     let x = 1;
    |         - help: consider changing this to be mutable: `mut x`
-LL |     to_fn_once(move|| { x = 2; });
-   |                         ^^^^^ cannot assign
+LL |     to_fn_once(move || { x = 2; });
+   |                          ^^^^^ cannot assign
 
 error[E0596]: cannot borrow `s` as mutable, as it is not declared as mutable
-  --> $DIR/cannot-mutate-captured-non-mut-var.rs:13:25
+  --> $DIR/cannot-mutate-captured-non-mut-var.rs:13:26
    |
 LL |     let s = std::io::stdin();
    |         - help: consider changing this to be mutable: `mut s`
-LL |     to_fn_once(move|| { s.read_to_end(&mut Vec::new()); });
-   |                         ^ cannot borrow as mutable
+LL |     to_fn_once(move || { s.read_to_end(&mut Vec::new()); });
+   |                          ^ cannot borrow as mutable
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/closures/issue-10398.rs
+++ b/tests/ui/closures/issue-10398.rs
@@ -1,6 +1,6 @@
 fn main() {
     let x: Box<_> = Box::new(1);
-    let f = move|| {
+    let f = move || {
         let _a = x;
         drop(x);
         //~^ ERROR: use of moved value: `x`

--- a/tests/ui/closures/issue-10682.rs
+++ b/tests/ui/closures/issue-10682.rs
@@ -9,5 +9,5 @@ fn foo<F:FnOnce()>(_: F) {}
 
 pub fn main() {
   let a = Box::new(1);
-  foo(move|| { foo(move|| { work(a) }) })
+  foo(move || { foo(move || { work(a) }) })
 }

--- a/tests/ui/closures/once-move-out-on-heap.rs
+++ b/tests/ui/closures/once-move-out-on-heap.rs
@@ -11,7 +11,7 @@ fn foo<F:FnOnce()>(blk: F) {
 
 pub fn main() {
     let x = Arc::new(true);
-    foo(move|| {
+    foo(move || {
         assert!(*x);
         drop(x);
     });

--- a/tests/ui/closures/print/closure-print-generic-verbose-1.rs
+++ b/tests/ui/closures/print/closure-print-generic-verbose-1.rs
@@ -9,7 +9,7 @@ fn f<T: std::fmt::Display>(y: T) {
 
     let foo =  Foo{ x: "x" };
 
-    let c = to_fn_once(move|| {
+    let c = to_fn_once(move || {
         println!("{} {}", foo.x, y);
     });
 

--- a/tests/ui/closures/print/closure-print-generic-verbose-1.stderr
+++ b/tests/ui/closures/print/closure-print-generic-verbose-1.stderr
@@ -1,7 +1,7 @@
 error[E0382]: use of moved value: `c`
   --> $DIR/closure-print-generic-verbose-1.rs:17:5
    |
-LL |     let c = to_fn_once(move|| {
+LL |     let c = to_fn_once(move || {
    |         - move occurs because `c` has type `{f<T>::{closure#0} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'?9 str>, T)}`, which does not implement the `Copy` trait
 ...
 LL |     c();

--- a/tests/ui/cross-crate/auxiliary/cci_capture_clause.rs
+++ b/tests/ui/cross-crate/auxiliary/cci_capture_clause.rs
@@ -3,7 +3,7 @@ use std::sync::mpsc::{Receiver, channel};
 
 pub fn foo<T:'static + Send + Clone>(x: T) -> Receiver<T> {
     let (tx, rx) = channel();
-    thread::spawn(move|| {
+    thread::spawn(move || {
         tx.send(x.clone());
     });
     rx

--- a/tests/ui/drop/drop-trait-enum.rs
+++ b/tests/ui/drop/drop-trait-enum.rs
@@ -63,7 +63,7 @@ pub fn main() {
     assert_eq!(receiver.recv().ok(), None);
 
     let (sender, receiver) = channel();
-    let t = thread::spawn(move|| {
+    let t = thread::spawn(move || {
         let v = Foo::FailingVariant { on_drop: SendOnDrop { sender: sender } };
     });
     assert_eq!(receiver.recv().unwrap(), Message::Dropped);
@@ -72,7 +72,7 @@ pub fn main() {
 
     let (sender, receiver) = channel();
     let t = {
-        thread::spawn(move|| {
+        thread::spawn(move || {
             let mut v = Foo::NestedVariant(Box::new(42), SendOnDrop {
                 sender: sender.clone()
             }, sender.clone());

--- a/tests/ui/drop/terminate-in-initializer.rs
+++ b/tests/ui/drop/terminate-in-initializer.rs
@@ -16,13 +16,13 @@ fn test_ret() { let _x: Box<isize> = return; }
 
 fn test_panic() {
     fn f() { let _x: Box<isize> = panic!(); }
-    thread::spawn(move|| f() ).join().unwrap_err();
+    thread::spawn(move || f() ).join().unwrap_err();
 }
 
 fn test_panic_indirect() {
     fn f() -> ! { panic!(); }
     fn g() { let _x: Box<isize> = f(); }
-    thread::spawn(move|| g() ).join().unwrap_err();
+    thread::spawn(move || g() ).join().unwrap_err();
 }
 
 pub fn main() {

--- a/tests/ui/hashmap/hashmap-memory.rs
+++ b/tests/ui/hashmap/hashmap-memory.rs
@@ -32,7 +32,7 @@ mod map_reduce {
         for i in &inputs {
             let ctrl = ctrl.clone();
             let i = i.clone();
-            thread::spawn(move|| map_task(ctrl.clone(), i.clone()) );
+            thread::spawn(move || map_task(ctrl.clone(), i.clone()) );
         }
     }
 

--- a/tests/ui/issues/issue-11958.rs
+++ b/tests/ui/issues/issue-11958.rs
@@ -5,7 +5,7 @@
 
 pub fn main() {
     let mut x = 1;
-    let _thunk = Box::new(move|| { x = 2; });
+    let _thunk = Box::new(move || { x = 2; });
     //~^ WARN value assigned to `x` is never read
     //~| WARN unused variable: `x`
 }

--- a/tests/ui/issues/issue-11958.stderr
+++ b/tests/ui/issues/issue-11958.stderr
@@ -1,17 +1,17 @@
 warning: value assigned to `x` is never read
-  --> $DIR/issue-11958.rs:8:36
+  --> $DIR/issue-11958.rs:8:37
    |
-LL |     let _thunk = Box::new(move|| { x = 2; });
-   |                                    ^
+LL |     let _thunk = Box::new(move || { x = 2; });
+   |                                     ^
    |
    = help: maybe it is overwritten before being read?
    = note: `#[warn(unused_assignments)]` on by default
 
 warning: unused variable: `x`
-  --> $DIR/issue-11958.rs:8:36
+  --> $DIR/issue-11958.rs:8:37
    |
-LL |     let _thunk = Box::new(move|| { x = 2; });
-   |                                    ^
+LL |     let _thunk = Box::new(move || { x = 2; });
+   |                                     ^
    |
    = help: did you mean to capture by reference instead?
    = note: `#[warn(unused_variables)]` on by default

--- a/tests/ui/issues/issue-12041.rs
+++ b/tests/ui/issues/issue-12041.rs
@@ -3,7 +3,7 @@ use std::thread;
 
 fn main() {
     let (tx, rx) = channel();
-    let _t = thread::spawn(move|| -> () {
+    let _t = thread::spawn(move || -> () {
         loop {
             let tx = tx;
             //~^ ERROR: use of moved value: `tx`

--- a/tests/ui/issues/issue-12127.rs
+++ b/tests/ui/issues/issue-12127.rs
@@ -5,8 +5,8 @@ fn do_it(x: &isize) { }
 
 fn main() {
     let x: Box<_> = Box::new(22);
-    let f = to_fn_once(move|| do_it(&*x));
-    to_fn_once(move|| {
+    let f = to_fn_once(move || do_it(&*x));
+    to_fn_once(move || {
         f();
         f();
         //~^ ERROR: use of moved value: `f`

--- a/tests/ui/issues/issue-12127.stderr
+++ b/tests/ui/issues/issue-12127.stderr
@@ -11,7 +11,7 @@ note: this value implements `FnOnce`, which causes it to be moved when called
    |
 LL |         f();
    |         ^
-   = note: move occurs because `f` has type `{closure@$DIR/issue-12127.rs:8:24: 8:30}`, which does not implement the `Copy` trait
+   = note: move occurs because `f` has type `{closure@$DIR/issue-12127.rs:8:24: 8:31}`, which does not implement the `Copy` trait
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-15571.rs
+++ b/tests/ui/issues/issue-15571.rs
@@ -37,7 +37,7 @@ fn match_on_binding() {
 
 fn match_on_upvar() {
     let mut foo: Option<Box<_>> = Some(Box::new(8));
-    let f = move|| {
+    let f = move || {
         match foo {
             None => {},
             Some(x) => {

--- a/tests/ui/issues/issue-16560.rs
+++ b/tests/ui/issues/issue-16560.rs
@@ -12,7 +12,7 @@ fn main() {
     // Check that both closures are capturing by value
     assert_eq!(1, mem::size_of_val(&closure));
 
-    thread::spawn(move|| {
+    thread::spawn(move || {
         let ok = closure;
     }).join().ok().unwrap();
 }

--- a/tests/ui/issues/issue-16671.rs
+++ b/tests/ui/issues/issue-16671.rs
@@ -6,7 +6,7 @@ fn foo<F: FnOnce()>(_f: F) { }
 
 fn main() {
     let mut var = Vec::new();
-    foo(move|| {
+    foo(move || {
         var.push(1);
     });
 }

--- a/tests/ui/issues/issue-2190-1.rs
+++ b/tests/ui/issues/issue-2190-1.rs
@@ -10,11 +10,11 @@ use std::thread::Builder;
 static generations: usize = 1024+256+128+49;
 
 fn spawn(mut f: Box<dyn FnMut() + 'static + Send>) {
-    Builder::new().stack_size(32 * 1024).spawn(move|| f());
+    Builder::new().stack_size(32 * 1024).spawn(move || f());
 }
 
 fn child_no(x: usize) -> Box<dyn FnMut() + 'static + Send> {
-    Box::new(move|| {
+    Box::new(move || {
         if x < generations {
             spawn(child_no(x+1));
         }

--- a/tests/ui/issues/issue-26655.rs
+++ b/tests/ui/issues/issue-26655.rs
@@ -17,7 +17,7 @@ impl Drop for WithDtor {
 }
 
 pub fn main() {
-    thread::spawn(move|| {
+    thread::spawn(move || {
         let _e: WithDtor = WithDtor::Val;
         panic!("fail");
     }).join().unwrap_err();

--- a/tests/ui/issues/issue-3609.rs
+++ b/tests/ui/issues/issue-3609.rs
@@ -14,7 +14,7 @@ enum Msg
 }
 
 fn foo(name: String, samples_chan: Sender<Msg>) {
-    thread::spawn(move|| {
+    thread::spawn(move || {
         let mut samples_chan = samples_chan;
 
         let callback: SamplesFn = Box::new(move |buffer| {

--- a/tests/ui/kindck/kindck-nonsendable-1.rs
+++ b/tests/ui/kindck/kindck-nonsendable-1.rs
@@ -6,6 +6,6 @@ fn bar<F:FnOnce() + Send>(_: F) { }
 
 fn main() {
     let x = Rc::new(3);
-    bar(move|| foo(x));
+    bar(move || foo(x));
     //~^ ERROR `Rc<usize>` cannot be sent between threads safely
 }

--- a/tests/ui/kindck/kindck-nonsendable-1.stderr
+++ b/tests/ui/kindck/kindck-nonsendable-1.stderr
@@ -1,19 +1,19 @@
 error[E0277]: `Rc<usize>` cannot be sent between threads safely
   --> $DIR/kindck-nonsendable-1.rs:9:9
    |
-LL |     bar(move|| foo(x));
-   |     --- ------^^^^^^^
+LL |     bar(move || foo(x));
+   |     --- -------^^^^^^^
    |     |   |
    |     |   `Rc<usize>` cannot be sent between threads safely
-   |     |   within this `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:15}`
+   |     |   within this `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:16}`
    |     required by a bound introduced by this call
    |
-   = help: within `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:15}`, the trait `Send` is not implemented for `Rc<usize>`, which is required by `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:15}: Send`
+   = help: within `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:16}`, the trait `Send` is not implemented for `Rc<usize>`, which is required by `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:16}: Send`
 note: required because it's used within this closure
   --> $DIR/kindck-nonsendable-1.rs:9:9
    |
-LL |     bar(move|| foo(x));
-   |         ^^^^^^
+LL |     bar(move || foo(x));
+   |         ^^^^^^^
 note: required by a bound in `bar`
   --> $DIR/kindck-nonsendable-1.rs:5:21
    |

--- a/tests/ui/lint/unused/unused-mut-warning-captured-var.fixed
+++ b/tests/ui/lint/unused/unused-mut-warning-captured-var.fixed
@@ -5,5 +5,5 @@
 fn main() {
     let x = 1;
     //~^ ERROR: variable does not need to be mutable
-    (move|| { println!("{}", x); })();
+    (move || { println!("{}", x); })();
 }

--- a/tests/ui/lint/unused/unused-mut-warning-captured-var.rs
+++ b/tests/ui/lint/unused/unused-mut-warning-captured-var.rs
@@ -5,5 +5,5 @@
 fn main() {
     let mut x = 1;
     //~^ ERROR: variable does not need to be mutable
-    (move|| { println!("{}", x); })();
+    (move || { println!("{}", x); })();
 }

--- a/tests/ui/macros/macro-with-braces-in-expr-position.rs
+++ b/tests/ui/macros/macro-with-braces-in-expr-position.rs
@@ -8,7 +8,7 @@ macro_rules! expr { ($e: expr) => { $e } }
 
 macro_rules! spawn {
     ($($code: tt)*) => {
-        expr!(thread::spawn(move|| {$($code)*}).join())
+        expr!(thread::spawn(move || {$($code)*}).join())
     }
 }
 

--- a/tests/ui/moves/moves-based-on-type-capture-clause.rs
+++ b/tests/ui/moves/moves-based-on-type-capture-clause.rs
@@ -6,7 +6,7 @@ use std::thread;
 
 pub fn main() {
     let x = "Hello world!".to_string();
-    thread::spawn(move|| {
+    thread::spawn(move || {
         println!("{}", x);
     }).join();
 }

--- a/tests/ui/no-capture-arc.rs
+++ b/tests/ui/no-capture-arc.rs
@@ -7,7 +7,7 @@ fn main() {
     let v = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     let arc_v = Arc::new(v);
 
-    thread::spawn(move|| {
+    thread::spawn(move || {
         assert_eq!((*arc_v)[3], 4);
     });
 

--- a/tests/ui/no-capture-arc.stderr
+++ b/tests/ui/no-capture-arc.stderr
@@ -4,8 +4,8 @@ error[E0382]: borrow of moved value: `arc_v`
 LL |     let arc_v = Arc::new(v);
    |         ----- move occurs because `arc_v` has type `Arc<Vec<i32>>`, which does not implement the `Copy` trait
 LL |
-LL |     thread::spawn(move|| {
-   |                   ------ value moved into closure here
+LL |     thread::spawn(move || {
+   |                   ------- value moved into closure here
 LL |         assert_eq!((*arc_v)[3], 4);
    |                      ----- variable moved due to use in closure
 ...

--- a/tests/ui/no-reuse-move-arc.rs
+++ b/tests/ui/no-reuse-move-arc.rs
@@ -5,7 +5,7 @@ fn main() {
     let v = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     let arc_v = Arc::new(v);
 
-    thread::spawn(move|| {
+    thread::spawn(move || {
         assert_eq!((*arc_v)[3], 4);
     });
 

--- a/tests/ui/no-reuse-move-arc.stderr
+++ b/tests/ui/no-reuse-move-arc.stderr
@@ -4,8 +4,8 @@ error[E0382]: borrow of moved value: `arc_v`
 LL |     let arc_v = Arc::new(v);
    |         ----- move occurs because `arc_v` has type `Arc<Vec<i32>>`, which does not implement the `Copy` trait
 LL |
-LL |     thread::spawn(move|| {
-   |                   ------ value moved into closure here
+LL |     thread::spawn(move || {
+   |                   ------- value moved into closure here
 LL |         assert_eq!((*arc_v)[3], 4);
    |                      ----- variable moved due to use in closure
 ...

--- a/tests/ui/no-send-res-ports.rs
+++ b/tests/ui/no-send-res-ports.rs
@@ -22,7 +22,7 @@ fn main() {
 
     let x = foo(Port(Rc::new(())));
 
-    thread::spawn(move|| {
+    thread::spawn(move || {
         //~^ ERROR `Rc<()>` cannot be sent between threads safely
         let y = x;
         println!("{:?}", y);

--- a/tests/ui/no-send-res-ports.stderr
+++ b/tests/ui/no-send-res-ports.stderr
@@ -1,10 +1,10 @@
 error[E0277]: `Rc<()>` cannot be sent between threads safely
   --> $DIR/no-send-res-ports.rs:25:19
    |
-LL |       thread::spawn(move|| {
-   |       ------------- ^-----
+LL |       thread::spawn(move || {
+   |       ------------- ^------
    |       |             |
-   |  _____|_____________within this `{closure@$DIR/no-send-res-ports.rs:25:19: 25:25}`
+   |  _____|_____________within this `{closure@$DIR/no-send-res-ports.rs:25:19: 25:26}`
    | |     |
    | |     required by a bound introduced by this call
 LL | |
@@ -13,7 +13,7 @@ LL | |         println!("{:?}", y);
 LL | |     });
    | |_____^ `Rc<()>` cannot be sent between threads safely
    |
-   = help: within `{closure@$DIR/no-send-res-ports.rs:25:19: 25:25}`, the trait `Send` is not implemented for `Rc<()>`, which is required by `{closure@$DIR/no-send-res-ports.rs:25:19: 25:25}: Send`
+   = help: within `{closure@$DIR/no-send-res-ports.rs:25:19: 25:26}`, the trait `Send` is not implemented for `Rc<()>`, which is required by `{closure@$DIR/no-send-res-ports.rs:25:19: 25:26}: Send`
 note: required because it appears within the type `Port<()>`
   --> $DIR/no-send-res-ports.rs:5:8
    |
@@ -27,8 +27,8 @@ LL |     struct Foo {
 note: required because it's used within this closure
   --> $DIR/no-send-res-ports.rs:25:19
    |
-LL |     thread::spawn(move|| {
-   |                   ^^^^^^
+LL |     thread::spawn(move || {
+   |                   ^^^^^^^
 note: required by a bound in `spawn`
   --> $SRC_DIR/std/src/thread/mod.rs:LL:COL
 

--- a/tests/ui/numbers-arithmetic/issue-8460.rs
+++ b/tests/ui/numbers-arithmetic/issue-8460.rs
@@ -21,7 +21,7 @@ doit! { i8 i16 i32 i64 isize }
 macro_rules! check {
     ($($e:expr),*) => {
         $(assert!(thread::spawn({
-            move|| { $e; }
+            move || { $e; }
         }).join().is_err());)*
     }
 }

--- a/tests/ui/once-cant-call-twice-on-heap.rs
+++ b/tests/ui/once-cant-call-twice-on-heap.rs
@@ -10,7 +10,7 @@ fn foo<F:FnOnce()>(blk: F) {
 
 fn main() {
     let x = Arc::new(true);
-    foo(move|| {
+    foo(move || {
         assert!(*x);
         drop(x);
     });

--- a/tests/ui/panics/panic-in-dtor-drops-fields.rs
+++ b/tests/ui/panics/panic-in-dtor-drops-fields.rs
@@ -30,7 +30,7 @@ impl Drop for B {
 }
 
 pub fn main() {
-    let ret = thread::spawn(move|| {
+    let ret = thread::spawn(move || {
         let _a = A { b: B { foo: 3 } };
     }).join();
     assert!(ret.is_err());

--- a/tests/ui/process/core-run-destroy.rs
+++ b/tests/ui/process/core-run-destroy.rs
@@ -68,7 +68,7 @@ fn test_destroy_actually_kills() {
 
     // Don't let this test time out, this should be quick
     let (tx, rx) = channel();
-    thread::spawn(move|| {
+    thread::spawn(move || {
         thread::sleep_ms(1000);
         if rx.try_recv().is_err() {
             process::exit(1);

--- a/tests/ui/regions/regions-infer-proc-static-upvar.rs
+++ b/tests/ui/regions/regions-infer-proc-static-upvar.rs
@@ -8,7 +8,7 @@ static i: isize = 3;
 fn capture_local() {
     let x = 3;
     let y = &x; //~ ERROR `x` does not live long enough
-    foo(move|| {
+    foo(move || {
         let _a = *y;
     });
 }
@@ -16,7 +16,7 @@ fn capture_local() {
 fn capture_static() {
     // Legal because &i can have static lifetime:
     let y = &i;
-    foo(move|| {
+    foo(move || {
         let _a = *y;
     });
 }

--- a/tests/ui/regions/regions-infer-proc-static-upvar.stderr
+++ b/tests/ui/regions/regions-infer-proc-static-upvar.stderr
@@ -5,7 +5,7 @@ LL |       let x = 3;
    |           - binding `x` declared here
 LL |       let y = &x;
    |               ^^ borrowed value does not live long enough
-LL | /     foo(move|| {
+LL | /     foo(move || {
 LL | |         let _a = *y;
 LL | |     });
    | |______- argument requires that `x` is borrowed for `'static`

--- a/tests/ui/regions/regions-infer-static-from-proc.rs
+++ b/tests/ui/regions/regions-infer-static-from-proc.rs
@@ -12,7 +12,7 @@ fn foo<F:FnOnce()+'static>(_: F) {}
 fn read(_: usize) { }
 pub fn main() {
     let x = &i;
-    foo(move|| {
+    foo(move || {
         read(*x);
     });
 }

--- a/tests/ui/regions/regions-proc-bound-capture.rs
+++ b/tests/ui/regions/regions-proc-bound-capture.rs
@@ -1,7 +1,7 @@
 fn borrowed_proc<'a>(x: &'a isize) -> Box<dyn FnMut()->(isize) + 'a> {
     // This is legal, because the region bound on `proc`
     // states that it captures `x`.
-    Box::new(move|| { *x })
+    Box::new(move || { *x })
 }
 
 fn static_proc(x: &isize) -> Box<dyn FnMut() -> (isize) + 'static> {

--- a/tests/ui/sepcomp/sepcomp-unwind.rs
+++ b/tests/ui/sepcomp/sepcomp-unwind.rs
@@ -31,5 +31,5 @@ mod b {
 }
 
 fn main() {
-    thread::spawn(move|| { ::b::g() }).join().unwrap_err();
+    thread::spawn(move || { ::b::g() }).join().unwrap_err();
 }

--- a/tests/ui/span/issue-11925.rs
+++ b/tests/ui/span/issue-11925.rs
@@ -5,7 +5,7 @@ fn to_fn_once<A:std::marker::Tuple,F:FnOnce<A>>(f: F) -> F { f }
 fn main() {
     let r = {
         let x: Box<_> = Box::new(42);
-        let f = to_fn_once(move|| &x); //~ ERROR cannot return reference to local data `x`
+        let f = to_fn_once(move || &x); //~ ERROR cannot return reference to local data `x`
         f()
     };
 

--- a/tests/ui/span/issue-11925.stderr
+++ b/tests/ui/span/issue-11925.stderr
@@ -1,8 +1,8 @@
 error[E0515]: cannot return reference to local data `x`
-  --> $DIR/issue-11925.rs:8:35
+  --> $DIR/issue-11925.rs:8:36
    |
-LL |         let f = to_fn_once(move|| &x);
-   |                                   ^^ returns a reference to data owned by the current function
+LL |         let f = to_fn_once(move || &x);
+   |                                    ^^ returns a reference to data owned by the current function
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/structs-enums/ivec-tag.rs
+++ b/tests/ui/structs-enums/ivec-tag.rs
@@ -13,7 +13,7 @@ fn producer(tx: &Sender<Vec<u8>>) {
 
 pub fn main() {
     let (tx, rx) = channel::<Vec<u8>>();
-    let prod = thread::spawn(move|| {
+    let prod = thread::spawn(move || {
         producer(&tx)
     });
 

--- a/tests/ui/structs-enums/unit-like-struct-drop-run.rs
+++ b/tests/ui/structs-enums/unit-like-struct-drop-run.rs
@@ -15,7 +15,7 @@ impl Drop for Foo {
 }
 
 pub fn main() {
-    let x = thread::spawn(move|| {
+    let x = thread::spawn(move || {
         let _b = Foo;
     }).join();
 

--- a/tests/ui/threads-sendsync/child-outlives-parent.rs
+++ b/tests/ui/threads-sendsync/child-outlives-parent.rs
@@ -9,5 +9,5 @@ use std::thread;
 fn child2(_s: String) { }
 
 pub fn main() {
-    let _x = thread::spawn(move|| child2("hi".to_string()));
+    let _x = thread::spawn(move || child2("hi".to_string()));
 }

--- a/tests/ui/threads-sendsync/clone-with-exterior.rs
+++ b/tests/ui/threads-sendsync/clone-with-exterior.rs
@@ -13,7 +13,7 @@ struct Pair {
 pub fn main() {
     let z: Box<_> = Box::new(Pair { a : 10, b : 12});
 
-    thread::spawn(move|| {
+    thread::spawn(move || {
         assert_eq!(z.a, 10);
         assert_eq!(z.b, 12);
     }).join();

--- a/tests/ui/threads-sendsync/issue-4446.rs
+++ b/tests/ui/threads-sendsync/issue-4446.rs
@@ -9,7 +9,7 @@ pub fn main() {
 
     tx.send("hello, world").unwrap();
 
-    thread::spawn(move|| {
+    thread::spawn(move || {
         println!("{}", rx.recv().unwrap());
     }).join().ok().unwrap();
 }

--- a/tests/ui/threads-sendsync/issue-4448.rs
+++ b/tests/ui/threads-sendsync/issue-4448.rs
@@ -7,7 +7,7 @@ use std::thread;
 pub fn main() {
     let (tx, rx) = channel::<&'static str>();
 
-    let t = thread::spawn(move|| {
+    let t = thread::spawn(move || {
         assert_eq!(rx.recv().unwrap(), "hello, world");
     });
 

--- a/tests/ui/threads-sendsync/issue-8827.rs
+++ b/tests/ui/threads-sendsync/issue-8827.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc::{channel, Receiver};
 
 fn periodical(n: isize) -> Receiver<bool> {
     let (chan, port) = channel();
-    thread::spawn(move|| {
+    thread::spawn(move || {
         loop {
             for _ in 1..n {
                 match chan.send(false) {
@@ -25,7 +25,7 @@ fn periodical(n: isize) -> Receiver<bool> {
 
 fn integers() -> Receiver<isize> {
     let (chan, port) = channel();
-    thread::spawn(move|| {
+    thread::spawn(move || {
         let mut i = 1;
         loop {
             match chan.send(i) {

--- a/tests/ui/threads-sendsync/issue-9396.rs
+++ b/tests/ui/threads-sendsync/issue-9396.rs
@@ -8,7 +8,7 @@ use std::thread;
 
 pub fn main() {
     let (tx, rx) = channel();
-    let t = thread::spawn(move||{
+    let t = thread::spawn(move ||{
         thread::sleep_ms(10);
         tx.send(()).unwrap();
     });

--- a/tests/ui/threads-sendsync/send-resource.rs
+++ b/tests/ui/threads-sendsync/send-resource.rs
@@ -26,7 +26,7 @@ fn test(f: isize) -> test {
 pub fn main() {
     let (tx, rx) = channel();
 
-    let t = thread::spawn(move|| {
+    let t = thread::spawn(move || {
         let (tx2, rx2) = channel();
         tx.send(tx2).unwrap();
 

--- a/tests/ui/threads-sendsync/sendfn-spawn-with-fn-arg.rs
+++ b/tests/ui/threads-sendsync/sendfn-spawn-with-fn-arg.rs
@@ -15,7 +15,7 @@ fn test05() {
         println!("{}", *three + n); // will copy x into the closure
         assert_eq!(*three, 3);
     };
-    thread::spawn(move|| {
+    thread::spawn(move || {
         test05_start(fn_to_send);
     }).join().ok().unwrap();
 }

--- a/tests/ui/threads-sendsync/spawn-types.rs
+++ b/tests/ui/threads-sendsync/spawn-types.rs
@@ -20,6 +20,6 @@ fn iotask(_tx: &ctx, ip: String) {
 
 pub fn main() {
     let (tx, _rx) = channel::<isize>();
-    let t = thread::spawn(move|| iotask(&tx, "localhost".to_string()) );
+    let t = thread::spawn(move || iotask(&tx, "localhost".to_string()) );
     t.join().ok().unwrap();
 }

--- a/tests/ui/threads-sendsync/spawn.rs
+++ b/tests/ui/threads-sendsync/spawn.rs
@@ -4,7 +4,7 @@
 use std::thread;
 
 pub fn main() {
-    thread::spawn(move|| child(10)).join().ok().unwrap();
+    thread::spawn(move || child(10)).join().ok().unwrap();
 }
 
 fn child(i: isize) { println!("{}", i); assert_eq!(i, 10); }

--- a/tests/ui/threads-sendsync/spawn2.rs
+++ b/tests/ui/threads-sendsync/spawn2.rs
@@ -4,7 +4,7 @@
 use std::thread;
 
 pub fn main() {
-    let t = thread::spawn(move|| child((10, 20, 30, 40, 50, 60, 70, 80, 90)) );
+    let t = thread::spawn(move || child((10, 20, 30, 40, 50, 60, 70, 80, 90)) );
     t.join().ok().unwrap(); // forget Err value, since it doesn't implement Debug
 }
 

--- a/tests/ui/threads-sendsync/task-comm-0.rs
+++ b/tests/ui/threads-sendsync/task-comm-0.rs
@@ -18,7 +18,7 @@ fn test05_start(tx : &Sender<isize>) {
 
 fn test05() {
     let (tx, rx) = channel();
-    let t = thread::spawn(move|| { test05_start(&tx) });
+    let t = thread::spawn(move || { test05_start(&tx) });
     let mut value: isize = rx.recv().unwrap();
     println!("{}", value);
     value = rx.recv().unwrap();

--- a/tests/ui/threads-sendsync/task-comm-1.rs
+++ b/tests/ui/threads-sendsync/task-comm-1.rs
@@ -9,6 +9,6 @@ pub fn main() { test00(); }
 fn start() { println!("Started / Finished task."); }
 
 fn test00() {
-    thread::spawn(move|| start() ).join();
+    thread::spawn(move || start() ).join();
     println!("Completing.");
 }

--- a/tests/ui/threads-sendsync/task-comm-10.rs
+++ b/tests/ui/threads-sendsync/task-comm-10.rs
@@ -22,7 +22,7 @@ fn start(tx: &Sender<Sender<String>>) {
 
 pub fn main() {
     let (tx, rx) = channel();
-    let child = thread::spawn(move|| { start(&tx) });
+    let child = thread::spawn(move || { start(&tx) });
 
     let mut c = rx.recv().unwrap();
     c.send("A".to_string()).unwrap();

--- a/tests/ui/threads-sendsync/task-comm-11.rs
+++ b/tests/ui/threads-sendsync/task-comm-11.rs
@@ -13,7 +13,7 @@ fn start(tx: &Sender<Sender<isize>>) {
 
 pub fn main() {
     let (tx, rx) = channel();
-    let child = thread::spawn(move|| {
+    let child = thread::spawn(move || {
         start(&tx)
     });
     let _tx = rx.recv().unwrap();

--- a/tests/ui/threads-sendsync/task-comm-12.rs
+++ b/tests/ui/threads-sendsync/task-comm-12.rs
@@ -11,7 +11,7 @@ fn start(_task_number: isize) { println!("Started / Finished task."); }
 
 fn test00() {
     let i: isize = 0;
-    let mut result = thread::spawn(move|| {
+    let mut result = thread::spawn(move || {
         start(i)
     });
 

--- a/tests/ui/threads-sendsync/task-comm-13.rs
+++ b/tests/ui/threads-sendsync/task-comm-13.rs
@@ -13,6 +13,6 @@ fn start(tx: &Sender<isize>, start: isize, number_of_messages: isize) {
 pub fn main() {
     println!("Check that we don't deadlock.");
     let (tx, rx) = channel();
-    let _ = thread::spawn(move|| { start(&tx, 0, 10) }).join();
+    let _ = thread::spawn(move || { start(&tx, 0, 10) }).join();
     println!("Joined task");
 }

--- a/tests/ui/threads-sendsync/task-comm-14.rs
+++ b/tests/ui/threads-sendsync/task-comm-14.rs
@@ -13,7 +13,7 @@ pub fn main() {
     while (i > 0) {
         println!("{}", i);
         let tx = tx.clone();
-        thread::spawn({let i = i; move|| { child(i, &tx) }});
+        thread::spawn({let i = i; move || { child(i, &tx) }});
         i = i - 1;
     }
 

--- a/tests/ui/threads-sendsync/task-comm-15.rs
+++ b/tests/ui/threads-sendsync/task-comm-15.rs
@@ -20,7 +20,7 @@ pub fn main() {
     // the child's point of view the receiver may die. We should
     // drop messages on the floor in this case, and not crash!
     let (tx, rx) = channel();
-    let t = thread::spawn(move|| {
+    let t = thread::spawn(move || {
         start(&tx, 10)
     });
     rx.recv();

--- a/tests/ui/threads-sendsync/task-comm-17.rs
+++ b/tests/ui/threads-sendsync/task-comm-17.rs
@@ -13,5 +13,5 @@ fn f() {
 }
 
 pub fn main() {
-    thread::spawn(move|| f() ).join();
+    thread::spawn(move || f() ).join();
 }

--- a/tests/ui/threads-sendsync/task-comm-3.rs
+++ b/tests/ui/threads-sendsync/task-comm-3.rs
@@ -34,7 +34,7 @@ fn test00() {
         let tx = tx.clone();
         results.push(thread::spawn({
             let i = i;
-            move|| {
+            move || {
                 test00_start(&tx, i, number_of_messages)
             }
         }));

--- a/tests/ui/threads-sendsync/task-comm-7.rs
+++ b/tests/ui/threads-sendsync/task-comm-7.rs
@@ -21,19 +21,19 @@ fn test00() {
     let number_of_messages: isize = 10;
 
     let tx2 = tx.clone();
-    let t1 = thread::spawn(move|| {
+    let t1 = thread::spawn(move || {
         test00_start(&tx2, number_of_messages * 0, number_of_messages);
     });
     let tx2 = tx.clone();
-    let t2 = thread::spawn(move|| {
+    let t2 = thread::spawn(move || {
         test00_start(&tx2, number_of_messages * 1, number_of_messages);
     });
     let tx2 = tx.clone();
-    let t3 = thread::spawn(move|| {
+    let t3 = thread::spawn(move || {
         test00_start(&tx2, number_of_messages * 2, number_of_messages);
     });
     let tx2 = tx.clone();
-    let t4 = thread::spawn(move|| {
+    let t4 = thread::spawn(move || {
         test00_start(&tx2, number_of_messages * 3, number_of_messages);
     });
 

--- a/tests/ui/threads-sendsync/task-comm-9.rs
+++ b/tests/ui/threads-sendsync/task-comm-9.rs
@@ -18,7 +18,7 @@ fn test00() {
     let (tx, rx) = channel();
     let number_of_messages: isize = 10;
 
-    let result = thread::spawn(move|| {
+    let result = thread::spawn(move || {
         test00_start(&tx, number_of_messages);
     });
 

--- a/tests/ui/threads-sendsync/task-life-0.rs
+++ b/tests/ui/threads-sendsync/task-life-0.rs
@@ -6,7 +6,7 @@
 use std::thread;
 
 pub fn main() {
-    thread::spawn(move|| child("Hello".to_string()) ).join();
+    thread::spawn(move || child("Hello".to_string()) ).join();
 }
 
 fn child(_s: String) {

--- a/tests/ui/threads-sendsync/tcp-stress.rs
+++ b/tests/ui/threads-sendsync/tcp-stress.rs
@@ -15,7 +15,7 @@ const TARGET_CNT: usize = 200;
 
 fn main() {
     // This test has a chance to time out, try to not let it time out
-    thread::spawn(move|| -> () {
+    thread::spawn(move || -> () {
         thread::sleep(Duration::from_secs(30));
         process::exit(1);
     });
@@ -38,7 +38,7 @@ fn main() {
     let mut spawned_cnt = 0;
     for _ in 0..TARGET_CNT {
         let tx = tx.clone();
-        let res = Builder::new().stack_size(64 * 1024).spawn(move|| {
+        let res = Builder::new().stack_size(64 * 1024).spawn(move || {
             match TcpStream::connect(addr) {
                 Ok(mut stream) => {
                     let _ = stream.write(&[1]);

--- a/tests/ui/threads-sendsync/threads.rs
+++ b/tests/ui/threads-sendsync/threads.rs
@@ -7,7 +7,7 @@ use std::thread;
 pub fn main() {
     let mut i = 10;
     while i > 0 {
-        thread::spawn({let i = i; move|| child(i)}).join();
+        thread::spawn({let i = i; move || child(i)}).join();
         i = i - 1;
     }
     println!("main thread exiting");

--- a/tests/ui/threads-sendsync/unwind-resource.rs
+++ b/tests/ui/threads-sendsync/unwind-resource.rs
@@ -33,7 +33,7 @@ fn f(tx: Sender<bool>) {
 
 pub fn main() {
     let (tx, rx) = channel();
-    let t = thread::spawn(move|| f(tx.clone()));
+    let t = thread::spawn(move || f(tx.clone()));
     println!("hiiiiiiiii");
     assert!(rx.recv().unwrap());
     drop(t.join());

--- a/tests/ui/traits/bound/in-arc.rs
+++ b/tests/ui/traits/bound/in-arc.rs
@@ -72,13 +72,13 @@ pub fn main() {
         Box::new(dogge2) as Box<dyn Pet+Sync+Send>]);
     let (tx1, rx1) = channel();
     let arc1 = arc.clone();
-    let t1 = thread::spawn(move|| { check_legs(arc1); tx1.send(()); });
+    let t1 = thread::spawn(move || { check_legs(arc1); tx1.send(()); });
     let (tx2, rx2) = channel();
     let arc2 = arc.clone();
-    let t2 = thread::spawn(move|| { check_names(arc2); tx2.send(()); });
+    let t2 = thread::spawn(move || { check_names(arc2); tx2.send(()); });
     let (tx3, rx3) = channel();
     let arc3 = arc.clone();
-    let t3 = thread::spawn(move|| { check_pedigree(arc3); tx3.send(()); });
+    let t3 = thread::spawn(move || { check_pedigree(arc3); tx3.send(()); });
     rx1.recv();
     rx2.recv();
     rx3.recv();


### PR DESCRIPTION
There were about 134 instances of `move||` across 91 files in the repo.

I have replaced all such instances with `move ||` instead as it better adheres to modern formatting standards.

Ideally, we would have this automated by rustfmt or some other tool, but I do not have the time to implement such a feature or tool. Nonetheless, I would encourage any effort invested into such a tool or feature.

Tests have been run and had their outputs replaced with `--bless`, I have manually reviewed all the changes to make sure nothing strange was blessed - but I may have made mistakes.