### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ build/
 /src/tools/x/target
 # Created by default with `src/ci/docker/run.sh`
 /obj/
+/rustc-ice*
 
 ## Temporary files
 *~

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3158,13 +3158,16 @@ pub struct Delegation {
     pub path: Path,
     pub rename: Option<Ident>,
     pub body: Option<P<Block>>,
+    /// The item was expanded from a glob delegation item.
+    pub from_glob: bool,
 }
 
 #[derive(Clone, Encodable, Decodable, Debug)]
 pub struct DelegationMac {
     pub qself: Option<P<QSelf>>,
     pub prefix: Path,
-    pub suffixes: ThinVec<(Ident, Option<Ident>)>,
+    // Some for list delegation, and None for glob delegation.
+    pub suffixes: Option<ThinVec<(Ident, Option<Ident>)>>,
     pub body: Option<P<Block>>,
 }
 
@@ -3291,7 +3294,7 @@ pub enum ItemKind {
     ///
     /// E.g. `reuse <Type as Trait>::name { target_expr_template }`.
     Delegation(Box<Delegation>),
-    /// A list delegation item (`reuse prefix::{a, b, c}`).
+    /// A list or glob delegation item (`reuse prefix::{a, b, c}`, `reuse prefix::*`).
     /// Treated similarly to a macro call and expanded early.
     DelegationMac(Box<DelegationMac>),
 }
@@ -3372,7 +3375,7 @@ pub enum AssocItemKind {
     MacCall(P<MacCall>),
     /// An associated delegation item.
     Delegation(Box<Delegation>),
-    /// An associated delegation item list.
+    /// An associated list or glob delegation item.
     DelegationMac(Box<DelegationMac>),
 }
 

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1162,7 +1162,14 @@ impl NoopVisitItemKind for ItemKind {
             }
             ItemKind::MacCall(m) => vis.visit_mac_call(m),
             ItemKind::MacroDef(def) => vis.visit_macro_def(def),
-            ItemKind::Delegation(box Delegation { id, qself, path, rename, body }) => {
+            ItemKind::Delegation(box Delegation {
+                id,
+                qself,
+                path,
+                rename,
+                body,
+                from_glob: _,
+            }) => {
                 vis.visit_id(id);
                 vis.visit_qself(qself);
                 vis.visit_path(path);
@@ -1176,10 +1183,12 @@ impl NoopVisitItemKind for ItemKind {
             ItemKind::DelegationMac(box DelegationMac { qself, prefix, suffixes, body }) => {
                 vis.visit_qself(qself);
                 vis.visit_path(prefix);
-                for (ident, rename) in suffixes {
-                    vis.visit_ident(ident);
-                    if let Some(rename) = rename {
-                        vis.visit_ident(rename);
+                if let Some(suffixes) = suffixes {
+                    for (ident, rename) in suffixes {
+                        vis.visit_ident(ident);
+                        if let Some(rename) = rename {
+                            vis.visit_ident(rename);
+                        }
                     }
                 }
                 if let Some(body) = body {
@@ -1218,7 +1227,14 @@ impl NoopVisitItemKind for AssocItemKind {
                 visit_opt(ty, |ty| visitor.visit_ty(ty));
             }
             AssocItemKind::MacCall(mac) => visitor.visit_mac_call(mac),
-            AssocItemKind::Delegation(box Delegation { id, qself, path, rename, body }) => {
+            AssocItemKind::Delegation(box Delegation {
+                id,
+                qself,
+                path,
+                rename,
+                body,
+                from_glob: _,
+            }) => {
                 visitor.visit_id(id);
                 visitor.visit_qself(qself);
                 visitor.visit_path(path);
@@ -1232,10 +1248,12 @@ impl NoopVisitItemKind for AssocItemKind {
             AssocItemKind::DelegationMac(box DelegationMac { qself, prefix, suffixes, body }) => {
                 visitor.visit_qself(qself);
                 visitor.visit_path(prefix);
-                for (ident, rename) in suffixes {
-                    visitor.visit_ident(ident);
-                    if let Some(rename) = rename {
-                        visitor.visit_ident(rename);
+                if let Some(suffixes) = suffixes {
+                    for (ident, rename) in suffixes {
+                        visitor.visit_ident(ident);
+                        if let Some(rename) = rename {
+                            visitor.visit_ident(rename);
+                        }
                     }
                 }
                 if let Some(body) = body {

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -398,7 +398,14 @@ impl WalkItemKind for ItemKind {
             }
             ItemKind::MacCall(mac) => try_visit!(visitor.visit_mac_call(mac)),
             ItemKind::MacroDef(ts) => try_visit!(visitor.visit_mac_def(ts, item.id)),
-            ItemKind::Delegation(box Delegation { id, qself, path, rename, body }) => {
+            ItemKind::Delegation(box Delegation {
+                id,
+                qself,
+                path,
+                rename,
+                body,
+                from_glob: _,
+            }) => {
                 if let Some(qself) = qself {
                     try_visit!(visitor.visit_ty(&qself.ty));
                 }
@@ -411,10 +418,12 @@ impl WalkItemKind for ItemKind {
                     try_visit!(visitor.visit_ty(&qself.ty));
                 }
                 try_visit!(visitor.visit_path(prefix, item.id));
-                for (ident, rename) in suffixes {
-                    visitor.visit_ident(*ident);
-                    if let Some(rename) = rename {
-                        visitor.visit_ident(*rename);
+                if let Some(suffixes) = suffixes {
+                    for (ident, rename) in suffixes {
+                        visitor.visit_ident(*ident);
+                        if let Some(rename) = rename {
+                            visitor.visit_ident(*rename);
+                        }
                     }
                 }
                 visit_opt!(visitor, visit_block, body);
@@ -828,7 +837,14 @@ impl WalkItemKind for AssocItemKind {
             AssocItemKind::MacCall(mac) => {
                 try_visit!(visitor.visit_mac_call(mac));
             }
-            AssocItemKind::Delegation(box Delegation { id, qself, path, rename, body }) => {
+            AssocItemKind::Delegation(box Delegation {
+                id,
+                qself,
+                path,
+                rename,
+                body,
+                from_glob: _,
+            }) => {
                 if let Some(qself) = qself {
                     try_visit!(visitor.visit_ty(&qself.ty));
                 }
@@ -841,10 +857,12 @@ impl WalkItemKind for AssocItemKind {
                     try_visit!(visitor.visit_ty(&qself.ty));
                 }
                 try_visit!(visitor.visit_path(prefix, item.id));
-                for (ident, rename) in suffixes {
-                    visitor.visit_ident(*ident);
-                    if let Some(rename) = rename {
-                        visitor.visit_ident(*rename);
+                if let Some(suffixes) = suffixes {
+                    for (ident, rename) in suffixes {
+                        visitor.visit_ident(*ident);
+                        if let Some(rename) = rename {
+                            visitor.visit_ident(*rename);
+                        }
                     }
                 }
                 visit_opt!(visitor, visit_block, body);

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1311,6 +1311,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
             CoroutineKind::AsyncGen { .. } => hir::CoroutineDesugaring::AsyncGen,
         };
         let closure_id = coroutine_kind.closure_id();
+
+        let span = if let FnRetTy::Default(span) = decl.output
+            && matches!(coroutine_source, rustc_hir::CoroutineSource::Closure)
+        {
+            body_span.with_lo(span.lo())
+        } else {
+            body_span
+        };
         let coroutine_expr = self.make_desugared_coroutine_expr(
             // The default capture mode here is by-ref. Later on during upvar analysis,
             // we will force the captured arguments to by-move, but for async closures,
@@ -1319,7 +1327,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             CaptureBy::Ref,
             closure_id,
             None,
-            body_span,
+            span,
             desugaring_kind,
             coroutine_source,
             mkbody,

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -9,6 +9,12 @@ use rustc_ast::ptr::P;
 use rustc_ast::ModKind;
 use rustc_span::symbol::Ident;
 
+enum DelegationKind<'a> {
+    Single,
+    List(&'a [(Ident, Option<Ident>)]),
+    Glob,
+}
+
 fn visibility_qualified(vis: &ast::Visibility, s: &str) -> String {
     format!("{}{}", State::to_string(|s| s.print_visibility(vis)), s)
 }
@@ -387,7 +393,7 @@ impl<'a> State<'a> {
                 &item.vis,
                 &deleg.qself,
                 &deleg.path,
-                None,
+                DelegationKind::Single,
                 &deleg.body,
             ),
             ast::ItemKind::DelegationMac(deleg) => self.print_delegation(
@@ -395,7 +401,7 @@ impl<'a> State<'a> {
                 &item.vis,
                 &deleg.qself,
                 &deleg.prefix,
-                Some(&deleg.suffixes),
+                deleg.suffixes.as_ref().map_or(DelegationKind::Glob, |s| DelegationKind::List(s)),
                 &deleg.body,
             ),
         }
@@ -579,7 +585,7 @@ impl<'a> State<'a> {
                 vis,
                 &deleg.qself,
                 &deleg.path,
-                None,
+                DelegationKind::Single,
                 &deleg.body,
             ),
             ast::AssocItemKind::DelegationMac(deleg) => self.print_delegation(
@@ -587,20 +593,20 @@ impl<'a> State<'a> {
                 vis,
                 &deleg.qself,
                 &deleg.prefix,
-                Some(&deleg.suffixes),
+                deleg.suffixes.as_ref().map_or(DelegationKind::Glob, |s| DelegationKind::List(s)),
                 &deleg.body,
             ),
         }
         self.ann.post(self, AnnNode::SubItem(id))
     }
 
-    pub(crate) fn print_delegation(
+    fn print_delegation(
         &mut self,
         attrs: &[ast::Attribute],
         vis: &ast::Visibility,
         qself: &Option<P<ast::QSelf>>,
         path: &ast::Path,
-        suffixes: Option<&[(Ident, Option<Ident>)]>,
+        kind: DelegationKind<'_>,
         body: &Option<P<ast::Block>>,
     ) {
         if body.is_some() {
@@ -614,21 +620,28 @@ impl<'a> State<'a> {
         } else {
             self.print_path(path, false, 0);
         }
-        if let Some(suffixes) = suffixes {
-            self.word("::");
-            self.word("{");
-            for (i, (ident, rename)) in suffixes.iter().enumerate() {
-                self.print_ident(*ident);
-                if let Some(rename) = rename {
-                    self.nbsp();
-                    self.word_nbsp("as");
-                    self.print_ident(*rename);
+        match kind {
+            DelegationKind::Single => {}
+            DelegationKind::List(suffixes) => {
+                self.word("::");
+                self.word("{");
+                for (i, (ident, rename)) in suffixes.iter().enumerate() {
+                    self.print_ident(*ident);
+                    if let Some(rename) = rename {
+                        self.nbsp();
+                        self.word_nbsp("as");
+                        self.print_ident(*rename);
+                    }
+                    if i != suffixes.len() - 1 {
+                        self.word_space(",");
+                    }
                 }
-                if i != suffixes.len() - 1 {
-                    self.word_space(",");
-                }
+                self.word("}");
             }
-            self.word("}");
+            DelegationKind::Glob => {
+                self.word("::");
+                self.word("*");
+            }
         }
         if let Some(body) = body {
             self.nbsp();

--- a/compiler/rustc_const_eval/src/interpret/discriminant.rs
+++ b/compiler/rustc_const_eval/src/interpret/discriminant.rs
@@ -241,7 +241,16 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         variant_index: VariantIdx,
     ) -> InterpResult<'tcx, Option<(ScalarInt, usize)>> {
         match self.layout_of(ty)?.variants {
-            abi::Variants::Single { .. } => Ok(None),
+            abi::Variants::Single { .. } => {
+                // The tag of a `Single` enum is like the tag of the niched
+                // variant: there's no tag as the discriminant is encoded
+                // entirely implicitly. If `write_discriminant` ever hits this
+                // case, we do a "validation read" to ensure the the right
+                // discriminant is encoded implicitly, so any attempt to write
+                // the wrong discriminant for a `Single` enum will reliably
+                // result in UB.
+                Ok(None)
+            }
 
             abi::Variants::Multiple {
                 tag_encoding: TagEncoding::Direct,

--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -35,8 +35,8 @@ expand_duplicate_matcher_binding = duplicate matcher binding
     .label = duplicate binding
     .label2 = previous binding
 
-expand_empty_delegation_list =
-    empty list delegation is not supported
+expand_empty_delegation_mac =
+    empty {$kind} delegation is not supported
 
 expand_expected_paren_or_brace =
     expected `(` or `{"{"}`, found `{$token}`
@@ -57,6 +57,9 @@ expand_feature_removed =
     feature has been removed
     .label = feature has been removed
     .reason = {$reason}
+
+expand_glob_delegation_outside_impls =
+    glob delegation is only supported in impls
 
 expand_helper_attribute_name_invalid =
     `{$name}` cannot be a name of derive helper attribute

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -435,8 +435,16 @@ pub struct ExpectedParenOrBrace<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(expand_empty_delegation_list)]
-pub(crate) struct EmptyDelegationList {
+#[diag(expand_empty_delegation_mac)]
+pub(crate) struct EmptyDelegationMac {
+    #[primary_span]
+    pub span: Span,
+    pub kind: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(expand_glob_delegation_outside_impls)]
+pub(crate) struct GlobDelegationOutsideImpls {
     #[primary_span]
     pub span: Span,
 }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -588,6 +588,8 @@ declare_features! (
     (incomplete, return_type_notation, "1.70.0", Some(109417)),
     /// Allows `extern "rust-cold"`.
     (unstable, rust_cold_cc, "1.63.0", Some(97544)),
+    /// Shortern the tail expression lifetime
+    (unstable, shorter_tail_lifetimes, "1.79.0", Some(123739)),
     /// Allows the use of SIMD types in functions declared in `extern` blocks.
     (unstable, simd_ffi, "1.0.0", Some(27731)),
     /// Allows specialization of implementations (RFC 1210).

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -859,10 +859,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 } else {
                     // Only point to return type if the expected type is the return type, as if they
                     // are not, the expectation must have been caused by something else.
-                    debug!("return type {:?}", hir_ty);
+                    debug!(?hir_ty, "return type");
                     let ty = self.lowerer().lower_ty(hir_ty);
-                    debug!("return type {:?}", ty);
-                    debug!("expected type {:?}", expected);
+                    debug!(?ty, "return type (lowered)");
+                    debug!(?expected, "expected type");
                     let bound_vars = self.tcx.late_bound_vars(hir_ty.hir_id.owner.into());
                     let ty = Binder::bind_with_vars(ty, bound_vars);
                     let ty = self.normalize(hir_ty.span, ty);
@@ -873,7 +873,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             expected,
                         });
                         self.try_suggest_return_impl_trait(err, expected, found, fn_id);
-                        self.note_caller_chooses_ty_for_ty_param(err, expected, found);
+                        self.try_note_caller_chooses_ty_for_ty_param(err, expected, found);
                         return true;
                     }
                 }
@@ -883,18 +883,30 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         false
     }
 
-    fn note_caller_chooses_ty_for_ty_param(
+    fn try_note_caller_chooses_ty_for_ty_param(
         &self,
         diag: &mut Diag<'_>,
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
     ) {
-        if let ty::Param(expected_ty_as_param) = expected.kind() {
-            diag.subdiagnostic(errors::NoteCallerChoosesTyForTyParam {
-                ty_param_name: expected_ty_as_param.name,
-                found_ty: found,
-            });
+        // Only show the note if:
+        // 1. `expected` ty is a type parameter;
+        // 2. The `expected` type parameter does *not* occur in the return expression type. This can
+        //    happen for e.g. `fn foo<T>(t: &T) -> T { t }`, where `expected` is `T` but `found` is
+        //    `&T`. Saying "the caller chooses a type for `T` which can be different from `&T`" is
+        //    "well duh" and is only confusing and not helpful.
+        let ty::Param(expected_ty_as_param) = expected.kind() else {
+            return;
+        };
+
+        if found.contains(expected) {
+            return;
         }
+
+        diag.subdiagnostic(errors::NoteCallerChoosesTyForTyParam {
+            ty_param_name: expected_ty_as_param.name,
+            found_ty: found,
+        });
     }
 
     /// check whether the return type is a generic type with a trait bound

--- a/compiler/rustc_hir_typeck/src/typeck_root_ctxt.rs
+++ b/compiler/rustc_hir_typeck/src/typeck_root_ctxt.rs
@@ -22,7 +22,7 @@ use std::ops::Deref;
 /// e.g. closures defined within the function. For example:
 /// ```ignore (illustrative)
 /// fn foo() {
-///     bar(move|| { ... })
+///     bar(move || { ... })
 /// }
 /// ```
 /// Here, the function `foo()` and the closure passed to

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -548,6 +548,7 @@ lint_non_local_definitions_impl = non-local `impl` definition, `impl` blocks sho
     .without_trait = methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
     .with_trait = an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
     .bounds = `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+    .doctest = make this doc-test a standalone test with its own `fn main() {"{"} ... {"}"}`
     .exception = items in an anonymous const item (`const _: () = {"{"} ... {"}"}`) are treated as in the same scope as the anonymous const's declaration
     .const_anon = use a const-anon item to suppress this lint
 

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1368,8 +1368,7 @@ pub enum NonLocalDefinitionsDiag {
         depth: u32,
         body_kind_descr: &'static str,
         body_name: String,
-        help: Option<()>,
-        doctest_help: Option<()>,
+        doctest: bool,
         cargo_update: Option<NonLocalDefinitionsCargoUpdateNote>,
     },
 }
@@ -1448,8 +1447,7 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                 depth,
                 body_kind_descr,
                 body_name,
-                help,
-                doctest_help,
+                doctest,
                 cargo_update,
             } => {
                 diag.primary_message(fluent::lint_non_local_definitions_macro_rules);
@@ -1457,11 +1455,10 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                 diag.arg("body_kind_descr", body_kind_descr);
                 diag.arg("body_name", body_name);
 
-                if let Some(()) = help {
-                    diag.help(fluent::lint_help);
-                }
-                if let Some(()) = doctest_help {
+                if doctest {
                     diag.help(fluent::lint_help_doctest);
+                } else {
+                    diag.help(fluent::lint_help);
                 }
 
                 diag.note(fluent::lint_non_local);

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1358,6 +1358,7 @@ pub enum NonLocalDefinitionsDiag {
         cargo_update: Option<NonLocalDefinitionsCargoUpdateNote>,
         const_anon: Option<Option<Span>>,
         move_to: Option<(Span, Vec<Span>)>,
+        doctest: bool,
         may_remove: Option<(Span, String)>,
         has_trait: bool,
         self_ty_str: String,
@@ -1383,6 +1384,7 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                 cargo_update,
                 const_anon,
                 move_to,
+                doctest,
                 may_remove,
                 has_trait,
                 self_ty_str,
@@ -1410,6 +1412,9 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                         ms.push_span_label(sp, fluent::lint_non_local_definitions_may_move);
                     }
                     diag.span_help(ms, fluent::lint_non_local_definitions_impl_move_help);
+                }
+                if doctest {
+                    diag.help(fluent::lint_doctest);
                 }
 
                 if let Some((span, part)) = may_remove {

--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -304,8 +304,7 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                             .map(|s| s.to_ident_string())
                             .unwrap_or_else(|| "<unnameable>".to_string()),
                         cargo_update: cargo_update(),
-                        help: (!is_at_toplevel_doctest()).then_some(()),
-                        doctest_help: is_at_toplevel_doctest().then_some(()),
+                        doctest: is_at_toplevel_doctest(),
                     },
                 )
             }

--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -111,6 +111,12 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
             }
         };
 
+        // determining if we are in a doctest context can't currently be determined
+        // by the code itself (there are no specific attributes), but fortunately rustdoc
+        // sets a perma-unstable env var for libtest so we just reuse that for now
+        let is_at_toplevel_doctest =
+            || self.body_depth == 2 && std::env::var("UNSTABLE_RUSTDOC_TEST_PATH").is_ok();
+
         match item.kind {
             ItemKind::Impl(impl_) => {
                 // The RFC states:
@@ -191,29 +197,6 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                     None
                 };
 
-                let mut collector = PathCollector { paths: Vec::new() };
-                collector.visit_ty(&impl_.self_ty);
-                if let Some(of_trait) = &impl_.of_trait {
-                    collector.visit_trait_ref(of_trait);
-                }
-                collector.visit_generics(&impl_.generics);
-
-                let mut may_move: Vec<Span> = collector
-                    .paths
-                    .into_iter()
-                    .filter_map(|path| {
-                        if let Some(did) = path.res.opt_def_id()
-                            && did_has_local_parent(did, cx.tcx, parent, parent_parent)
-                        {
-                            Some(cx.tcx.def_span(did))
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                may_move.sort();
-                may_move.dedup();
-
                 let const_anon = matches!(parent_def_kind, DefKind::Const | DefKind::Static { .. })
                     .then_some(span_for_const_anon_suggestion);
 
@@ -248,14 +231,44 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                 } else {
                     None
                 };
-                let move_to = if may_move.is_empty() {
-                    ms.push_span_label(
-                        cx.tcx.def_span(parent),
-                        fluent::lint_non_local_definitions_impl_move_help,
-                    );
-                    None
+
+                let (doctest, move_to) = if is_at_toplevel_doctest() {
+                    (true, None)
                 } else {
-                    Some((cx.tcx.def_span(parent), may_move))
+                    let mut collector = PathCollector { paths: Vec::new() };
+                    collector.visit_ty(&impl_.self_ty);
+                    if let Some(of_trait) = &impl_.of_trait {
+                        collector.visit_trait_ref(of_trait);
+                    }
+                    collector.visit_generics(&impl_.generics);
+
+                    let mut may_move: Vec<Span> = collector
+                        .paths
+                        .into_iter()
+                        .filter_map(|path| {
+                            if let Some(did) = path.res.opt_def_id()
+                                && did_has_local_parent(did, cx.tcx, parent, parent_parent)
+                            {
+                                Some(cx.tcx.def_span(did))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    may_move.sort();
+                    may_move.dedup();
+
+                    let move_to = if may_move.is_empty() {
+                        ms.push_span_label(
+                            cx.tcx.def_span(parent),
+                            fluent::lint_non_local_definitions_impl_move_help,
+                        );
+                        None
+                    } else {
+                        Some((cx.tcx.def_span(parent), may_move))
+                    };
+
+                    (false, move_to)
                 };
 
                 cx.emit_span_lint(
@@ -272,6 +285,7 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                         self_ty_str,
                         of_trait_str,
                         move_to,
+                        doctest,
                         may_remove,
                         has_trait: impl_.of_trait.is_some(),
                     },
@@ -280,12 +294,6 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
             ItemKind::Macro(_macro, MacroKind::Bang)
                 if cx.tcx.has_attr(item.owner_id.def_id, sym::macro_export) =>
             {
-                // determining we if are in a doctest context can't currently be determined
-                // by the code it-self (no specific attrs), but fortunatly rustdoc sets a
-                // perma-unstable env for libtest so we just re-use that env for now
-                let is_at_toplevel_doctest =
-                    self.body_depth == 2 && std::env::var("UNSTABLE_RUSTDOC_TEST_PATH").is_ok();
-
                 cx.emit_span_lint(
                     NON_LOCAL_DEFINITIONS,
                     item.span,
@@ -296,8 +304,8 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                             .map(|s| s.to_ident_string())
                             .unwrap_or_else(|| "<unnameable>".to_string()),
                         cargo_update: cargo_update(),
-                        help: (!is_at_toplevel_doctest).then_some(()),
-                        doctest_help: is_at_toplevel_doctest.then_some(()),
+                        help: (!is_at_toplevel_doctest()).then_some(()),
+                        doctest_help: is_at_toplevel_doctest().then_some(()),
                     },
                 )
             }

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2699,12 +2699,13 @@ pub(crate) struct SingleColonImportPath {
 
 #[derive(Diagnostic)]
 #[diag(parse_bad_item_kind)]
-#[help]
 pub(crate) struct BadItemKind {
     #[primary_span]
     pub span: Span,
     pub descr: &'static str,
     pub ctx: &'static str,
+    #[help]
+    pub help: Option<()>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -707,15 +707,25 @@ impl<'a> Parser<'a> {
         };
 
         let (ident, item_kind) = if self.eat(&token::PathSep) {
-            let (suffixes, _) = self.parse_delim_comma_seq(Delimiter::Brace, |p| {
-                Ok((p.parse_path_segment_ident()?, rename(p)?))
-            })?;
+            let suffixes = if self.eat(&token::BinOp(token::Star)) {
+                None
+            } else {
+                let parse_suffix = |p: &mut Self| Ok((p.parse_path_segment_ident()?, rename(p)?));
+                Some(self.parse_delim_comma_seq(Delimiter::Brace, parse_suffix)?.0)
+            };
             let deleg = DelegationMac { qself, prefix: path, suffixes, body: body(self)? };
             (Ident::empty(), ItemKind::DelegationMac(Box::new(deleg)))
         } else {
             let rename = rename(self)?;
             let ident = rename.unwrap_or_else(|| path.segments.last().unwrap().ident);
-            let deleg = Delegation { id: DUMMY_NODE_ID, qself, path, rename, body: body(self)? };
+            let deleg = Delegation {
+                id: DUMMY_NODE_ID,
+                qself,
+                path,
+                rename,
+                body: body(self)?,
+                from_glob: false,
+            };
             (ident, ItemKind::Delegation(Box::new(deleg)))
         };
 
@@ -1237,7 +1247,11 @@ impl<'a> Parser<'a> {
         // FIXME(#100717): needs variant for each `ItemKind` (instead of using `ItemKind::descr()`)
         let span = self.psess.source_map().guess_head_span(span);
         let descr = kind.descr();
-        self.dcx().emit_err(errors::BadItemKind { span, descr, ctx });
+        let help = match kind {
+            ItemKind::DelegationMac(deleg) if deleg.suffixes.is_none() => None,
+            _ => Some(()),
+        };
+        self.dcx().emit_err(errors::BadItemKind { span, descr, ctx, help });
         None
     }
 

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -144,8 +144,9 @@ impl<'a, 'b, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'b, 'tcx> {
             }
             ItemKind::GlobalAsm(..) => DefKind::GlobalAsm,
             ItemKind::Use(..) => return visit::walk_item(self, i),
-            ItemKind::MacCall(..) => return self.visit_macro_invoc(i.id),
-            ItemKind::DelegationMac(..) => unreachable!(),
+            ItemKind::MacCall(..) | ItemKind::DelegationMac(..) => {
+                return self.visit_macro_invoc(i.id);
+            }
         };
         let def_id = self.create_def(i.id, i.ident.name, def_kind, i.span);
 
@@ -294,8 +295,9 @@ impl<'a, 'b, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'b, 'tcx> {
             AssocItemKind::Fn(..) | AssocItemKind::Delegation(..) => DefKind::AssocFn,
             AssocItemKind::Const(..) => DefKind::AssocConst,
             AssocItemKind::Type(..) => DefKind::AssocTy,
-            AssocItemKind::MacCall(..) => return self.visit_macro_invoc(i.id),
-            AssocItemKind::DelegationMac(..) => unreachable!(),
+            AssocItemKind::MacCall(..) | AssocItemKind::DelegationMac(..) => {
+                return self.visit_macro_invoc(i.id);
+            }
         };
 
         let def = self.create_def(i.id, i.ident.name, def_kind, i.span);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3281,17 +3281,19 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
         }
         self.visit_path(&delegation.path, delegation.id);
         if let Some(body) = &delegation.body {
-            // `PatBoundCtx` is not necessary in this context
-            let mut bindings = smallvec![(PatBoundCtx::Product, Default::default())];
+            self.with_rib(ValueNS, RibKind::FnOrCoroutine, |this| {
+                // `PatBoundCtx` is not necessary in this context
+                let mut bindings = smallvec![(PatBoundCtx::Product, Default::default())];
 
-            let span = delegation.path.segments.last().unwrap().ident.span;
-            self.fresh_binding(
-                Ident::new(kw::SelfLower, span),
-                delegation.id,
-                PatternSource::FnParam,
-                &mut bindings,
-            );
-            self.visit_block(body);
+                let span = delegation.path.segments.last().unwrap().ident.span;
+                this.fresh_binding(
+                    Ident::new(kw::SelfLower, span),
+                    delegation.id,
+                    PatternSource::FnParam,
+                    &mut bindings,
+                );
+                this.visit_block(body);
+            });
         }
     }
 

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -5,7 +5,7 @@ use crate::errors::CannotDetermineMacroResolution;
 use crate::errors::{self, AddAsNonDerive, CannotFindIdentInThisScope};
 use crate::errors::{MacroExpectedFound, RemoveSurroundingDerive};
 use crate::Namespace::*;
-use crate::{BuiltinMacroState, Determinacy, MacroData, Used};
+use crate::{BindingKey, BuiltinMacroState, Determinacy, MacroData, Used};
 use crate::{DeriveData, Finalize, ParentScope, ResolutionError, Resolver, ScopeSet};
 use crate::{ModuleKind, ModuleOrUniformRoot, NameBinding, PathResult, Segment, ToNameBinding};
 use rustc_ast::expand::StrippedCfgItem;
@@ -198,6 +198,11 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
         self.output_macro_rules_scopes.insert(expansion, output_macro_rules_scope);
 
         parent_scope.module.unexpanded_invocations.borrow_mut().remove(&expansion);
+        if let Some(unexpanded_invocations) =
+            self.impl_unexpanded_invocations.get_mut(&self.invocation_parent(expansion))
+        {
+            unexpanded_invocations.remove(&expansion);
+        }
     }
 
     fn register_builtin_macro(&mut self, name: Symbol, ext: SyntaxExtensionKind) {
@@ -262,15 +267,21 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
             }
         };
 
-        let (path, kind, inner_attr, derives) = match invoc.kind {
-            InvocationKind::Attr { ref attr, ref derives, .. } => (
-                &attr.get_normal_item().path,
-                MacroKind::Attr,
-                attr.style == ast::AttrStyle::Inner,
-                self.arenas.alloc_ast_paths(derives),
-            ),
-            InvocationKind::Bang { ref mac, .. } => (&mac.path, MacroKind::Bang, false, &[][..]),
-            InvocationKind::Derive { ref path, .. } => (path, MacroKind::Derive, false, &[][..]),
+        let (mut derives, mut inner_attr, mut deleg_impl) = (&[][..], false, None);
+        let (path, kind) = match invoc.kind {
+            InvocationKind::Attr { ref attr, derives: ref attr_derives, .. } => {
+                derives = self.arenas.alloc_ast_paths(attr_derives);
+                inner_attr = attr.style == ast::AttrStyle::Inner;
+                (&attr.get_normal_item().path, MacroKind::Attr)
+            }
+            InvocationKind::Bang { ref mac, .. } => (&mac.path, MacroKind::Bang),
+            InvocationKind::Derive { ref path, .. } => (path, MacroKind::Derive),
+            InvocationKind::GlobDelegation { ref item } => {
+                let ast::AssocItemKind::DelegationMac(deleg) = &item.kind else { unreachable!() };
+                deleg_impl = Some(self.invocation_parent(invoc_id));
+                // It is sufficient to consider glob delegation a bang macro for now.
+                (&deleg.prefix, MacroKind::Bang)
+            }
         };
 
         // Derives are not included when `invocations` are collected, so we have to add them here.
@@ -286,10 +297,11 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
             node_id,
             force,
             soft_custom_inner_attributes_gate(path, invoc),
+            deleg_impl,
         )?;
 
         let span = invoc.span();
-        let def_id = res.opt_def_id();
+        let def_id = if deleg_impl.is_some() { None } else { res.opt_def_id() };
         invoc_id.set_expn_data(
             ext.expn_data(
                 parent_scope.expansion,
@@ -452,6 +464,45 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
     fn registered_tools(&self) -> &RegisteredTools {
         self.registered_tools
     }
+
+    fn register_glob_delegation(&mut self, invoc_id: LocalExpnId) {
+        self.glob_delegation_invoc_ids.insert(invoc_id);
+    }
+
+    fn glob_delegation_suffixes(
+        &mut self,
+        trait_def_id: DefId,
+        impl_def_id: LocalDefId,
+    ) -> Result<Vec<(Ident, Option<Ident>)>, Indeterminate> {
+        let target_trait = self.expect_module(trait_def_id);
+        if !target_trait.unexpanded_invocations.borrow().is_empty() {
+            return Err(Indeterminate);
+        }
+        // FIXME: Instead of waiting try generating all trait methods, and pruning
+        // the shadowed ones a bit later, e.g. when all macro expansion completes.
+        // Pros: expansion will be stuck less (but only in exotic cases), the implementation may be
+        // less hacky.
+        // Cons: More code is generated just to be deleted later, deleting already created `DefId`s
+        // may be nontrivial.
+        if let Some(unexpanded_invocations) = self.impl_unexpanded_invocations.get(&impl_def_id)
+            && !unexpanded_invocations.is_empty()
+        {
+            return Err(Indeterminate);
+        }
+
+        let mut idents = Vec::new();
+        target_trait.for_each_child(self, |this, ident, ns, _binding| {
+            // FIXME: Adjust hygiene for idents from globs, like for glob imports.
+            if let Some(overriding_keys) = this.impl_binding_keys.get(&impl_def_id)
+                && overriding_keys.contains(&BindingKey::new(ident.normalize_to_macros_2_0(), ns))
+            {
+                // The name is overridden, do not produce it from the glob delegation.
+            } else {
+                idents.push((ident, None));
+            }
+        });
+        Ok(idents)
+    }
 }
 
 impl<'a, 'tcx> Resolver<'a, 'tcx> {
@@ -468,14 +519,39 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         node_id: NodeId,
         force: bool,
         soft_custom_inner_attributes_gate: bool,
+        deleg_impl: Option<LocalDefId>,
     ) -> Result<(Lrc<SyntaxExtension>, Res), Indeterminate> {
-        let (ext, res) = match self.resolve_macro_path(path, Some(kind), parent_scope, true, force)
-        {
+        let (ext, res) = match self.resolve_macro_or_delegation_path(
+            path,
+            Some(kind),
+            parent_scope,
+            true,
+            force,
+            deleg_impl,
+        ) {
             Ok((Some(ext), res)) => (ext, res),
             Ok((None, res)) => (self.dummy_ext(kind), res),
             Err(Determinacy::Determined) => (self.dummy_ext(kind), Res::Err),
             Err(Determinacy::Undetermined) => return Err(Indeterminate),
         };
+
+        // Everything below is irrelevant to glob delegation, take a shortcut.
+        if deleg_impl.is_some() {
+            if !matches!(res, Res::Err | Res::Def(DefKind::Trait, _)) {
+                self.dcx().emit_err(MacroExpectedFound {
+                    span: path.span,
+                    expected: "trait",
+                    article: "a",
+                    found: res.descr(),
+                    macro_path: &pprust::path_to_string(path),
+                    remove_surrounding_derive: None,
+                    add_as_non_derive: None,
+                });
+                return Ok((self.dummy_ext(kind), Res::Err));
+            }
+
+            return Ok((ext, res));
+        }
 
         // Report errors for the resolved macro.
         for segment in &path.segments {
@@ -606,11 +682,24 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         trace: bool,
         force: bool,
     ) -> Result<(Option<Lrc<SyntaxExtension>>, Res), Determinacy> {
+        self.resolve_macro_or_delegation_path(path, kind, parent_scope, trace, force, None)
+    }
+
+    fn resolve_macro_or_delegation_path(
+        &mut self,
+        path: &ast::Path,
+        kind: Option<MacroKind>,
+        parent_scope: &ParentScope<'a>,
+        trace: bool,
+        force: bool,
+        deleg_impl: Option<LocalDefId>,
+    ) -> Result<(Option<Lrc<SyntaxExtension>>, Res), Determinacy> {
         let path_span = path.span;
         let mut path = Segment::from_path(path);
 
         // Possibly apply the macro helper hack
-        if kind == Some(MacroKind::Bang)
+        if deleg_impl.is_none()
+            && kind == Some(MacroKind::Bang)
             && path.len() == 1
             && path[0].ident.span.ctxt().outer_expn_data().local_inner_macros
         {
@@ -618,13 +707,17 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             path.insert(0, Segment::from_ident(root));
         }
 
-        let res = if path.len() > 1 {
-            let res = match self.maybe_resolve_path(&path, Some(MacroNS), parent_scope) {
+        let res = if deleg_impl.is_some() || path.len() > 1 {
+            let ns = if deleg_impl.is_some() { TypeNS } else { MacroNS };
+            let res = match self.maybe_resolve_path(&path, Some(ns), parent_scope) {
                 PathResult::NonModule(path_res) if let Some(res) = path_res.full_res() => Ok(res),
                 PathResult::Indeterminate if !force => return Err(Determinacy::Undetermined),
                 PathResult::NonModule(..)
                 | PathResult::Indeterminate
                 | PathResult::Failed { .. } => Err(Determinacy::Determined),
+                PathResult::Module(ModuleOrUniformRoot::Module(module)) => {
+                    Ok(module.res().unwrap())
+                }
                 PathResult::Module(..) => unreachable!(),
             };
 
@@ -636,6 +729,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     kind,
                     *parent_scope,
                     res.ok(),
+                    ns,
                 ));
             }
 
@@ -670,7 +764,18 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             res
         };
 
-        res.map(|res| (self.get_macro(res).map(|macro_data| macro_data.ext.clone()), res))
+        let res = res?;
+        let ext = match deleg_impl {
+            Some(impl_def_id) => match res {
+                def::Res::Def(DefKind::Trait, def_id) => {
+                    let edition = self.tcx.sess.edition();
+                    Some(Lrc::new(SyntaxExtension::glob_delegation(def_id, impl_def_id, edition)))
+                }
+                _ => None,
+            },
+            None => self.get_macro(res).map(|macro_data| macro_data.ext.clone()),
+        };
+        Ok((ext, res))
     }
 
     pub(crate) fn finalize_macro_resolutions(&mut self, krate: &Crate) {
@@ -706,14 +811,14 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         };
 
         let macro_resolutions = mem::take(&mut self.multi_segment_macro_resolutions);
-        for (mut path, path_span, kind, parent_scope, initial_res) in macro_resolutions {
+        for (mut path, path_span, kind, parent_scope, initial_res, ns) in macro_resolutions {
             // FIXME: Path resolution will ICE if segment IDs present.
             for seg in &mut path {
                 seg.id = None;
             }
             match self.resolve_path(
                 &path,
-                Some(MacroNS),
+                Some(ns),
                 &parent_scope,
                 Some(Finalize::new(ast::CRATE_NODE_ID, path_span)),
                 None,
@@ -721,6 +826,15 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 PathResult::NonModule(path_res) if let Some(res) = path_res.full_res() => {
                     check_consistency(self, &path, path_span, kind, initial_res, res)
                 }
+                // This may be a trait for glob delegation expansions.
+                PathResult::Module(ModuleOrUniformRoot::Module(module)) => check_consistency(
+                    self,
+                    &path,
+                    path_span,
+                    kind,
+                    initial_res,
+                    module.res().unwrap(),
+                ),
                 path_res @ (PathResult::NonModule(..) | PathResult::Failed { .. }) => {
                     let mut suggestion = None;
                     let (span, label, module) =

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1678,6 +1678,7 @@ symbols! {
         shadow_call_stack,
         shl,
         shl_assign,
+        shorter_tail_lifetimes,
         should_panic,
         shr,
         shr_assign,

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -183,7 +183,7 @@
 //!
 //!     let spinlock_clone = Arc::clone(&spinlock);
 //!
-//!     let thread = thread::spawn(move|| {
+//!     let thread = thread::spawn(move || {
 //!         spinlock_clone.store(0, Ordering::Release);
 //!     });
 //!

--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -20,7 +20,7 @@ use crate::sync::{Condvar, Mutex};
 ///     let c = Arc::clone(&barrier);
 ///     // The same messages will be printed together.
 ///     // You will NOT see any interleaving.
-///     handles.push(thread::spawn(move|| {
+///     handles.push(thread::spawn(move || {
 ///         println!("before wait");
 ///         c.wait();
 ///         println!("after wait");
@@ -115,7 +115,7 @@ impl Barrier {
     ///     let c = Arc::clone(&barrier);
     ///     // The same messages will be printed together.
     ///     // You will NOT see any interleaving.
-    ///     handles.push(thread::spawn(move|| {
+    ///     handles.push(thread::spawn(move || {
     ///         println!("before wait");
     ///         c.wait();
     ///         println!("after wait");

--- a/library/std/src/sync/condvar.rs
+++ b/library/std/src/sync/condvar.rs
@@ -88,7 +88,7 @@ impl WaitTimeoutResult {
 /// let pair2 = Arc::clone(&pair);
 ///
 /// // Inside of our lock, spawn a new thread, and then wait for it to start.
-/// thread::spawn(move|| {
+/// thread::spawn(move || {
 ///     let (lock, cvar) = &*pair2;
 ///     let mut started = lock.lock().unwrap();
 ///     *started = true;
@@ -166,7 +166,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut started = lock.lock().unwrap();
     ///     *started = true;
@@ -221,7 +221,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(true), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut pending = lock.lock().unwrap();
     ///     *pending = false;
@@ -280,7 +280,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut started = lock.lock().unwrap();
     ///     *started = true;
@@ -352,7 +352,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut started = lock.lock().unwrap();
     ///     *started = true;
@@ -420,7 +420,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(true), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut pending = lock.lock().unwrap();
     ///     *pending = false;
@@ -484,7 +484,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut started = lock.lock().unwrap();
     ///     *started = true;
@@ -524,7 +524,7 @@ impl Condvar {
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
     /// let pair2 = Arc::clone(&pair);
     ///
-    /// thread::spawn(move|| {
+    /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
     ///     let mut started = lock.lock().unwrap();
     ///     *started = true;

--- a/library/std/src/sync/mpsc/mod.rs
+++ b/library/std/src/sync/mpsc/mod.rs
@@ -51,7 +51,7 @@
 //!
 //! // Create a simple streaming channel
 //! let (tx, rx) = channel();
-//! thread::spawn(move|| {
+//! thread::spawn(move || {
 //!     tx.send(10).unwrap();
 //! });
 //! assert_eq!(rx.recv().unwrap(), 10);
@@ -69,7 +69,7 @@
 //! let (tx, rx) = channel();
 //! for i in 0..10 {
 //!     let tx = tx.clone();
-//!     thread::spawn(move|| {
+//!     thread::spawn(move || {
 //!         tx.send(i).unwrap();
 //!     });
 //! }
@@ -99,7 +99,7 @@
 //! use std::sync::mpsc::sync_channel;
 //!
 //! let (tx, rx) = sync_channel::<i32>(0);
-//! thread::spawn(move|| {
+//! thread::spawn(move || {
 //!     // This will wait for the parent thread to start receiving
 //!     tx.send(53).unwrap();
 //! });
@@ -510,7 +510,7 @@ pub enum TrySendError<T> {
 /// let (sender, receiver) = channel();
 ///
 /// // Spawn off an expensive computation
-/// thread::spawn(move|| {
+/// thread::spawn(move || {
 /// #   fn expensive_computation() {}
 ///     sender.send(expensive_computation()).unwrap();
 /// });
@@ -561,7 +561,7 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 /// // this returns immediately
 /// sender.send(1).unwrap();
 ///
-/// thread::spawn(move|| {
+/// thread::spawn(move || {
 ///     // this will block until the previous message has been received
 ///     sender.send(2).unwrap();
 /// });

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -62,7 +62,7 @@ use crate::fmt;
 /// FOO.set(2);
 ///
 /// // each thread starts out with the initial value of 1
-/// let t = thread::spawn(move|| {
+/// let t = thread::spawn(move || {
 ///     assert_eq!(FOO.get(), 1);
 ///     FOO.set(3);
 /// });

--- a/src/ci/docker/scripts/fuchsia-test-runner.py
+++ b/src/ci/docker/scripts/fuchsia-test-runner.py
@@ -8,34 +8,137 @@ https://doc.rust-lang.org/stable/rustc/platform-support/fuchsia.html#aarch64-unk
 """
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 import glob
-import hashlib
+import io
 import json
+import logging
 import os
 import platform
+import shlex
 import shutil
 import subprocess
 import sys
-from typing import ClassVar, List
+from pathlib import Path
+from typing import ClassVar, List, Optional
 
 
-@dataclass
+def check_call_with_logging(
+    args, *, stdout_handler, stderr_handler, check=True, text=True, **kwargs
+):
+    stdout_handler(f"Subprocess: {shlex.join(str(arg) for arg in args)}")
+
+    with subprocess.Popen(
+        args,
+        text=text,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **kwargs,
+    ) as process:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+
+            def exhaust_pipe(handler, pipe):
+                for line in pipe:
+                    handler(line.rstrip())
+
+            executor_out = executor.submit(
+                exhaust_pipe, stdout_handler, process.stdout
+            )
+            executor_err = executor.submit(
+                exhaust_pipe, stderr_handler, process.stderr
+            )
+            executor_out.result()
+            executor_err.result()
+    retcode = process.poll()
+    if check and retcode:
+        raise subprocess.CalledProcessError(retcode, process.args)
+    return subprocess.CompletedProcess(process.args, retcode)
+
+
+def check_output_with_logging(
+    args, *, stdout_handler, stderr_handler, check=True, text=True, **kwargs
+):
+    stdout_handler(f"Subprocess: {shlex.join(str(arg) for arg in args)}")
+
+    buf = io.StringIO()
+
+    with subprocess.Popen(
+        args,
+        text=text,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **kwargs,
+    ) as process:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+
+            def exhaust_stdout(handler, buf, pipe):
+                for line in pipe:
+                    handler(line.rstrip())
+                    buf.write(line)
+                    buf.write("\n")
+
+            def exhaust_stderr(handler, pipe):
+                for line in pipe:
+                    handler(line.rstrip())
+
+            executor_out = executor.submit(
+                exhaust_stdout, stdout_handler, buf, process.stdout
+            )
+            executor_err = executor.submit(
+                exhaust_stderr, stderr_handler, process.stderr
+            )
+            executor_out.result()
+            executor_err.result()
+    retcode = process.poll()
+    if check and retcode:
+        raise subprocess.CalledProcessError(retcode, process.args)
+
+    return buf.getvalue()
+
+
+def atomic_link(link: Path, target: Path):
+    link_dir = link.parent
+    os.makedirs(link_dir, exist_ok=True)
+    link_file = link.name
+    tmp_file = link_dir.joinpath(link_file + "_tmp")
+    os.link(target, tmp_file)
+    try:
+        os.rename(tmp_file, link)
+    except Exception as e:
+        raise e
+    finally:
+        if tmp_file.exists():
+            os.remove(tmp_file)
+
+
+@dataclass(kw_only=True)
 class TestEnvironment:
-    rust_build_dir: str
-    sdk_dir: str
+    rust_build_dir: Path
+    sdk_dir: Path
     target: str
+    toolchain_dir: Path
+    local_pb_path: Optional[Path]
+    use_local_pb: bool
     verbose: bool = False
 
-    @staticmethod
-    def tmp_dir():
-        tmp_dir = os.environ.get("TEST_TOOLCHAIN_TMP_DIR")
-        if tmp_dir is not None:
-            return os.path.abspath(tmp_dir)
-        return os.path.join(os.path.dirname(__file__), "tmp~")
+    env_logger = logging.getLogger("env")
+    subprocess_logger = logging.getLogger("env.subprocess")
+    __tmp_dir = None
 
     @staticmethod
-    def triple_to_arch(triple):
+    def tmp_dir() -> Path:
+        if TestEnvironment.__tmp_dir:
+            return TestEnvironment.__tmp_dir
+        tmp_dir = os.environ.get("TEST_TOOLCHAIN_TMP_DIR")
+        if tmp_dir is not None:
+            TestEnvironment.__tmp_dir = Path(tmp_dir).absolute()
+        else:
+            TestEnvironment.__tmp_dir = Path(__file__).parent.joinpath("tmp~")
+        return TestEnvironment.__tmp_dir
+
+    @staticmethod
+    def triple_to_arch(triple) -> str:
         if "x86_64" in triple:
             return "x64"
         elif "aarch64" in triple:
@@ -44,61 +147,175 @@ class TestEnvironment:
             raise Exception(f"Unrecognized target triple {triple}")
 
     @classmethod
-    def env_file_path(cls):
-        return os.path.join(cls.tmp_dir(), "test_env.json")
+    def env_file_path(cls) -> Path:
+        return cls.tmp_dir().joinpath("test_env.json")
 
     @classmethod
     def from_args(cls, args):
+        local_pb_path = args.local_product_bundle_path
+        if local_pb_path is not None:
+            local_pb_path = Path(local_pb_path).absolute()
+
         return cls(
-            os.path.abspath(args.rust_build),
-            os.path.abspath(args.sdk),
-            args.target,
+            rust_build_dir=Path(args.rust_build).absolute(),
+            sdk_dir=Path(args.sdk).absolute(),
+            target=args.target,
+            toolchain_dir=Path(args.toolchain_dir).absolute(),
+            local_pb_path=local_pb_path,
+            use_local_pb=args.use_local_product_bundle_if_exists,
             verbose=args.verbose,
         )
 
     @classmethod
     def read_from_file(cls):
         with open(cls.env_file_path(), encoding="utf-8") as f:
-            test_env = json.loads(f.read())
+            test_env = json.load(f)
+            local_pb_path = test_env["local_pb_path"]
+            if local_pb_path is not None:
+                local_pb_path = Path(local_pb_path)
+
             return cls(
-                test_env["rust_build_dir"],
-                test_env["sdk_dir"],
-                test_env["target"],
+                rust_build_dir=Path(test_env["rust_build_dir"]),
+                sdk_dir=Path(test_env["sdk_dir"]),
+                target=test_env["target"],
+                toolchain_dir=Path(test_env["toolchain_dir"]),
+                local_pb_path=local_pb_path,
+                use_local_pb=test_env["use_local_pb"],
                 verbose=test_env["verbose"],
             )
 
+    def build_id(self, binary):
+        llvm_readelf = Path(self.toolchain_dir).joinpath("bin", "llvm-readelf")
+        process = subprocess.run(
+            args=[
+                llvm_readelf,
+                "-n",
+                "--elf-output-style=JSON",
+                binary,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        if process.returncode:
+            self.env_logger.error(
+                f"llvm-readelf failed for binary {binary} with output {process.stdout}"
+            )
+            raise Exception(f"Unreadable build-id for binary {binary}")
+        data = json.loads(process.stdout)
+        if len(data) != 1:
+            raise Exception(
+                f"Unreadable output from llvm-readelf for binary {binary}"
+            )
+        notes = data[0]["Notes"]
+        for note in notes:
+            note_section = note["NoteSection"]
+            if note_section["Name"] == ".note.gnu.build-id":
+                return note_section["Note"]["Build ID"]
+        raise Exception(f"Build ID not found for binary {binary}")
+
+    def generate_buildid_dir(
+        self,
+        binary: Path,
+        build_id_dir: Path,
+        build_id: str,
+        log_handler: logging.Logger,
+    ):
+        os.makedirs(build_id_dir, exist_ok=True)
+        suffix = ".debug"
+        # Hardlink the original binary
+        build_id_prefix_dir = build_id_dir.joinpath(build_id[:2])
+        unstripped_binary = build_id_prefix_dir.joinpath(build_id[2:] + suffix)
+        build_id_prefix_dir.mkdir(parents=True, exist_ok=True)
+        atomic_link(unstripped_binary, binary)
+        assert unstripped_binary.exists()
+        stripped_binary = unstripped_binary.with_suffix("")
+        llvm_objcopy = Path(self.toolchain_dir).joinpath("bin", "llvm-objcopy")
+        strip_mode = "--strip-sections"
+        check_call_with_logging(
+            [
+                llvm_objcopy,
+                strip_mode,
+                unstripped_binary,
+                stripped_binary,
+            ],
+            stdout_handler=log_handler.info,
+            stderr_handler=log_handler.error,
+        )
+        return stripped_binary
+
     def write_to_file(self):
         with open(self.env_file_path(), "w", encoding="utf-8") as f:
-            f.write(json.dumps(self.__dict__))
+            local_pb_path = self.local_pb_path
+            if local_pb_path is not None:
+                local_pb_path = str(local_pb_path)
 
-    def package_server_log_path(self):
-        return os.path.join(self.tmp_dir(), "package_server_log")
+            json.dump(
+                {
+                    "rust_build_dir": str(self.rust_build_dir),
+                    "sdk_dir": str(self.sdk_dir),
+                    "target": self.target,
+                    "toolchain_dir": str(self.toolchain_dir),
+                    "local_pb_path": local_pb_path,
+                    "use_local_pb": self.use_local_pb,
+                    "verbose": self.verbose,
+                },
+                f,
+            )
 
-    def emulator_log_path(self):
-        return os.path.join(self.tmp_dir(), "emulator_log")
+    def setup_logging(self, log_to_file=False):
+        fs = logging.Formatter("%(asctime)s %(levelname)s:%(name)s:%(message)s")
+        if log_to_file:
+            logfile_handler = logging.FileHandler(
+                self.tmp_dir().joinpath("log")
+            )
+            logfile_handler.setLevel(logging.DEBUG)
+            logfile_handler.setFormatter(fs)
+            logging.getLogger().addHandler(logfile_handler)
+        stream_handler = logging.StreamHandler(sys.stdout)
+        stream_handler.setFormatter(fs)
+        if self.verbose:
+            stream_handler.setLevel(logging.DEBUG)
+        else:
+            stream_handler.setLevel(logging.INFO)
+        logging.getLogger().addHandler(stream_handler)
+        logging.getLogger().setLevel(logging.DEBUG)
 
-    def packages_dir(self):
-        return os.path.join(self.tmp_dir(), "packages")
+    @property
+    def package_server_log_path(self) -> Path:
+        return self.tmp_dir().joinpath("package_server_log")
 
-    def output_dir(self):
-        return os.path.join(self.tmp_dir(), "output")
+    @property
+    def emulator_log_path(self) -> Path:
+        return self.tmp_dir().joinpath("emulator_log")
+
+    @property
+    def packages_dir(self) -> Path:
+        return self.tmp_dir().joinpath("packages")
+
+    @property
+    def output_dir(self) -> Path:
+        return self.tmp_dir().joinpath("output")
+
+    def read_sdk_version(self):
+        meta_json_path = Path(self.sdk_dir).joinpath("meta", "manifest.json")
+        with open(meta_json_path, encoding="utf-8") as f:
+            meta_json = json.load(f)
+            return meta_json["id"]
 
     TEST_REPO_NAME: ClassVar[str] = "rust-testing"
 
-    def repo_dir(self):
-        return os.path.join(self.tmp_dir(), self.TEST_REPO_NAME)
+    def repo_dir(self) -> Path:
+        return self.tmp_dir().joinpath(self.TEST_REPO_NAME)
 
-    def libs_dir(self):
-        return os.path.join(
-            self.rust_build_dir,
+    def libs_dir(self) -> Path:
+        return self.rust_build_dir.joinpath(
             "host",
             "stage2",
             "lib",
         )
 
-    def rustlibs_dir(self):
-        return os.path.join(
-            self.libs_dir(),
+    def rustlibs_dir(self) -> Path:
+        return self.libs_dir().joinpath(
             "rustlib",
             self.target,
             "lib",
@@ -112,8 +329,8 @@ class TestEnvironment:
             return "a64"
         raise Exception(f"Unrecognized host architecture {machine}")
 
-    def tool_path(self, tool):
-        return os.path.join(self.sdk_dir, "tools", self.sdk_arch(), tool)
+    def tool_path(self, tool) -> Path:
+        return Path(self.sdk_dir).joinpath("tools", self.sdk_arch(), tool)
 
     def host_arch_triple(self):
         machine = platform.machine()
@@ -123,45 +340,25 @@ class TestEnvironment:
             return "aarch64-unknown-linux-gnu"
         raise Exception(f"Unrecognized host architecture {machine}")
 
-    def zxdb_script_path(self):
-        return os.path.join(self.tmp_dir(), "zxdb_script")
+    def zxdb_script_path(self) -> Path:
+        return Path(self.tmp_dir(), "zxdb_script")
 
-    def pm_lockfile_path(self):
-        return os.path.join(self.tmp_dir(), "pm.lock")
-
-    def log_info(self, msg):
-        print(msg)
-
-    def log_debug(self, msg):
-        if self.verbose:
-            print(msg)
-
-    def subprocess_output(self):
-        if self.verbose:
-            return sys.stdout
-        return subprocess.DEVNULL
-
-    def check_call(self, args, **kwargs):
-        self.log_info(f"Running: {' '.join(args)}")
-        return subprocess.check_call(args, **kwargs)
-
-    def check_output(self, args, **kwargs):
-        self.log_info(f"Running: {' '.join(args)}")
-        return subprocess.check_output(args, **kwargs)
-
+    @property
     def ffx_daemon_log_path(self):
-        return os.path.join(self.tmp_dir(), "ffx_daemon_log")
+        return self.tmp_dir().joinpath("ffx_daemon_log")
 
+    @property
     def ffx_isolate_dir(self):
-        return os.path.join(self.tmp_dir(), "ffx_isolate")
+        return self.tmp_dir().joinpath("ffx_isolate")
 
+    @property
     def home_dir(self):
-        return os.path.join(self.tmp_dir(), "user-home")
+        return self.tmp_dir().joinpath("user-home")
 
     def start_ffx_isolation(self):
         # Most of this is translated directly from ffx's isolate library
-        os.mkdir(self.ffx_isolate_dir())
-        os.mkdir(self.home_dir())
+        os.mkdir(self.ffx_isolate_dir)
+        os.mkdir(self.home_dir)
 
         ffx_path = self.tool_path("ffx")
         ffx_env = self.ffx_cmd_env()
@@ -170,7 +367,7 @@ class TestEnvironment:
         # We want this to be a long-running process that persists after the script finishes
         # pylint: disable=consider-using-with
         with open(
-            self.ffx_daemon_log_path(), "w", encoding="utf-8"
+            self.ffx_daemon_log_path, "w", encoding="utf-8"
         ) as ffx_daemon_log_file:
             subprocess.Popen(
                 [
@@ -184,7 +381,7 @@ class TestEnvironment:
             )
 
         # Disable analytics
-        self.check_call(
+        check_call_with_logging(
             [
                 ffx_path,
                 "config",
@@ -192,8 +389,8 @@ class TestEnvironment:
                 "disable",
             ],
             env=ffx_env,
-            stdout=self.subprocess_output(),
-            stderr=self.subprocess_output(),
+            stdout_handler=self.subprocess_logger.debug,
+            stderr_handler=self.subprocess_logger.debug,
         )
 
         # Set configs
@@ -203,7 +400,7 @@ class TestEnvironment:
             "test.experimental_structured_output": "true",
         }
         for key, value in configs.items():
-            self.check_call(
+            check_call_with_logging(
                 [
                     ffx_path,
                     "config",
@@ -212,14 +409,14 @@ class TestEnvironment:
                     value,
                 ],
                 env=ffx_env,
-                stdout=self.subprocess_output(),
-                stderr=self.subprocess_output(),
+                stdout_handler=self.subprocess_logger.debug,
+                stderr_handler=self.subprocess_logger.debug,
             )
 
     def ffx_cmd_env(self):
         return {
-            "HOME": self.home_dir(),
-            "FFX_ISOLATE_DIR": self.ffx_isolate_dir(),
+            "HOME": self.home_dir,
+            "FFX_ISOLATE_DIR": self.ffx_isolate_dir,
             # We want to use our own specified temp directory
             "TMP": self.tmp_dir(),
             "TEMP": self.tmp_dir(),
@@ -228,16 +425,15 @@ class TestEnvironment:
         }
 
     def stop_ffx_isolation(self):
-        self.check_call(
+        check_call_with_logging(
             [
                 self.tool_path("ffx"),
                 "daemon",
                 "stop",
-                "-w",
             ],
             env=self.ffx_cmd_env(),
-            stdout=self.subprocess_output(),
-            stderr=self.subprocess_output(),
+            stdout_handler=self.subprocess_logger.debug,
+            stderr_handler=self.subprocess_logger.debug,
         )
 
     def start(self):
@@ -256,22 +452,23 @@ class TestEnvironment:
         """
 
         # Initialize temp directory
-        if not os.path.exists(self.tmp_dir()):
-            os.mkdir(self.tmp_dir())
-        elif len(os.listdir(self.tmp_dir())) != 0:
-            raise Exception(f"Temp directory is not clean (in {self.tmp_dir()})")
-
-        os.mkdir(self.output_dir())
+        os.makedirs(self.tmp_dir(), exist_ok=True)
+        if len(os.listdir(self.tmp_dir())) != 0:
+            raise Exception(
+                f"Temp directory is not clean (in {self.tmp_dir()})"
+            )
+        self.setup_logging(log_to_file=True)
+        os.mkdir(self.output_dir)
 
         ffx_path = self.tool_path("ffx")
         ffx_env = self.ffx_cmd_env()
 
         # Start ffx isolation
-        self.log_info("Starting ffx isolation...")
+        self.env_logger.info("Starting ffx isolation...")
         self.start_ffx_isolation()
 
         # Stop any running emulators (there shouldn't be any)
-        self.check_call(
+        check_call_with_logging(
             [
                 ffx_path,
                 "emu",
@@ -279,79 +476,95 @@ class TestEnvironment:
                 "--all",
             ],
             env=ffx_env,
-            stdout=self.subprocess_output(),
-            stderr=self.subprocess_output(),
+            stdout_handler=self.subprocess_logger.debug,
+            stderr_handler=self.subprocess_logger.debug,
         )
 
-        # Look up the product bundle transfer manifest.
-        self.log_info("Looking up the product bundle transfer manifest...")
-        product_name = "minimal." + self.triple_to_arch(self.target)
-        fuchsia_version = "21.20240610.2.1"
+        if not self.local_pb_path:
+            self.local_pb_path = os.path.join(self.tmp_dir(), "local_pb")
+        else:
+            self.local_pb_path = os.path.abspath(self.local_pb_path)
 
-        out = self.check_output(
-            [
-                ffx_path,
-                "--machine",
-                "json",
-                "product",
-                "lookup",
-                product_name,
-                fuchsia_version,
-                "--base-url",
-                "gs://fuchsia/development/" + fuchsia_version,
-            ],
-            env=ffx_env,
-            stderr=self.subprocess_output(),
-        )
+        if self.use_local_pb and os.path.exists(self.local_pb_path):
+            self.env_logger.info(
+                'Using existing emulator image at "%s"' % self.local_pb_path
+            )
+        else:
+            shutil.rmtree(self.local_pb_path, ignore_errors=True)
 
-        self.log_debug(out)
+            # Look up the product bundle transfer manifest.
+            self.env_logger.info(
+                "Looking up the product bundle transfer manifest..."
+            )
+            product_name = "minimal." + self.triple_to_arch(self.target)
+            sdk_version = self.read_sdk_version()
 
-        try:
-            transfer_manifest_url = json.loads(out)["transfer_manifest_url"]
-        except Exception as e:
-            print(e)
-            raise Exception("Unable to parse transfer manifest") from e
+            output = check_output_with_logging(
+                [
+                    ffx_path,
+                    "--machine",
+                    "json",
+                    "product",
+                    "lookup",
+                    product_name,
+                    sdk_version,
+                    "--base-url",
+                    "gs://fuchsia/development/" + sdk_version,
+                ],
+                env=ffx_env,
+                stdout_handler=self.subprocess_logger.debug,
+                stderr_handler=self.subprocess_logger.debug,
+            )
 
-        # Download the product bundle.
-        product_bundle_dir = os.path.join(self.tmp_dir(), 'product-bundle')
-        self.check_call(
-            [
-                ffx_path,
-                "product",
-                "download",
-                transfer_manifest_url,
-                product_bundle_dir,
-                "--force",
-            ],
-            env=ffx_env,
-            stdout=self.subprocess_output(),
-            stderr=self.subprocess_output(),
-        )
+            try:
+                transfer_manifest_url = json.loads(output)[
+                    "transfer_manifest_url"
+                ]
+            except Exception as e:
+                print(e)
+                raise Exception("Unable to parse transfer manifest") from e
+
+            # Download the product bundle.
+            self.env_logger.info("Downloading the product bundle...")
+            check_call_with_logging(
+                [
+                    ffx_path,
+                    "product",
+                    "download",
+                    transfer_manifest_url,
+                    self.local_pb_path,
+                ],
+                env=ffx_env,
+                stdout_handler=self.subprocess_logger.debug,
+                stderr_handler=self.subprocess_logger.debug,
+            )
 
         # Start emulator
+        self.env_logger.info("Starting emulator...")
+
         # FIXME: condition --accel hyper on target arch matching host arch
-        self.check_call(
+        check_call_with_logging(
             [
                 ffx_path,
                 "emu",
                 "start",
-                product_bundle_dir,
+                self.local_pb_path,
                 "--headless",
                 "--log",
-                self.emulator_log_path(),
+                self.emulator_log_path,
                 "--net",
-                "tap",
+                "auto",
                 "--accel",
-                "hyper",
+                "auto",
             ],
             env=ffx_env,
-            stdout=self.subprocess_output(),
-            stderr=self.subprocess_output(),
+            stdout_handler=self.subprocess_logger.debug,
+            stderr_handler=self.subprocess_logger.debug,
         )
 
         # Create new package repo
-        self.log_info("Creating package repo...")
-        self.check_call(
+        self.env_logger.info("Creating package repo...")
+        check_call_with_logging(
             [
                 ffx_path,
                 "repository",
@@ -359,11 +572,12 @@ class TestEnvironment:
                 self.repo_dir(),
             ],
             env=ffx_env,
-            stdout=self.subprocess_output(),
-            stderr=self.subprocess_output(),
+            stdout_handler=self.subprocess_logger.debug,
+            stderr_handler=self.subprocess_logger.debug,
         )
 
-        self.check_call(
+        # Add repository
+        check_call_with_logging(
             [
                 ffx_path,
                 "repository",
@@ -373,15 +587,12 @@ class TestEnvironment:
                 self.repo_dir(),
             ],
             env=ffx_env,
-            stdout=self.subprocess_output(),
-            stderr=self.subprocess_output(),
+            stdout_handler=self.subprocess_logger.debug,
+            stderr_handler=self.subprocess_logger.debug,
         )
 
-        # Write to file
-        self.write_to_file()
-
         # Start repository server
-        self.check_call(
+        check_call_with_logging(
             [
                 ffx_path,
                 "repository",
@@ -391,12 +602,12 @@ class TestEnvironment:
                 "[::]:0",
             ],
             env=ffx_env,
-            stdout=self.subprocess_output(),
-            stderr=self.subprocess_output(),
+            stdout_handler=self.subprocess_logger.debug,
+            stderr_handler=self.subprocess_logger.debug,
         )
 
         # Register with newly-started emulator
-        self.check_call(
+        check_call_with_logging(
             [
                 ffx_path,
                 "target",
@@ -406,11 +617,14 @@ class TestEnvironment:
                 self.TEST_REPO_NAME,
             ],
             env=ffx_env,
-            stdout=self.subprocess_output(),
-            stderr=self.subprocess_output(),
+            stdout_handler=self.subprocess_logger.debug,
+            stderr_handler=self.subprocess_logger.debug,
         )
 
-        self.log_info("Success! Your environment is ready to run tests.")
+        # Write to file
+        self.write_to_file()
+
+        self.env_logger.info("Success! Your environment is ready to run tests.")
 
     # FIXME: shardify this
     # `facet` statement required for TCP testing via
@@ -481,7 +695,7 @@ class TestEnvironment:
         - Forward the test's stdout and stderr as this script's stdout and stderr
         """
 
-        bin_path = os.path.abspath(args.bin_path)
+        bin_path = Path(args.bin_path).absolute()
 
         # Find libstd and libtest
         libstd_paths = glob.glob(os.path.join(self.rustlibs_dir(), "libstd-*.so"))
@@ -490,233 +704,240 @@ class TestEnvironment:
         if not libstd_paths:
             raise Exception(f"Failed to locate libstd (in {self.rustlibs_dir()})")
 
-        # Build a unique, deterministic name for the test using the name of the
-        # binary and the last 6 hex digits of the hash of the full path
-        def path_checksum(path):
-            m = hashlib.sha256()
-            m.update(path.encode("utf-8"))
-            return m.hexdigest()[0:6]
-
         base_name = os.path.basename(os.path.dirname(args.bin_path))
         exe_name = base_name.lower().replace(".", "_")
-        package_name = f"{exe_name}_{path_checksum(bin_path)}"
+        build_id = self.build_id(bin_path)
+        package_name = f"{exe_name}_{build_id}"
 
-        package_dir = os.path.join(self.packages_dir(), package_name)
-        cml_path = os.path.join(package_dir, "meta", f"{package_name}.cml")
-        cm_path = os.path.join(package_dir, "meta", f"{package_name}.cm")
-        manifest_path = os.path.join(package_dir, f"{package_name}.manifest")
-        manifest_json_path = os.path.join(package_dir, "package_manifest.json")
-        far_path = os.path.join(package_dir, f"{package_name}-0.far")
+        package_dir = self.packages_dir.joinpath(package_name)
+        package_dir.mkdir(parents=True, exist_ok=True)
+        meta_dir = package_dir.joinpath("meta")
+        meta_dir.mkdir(parents=True, exist_ok=True)
+        meta_package_path = meta_dir.joinpath("package")
+        cml_path = meta_dir.joinpath(f"{package_name}.cml")
+        cm_path = meta_dir.joinpath(f"{package_name}.cm")
+        manifest_path = package_dir.joinpath(f"{package_name}.manifest")
 
         shared_libs = args.shared_libs[: args.n]
         arguments = args.shared_libs[args.n :]
 
-        test_output_dir = os.path.join(self.output_dir(), package_name)
+        test_output_dir = self.output_dir.joinpath(package_name)
 
         # Clean and create temporary output directory
-        if os.path.exists(test_output_dir):
+        if test_output_dir.exists():
             shutil.rmtree(test_output_dir)
-
-        os.mkdir(test_output_dir)
+        test_output_dir.mkdir(parents=True)
 
         # Open log file
-        log_path = os.path.join(test_output_dir, "log")
-        with open(log_path, "w", encoding="utf-8") as log_file:
+        runner_logger = logging.getLogger(f"env.package.{package_name}")
+        runner_logger.setLevel(logging.DEBUG)
+        logfile_handler = logging.FileHandler(test_output_dir.joinpath("log"))
+        logfile_handler.setLevel(logging.DEBUG)
+        logfile_handler.setFormatter(
+            logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+        )
+        runner_logger.addHandler(logfile_handler)
 
-            def log(msg):
-                print(msg, file=log_file)
-                log_file.flush()
+        runner_logger.info(f"Bin path: {bin_path}")
+        runner_logger.info("Setting up package...")
 
-            log(f"Bin path: {bin_path}")
+        # Link binary to build-id dir and strip it.
+        build_id_dir = self.tmp_dir().joinpath(".build-id")
+        stripped_binary = self.generate_buildid_dir(
+            binary=bin_path,
+            build_id_dir=build_id_dir,
+            build_id=build_id,
+            log_handler=runner_logger,
+        )
+        runner_logger.info(f"Stripped Bin path: {stripped_binary}")
 
-            log("Writing CML...")
+        runner_logger.info("Writing CML...")
 
-            # Write and compile CML
-            with open(cml_path, "w", encoding="utf-8") as cml:
-                # Collect environment variables
-                env_vars = ""
-                for var_name in self.TEST_ENV_VARS:
-                    var_value = os.getenv(var_name)
-                    if var_value is not None:
-                        env_vars += f'\n            "{var_name}={var_value}",'
+        # Write and compile CML
+        with open(cml_path, "w", encoding="utf-8") as cml:
+            # Collect environment variables
+            env_vars = ""
+            for var_name in self.TEST_ENV_VARS:
+                var_value = os.getenv(var_name)
+                if var_value is not None:
+                    env_vars += f'\n            "{var_name}={var_value}",'
 
-                # Default to no backtrace for test suite
-                if os.getenv("RUST_BACKTRACE") is None:
-                    env_vars += '\n            "RUST_BACKTRACE=0",'
+            # Default to no backtrace for test suite
+            if os.getenv("RUST_BACKTRACE") is None:
+                env_vars += '\n            "RUST_BACKTRACE=0",'
 
-                # Use /tmp as the test temporary directory
-                env_vars += '\n            "RUST_TEST_TMPDIR=/tmp",'
+            # Use /tmp as the test temporary directory
+            env_vars += '\n            "RUST_TEST_TMPDIR=/tmp",'
 
-                cml.write(
-                    self.CML_TEMPLATE.format(env_vars=env_vars, exe_name=exe_name)
-                )
-
-            log("Compiling CML...")
-
-            self.check_call(
-                [
-                    self.tool_path("cmc"),
-                    "compile",
-                    cml_path,
-                    "--includepath",
-                    ".",
-                    "--output",
-                    cm_path,
-                ],
-                stdout=log_file,
-                stderr=log_file,
+            cml.write(
+                self.CML_TEMPLATE.format(env_vars=env_vars, exe_name=exe_name)
             )
 
-            log("Writing manifest...")
+        runner_logger.info("Compiling CML...")
 
-            # Write, build, and archive manifest
-            with open(manifest_path, "w", encoding="utf-8") as manifest:
+        check_call_with_logging(
+            [
+                self.tool_path("cmc"),
+                "compile",
+                cml_path,
+                "--includepath",
+                ".",
+                "--output",
+                cm_path,
+            ],
+            stdout_handler=runner_logger.info,
+            stderr_handler=runner_logger.warning,
+        )
+
+        runner_logger.info("Writing meta/package...")
+        with open(meta_package_path, "w", encoding="utf-8") as f:
+            json.dump({"name": package_name, "version": "0"}, f)
+
+        runner_logger.info("Writing manifest...")
+
+        # Write package manifest
+        with open(manifest_path, "w", encoding="utf-8") as manifest:
+            manifest.write(
+                self.MANIFEST_TEMPLATE.format(
+                    bin_path=stripped_binary,
+                    exe_name=exe_name,
+                    package_dir=package_dir,
+                    package_name=package_name,
+                    target=self.target,
+                    sdk_dir=self.sdk_dir,
+                    libstd_name=os.path.basename(libstd_paths[0]),
+                    libstd_path=libstd_paths[0],
+                    target_arch=self.triple_to_arch(self.target),
+                )
+            )
+            # `libtest`` was historically a shared library, but now seems to be (sometimes?)
+            # statically linked. If we find it as a shared library, include it in the manifest.
+            if libtest_paths:
                 manifest.write(
-                    self.MANIFEST_TEMPLATE.format(
-                        bin_path=bin_path,
-                        exe_name=exe_name,
-                        package_dir=package_dir,
-                        package_name=package_name,
-                        target=self.target,
-                        sdk_dir=self.sdk_dir,
-                        libstd_name=os.path.basename(libstd_paths[0]),
-                        libstd_path=libstd_paths[0],
-                        target_arch=self.triple_to_arch(self.target),
-                    )
+                    f"lib/{os.path.basename(libtest_paths[0])}={libtest_paths[0]}\n"
                 )
-                # `libtest`` was historically a shared library, but now seems to be (sometimes?)
-                # statically linked. If we find it as a shared library, include it in the manifest.
-                if libtest_paths:
-                    manifest.write(
-                        f"lib/{os.path.basename(libtest_paths[0])}={libtest_paths[0]}\n"
-                    )
-                for shared_lib in shared_libs:
-                    manifest.write(f"lib/{os.path.basename(shared_lib)}={shared_lib}\n")
+            for shared_lib in shared_libs:
+                manifest.write(f"lib/{os.path.basename(shared_lib)}={shared_lib}\n")
 
-            log("Determining API level...")
-            out = self.check_output(
-                [
-                    self.tool_path("ffx"),
-                    "--machine",
-                    "json",
-                    "version",
-                ],
-                env=self.ffx_cmd_env(),
-                stderr=log_file,
-            )
-            api_level = json.loads(out)["tool_version"]["api_level"]
+        runner_logger.info("Determining API level...")
+        out = check_output_with_logging(
+            [
+                self.tool_path("ffx"),
+                "--machine",
+                "json",
+                "version",
+            ],
+            env=self.ffx_cmd_env(),
+            stdout_handler=self.subprocess_logger.debug,
+            stderr_handler=self.subprocess_logger.debug,
+        )
+        api_level = json.loads(out)["tool_version"]["api_level"]
 
-            log("Compiling and archiving manifest...")
+        runner_logger.info("Compiling manifest...")
 
-            self.check_call(
-                [
-                    self.tool_path("ffx"),
-                    "package",
-                    "build",
-                    manifest_path,
-                    "-o",
-                    package_dir,
-                    "--api-level",
-                    str(api_level),
-                ],
-                env=self.ffx_cmd_env(),
-                stdout=log_file,
-                stderr=log_file,
-            )
+        check_call_with_logging(
+            [
+                self.tool_path("ffx"),
+                "package",
+                "build",
+                manifest_path,
+                "-o",
+                package_dir,
+                "--api-level",
+                str(api_level),
+            ],
+            env=self.ffx_cmd_env(),
+            stdout_handler=runner_logger.info,
+            stderr_handler=runner_logger.warning,
+        )
 
-            self.check_call(
-                [
-                    self.tool_path("ffx"),
-                    "package",
-                    "archive",
-                    "create",
-                    "-o",
-                    far_path,
-                    manifest_json_path,
-                ],
-                env=self.ffx_cmd_env(),
-                stdout=log_file,
-                stderr=log_file,
-            )
+        runner_logger.info("Publishing package to repo...")
 
-            log("Publishing package to repo...")
+        # Publish package to repo
+        check_call_with_logging(
+            [
+                self.tool_path("ffx"),
+                "repository",
+                "publish",
+                "--package",
+                os.path.join(package_dir, "package_manifest.json"),
+                self.repo_dir(),
+            ],
+            env=self.ffx_cmd_env(),
+            stdout_handler=runner_logger.info,
+            stderr_handler=runner_logger.warning,
+        )
 
-            # Publish package to repo
-            self.check_call(
-                [
-                    self.tool_path("ffx"),
-                    "repository",
-                    "publish",
-                    "--package",
-                    os.path.join(package_dir, "package_manifest.json"),
-                    self.repo_dir(),
-                ],
-                stdout=log_file,
-                stderr=log_file,
-            )
+        runner_logger.info("Running ffx test...")
 
-            log("Running ffx test...")
+        # Run test on emulator
+        check_call_with_logging(
+            [
+                self.tool_path("ffx"),
+                "test",
+                "run",
+                f"fuchsia-pkg://{self.TEST_REPO_NAME}/{package_name}#meta/{package_name}.cm",
+                "--min-severity-logs",
+                "TRACE",
+                "--output-directory",
+                test_output_dir,
+                "--",
+            ]
+            + arguments,
+            env=self.ffx_cmd_env(),
+            check=False,
+            stdout_handler=runner_logger.info,
+            stderr_handler=runner_logger.warning,
+        )
 
-            # Run test on emulator
-            subprocess.run(
-                [
-                    self.tool_path("ffx"),
-                    "test",
-                    "run",
-                    f"fuchsia-pkg://{self.TEST_REPO_NAME}/{package_name}#meta/{package_name}.cm",
-                    "--min-severity-logs",
-                    "TRACE",
-                    "--output-directory",
-                    test_output_dir,
-                    "--",
-                ]
-                + arguments,
-                env=self.ffx_cmd_env(),
-                check=False,
-                stdout=log_file,
-                stderr=log_file,
-            )
+        runner_logger.info("Reporting test suite output...")
 
-            log("Reporting test suite output...")
+        # Read test suite output
+        run_summary_path = test_output_dir.joinpath("run_summary.json")
+        if not run_summary_path.exists():
+            runner_logger.error("Failed to open test run summary")
+            return 254
 
-            # Read test suite output
-            run_summary_path = os.path.join(test_output_dir, "run_summary.json")
-            if os.path.exists(run_summary_path):
-                with open(run_summary_path, encoding="utf-8") as f:
-                    run_summary = json.loads(f.read())
+        with open(run_summary_path, encoding="utf-8") as f:
+            run_summary = json.load(f)
 
-                suite = run_summary["data"]["suites"][0]
-                case = suite["cases"][0]
+        suite = run_summary["data"]["suites"][0]
+        case = suite["cases"][0]
 
-                return_code = 0 if case["outcome"] == "PASSED" else 1
+        return_code = 0 if case["outcome"] == "PASSED" else 1
 
-                artifacts = case["artifacts"]
-                artifact_dir = case["artifact_dir"]
-                stdout_path = None
-                stderr_path = None
+        artifacts = case["artifacts"]
+        artifact_dir = case["artifact_dir"]
+        stdout_path = None
+        stderr_path = None
 
-                for path, artifact in artifacts.items():
-                    artifact_path = os.path.join(test_output_dir, artifact_dir, path)
-                    artifact_type = artifact["artifact_type"]
+        for path, artifact in artifacts.items():
+            artifact_path = os.path.join(test_output_dir, artifact_dir, path)
+            artifact_type = artifact["artifact_type"]
 
-                    if artifact_type == "STDERR":
-                        stderr_path = artifact_path
-                    elif artifact_type == "STDOUT":
-                        stdout_path = artifact_path
+            if artifact_type == "STDERR":
+                stderr_path = artifact_path
+            elif artifact_type == "STDOUT":
+                stdout_path = artifact_path
 
-                if stdout_path is not None and os.path.exists(stdout_path):
-                    with open(stdout_path, encoding="utf-8") as f:
-                        print(f.read(), file=sys.stdout, end="")
-
-                if stderr_path is not None and os.path.exists(stderr_path):
-                    with open(stderr_path, encoding="utf-8") as f:
-                        print(f.read(), file=sys.stderr, end="")
+        if stdout_path is not None:
+            if not os.path.exists(stdout_path):
+                runner_logger.error(
+                    f"stdout file {stdout_path} does not exist."
+                )
             else:
-                log("Failed to open test run summary")
-                return_code = 254
+                with open(stdout_path, encoding="utf-8", errors="ignore") as f:
+                    runner_logger.info(f.read())
+        if stderr_path is not None:
+            if not os.path.exists(stderr_path):
+                runner_logger.error(
+                    f"stderr file {stderr_path} does not exist."
+                )
+            else:
+                with open(stderr_path, encoding="utf-8", errors="ignore") as f:
+                    runner_logger.error(f.read())
 
-            log("Done!")
-
+        runner_logger.info("Done!")
         return return_code
 
     def stop(self):
@@ -730,65 +951,65 @@ class TestEnvironment:
         During cleanup, this function will stop the emulator, package server, and
         update server, then delete all temporary files. If an error is encountered
         while stopping any running processes, the temporary files will not be deleted.
-        Passing --delete-tmp will force the process to delete the files anyway.
+        Passing --cleanup will force the process to delete the files anyway.
         """
 
-        self.log_debug("Reporting logs...")
+        self.env_logger.debug("Reporting logs...")
 
         # Print test log files
-        for test_dir in os.listdir(self.output_dir()):
-            log_path = os.path.join(self.output_dir(), test_dir, "log")
-            self.log_debug(f"\n---- Logs for test '{test_dir}' ----\n")
+        for test_dir in os.listdir(self.output_dir):
+            log_path = os.path.join(self.output_dir, test_dir, "log")
+            self.env_logger.debug(f"\n---- Logs for test '{test_dir}' ----\n")
             if os.path.exists(log_path):
-                with open(log_path, encoding="utf-8") as log:
-                    self.log_debug(log.read())
+                with open(log_path, encoding="utf-8", errors="ignore") as log:
+                    self.env_logger.debug(log.read())
             else:
-                self.log_debug("No logs found")
+                self.env_logger.debug("No logs found")
 
         # Print the emulator log
-        self.log_debug("\n---- Emulator logs ----\n")
-        if os.path.exists(self.emulator_log_path()):
-            with open(self.emulator_log_path(), encoding="utf-8") as log:
-                self.log_debug(log.read())
+        self.env_logger.debug("\n---- Emulator logs ----\n")
+        if os.path.exists(self.emulator_log_path):
+            with open(self.emulator_log_path, encoding="utf-8") as log:
+                self.env_logger.debug(log.read())
         else:
-            self.log_debug("No emulator logs found")
+            self.env_logger.debug("No emulator logs found")
 
         # Print the package server log
-        self.log_debug("\n---- Package server log ----\n")
-        if os.path.exists(self.package_server_log_path()):
-            with open(self.package_server_log_path(), encoding="utf-8") as log:
-                self.log_debug(log.read())
+        self.env_logger.debug("\n---- Package server log ----\n")
+        if os.path.exists(self.package_server_log_path):
+            with open(self.package_server_log_path, encoding="utf-8") as log:
+                self.env_logger.debug(log.read())
         else:
-            self.log_debug("No package server log found")
+            self.env_logger.debug("No package server log found")
 
         # Print the ffx daemon log
-        self.log_debug("\n---- ffx daemon log ----\n")
-        if os.path.exists(self.ffx_daemon_log_path()):
-            with open(self.ffx_daemon_log_path(), encoding="utf-8") as log:
-                self.log_debug(log.read())
+        self.env_logger.debug("\n---- ffx daemon log ----\n")
+        if os.path.exists(self.ffx_daemon_log_path):
+            with open(self.ffx_daemon_log_path, encoding="utf-8") as log:
+                self.env_logger.debug(log.read())
         else:
-            self.log_debug("No ffx daemon log found")
+            self.env_logger.debug("No ffx daemon log found")
 
         # Shut down the emulator
-        self.log_info("Stopping emulator...")
-        self.check_call(
+        self.env_logger.info("Stopping emulator...")
+        check_call_with_logging(
             [
                 self.tool_path("ffx"),
                 "emu",
                 "stop",
             ],
             env=self.ffx_cmd_env(),
-            stdout=self.subprocess_output(),
-            stderr=self.subprocess_output(),
+            stdout_handler=self.subprocess_logger.debug,
+            stderr_handler=self.subprocess_logger.debug,
         )
 
         # Stop ffx isolation
-        self.log_info("Stopping ffx isolation...")
+        self.env_logger.info("Stopping ffx isolation...")
         self.stop_ffx_isolation()
 
-    def delete_tmp(self):
+    def cleanup(self):
         # Remove temporary files
-        self.log_info("Deleting temporary files...")
+        self.env_logger.info("Deleting temporary files...")
         shutil.rmtree(self.tmp_dir(), ignore_errors=True)
 
     def debug(self, args):
@@ -816,7 +1037,7 @@ class TestEnvironment:
                 f"--symbol-path={self.rust_dir}/lib/rustlib/{self.target}/lib",
             ]
 
-        # Add rust source if it's available
+      # Add rust source if it's available
         rust_src_map = None
         if args.rust_src is not None:
             # This matches the remapped prefix used by compiletest. There's no
@@ -908,21 +1129,24 @@ def start(args):
 
 def run(args):
     test_env = TestEnvironment.read_from_file()
+    test_env.setup_logging(log_to_file=True)
     return test_env.run(args)
 
 
 def stop(args):
     test_env = TestEnvironment.read_from_file()
+    test_env.setup_logging(log_to_file=False)
     test_env.stop()
-    if not args.no_delete:
-        test_env.delete_tmp()
+    if not args.no_cleanup:
+        test_env.cleanup()
     return 0
 
 
-def delete_tmp(args):
+def cleanup(args):
     del args
     test_env = TestEnvironment.read_from_file()
-    test_env.delete_tmp()
+    test_env.setup_logging(log_to_file=False)
+    test_env.cleanup()
     return 0
 
 
@@ -934,6 +1158,7 @@ def debug(args):
 
 def syslog(args):
     test_env = TestEnvironment.read_from_file()
+    test_env.setup_logging(log_to_file=True)
     test_env.syslog(args)
     return 0
 
@@ -973,6 +1198,21 @@ def main():
         help="the target platform to test",
         required=True,
     )
+    start_parser.add_argument(
+        "--toolchain-dir",
+        help="the toolchain directory",
+        required=True,
+    )
+    start_parser.add_argument(
+        "--local-product-bundle-path",
+        help="the path where the product-bundle should be downloaded to",
+    )
+    start_parser.add_argument(
+        "--use-local-product-bundle-if-exists",
+        help="if the product bundle already exists in the local path, use "
+            "it instead of downloading it again",
+        action="store_true",
+    )
     start_parser.set_defaults(func=start)
 
     run_parser = subparsers.add_parser(
@@ -993,18 +1233,23 @@ def main():
         "stop", help="shuts down and cleans up the testing environment"
     )
     stop_parser.add_argument(
-        "--no-delete",
+        "--no-cleanup",
         default=False,
         action="store_true",
         help="don't delete temporary files after stopping",
     )
     stop_parser.set_defaults(func=stop)
 
-    delete_parser = subparsers.add_parser(
-        "delete-tmp",
+    cleanup_parser = subparsers.add_parser(
+        "cleanup",
         help="deletes temporary files after the testing environment has been manually cleaned up",
     )
-    delete_parser.set_defaults(func=delete_tmp)
+    cleanup_parser.set_defaults(func=cleanup)
+
+    syslog_parser = subparsers.add_parser(
+        "syslog", help="prints the device syslog"
+    )
+    syslog_parser.set_defaults(func=syslog)
 
     debug_parser = subparsers.add_parser(
         "debug",
@@ -1032,9 +1277,6 @@ def main():
         help="any additional arguments to pass to zxdb",
     )
     debug_parser.set_defaults(func=debug)
-
-    syslog_parser = subparsers.add_parser("syslog", help="prints the device syslog")
-    syslog_parser.set_defaults(func=syslog)
 
     args = parser.parse_args()
     return args.func(args)

--- a/src/doc/rustc/src/platform-support/apple-ios-macabi.md
+++ b/src/doc/rustc/src/platform-support/apple-ios-macabi.md
@@ -9,6 +9,8 @@ Apple Mac Catalyst targets.
 
 ## Target maintainers
 
+- [@badboy](https://github.com/badboy)
+- [@BlackHoleFox](https://github.com/BlackHoleFox)
 - [@madsmtm](https://github.com/madsmtm)
 
 ## Requirements

--- a/tests/rustdoc-ui/doctest/auxiliary/pub_trait.rs
+++ b/tests/rustdoc-ui/doctest/auxiliary/pub_trait.rs
@@ -1,0 +1,1 @@
+pub trait Trait {}

--- a/tests/rustdoc-ui/doctest/non-local-defs-impl.rs
+++ b/tests/rustdoc-ui/doctest/non-local-defs-impl.rs
@@ -1,0 +1,31 @@
+//@ check-fail
+//@ edition:2018
+//@ failure-status: 101
+//@ aux-build:pub_trait.rs
+//@ compile-flags: --test --test-args --test-threads=1
+//@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+#![doc(test(attr(deny(non_local_definitions))))]
+#![doc(test(attr(allow(dead_code))))]
+
+/// This will produce a warning:
+/// ```rust,no_run
+/// # extern crate pub_trait;
+/// # use pub_trait::Trait;
+///
+/// struct Local;
+/// impl Trait for &Local {}
+/// ```
+///
+/// But this shoudln't produce a warning:
+/// ```rust,no_run
+/// # extern crate pub_trait;
+/// # use pub_trait::Trait;
+///
+/// struct Local;
+/// impl Trait for &Local {}
+///
+/// # fn main() {}
+/// ```
+pub fn doctest() {}

--- a/tests/rustdoc-ui/doctest/non-local-defs-impl.stdout
+++ b/tests/rustdoc-ui/doctest/non-local-defs-impl.stdout
@@ -1,0 +1,37 @@
+
+running 2 tests
+test $DIR/non-local-defs-impl.rs - doctest (line 13) - compile ... FAILED
+test $DIR/non-local-defs-impl.rs - doctest (line 22) - compile ... ok
+
+failures:
+
+---- $DIR/non-local-defs-impl.rs - doctest (line 13) stdout ----
+error: non-local `impl` definition, `impl` blocks should be written at the same level as their item
+  --> $DIR/non-local-defs-impl.rs:18:1
+   |
+LL | impl Trait for &Local {}
+   | ^^^^^-----^^^^^------
+   |      |         |
+   |      |         `&'_ Local` is not local
+   |      |         help: remove `&` to make the `impl` local
+   |      `Trait` is not local
+   |
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+   = help: make this doc-test a standalone test with its own `fn main() { ... }`
+   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
+note: the lint level is defined here
+  --> $DIR/non-local-defs-impl.rs:11:9
+   |
+LL | #![deny(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+
+failures:
+    $DIR/non-local-defs-impl.rs - doctest (line 13)
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/ui/async-await/async-closures/wrong-fn-kind.stderr
+++ b/tests/ui/async-await/async-closures/wrong-fn-kind.stderr
@@ -20,15 +20,16 @@ LL | fn needs_async_fn(_: impl async Fn()) {}
    |                           ^^^^^^^^^^ required by this bound in `needs_async_fn`
 
 error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
-  --> $DIR/wrong-fn-kind.rs:9:29
+  --> $DIR/wrong-fn-kind.rs:9:20
    |
 LL |   fn needs_async_fn(_: impl async Fn()) {}
    |                        --------------- change this to accept `FnMut` instead of `Fn`
 ...
 LL |       needs_async_fn(async || {
-   |  _____--------------_--------_^
-   | |     |              |
-   | |     |              in this closure
+   |       -------------- ^-------
+   |       |              |
+   |  _____|______________in this closure
+   | |     |
    | |     expects `Fn` instead of `FnMut`
 LL | |
 LL | |         x += 1;

--- a/tests/ui/coroutine/break-inside-coroutine-issue-124495.rs
+++ b/tests/ui/coroutine/break-inside-coroutine-issue-124495.rs
@@ -18,6 +18,7 @@ async gen fn async_gen_fn() {
 
 fn main() {
     let _ = async { break; }; //~ ERROR `break` inside `async` block
+
     let _ = async || { break; }; //~ ERROR `break` inside `async` closure
 
     let _ = gen { break; }; //~ ERROR `break` inside `gen` block

--- a/tests/ui/coroutine/break-inside-coroutine-issue-124495.stderr
+++ b/tests/ui/coroutine/break-inside-coroutine-issue-124495.stderr
@@ -38,16 +38,16 @@ LL |     let _ = async { break; };
    |             enclosing `async` block
 
 error[E0267]: `break` inside `async` closure
-  --> $DIR/break-inside-coroutine-issue-124495.rs:21:24
+  --> $DIR/break-inside-coroutine-issue-124495.rs:22:24
    |
 LL |     let _ = async || { break; };
-   |                      --^^^^^---
-   |                      | |
-   |                      | cannot `break` inside `async` closure
-   |                      enclosing `async` closure
+   |             -----------^^^^^---
+   |             |          |
+   |             |          cannot `break` inside `async` closure
+   |             enclosing `async` closure
 
 error[E0267]: `break` inside `gen` block
-  --> $DIR/break-inside-coroutine-issue-124495.rs:23:19
+  --> $DIR/break-inside-coroutine-issue-124495.rs:24:19
    |
 LL |     let _ = gen { break; };
    |             ------^^^^^---
@@ -56,7 +56,7 @@ LL |     let _ = gen { break; };
    |             enclosing `gen` block
 
 error[E0267]: `break` inside `async gen` block
-  --> $DIR/break-inside-coroutine-issue-124495.rs:25:25
+  --> $DIR/break-inside-coroutine-issue-124495.rs:26:25
    |
 LL |     let _ = async gen { break; };
    |             ------------^^^^^---

--- a/tests/ui/delegation/body-identity-glob.rs
+++ b/tests/ui/delegation/body-identity-glob.rs
@@ -1,0 +1,32 @@
+//@ check-pass
+
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    fn foo(&self) {}
+    fn bar(&self) {}
+}
+
+impl Trait for u8 {}
+
+struct S(u8);
+
+mod to_import {
+    pub fn check(arg: &u8) -> &u8 { arg }
+}
+
+impl Trait for S {
+    reuse Trait::* {
+        use to_import::check;
+
+        let _arr = Some(self.0).map(|x| [x * 2; 3]);
+        check(&self.0)
+    }
+}
+
+fn main() {
+    let s = S(0);
+    s.foo();
+    s.bar();
+}

--- a/tests/ui/delegation/empty-glob.rs
+++ b/tests/ui/delegation/empty-glob.rs
@@ -1,0 +1,11 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {}
+
+struct S;
+impl S {
+    reuse Trait::*; //~ ERROR empty glob delegation is not supported
+}
+
+fn main() {}

--- a/tests/ui/delegation/empty-glob.stderr
+++ b/tests/ui/delegation/empty-glob.stderr
@@ -1,0 +1,8 @@
+error: empty glob delegation is not supported
+  --> $DIR/empty-glob.rs:8:5
+   |
+LL |     reuse Trait::*;
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/delegation/glob-bad-path.rs
+++ b/tests/ui/delegation/glob-bad-path.rs
@@ -1,0 +1,12 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {}
+struct S;
+
+impl Trait for u8 {
+    reuse unresolved::*; //~ ERROR failed to resolve: use of undeclared crate or module `unresolved`
+    reuse S::*; //~ ERROR expected trait, found struct `S`
+}
+
+fn main() {}

--- a/tests/ui/delegation/glob-bad-path.stderr
+++ b/tests/ui/delegation/glob-bad-path.stderr
@@ -1,0 +1,15 @@
+error: expected trait, found struct `S`
+  --> $DIR/glob-bad-path.rs:9:11
+   |
+LL |     reuse S::*;
+   |           ^ not a trait
+
+error[E0433]: failed to resolve: use of undeclared crate or module `unresolved`
+  --> $DIR/glob-bad-path.rs:8:11
+   |
+LL |     reuse unresolved::*;
+   |           ^^^^^^^^^^ use of undeclared crate or module `unresolved`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/delegation/glob-glob-conflict.rs
+++ b/tests/ui/delegation/glob-glob-conflict.rs
@@ -1,0 +1,33 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait1 {
+    fn method(&self) -> u8;
+}
+trait Trait2 {
+    fn method(&self) -> u8;
+}
+trait Trait {
+    fn method(&self) -> u8;
+}
+
+impl Trait1 for u8 {
+    fn method(&self) -> u8 { 0 }
+}
+impl Trait1 for u16 {
+    fn method(&self) -> u8 { 1 }
+}
+impl Trait2 for u8 {
+    fn method(&self) -> u8 { 2 }
+}
+
+impl Trait for u8 {
+    reuse Trait1::*;
+    reuse Trait2::*; //~ ERROR duplicate definitions with name `method`
+}
+impl Trait for u16 {
+    reuse Trait1::*;
+    reuse Trait1::*; //~ ERROR duplicate definitions with name `method`
+}
+
+fn main() {}

--- a/tests/ui/delegation/glob-glob-conflict.stderr
+++ b/tests/ui/delegation/glob-glob-conflict.stderr
@@ -1,0 +1,25 @@
+error[E0201]: duplicate definitions with name `method`:
+  --> $DIR/glob-glob-conflict.rs:26:5
+   |
+LL |     fn method(&self) -> u8;
+   |     ----------------------- item in trait
+...
+LL |     reuse Trait1::*;
+   |     ---------------- previous definition here
+LL |     reuse Trait2::*;
+   |     ^^^^^^^^^^^^^^^^ duplicate definition
+
+error[E0201]: duplicate definitions with name `method`:
+  --> $DIR/glob-glob-conflict.rs:30:5
+   |
+LL |     fn method(&self) -> u8;
+   |     ----------------------- item in trait
+...
+LL |     reuse Trait1::*;
+   |     ---------------- previous definition here
+LL |     reuse Trait1::*;
+   |     ^^^^^^^^^^^^^^^^ duplicate definition
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0201`.

--- a/tests/ui/delegation/glob-glob.rs
+++ b/tests/ui/delegation/glob-glob.rs
@@ -1,0 +1,36 @@
+//@ check-pass
+
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+mod inner {
+    pub trait TraitFoo {
+        fn foo(&self) -> u8;
+    }
+    pub trait TraitBar {
+        fn bar(&self) -> u8;
+    }
+
+    impl TraitFoo for u8 {
+        fn foo(&self) -> u8 { 0 }
+    }
+    impl TraitBar for u8 {
+        fn bar(&self) -> u8 { 1 }
+    }
+}
+
+trait Trait {
+    fn foo(&self) -> u8;
+    fn bar(&self) -> u8;
+}
+
+impl Trait for u8 {
+    reuse inner::TraitFoo::*;
+    reuse inner::TraitBar::*;
+}
+
+fn main() {
+    let u = 0u8;
+    u.foo();
+    u.bar();
+}

--- a/tests/ui/delegation/glob-non-fn.rs
+++ b/tests/ui/delegation/glob-non-fn.rs
@@ -1,0 +1,38 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    fn method(&self);
+    const CONST: u8;
+    type Type;
+    #[allow(non_camel_case_types)]
+    type method;
+}
+
+impl Trait for u8 {
+    fn method(&self) {}
+    const CONST: u8 = 0;
+    type Type = u8;
+    type method = u8;
+}
+
+struct Good(u8);
+impl Trait for Good {
+    reuse Trait::* { &self.0 }
+    // Explicit definitions for non-delegatable items.
+    const CONST: u8 = 0;
+    type Type = u8;
+    type method = u8;
+}
+
+struct Bad(u8);
+impl Trait for Bad { //~ ERROR not all trait items implemented, missing: `CONST`, `Type`, `method`
+    reuse Trait::* { &self.0 }
+    //~^ ERROR item `CONST` is an associated method, which doesn't match its trait `Trait`
+    //~| ERROR item `Type` is an associated method, which doesn't match its trait `Trait`
+    //~| ERROR duplicate definitions with name `method`
+    //~| ERROR expected function, found associated constant `Trait::CONST`
+    //~| ERROR expected function, found associated type `Trait::Type`
+}
+
+fn main() {}

--- a/tests/ui/delegation/glob-non-fn.stderr
+++ b/tests/ui/delegation/glob-non-fn.stderr
@@ -1,0 +1,62 @@
+error[E0324]: item `CONST` is an associated method, which doesn't match its trait `Trait`
+  --> $DIR/glob-non-fn.rs:30:5
+   |
+LL |     const CONST: u8;
+   |     ---------------- item in trait
+...
+LL |     reuse Trait::* { &self.0 }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ does not match trait
+
+error[E0324]: item `Type` is an associated method, which doesn't match its trait `Trait`
+  --> $DIR/glob-non-fn.rs:30:5
+   |
+LL |     type Type;
+   |     ---------- item in trait
+...
+LL |     reuse Trait::* { &self.0 }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ does not match trait
+
+error[E0201]: duplicate definitions with name `method`:
+  --> $DIR/glob-non-fn.rs:30:5
+   |
+LL |     fn method(&self);
+   |     ----------------- item in trait
+...
+LL |     reuse Trait::* { &self.0 }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     duplicate definition
+   |     previous definition here
+
+error[E0423]: expected function, found associated constant `Trait::CONST`
+  --> $DIR/glob-non-fn.rs:30:11
+   |
+LL |     reuse Trait::* { &self.0 }
+   |           ^^^^^ not a function
+
+error[E0423]: expected function, found associated type `Trait::Type`
+  --> $DIR/glob-non-fn.rs:30:11
+   |
+LL |     reuse Trait::* { &self.0 }
+   |           ^^^^^
+   |
+   = note: can't use a type alias as a constructor
+
+error[E0046]: not all trait items implemented, missing: `CONST`, `Type`, `method`
+  --> $DIR/glob-non-fn.rs:29:1
+   |
+LL |     const CONST: u8;
+   |     --------------- `CONST` from trait
+LL |     type Type;
+   |     --------- `Type` from trait
+LL |     #[allow(non_camel_case_types)]
+LL |     type method;
+   |     ----------- `method` from trait
+...
+LL | impl Trait for Bad {
+   | ^^^^^^^^^^^^^^^^^^ missing `CONST`, `Type`, `method` in implementation
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0046, E0201, E0324, E0423.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/delegation/glob-non-impl.rs
+++ b/tests/ui/delegation/glob-non-impl.rs
@@ -1,0 +1,20 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    fn method() {}
+}
+
+reuse Trait::*; //~ ERROR glob delegation is only supported in impls
+
+trait OtherTrait {
+    reuse Trait::*; //~ ERROR glob delegation is only supported in impls
+}
+
+extern {
+    reuse Trait::*; //~ ERROR delegation is not supported in `extern` blocks
+}
+
+fn main() {
+    reuse Trait::*; //~ ERROR glob delegation is only supported in impls
+}

--- a/tests/ui/delegation/glob-non-impl.stderr
+++ b/tests/ui/delegation/glob-non-impl.stderr
@@ -1,0 +1,26 @@
+error: delegation is not supported in `extern` blocks
+  --> $DIR/glob-non-impl.rs:15:5
+   |
+LL |     reuse Trait::*;
+   |     ^^^^^^^^^^^^^^^
+
+error: glob delegation is only supported in impls
+  --> $DIR/glob-non-impl.rs:8:1
+   |
+LL | reuse Trait::*;
+   | ^^^^^^^^^^^^^^^
+
+error: glob delegation is only supported in impls
+  --> $DIR/glob-non-impl.rs:11:5
+   |
+LL |     reuse Trait::*;
+   |     ^^^^^^^^^^^^^^^
+
+error: glob delegation is only supported in impls
+  --> $DIR/glob-non-impl.rs:19:5
+   |
+LL |     reuse Trait::*;
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/delegation/glob-override.rs
+++ b/tests/ui/delegation/glob-override.rs
@@ -1,0 +1,37 @@
+//@ check-pass
+
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    fn foo(&self) -> u8;
+    fn bar(&self) -> u8;
+}
+
+impl Trait for u8 {
+    fn foo(&self) -> u8 { 0 }
+    fn bar(&self) -> u8 { 1 }
+}
+
+struct S(u8);
+struct Z(u8);
+
+impl Trait for S {
+    reuse Trait::* { &self.0 }
+    fn bar(&self) -> u8 { 2 }
+}
+
+impl Trait for Z {
+    reuse Trait::* { &self.0 }
+    reuse Trait::bar { &self.0 }
+}
+
+fn main() {
+    let s = S(2);
+    s.foo();
+    s.bar();
+
+    let z = Z(2);
+    z.foo();
+    z.bar();
+}

--- a/tests/ui/delegation/glob.rs
+++ b/tests/ui/delegation/glob.rs
@@ -4,23 +4,32 @@
 #![allow(incomplete_features)]
 
 trait Trait {
+    fn foo(&self) -> u8;
+    fn bar(&self) -> u8;
+}
+
+impl Trait for u8 {
     fn foo(&self) -> u8 { 0 }
     fn bar(&self) -> u8 { 1 }
 }
 
-impl Trait for u8 {}
-
 struct S(u8);
+struct Z(u8);
 
-// Macro expansion works inside delegation items.
-macro_rules! u8 { () => { u8 } }
-macro_rules! self_0 { ($self:ident) => { &$self.0 } }
 impl Trait for S {
-    reuse <u8!() as Trait>::{foo, bar} { self_0!(self) }
+    reuse Trait::* { &self.0 }
+}
+
+impl Trait for Z {
+    reuse <u8 as Trait>::* { &self.0 }
 }
 
 fn main() {
     let s = S(2);
     s.foo();
     s.bar();
+
+    let z = Z(3);
+    z.foo();
+    z.bar();
 }

--- a/tests/ui/delegation/macro-inside-glob.rs
+++ b/tests/ui/delegation/macro-inside-glob.rs
@@ -16,7 +16,7 @@ struct S(u8);
 macro_rules! u8 { () => { u8 } }
 macro_rules! self_0 { ($self:ident) => { &$self.0 } }
 impl Trait for S {
-    reuse <u8!() as Trait>::{foo, bar} { self_0!(self) }
+    reuse <u8!() as Trait>::* { self_0!(self) }
 }
 
 fn main() {

--- a/tests/ui/drop/auxiliary/edition-2021-macros.rs
+++ b/tests/ui/drop/auxiliary/edition-2021-macros.rs
@@ -1,0 +1,8 @@
+//@ edition:2021
+
+#[macro_export]
+macro_rules! edition_2021_block {
+    ($($c:tt)*) => {
+        { $($c)* }
+    }
+}

--- a/tests/ui/drop/auxiliary/edition-2024-macros.rs
+++ b/tests/ui/drop/auxiliary/edition-2024-macros.rs
@@ -1,0 +1,9 @@
+//@ edition:2024
+//@ compile-flags: -Zunstable-options
+
+#[macro_export]
+macro_rules! edition_2024_block {
+    ($($c:tt)*) => {
+        { $($c)* }
+    }
+}

--- a/tests/ui/drop/tail-expr-drop-order-negative.edition2024.stderr
+++ b/tests/ui/drop/tail-expr-drop-order-negative.edition2024.stderr
@@ -1,0 +1,16 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/tail-expr-drop-order-negative.rs:11:15
+   |
+LL |     x.replace(std::cell::RefCell::new(123).borrow()).is_some()
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                   - temporary value is freed at the end of this statement
+   |               |
+   |               creates a temporary value which is freed while still in use
+LL |
+LL | }
+   | - borrow might be used here, when `x` is dropped and runs the destructor for type `Option<Ref<'_, i32>>`
+   |
+   = note: consider using a `let` binding to create a longer lived value
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/drop/tail-expr-drop-order-negative.rs
+++ b/tests/ui/drop/tail-expr-drop-order-negative.rs
@@ -1,0 +1,17 @@
+//@ revisions: edition2021 edition2024
+//@ [edition2024] compile-flags: -Zunstable-options
+//@ [edition2024] edition: 2024
+//@ [edition2021] check-pass
+
+#![feature(shorter_tail_lifetimes)]
+
+fn why_would_you_do_this() -> bool {
+    let mut x = None;
+    // Make a temporary `RefCell` and put a `Ref` that borrows it in `x`.
+    x.replace(std::cell::RefCell::new(123).borrow()).is_some()
+    //[edition2024]~^ ERROR: temporary value dropped while borrowed
+}
+
+fn main() {
+    why_would_you_do_this();
+}

--- a/tests/ui/drop/tail-expr-drop-order.rs
+++ b/tests/ui/drop/tail-expr-drop-order.rs
@@ -1,0 +1,108 @@
+//@ aux-build:edition-2021-macros.rs
+//@ aux-build:edition-2024-macros.rs
+//@ compile-flags: -Z validate-mir -Zunstable-options
+//@ edition: 2024
+//@ run-pass
+
+#![feature(shorter_tail_lifetimes)]
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+#[macro_use]
+extern crate edition_2021_macros;
+#[macro_use]
+extern crate edition_2024_macros;
+use std::cell::RefCell;
+use std::convert::TryInto;
+
+#[derive(Default)]
+struct DropOrderCollector(RefCell<Vec<u32>>);
+
+struct LoudDrop<'a>(&'a DropOrderCollector, u32);
+
+impl Drop for LoudDrop<'_> {
+    fn drop(&mut self) {
+        println!("{}", self.1);
+        self.0.0.borrow_mut().push(self.1);
+    }
+}
+
+impl DropOrderCollector {
+    fn option_loud_drop(&self, n: u32) -> Option<LoudDrop> {
+        Some(LoudDrop(self, n))
+    }
+
+    fn loud_drop(&self, n: u32) -> LoudDrop {
+        LoudDrop(self, n)
+    }
+
+    fn assert_sorted(&self, expected: usize) {
+        let result = self.0.borrow();
+        assert_eq!(result.len(), expected);
+        for i in 1..result.len() {
+            assert!(
+                result[i - 1] < result[i],
+                "inversion at {} ({} followed by {})",
+                i - 1,
+                result[i - 1],
+                result[i]
+            );
+        }
+    }
+}
+
+fn edition_2021_around_2021() {
+    let c = DropOrderCollector::default();
+    let _ = edition_2021_block! {
+        let a = c.loud_drop(1);
+        edition_2021_block! {
+            let b = c.loud_drop(0);
+            c.loud_drop(2).1
+        }
+    };
+    c.assert_sorted(3);
+}
+
+fn edition_2021_around_2024() {
+    let c = DropOrderCollector::default();
+    let _ = edition_2021_block! {
+        let a = c.loud_drop(2);
+        edition_2024_block! {
+            let b = c.loud_drop(1);
+            c.loud_drop(0).1
+        }
+    };
+    c.assert_sorted(3);
+}
+
+fn edition_2024_around_2021() {
+    let c = DropOrderCollector::default();
+    let _ = edition_2024_block! {
+        let a = c.loud_drop(2);
+        edition_2021_block! {
+            let b = c.loud_drop(0);
+            c.loud_drop(1).1
+        }
+    };
+    c.assert_sorted(3);
+}
+
+fn edition_2024_around_2024() {
+    let c = DropOrderCollector::default();
+    let _ = edition_2024_block! {
+        let a = c.loud_drop(2);
+        edition_2024_block! {
+            let b = c.loud_drop(1);
+            c.loud_drop(0).1
+        }
+    };
+    c.assert_sorted(3);
+}
+
+fn main() {
+    edition_2021_around_2021();
+    edition_2021_around_2024();
+    edition_2024_around_2021();
+    edition_2024_around_2024();
+}

--- a/tests/ui/feature-gates/feature-gate-shorter_tail_lifetimes.rs
+++ b/tests/ui/feature-gates/feature-gate-shorter_tail_lifetimes.rs
@@ -1,0 +1,8 @@
+fn f() -> usize {
+    let c = std::cell::RefCell::new("..");
+    c.borrow().len() //~ ERROR: `c` does not live long enough
+}
+
+fn main() {
+    let _ = f();
+}

--- a/tests/ui/feature-gates/feature-gate-shorter_tail_lifetimes.stderr
+++ b/tests/ui/feature-gates/feature-gate-shorter_tail_lifetimes.stderr
@@ -1,0 +1,26 @@
+error[E0597]: `c` does not live long enough
+  --> $DIR/feature-gate-shorter_tail_lifetimes.rs:3:5
+   |
+LL |     let c = std::cell::RefCell::new("..");
+   |         - binding `c` declared here
+LL |     c.borrow().len()
+   |     ^---------
+   |     |
+   |     borrowed value does not live long enough
+   |     a temporary with access to the borrow is created here ...
+LL | }
+   | -
+   | |
+   | `c` dropped here while still borrowed
+   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, &str>`
+   |
+   = note: the temporary is part of an expression at the end of a block;
+           consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
+help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
+   |
+LL |     let x = c.borrow().len(); x
+   |     +++++++                 +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/lifetimes/refcell-in-tail-expr.edition2021.stderr
+++ b/tests/ui/lifetimes/refcell-in-tail-expr.edition2021.stderr
@@ -1,0 +1,26 @@
+error[E0597]: `cell` does not live long enough
+  --> $DIR/refcell-in-tail-expr.rs:12:27
+   |
+LL |     let cell = std::cell::RefCell::new(0u8);
+   |         ---- binding `cell` declared here
+LL |
+LL |     if let Ok(mut byte) = cell.try_borrow_mut() {
+   |                           ^^^^-----------------
+   |                           |
+   |                           borrowed value does not live long enough
+   |                           a temporary with access to the borrow is created here ...
+...
+LL | }
+   | -
+   | |
+   | `cell` dropped here while still borrowed
+   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Result<RefMut<'_, u8>, BorrowMutError>`
+   |
+help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
+   |
+LL |     };
+   |      +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/lifetimes/refcell-in-tail-expr.rs
+++ b/tests/ui/lifetimes/refcell-in-tail-expr.rs
@@ -1,0 +1,16 @@
+//@ revisions: edition2021 edition2024
+//@ [edition2021] edition: 2021
+//@ [edition2024] edition: 2024
+//@ [edition2024] compile-flags: -Zunstable-options
+//@ [edition2024] check-pass
+
+#![cfg_attr(edition2024, feature(shorter_tail_lifetimes))]
+
+fn main() {
+    let cell = std::cell::RefCell::new(0u8);
+
+    if let Ok(mut byte) = cell.try_borrow_mut() {
+        //[edition2021]~^ ERROR: `cell` does not live long enough
+        *byte = 1;
+    }
+}

--- a/tests/ui/lifetimes/shorter-tail-expr-lifetime.edition2021.stderr
+++ b/tests/ui/lifetimes/shorter-tail-expr-lifetime.edition2021.stderr
@@ -1,0 +1,26 @@
+error[E0597]: `c` does not live long enough
+  --> $DIR/shorter-tail-expr-lifetime.rs:10:5
+   |
+LL |     let c = std::cell::RefCell::new("..");
+   |         - binding `c` declared here
+LL |     c.borrow().len()
+   |     ^---------
+   |     |
+   |     borrowed value does not live long enough
+   |     a temporary with access to the borrow is created here ...
+LL | }
+   | -
+   | |
+   | `c` dropped here while still borrowed
+   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, &str>`
+   |
+   = note: the temporary is part of an expression at the end of a block;
+           consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
+help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
+   |
+LL |     let x = c.borrow().len(); x
+   |     +++++++                 +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/lifetimes/shorter-tail-expr-lifetime.rs
+++ b/tests/ui/lifetimes/shorter-tail-expr-lifetime.rs
@@ -1,0 +1,15 @@
+//@ revisions: edition2021 edition2024
+//@ [edition2024] compile-flags: -Zunstable-options
+//@ [edition2024] edition: 2024
+//@ [edition2024] run-pass
+
+#![cfg_attr(edition2024, feature(shorter_tail_lifetimes))]
+
+fn f() -> usize {
+    let c = std::cell::RefCell::new("..");
+    c.borrow().len() //[edition2021]~ ERROR: `c` does not live long enough
+}
+
+fn main() {
+    let _ = f();
+}

--- a/tests/ui/lifetimes/tail-expr-in-nested-expr.rs
+++ b/tests/ui/lifetimes/tail-expr-in-nested-expr.rs
@@ -1,0 +1,9 @@
+//@ edition: 2024
+//@ compile-flags: -Zunstable-options
+
+#![feature(shorter_tail_lifetimes)]
+
+fn main() {
+    let _ = { String::new().as_str() }.len();
+    //~^ ERROR temporary value dropped while borrowed
+}

--- a/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
+++ b/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
@@ -1,0 +1,15 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/tail-expr-in-nested-expr.rs:7:15
+   |
+LL |     let _ = { String::new().as_str() }.len();
+   |               ^^^^^^^^^^^^^---------
+   |               |                    |
+   |               |                    temporary value is freed at the end of this statement
+   |               creates a temporary value which is freed while still in use
+   |               borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/lifetimes/tail-expr-lock-poisoning.rs
+++ b/tests/ui/lifetimes/tail-expr-lock-poisoning.rs
@@ -1,0 +1,29 @@
+//@ revisions: edition2021 edition2024
+//@ ignore-wasm no panic or subprocess support
+//@ [edition2024] compile-flags: -Zunstable-options
+//@ [edition2024] edition: 2024
+//@ run-pass
+#![cfg_attr(edition2024, feature(shorter_tail_lifetimes))]
+
+use std::sync::Mutex;
+
+struct PanicOnDrop;
+impl Drop for PanicOnDrop {
+    fn drop(&mut self) {
+        panic!()
+    }
+}
+
+fn f(m: &Mutex<i32>) -> i32 {
+    let _x = PanicOnDrop;
+    *m.lock().unwrap()
+}
+
+fn main() {
+    let m = Mutex::new(0);
+    let _ = std::panic::catch_unwind(|| f(&m));
+    #[cfg(edition2024)]
+    assert!(m.lock().is_ok());
+    #[cfg(edition2021)]
+    assert!(m.lock().is_err());
+}

--- a/tests/ui/nll/issue-52534-1.rs
+++ b/tests/ui/nll/issue-52534-1.rs
@@ -17,14 +17,14 @@ fn foo(x: &u32) -> &u32 {
 fn baz(x: &u32) -> &&u32 {
     let x = 22;
     &&x
-//~^ ERROR cannot return value referencing local variable
+//~^ ERROR cannot return value referencing local variable `x`
 //~| ERROR cannot return reference to temporary value
 }
 
 fn foobazbar<'a>(x: u32, y: &'a u32) -> &'a u32 {
     let x = 22;
     &x
-//~^ ERROR cannot return reference to local variable
+//~^ ERROR cannot return reference to local variable `x`
 }
 
 fn foobar<'a>(x: &'a u32) -> &'a u32 {

--- a/tests/ui/return/return-ty-mismatch-note.rs
+++ b/tests/ui/return/return-ty-mismatch-note.rs
@@ -1,4 +1,5 @@
-// Checks existence of a note for "a caller chooses ty for ty param" upon return ty mismatch.
+// Checks existence or absence of a note for "a caller chooses ty for ty param" upon return ty
+// mismatch.
 
 fn f<T>() -> (T,) {
     (0,) //~ ERROR mismatched types
@@ -12,6 +13,14 @@ fn g<U, V>() -> (U, V) {
 
 fn h() -> u8 {
     0u8
+}
+
+// This case was reported in <https://github.com/rust-lang/rust/issues/126547> where it doesn't
+// make sense to make the "note caller chooses ty for ty param" note if the found type contains
+// the ty param...
+fn k<T>(_t: &T) -> T {
+    _t
+    //~^ ERROR mismatched types
 }
 
 fn main() {

--- a/tests/ui/return/return-ty-mismatch-note.stderr
+++ b/tests/ui/return/return-ty-mismatch-note.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/return-ty-mismatch-note.rs:4:6
+  --> $DIR/return-ty-mismatch-note.rs:5:6
    |
 LL | fn f<T>() -> (T,) {
    |      - expected this type parameter
@@ -10,7 +10,7 @@ LL |     (0,)
                         found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/return-ty-mismatch-note.rs:8:6
+  --> $DIR/return-ty-mismatch-note.rs:9:6
    |
 LL | fn g<U, V>() -> (U, V) {
    |      - expected this type parameter
@@ -21,7 +21,7 @@ LL |     (0, "foo")
                         found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/return-ty-mismatch-note.rs:8:9
+  --> $DIR/return-ty-mismatch-note.rs:9:9
    |
 LL | fn g<U, V>() -> (U, V) {
    |         - expected this type parameter
@@ -31,6 +31,19 @@ LL |     (0, "foo")
    = note: expected type parameter `V`
                    found reference `&'static str`
 
-error: aborting due to 3 previous errors
+error[E0308]: mismatched types
+  --> $DIR/return-ty-mismatch-note.rs:22:5
+   |
+LL | fn k<T>(_t: &T) -> T {
+   |      -             - expected `T` because of return type
+   |      |
+   |      expected this type parameter
+LL |     _t
+   |     ^^ expected type parameter `T`, found `&T`
+   |
+   = note: expected type parameter `_`
+                   found reference `&_`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
+++ b/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
@@ -10,7 +10,6 @@ LL |     t.clone()
    |
    = note: expected type parameter `_`
                    found reference `&_`
-   = note: the caller chooses a type for `T` which can be different from `&T`
 note: `T` does not implement `Clone`, so `&T` was cloned instead
   --> $DIR/clone-on-unconstrained-borrowed-type-param.rs:3:5
    |

--- a/tests/ui/transmutability/enums/uninhabited_optimization.rs
+++ b/tests/ui/transmutability/enums/uninhabited_optimization.rs
@@ -19,8 +19,14 @@ enum SingleUninhabited {
     Y(Uninhabited),
 }
 
+enum MultipleUninhabited {
+    X(u8, Uninhabited),
+    Y(Uninhabited, u16),
+}
+
 fn main() {
     assert_transmutable::<Uninhabited>();
     assert_transmutable::<SingleInhabited>();
     assert_transmutable::<SingleUninhabited>();
+    assert_transmutable::<MultipleUninhabited>();
 }

--- a/tests/ui/transmutability/uninhabited.rs
+++ b/tests/ui/transmutability/uninhabited.rs
@@ -30,10 +30,32 @@ fn void() {
 }
 
 // Non-ZST uninhabited types are, nonetheless, uninhabited.
-fn yawning_void() {
+fn yawning_void_struct() {
     enum Void {}
 
     struct YawningVoid(Void, u128);
+
+    const _: () = {
+        assert!(std::mem::size_of::<YawningVoid>() == std::mem::size_of::<u128>());
+        // Just to be sure the above constant actually evaluated:
+        assert!(false); //~ ERROR: evaluation of constant value failed
+    };
+
+    // This transmutation is vacuously acceptable; since one cannot construct a
+    // `Void`, unsoundness cannot directly arise from transmuting a void into
+    // anything else.
+    assert::is_maybe_transmutable::<YawningVoid, u128>();
+
+    assert::is_maybe_transmutable::<(), Void>(); //~ ERROR: cannot be safely transmuted
+}
+
+// Non-ZST uninhabited types are, nonetheless, uninhabited.
+fn yawning_void_enum() {
+    enum Void {}
+
+    enum YawningVoid {
+        A(Void, u128),
+    }
 
     const _: () = {
         assert!(std::mem::size_of::<YawningVoid>() == std::mem::size_of::<u128>());

--- a/tests/ui/transmutability/uninhabited.stderr
+++ b/tests/ui/transmutability/uninhabited.stderr
@@ -7,10 +7,18 @@ LL |         assert!(false);
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/uninhabited.rs:65:9
+  --> $DIR/uninhabited.rs:63:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:65:9
+   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:63:9
+   |
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/uninhabited.rs:87:9
+   |
+LL |         assert!(false);
+   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:87:9
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -36,11 +44,33 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error[E0277]: `()` cannot be safely transmuted into `yawning_void::Void`
+error[E0277]: `()` cannot be safely transmuted into `yawning_void_struct::Void`
   --> $DIR/uninhabited.rs:49:41
    |
 LL |     assert::is_maybe_transmutable::<(), Void>();
-   |                                         ^^^^ `yawning_void::Void` is uninhabited
+   |                                         ^^^^ `yawning_void_struct::Void` is uninhabited
+   |
+note: required by a bound in `is_maybe_transmutable`
+  --> $DIR/uninhabited.rs:10:14
+   |
+LL |       pub fn is_maybe_transmutable<Src, Dst>()
+   |              --------------------- required by a bound in this function
+LL |       where
+LL |           Dst: BikeshedIntrinsicFrom<Src, {
+   |  ______________^
+LL | |             Assume {
+LL | |                 alignment: true,
+LL | |                 lifetimes: true,
+...  |
+LL | |             }
+LL | |         }>
+   | |__________^ required by this bound in `is_maybe_transmutable`
+
+error[E0277]: `()` cannot be safely transmuted into `yawning_void_enum::Void`
+  --> $DIR/uninhabited.rs:71:41
+   |
+LL |     assert::is_maybe_transmutable::<(), Void>();
+   |                                         ^^^^ `yawning_void_enum::Void` is uninhabited
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/uninhabited.rs:10:14
@@ -59,7 +89,7 @@ LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
 error[E0277]: `u128` cannot be safely transmuted into `DistantVoid`
-  --> $DIR/uninhabited.rs:70:43
+  --> $DIR/uninhabited.rs:92:43
    |
 LL |     assert::is_maybe_transmutable::<u128, DistantVoid>();
    |                                           ^^^^^^^^^^^ at least one value of `u128` isn't a bit-valid value of `DistantVoid`
@@ -80,7 +110,7 @@ LL | |             }
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0080, E0277.
 For more information about an error, try `rustc --explain E0080`.


### PR DESCRIPTION
Successful merges:

 - #124135 (delegation: Implement glob delegation)
 - #125078 (fix: break inside async closure has incorrect span for enclosing closure)
 - #125293 (Place tail expression behind terminating scope)
 - #126422 (Suggest using a standalone doctest for non-local impl defs)
 - #126493 (safe transmute: support non-ZST, variantful, uninhabited enums)
 - #126504 (Sync fuchsia test runner with clang test runner)
 - #126558 (hir_typeck: be more conservative in making "note caller chooses ty param" note)
 - #126586 (Add @badboy and @BlackHoleFox as Mac Catalyst maintainers)
 - #126615 (Add `rustc-ice*` to `.gitignore`)
 - #126632 (Replace `move||` with `move ||`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=124135,125078,125293,126422,126493,126504,126558,126586,126615,126632)
<!-- homu-ignore:end -->