### PR TITLE
More status-quo tests for the `#[coverage(..)]` attribute

### DIFF
--- a/tests/ui/coverage-attr/bad-syntax.rs
+++ b/tests/ui/coverage-attr/bad-syntax.rs
@@ -3,13 +3,13 @@
 // Tests the error messages produced (or not produced) by various unusual
 // uses of the `#[coverage(..)]` attribute.
 
-// FIXME(#84605): Multiple coverage attributes with the same value are useless,
+// FIXME(#126658): Multiple coverage attributes with the same value are useless,
 // and should probably produce a diagnostic.
 #[coverage(off)]
 #[coverage(off)]
 fn multiple_consistent() {}
 
-// FIXME(#84605): When there are multiple inconsistent coverage attributes,
+// FIXME(#126658): When there are multiple inconsistent coverage attributes,
 // it's unclear which one will prevail.
 #[coverage(off)]
 #[coverage(on)]
@@ -18,7 +18,7 @@ fn multiple_inconsistent() {}
 #[coverage] //~ ERROR expected `coverage(off)` or `coverage(on)`
 fn bare_word() {}
 
-// FIXME(#84605): This shows as multiple different errors, one of which suggests
+// FIXME(#126658): This shows as multiple different errors, one of which suggests
 // writing bare `#[coverage]`, which is not allowed.
 #[coverage = true]
 //~^ ERROR expected `coverage(off)` or `coverage(on)`
@@ -48,7 +48,7 @@ fn bogus_word_after() {}
 #[coverage(off,)]
 fn comma_after() {}
 
-// FIXME(#84605): This shows as multiple different errors.
+// FIXME(#126658): This shows as multiple different errors.
 #[coverage(,off)]
 //~^ ERROR expected identifier, found `,`
 //~| HELP remove this comma

--- a/tests/ui/coverage-attr/name-value.rs
+++ b/tests/ui/coverage-attr/name-value.rs
@@ -1,0 +1,64 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+
+// Demonstrates the diagnostics produced when using the syntax
+// `#[coverage = "off"]`, which should not be allowed.
+//
+// The syntax is tested both in places that can have a coverage attribute,
+// and in places that cannot have a coverage attribute, to demonstrate the
+// interaction between multiple errors.
+
+// FIXME(#126658): The error messages for using this syntax are inconsistent
+// with the error message in other cases. They also sometimes appear together
+// with other errors, and they suggest using the incorrect `#[coverage]` syntax.
+
+#[coverage = "off"] //~ ERROR malformed `coverage` attribute input
+mod my_mod {}
+
+mod my_mod_inner {
+    #![coverage = "off"] //~ ERROR malformed `coverage` attribute input
+}
+
+#[coverage = "off"]
+//~^ ERROR `#[coverage]` must be applied to coverable code
+//~| ERROR malformed `coverage` attribute input
+struct MyStruct;
+
+#[coverage = "off"] //~ ERROR malformed `coverage` attribute input
+impl MyStruct {
+    #[coverage = "off"]
+    //~^ ERROR `#[coverage]` must be applied to coverable code
+    //~| ERROR malformed `coverage` attribute input
+    const X: u32 = 7;
+}
+
+#[coverage = "off"] //~ ERROR malformed `coverage` attribute input
+trait MyTrait {
+    #[coverage = "off"]
+    //~^ ERROR `#[coverage]` must be applied to coverable code
+    //~| ERROR malformed `coverage` attribute input
+    const X: u32;
+
+    #[coverage = "off"]
+    //~^ ERROR `#[coverage]` must be applied to coverable code
+    //~| ERROR malformed `coverage` attribute input
+    type T;
+}
+
+#[coverage = "off"] //~ ERROR malformed `coverage` attribute input
+impl MyTrait for MyStruct {
+    #[coverage = "off"]
+    //~^ ERROR `#[coverage]` must be applied to coverable code
+    //~| ERROR malformed `coverage` attribute input
+    const X: u32 = 8;
+
+    #[coverage = "off"]
+    //~^ ERROR `#[coverage]` must be applied to coverable code
+    //~| ERROR malformed `coverage` attribute input
+    type T = ();
+}
+
+#[coverage = "off"]
+//~^ ERROR expected `coverage(off)` or `coverage(on)`
+//~| ERROR malformed `coverage` attribute input
+fn main() {}

--- a/tests/ui/coverage-attr/name-value.stderr
+++ b/tests/ui/coverage-attr/name-value.stderr
@@ -1,0 +1,219 @@
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:15:1
+   |
+LL | #[coverage = "off"]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL | #[coverage(on|off)]
+   | ~~~~~~~~~~~~~~~~~~~
+LL | #[coverage]
+   | ~~~~~~~~~~~
+
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:19:5
+   |
+LL |     #![coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL |     #![coverage(on|off)]
+   |     ~~~~~~~~~~~~~~~~~~~~
+LL |     #![coverage]
+   |     ~~~~~~~~~~~~
+
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:22:1
+   |
+LL | #[coverage = "off"]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL | #[coverage(on|off)]
+   |
+LL | #[coverage]
+   |
+
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:29:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL |     #[coverage(on|off)]
+   |
+LL |     #[coverage]
+   |
+
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:27:1
+   |
+LL | #[coverage = "off"]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL | #[coverage(on|off)]
+   | ~~~~~~~~~~~~~~~~~~~
+LL | #[coverage]
+   | ~~~~~~~~~~~
+
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:37:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL |     #[coverage(on|off)]
+   |
+LL |     #[coverage]
+   |
+
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:42:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL |     #[coverage(on|off)]
+   |
+LL |     #[coverage]
+   |
+
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:35:1
+   |
+LL | #[coverage = "off"]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL | #[coverage(on|off)]
+   | ~~~~~~~~~~~~~~~~~~~
+LL | #[coverage]
+   | ~~~~~~~~~~~
+
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:50:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL |     #[coverage(on|off)]
+   |
+LL |     #[coverage]
+   |
+
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:55:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL |     #[coverage(on|off)]
+   |
+LL |     #[coverage]
+   |
+
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:48:1
+   |
+LL | #[coverage = "off"]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL | #[coverage(on|off)]
+   | ~~~~~~~~~~~~~~~~~~~
+LL | #[coverage]
+   | ~~~~~~~~~~~
+
+error: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:61:1
+   |
+LL | #[coverage = "off"]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL | #[coverage(on|off)]
+   |
+LL | #[coverage]
+   |
+
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/name-value.rs:22:1
+   |
+LL | #[coverage = "off"]
+   | ^^^^^^^^^^^^^^^^^^^
+...
+LL | struct MyStruct;
+   | ---------------- not coverable code
+
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/name-value.rs:37:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^
+...
+LL |     const X: u32;
+   |     ------------- not coverable code
+
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/name-value.rs:42:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^
+...
+LL |     type T;
+   |     ------- not coverable code
+
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/name-value.rs:29:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^
+...
+LL |     const X: u32 = 7;
+   |     ----------------- not coverable code
+
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/name-value.rs:50:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^
+...
+LL |     const X: u32 = 8;
+   |     ----------------- not coverable code
+
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/name-value.rs:55:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^
+...
+LL |     type T = ();
+   |     ------------ not coverable code
+
+error: expected `coverage(off)` or `coverage(on)`
+  --> $DIR/name-value.rs:61:1
+   |
+LL | #[coverage = "off"]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 19 previous errors
+
+For more information about this error, try `rustc --explain E0788`.

--- a/tests/ui/coverage-attr/subword.rs
+++ b/tests/ui/coverage-attr/subword.rs
@@ -1,0 +1,19 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+
+// Check that yes/no in `#[coverage(yes)]` and `#[coverage(no)]` must be bare
+// words, not part of a more complicated substructure.
+
+#[coverage(yes(milord))] //~ ERROR expected `coverage(off)` or `coverage(on)`
+fn yes_list() {}
+
+#[coverage(no(milord))] //~ ERROR expected `coverage(off)` or `coverage(on)`
+fn no_list() {}
+
+#[coverage(yes = "milord")] //~ ERROR expected `coverage(off)` or `coverage(on)`
+fn yes_key() {}
+
+#[coverage(no = "milord")] //~ ERROR expected `coverage(off)` or `coverage(on)`
+fn no_key() {}
+
+fn main() {}

--- a/tests/ui/coverage-attr/subword.stderr
+++ b/tests/ui/coverage-attr/subword.stderr
@@ -1,0 +1,26 @@
+error: expected `coverage(off)` or `coverage(on)`
+  --> $DIR/subword.rs:7:1
+   |
+LL | #[coverage(yes(milord))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected `coverage(off)` or `coverage(on)`
+  --> $DIR/subword.rs:10:1
+   |
+LL | #[coverage(no(milord))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected `coverage(off)` or `coverage(on)`
+  --> $DIR/subword.rs:13:1
+   |
+LL | #[coverage(yes = "milord")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected `coverage(off)` or `coverage(on)`
+  --> $DIR/subword.rs:16:1
+   |
+LL | #[coverage(no = "milord")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/coverage-attr/word-only.rs
+++ b/tests/ui/coverage-attr/word-only.rs
@@ -1,0 +1,54 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+
+// Demonstrates the diagnostics produced when using the syntax `#[coverage]`,
+// which should not be allowed.
+//
+// The syntax is tested both in places that can have a coverage attribute,
+// and in places that cannot have a coverage attribute, to demonstrate the
+// interaction between multiple errors.
+
+// FIXME(#126658): The error messages for using this syntax give the impression
+// that it is legal, even though it should never be legal.
+
+// FIXME(#126658): This is silently allowed, but should not be.
+#[coverage]
+mod my_mod {}
+
+// FIXME(#126658): This is silently allowed, but should not be.
+mod my_mod_inner {
+    #![coverage]
+}
+
+#[coverage] //~ ERROR `#[coverage]` must be applied to coverable code
+struct MyStruct;
+
+// FIXME(#126658): This is silently allowed, but should not be.
+#[coverage]
+impl MyStruct {
+    #[coverage] //~ ERROR `#[coverage]` must be applied to coverable code
+    const X: u32 = 7;
+}
+
+// FIXME(#126658): This is silently allowed, but should not be.
+#[coverage]
+trait MyTrait {
+    #[coverage] //~ ERROR `#[coverage]` must be applied to coverable code
+    const X: u32;
+
+    #[coverage] //~ ERROR `#[coverage]` must be applied to coverable code
+    type T;
+}
+
+// FIXME(#126658): This is silently allowed, but should not be.
+#[coverage]
+impl MyTrait for MyStruct {
+    #[coverage] //~ ERROR `#[coverage]` must be applied to coverable code
+    const X: u32 = 8;
+
+    #[coverage] //~ ERROR `#[coverage]` must be applied to coverable code
+    type T = ();
+}
+
+#[coverage] //~ ERROR expected `coverage(off)` or `coverage(on)`
+fn main() {}

--- a/tests/ui/coverage-attr/word-only.stderr
+++ b/tests/ui/coverage-attr/word-only.stderr
@@ -1,0 +1,57 @@
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/word-only.rs:23:1
+   |
+LL | #[coverage]
+   | ^^^^^^^^^^^
+LL | struct MyStruct;
+   | ---------------- not coverable code
+
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/word-only.rs:36:5
+   |
+LL |     #[coverage]
+   |     ^^^^^^^^^^^
+LL |     const X: u32;
+   |     ------------- not coverable code
+
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/word-only.rs:39:5
+   |
+LL |     #[coverage]
+   |     ^^^^^^^^^^^
+LL |     type T;
+   |     ------- not coverable code
+
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/word-only.rs:29:5
+   |
+LL |     #[coverage]
+   |     ^^^^^^^^^^^
+LL |     const X: u32 = 7;
+   |     ----------------- not coverable code
+
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/word-only.rs:46:5
+   |
+LL |     #[coverage]
+   |     ^^^^^^^^^^^
+LL |     const X: u32 = 8;
+   |     ----------------- not coverable code
+
+error[E0788]: `#[coverage]` must be applied to coverable code
+  --> $DIR/word-only.rs:49:5
+   |
+LL |     #[coverage]
+   |     ^^^^^^^^^^^
+LL |     type T = ();
+   |     ------------ not coverable code
+
+error: expected `coverage(off)` or `coverage(on)`
+  --> $DIR/word-only.rs:53:1
+   |
+LL | #[coverage]
+   | ^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0788`.


### PR DESCRIPTION
Follow-up to #126621, after I found even more weird corner-cases in the handling of the coverage attribute.

These tests reveal some inconsistencies that are tracked by #126658.
