### PR TITLE
remove `GIT_DIR` handling in pre-push hook

### DIFF
--- a/src/etc/pre-push.sh
+++ b/src/etc/pre-push.sh
@@ -7,8 +7,6 @@
 
 set -Euo pipefail
 
-# https://github.com/rust-lang/rust/issues/77620#issuecomment-705144570
-unset GIT_DIR
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 
 echo "Running pre-push script $ROOT_DIR/x test tidy"


### PR DESCRIPTION
This is already handled from bootstrap: https://github.com/rust-lang/rust/blob/a1ca449981e3b8442e358026437b7bedb9a1458e/src/bootstrap/src/utils/helpers.rs#L504-L506
