### PR TITLE
Remove now NOP attrs `#[rustc_dump{,_env}_program_clauses]`

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -1089,14 +1089,6 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         "the `#[custom_mir]` attribute is just used for the Rust test suite",
     ),
     rustc_attr!(
-        TEST, rustc_dump_program_clauses, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
-    ),
-    rustc_attr!(
-        TEST, rustc_dump_env_program_clauses, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
-    ),
-    rustc_attr!(
         TEST, rustc_object_lifetime_default, Normal, template!(Word),
         WarnFollowing, EncodeCrossCrate::No
     ),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1592,8 +1592,6 @@ symbols! {
         rustc_do_not_const_check,
         rustc_doc_primitive,
         rustc_dummy,
-        rustc_dump_env_program_clauses,
-        rustc_dump_program_clauses,
         rustc_dump_user_args,
         rustc_dump_vtable,
         rustc_effective_visibility,


### PR DESCRIPTION
Likely NOP since #113303.

r? @fee1-dead