### PR TITLE
Allow tracing through item_bounds query invocations on opaques

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
+++ b/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
@@ -59,7 +59,7 @@ fn associated_type_bounds<'tcx>(
 /// impl trait it isn't possible to write a suitable predicate on the
 /// containing function and for type-alias impl trait we don't have a backwards
 /// compatibility issue.
-#[instrument(level = "trace", skip(tcx), ret)]
+#[instrument(level = "trace", skip(tcx, item_ty))]
 fn opaque_type_bounds<'tcx>(
     tcx: TyCtxt<'tcx>,
     opaque_def_id: LocalDefId,

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -620,7 +620,9 @@ macro_rules! define_queries {
                                 tcx,
                                 {
                                     let ret = call_provider!([$($modifiers)*][tcx, $name, key]);
-                                    tracing::trace!(?ret);
+                                    rustc_middle::ty::print::with_reduced_queries!({
+                                        tracing::trace!(?ret);
+                                    });
                                     ret
                                 }
                             )


### PR DESCRIPTION
Previously these caused cycles when printing the result of the query.
