### PR TITLE
Exposing STARTUPINFOW.wShowWindow in CommandExt trait

### DIFF
--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -183,9 +183,9 @@ pub trait CommandExt: Sealed {
 
     /// Sets the field `wShowWindow` of [STARTUPINFO][1] that is passed to `CreateProcess`.
     /// Allowed values are the ones listed in
-    /// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow
+    /// <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow>
     ///
-    /// [1]: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow
+    /// [1]: <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow>
     #[unstable(feature = "windows_process_extensions_show_window", issue = "127544")]
     fn show_window(&mut self, cmd_show: u16) -> &mut process::Command;
 

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -181,11 +181,12 @@ pub trait CommandExt: Sealed {
     #[stable(feature = "windows_process_extensions", since = "1.16.0")]
     fn creation_flags(&mut self, flags: u32) -> &mut process::Command;
 
-    /// Sets the field [wShowWindow][1] of [STARTUPINFO][2] that is passed to `CreateProcess`.
+    /// Sets the field `wShowWindow` of [STARTUPINFO][1] that is passed to `CreateProcess`.
+    /// Allowed values are the ones listed in
+    /// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow
     ///
-    /// [1]: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow
-    /// [2]: https://learn.microsoft.com/es-es/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow
-    #[unstable(feature = "windows_process_extensions_show_window", issue = "none")]
+    /// [1]: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow
+    #[unstable(feature = "windows_process_extensions_show_window", issue = "127544")]
     fn show_window(&mut self, cmd_show: u16) -> &mut process::Command;
 
     /// Forces all arguments to be wrapped in quote (`"`) characters.

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -181,6 +181,13 @@ pub trait CommandExt: Sealed {
     #[stable(feature = "windows_process_extensions", since = "1.16.0")]
     fn creation_flags(&mut self, flags: u32) -> &mut process::Command;
 
+    /// Sets the field [wShowWindow][1] of [STARTUPINFO][2] that is passed to `CreateProcess`.
+    ///
+    /// [1]: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow
+    /// [2]: https://learn.microsoft.com/es-es/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow
+    #[unstable(feature = "windows_process_extensions_show_window", issue = "none")]
+    fn show_window(&mut self, cmd_show: u16) -> &mut process::Command;
+
     /// Forces all arguments to be wrapped in quote (`"`) characters.
     ///
     /// This is useful for passing arguments to [MSYS2/Cygwin][1] based
@@ -367,6 +374,11 @@ pub trait CommandExt: Sealed {
 impl CommandExt for process::Command {
     fn creation_flags(&mut self, flags: u32) -> &mut process::Command {
         self.as_inner_mut().creation_flags(flags);
+        self
+    }
+
+    fn show_window(&mut self, cmd_show: u16) -> &mut process::Command {
+        self.as_inner_mut().show_window(Some(cmd_show));
         self
     }
 

--- a/library/std/src/sys/pal/windows/process.rs
+++ b/library/std/src/sys/pal/windows/process.rs
@@ -163,6 +163,7 @@ pub struct Command {
     env: CommandEnv,
     cwd: Option<OsString>,
     flags: u32,
+    show_window: Option<u16>,
     detach: bool, // not currently exposed in std::process
     stdin: Option<Stdio>,
     stdout: Option<Stdio>,
@@ -194,6 +195,7 @@ impl Command {
             env: Default::default(),
             cwd: None,
             flags: 0,
+            show_window: None,
             detach: false,
             stdin: None,
             stdout: None,
@@ -223,6 +225,9 @@ impl Command {
     }
     pub fn creation_flags(&mut self, flags: u32) {
         self.flags = flags;
+    }
+    pub fn show_window(&mut self, cmd_show: Option<u16>) {
+        self.show_window = cmd_show;
     }
 
     pub fn force_quotes(&mut self, enabled: bool) {
@@ -335,6 +340,11 @@ impl Command {
             si.hStdInput = stdin.as_raw_handle();
             si.hStdOutput = stdout.as_raw_handle();
             si.hStdError = stderr.as_raw_handle();
+        }
+
+        if let Some(cmd_show) = self.show_window {
+            si.dwFlags |= c::STARTF_USESHOWWINDOW;
+            si.wShowWindow = cmd_show;
         }
 
         let si_ptr: *mut c::STARTUPINFOW;


### PR DESCRIPTION
Hi:

I needed a way to control how a new process's window is displayed in Windows (normal, minimized, maximized, etc).
I noticed that there is no direct way to do that (I even searched for crates doing this, but didn't find any).

Inspecting the standard library source code, I figured that it would be a good addition to CommandExt trait that allows some Windows specific customization to a Command.

This is my first time contributing to Rust, so please bear with me if I'm not following the rules :)