### PR TITLE
[RFC] mbe: consider the `_` in 2024 an expression

### DIFF
--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -48,7 +48,7 @@ impl<'a> Parser<'a> {
             }
             // Current edition expressions
             NonterminalKind::Expr(Expr) => {
-                // In Edition 2024, `_` will be considered an expression, so we
+                // In Edition 2024, `_` is considered an expression, so we
                 // need to allow it here because `token.can_begin_expr()` does
                 // not consider `_` to be an expression.
                 //

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -38,6 +38,7 @@ impl<'a> Parser<'a> {
         }
 
         match kind {
+            // `expr_2021` and earlier
             NonterminalKind::Expr(Expr2021 { .. }) => {
                 token.can_begin_expr()
                 // This exception is here for backwards compatibility.
@@ -45,8 +46,16 @@ impl<'a> Parser<'a> {
                 // This exception is here for backwards compatibility.
                 && !token.is_keyword(kw::Const)
             }
+            // Current edition expressions
             NonterminalKind::Expr(Expr) => {
-                token.can_begin_expr()
+                // In Edition 2024, `_` will be considered an expression, so we
+                // need to allow it here because `token.can_begin_expr()` does
+                // not consider `_` to be an expression.
+                //
+                // Because `can_begin_expr` is used elsewhere, we need to reduce
+                // the scope of where the `_` is considered an expression to
+                // just macro parsing code.
+                (token.can_begin_expr() || token.is_keyword(kw::Underscore))
                 // This exception is here for backwards compatibility.
                 && !token.is_keyword(kw::Let)
             }

--- a/tests/ui/macros/expr_2024_underscore_expr.edi2021.stderr
+++ b/tests/ui/macros/expr_2024_underscore_expr.edi2021.stderr
@@ -1,0 +1,32 @@
+error: no rules expected the token `_`
+  --> $DIR/expr_2024_underscore_expr.rs:22:12
+   |
+LL | macro_rules! m2021 {
+   | ------------------ when calling this macro
+...
+LL |     m2021!(_);
+   |            ^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$e:expr_2021`
+  --> $DIR/expr_2024_underscore_expr.rs:10:6
+   |
+LL |     ($e:expr_2021) => {
+   |      ^^^^^^^^^^^^
+
+error: no rules expected the token `_`
+  --> $DIR/expr_2024_underscore_expr.rs:23:12
+   |
+LL | macro_rules! m2024 {
+   | ------------------ when calling this macro
+...
+LL |     m2024!(_);
+   |            ^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$e:expr`
+  --> $DIR/expr_2024_underscore_expr.rs:16:6
+   |
+LL |     ($e:expr) => {
+   |      ^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/macros/expr_2024_underscore_expr.edi2024.stderr
+++ b/tests/ui/macros/expr_2024_underscore_expr.edi2024.stderr
@@ -1,5 +1,5 @@
 error: no rules expected the token `_`
-  --> $DIR/expr_2024_underscore_expr.rs:23:12
+  --> $DIR/expr_2024_underscore_expr.rs:22:12
    |
 LL | macro_rules! m2021 {
    | ------------------ when calling this macro
@@ -8,7 +8,7 @@ LL |     m2021!(_);
    |            ^ no rules expected this token in macro call
    |
 note: while trying to match meta-variable `$e:expr_2021`
-  --> $DIR/expr_2024_underscore_expr.rs:11:6
+  --> $DIR/expr_2024_underscore_expr.rs:10:6
    |
 LL |     ($e:expr_2021) => {
    |      ^^^^^^^^^^^^

--- a/tests/ui/macros/expr_2024_underscore_expr.edi2024.stderr
+++ b/tests/ui/macros/expr_2024_underscore_expr.edi2024.stderr
@@ -1,0 +1,17 @@
+error: no rules expected the token `_`
+  --> $DIR/expr_2024_underscore_expr.rs:23:12
+   |
+LL | macro_rules! m2021 {
+   | ------------------ when calling this macro
+...
+LL |     m2021!(_);
+   |            ^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$e:expr_2021`
+  --> $DIR/expr_2024_underscore_expr.rs:11:6
+   |
+LL |     ($e:expr_2021) => {
+   |      ^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/macros/expr_2024_underscore_expr.rs
+++ b/tests/ui/macros/expr_2024_underscore_expr.rs
@@ -1,0 +1,24 @@
+//@ revisions: edi2021 edi2024
+//@[edi2024]compile-flags: --edition=2024 -Z unstable-options
+//@[edi2021]compile-flags: --edition=2021
+// This test ensures that the `_` tok is considered an
+// expression on edition 2024.
+#![feature(expr_fragment_specifier_2024)]
+#![allow(incomplete_features)]
+
+macro_rules! m2021 {
+    ($e:expr_2021) => {
+        $e = 1;
+    };
+}
+
+macro_rules! m2024 {
+    ($e:expr) => {
+        $e = 1;
+    };
+}
+
+fn main() {
+    m2021!(_); //~ ERROR: no rules expected the token `_`
+    m2024!(_); //[edi2021]~ ERROR: no rules expected the token `_`
+}


### PR DESCRIPTION
This commit is adding the possibility to parse the `_` as an expression inside the esition 2024.

Link: https://rust-lang.zulipchat.com/#narrow/stream/404510-wg-macros/topic/supporting.20.60_.60.20expressions

Issue https://github.com/rust-lang/rust/issues/123742

r? @eholk

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
