### PR TITLE
ignore `llvm::Lld` if lld is not enabled

### DIFF
--- a/src/bootstrap/defaults/config.dist.toml
+++ b/src/bootstrap/defaults/config.dist.toml
@@ -16,6 +16,7 @@ download-ci-llvm = false
 # Make sure they don't get set when installing from source.
 channel = "nightly"
 download-rustc = false
+lld = true
 # Build the llvm-bitcode-linker
 llvm-bitcode-linker = true
 

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -195,4 +195,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "Removed `dist.missing-tools` configuration as it was deprecated long time ago.",
     },
+    ChangeInfo {
+        change_id: 126701,
+        severity: ChangeSeverity::Warning,
+        summary: "`llvm.lld` is enabled by default for the dist profile. If set to false, `lld` will not be included in the dist build.",
+    },
 ];

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -85,6 +85,10 @@ fi
 # space required for CI artifacts.
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --dist-compression-formats=xz"
 
+if [ "$EXTERNAL_LLVM" = "1" ]; then
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.lld=false"
+fi
+
 # Enable the `c` feature for compiler_builtins, but only when the `compiler-rt` source is available
 # (to avoid spending a lot of time cloning llvm)
 if [ "$EXTERNAL_LLVM" = "" ]; then

--- a/tests/run-make/rust-lld-by-default/rmake.rs
+++ b/tests/run-make/rust-lld-by-default/rmake.rs
@@ -2,6 +2,8 @@
 // also be turned off with a CLI flag.
 
 //@ needs-rust-lld
+//@ ignore-beta
+//@ ignore-stable
 //@ only-x86_64-unknown-linux-gnu
 
 use run_make_support::regex::Regex;

--- a/tests/run-make/windows-safeseh/rmake.rs
+++ b/tests/run-make/windows-safeseh/rmake.rs
@@ -1,4 +1,4 @@
-//@ only-windows
+//@ only-x86_64-pc-windows-msvc
 //@ needs-rust-lld
 
 use run_make_support::rustc;


### PR DESCRIPTION
People are having trouble ([ref. zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/MSVC.20Runtime.20mismatch.20when.20building.20LLD)) when they don't want to build `lld` for their custom distribution tarballs even with `lld = false` in their config.toml. This is because it is not controlled by `lld_enabled` flag. This change ensures that `llvm:Lld` is controlled by lld configuration.

Additionally, `lld = true` is set by default for dist profile, because we have been building it all along and this maintains that behavior.

try-job: x86_64-mingw