### PR TITLE
Clean up some comments near `use` declarations

### DIFF
--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -1,6 +1,7 @@
+//! The expansion from a test function to the appropriate test struct for libtest
+//! Ideally, this code would be in libtest but for efficiency and error messages it lives here.
+
 use crate::errors;
-/// The expansion from a test function to the appropriate test struct for libtest
-/// Ideally, this code would be in libtest but for efficiency and error messages it lives here.
 use crate::util::{check_builtin_macro_attribute, warn_on_duplicate_attribute};
 use rustc_ast::ptr::P;
 use rustc_ast::{self as ast, attr, GenericParamKind};

--- a/compiler/rustc_codegen_gcc/tests/lang_tests_common.rs
+++ b/compiler/rustc_codegen_gcc/tests/lang_tests_common.rs
@@ -1,4 +1,5 @@
 //! The common code for `tests/lang_tests_*.rs`
+
 use std::{
     env::{self, current_dir},
     path::{Path, PathBuf},

--- a/compiler/rustc_codegen_ssa/src/mir/locals.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/locals.rs
@@ -1,6 +1,7 @@
 //! Locals are in a private module as updating `LocalRef::Operand` has to
 //! be careful wrt to subtyping. To deal with this we only allow updates by using
 //! `FunctionCx::overwrite_local` which handles it automatically.
+
 use crate::mir::{FunctionCx, LocalRef};
 use crate::traits::BuilderMethods;
 use rustc_index::IndexVec;

--- a/compiler/rustc_data_structures/src/base_n.rs
+++ b/compiler/rustc_data_structures/src/base_n.rs
@@ -1,5 +1,6 @@
-/// Converts unsigned integers into a string representation with some base.
-/// Bases up to and including 36 can be used for case-insensitive things.
+//! Converts unsigned integers into a string representation with some base.
+//! Bases up to and including 36 can be used for case-insensitive things.
+
 use std::ascii;
 use std::fmt;
 

--- a/compiler/rustc_errors/src/markdown/mod.rs
+++ b/compiler/rustc_errors/src/markdown/mod.rs
@@ -1,6 +1,7 @@
 //! A simple markdown parser that can write formatted text to the terminal
 //!
 //! Entrypoint is `MdStream::parse_str(...)`
+
 use std::io;
 
 use termcolor::{Buffer, BufferWriter, ColorChoice};

--- a/compiler/rustc_expand/src/mbe/macro_check.rs
+++ b/compiler/rustc_expand/src/mbe/macro_check.rs
@@ -104,6 +104,7 @@
 //! Kleene operators under which a meta-variable is repeating is the concatenation of the stacks
 //! stored when entering a macro definition starting from the state in which the meta-variable is
 //! bound.
+
 use crate::errors;
 use crate::mbe::{KleeneToken, TokenTree};
 

--- a/compiler/rustc_fs_util/src/lib.rs
+++ b/compiler/rustc_fs_util/src/lib.rs
@@ -1,9 +1,7 @@
-// tidy-alphabetical-start
 use std::ffi::CString;
 use std::fs;
 use std::io;
 use std::path::{absolute, Path, PathBuf};
-// tidy-alphabetical-end
 
 // Unfortunately, on windows, it looks like msvcrt.dll is silently translating
 // verbatim paths under the hood to non-verbatim paths! This manifests itself as

--- a/compiler/rustc_hir_analysis/src/check/dropck.rs
+++ b/compiler/rustc_hir_analysis/src/check/dropck.rs
@@ -1,6 +1,7 @@
 // FIXME(@lcnr): Move this module out of `rustc_hir_analysis`.
 //
 // We don't do any drop checking during hir typeck.
+
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{codes::*, struct_span_code_err, ErrorGuaranteed};
 use rustc_infer::infer::outlives::env::OutlivesEnvironment;

--- a/compiler/rustc_hir_typeck/src/autoderef.rs
+++ b/compiler/rustc_hir_typeck/src/autoderef.rs
@@ -1,4 +1,5 @@
-//! Some helper functions for `AutoDeref`
+//! Some helper functions for `AutoDeref`.
+
 use super::method::MethodCallee;
 use super::{FnCtxt, PlaceOp};
 

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -1,4 +1,5 @@
 //! Errors emitted by `rustc_hir_typeck`.
+
 use std::borrow::Cow;
 
 use crate::fluent_generated as fluent;

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
@@ -1,4 +1,5 @@
 //! A utility module to inspect currently ambiguous obligations in the current context.
+
 use crate::FnCtxt;
 use rustc_infer::traits::{self, ObligationCause};
 use rustc_middle::traits::solve::Goal;

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/named_anon_conflict.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/named_anon_conflict.rs
@@ -1,5 +1,6 @@
 //! Error Reporting for Anonymous Region Lifetime Errors
 //! where one region is named and the other is anonymous.
+
 use crate::infer::error_reporting::nice_region_error::NiceRegionError;
 use crate::{
     errors::ExplicitLifetimeRequired,

--- a/compiler/rustc_infer/src/infer/freshen.rs
+++ b/compiler/rustc_infer/src/infer/freshen.rs
@@ -30,6 +30,7 @@
 //! solving a set of constraints. In contrast, the type inferencer assigns a value to each type
 //! variable only once, and it does so as soon as it can, so it is reasonable to ask what the type
 //! inferencer knows "so far".
+
 use super::InferCtxt;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::bug;

--- a/compiler/rustc_infer/src/infer/outlives/mod.rs
+++ b/compiler/rustc_infer/src/infer/outlives/mod.rs
@@ -1,4 +1,5 @@
 //! Various code related to computing outlives relations.
+
 use self::env::OutlivesEnvironment;
 use super::region_constraints::RegionConstraintData;
 use super::{InferCtxt, RegionResolutionError, SubregionOrigin};

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -1,4 +1,3 @@
-// tidy-alphabetical-start
 pub use self::Level::*;
 use rustc_ast::node_id::NodeId;
 use rustc_ast::{AttrId, Attribute};
@@ -15,7 +14,6 @@ use rustc_span::edition::Edition;
 use rustc_span::symbol::MacroRulesNormalizedIdent;
 use rustc_span::{sym, symbol::Ident, Span, Symbol};
 use rustc_target::spec::abi::Abi;
-// tidy-alphabetical-end
 
 use serde::{Deserialize, Serialize};
 

--- a/compiler/rustc_middle/src/middle/privacy.rs
+++ b/compiler/rustc_middle/src/middle/privacy.rs
@@ -1,6 +1,7 @@
 //! A pass that checks to make sure private fields and methods aren't used
 //! outside their scopes. This pass will also generate a set of exported items
 //! which are available for use externally when compiled as a library.
+
 use crate::ty::{TyCtxt, Visibility};
 use rustc_data_structures::fx::{FxIndexMap, IndexEntry};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -1,4 +1,5 @@
-/// Functionality for statements, operands, places, and things that appear in them.
+//! Functionality for statements, operands, places, and things that appear in them.
+
 use super::{interpret::GlobalAlloc, *};
 
 ///////////////////////////////////////////////////////////////////////////

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -1,4 +1,5 @@
-/// Functionality for terminators and helper types that appear in terminators.
+//! Functionality for terminators and helper types that appear in terminators.
+
 use rustc_hir::LangItem;
 use smallvec::{smallvec, SmallVec};
 

--- a/compiler/rustc_middle/src/ty/abstract_const.rs
+++ b/compiler/rustc_middle/src/ty/abstract_const.rs
@@ -1,4 +1,5 @@
 //! A subset of a mir body used for const evaluability checking.
+
 use crate::ty::{
     self, Const, EarlyBinder, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
     TypeVisitableExt,

--- a/compiler/rustc_mir_transform/src/ctfe_limit.rs
+++ b/compiler/rustc_mir_transform/src/ctfe_limit.rs
@@ -1,5 +1,6 @@
 //! A pass that inserts the `ConstEvalCounter` instruction into any blocks that have a back edge
 //! (thus indicating there is a loop in the CFG), or whose terminator is a function call.
+
 use crate::MirPass;
 
 use rustc_data_structures::graph::dominators::Dominators;

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -1,4 +1,5 @@
-//! Inlining pass for MIR functions
+//! Inlining pass for MIR functions.
+
 use crate::deref_separator::deref_finder;
 use rustc_attr::InlineAttr;
 use rustc_hir::def::DefKind;

--- a/compiler/rustc_mir_transform/src/lint.rs
+++ b/compiler/rustc_mir_transform/src/lint.rs
@@ -1,6 +1,7 @@
 //! This pass statically detects code which has undefined behaviour or is likely to be erroneous.
 //! It can be used to locate problems in MIR building or optimizations. It assumes that all code
 //! can be executed, so it has false positives.
+
 use rustc_data_structures::fx::FxHashSet;
 use rustc_index::bit_set::BitSet;
 use rustc_middle::mir::visit::{PlaceContext, Visitor};

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1,4 +1,5 @@
 // ignore-tidy-filelength
+
 use super::diagnostics::SnapshotParser;
 use super::pat::{CommaRecoveryMode, Expected, RecoverColon, RecoverComma};
 use super::ty::{AllowPlus, RecoverQPath, RecoverReturnSign};

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -1,5 +1,6 @@
 //! As explained in [`crate::usefulness`], values and patterns are made from constructors applied to
 //! fields. This file defines types that represent patterns in this way.
+
 use std::fmt;
 
 use smallvec::{smallvec, SmallVec};

--- a/compiler/rustc_pattern_analysis/tests/complexity.rs
+++ b/compiler/rustc_pattern_analysis/tests/complexity.rs
@@ -1,4 +1,5 @@
 //! Test the pattern complexity limit.
+
 use common::*;
 use rustc_pattern_analysis::{pat::DeconstructedPat, usefulness::PlaceValidity, MatchArm};
 

--- a/compiler/rustc_pattern_analysis/tests/exhaustiveness.rs
+++ b/compiler/rustc_pattern_analysis/tests/exhaustiveness.rs
@@ -1,4 +1,5 @@
 //! Test exhaustiveness checking.
+
 use common::*;
 use rustc_pattern_analysis::{
     pat::{DeconstructedPat, WitnessPat},

--- a/compiler/rustc_pattern_analysis/tests/intersection.rs
+++ b/compiler/rustc_pattern_analysis/tests/intersection.rs
@@ -1,4 +1,5 @@
 //! Test the computation of arm intersections.
+
 use common::*;
 use rustc_pattern_analysis::{pat::DeconstructedPat, usefulness::PlaceValidity, MatchArm};
 

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/encode.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/encode.rs
@@ -4,6 +4,7 @@
 //!
 //! For more information about LLVM CFI and cross-language LLVM CFI support for the Rust compiler,
 //! see design document in the tracking issue #89653.
+
 use rustc_data_structures::base_n::ToBaseN;
 use rustc_data_structures::base_n::ALPHANUMERIC_ONLY;
 use rustc_data_structures::base_n::CASE_INSENSITIVE;

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/mod.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/mod.rs
@@ -3,6 +3,7 @@
 //!
 //! For more information about LLVM CFI and cross-language LLVM CFI support for the Rust compiler,
 //! see design document in the tracking issue #89653.
+
 use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::bug;
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt, TypeFoldable};

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -3,6 +3,7 @@
 //!
 //! For more information about LLVM CFI and cross-language LLVM CFI support for the Rust compiler,
 //! see design document in the tracking issue #89653.
+
 use rustc_hir as hir;
 use rustc_hir::LangItem;
 use rustc_middle::bug;

--- a/compiler/rustc_sanitizers/src/cfi/typeid/mod.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/mod.rs
@@ -3,6 +3,7 @@
 //!
 //! For more information about LLVM CFI and cross-language LLVM CFI support for the Rust compiler,
 //! see design document in the tracking issue #89653.
+
 use bitflags::bitflags;
 use rustc_middle::ty::{Instance, Ty, TyCtxt};
 use rustc_target::abi::call::FnAbi;

--- a/compiler/rustc_sanitizers/src/kcfi/typeid/mod.rs
+++ b/compiler/rustc_sanitizers/src/kcfi/typeid/mod.rs
@@ -3,6 +3,7 @@
 //!
 //! For more information about LLVM KCFI and cross-language LLVM KCFI support for the Rust compiler,
 //! see the tracking issue #123479.
+
 use rustc_middle::ty::{Instance, InstanceKind, ReifyReason, Ty, TyCtxt};
 use rustc_target::abi::call::FnAbi;
 use std::hash::Hasher;

--- a/compiler/rustc_session/src/output.rs
+++ b/compiler/rustc_session/src/output.rs
@@ -1,4 +1,5 @@
 //! Related to out filenames of compilation (e.g. binaries).
+
 use crate::config::{self, CrateType, Input, OutFileName, OutputFilenames, OutputType};
 use crate::errors::{
     self, CrateNameDoesNotMatch, CrateNameEmpty, CrateNameInvalid, FileIsNotWriteable,

--- a/compiler/rustc_smir/src/rustc_smir/builder.rs
+++ b/compiler/rustc_smir/src/rustc_smir/builder.rs
@@ -3,6 +3,7 @@
 //! We first retrieve and monomorphize the rustc body representation, i.e., we generate a
 //! monomorphic body using internal representation.
 //! After that, we convert the internal representation into a stable one.
+
 use crate::rustc_smir::{Stable, Tables};
 use rustc_hir::def::DefKind;
 use rustc_middle::mir;

--- a/compiler/rustc_smir/src/rustc_smir/convert/error.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/error.rs
@@ -1,6 +1,7 @@
 //! Handle the conversion of different internal errors into a stable version.
 //!
 //! Currently we encode everything as [stable_mir::Error], which is represented as a string.
+
 use crate::rustc_smir::{Stable, Tables};
 use rustc_middle::mir::interpret::AllocError;
 use rustc_middle::ty::layout::LayoutError;

--- a/compiler/rustc_target/src/spec/targets/mips64_openwrt_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/mips64_openwrt_linux_musl.rs
@@ -1,5 +1,5 @@
-/// A target tuple for OpenWrt MIPS64 targets
-///
+//! A target tuple for OpenWrt MIPS64 targets.
+
 use crate::abi::Endian;
 use crate::spec::{base, Target, TargetOptions};
 

--- a/compiler/rustc_trait_selection/src/traits/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/normalize.rs
@@ -1,4 +1,5 @@
 //! Deeply normalize types using the old trait solver.
+
 use super::error_reporting::OverflowCause;
 use super::error_reporting::TypeErrCtxtExt;
 use super::SelectionContext;

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -6,6 +6,7 @@
 //!
 //! [rustc dev guide]:
 //! https://rustc-dev-guide.rust-lang.org/traits/resolution.html#confirmation
+
 use rustc_ast::Mutability;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_hir::lang_items::LangItem;

--- a/compiler/stable_mir/src/mir/alloc.rs
+++ b/compiler/stable_mir/src/mir/alloc.rs
@@ -1,4 +1,5 @@
 //! This module provides methods to retrieve allocation information, such as static variables.
+
 use crate::mir::mono::{Instance, StaticDef};
 use crate::target::{Endian, MachineInfo};
 use crate::ty::{Allocation, Binder, ExistentialTraitRef, IndexedVal, Ty};

--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -1,6 +1,7 @@
-// Based on
-// https://github.com/matthieu-m/rfc2580/blob/b58d1d3cba0d4b5e859d3617ea2d0943aaa31329/examples/thin.rs
-// by matthieu-m
+//! Based on
+//! <https://github.com/matthieu-m/rfc2580/blob/b58d1d3cba0d4b5e859d3617ea2d0943aaa31329/examples/thin.rs>
+//! by matthieu-m
+
 use crate::alloc::{self, Layout, LayoutError};
 use core::error::Error;
 use core::fmt::{self, Debug, Display, Formatter};

--- a/library/alloc/src/vec/in_place_collect.rs
+++ b/library/alloc/src/vec/in_place_collect.rs
@@ -154,6 +154,7 @@
 //! }
 //! vec.truncate(write_idx);
 //! ```
+
 use crate::alloc::{handle_alloc_error, Global};
 use core::alloc::Allocator;
 use core::alloc::Layout;

--- a/library/core/src/str/count.rs
+++ b/library/core/src/str/count.rs
@@ -17,6 +17,7 @@
 //! Note: Because the term "leading byte" can sometimes be ambiguous (for
 //! example, it could also refer to the first byte of a slice), we'll often use
 //! the term "non-continuation byte" to refer to these bytes in the code.
+
 use core::intrinsics::unlikely;
 
 const USIZE_SIZE: usize = core::mem::size_of::<usize>();

--- a/library/core/tests/iter/adapters/map_windows.rs
+++ b/library/core/tests/iter/adapters/map_windows.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 #[cfg(not(panic = "abort"))]
 mod drop_checks {
     //! These tests mainly make sure the elements are correctly dropped.
+
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
 
     #[derive(Debug)]

--- a/library/core/tests/net/parser.rs
+++ b/library/core/tests/net/parser.rs
@@ -1,4 +1,5 @@
 // FIXME: These tests are all excellent candidates for AFL fuzz testing
+
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use core::str::FromStr;
 

--- a/library/core/tests/num/ieee754.rs
+++ b/library/core/tests/num/ieee754.rs
@@ -27,6 +27,7 @@
 //! standard. That is why they accept wildly diverse inputs or may seem to duplicate other tests.
 //! Please consider this carefully when adding, removing, or reorganizing these tests. They are
 //! here so that it is clear what tests are required by the standard and what can be changed.
+
 use ::core::str::FromStr;
 
 // IEEE 754 for many tests is applied to specific bit patterns.

--- a/library/core/tests/pin_macro.rs
+++ b/library/core/tests/pin_macro.rs
@@ -1,4 +1,5 @@
 // edition:2021
+
 use core::{
     marker::PhantomPinned,
     mem::{drop as stuff, transmute},

--- a/library/panic_unwind/src/miri.rs
+++ b/library/panic_unwind/src/miri.rs
@@ -1,4 +1,5 @@
 //! Unwinding panics for Miri.
+
 use alloc::boxed::Box;
 use core::any::Any;
 

--- a/library/portable-simd/crates/core_simd/examples/dot_product.rs
+++ b/library/portable-simd/crates/core_simd/examples/dot_product.rs
@@ -1,6 +1,5 @@
-// Code taken from the `packed_simd` crate
-// Run this code with `cargo test --example dot_product`
-//use std::iter::zip;
+//! Code taken from the `packed_simd` crate.
+//! Run this code with `cargo test --example dot_product`.
 
 #![feature(array_chunks)]
 #![feature(slice_as_chunks)]

--- a/library/portable-simd/crates/core_simd/src/ops/assign.rs
+++ b/library/portable-simd/crates/core_simd/src/ops/assign.rs
@@ -1,4 +1,5 @@
 //! Assignment operators
+
 use super::*;
 use core::ops::{AddAssign, MulAssign}; // commutative binary op-assignment
 use core::ops::{BitAndAssign, BitOrAssign, BitXorAssign}; // commutative bit binary op-assignment

--- a/library/portable-simd/crates/core_simd/src/ops/deref.rs
+++ b/library/portable-simd/crates/core_simd/src/ops/deref.rs
@@ -2,6 +2,7 @@
 //! Ideally, Rust would take care of this itself,
 //! and method calls usually handle the LHS implicitly.
 //! But this is not the case with arithmetic ops.
+
 use super::*;
 
 macro_rules! deref_lhs {

--- a/library/std/src/hash/random.rs
+++ b/library/std/src/hash/random.rs
@@ -6,6 +6,7 @@
 //! outside this crate.
 //!
 //! [`collections`]: crate::collections
+
 #[allow(deprecated)]
 use super::{BuildHasher, Hasher, SipHasher13};
 use crate::cell::Cell;

--- a/library/std/src/io/buffered/bufreader/buffer.rs
+++ b/library/std/src/io/buffered/bufreader/buffer.rs
@@ -1,13 +1,14 @@
-///! An encapsulation of `BufReader`'s buffer management logic.
-///
-/// This module factors out the basic functionality of `BufReader` in order to protect two core
-/// invariants:
-/// * `filled` bytes of `buf` are always initialized
-/// * `pos` is always <= `filled`
-/// Since this module encapsulates the buffer management logic, we can ensure that the range
-/// `pos..filled` is always a valid index into the initialized region of the buffer. This means
-/// that user code which wants to do reads from a `BufReader` via `buffer` + `consume` can do so
-/// without encountering any runtime bounds checks.
+//! An encapsulation of `BufReader`'s buffer management logic.
+//!
+//! This module factors out the basic functionality of `BufReader` in order to protect two core
+//! invariants:
+//! * `filled` bytes of `buf` are always initialized
+//! * `pos` is always <= `filled`
+//! Since this module encapsulates the buffer management logic, we can ensure that the range
+//! `pos..filled` is always a valid index into the initialized region of the buffer. This means
+//! that user code which wants to do reads from a `BufReader` via `buffer` + `consume` can do so
+//! without encountering any runtime bounds checks.
+
 use crate::cmp;
 use crate::io::{self, BorrowedBuf, Read};
 use crate::mem::MaybeUninit;

--- a/library/std/src/sys/os_str/wtf8.rs
+++ b/library/std/src/sys/os_str/wtf8.rs
@@ -1,5 +1,6 @@
-/// The underlying OsString/OsStr implementation on Windows is a
-/// wrapper around the "WTF-8" encoding; see the `wtf8` module for more.
+//! The underlying OsString/OsStr implementation on Windows is a
+//! wrapper around the "WTF-8" encoding; see the `wtf8` module for more.
+
 use crate::borrow::Cow;
 use crate::collections::TryReserveError;
 use crate::fmt;

--- a/library/std/src/sys/pal/itron/thread.rs
+++ b/library/std/src/sys/pal/itron/thread.rs
@@ -1,5 +1,6 @@
 //! Thread implementation backed by μITRON tasks. Assumes `acre_tsk` and
 //! `exd_tsk` are available.
+
 use super::{
     abi,
     error::{expect_success, expect_success_aborting, ItronError},

--- a/library/std/src/sys/pal/solid/abi/fs.rs
+++ b/library/std/src/sys/pal/solid/abi/fs.rs
@@ -1,4 +1,5 @@
 //! `solid_fs.h`
+
 use crate::os::raw::{c_char, c_int, c_uchar};
 pub use libc::{
     ino_t, off_t, stat, time_t, O_APPEND, O_CREAT, O_EXCL, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY,

--- a/library/std/src/sys/pal/unix/process/process_unsupported/wait_status.rs
+++ b/library/std/src/sys/pal/unix/process/process_unsupported/wait_status.rs
@@ -1,6 +1,7 @@
 //! Emulated wait status for non-Unix #[cfg(unix) platforms
 //!
 //! Separate module to facilitate testing against a real Unix implementation.
+
 use crate::ffi::c_int;
 use crate::fmt;
 use crate::num::NonZero;

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -475,6 +475,7 @@ mod cgroups {
     //! * cgroup v2 in non-standard mountpoints
     //! * paths containing control characters or spaces, since those would be escaped in procfs
     //!   output and we don't unescape
+
     use crate::borrow::Cow;
     use crate::ffi::OsString;
     use crate::fs::{try_exists, File};

--- a/library/std/src/sys/sync/condvar/itron.rs
+++ b/library/std/src/sys/sync/condvar/itron.rs
@@ -1,4 +1,5 @@
 //! POSIX conditional variable implementation based on user-space wait queues.
+
 use crate::sys::pal::itron::{
     abi, error::expect_success_aborting, spin::SpinMutex, task, time::with_tmos_strong,
 };

--- a/library/std/src/sys/sync/mutex/itron.rs
+++ b/library/std/src/sys/sync/mutex/itron.rs
@@ -1,5 +1,6 @@
 //! Mutex implementation backed by μITRON mutexes. Assumes `acre_mtx` and
 //! `TA_INHERIT` are available.
+
 use crate::sys::pal::itron::{
     abi,
     error::{expect_success, expect_success_aborting, fail, ItronError},

--- a/library/std/src/sys/sync/rwlock/solid.rs
+++ b/library/std/src/sys/sync/rwlock/solid.rs
@@ -1,4 +1,5 @@
 //! A readers-writer lock implementation backed by the SOLID kernel extension.
+
 use crate::sys::pal::{
     abi,
     itron::{

--- a/library/std/tests/create_dir_all_bare.rs
+++ b/library/std/tests/create_dir_all_bare.rs
@@ -2,6 +2,7 @@
 
 //! Note that this test changes the current directory so
 //! should not be in the same process as other tests.
+
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/library/test/src/bench.rs
+++ b/library/test/src/bench.rs
@@ -1,4 +1,5 @@
 //! Benchmarking module.
+
 use super::{
     event::CompletedTest,
     options::BenchMode,

--- a/library/test/src/helpers/concurrency.rs
+++ b/library/test/src/helpers/concurrency.rs
@@ -1,5 +1,6 @@
 //! Helper module which helps to determine amount of threads to be used
 //! during tests execution.
+
 use std::{env, num::NonZero, thread};
 
 pub fn get_concurrency() -> usize {

--- a/library/test/src/helpers/metrics.rs
+++ b/library/test/src/helpers/metrics.rs
@@ -1,4 +1,5 @@
 //! Benchmark metrics.
+
 use std::collections::BTreeMap;
 
 #[derive(Clone, PartialEq, Debug, Copy)]

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -1,4 +1,5 @@
 //! Calculates information used for the --show-coverage flag.
+
 use crate::clean;
 use crate::core::DocContext;
 use crate::html::markdown::{find_testable_code, ErrorCodes};

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -1,6 +1,7 @@
 //! Collects trait impls for each item in the crate. For example, if a crate
 //! defines a struct that implements a trait, this pass will note that the
 //! struct implements that trait.
+
 use super::Pass;
 use crate::clean::*;
 use crate::core::DocContext;

--- a/src/librustdoc/passes/lint/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/lint/check_code_block_syntax.rs
@@ -1,4 +1,5 @@
 //! Validates syntax inside Rust code blocks (\`\`\`rust).
+
 use rustc_data_structures::sync::{Lock, Lrc};
 use rustc_errors::{
     emitter::Emitter,

--- a/src/librustdoc/passes/lint/html_tags.rs
+++ b/src/librustdoc/passes/lint/html_tags.rs
@@ -1,4 +1,5 @@
 //! Detects invalid HTML (like an unclosed `<span>`) in doc comments.
+
 use crate::clean::*;
 use crate::core::DocContext;
 use crate::html::markdown::main_body_opts;

--- a/src/librustdoc/passes/propagate_doc_cfg.rs
+++ b/src/librustdoc/passes/propagate_doc_cfg.rs
@@ -1,4 +1,5 @@
 //! Propagates [`#[doc(cfg(...))]`](https://github.com/rust-lang/rust/issues/43781) to child items.
+
 use std::sync::Arc;
 
 use crate::clean::cfg::Cfg;

--- a/src/librustdoc/passes/strip_priv_imports.rs
+++ b/src/librustdoc/passes/strip_priv_imports.rs
@@ -1,5 +1,6 @@
 //! Strips all private import statements (use, extern crate) from a
 //! crate.
+
 use crate::clean;
 use crate::core::DocContext;
 use crate::fold::DocFolder;

--- a/src/librustdoc/passes/strip_private.rs
+++ b/src/librustdoc/passes/strip_private.rs
@@ -1,5 +1,6 @@
 //! Strip all private items from the output. Additionally implies strip_priv_imports.
 //! Basically, the goal is to remove items that are not relevant for public documentation.
+
 use crate::clean::{self, ItemIdSet};
 use crate::core::DocContext;
 use crate::fold::DocFolder;

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -1,4 +1,5 @@
 //! A collection of utility functions for the `strip_*` passes.
+
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::{TyCtxt, Visibility};
 use std::mem;

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -1,6 +1,7 @@
 //! Tidy check to ensure below in UI test directories:
 //! - the number of entries in each directory must be less than `ENTRY_LIMIT`
 //! - there are no stray `.stderr` files
+
 use ignore::Walk;
 use std::collections::{BTreeSet, HashMap};
 use std::ffi::OsStr;

--- a/tests/mir-opt/issue_76432.rs
+++ b/tests/mir-opt/issue_76432.rs
@@ -3,9 +3,9 @@
 //@ compile-flags: -Zmir-enable-passes=-NormalizeArrayLen
 // Check that we do not insert StorageDead at each target if StorageDead was never seen
 
-// EMIT_MIR issue_76432.test.SimplifyComparisonIntegral.diff
 use std::fmt::Debug;
 
+// EMIT_MIR issue_76432.test.SimplifyComparisonIntegral.diff
 fn test<T: Copy + Debug + PartialEq>(x: T) {
     let v: &[T] = &[x, x, x];
     match v {

--- a/tests/run-make/symlinked-libraries/rmake.rs
+++ b/tests/run-make/symlinked-libraries/rmake.rs
@@ -6,6 +6,7 @@
 // See https://github.com/rust-lang/rust/issues/12459
 
 //@ ignore-cross-compile
+
 use run_make_support::{create_symlink, dynamic_lib_name, fs_wrapper, rustc};
 
 fn main() {


### PR DESCRIPTION
#125443 will reformat all `use` declarations in the repository. There are a few edge cases involving comments on `use` declarations that require care. This PR cleans up some clumsy comment cases, taking us a step closer to #125443 being able to merge.

r? @lqd 