### PR TITLE
Fix assertion failure for some `Expect` diagnostics.

### DIFF
--- a/tests/ui/lint/expect-future_breakage-crash-issue-126521.rs
+++ b/tests/ui/lint/expect-future_breakage-crash-issue-126521.rs
@@ -1,4 +1,3 @@
-//@ known-bug: rust-lang/rust#126521
 macro_rules! foo {
     ($val:ident) => {
         true;
@@ -7,5 +6,6 @@ macro_rules! foo {
 
 fn main() {
     #[expect(semicolon_in_expressions_from_macros)]
+    //~^ ERROR the `#[expect]` attribute is an experimental feature
     let _ = foo!(x);
 }

--- a/tests/ui/lint/expect-future_breakage-crash-issue-126521.stderr
+++ b/tests/ui/lint/expect-future_breakage-crash-issue-126521.stderr
@@ -1,0 +1,13 @@
+error[E0658]: the `#[expect]` attribute is an experimental feature
+  --> $DIR/expect-future_breakage-crash-issue-126521.rs:8:5
+   |
+LL |     #[expect(semicolon_in_expressions_from_macros)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #54503 <https://github.com/rust-lang/rust/issues/54503> for more information
+   = help: add `#![feature(lint_reasons)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
In #120699 I moved some code dealing with `has_future_breakage` earlier in `emit_diagnostic`. Issue #126521 identified a case where that reordering was invalid (leading to an assertion failure) for some `Expect` diagnostics.

This commit partially undoes the change, by moving the handling of unstable `Expect` diagnostics earlier again. This makes `emit_diagnostic` a bit uglier, but is necessary to fix the problem.

Fixes #126521.

r? @oli-obk 