### PR TITLE
Ignore `branch-protection-check-IBT` run-make test

### DIFF
--- a/tests/run-make/branch-protection-check-IBT/Makefile
+++ b/tests/run-make/branch-protection-check-IBT/Makefile
@@ -7,6 +7,12 @@ include ../tools.mk
 
 # only-x86_64
 
+# ignore-test
+# FIXME(jieyouxu): This test never runs because the `ifeq` check on line 17
+# compares `x86` to `x86_64`, which always evaluates to false.
+# When the test does run, the compilation does not include `.note.gnu.property`.
+# See https://github.com/rust-lang/rust/pull/126720 for more information.
+
 all:
 ifeq ($(filter x86,$(LLVM_COMPONENTS)),x86_64)
 	$(RUSTC) --target x86_64-unknown-linux-gnu -Z cf-protection=branch -L$(TMPDIR) -C link-args='-nostartfiles'  -C save-temps  ./main.rs -o $(TMPDIR)/rsmain

--- a/tests/run-make/branch-protection-check-IBT/_rmake.rs
+++ b/tests/run-make/branch-protection-check-IBT/_rmake.rs
@@ -1,0 +1,31 @@
+// Check for GNU Property Note
+
+// How to run this
+// python3 x.py test --target x86_64-unknown-linux-gnu  tests/run-make/branch-protection-check-IBT/
+
+//@ only-x86_64
+
+//@ ignore-test
+// FIXME(jieyouxu): see the FIXME in the Makefile
+
+use run_make_support::llvm_readobj;
+use run_make_support::rustc;
+use run_make_support::{cwd, env_var};
+
+fn main() {
+    let llvm_components = env_var("LLVM_COMPONENTS");
+    if !format!(" {llvm_components} ").contains(" x86 ") {
+        return;
+    }
+
+    rustc()
+        .input("main.rs")
+        .target("x86_64-unknown-linux-gnu")
+        .arg("-Zcf-protection=branch")
+        .arg(format!("-L{}", cwd().display()))
+        .arg("-Clink-args=-nostartfiles")
+        .arg("-Csave-temps")
+        .run();
+
+    llvm_readobj().arg("-nW").input("main").run().assert_stdout_contains(".note.gnu.property");
+}


### PR DESCRIPTION
The old Makefile implementation (#110304) had an improper comparison which caused the test to never run. However, both the updated Makefile implementation and the rmake implementation fail (missing `.note.gnu.property`). This could be a bug in the original implementation or test flakiness.

Edit: Manually recreating the test case shows that `.note.gnu.property` does not appear in nightly.
```rust
// main.rs
fn main() {
    println!("hello world");
}
```
```sh
$ rustc +nightly -V
rustc 1.81.0-nightly (c1b336cb6 2024-06-21)
$ rustc +stable -V
rustc 1.79.0 (129f3b996 2024-06-10)
```
```sh
$ rustc +nightly -Zcf-protection=branch -Clink-args=-nostartfiles -Csave-temps "-L$PWD" main.rs -o main
$ llvm-readobj --elf-output-style=GNU -nW main
Displaying notes found in: .note.gnu.build-id
  Owner                Data size        Description
  GNU                  0x00000008       NT_GNU_BUILD_ID (unique build ID bitstring)
    Build ID: bcae34e6431b2a37
```
Compiling without the other flags still does not show `.note.gnu.property`.
```sh
$ rustc +nightly main.rs -o main
$ llvm-readobj --elf-output-style=GNU -nW main
Displaying notes found in: .note.ABI-tag
  Owner                Data size        Description
  GNU                  0x00000010       NT_GNU_ABI_TAG (ABI version tag)
    OS: Linux, ABI: 4.4.0

Displaying notes found in: .note.gnu.build-id
  Owner                Data size        Description
  GNU                  0x00000008       NT_GNU_BUILD_ID (unique build ID bitstring)
    Build ID: d60d5f108b63bf3a
```
Compiling on stable shows `.note.gnu.property`.
```sh
$ rustc +stable main.rs -o main
$ llvm-readobj --elf-output-style=GNU -nW main
Displaying notes found in: .note.gnu.property
  Owner                Data size        Description
  GNU                  0x00000010       NT_GNU_PROPERTY_TYPE_0 (property note)
    Properties:    x86 ISA needed: x86-64-baseline


Displaying notes found in: .note.gnu.build-id
  Owner                Data size        Description
  GNU                  0x00000014       NT_GNU_BUILD_ID (unique build ID bitstring)
    Build ID: 4a494eb578123314e6ff1caf1c8877e27004664f

Displaying notes found in: .note.ABI-tag
  Owner                Data size        Description
  GNU                  0x00000010       NT_GNU_ABI_TAG (ABI version tag)
    OS: Linux, ABI: 4.4.0
```

Part of #121876.

r? @jieyouxu 