### PR TITLE
coverage: Make `#[coverage(..)]` apply recursively to nested functions

### DIFF
--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -124,22 +124,6 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                         .emit();
                 }
             }
-            sym::coverage => {
-                let inner = attr.meta_item_list();
-                match inner.as_deref() {
-                    Some([item]) if item.has_name(sym::off) => {
-                        codegen_fn_attrs.flags |= CodegenFnAttrFlags::NO_COVERAGE;
-                    }
-                    Some([item]) if item.has_name(sym::on) => {
-                        // Allow #[coverage(on)] for being explicit, maybe also in future to enable
-                        // coverage on a smaller scope within an excluded larger scope.
-                    }
-                    Some(_) | None => {
-                        tcx.dcx()
-                            .span_delayed_bug(attr.span, "unexpected value of coverage attribute");
-                    }
-                }
-            }
             sym::rustc_std_internal_symbol => {
                 codegen_fn_attrs.flags |= CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL
             }
@@ -584,7 +568,6 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
     }
 
     if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::NAKED) {
-        codegen_fn_attrs.flags |= CodegenFnAttrFlags::NO_COVERAGE;
         codegen_fn_attrs.inline = InlineAttr::Never;
     }
 

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -87,10 +87,7 @@ bitflags::bitflags! {
         /// #[cmse_nonsecure_entry]: with a TrustZone-M extension, declare a
         /// function as an entry function from Non-Secure code.
         const CMSE_NONSECURE_ENTRY      = 1 << 13;
-        /// `#[coverage(off)]`: indicates that the function should be ignored by
-        /// the MIR `InstrumentCoverage` pass and not added to the coverage map
-        /// during codegen.
-        const NO_COVERAGE               = 1 << 14;
+        // (Bit 14 was used for `#[coverage(off)]`, but is now unused.)
         /// `#[used(linker)]`:
         /// indicates that neither LLVM nor the linker will eliminate this function.
         const USED_LINKER               = 1 << 15;

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -572,6 +572,14 @@ rustc_queries! {
         separate_provide_extern
     }
 
+    /// Checks for `#[coverage(off)]` or `#[coverage(on)]`.
+    ///
+    /// Returns `false` if `#[coverage(off)]` was found, or `true` if
+    /// either `#[coverage(on)]` or no coverage attribute was found.
+    query coverage_attr_on(key: LocalDefId) -> bool {
+        desc { |tcx| "checking for `#[coverage(..)]` on `{}`", tcx.def_path_str(key) }
+    }
+
     /// Summarizes coverage IDs inserted by the `InstrumentCoverage` MIR pass
     /// (for compiler option `-Cinstrument-coverage`), after MIR optimizations
     /// have had a chance to potentially remove some of them.

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -572,7 +572,8 @@ rustc_queries! {
         separate_provide_extern
     }
 
-    /// Checks for `#[coverage(off)]` or `#[coverage(on)]`.
+    /// Checks for the nearest `#[coverage(off)]` or `#[coverage(on)]` on
+    /// this def and any enclosing defs, up to the crate root.
     ///
     /// Returns `false` if `#[coverage(off)]` was found, or `true` if
     /// either `#[coverage(on)]` or no coverage attribute was found.

--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -6,11 +6,13 @@ use rustc_middle::query::TyCtxtAt;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_middle::util::Providers;
 use rustc_span::def_id::LocalDefId;
+use rustc_span::sym;
 
 /// Registers query/hook implementations related to coverage.
 pub(crate) fn provide(providers: &mut Providers) {
     providers.hooks.is_eligible_for_coverage =
         |TyCtxtAt { tcx, .. }, def_id| is_eligible_for_coverage(tcx, def_id);
+    providers.queries.coverage_attr_on = coverage_attr_on;
     providers.queries.coverage_ids_info = coverage_ids_info;
 }
 
@@ -38,11 +40,34 @@ fn is_eligible_for_coverage(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
         return false;
     }
 
-    if tcx.codegen_fn_attrs(def_id).flags.contains(CodegenFnAttrFlags::NO_COVERAGE) {
+    if tcx.codegen_fn_attrs(def_id).flags.contains(CodegenFnAttrFlags::NAKED) {
+        trace!("InstrumentCoverage skipped for {def_id:?} (`#[naked]`)");
+        return false;
+    }
+
+    if !tcx.coverage_attr_on(def_id) {
         trace!("InstrumentCoverage skipped for {def_id:?} (`#[coverage(off)]`)");
         return false;
     }
 
+    true
+}
+
+/// Query implementation for `coverage_attr_on`.
+fn coverage_attr_on(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
+    if let Some(attr) = tcx.get_attr(def_id, sym::coverage) {
+        match attr.meta_item_list().as_deref() {
+            Some([item]) if item.has_name(sym::off) => return false,
+            Some([item]) if item.has_name(sym::on) => return true,
+            Some(_) | None => {
+                // Other possibilities should have been rejected by `rustc_parse::validate_attr`.
+                tcx.dcx().span_bug(attr.span, "unexpected value of coverage attribute");
+            }
+        }
+    }
+
+    // We didn't see an explicit coverage attribute, so
+    // allow coverage instrumentation by default.
     true
 }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -369,13 +369,16 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         }
     }
 
-    /// Checks that `#[coverage(..)]` is applied to a function or closure.
+    /// Checks that `#[coverage(..)]` is applied to a function/closure/method,
+    /// or to an impl block or module.
     fn check_coverage(&self, attr: &Attribute, span: Span, target: Target) -> bool {
         match target {
-            // #[coverage(..)] on function is fine
             Target::Fn
             | Target::Closure
-            | Target::Method(MethodKind::Trait { body: true } | MethodKind::Inherent) => true,
+            | Target::Method(MethodKind::Trait { body: true } | MethodKind::Inherent)
+            | Target::Impl
+            | Target::Mod => true,
+
             _ => {
                 self.dcx().emit_err(errors::CoverageNotFnOrClosure {
                     attr_span: attr.span,

--- a/tests/coverage/attr/impl.cov-map
+++ b/tests/coverage/attr/impl.cov-map
@@ -1,0 +1,24 @@
+Function name: <impl::MyStruct>::off_on (unused)
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 0e, 05, 00, 13]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Zero) at (prev + 14, 5) to (start + 0, 19)
+
+Function name: <impl::MyStruct>::on_inherit (unused)
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 16, 05, 00, 17]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Zero) at (prev + 22, 5) to (start + 0, 23)
+
+Function name: <impl::MyStruct>::on_on (unused)
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 19, 05, 00, 12]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Zero) at (prev + 25, 5) to (start + 0, 18)
+

--- a/tests/coverage/attr/impl.coverage
+++ b/tests/coverage/attr/impl.coverage
@@ -1,0 +1,42 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2021
+   LL|       |
+   LL|       |// Checks that `#[coverage(..)]` can be applied to impl and impl-trait blocks,
+   LL|       |// and is inherited by any enclosed functions.
+   LL|       |
+   LL|       |struct MyStruct;
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |impl MyStruct {
+   LL|       |    fn off_inherit() {}
+   LL|       |
+   LL|       |    #[coverage(on)]
+   LL|      0|    fn off_on() {}
+   LL|       |
+   LL|       |    #[coverage(off)]
+   LL|       |    fn off_off() {}
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(on)]
+   LL|       |impl MyStruct {
+   LL|      0|    fn on_inherit() {}
+   LL|       |
+   LL|       |    #[coverage(on)]
+   LL|      0|    fn on_on() {}
+   LL|       |
+   LL|       |    #[coverage(off)]
+   LL|       |    fn on_off() {}
+   LL|       |}
+   LL|       |
+   LL|       |trait MyTrait {
+   LL|       |    fn method();
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |impl MyTrait for MyStruct {
+   LL|       |    fn method() {}
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {}
+

--- a/tests/coverage/attr/impl.rs
+++ b/tests/coverage/attr/impl.rs
@@ -1,0 +1,41 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+
+// Checks that `#[coverage(..)]` can be applied to impl and impl-trait blocks,
+// and is inherited by any enclosed functions.
+
+struct MyStruct;
+
+#[coverage(off)]
+impl MyStruct {
+    fn off_inherit() {}
+
+    #[coverage(on)]
+    fn off_on() {}
+
+    #[coverage(off)]
+    fn off_off() {}
+}
+
+#[coverage(on)]
+impl MyStruct {
+    fn on_inherit() {}
+
+    #[coverage(on)]
+    fn on_on() {}
+
+    #[coverage(off)]
+    fn on_off() {}
+}
+
+trait MyTrait {
+    fn method();
+}
+
+#[coverage(off)]
+impl MyTrait for MyStruct {
+    fn method() {}
+}
+
+#[coverage(off)]
+fn main() {}

--- a/tests/coverage/attr/module.cov-map
+++ b/tests/coverage/attr/module.cov-map
@@ -1,0 +1,24 @@
+Function name: module::off::on (unused)
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 0c, 05, 00, 0f]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Zero) at (prev + 12, 5) to (start + 0, 15)
+
+Function name: module::on::inherit (unused)
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 14, 05, 00, 14]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Zero) at (prev + 20, 5) to (start + 0, 20)
+
+Function name: module::on::on (unused)
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 17, 05, 00, 0f]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Zero) at (prev + 23, 5) to (start + 0, 15)
+

--- a/tests/coverage/attr/module.coverage
+++ b/tests/coverage/attr/module.coverage
@@ -1,0 +1,38 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2021
+   LL|       |
+   LL|       |// Checks that `#[coverage(..)]` can be applied to modules, and is inherited
+   LL|       |// by any enclosed functions.
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |mod off {
+   LL|       |    fn inherit() {}
+   LL|       |
+   LL|       |    #[coverage(on)]
+   LL|      0|    fn on() {}
+   LL|       |
+   LL|       |    #[coverage(off)]
+   LL|       |    fn off() {}
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(on)]
+   LL|       |mod on {
+   LL|      0|    fn inherit() {}
+   LL|       |
+   LL|       |    #[coverage(on)]
+   LL|      0|    fn on() {}
+   LL|       |
+   LL|       |    #[coverage(off)]
+   LL|       |    fn off() {}
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |mod nested_a {
+   LL|       |    mod nested_b {
+   LL|       |        fn inner() {}
+   LL|       |    }
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {}
+

--- a/tests/coverage/attr/module.rs
+++ b/tests/coverage/attr/module.rs
@@ -1,0 +1,37 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+
+// Checks that `#[coverage(..)]` can be applied to modules, and is inherited
+// by any enclosed functions.
+
+#[coverage(off)]
+mod off {
+    fn inherit() {}
+
+    #[coverage(on)]
+    fn on() {}
+
+    #[coverage(off)]
+    fn off() {}
+}
+
+#[coverage(on)]
+mod on {
+    fn inherit() {}
+
+    #[coverage(on)]
+    fn on() {}
+
+    #[coverage(off)]
+    fn off() {}
+}
+
+#[coverage(off)]
+mod nested_a {
+    mod nested_b {
+        fn inner() {}
+    }
+}
+
+#[coverage(off)]
+fn main() {}

--- a/tests/coverage/attr/nested.cov-map
+++ b/tests/coverage/attr/nested.cov-map
@@ -1,35 +1,3 @@
-Function name: <<<nested::MyOuter as nested::MyTrait>::trait_method::MyMiddle as nested::MyTrait>::trait_method::MyInner as nested::MyTrait>::trait_method (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 39, 15, 02, 16]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Zero) at (prev + 57, 21) to (start + 2, 22)
-
-Function name: <<<nested::MyOuter>::outer_method::MyMiddle>::middle_method::MyInner>::inner_method (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 23, 15, 02, 16]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Zero) at (prev + 35, 21) to (start + 2, 22)
-
-Function name: <<nested::MyOuter as nested::MyTrait>::trait_method::MyMiddle as nested::MyTrait>::trait_method (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 36, 0d, 08, 0e]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Zero) at (prev + 54, 13) to (start + 8, 14)
-
-Function name: <<nested::MyOuter>::outer_method::MyMiddle>::middle_method (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 20, 0d, 08, 0e]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Zero) at (prev + 32, 13) to (start + 8, 14)
-
 Function name: nested::closure_expr
 Raw bytes (14): 0x[01, 01, 00, 02, 01, 44, 01, 01, 0f, 01, 0b, 05, 01, 02]
 Number of files: 1
@@ -39,23 +7,6 @@ Number of file 0 mappings: 2
 - Code(Counter(0)) at (prev + 68, 1) to (start + 1, 15)
 - Code(Counter(0)) at (prev + 11, 5) to (start + 1, 2)
 
-Function name: nested::closure_expr::{closure#0}::{closure#0} (unused)
-Raw bytes (14): 0x[01, 01, 00, 02, 00, 47, 1a, 01, 17, 00, 04, 0d, 01, 0a]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 2
-- Code(Zero) at (prev + 71, 26) to (start + 1, 23)
-- Code(Zero) at (prev + 4, 13) to (start + 1, 10)
-
-Function name: nested::closure_expr::{closure#0}::{closure#0}::{closure#0} (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 48, 1d, 02, 0e]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Zero) at (prev + 72, 29) to (start + 2, 14)
-
 Function name: nested::closure_tail
 Raw bytes (14): 0x[01, 01, 00, 02, 01, 53, 01, 01, 0f, 01, 11, 05, 01, 02]
 Number of files: 1
@@ -64,37 +15,4 @@ Number of expressions: 0
 Number of file 0 mappings: 2
 - Code(Counter(0)) at (prev + 83, 1) to (start + 1, 15)
 - Code(Counter(0)) at (prev + 17, 5) to (start + 1, 2)
-
-Function name: nested::closure_tail::{closure#0}::{closure#0} (unused)
-Raw bytes (14): 0x[01, 01, 00, 02, 00, 58, 14, 01, 1f, 00, 06, 15, 01, 12]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 2
-- Code(Zero) at (prev + 88, 20) to (start + 1, 31)
-- Code(Zero) at (prev + 6, 21) to (start + 1, 18)
-
-Function name: nested::closure_tail::{closure#0}::{closure#0}::{closure#0} (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 5a, 1c, 02, 1a]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Zero) at (prev + 90, 28) to (start + 2, 26)
-
-Function name: nested::outer_fn::middle_fn (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 11, 05, 05, 06]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Zero) at (prev + 17, 5) to (start + 5, 6)
-
-Function name: nested::outer_fn::middle_fn::inner_fn (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 12, 09, 02, 0a]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Zero) at (prev + 18, 9) to (start + 2, 10)
 

--- a/tests/coverage/attr/nested.coverage
+++ b/tests/coverage/attr/nested.coverage
@@ -14,12 +14,12 @@
    LL|       |
    LL|       |#[coverage(off)]
    LL|       |fn outer_fn() {
-   LL|      0|    fn middle_fn() {
-   LL|      0|        fn inner_fn() {
-   LL|      0|            do_stuff();
-   LL|      0|        }
-   LL|      0|        do_stuff();
-   LL|      0|    }
+   LL|       |    fn middle_fn() {
+   LL|       |        fn inner_fn() {
+   LL|       |            do_stuff();
+   LL|       |        }
+   LL|       |        do_stuff();
+   LL|       |    }
    LL|       |    do_stuff();
    LL|       |}
    LL|       |
@@ -29,15 +29,15 @@
    LL|       |    fn outer_method(&self) {
    LL|       |        struct MyMiddle;
    LL|       |        impl MyMiddle {
-   LL|      0|            fn middle_method(&self) {
-   LL|      0|                struct MyInner;
-   LL|      0|                impl MyInner {
-   LL|      0|                    fn inner_method(&self) {
-   LL|      0|                        do_stuff();
-   LL|      0|                    }
-   LL|      0|                }
-   LL|      0|                do_stuff();
-   LL|      0|            }
+   LL|       |            fn middle_method(&self) {
+   LL|       |                struct MyInner;
+   LL|       |                impl MyInner {
+   LL|       |                    fn inner_method(&self) {
+   LL|       |                        do_stuff();
+   LL|       |                    }
+   LL|       |                }
+   LL|       |                do_stuff();
+   LL|       |            }
    LL|       |        }
    LL|       |        do_stuff();
    LL|       |    }
@@ -51,15 +51,15 @@
    LL|       |    fn trait_method(&self) {
    LL|       |        struct MyMiddle;
    LL|       |        impl MyTrait for MyMiddle {
-   LL|      0|            fn trait_method(&self) {
-   LL|      0|                struct MyInner;
-   LL|      0|                impl MyTrait for MyInner {
-   LL|      0|                    fn trait_method(&self) {
-   LL|      0|                        do_stuff();
-   LL|      0|                    }
-   LL|      0|                }
-   LL|      0|                do_stuff();
-   LL|      0|            }
+   LL|       |            fn trait_method(&self) {
+   LL|       |                struct MyInner;
+   LL|       |                impl MyTrait for MyInner {
+   LL|       |                    fn trait_method(&self) {
+   LL|       |                        do_stuff();
+   LL|       |                    }
+   LL|       |                }
+   LL|       |                do_stuff();
+   LL|       |            }
    LL|       |        }
    LL|       |        do_stuff();
    LL|       |    }
@@ -68,12 +68,12 @@
    LL|      1|fn closure_expr() {
    LL|      1|    let _outer = #[coverage(off)]
    LL|       |    || {
-   LL|      0|        let _middle = || {
-   LL|      0|            let _inner = || {
-   LL|      0|                do_stuff();
-   LL|      0|            };
-   LL|      0|            do_stuff();
-   LL|      0|        };
+   LL|       |        let _middle = || {
+   LL|       |            let _inner = || {
+   LL|       |                do_stuff();
+   LL|       |            };
+   LL|       |            do_stuff();
+   LL|       |        };
    LL|       |        do_stuff();
    LL|       |    };
    LL|      1|    do_stuff();
@@ -85,14 +85,14 @@
    LL|       |        #[coverage(off)]
    LL|       |        || {
    LL|       |            let _middle = {
-   LL|      0|                || {
-   LL|      0|                    let _inner = {
-   LL|      0|                        || {
-   LL|      0|                            do_stuff();
-   LL|      0|                        }
+   LL|       |                || {
+   LL|       |                    let _inner = {
+   LL|       |                        || {
+   LL|       |                            do_stuff();
+   LL|       |                        }
    LL|       |                    };
-   LL|      0|                    do_stuff();
-   LL|      0|                }
+   LL|       |                    do_stuff();
+   LL|       |                }
    LL|       |            };
    LL|       |            do_stuff();
    LL|       |        }

--- a/tests/coverage/attr/off-on-sandwich.cov-map
+++ b/tests/coverage/attr/off-on-sandwich.cov-map
@@ -6,14 +6,6 @@ Number of expressions: 0
 Number of file 0 mappings: 1
 - Code(Counter(0)) at (prev + 20, 5) to (start + 7, 6)
 
-Function name: off_on_sandwich::sparse_a::sparse_b
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 22, 05, 10, 06]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 34, 5) to (start + 16, 6)
-
 Function name: off_on_sandwich::sparse_a::sparse_b::sparse_c
 Raw bytes (9): 0x[01, 01, 00, 01, 01, 26, 09, 0b, 0a]
 Number of files: 1

--- a/tests/coverage/attr/off-on-sandwich.coverage
+++ b/tests/coverage/attr/off-on-sandwich.coverage
@@ -31,10 +31,10 @@
    LL|       |fn sparse_a() {
    LL|       |    sparse_b();
    LL|       |    sparse_b();
-   LL|      2|    fn sparse_b() {
-   LL|      2|        sparse_c();
-   LL|      2|        sparse_c();
-   LL|      2|        #[coverage(on)]
+   LL|       |    fn sparse_b() {
+   LL|       |        sparse_c();
+   LL|       |        sparse_c();
+   LL|       |        #[coverage(on)]
    LL|      4|        fn sparse_c() {
    LL|      4|            sparse_d();
    LL|      4|            sparse_d();
@@ -47,7 +47,7 @@
    LL|      8|                }
    LL|      8|            }
    LL|      4|        }
-   LL|      2|    }
+   LL|       |    }
    LL|       |}
    LL|       |
    LL|       |#[coverage(off)]

--- a/tests/coverage/no_cov_crate.cov-map
+++ b/tests/coverage/no_cov_crate.cov-map
@@ -59,16 +59,3 @@ Number of file 0 mappings: 4
     = (c0 - c1)
 - Code(Counter(0)) at (prev + 3, 9) to (start + 0, 10)
 
-Function name: no_cov_crate::nested_fns::outer_not_covered::inner
-Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 26, 09, 01, 17, 05, 01, 18, 02, 0e, 02, 02, 14, 02, 0e, 01, 03, 09, 00, 0a]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 1
-- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 38, 9) to (start + 1, 23)
-- Code(Counter(1)) at (prev + 1, 24) to (start + 2, 14)
-- Code(Expression(0, Sub)) at (prev + 2, 20) to (start + 2, 14)
-    = (c0 - c1)
-- Code(Counter(0)) at (prev + 3, 9) to (start + 0, 10)
-

--- a/tests/coverage/no_cov_crate.coverage
+++ b/tests/coverage/no_cov_crate.coverage
@@ -35,13 +35,13 @@
    LL|       |mod nested_fns {
    LL|       |    #[coverage(off)]
    LL|       |    pub fn outer_not_covered(is_true: bool) {
-   LL|      1|        fn inner(is_true: bool) {
-   LL|      1|            if is_true {
-   LL|      1|                println!("called and covered");
-   LL|      1|            } else {
-   LL|      0|                println!("absolutely not covered");
-   LL|      0|            }
-   LL|      1|        }
+   LL|       |        fn inner(is_true: bool) {
+   LL|       |            if is_true {
+   LL|       |                println!("called and covered");
+   LL|       |            } else {
+   LL|       |                println!("absolutely not covered");
+   LL|       |            }
+   LL|       |        }
    LL|       |        println!("called but not covered");
    LL|       |        inner(is_true);
    LL|       |    }

--- a/tests/ui/coverage-attr/name-value.rs
+++ b/tests/ui/coverage-attr/name-value.rs
@@ -10,13 +10,11 @@
 
 #[coverage = "off"]
 //~^ ERROR malformed `coverage` attribute input
-//~| ERROR attribute should be applied to a function definition or closure
 mod my_mod {}
 
 mod my_mod_inner {
     #![coverage = "off"]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR attribute should be applied to a function definition or closure
 }
 
 #[coverage = "off"]
@@ -26,7 +24,6 @@ struct MyStruct;
 
 #[coverage = "off"]
 //~^ ERROR malformed `coverage` attribute input
-//~| ERROR attribute should be applied to a function definition or closure
 impl MyStruct {
     #[coverage = "off"]
     //~^ ERROR malformed `coverage` attribute input
@@ -51,7 +48,6 @@ trait MyTrait {
 
 #[coverage = "off"]
 //~^ ERROR malformed `coverage` attribute input
-//~| ERROR attribute should be applied to a function definition or closure
 impl MyTrait for MyStruct {
     #[coverage = "off"]
     //~^ ERROR malformed `coverage` attribute input

--- a/tests/ui/coverage-attr/name-value.stderr
+++ b/tests/ui/coverage-attr/name-value.stderr
@@ -12,7 +12,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:17:5
+  --> $DIR/name-value.rs:16:5
    |
 LL |     #![coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     #![coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:22:1
+  --> $DIR/name-value.rs:20:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:31:5
+  --> $DIR/name-value.rs:28:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -51,7 +51,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:27:1
+  --> $DIR/name-value.rs:25:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:41:5
+  --> $DIR/name-value.rs:38:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:46:5
+  --> $DIR/name-value.rs:43:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:37:1
+  --> $DIR/name-value.rs:34:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:56:5
+  --> $DIR/name-value.rs:52:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -116,7 +116,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:61:5
+  --> $DIR/name-value.rs:57:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -129,7 +129,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:52:1
+  --> $DIR/name-value.rs:49:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -142,7 +142,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:67:1
+  --> $DIR/name-value.rs:63:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -155,27 +155,7 @@ LL | #[coverage(on)]
    |
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:11:1
-   |
-LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^
-...
-LL | mod my_mod {}
-   | ------------- not a function or closure
-
-error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:17:5
-   |
-LL | / mod my_mod_inner {
-LL | |     #![coverage = "off"]
-   | |     ^^^^^^^^^^^^^^^^^^^^
-LL | |
-LL | |
-LL | | }
-   | |_- not a function or closure
-
-error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:22:1
+  --> $DIR/name-value.rs:20:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -184,21 +164,7 @@ LL | struct MyStruct;
    | ---------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:27:1
-   |
-LL |   #[coverage = "off"]
-   |   ^^^^^^^^^^^^^^^^^^^
-...
-LL | / impl MyStruct {
-LL | |     #[coverage = "off"]
-LL | |
-LL | |
-LL | |     const X: u32 = 7;
-LL | | }
-   | |_- not a function or closure
-
-error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:37:1
+  --> $DIR/name-value.rs:34:1
    |
 LL |   #[coverage = "off"]
    |   ^^^^^^^^^^^^^^^^^^^
@@ -213,22 +179,7 @@ LL | | }
    | |_- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:52:1
-   |
-LL |   #[coverage = "off"]
-   |   ^^^^^^^^^^^^^^^^^^^
-...
-LL | / impl MyTrait for MyStruct {
-LL | |     #[coverage = "off"]
-LL | |
-LL | |
-...  |
-LL | |     type T = ();
-LL | | }
-   | |_- not a function or closure
-
-error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:41:5
+  --> $DIR/name-value.rs:38:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -237,7 +188,7 @@ LL |     const X: u32;
    |     ------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:46:5
+  --> $DIR/name-value.rs:43:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -246,7 +197,7 @@ LL |     type T;
    |     ------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:31:5
+  --> $DIR/name-value.rs:28:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -255,7 +206,7 @@ LL |     const X: u32 = 7;
    |     ----------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:56:5
+  --> $DIR/name-value.rs:52:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -264,7 +215,7 @@ LL |     const X: u32 = 8;
    |     ----------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:61:5
+  --> $DIR/name-value.rs:57:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -272,6 +223,6 @@ LL |     #[coverage = "off"]
 LL |     type T = ();
    |     ------------ not a function or closure
 
-error: aborting due to 23 previous errors
+error: aborting due to 19 previous errors
 
 For more information about this error, try `rustc --explain E0788`.

--- a/tests/ui/coverage-attr/no-coverage.rs
+++ b/tests/ui/coverage-attr/no-coverage.rs
@@ -2,7 +2,7 @@
 #![feature(coverage_attribute)]
 #![feature(impl_trait_in_assoc_type)]
 #![warn(unused_attributes)]
-#![coverage(off)] //~ ERROR attribute should be applied to a function definition or closure
+#![coverage(off)]
 
 #[coverage(off)] //~ ERROR attribute should be applied to a function definition or closure
 trait Trait {
@@ -15,7 +15,7 @@ trait Trait {
     type U;
 }
 
-#[coverage(off)] //~ ERROR attribute should be applied to a function definition or closure
+#[coverage(off)]
 impl Trait for () {
     const X: u32 = 0;
 

--- a/tests/ui/coverage-attr/no-coverage.stderr
+++ b/tests/ui/coverage-attr/no-coverage.stderr
@@ -12,20 +12,6 @@ LL | | }
    | |_- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:18:1
-   |
-LL |   #[coverage(off)]
-   |   ^^^^^^^^^^^^^^^^
-LL | / impl Trait for () {
-LL | |     const X: u32 = 0;
-LL | |
-LL | |     #[coverage(off)]
-...  |
-LL | |     type U = impl Trait;
-LL | | }
-   | |_- not a function or closure
-
-error[E0788]: attribute should be applied to a function definition or closure
   --> $DIR/no-coverage.rs:39:5
    |
 LL |     #[coverage(off)]
@@ -97,12 +83,6 @@ LL |     #[coverage(off)]
 LL |     type T;
    |     ------- not a function or closure
 
-error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:5:1
-   |
-LL | #![coverage(off)]
-   | ^^^^^^^^^^^^^^^^^ not a function or closure
-
 error: unconstrained opaque type
   --> $DIR/no-coverage.rs:26:14
    |
@@ -111,6 +91,6 @@ LL |     type U = impl Trait;
    |
    = note: `U` must be used in combination with a concrete type within the same impl
 
-error: aborting due to 13 previous errors
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0788`.

--- a/tests/ui/coverage-attr/word-only.rs
+++ b/tests/ui/coverage-attr/word-only.rs
@@ -10,13 +10,11 @@
 
 #[coverage]
 //~^ ERROR malformed `coverage` attribute input
-//~| ERROR attribute should be applied to a function definition or closure
 mod my_mod {}
 
 mod my_mod_inner {
     #![coverage]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR attribute should be applied to a function definition or closure
 }
 
 #[coverage]
@@ -26,7 +24,6 @@ struct MyStruct;
 
 #[coverage]
 //~^ ERROR malformed `coverage` attribute input
-//~| ERROR attribute should be applied to a function definition or closure
 impl MyStruct {
     #[coverage]
     //~^ ERROR malformed `coverage` attribute input
@@ -51,7 +48,6 @@ trait MyTrait {
 
 #[coverage]
 //~^ ERROR malformed `coverage` attribute input
-//~| ERROR attribute should be applied to a function definition or closure
 impl MyTrait for MyStruct {
     #[coverage]
     //~^ ERROR malformed `coverage` attribute input

--- a/tests/ui/coverage-attr/word-only.stderr
+++ b/tests/ui/coverage-attr/word-only.stderr
@@ -12,7 +12,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:17:5
+  --> $DIR/word-only.rs:16:5
    |
 LL |     #![coverage]
    |     ^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     #![coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:22:1
+  --> $DIR/word-only.rs:20:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:31:5
+  --> $DIR/word-only.rs:28:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -51,7 +51,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:27:1
+  --> $DIR/word-only.rs:25:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:41:5
+  --> $DIR/word-only.rs:38:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:46:5
+  --> $DIR/word-only.rs:43:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:37:1
+  --> $DIR/word-only.rs:34:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:56:5
+  --> $DIR/word-only.rs:52:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -116,7 +116,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:61:5
+  --> $DIR/word-only.rs:57:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -129,7 +129,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:52:1
+  --> $DIR/word-only.rs:49:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -142,7 +142,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:67:1
+  --> $DIR/word-only.rs:63:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -155,27 +155,7 @@ LL | #[coverage(on)]
    |
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:11:1
-   |
-LL | #[coverage]
-   | ^^^^^^^^^^^
-...
-LL | mod my_mod {}
-   | ------------- not a function or closure
-
-error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:17:5
-   |
-LL | / mod my_mod_inner {
-LL | |     #![coverage]
-   | |     ^^^^^^^^^^^^
-LL | |
-LL | |
-LL | | }
-   | |_- not a function or closure
-
-error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:22:1
+  --> $DIR/word-only.rs:20:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -184,21 +164,7 @@ LL | struct MyStruct;
    | ---------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:27:1
-   |
-LL |   #[coverage]
-   |   ^^^^^^^^^^^
-...
-LL | / impl MyStruct {
-LL | |     #[coverage]
-LL | |
-LL | |
-LL | |     const X: u32 = 7;
-LL | | }
-   | |_- not a function or closure
-
-error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:37:1
+  --> $DIR/word-only.rs:34:1
    |
 LL |   #[coverage]
    |   ^^^^^^^^^^^
@@ -213,22 +179,7 @@ LL | | }
    | |_- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:52:1
-   |
-LL |   #[coverage]
-   |   ^^^^^^^^^^^
-...
-LL | / impl MyTrait for MyStruct {
-LL | |     #[coverage]
-LL | |
-LL | |
-...  |
-LL | |     type T = ();
-LL | | }
-   | |_- not a function or closure
-
-error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:41:5
+  --> $DIR/word-only.rs:38:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -237,7 +188,7 @@ LL |     const X: u32;
    |     ------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:46:5
+  --> $DIR/word-only.rs:43:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -246,7 +197,7 @@ LL |     type T;
    |     ------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:31:5
+  --> $DIR/word-only.rs:28:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -255,7 +206,7 @@ LL |     const X: u32 = 7;
    |     ----------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:56:5
+  --> $DIR/word-only.rs:52:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -264,7 +215,7 @@ LL |     const X: u32 = 8;
    |     ----------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:61:5
+  --> $DIR/word-only.rs:57:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -272,6 +223,6 @@ LL |     #[coverage]
 LL |     type T = ();
    |     ------------ not a function or closure
 
-error: aborting due to 23 previous errors
+error: aborting due to 19 previous errors
 
 For more information about this error, try `rustc --explain E0788`.


### PR DESCRIPTION
This PR makes the (currently-unstable) `#[coverage(off)]` and `#[coverage(on)]` attributes apply recursively to all nested functions/closures, instead of just the function they are directly attached to.

Those attributes can now also be applied to modules and to impl/impl-trait blocks, where they have no direct effect, but will be inherited by all enclosed functions/closures/methods that don't override the inherited value.

---

Fixes #126625.
