### PR TITLE
Add method to get `FnAbi` of function pointer

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -533,6 +533,13 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         Ok(tables.fn_abi_of_instance(instance, List::empty())?.stable(&mut *tables))
     }
 
+    fn fn_ptr_abi(&self, fn_ptr: PolyFnSig) -> Result<FnAbi, Error> {
+        let mut tables = self.0.borrow_mut();
+        let tcx = tables.tcx;
+        let sig = fn_ptr.internal(&mut *tables, tcx);
+        Ok(tables.fn_abi_of_fn_ptr(sig, List::empty())?.stable(&mut *tables))
+    }
+
     fn instance_def_id(&self, def: InstanceDef) -> stable_mir::DefId {
         let mut tables = self.0.borrow_mut();
         let def_id = tables.instances[def].def_id();

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -215,6 +215,9 @@ pub trait Context {
     /// Get an instance ABI.
     fn instance_abi(&self, def: InstanceDef) -> Result<FnAbi, Error>;
 
+    /// Get the ABI of a function pointer.
+    fn fn_ptr_abi(&self, fn_ptr: PolyFnSig) -> Result<FnAbi, Error>;
+
     /// Get the layout of a type.
     fn ty_layout(&self, ty: Ty) -> Result<Layout, Error>;
 

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -2,7 +2,7 @@ use super::{
     mir::{Body, Mutability, Safety},
     with, DefId, Error, Symbol,
 };
-use crate::abi::Layout;
+use crate::abi::{FnAbi, Layout};
 use crate::crate_def::{CrateDef, CrateDefType};
 use crate::mir::alloc::{read_target_int, read_target_uint, AllocId};
 use crate::mir::mono::StaticDef;
@@ -995,6 +995,16 @@ pub struct AliasTerm {
 }
 
 pub type PolyFnSig = Binder<FnSig>;
+
+impl PolyFnSig {
+    /// Compute a `FnAbi` suitable for indirect calls, i.e. to `fn` pointers.
+    ///
+    /// NB: this doesn't handle virtual calls - those should use `Instance::fn_abi`
+    /// instead, where the instance is an `InstanceKind::Virtual`.
+    pub fn fn_ptr_abi(self) -> Result<FnAbi, Error> {
+        with(|cx| cx.fn_ptr_abi(self))
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FnSig {


### PR DESCRIPTION
Provide a StableMIR API to query `FnAbi` of a function pointer.

Fixes [rust-lang/project-stable-mir#63](https://github.com/rust-lang/project-stable-mir/issues/63)