### PR TITLE
Fix `...` in multline code-skips in suggestions

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1905,7 +1905,7 @@ impl HumanEmitter {
                     //
                     // LL | this line was highlighted
                     // LL | this line is just for context
-                    //   ...
+                    // ...
                     // LL | this line is just for context
                     // LL | this line was highlighted
                     _ => {
@@ -1926,7 +1926,7 @@ impl HumanEmitter {
                             )
                         }
 
-                        buffer.puts(row_num, max_line_num_len - 1, "...", Style::LineNumber);
+                        buffer.puts(row_num, 0, "...", Style::LineNumber);
                         row_num += 1;
 
                         if let Some((p, l)) = last_line {

--- a/src/tools/clippy/tests/ui/bind_instead_of_map_multipart.stderr
+++ b/src/tools/clippy/tests/ui/bind_instead_of_map_multipart.stderr
@@ -62,7 +62,7 @@ LL |         }
 LL |         match s.len() {
 LL ~             10 => 2,
 LL |             20 => {
- ...
+...
 LL |                         if foo() {
 LL ~                             return 20;
 LL |                         }

--- a/src/tools/clippy/tests/ui/needless_collect_indirect.stderr
+++ b/src/tools/clippy/tests/ui/needless_collect_indirect.stderr
@@ -212,7 +212,7 @@ help: check if the original Iterator contains an element instead of collecting t
    |
 LL ~             
 LL |
- ...
+...
 LL |                 // Do lint
 LL ~                 vec.iter().map(|k| k * k).any(|x| x == n);
    |

--- a/src/tools/clippy/tests/ui/needless_late_init.stderr
+++ b/src/tools/clippy/tests/ui/needless_late_init.stderr
@@ -215,7 +215,7 @@ help: move the declaration `x` here
    |
 LL ~     
 LL |     // types that should be considered insignificant
- ...
+...
 LL |     let y = Box::new(4);
 LL ~     let x = SignificantDrop;
    |

--- a/src/tools/clippy/tests/ui/needless_return.stderr
+++ b/src/tools/clippy/tests/ui/needless_return.stderr
@@ -518,7 +518,7 @@ help: remove `return`
    |
 LL ~             10
 LL |         },
- ...
+...
 LL |         },
 LL ~     }
    |

--- a/tests/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -17,7 +17,7 @@ help: add a dummy let to cause `fptr` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = &fptr; unsafe {
 LL |
- ...
+...
 LL |
 LL ~     } }).join().unwrap();
    |
@@ -39,7 +39,7 @@ help: add a dummy let to cause `fptr` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = &fptr; unsafe {
 LL |
- ...
+...
 LL |
 LL ~     } }).join().unwrap();
    |

--- a/tests/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
@@ -109,7 +109,7 @@ help: add a dummy let to cause `fptr1`, `fptr2` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = (&fptr1, &fptr2); unsafe {
 LL |
- ...
+...
 LL |
 LL ~     } }).join().unwrap();
    |

--- a/tests/ui/imports/issue-59764.stderr
+++ b/tests/ui/imports/issue-59764.stderr
@@ -209,7 +209,7 @@ help: a macro with this name exists at the root of the crate
    |
 LL ~         issue_59764::{makro as foobar, 
 LL |
- ...
+...
 LL |
 LL ~             foo::{baz}
    |

--- a/tests/ui/issues/issue-22644.stderr
+++ b/tests/ui/issues/issue-22644.stderr
@@ -64,7 +64,7 @@ help: try comparing the cast value
    |
 LL ~     println!("{}", (a
 LL |
- ...
+...
 LL |
 LL ~                    usize)
    |

--- a/tests/ui/issues/issue-57271.stderr
+++ b/tests/ui/issues/issue-57271.stderr
@@ -17,7 +17,7 @@ help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
    |
 LL ~     Array(Box<TypeSignature>),
 LL |     TypeVariable(()),
- ...
+...
 LL |     Base(BaseType),
 LL ~     Object(Box<ObjectType>),
    |

--- a/tests/ui/let-else/let-else-if.stderr
+++ b/tests/ui/let-else/let-else-if.stderr
@@ -8,7 +8,7 @@ help: try placing this code inside a block
    |
 LL ~     let Some(_) = Some(()) else { if true {
 LL |
- ...
+...
 LL |         return;
 LL ~     } };
    |

--- a/tests/ui/loops/loop-else-break-with-value.stderr
+++ b/tests/ui/loops/loop-else-break-with-value.stderr
@@ -27,7 +27,7 @@ help: you might want to use `if let` to ignore the variant that isn't matched
    |
 LL ~     if let Some(1) = loop {
 LL |
- ...
+...
 LL |         return;
 LL ~     } { todo!() };
    |

--- a/tests/ui/moves/nested-loop-moved-value-wrong-continue.stderr
+++ b/tests/ui/moves/nested-loop-moved-value-wrong-continue.stderr
@@ -26,7 +26,7 @@ help: consider moving the expression out of the loop so it is only moved once
 LL ~     for foo in foos { let mut value = baz.push(foo);
 LL ~     for bar in &bars { if foo == *bar {
 LL |
- ...
+...
 LL |
 LL ~         value;
    |
@@ -69,7 +69,7 @@ help: consider moving the expression out of the loop so it is only moved once
 LL ~         let mut value = baz.push(foo);
 LL ~         for bar in &bars {
 LL |
- ...
+...
 LL |             if foo == *bar {
 LL ~                 value;
    |

--- a/tests/ui/parser/recover/recover-labeled-non-block-expr.stderr
+++ b/tests/ui/parser/recover/recover-labeled-non-block-expr.stderr
@@ -54,7 +54,7 @@ help: consider enclosing expression in a block
    |
 LL ~     let _i = 'label: { match x {
 LL |         0 => 42,
- ...
+...
 LL |         _ => 1,
 LL ~     } };
    |

--- a/tests/ui/span/recursive-type-field.stderr
+++ b/tests/ui/span/recursive-type-field.stderr
@@ -17,7 +17,7 @@ help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
    |
 LL ~     bar: Box<Bar<'a>>,
 LL |     b: Rc<Bar<'a>>,
- ...
+...
 LL | struct Bar<'a> {
 LL ~     y: (Box<Foo<'a>>, Box<Foo<'a>>),
    |

--- a/tests/ui/suggestions/issue-68049-2.stderr
+++ b/tests/ui/suggestions/issue-68049-2.stderr
@@ -19,7 +19,7 @@ help: consider changing this to be a mutable reference in the `impl` method and 
    |
 LL ~   fn example(&mut self, input: &i32);
 LL | }
- ...
+...
 LL | impl Hello for Test2 {
 LL ~   fn example(&mut self, input: &i32) {
    |

--- a/tests/ui/try-trait/try-operator-on-main.stderr
+++ b/tests/ui/try-trait/try-operator-on-main.stderr
@@ -12,7 +12,7 @@ help: consider adding return type
    |
 LL ~ fn main() -> Result<(), Box<dyn std::error::Error>> {
 LL |     // error for a `Try` type on a non-`Try` fn
- ...
+...
 LL |     try_trait_generic::<()>();
 LL + 
 LL +     Ok(())

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
@@ -14,7 +14,7 @@ help: consider introducing a named lifetime parameter
    |
 LL ~ fn main<'a>() {
 LL |     eq::< dyn for<'a> Foo<(&'a isize,), Output=&'a isize>,
- ...
+...
 LL |
 LL ~     let _: dyn Foo(&'a isize, &'a usize) -> &'a usize;
    |


### PR DESCRIPTION
When we have long code skips, we write `...` in the line number gutter.

For suggestions, we were "centering" the `...` with the line, but that was inconsistent with what we do in every other case *and* off-center.