### PR TITLE
Add opaque type corner case test

### DIFF
--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.next.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.next.stderr
@@ -1,0 +1,9 @@
+error[E0284]: type annotations needed: cannot satisfy `Foo == _`
+  --> $DIR/norm-before-method-resolution-opaque-type.rs:16:19
+   |
+LL | fn weird_bound<X>(x: &<X as Trait<'static>>::Out<Foo>) -> X
+   |                   ^ cannot satisfy `Foo == _`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.old.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.old.stderr
@@ -1,0 +1,36 @@
+error: item does not constrain `Foo::{opaque#0}`, but has it in its signature
+  --> $DIR/norm-before-method-resolution-opaque-type.rs:16:4
+   |
+LL | fn weird_bound<X>(x: &<X as Trait<'static>>::Out<Foo>) -> X
+   |    ^^^^^^^^^^^
+   |
+   = note: consider moving the opaque type's declaration and defining uses into a separate module
+note: this opaque type is in the signature
+  --> $DIR/norm-before-method-resolution-opaque-type.rs:13:12
+   |
+LL | type Foo = impl Sized;
+   |            ^^^^^^^^^^
+
+error: unconstrained opaque type
+  --> $DIR/norm-before-method-resolution-opaque-type.rs:13:12
+   |
+LL | type Foo = impl Sized;
+   |            ^^^^^^^^^^
+   |
+   = note: `Foo` must be used in combination with a concrete type within the same module
+
+error[E0507]: cannot move out of `*x` which is behind a shared reference
+  --> $DIR/norm-before-method-resolution-opaque-type.rs:23:13
+   |
+LL |     let x = *x;
+   |             ^^ move occurs because `*x` has type `<X as Trait<'_>>::Out<Foo>`, which does not implement the `Copy` trait
+   |
+help: consider removing the dereference here
+   |
+LL -     let x = *x;
+LL +     let x = x;
+   |
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.rs
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.rs
@@ -1,0 +1,29 @@
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver
+
+#![feature(type_alias_impl_trait)]
+trait Trait<'a> {
+    type Out<U>;
+}
+
+impl<'a, T> Trait<'a> for T {
+    type Out<U> = T;
+}
+
+type Foo = impl Sized;
+//[old]~^ ERROR: unconstrained opaque type
+
+fn weird_bound<X>(x: &<X as Trait<'static>>::Out<Foo>) -> X
+//[old]~^ ERROR: item does not constrain
+//[next]~^^ ERROR: cannot satisfy `Foo == _`
+where
+    for<'a> X: Trait<'a>,
+    for<'a> <X as Trait<'a>>::Out<()>: Copy,
+{
+    let x = *x; //[old]~ ERROR: cannot move out of `*x`
+    todo!();
+}
+
+fn main() {
+    let _: () = weird_bound(&());
+}

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution.rs
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-// Should pass, but we normalize and check bounds before we resolve the generics
+// We normalize and check bounds before we resolve the generics
 // of the function (which we know because of the return type).
 
 trait Trait<'a> {
@@ -12,10 +12,12 @@ impl<'a, T> Trait<'a> for T {
 }
 
 fn weird_bound<X>() -> X
-    where
-        for<'a> X: Trait<'a>,
-        for<'a> <X as Trait<'a>>::Out: Copy
-{ todo!() }
+where
+    for<'a> X: Trait<'a>,
+    for<'a> <X as Trait<'a>>::Out: Copy,
+{
+    todo!()
+}
 
 fn main() {
     let _: () = weird_bound();


### PR DESCRIPTION
r? @lcnr

I can't make sense of the new solver tracing logs yet, so I just added the test without explanation.

The old solver does not yet figure out that `Foo == ()` from the where bounds. Unfortunately, even if we make it understand that, it will later try to prove `<X as Trait<'static>>::Out<Foo>: Sized` via the `is_sized_raw` query, which does not take a list of defineable opaque types, causing that check to fail with an ICE.

Thus I'm submitting this test case on its own just to ensure we handle it correctly in the future with any new solver or old solver changes.