### PR TITLE
Stabilize `PanicInfo::message()` and `PanicMessage`

### DIFF
--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -12,7 +12,7 @@ use crate::any::Any;
 pub use self::location::Location;
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 pub use self::panic_info::PanicInfo;
-#[unstable(feature = "panic_info_message", issue = "66745")]
+#[stable(feature = "panic_info_message", since = "CURRENT_RUSTC_VERSION")]
 pub use self::panic_info::PanicMessage;
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 pub use self::unwind_safe::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -24,7 +24,7 @@ pub struct PanicInfo<'a> {
 /// that were given to the `panic!()` macro.
 ///
 /// See [`PanicInfo::message`].
-#[unstable(feature = "panic_info_message", issue = "66745")]
+#[stable(feature = "panic_info_message", since = "CURRENT_RUSTC_VERSION")]
 pub struct PanicMessage<'a> {
     message: fmt::Arguments<'a>,
 }
@@ -57,7 +57,7 @@ impl<'a> PanicInfo<'a> {
     /// }
     /// ```
     #[must_use]
-    #[unstable(feature = "panic_info_message", issue = "66745")]
+    #[stable(feature = "panic_info_message", since = "CURRENT_RUSTC_VERSION")]
     pub fn message(&self) -> PanicMessage<'_> {
         PanicMessage { message: self.message }
     }
@@ -164,7 +164,7 @@ impl<'a> PanicMessage<'a> {
     /// For most cases with placeholders, this function will return `None`.
     ///
     /// See [`fmt::Arguments::as_str`] for details.
-    #[unstable(feature = "panic_info_message", issue = "66745")]
+    #[stable(feature = "panic_info_message", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_const_unstable(feature = "const_arguments_as_str", issue = "103900")]
     #[must_use]
     #[inline]
@@ -173,7 +173,7 @@ impl<'a> PanicMessage<'a> {
     }
 }
 
-#[unstable(feature = "panic_info_message", issue = "66745")]
+#[stable(feature = "panic_info_message", since = "CURRENT_RUSTC_VERSION")]
 impl Display for PanicMessage<'_> {
     #[inline]
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -181,7 +181,7 @@ impl Display for PanicMessage<'_> {
     }
 }
 
-#[unstable(feature = "panic_info_message", issue = "66745")]
+#[stable(feature = "panic_info_message", since = "CURRENT_RUSTC_VERSION")]
 impl fmt::Debug for PanicMessage<'_> {
     #[inline]
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -341,7 +341,6 @@
 #![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_write_slice)]
 #![feature(panic_can_unwind)]
-#![feature(panic_info_message)]
 #![feature(panic_internals)]
 #![feature(pointer_is_aligned_to)]
 #![feature(portable_simd)]

--- a/tests/run-make/wasm-exceptions-nostd/src/lib.rs
+++ b/tests/run-make/wasm-exceptions-nostd/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(core_intrinsics)]
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
-#![feature(panic_info_message)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Resolves #66745

This stabilizes the [`PanicInfo::message()`](https://doc.rust-lang.org/nightly/core/panic/struct.PanicInfo.html#method.message) and [`PanicMessage`](https://doc.rust-lang.org/nightly/core/panic/struct.PanicMessage.html).

Demonstration of [custom panic handler](https://github.com/StackOverflowExcept1on/panicker):
```rust
#![no_std]
#![no_main]

extern crate libc;

#[no_mangle]
extern "C" fn main() -> libc::c_int {
    panic!("I just panic every time");
}

#[panic_handler]
fn my_panic(panic_info: &core::panic::PanicInfo) -> ! {
    use arrayvec::ArrayString;
    use core::fmt::Write;

    let message = panic_info.message();
    let location = panic_info.location().unwrap();

    let mut debug_msg = ArrayString::<1024>::new();
    let _ = write!(&mut debug_msg, "panicked with '{message}' at '{location}'");

    if debug_msg.try_push_str("\0").is_ok() {
        unsafe {
            libc::puts(debug_msg.as_ptr() as *const _);
        }
    }

    unsafe { libc::exit(libc::EXIT_FAILURE) }
}
```
```
$ cargo +stage1 run --release
panicked with 'I just panic every time' at 'src/main.rs:8:5'
```

- [x] FCP: https://github.com/rust-lang/rust/issues/66745#issuecomment-2198143725

r? libs-api
