### PR TITLE
Remove `feature(const_closures)` from libcore

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -209,7 +209,6 @@
 #![feature(cfg_sanitize)]
 #![feature(cfg_target_has_atomic)]
 #![feature(cfg_target_has_atomic_equal_alignment)]
-#![feature(const_closures)]
 #![feature(const_fn_floating_point_arithmetic)]
 #![feature(const_for)]
 #![feature(const_mut_refs)]


### PR DESCRIPTION
This is an incomplete feature and apparently it has no uses in `core`. Incomplete features should generally not be used in our standard library.