### PR TITLE
add `needs-unwind` to UI test

### DIFF
--- a/tests/ui/lifetimes/tail-expr-lock-poisoning.rs
+++ b/tests/ui/lifetimes/tail-expr-lock-poisoning.rs
@@ -3,6 +3,7 @@
 //@ [edition2024] compile-flags: -Zunstable-options
 //@ [edition2024] edition: 2024
 //@ run-pass
+//@ needs-unwind
 #![cfg_attr(edition2024, feature(shorter_tail_lifetimes))]
 
 use std::sync::Mutex;


### PR DESCRIPTION
the `tail-expr-lock-poisoning` UI test uses the `panic::catch_unwind` API so it relies on unwinding being implemented. this test ought not to run on targets that do not support unwinding. add the `needs-unwind` attribute to signal this

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
