### PR TITLE
Properly gate `safe` keyword in pre-expansion

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -562,6 +562,10 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     gate_all!(precise_capturing, "precise captures on `impl Trait` are experimental");
     gate_all!(global_registration, "global registration is experimental");
     gate_all!(unsafe_attributes, "`#[unsafe()]` markers for attributes are experimental");
+    gate_all!(
+        unsafe_extern_blocks,
+        "`unsafe extern {}` blocks and `safe` keyword are experimental"
+    );
 
     if !visitor.features.never_patterns {
         if let Some(spans) = spans.get(&sym::never_patterns) {

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1214,6 +1214,9 @@ impl<'a> Parser<'a> {
         if self.eat_keyword_case(kw::Unsafe, case) {
             Safety::Unsafe(self.prev_token.uninterpolated_span())
         } else if self.eat_keyword_case(kw::Safe, case) {
+            self.psess
+                .gated_spans
+                .gate(sym::unsafe_extern_blocks, self.prev_token.uninterpolated_span());
             Safety::Safe(self.prev_token.uninterpolated_span())
         } else {
             Safety::Default

--- a/tests/ui/feature-gates/feature-gate-unsafe-extern-blocks.rs
+++ b/tests/ui/feature-gates/feature-gate-unsafe-extern-blocks.rs
@@ -2,4 +2,12 @@ unsafe extern "C" {
     //~^ ERROR extern block cannot be declared unsafe
 }
 
+// We can't gate `unsafe extern` blocks themselves since they were previously
+// allowed, but we should gate the `safe` soft keyword.
+#[cfg(any())]
+unsafe extern "C" {
+    safe fn foo();
+    //~^ ERROR `unsafe extern {}` blocks and `safe` keyword are experimental
+}
+
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-unsafe-extern-blocks.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsafe-extern-blocks.stderr
@@ -4,5 +4,16 @@ error: extern block cannot be declared unsafe
 LL | unsafe extern "C" {
    | ^^^^^^
 
-error: aborting due to 1 previous error
+error[E0658]: `unsafe extern {}` blocks and `safe` keyword are experimental
+  --> $DIR/feature-gate-unsafe-extern-blocks.rs:9:5
+   |
+LL |     safe fn foo();
+   |     ^^^^
+   |
+   = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
+   = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
This PR gates `safe` keyword in pre-expansion contexts. Should mitigate the fallout of https://github.com/rust-lang/rust/issues/126755, which is that `safe` is now usable on beta lol.

r? @spastorino or @oli-obk

cc #124482 tracking #123743