### PR TITLE
Do not allow safe/unsafe on static and fn items

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -30,6 +30,9 @@ ast_passes_auto_super_lifetime = auto traits cannot have super traits or lifetim
 
 ast_passes_bad_c_variadic = only foreign or `unsafe extern "C"` functions may be C-variadic
 
+ast_passes_bare_fn_invalid_safety = function pointers cannot be declared with `safe` safety qualifier
+    .suggestion = remove safe from this item
+
 ast_passes_body_in_extern = incorrect `{$kind}` inside `extern` block
     .cannot_have = cannot have a body
     .invalid = the invalid body
@@ -166,6 +169,9 @@ ast_passes_invalid_unnamed_field =
 ast_passes_invalid_unnamed_field_ty =
     unnamed fields can only have struct or union types
     .label = not a struct or union
+
+ast_passes_item_invalid_safety = items outside of `unsafe extern {"{ }"}` cannot be declared with `safe` safety qualifier
+    .suggestion = remove safe from this item
 
 ast_passes_item_underscore = `{$kind}` items in this context need a name
     .label = `_` is not a valid name for this `{$kind}` item

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -226,6 +226,20 @@ pub struct InvalidSafetyOnExtern {
 }
 
 #[derive(Diagnostic)]
+#[diag(ast_passes_item_invalid_safety)]
+pub struct InvalidSafetyOnItem {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(ast_passes_bare_fn_invalid_safety)]
+pub struct InvalidSafetyOnBareFn {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(ast_passes_bound_in_context)]
 pub struct BoundInContext<'a> {
     #[primary_span]

--- a/tests/ui/parser/fn-header-semantic-fail.stderr
+++ b/tests/ui/parser/fn-header-semantic-fail.stderr
@@ -105,15 +105,6 @@ LL |     extern "C" {
 LL |         extern "C" fn fe4();
    |         ^^^^^^^^^^ help: remove this qualifier
 
-error: items in unadorned `extern` blocks cannot have safety qualifiers
-  --> $DIR/fn-header-semantic-fail.rs:50:9
-   |
-LL |     extern "C" {
-   |     ---------- help: add unsafe to this `extern` block
-...
-LL |         const async unsafe extern "C" fn fe5();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/fn-header-semantic-fail.rs:50:15
    |
@@ -140,6 +131,15 @@ LL |     extern "C" {
 ...
 LL |         const async unsafe extern "C" fn fe5();
    |                            ^^^^^^^^^^ help: remove this qualifier
+
+error: items in unadorned `extern` blocks cannot have safety qualifiers
+  --> $DIR/fn-header-semantic-fail.rs:50:9
+   |
+LL |     extern "C" {
+   |     ---------- help: add unsafe to this `extern` block
+...
+LL |         const async unsafe extern "C" fn fe5();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:50:9

--- a/tests/ui/parser/no-const-fn-in-extern-block.stderr
+++ b/tests/ui/parser/no-const-fn-in-extern-block.stderr
@@ -6,15 +6,6 @@ LL | extern "C" {
 LL |     const fn foo();
    |     ^^^^^ help: remove this qualifier
 
-error: items in unadorned `extern` blocks cannot have safety qualifiers
-  --> $DIR/no-const-fn-in-extern-block.rs:4:5
-   |
-LL | extern "C" {
-   | ---------- help: add unsafe to this `extern` block
-...
-LL |     const unsafe fn bar();
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/no-const-fn-in-extern-block.rs:4:5
    |
@@ -23,6 +14,15 @@ LL | extern "C" {
 ...
 LL |     const unsafe fn bar();
    |     ^^^^^ help: remove this qualifier
+
+error: items in unadorned `extern` blocks cannot have safety qualifiers
+  --> $DIR/no-const-fn-in-extern-block.rs:4:5
+   |
+LL | extern "C" {
+   | ---------- help: add unsafe to this `extern` block
+...
+LL |     const unsafe fn bar();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rust-2024/safe-outside-extern.gated.stderr
+++ b/tests/ui/rust-2024/safe-outside-extern.gated.stderr
@@ -1,0 +1,32 @@
+error: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+  --> $DIR/safe-outside-extern.rs:4:1
+   |
+LL | safe fn foo() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+  --> $DIR/safe-outside-extern.rs:8:1
+   |
+LL | safe static FOO: i32 = 1;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+  --> $DIR/safe-outside-extern.rs:13:5
+   |
+LL |     safe fn foo();
+   |     ^^^^^^^^^^^^^^
+
+error: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+  --> $DIR/safe-outside-extern.rs:19:5
+   |
+LL |     safe fn foo() {}
+   |     ^^^^^^^^^^^^^^^^
+
+error: function pointers cannot be declared with `safe` safety qualifier
+  --> $DIR/safe-outside-extern.rs:24:14
+   |
+LL | type FnPtr = safe fn(i32, i32) -> i32;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/rust-2024/safe-outside-extern.rs
+++ b/tests/ui/rust-2024/safe-outside-extern.rs
@@ -1,0 +1,28 @@
+//@ revisions: gated ungated
+#![cfg_attr(gated, feature(unsafe_extern_blocks))]
+
+safe fn foo() {}
+//~^ ERROR: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+//[ungated]~| ERROR: unsafe extern {}` blocks and `safe` keyword are experimental [E0658]
+
+safe static FOO: i32 = 1;
+//~^ ERROR: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+//[ungated]~| ERROR: unsafe extern {}` blocks and `safe` keyword are experimental [E0658]
+
+trait Foo {
+    safe fn foo();
+    //~^ ERROR: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+    //[ungated]~| ERROR: unsafe extern {}` blocks and `safe` keyword are experimental [E0658]
+}
+
+impl Foo for () {
+    safe fn foo() {}
+    //~^ ERROR: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+    //[ungated]~| ERROR: unsafe extern {}` blocks and `safe` keyword are experimental [E0658]
+}
+
+type FnPtr = safe fn(i32, i32) -> i32;
+//~^ ERROR: function pointers cannot be declared with `safe` safety qualifier
+//[ungated]~| ERROR: unsafe extern {}` blocks and `safe` keyword are experimental [E0658]
+
+fn main() {}

--- a/tests/ui/rust-2024/safe-outside-extern.ungated.stderr
+++ b/tests/ui/rust-2024/safe-outside-extern.ungated.stderr
@@ -1,0 +1,83 @@
+error: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+  --> $DIR/safe-outside-extern.rs:4:1
+   |
+LL | safe fn foo() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+  --> $DIR/safe-outside-extern.rs:8:1
+   |
+LL | safe static FOO: i32 = 1;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+  --> $DIR/safe-outside-extern.rs:13:5
+   |
+LL |     safe fn foo();
+   |     ^^^^^^^^^^^^^^
+
+error: items outside of `unsafe extern { }` cannot be declared with `safe` safety qualifier
+  --> $DIR/safe-outside-extern.rs:19:5
+   |
+LL |     safe fn foo() {}
+   |     ^^^^^^^^^^^^^^^^
+
+error: function pointers cannot be declared with `safe` safety qualifier
+  --> $DIR/safe-outside-extern.rs:24:14
+   |
+LL | type FnPtr = safe fn(i32, i32) -> i32;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0658]: `unsafe extern {}` blocks and `safe` keyword are experimental
+  --> $DIR/safe-outside-extern.rs:4:1
+   |
+LL | safe fn foo() {}
+   | ^^^^
+   |
+   = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
+   = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `unsafe extern {}` blocks and `safe` keyword are experimental
+  --> $DIR/safe-outside-extern.rs:8:1
+   |
+LL | safe static FOO: i32 = 1;
+   | ^^^^
+   |
+   = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
+   = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `unsafe extern {}` blocks and `safe` keyword are experimental
+  --> $DIR/safe-outside-extern.rs:13:5
+   |
+LL |     safe fn foo();
+   |     ^^^^
+   |
+   = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
+   = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `unsafe extern {}` blocks and `safe` keyword are experimental
+  --> $DIR/safe-outside-extern.rs:19:5
+   |
+LL |     safe fn foo() {}
+   |     ^^^^
+   |
+   = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
+   = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `unsafe extern {}` blocks and `safe` keyword are experimental
+  --> $DIR/safe-outside-extern.rs:24:14
+   |
+LL | type FnPtr = safe fn(i32, i32) -> i32;
+   |              ^^^^
+   |
+   = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
+   = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Fixes #126749

r? @compiler-errors

Tracking:

- https://github.com/rust-lang/rust/issues/123743