### PR TITLE
Clean up more comments near use declarations

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -34,7 +34,6 @@ use super::{
     Pointer, Projectable, Scalar, ValueVisitor,
 };
 
-// for the validation errors
 use super::InterpError::UndefinedBehavior as Ub;
 use super::InterpError::Unsupported as Unsup;
 use super::UndefinedBehaviorInfo::*;

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -120,7 +120,6 @@ use types::*;
 use unit_bindings::*;
 use unused::*;
 
-/// Useful for other parts of the compiler / Clippy.
 pub use builtin::{MissingDoc, SoftLints};
 pub use context::{CheckLintNameResult, FindLintError, LintStore};
 pub use context::{EarlyContext, LateContext, LintContext};

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -21,9 +21,7 @@ rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
 
 use std::fmt;
 
-// Re-exports to avoid rustc_index version issues.
-pub use rustc_index::Idx;
-pub use rustc_index::IndexVec;
+pub use rustc_index::{Idx, IndexVec}; // re-exported to avoid rustc_index version issues
 
 #[cfg(feature = "rustc")]
 use rustc_middle::ty::Ty;

--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -4,6 +4,7 @@
 //! due to incomplete stable coverage.
 
 // Prefer importing stable_mir over internal rustc constructs to make this file more readable.
+
 use crate::rustc_smir::Tables;
 use rustc_middle::ty::{self as rustc_ty, Const as InternalConst, Ty as InternalTy, TyCtxt};
 use rustc_span::Symbol;

--- a/library/alloc/src/testing/crash_test.rs
+++ b/library/alloc/src/testing/crash_test.rs
@@ -1,5 +1,4 @@
-// We avoid relying on anything else in the crate, apart from the `Debug` trait.
-use crate::fmt::Debug;
+use crate::fmt::Debug; // the `Debug` trait is the only thing we use from `crate::fmt`
 use std::cmp::Ordering;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -24,7 +24,6 @@ mod convert;
 mod decode;
 mod methods;
 
-// stable re-exports
 #[stable(feature = "try_from", since = "1.34.0")]
 pub use self::convert::CharTryFromError;
 #[stable(feature = "char_from_str", since = "1.20.0")]
@@ -32,11 +31,10 @@ pub use self::convert::ParseCharError;
 #[stable(feature = "decode_utf16", since = "1.9.0")]
 pub use self::decode::{DecodeUtf16, DecodeUtf16Error};
 
-// perma-unstable re-exports
 #[unstable(feature = "char_internals", reason = "exposed only for libstd", issue = "none")]
-pub use self::methods::encode_utf16_raw;
+pub use self::methods::encode_utf16_raw; // perma-unstable
 #[unstable(feature = "char_internals", reason = "exposed only for libstd", issue = "none")]
-pub use self::methods::encode_utf8_raw;
+pub use self::methods::encode_utf8_raw; // perma-unstable
 
 use crate::ascii;
 use crate::error::Error;

--- a/library/core/src/prelude/common.rs
+++ b/library/core/src/prelude/common.rs
@@ -33,10 +33,7 @@ pub use crate::convert::{AsMut, AsRef, From, Into};
 pub use crate::default::Default;
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator};
-#[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use crate::iter::{Extend, IntoIterator, Iterator};
+pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator, Extend, IntoIterator, Iterator};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use crate::option::Option::{self, None, Some};

--- a/library/core/src/prelude/common.rs
+++ b/library/core/src/prelude/common.rs
@@ -2,6 +2,9 @@
 //!
 //! See the [module-level documentation](super) for more.
 
+// No formatting: this file is nothing but re-exports, and their order is worth preserving.
+#![cfg_attr(rustfmt, rustfmt::skip)]
+
 // Re-exported core operators
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]

--- a/library/core/src/prelude/mod.rs
+++ b/library/core/src/prelude/mod.rs
@@ -4,6 +4,9 @@
 //! This module is imported by default when `#![no_std]` is used in the same
 //! manner as the standard library's prelude.
 
+// No formatting: this file is nothing but re-exports, and their order is worth preserving.
+#![cfg_attr(rustfmt, rustfmt::skip)]
+
 #![stable(feature = "core_prelude", since = "1.4.0")]
 
 mod common;

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1809,10 +1809,9 @@ pub(crate) const unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usiz
     // FIXME(#75598): Direct use of these intrinsics improves codegen significantly at opt-level <=
     // 1, where the method versions of these operations are not inlined.
     use intrinsics::{
-        assume, cttz_nonzero, exact_div, mul_with_overflow, unchecked_rem, unchecked_sub,
-        wrapping_add, wrapping_mul, wrapping_sub,
+        assume, cttz_nonzero, exact_div, mul_with_overflow, unchecked_rem, unchecked_shl,
+        unchecked_shr, unchecked_sub, wrapping_add, wrapping_mul, wrapping_sub,
     };
-    use intrinsics::{unchecked_shl, unchecked_shr};
 
     /// Calculate multiplicative modular inverse of `x` modulo `m`.
     ///

--- a/library/core/src/unicode/mod.rs
+++ b/library/core/src/unicode/mod.rs
@@ -1,6 +1,19 @@
 #![unstable(feature = "unicode_internals", issue = "none")]
 #![allow(missing_docs)]
 
+// The `pub use` ones are for use in alloc, and are not re-exported in std.
+
+pub(crate) use unicode_data::alphabetic::lookup as Alphabetic;
+pub use unicode_data::case_ignorable::lookup as Case_Ignorable;
+pub use unicode_data::cased::lookup as Cased;
+pub(crate) use unicode_data::cc::lookup as Cc;
+pub use unicode_data::conversions;
+pub(crate) use unicode_data::grapheme_extend::lookup as Grapheme_Extend;
+pub(crate) use unicode_data::lowercase::lookup as Lowercase;
+pub(crate) use unicode_data::n::lookup as N;
+pub(crate) use unicode_data::uppercase::lookup as Uppercase;
+pub(crate) use unicode_data::white_space::lookup as White_Space;
+
 pub(crate) mod printable;
 mod unicode_data;
 
@@ -16,16 +29,3 @@ mod unicode_data;
 /// [Unicode 11.0 or later, Section 3.1 Versions of the Unicode Standard](https://www.unicode.org/versions/Unicode11.0.0/ch03.pdf#page=4).
 #[stable(feature = "unicode_version", since = "1.45.0")]
 pub const UNICODE_VERSION: (u8, u8, u8) = unicode_data::UNICODE_VERSION;
-
-// For use in alloc, not re-exported in std.
-pub use unicode_data::{
-    case_ignorable::lookup as Case_Ignorable, cased::lookup as Cased, conversions,
-};
-
-pub(crate) use unicode_data::alphabetic::lookup as Alphabetic;
-pub(crate) use unicode_data::cc::lookup as Cc;
-pub(crate) use unicode_data::grapheme_extend::lookup as Grapheme_Extend;
-pub(crate) use unicode_data::lowercase::lookup as Lowercase;
-pub(crate) use unicode_data::n::lookup as N;
-pub(crate) use unicode_data::uppercase::lookup as Uppercase;
-pub(crate) use unicode_data::white_space::lookup as White_Space;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -469,7 +469,6 @@ pub mod rt;
 // The Rust prelude
 pub mod prelude;
 
-// Public module declarations and re-exports
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc_crate::borrow;
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/os/fortanix_sgx/mod.rs
+++ b/library/std/src/os/fortanix_sgx/mod.rs
@@ -28,7 +28,6 @@ pub mod usercalls {
         pub use crate::sys::abi::usercalls::raw::{do_usercall, Usercalls as UsercallNrs};
         pub use crate::sys::abi::usercalls::raw::{Register, RegisterArgument, ReturnValue};
 
-        // fortanix-sgx-abi re-exports
         pub use crate::sys::abi::usercalls::raw::Error;
         pub use crate::sys::abi::usercalls::raw::{
             ByteBuffer, Cancel, FifoDescriptor, Return, Usercall,

--- a/library/std/src/prelude/common.rs
+++ b/library/std/src/prelude/common.rs
@@ -2,6 +2,9 @@
 //!
 //! See the [module-level documentation](super) for more.
 
+// No formatting: this file is nothing but re-exports, and their order is worth preserving.
+#![cfg_attr(rustfmt, rustfmt::skip)]
+
 // Re-exported core operators
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -95,6 +95,9 @@
 //! [book-enums]: ../../book/ch06-01-defining-an-enum.html
 //! [book-iter]: ../../book/ch13-02-iterators.html
 
+// No formatting: this file is nothing but re-exports, and their order is worth preserving.
+#![cfg_attr(rustfmt, rustfmt::skip)]
+
 #![stable(feature = "rust1", since = "1.0.0")]
 
 mod common;

--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -16,7 +16,6 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(unused_macros)]
 
-// Re-export some of our utilities which are expected by other crates.
 pub use crate::panicking::{begin_panic, panic_count};
 pub use core::panicking::{panic_display, panic_fmt};
 

--- a/library/std/src/sys/pal/wasi/mod.rs
+++ b/library/std/src/sys/pal/wasi/mod.rs
@@ -39,12 +39,15 @@ pub mod time;
 #[deny(unsafe_op_in_unsafe_fn)]
 #[allow(unused)]
 mod common;
+
 pub use common::*;
 
 mod helpers;
-// These exports are listed individually to work around Rust's glob import
-// conflict rules. If we glob export `helpers` and `common` together, then
-// the compiler complains about conflicts.
+
+// The following exports are listed individually to work around Rust's glob
+// import conflict rules. If we glob export `helpers` and `common` together,
+// then the compiler complains about conflicts.
+
 pub use helpers::abort_internal;
 pub use helpers::decode_error_kind;
 use helpers::err2io;

--- a/library/std/src/sys/pal/wasip2/mod.rs
+++ b/library/std/src/sys/pal/wasip2/mod.rs
@@ -41,13 +41,16 @@ pub mod time;
 #[deny(unsafe_op_in_unsafe_fn)]
 #[allow(unused)]
 mod common;
+
 pub use common::*;
 
 #[path = "../wasi/helpers.rs"]
 mod helpers;
-// These exports are listed individually to work around Rust's glob import
-// conflict rules. If we glob export `helpers` and `common` together, then
-// the compiler complains about conflicts.
+
+// The following exports are listed individually to work around Rust's glob
+// import conflict rules. If we glob export `helpers` and `common` together,
+// then the compiler complains about conflicts.
+
 pub use helpers::abort_internal;
 pub use helpers::decode_error_kind;
 use helpers::err2io;

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -25,7 +25,6 @@
 #![feature(test)]
 #![allow(internal_features)]
 
-// Public reexports
 pub use self::bench::{black_box, Bencher};
 pub use self::console::run_tests_console;
 pub use self::options::{ColorConfig, Options, OutputFormat, RunIgnored, ShouldPanic};


### PR DESCRIPTION
#125443 will reformat all use declarations in the repository. There are a few edge cases involving comments on use declarations that require care. This PR fixes them up so #125443 can go ahead with a simple `x fmt --all`. A follow-up to #126717.

r? @cuviper 

[**Post-merge update**] Just to clarify what happened here: with auto-formatting of `use` declarations there is a very small loss of expressivity involving comments that apply to multiple `use` declarations. Imagine you want to write this:
```rust
use a::b::c;
use a::c::d;

// These two are special.
use a::d::e;
use a::e::f;
```
You just can't have a custom separate section any more; the sections are fixed. (Unless https://github.com/rust-lang/rustfmt/issues/6241 is addressed, which may happen in the future.)

[**Second update**] I learned that you can have custom groups, by using `#[rustfmt::skip]`:
```rust
use a::b::c;
use a::c::d;

// These two are special.
#[rustfmt::skip]
use a::d::e;
use a::e::f;
```
The `use a::d::e` acts as a barrier: rustfmt won't reorder other `use` declarations around it. This is a very nice, idiomatic way of doing a custom group.)

[**end of second update**]

Fortunately, there are multiple reasonable alternatives:
```rust
use a::b::c;
use a::c::d;
use a::d::e; // this one is special
use a::e::f; // this one is special
```
or this:
```rust
use a::b::c;
use a::c::d;
// This one is special.
use a::d::e;
// This one is special.
use a::e::f; 
```
or this:
```rust
// `a::d::e` and `a::e::f` are special.

use a::b::c;
use a::c::d;
use a::d::e;
use a::e::f;
```
or you could even exclude the comment if it's not that important.

Comments having the first form are rare in practice. This PR converted the small number of them in the repository into one of the subsequent forms.