### PR TITLE
Require a colon in `//@ normalize-*:` test headers

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1121,13 +1121,11 @@ fn expand_variables(mut value: String, config: &Config) -> String {
 /// normalize-*: "REGEX" -> "REPLACEMENT"
 /// ```
 fn parse_normalize_rule(header: &str) -> Option<(String, String)> {
-    // FIXME(#126370): A colon after the header name should be mandatory, but
-    // currently is not, and there are many tests that lack the colon.
     // FIXME: Support escaped double-quotes in strings.
     let captures = static_regex!(
         r#"(?x) # (verbose mode regex)
         ^
-        [^:\s]+:?\s*            # (header name followed by optional colon)
+        [^:\s]+:\s*             # (header name followed by colon)
         "(?<regex>[^"]*)"       # "REGEX"
         \s+->\s+                # ->
         "(?<replacement>[^"]*)" # "REPLACEMENT"

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -33,20 +33,11 @@ fn make_test_description<R: Read>(
 
 #[test]
 fn test_parse_normalize_rule() {
-    let good_data = &[
-        (
-            r#"normalize-stderr-32bit: "something (32 bits)" -> "something ($WORD bits)""#,
-            "something (32 bits)",
-            "something ($WORD bits)",
-        ),
-        // FIXME(#126370): A colon after the header name should be mandatory,
-        // but currently is not, and there are many tests that lack the colon.
-        (
-            r#"normalize-stderr-32bit "something (32 bits)" -> "something ($WORD bits)""#,
-            "something (32 bits)",
-            "something ($WORD bits)",
-        ),
-    ];
+    let good_data = &[(
+        r#"normalize-stderr-32bit: "something (32 bits)" -> "something ($WORD bits)""#,
+        "something (32 bits)",
+        "something ($WORD bits)",
+    )];
 
     for &(input, expected_regex, expected_replacement) in good_data {
         let parsed = parse_normalize_rule(input);
@@ -56,6 +47,7 @@ fn test_parse_normalize_rule() {
     }
 
     let bad_data = &[
+        r#"normalize-stderr-32bit "something (32 bits)" -> "something ($WORD bits)""#,
         r#"normalize-stderr-16bit: something (16 bits) -> something ($WORD bits)"#,
         r#"normalize-stderr-32bit: something (32 bits) -> something ($WORD bits)"#,
         r#"normalize-stderr-32bit: "something (32 bits) -> something ($WORD bits)"#,

--- a/tests/rustdoc-ui/doctest/block-doc-comment.rs
+++ b/tests/rustdoc-ui/doctest/block-doc-comment.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 //@ compile-flags:--test
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // This test ensures that no code block is detected in the doc comments.
 

--- a/tests/rustdoc-ui/doctest/cfg-test.rs
+++ b/tests/rustdoc-ui/doctest/cfg-test.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 //@ compile-flags:--test --test-args --test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // Crates like core have doctests gated on `cfg(not(test))` so we need to make
 // sure `cfg(test)` is not active when running `rustdoc --test`.

--- a/tests/rustdoc-ui/doctest/check-cfg-test.rs
+++ b/tests/rustdoc-ui/doctest/check-cfg-test.rs
@@ -2,7 +2,7 @@
 //@ compile-flags: --test --nocapture --check-cfg=cfg(feature,values("test")) -Z unstable-options
 //@ normalize-stderr-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 /// The doctest will produce a warning because feature invalid is unexpected
 /// ```

--- a/tests/rustdoc-ui/doctest/display-output.rs
+++ b/tests/rustdoc-ui/doctest/display-output.rs
@@ -4,7 +4,7 @@
 //@ edition:2018
 //@ compile-flags:--test --test-args=--show-output
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 /// ```
 /// #![warn(unused)]

--- a/tests/rustdoc-ui/doctest/doc-comment-multi-line-attr.rs
+++ b/tests/rustdoc-ui/doctest/doc-comment-multi-line-attr.rs
@@ -1,7 +1,7 @@
 // Regression test for #97440: Multiline inner attribute triggers ICE during doctest
 //@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ check-pass
 
 //! ```rust

--- a/tests/rustdoc-ui/doctest/doc-comment-multi-line-cfg-attr.rs
+++ b/tests/rustdoc-ui/doctest/doc-comment-multi-line-cfg-attr.rs
@@ -1,6 +1,6 @@
 //@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ check-pass
 
 /// ```

--- a/tests/rustdoc-ui/doctest/doc-test-doctest-feature.rs
+++ b/tests/rustdoc-ui/doctest/doc-test-doctest-feature.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 //@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // Make sure `cfg(doctest)` is set when finding doctests but not inside
 // the doctests.

--- a/tests/rustdoc-ui/doctest/doc-test-rustdoc-feature.rs
+++ b/tests/rustdoc-ui/doctest/doc-test-rustdoc-feature.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 //@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 #![feature(doc_cfg)]
 

--- a/tests/rustdoc-ui/doctest/doctest-multiline-crate-attribute.rs
+++ b/tests/rustdoc-ui/doctest/doctest-multiline-crate-attribute.rs
@@ -1,6 +1,6 @@
 //@ compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ check-pass
 
 /// ```

--- a/tests/rustdoc-ui/doctest/doctest-output.rs
+++ b/tests/rustdoc-ui/doctest/doctest-output.rs
@@ -2,7 +2,7 @@
 //@ aux-build:extern_macros.rs
 //@ compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ check-pass
 
 //! ```

--- a/tests/rustdoc-ui/doctest/failed-doctest-compile-fail.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-compile-fail.rs
@@ -3,7 +3,7 @@
 
 //@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101
 
 /// ```compile_fail

--- a/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.rs
@@ -3,7 +3,7 @@
 
 //@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101
 
 /// <https://github.com/rust-lang/rust/issues/91014>

--- a/tests/rustdoc-ui/doctest/failed-doctest-missing-codes.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-missing-codes.rs
@@ -3,7 +3,7 @@
 
 //@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101
 
 /// ```compile_fail,E0004

--- a/tests/rustdoc-ui/doctest/failed-doctest-output-windows.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-output-windows.rs
@@ -8,7 +8,7 @@
 //@ compile-flags:--test --test-args --test-threads=1
 //@ rustc-env:RUST_BACKTRACE=0
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101
 
 // doctest fails at runtime

--- a/tests/rustdoc-ui/doctest/failed-doctest-output.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-output.rs
@@ -8,7 +8,7 @@
 //@ compile-flags:--test --test-args --test-threads=1
 //@ rustc-env:RUST_BACKTRACE=0
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101
 
 // doctest fails at runtime

--- a/tests/rustdoc-ui/doctest/failed-doctest-should-panic.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-should-panic.rs
@@ -3,7 +3,7 @@
 
 //@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101
 
 /// ```should_panic

--- a/tests/rustdoc-ui/doctest/no-run-flag.rs
+++ b/tests/rustdoc-ui/doctest/no-run-flag.rs
@@ -3,7 +3,7 @@
 //@ check-pass
 //@ compile-flags:-Z unstable-options --test --no-run --test-args=--test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 /// ```
 /// let a = true;

--- a/tests/rustdoc-ui/doctest/nocapture-fail.rs
+++ b/tests/rustdoc-ui/doctest/nocapture-fail.rs
@@ -2,7 +2,7 @@
 //@ compile-flags:--test -Zunstable-options --nocapture
 //@ normalize-stderr-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 /// ```compile_fail
 /// fn foo() {

--- a/tests/rustdoc-ui/doctest/nocapture.rs
+++ b/tests/rustdoc-ui/doctest/nocapture.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 //@ compile-flags:--test -Zunstable-options --nocapture
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 /// ```
 /// println!("hello!");

--- a/tests/rustdoc-ui/doctest/non-local-defs-impl.rs
+++ b/tests/rustdoc-ui/doctest/non-local-defs-impl.rs
@@ -4,7 +4,7 @@
 //@ aux-build:pub_trait.rs
 //@ compile-flags: --test --test-args --test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 #![doc(test(attr(deny(non_local_definitions))))]
 #![doc(test(attr(allow(dead_code))))]

--- a/tests/rustdoc-ui/doctest/non_local_defs.rs
+++ b/tests/rustdoc-ui/doctest/non_local_defs.rs
@@ -2,7 +2,7 @@
 //@ compile-flags:--test --test-args --test-threads=1 --nocapture -Zunstable-options
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stderr-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 #![doc(test(attr(warn(non_local_definitions))))]
 

--- a/tests/rustdoc-ui/doctest/run-directory.rs
+++ b/tests/rustdoc-ui/doctest/run-directory.rs
@@ -5,7 +5,7 @@
 //@ [correct]compile-flags:--test --test-run-directory={{src-base}}
 //@ [incorrect]compile-flags:--test --test-run-directory={{src-base}}/coverage
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 /// ```
 /// assert_eq!(

--- a/tests/rustdoc-ui/doctest/test-no_std.rs
+++ b/tests/rustdoc-ui/doctest/test-no_std.rs
@@ -1,6 +1,6 @@
 //@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ check-pass
 
 #![no_std]

--- a/tests/rustdoc-ui/doctest/test-type.rs
+++ b/tests/rustdoc-ui/doctest/test-type.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: --test --test-args=--test-threads=1
 //@ check-pass
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 /// ```
 /// let a = true;

--- a/tests/rustdoc-ui/doctest/unparseable-doc-test.rs
+++ b/tests/rustdoc-ui/doctest/unparseable-doc-test.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: --test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101
 //@ rustc-env: RUST_BACKTRACE=0
 

--- a/tests/rustdoc-ui/ice-bug-report-url.rs
+++ b/tests/rustdoc-ui/ice-bug-report-url.rs
@@ -4,12 +4,12 @@
 //@ error-pattern: aborting due to
 //@ error-pattern: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-rustdoc&template=ice.md
 
-//@ normalize-stderr-test "note: compiler flags.*\n\n" -> ""
-//@ normalize-stderr-test "note: rustc.*running on.*" -> "note: rustc {version} running on {platform}"
-//@ normalize-stderr-test "thread.*panicked at compiler.*" -> ""
-//@ normalize-stderr-test " +\d{1,}: .*\n" -> ""
-//@ normalize-stderr-test " + at .*\n" -> ""
-//@ normalize-stderr-test ".*note: Some details are omitted.*\n" -> ""
+//@ normalize-stderr-test: "note: compiler flags.*\n\n" -> ""
+//@ normalize-stderr-test: "note: rustc.*running on.*" -> "note: rustc {version} running on {platform}"
+//@ normalize-stderr-test: "thread.*panicked at compiler.*" -> ""
+//@ normalize-stderr-test: " +\d{1,}: .*\n" -> ""
+//@ normalize-stderr-test: " + at .*\n" -> ""
+//@ normalize-stderr-test: ".*note: Some details are omitted.*\n" -> ""
 
 fn wrong()
 //~^ ERROR expected one of

--- a/tests/rustdoc-ui/issues/issue-80992.rs
+++ b/tests/rustdoc-ui/issues/issue-80992.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 //@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/issues" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 pub fn test() -> Result<(), ()> {
     //! ```compile_fail

--- a/tests/rustdoc-ui/issues/issue-81662-shortness.rs
+++ b/tests/rustdoc-ui/issues/issue-81662-shortness.rs
@@ -2,7 +2,7 @@
 //@ check-stdout
 //@ error-pattern:cannot find function `foo` in this scope
 //@ normalize-stdout-test: "tests/rustdoc-ui/issues" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101
 
 /// ```rust

--- a/tests/rustdoc-ui/issues/issue-91134.rs
+++ b/tests/rustdoc-ui/issues/issue-91134.rs
@@ -2,7 +2,7 @@
 //@ aux-build:empty-fn.rs
 //@ check-pass
 //@ normalize-stdout-test: "tests/rustdoc-ui/issues" -> "$$DIR"
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ edition:2021
 
 /// <https://github.com/rust-lang/rust/issues/91134>

--- a/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.rs
@@ -4,8 +4,8 @@
 //@ failure-status: 101
 //@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
 //@ rustc-env:RUST_BACKTRACE=0
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
-//@ normalize-stdout-test "exit (status|code): 101" -> "exit status: 101"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "exit (status|code): 101" -> "exit status: 101"
 
 // doctest fails at runtime
 /// ```

--- a/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.rs
@@ -4,7 +4,7 @@
 //@ failure-status: 101
 //@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
 //@ rustc-env:RUST_BACKTRACE=0
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // doctest fails to compile
 /// ```

--- a/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.rs
@@ -5,7 +5,7 @@
 // adapted to use that, and that normalize line can go away
 
 //@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // doctest passes at runtime
 /// ```

--- a/tests/rustdoc-ui/track-diagnostics.rs
+++ b/tests/rustdoc-ui/track-diagnostics.rs
@@ -3,7 +3,7 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-//@ normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr-test: ".rs:\d+:\d+" -> ".rs:LL:CC"
 
 struct A;
 struct B;

--- a/tests/ui-fulldeps/fluent-messages/test.rs
+++ b/tests/ui-fulldeps/fluent-messages/test.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "could not open Fluent resource:.*" -> "could not open Fluent resource: os-specific message"
+//@ normalize-stderr-test: "could not open Fluent resource:.*" -> "could not open Fluent resource: os-specific message"
 
 #![feature(rustc_private)]
 #![crate_type = "lib"]

--- a/tests/ui-fulldeps/missing-rustc-driver-error.rs
+++ b/tests/ui-fulldeps/missing-rustc-driver-error.rs
@@ -1,7 +1,7 @@
 // Test that we get the following hint when trying to use a compiler crate without rustc_driver.
 //@ error-pattern: try adding `extern crate rustc_driver;` at the top level of this crate
 //@ compile-flags: --emit link
-//@ normalize-stderr-test ".*crate .* required.*\n\n" -> ""
+//@ normalize-stderr-test: ".*crate .* required.*\n\n" -> ""
 //@ normalize-stderr-test: "aborting due to [0-9]+" -> "aborting due to NUMBER"
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.rs
@@ -1,7 +1,7 @@
 //@ check-fail
 // Tests that a doc comment will not preclude a field from being considered a diagnostic argument
-//@ normalize-stderr-test "the following other types implement trait `IntoDiagArg`:(?:.*\n){0,9}\s+and \d+ others" -> "normalized in stderr"
-//@ normalize-stderr-test "(COMPILER_DIR/.*\.rs):[0-9]+:[0-9]+" -> "$1:LL:CC"
+//@ normalize-stderr-test: "the following other types implement trait `IntoDiagArg`:(?:.*\n){0,9}\s+and \d+ others" -> "normalized in stderr"
+//@ normalize-stderr-test: "(COMPILER_DIR/.*\.rs):[0-9]+:[0-9]+" -> "$1:LL:CC"
 
 // The proc_macro2 crate handles spans differently when on beta/stable release rather than nightly,
 // changing the output of this test. Since Subdiagnostic is strictly internal to the compiler

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -1,7 +1,7 @@
 //@ check-fail
 // Tests error conditions for specifying diagnostics using #[derive(Diagnostic)]
-//@ normalize-stderr-test "the following other types implement trait `IntoDiagArg`:(?:.*\n){0,9}\s+and \d+ others" -> "normalized in stderr"
-//@ normalize-stderr-test "(COMPILER_DIR/.*\.rs):[0-9]+:[0-9]+" -> "$1:LL:CC"
+//@ normalize-stderr-test: "the following other types implement trait `IntoDiagArg`:(?:.*\n){0,9}\s+and \d+ others" -> "normalized in stderr"
+//@ normalize-stderr-test: "(COMPILER_DIR/.*\.rs):[0-9]+:[0-9]+" -> "$1:LL:CC"
 
 // The proc_macro2 crate handles spans differently when on beta/stable release rather than nightly,
 // changing the output of this test. Since Diagnostic is strictly internal to the compiler

--- a/tests/ui/abi/debug.rs
+++ b/tests/ui/abi/debug.rs
@@ -1,9 +1,9 @@
-//@ normalize-stderr-test "(abi|pref|unadjusted_abi_align): Align\([1-8] bytes\)" -> "$1: $$SOME_ALIGN"
-//@ normalize-stderr-test "(size): Size\([48] bytes\)" -> "$1: $$SOME_SIZE"
-//@ normalize-stderr-test "(can_unwind): (true|false)" -> "$1: $$SOME_BOOL"
-//@ normalize-stderr-test "(valid_range): 0\.\.=(4294967295|18446744073709551615)" -> "$1: $$FULL"
+//@ normalize-stderr-test: "(abi|pref|unadjusted_abi_align): Align\([1-8] bytes\)" -> "$1: $$SOME_ALIGN"
+//@ normalize-stderr-test: "(size): Size\([48] bytes\)" -> "$1: $$SOME_SIZE"
+//@ normalize-stderr-test: "(can_unwind): (true|false)" -> "$1: $$SOME_BOOL"
+//@ normalize-stderr-test: "(valid_range): 0\.\.=(4294967295|18446744073709551615)" -> "$1: $$FULL"
 // This pattern is prepared for when we account for alignment in the niche.
-//@ normalize-stderr-test "(valid_range): [1-9]\.\.=(429496729[0-9]|1844674407370955161[0-9])" -> "$1: $$NON_NULL"
+//@ normalize-stderr-test: "(valid_range): [1-9]\.\.=(429496729[0-9]|1844674407370955161[0-9])" -> "$1: $$NON_NULL"
 // Some attributes are only computed for release builds:
 //@ compile-flags: -O
 #![feature(rustc_attrs)]

--- a/tests/ui/attributes/dump-preds.rs
+++ b/tests/ui/attributes/dump-preds.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "DefId\(.+?\)" -> "DefId(..)"
+//@ normalize-stderr-test: "DefId\(.+?\)" -> "DefId(..)"
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/attributes/dump_def_parents.rs
+++ b/tests/ui/attributes/dump_def_parents.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "DefId\(.+?\)" -> "DefId(..)"
+//@ normalize-stderr-test: "DefId\(.+?\)" -> "DefId(..)"
 #![feature(rustc_attrs)]
 
 fn bar() {

--- a/tests/ui/const-generics/generic_const_exprs/issue-80742.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-80742.rs
@@ -1,9 +1,9 @@
 //@ check-fail
 //@ known-bug: #97477
 //@ failure-status: 101
-//@ normalize-stderr-test "note: .*\n\n" -> ""
-//@ normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
-//@ normalize-stderr-test "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
+//@ normalize-stderr-test: "note: .*\n\n" -> ""
+//@ normalize-stderr-test: "thread 'rustc' panicked.*\n" -> ""
+//@ normalize-stderr-test: "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
 //@ rustc-env:RUST_BACKTRACE=0
 
 // This test used to cause an ICE in rustc_mir::interpret::step::eval_rvalue_into_place

--- a/tests/ui/const-ptr/forbidden_slices.rs
+++ b/tests/ui/const-ptr/forbidden_slices.rs
@@ -1,6 +1,6 @@
 // Strip out raw byte dumps to make comparison platform-independent:
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 
 #![feature(
     slice_from_ptr_range,

--- a/tests/ui/consts/const-eval/const-eval-query-stack.rs
+++ b/tests/ui/consts/const-eval/const-eval-query-stack.rs
@@ -1,16 +1,16 @@
 //@ compile-flags: -Ztreat-err-as-bug=1
 //@ failure-status: 101
 //@ rustc-env:RUST_BACKTRACE=1
-//@ normalize-stderr-test "\nerror: .*unexpectedly panicked.*\n\n" -> ""
-//@ normalize-stderr-test "note: we would appreciate a bug report.*\n\n" -> ""
-//@ normalize-stderr-test "note: compiler flags.*\n\n" -> ""
-//@ normalize-stderr-test "note: rustc.*running on.*\n\n" -> ""
-//@ normalize-stderr-test "thread.*panicked.*:\n.*\n" -> ""
-//@ normalize-stderr-test "stack backtrace:\n" -> ""
-//@ normalize-stderr-test "\s\d{1,}: .*\n" -> ""
-//@ normalize-stderr-test "\s at .*\n" -> ""
-//@ normalize-stderr-test ".*note: Some details.*\n" -> ""
-//@ normalize-stderr-test ".*omitted \d{1,} frame.*\n" -> ""
+//@ normalize-stderr-test: "\nerror: .*unexpectedly panicked.*\n\n" -> ""
+//@ normalize-stderr-test: "note: we would appreciate a bug report.*\n\n" -> ""
+//@ normalize-stderr-test: "note: compiler flags.*\n\n" -> ""
+//@ normalize-stderr-test: "note: rustc.*running on.*\n\n" -> ""
+//@ normalize-stderr-test: "thread.*panicked.*:\n.*\n" -> ""
+//@ normalize-stderr-test: "stack backtrace:\n" -> ""
+//@ normalize-stderr-test: "\s\d{1,}: .*\n" -> ""
+//@ normalize-stderr-test: "\s at .*\n" -> ""
+//@ normalize-stderr-test: ".*note: Some details.*\n" -> ""
+//@ normalize-stderr-test: ".*omitted \d{1,} frame.*\n" -> ""
 #![allow(unconditional_panic)]
 
 const X: i32 = 1 / 0; //~ERROR constant

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
@@ -3,9 +3,9 @@
 #![feature(const_mut_refs)]
 
 // Strip out raw byte dumps to make comparison platform-independent:
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
-//@ normalize-stderr-test "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
 
 use std::intrinsics;
 

--- a/tests/ui/consts/const-eval/raw-bytes.rs
+++ b/tests/ui/consts/const-eval/raw-bytes.rs
@@ -1,7 +1,7 @@
 //@ stderr-per-bitwidth
 //@ ignore-endian-big
 // ignore-tidy-linelength
-//@ normalize-stderr-test "╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼" -> "╾ALLOC_ID$1╼"
+//@ normalize-stderr-test: "╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼" -> "╾ALLOC_ID$1╼"
 #![allow(invalid_value)]
 #![feature(never_type, rustc_attrs, ptr_metadata, slice_from_ptr_range, const_slice_from_ptr_range)]
 

--- a/tests/ui/consts/const-eval/ub-enum.rs
+++ b/tests/ui/consts/const-eval/ub-enum.rs
@@ -1,7 +1,7 @@
 // Strip out raw byte dumps to make comparison platform-independent:
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
-//@ normalize-stderr-test "0x0+" -> "0x0"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "0x0+" -> "0x0"
 #![feature(never_type)]
 #![allow(invalid_value)]
 

--- a/tests/ui/consts/const-eval/ub-nonnull.rs
+++ b/tests/ui/consts/const-eval/ub-nonnull.rs
@@ -1,6 +1,6 @@
 // Strip out raw byte dumps to make comparison platform-independent:
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?─*╼ )+ *│.*" -> "HEX_DUMP"
 #![allow(invalid_value)] // make sure we cannot allow away the errors tested here
 #![feature(rustc_attrs, ptr_metadata)]
 

--- a/tests/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.rs
@@ -1,7 +1,7 @@
 // ignore-tidy-linelength
 // Strip out raw byte dumps to make comparison platform-independent:
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 #![allow(invalid_value)]
 
 use std::mem;

--- a/tests/ui/consts/const-eval/ub-uninhabit.rs
+++ b/tests/ui/consts/const-eval/ub-uninhabit.rs
@@ -1,6 +1,6 @@
 // Strip out raw byte dumps to make comparison platform-independent:
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 #![feature(core_intrinsics)]
 #![feature(never_type)]
 

--- a/tests/ui/consts/const-eval/ub-wide-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.rs
@@ -5,10 +5,10 @@
 use std::{ptr, mem};
 
 // Strip out raw byte dumps to make comparison platform-independent:
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
-//@ normalize-stderr-test "offset \d+" -> "offset N"
-//@ normalize-stderr-test "size \d+" -> "size N"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "offset \d+" -> "offset N"
+//@ normalize-stderr-test: "size \d+" -> "size N"
 
 
 /// A newtype wrapper to prevent MIR generation from inserting reborrows that would affect the error

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.rs
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.rs
@@ -1,6 +1,6 @@
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "( 0x[0-9a-f][0-9a-f] │)? ([0-9a-f][0-9a-f] |__ |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> " HEX_DUMP"
-//@ normalize-stderr-test "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "( 0x[0-9a-f][0-9a-f] │)? ([0-9a-f][0-9a-f] |__ |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> " HEX_DUMP"
+//@ normalize-stderr-test: "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
 #![feature(const_mut_refs, const_refs_to_static)]
 #![feature(raw_ref_op)]
 

--- a/tests/ui/consts/const_refs_to_static_fail.rs
+++ b/tests/ui/consts/const_refs_to_static_fail.rs
@@ -1,5 +1,5 @@
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 #![feature(const_refs_to_static, const_mut_refs, sync_unsafe_cell)]
 use std::cell::SyncUnsafeCell;
 

--- a/tests/ui/consts/const_refs_to_static_fail_invalid.rs
+++ b/tests/ui/consts/const_refs_to_static_fail_invalid.rs
@@ -1,5 +1,5 @@
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 #![feature(const_refs_to_static)]
 #![allow(static_mut_refs)]
 

--- a/tests/ui/consts/dangling-alloc-id-ice.rs
+++ b/tests/ui/consts/dangling-alloc-id-ice.rs
@@ -1,8 +1,8 @@
 // https://github.com/rust-lang/rust/issues/55223
 // Strip out raw byte dumps to make comparison platform-independent:
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
-//@ normalize-stderr-test "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
 
 union Foo<'a> {
     y: &'a (),

--- a/tests/ui/consts/dangling-zst-ice-issue-126393.rs
+++ b/tests/ui/consts/dangling-zst-ice-issue-126393.rs
@@ -1,7 +1,7 @@
 // Strip out raw byte dumps to make comparison platform-independent:
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
-//@ normalize-stderr-test "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
 
 pub struct Wrapper;
 pub static MAGIC_FFI_REF: &'static Wrapper = unsafe {

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static.rs
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Zunleash-the-miri-inside-of-you
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: -Zunleash-the-miri-inside-of-you
 //@ aux-build:static_cross_crate.rs
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 #![feature(half_open_range_patterns_in_slices)]
 #![allow(static_mut_refs)]
 

--- a/tests/ui/consts/miri_unleashed/mutable_references.rs
+++ b/tests/ui/consts/miri_unleashed/mutable_references.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Zunleash-the-miri-inside-of-you
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 
 #![deny(const_eval_mutable_ptr_in_final_value)]
 use std::cell::UnsafeCell;

--- a/tests/ui/consts/miri_unleashed/mutable_references_err.rs
+++ b/tests/ui/consts/miri_unleashed/mutable_references_err.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Zunleash-the-miri-inside-of-you
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 #![allow(invalid_reference_casting, static_mut_refs)]
 #![deny(const_eval_mutable_ptr_in_final_value)]
 use std::cell::UnsafeCell;

--- a/tests/ui/consts/offset_ub.rs
+++ b/tests/ui/consts/offset_ub.rs
@@ -1,7 +1,7 @@
 use std::ptr;
 
 
-//@ normalize-stderr-test "0x7f+" -> "0x7f..f"
+//@ normalize-stderr-test: "0x7f+" -> "0x7f..f"
 
 
 pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) }; //~NOTE

--- a/tests/ui/consts/overflowing-consts.rs
+++ b/tests/ui/consts/overflowing-consts.rs
@@ -6,8 +6,8 @@
 //@ [opt]compile-flags: -O
 //@ [opt_with_overflow_checks]compile-flags: -C overflow-checks=on -O
 //@ ignore-pass (test tests codegen-time behaviour)
-//@ normalize-stderr-test "shift left by `(64|32)_usize`, which" -> "shift left by `%BITS%`, which"
-//@ normalize-stderr-test "shift right by `(64|32)_usize`, which" -> "shift right by `%BITS%`, which"
+//@ normalize-stderr-test: "shift left by `(64|32)_usize`, which" -> "shift left by `%BITS%`, which"
+//@ normalize-stderr-test: "shift right by `(64|32)_usize`, which" -> "shift right by `%BITS%`, which"
 
 
 #[cfg(target_pointer_width = "32")]

--- a/tests/ui/consts/transmute-size-mismatch-before-typeck.rs
+++ b/tests/ui/consts/transmute-size-mismatch-before-typeck.rs
@@ -1,7 +1,7 @@
-//@ normalize-stderr-64bit "64 bits" -> "word size"
-//@ normalize-stderr-32bit "32 bits" -> "word size"
-//@ normalize-stderr-64bit "128 bits" -> "2 * word size"
-//@ normalize-stderr-32bit "64 bits" -> "2 * word size"
+//@ normalize-stderr-64bit: "64 bits" -> "word size"
+//@ normalize-stderr-32bit: "32 bits" -> "word size"
+//@ normalize-stderr-64bit: "128 bits" -> "2 * word size"
+//@ normalize-stderr-32bit: "64 bits" -> "2 * word size"
 
 fn main() {
     match &b""[..] {

--- a/tests/ui/consts/validate_never_arrays.rs
+++ b/tests/ui/consts/validate_never_arrays.rs
@@ -1,6 +1,6 @@
 // Strip out raw byte dumps to make comparison platform-independent:
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 #![feature(never_type)]
 
 const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) }; //~ ERROR undefined behavior

--- a/tests/ui/coroutine/static-not-unpin.rs
+++ b/tests/ui/coroutine/static-not-unpin.rs
@@ -4,7 +4,7 @@
 
 #![feature(coroutines, stmt_expr_attributes)]
 
-//@ normalize-stderr-test "std::pin::Unpin" -> "std::marker::Unpin"
+//@ normalize-stderr-test: "std::pin::Unpin" -> "std::marker::Unpin"
 
 use std::marker::Unpin;
 

--- a/tests/ui/debuginfo/debuginfo-type-name-layout-ice-94961-1.rs
+++ b/tests/ui/debuginfo/debuginfo-type-name-layout-ice-94961-1.rs
@@ -4,8 +4,8 @@
 //@ compile-flags:-C debuginfo=2
 //@ build-fail
 //@ error-pattern: too big for the current architecture
-//@ normalize-stderr-64bit "18446744073709551615" -> "SIZE"
-//@ normalize-stderr-32bit "4294967295" -> "SIZE"
+//@ normalize-stderr-64bit: "18446744073709551615" -> "SIZE"
+//@ normalize-stderr-32bit: "4294967295" -> "SIZE"
 
 #![crate_type = "rlib"]
 

--- a/tests/ui/debuginfo/debuginfo-type-name-layout-ice-94961-2.rs
+++ b/tests/ui/debuginfo/debuginfo-type-name-layout-ice-94961-2.rs
@@ -6,8 +6,8 @@
 //@ compile-flags:-C debuginfo=2
 //@ build-fail
 //@ error-pattern: too big for the current architecture
-//@ normalize-stderr-64bit "18446744073709551615" -> "SIZE"
-//@ normalize-stderr-32bit "4294967295" -> "SIZE"
+//@ normalize-stderr-64bit: "18446744073709551615" -> "SIZE"
+//@ normalize-stderr-32bit: "4294967295" -> "SIZE"
 
 #![crate_type = "rlib"]
 

--- a/tests/ui/duplicate_entry_error.rs
+++ b/tests/ui/duplicate_entry_error.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "loaded from .*libstd-.*.rlib" -> "loaded from SYSROOT/libstd-*.rlib"
+//@ normalize-stderr-test: "loaded from .*libstd-.*.rlib" -> "loaded from SYSROOT/libstd-*.rlib"
 // note-pattern: first defined in crate `std`.
 
 // Test for issue #31788 and E0152

--- a/tests/ui/error-codes/E0017.rs
+++ b/tests/ui/error-codes/E0017.rs
@@ -1,7 +1,7 @@
 #![feature(const_mut_refs)]
 
-//@ normalize-stderr-test "\(size: ., align: .\)" -> ""
-//@ normalize-stderr-test " +│ ╾─+╼" -> ""
+//@ normalize-stderr-test: "\(size: ., align: .\)" -> ""
+//@ normalize-stderr-test: " +│ ╾─+╼" -> ""
 
 static X: i32 = 1;
 const C: i32 = 2;

--- a/tests/ui/error-codes/E0152.rs
+++ b/tests/ui/error-codes/E0152.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "loaded from .*liballoc-.*.rlib" -> "loaded from SYSROOT/liballoc-*.rlib"
+//@ normalize-stderr-test: "loaded from .*liballoc-.*.rlib" -> "loaded from SYSROOT/liballoc-*.rlib"
 #![feature(lang_items)]
 
 #[lang = "owned_box"]

--- a/tests/ui/extern/extern-C-non-FFI-safe-arg-ice-52334.rs
+++ b/tests/ui/extern/extern-C-non-FFI-safe-arg-ice-52334.rs
@@ -1,8 +1,8 @@
 // test for ICE when casting extern "C" fn when it has a non-FFI-safe argument
 // issue: rust-lang/rust#52334
 //@ check-pass
-//@ normalize-stderr-test "\[i8\]" -> "[i8 or u8 (arch dependant)]"
-//@ normalize-stderr-test "\[u8\]" -> "[i8 or u8 (arch dependant)]"
+//@ normalize-stderr-test: "\[i8\]" -> "[i8 or u8 (arch dependant)]"
+//@ normalize-stderr-test: "\[u8\]" -> "[i8 or u8 (arch dependant)]"
 
 type Foo = extern "C" fn(::std::ffi::CStr);
 //~^ WARN `extern` fn uses type

--- a/tests/ui/hygiene/panic-location.rs
+++ b/tests/ui/hygiene/panic-location.rs
@@ -1,7 +1,7 @@
 //@ run-fail
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
-//@ normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr-test: ".rs:\d+:\d+" -> ".rs:LL:CC"
 //
 // Regression test for issue #70963
 // The captured stderr from this test reports a location

--- a/tests/ui/hygiene/unpretty-debug.rs
+++ b/tests/ui/hygiene/unpretty-debug.rs
@@ -2,7 +2,7 @@
 //@ compile-flags: -Zunpretty=expanded,hygiene
 
 // Don't break whenever Symbol numbering changes
-//@ normalize-stdout-test "\d+#" -> "0#"
+//@ normalize-stdout-test: "\d+#" -> "0#"
 
 // minimal junk
 #![feature(no_core)]

--- a/tests/ui/hygiene/unpretty-debug.stdout
+++ b/tests/ui/hygiene/unpretty-debug.stdout
@@ -2,7 +2,7 @@
 //@ compile-flags: -Zunpretty=expanded,hygiene
 
 // Don't break whenever Symbol numbering changes
-//@ normalize-stdout-test "\d+#" -> "0#"
+//@ normalize-stdout-test: "\d+#" -> "0#"
 
 // minimal junk
 #![feature /* 0#0 */(no_core)]

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
@@ -2,7 +2,7 @@
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@ compile-flags: -Zverbose-internals
 //@[next] compile-flags: -Znext-solver
-//@ normalize-stderr-test "DefId\([^\)]+\)" -> "DefId(..)"
+//@ normalize-stderr-test: "DefId\([^\)]+\)" -> "DefId(..)"
 
 #![feature(rustc_attrs)]
 #![rustc_hidden_type_of_opaques]

--- a/tests/ui/intrinsics/not-overridden.rs
+++ b/tests/ui/intrinsics/not-overridden.rs
@@ -3,9 +3,9 @@
 #![feature(rustc_attrs)]
 //@ build-fail
 //@ failure-status:101
-//@ normalize-stderr-test ".*note: .*\n\n" -> ""
-//@ normalize-stderr-test "thread 'rustc' panicked.*:\n.*\n" -> ""
-//@ normalize-stderr-test "internal compiler error:.*: intrinsic const_deallocate " -> ""
+//@ normalize-stderr-test: ".*note: .*\n\n" -> ""
+//@ normalize-stderr-test: "thread 'rustc' panicked.*:\n.*\n" -> ""
+//@ normalize-stderr-test: "internal compiler error:.*: intrinsic const_deallocate " -> ""
 //@ rustc-env:RUST_BACKTRACE=0
 
 #[rustc_intrinsic]

--- a/tests/ui/io-checks/non-ice-error-on-worker-io-fail.rs
+++ b/tests/ui/io-checks/non-ice-error-on-worker-io-fail.rs
@@ -19,10 +19,10 @@
 //@ error-pattern: error
 
 // On Mac OS X, we get an error like the below
-//@ normalize-stderr-test "failed to write bytecode to ./does-not-exist/output.non_ice_error_on_worker_io_fail.*" -> "io error modifying ./does-not-exist/"
+//@ normalize-stderr-test: "failed to write bytecode to ./does-not-exist/output.non_ice_error_on_worker_io_fail.*" -> "io error modifying ./does-not-exist/"
 
 // On Linux, we get an error like the below
-//@ normalize-stderr-test "couldn't create a temp dir.*" -> "io error modifying ./does-not-exist/"
+//@ normalize-stderr-test: "couldn't create a temp dir.*" -> "io error modifying ./does-not-exist/"
 
 //@ ignore-windows - this is a unix-specific test
 //@ ignore-emscripten - the file-system issues do not replicate here

--- a/tests/ui/issues/issue-28625.rs
+++ b/tests/ui/issues/issue-28625.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "\d+ bits" -> "N bits"
+//@ normalize-stderr-test: "\d+ bits" -> "N bits"
 
 trait Bar {
     type Bar;

--- a/tests/ui/issues/issue-32377.rs
+++ b/tests/ui/issues/issue-32377.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "\d+ bits" -> "N bits"
+//@ normalize-stderr-test: "\d+ bits" -> "N bits"
 
 use std::mem;
 use std::marker::PhantomData;

--- a/tests/ui/lang-items/duplicate.rs
+++ b/tests/ui/lang-items/duplicate.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "loaded from .*libcore-.*.rlib" -> "loaded from SYSROOT/libcore-*.rlib"
+//@ normalize-stderr-test: "loaded from .*libcore-.*.rlib" -> "loaded from SYSROOT/libcore-*.rlib"
 #![feature(lang_items)]
 
 #[lang = "sized"]

--- a/tests/ui/layout/debug.rs
+++ b/tests/ui/layout/debug.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$SOME_ALIGN"
+//@ normalize-stderr-test: "pref: Align\([1-8] bytes\)" -> "pref: $$SOME_ALIGN"
 #![feature(never_type, rustc_attrs, type_alias_impl_trait, repr_simd)]
 #![crate_type = "lib"]
 

--- a/tests/ui/layout/enum-scalar-pair-int-ptr.rs
+++ b/tests/ui/layout/enum-scalar-pair-int-ptr.rs
@@ -1,6 +1,6 @@
-//@ normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
-//@ normalize-stderr-test "Int\(I[0-9]+," -> "Int(I?,"
-//@ normalize-stderr-test "valid_range: 0..=[0-9]+" -> "valid_range: $$VALID_RANGE"
+//@ normalize-stderr-test: "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
+//@ normalize-stderr-test: "Int\(I[0-9]+," -> "Int(I?,"
+//@ normalize-stderr-test: "valid_range: 0..=[0-9]+" -> "valid_range: $$VALID_RANGE"
 
 //! Enum layout tests related to scalar pairs with an int/ptr common primitive.
 

--- a/tests/ui/layout/enum.rs
+++ b/tests/ui/layout/enum.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
+//@ normalize-stderr-test: "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
 //! Various enum layout tests.
 
 #![feature(rustc_attrs)]

--- a/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.rs
+++ b/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
+//@ normalize-stderr-test: "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
 #![crate_type = "lib"]
 #![feature(rustc_attrs)]
 

--- a/tests/ui/layout/issue-96185-overaligned-enum.rs
+++ b/tests/ui/layout/issue-96185-overaligned-enum.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
+//@ normalize-stderr-test: "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
 #![crate_type = "lib"]
 #![feature(rustc_attrs)]
 

--- a/tests/ui/layout/struct.rs
+++ b/tests/ui/layout/struct.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
+//@ normalize-stderr-test: "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
 //! Various struct layout tests.
 
 #![feature(rustc_attrs)]

--- a/tests/ui/layout/valid_range_oob.rs
+++ b/tests/ui/layout/valid_range_oob.rs
@@ -1,6 +1,6 @@
 //@ failure-status: 101
-//@ normalize-stderr-test "note: .*\n\n" -> ""
-//@ normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+//@ normalize-stderr-test: "note: .*\n\n" -> ""
+//@ normalize-stderr-test: "thread 'rustc' panicked.*\n" -> ""
 //@ rustc-env:RUST_BACKTRACE=0
 
 #![feature(rustc_attrs)]

--- a/tests/ui/layout/zero-sized-array-enum-niche.rs
+++ b/tests/ui/layout/zero-sized-array-enum-niche.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
+//@ normalize-stderr-test: "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
 #![crate_type = "lib"]
 #![feature(rustc_attrs)]
 

--- a/tests/ui/limits/huge-enum.rs
+++ b/tests/ui/limits/huge-enum.rs
@@ -1,6 +1,6 @@
 //@ build-fail
-//@ normalize-stderr-test "std::option::Option<\[u32; \d+\]>" -> "TYPE"
-//@ normalize-stderr-test "\[u32; \d+\]" -> "TYPE"
+//@ normalize-stderr-test: "std::option::Option<\[u32; \d+\]>" -> "TYPE"
+//@ normalize-stderr-test: "\[u32; \d+\]" -> "TYPE"
 
 #[cfg(target_pointer_width = "32")]
 type BIG = Option<[u32; (1<<29)-1]>;

--- a/tests/ui/limits/huge-struct.rs
+++ b/tests/ui/limits/huge-struct.rs
@@ -1,6 +1,6 @@
 //@ build-fail
-//@ normalize-stderr-test "S32" -> "SXX"
-//@ normalize-stderr-test "S1M" -> "SXX"
+//@ normalize-stderr-test: "S32" -> "SXX"
+//@ normalize-stderr-test: "S1M" -> "SXX"
 //@ error-pattern: too big for the current
 
 struct S32<T> {

--- a/tests/ui/limits/issue-17913.rs
+++ b/tests/ui/limits/issue-17913.rs
@@ -1,5 +1,5 @@
 //@ build-fail
-//@ normalize-stderr-test "\[&usize; \d+\]" -> "[&usize; usize::MAX]"
+//@ normalize-stderr-test: "\[&usize; \d+\]" -> "[&usize; usize::MAX]"
 //@ error-pattern: too big for the current architecture
 
 #[cfg(target_pointer_width = "64")]

--- a/tests/ui/limits/issue-55878.rs
+++ b/tests/ui/limits/issue-55878.rs
@@ -1,6 +1,6 @@
 //@ build-fail
-//@ normalize-stderr-64bit "18446744073709551615" -> "SIZE"
-//@ normalize-stderr-32bit "4294967295" -> "SIZE"
+//@ normalize-stderr-64bit: "18446744073709551615" -> "SIZE"
+//@ normalize-stderr-32bit: "4294967295" -> "SIZE"
 
 //@ error-pattern: are too big for the current architecture
 fn main() {

--- a/tests/ui/lint/lint-overflowing-ops.rs
+++ b/tests/ui/lint/lint-overflowing-ops.rs
@@ -11,8 +11,8 @@
 //@ [opt_with_overflow_checks]compile-flags: -C overflow-checks=on -O -Z deduplicate-diagnostics=yes
 //@ build-fail
 //@ ignore-pass (test tests codegen-time behaviour)
-//@ normalize-stderr-test "shift left by `(64|32)_usize`, which" -> "shift left by `%BITS%`, which"
-//@ normalize-stderr-test "shift right by `(64|32)_usize`, which" -> "shift right by `%BITS%`, which"
+//@ normalize-stderr-test: "shift left by `(64|32)_usize`, which" -> "shift left by `%BITS%`, which"
+//@ normalize-stderr-test: "shift right by `(64|32)_usize`, which" -> "shift right by `%BITS%`, which"
 
 #![deny(arithmetic_overflow)]
 

--- a/tests/ui/mir/lint/storage-live.rs
+++ b/tests/ui/mir/lint/storage-live.rs
@@ -2,10 +2,10 @@
 //@ failure-status: 101
 //@ error-pattern: broken MIR in
 //@ error-pattern: StorageLive(_1) which already has storage here
-//@ normalize-stderr-test "note: .*\n\n" -> ""
-//@ normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
-//@ normalize-stderr-test "storage_live\[....\]" -> "storage_live[HASH]"
-//@ normalize-stderr-test "(delayed at [^:]+):\d+:\d+ - " -> "$1:LL:CC - "
+//@ normalize-stderr-test: "note: .*\n\n" -> ""
+//@ normalize-stderr-test: "thread 'rustc' panicked.*\n" -> ""
+//@ normalize-stderr-test: "storage_live\[....\]" -> "storage_live[HASH]"
+//@ normalize-stderr-test: "(delayed at [^:]+):\d+:\d+ - " -> "$1:LL:CC - "
 //@ rustc-env:RUST_BACKTRACE=0
 
 #![feature(custom_mir, core_intrinsics)]

--- a/tests/ui/native-library-link-flags/msvc-non-utf8-output.rs
+++ b/tests/ui/native-library-link-flags/msvc-non-utf8-output.rs
@@ -1,5 +1,5 @@
 //@ build-fail
 //@ compile-flags:-C link-arg=⦺ⅈ⽯⭏⽽◃⡽⚞
 //@ only-msvc
-//@ normalize-stderr-test "(?:.|\n)*(⦺ⅈ⽯⭏⽽◃⡽⚞)(?:.|\n)*" -> "$1"
+//@ normalize-stderr-test: "(?:.|\n)*(⦺ⅈ⽯⭏⽽◃⡽⚞)(?:.|\n)*" -> "$1"
 pub fn main() {}

--- a/tests/ui/packed/packed-struct-transmute.rs
+++ b/tests/ui/packed/packed-struct-transmute.rs
@@ -3,7 +3,7 @@
 // the error points to the start of the file, not the line with the
 // transmute
 
-//@ normalize-stderr-test "\d+ bits" -> "N bits"
+//@ normalize-stderr-test: "\d+ bits" -> "N bits"
 //@ error-pattern: cannot transmute between types of different sizes, or dependently-sized types
 
 use std::mem;

--- a/tests/ui/panic-handler/panic-handler-std.rs
+++ b/tests/ui/panic-handler/panic-handler-std.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "loaded from .*libstd-.*.rlib" -> "loaded from SYSROOT/libstd-*.rlib"
+//@ normalize-stderr-test: "loaded from .*libstd-.*.rlib" -> "loaded from SYSROOT/libstd-*.rlib"
 //@ error-pattern: found duplicate lang item `panic_impl`
 
 extern crate core;

--- a/tests/ui/panics/default-backtrace-ice.rs
+++ b/tests/ui/panics/default-backtrace-ice.rs
@@ -3,12 +3,12 @@
 //@ error-pattern:stack backtrace:
 //@ failure-status:101
 //@ ignore-msvc
-//@ normalize-stderr-test "note: .*" -> ""
-//@ normalize-stderr-test "thread 'rustc' .*" -> ""
-//@ normalize-stderr-test " +\d+:.*__rust_begin_short_backtrace.*" -> "(begin_short_backtrace)"
-//@ normalize-stderr-test " +\d+:.*__rust_end_short_backtrace.*" -> "(end_short_backtrace)"
-//@ normalize-stderr-test " +\d+:.*\n" -> ""
-//@ normalize-stderr-test " +at .*\n" -> ""
+//@ normalize-stderr-test: "note: .*" -> ""
+//@ normalize-stderr-test: "thread 'rustc' .*" -> ""
+//@ normalize-stderr-test: " +\d+:.*__rust_begin_short_backtrace.*" -> "(begin_short_backtrace)"
+//@ normalize-stderr-test: " +\d+:.*__rust_end_short_backtrace.*" -> "(end_short_backtrace)"
+//@ normalize-stderr-test: " +\d+:.*\n" -> ""
+//@ normalize-stderr-test: " +at .*\n" -> ""
 //
 // This test makes sure that full backtraces are used for ICEs when
 // RUST_BACKTRACE is not set. It does this by checking for the presence of

--- a/tests/ui/proc-macro/load-panic-backtrace.rs
+++ b/tests/ui/proc-macro/load-panic-backtrace.rs
@@ -1,8 +1,8 @@
 //@ aux-build:test-macros.rs
 //@ compile-flags: -Z proc-macro-backtrace
 //@ rustc-env:RUST_BACKTRACE=0
-//@ normalize-stderr-test "thread '.*' panicked " -> ""
-//@ normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+//@ normalize-stderr-test: "thread '.*' panicked " -> ""
+//@ normalize-stderr-test: "note:.*RUST_BACKTRACE=1.*\n" -> ""
 //@ needs-unwind proc macro panics to report errors
 
 #[macro_use]

--- a/tests/ui/proc-macro/meta-macro-hygiene.rs
+++ b/tests/ui/proc-macro/meta-macro-hygiene.rs
@@ -4,9 +4,9 @@
 //@ compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded,hygiene -Z trim-diagnostic-paths=no
 //@ check-pass
 // ignore-tidy-linelength
-//@ normalize-stdout-test "\d+#" -> "0#"
-//@ normalize-stdout-test "expn\d{3,}" -> "expnNNN"
-//@ normalize-stdout-test "extern crate compiler_builtins /\* \d+ \*/" -> "extern crate compiler_builtins /* NNN */"
+//@ normalize-stdout-test: "\d+#" -> "0#"
+//@ normalize-stdout-test: "expn\d{3,}" -> "expnNNN"
+//@ normalize-stdout-test: "extern crate compiler_builtins /\* \d+ \*/" -> "extern crate compiler_builtins /* NNN */"
 //
 // We don't care about symbol ids, so we set them all to 0
 // in the stdout

--- a/tests/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/tests/ui/proc-macro/meta-macro-hygiene.stdout
@@ -8,9 +8,9 @@ Respanned: TokenStream [Ident { ident: "$crate", span: $DIR/auxiliary/make-macro
 //@ compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded,hygiene -Z trim-diagnostic-paths=no
 //@ check-pass
 // ignore-tidy-linelength
-//@ normalize-stdout-test "\d+#" -> "0#"
-//@ normalize-stdout-test "expn\d{3,}" -> "expnNNN"
-//@ normalize-stdout-test "extern crate compiler_builtins /\* \d+ \*/" -> "extern crate compiler_builtins /* NNN */"
+//@ normalize-stdout-test: "\d+#" -> "0#"
+//@ normalize-stdout-test: "expn\d{3,}" -> "expnNNN"
+//@ normalize-stdout-test: "extern crate compiler_builtins /\* \d+ \*/" -> "extern crate compiler_builtins /* NNN */"
 //
 // We don't care about symbol ids, so we set them all to 0
 // in the stdout

--- a/tests/ui/proc-macro/nonterminal-token-hygiene.rs
+++ b/tests/ui/proc-macro/nonterminal-token-hygiene.rs
@@ -4,9 +4,9 @@
 //@ compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded,hygiene
 //@ compile-flags: -Z trim-diagnostic-paths=no
 // ignore-tidy-linelength
-//@ normalize-stdout-test "\d+#" -> "0#"
-//@ normalize-stdout-test "expn\d{3,}" -> "expnNNN"
-//@ normalize-stdout-test "extern crate compiler_builtins /\* \d+ \*/" -> "extern crate compiler_builtins /* NNN */"
+//@ normalize-stdout-test: "\d+#" -> "0#"
+//@ normalize-stdout-test: "expn\d{3,}" -> "expnNNN"
+//@ normalize-stdout-test: "extern crate compiler_builtins /\* \d+ \*/" -> "extern crate compiler_builtins /* NNN */"
 //@ aux-build:test-macros.rs
 
 #![feature(decl_macro)]

--- a/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
+++ b/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
@@ -28,9 +28,9 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
 //@ compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded,hygiene
 //@ compile-flags: -Z trim-diagnostic-paths=no
 // ignore-tidy-linelength
-//@ normalize-stdout-test "\d+#" -> "0#"
-//@ normalize-stdout-test "expn\d{3,}" -> "expnNNN"
-//@ normalize-stdout-test "extern crate compiler_builtins /\* \d+ \*/" -> "extern crate compiler_builtins /* NNN */"
+//@ normalize-stdout-test: "\d+#" -> "0#"
+//@ normalize-stdout-test: "expn\d{3,}" -> "expnNNN"
+//@ normalize-stdout-test: "extern crate compiler_builtins /\* \d+ \*/" -> "extern crate compiler_builtins /* NNN */"
 //@ aux-build:test-macros.rs
 
 #![feature /* 0#0 */(decl_macro)]

--- a/tests/ui/process/println-with-broken-pipe.rs
+++ b/tests/ui/process/println-with-broken-pipe.rs
@@ -5,7 +5,7 @@
 //@ ignore-fuchsia
 //@ ignore-horizon
 //@ ignore-android
-//@ normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr-test: ".rs:\d+:\d+" -> ".rs:LL:CC"
 //@ compile-flags: -Zon-broken-pipe=error
 
 // Test what the error message looks like when `println!()` panics because of

--- a/tests/ui/repr/repr-c-dead-variants.rs
+++ b/tests/ui/repr/repr-c-dead-variants.rs
@@ -6,7 +6,7 @@
 
 // See also: repr-c-int-dead-variants.rs
 
-//@ normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$SOME_ALIGN"
+//@ normalize-stderr-test: "pref: Align\([1-8] bytes\)" -> "pref: $$SOME_ALIGN"
 
 // This test depends on the value of the `c_enum_min_bits` target option.
 // As there's no way to actually check it from UI test, we only run this test on a subset of archs.

--- a/tests/ui/repr/repr-c-int-dead-variants.rs
+++ b/tests/ui/repr/repr-c-int-dead-variants.rs
@@ -3,7 +3,7 @@
 
 // See also: repr-c-dead-variants.rs
 
-//@ normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$SOME_ALIGN"
+//@ normalize-stderr-test: "pref: Align\([1-8] bytes\)" -> "pref: $$SOME_ALIGN"
 
 // A simple uninhabited type.
 enum Void {}

--- a/tests/ui/resolve/multiple_definitions_attribute_merging.rs
+++ b/tests/ui/resolve/multiple_definitions_attribute_merging.rs
@@ -4,9 +4,9 @@
 
 //@known-bug: #120873
 //@ failure-status: 101
-//@ normalize-stderr-test "note: .*\n\n" -> ""
-//@ normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
-//@ normalize-stderr-test "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
+//@ normalize-stderr-test: "note: .*\n\n" -> ""
+//@ normalize-stderr-test: "thread 'rustc' panicked.*\n" -> ""
+//@ normalize-stderr-test: "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
 //@ rustc-env:RUST_BACKTRACE=0
 
 #[repr(packed)]

--- a/tests/ui/resolve/proc_macro_generated_packed.rs
+++ b/tests/ui/resolve/proc_macro_generated_packed.rs
@@ -4,9 +4,9 @@
 //@aux-build: proc_macro_generate_packed.rs
 //@known-bug: #120873
 //@ failure-status: 101
-//@ normalize-stderr-test "note: .*\n\n" -> ""
-//@ normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
-//@ normalize-stderr-test "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
+//@ normalize-stderr-test: "note: .*\n\n" -> ""
+//@ normalize-stderr-test: "thread 'rustc' panicked.*\n" -> ""
+//@ normalize-stderr-test: "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
 //@ rustc-env:RUST_BACKTRACE=0
 
 extern crate proc_macro_generate_packed;

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/minicore.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/minicore.rs
@@ -1,7 +1,7 @@
 //@ known-bug: #110395
 //@ failure-status: 101
-//@ normalize-stderr-test ".*note: .*\n\n" -> ""
-//@ normalize-stderr-test "thread 'rustc' panicked.*:\n.*\n" -> ""
+//@ normalize-stderr-test: ".*note: .*\n\n" -> ""
+//@ normalize-stderr-test: "thread 'rustc' panicked.*:\n.*\n" -> ""
 //@ rustc-env:RUST_BACKTRACE=0
 // FIXME(effects) check-pass
 //@ compile-flags: -Znext-solver

--- a/tests/ui/statics/mutable_memory_validation.rs
+++ b/tests/ui/statics/mutable_memory_validation.rs
@@ -1,8 +1,8 @@
 //issue: rust-lang/rust#122548
 
 // Strip out raw byte dumps to make comparison platform-independent:
-//@ normalize-stderr-test "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
-//@ normalize-stderr-test "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr-test: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr-test: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 
 #![feature(const_mut_refs)]
 #![feature(const_refs_to_static)]

--- a/tests/ui/test-attrs/terse.rs
+++ b/tests/ui/test-attrs/terse.rs
@@ -3,7 +3,7 @@
 //@ run-flags: --test-threads=1 --quiet
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ ignore-emscripten no threads support
 //@ needs-unwind
 

--- a/tests/ui/test-attrs/test-filter-multiple.rs
+++ b/tests/ui/test-attrs/test-filter-multiple.rs
@@ -2,7 +2,7 @@
 //@ compile-flags: --test
 //@ run-flags: --test-threads=1 test1 test2
 //@ check-run-results
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ needs-threads
 
 #[test]

--- a/tests/ui/test-attrs/test-panic-abort-nocapture.rs
+++ b/tests/ui/test-attrs/test-panic-abort-nocapture.rs
@@ -4,7 +4,7 @@
 //@ run-fail
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 //@ ignore-android #120567
 //@ ignore-wasm no panic or subprocess support

--- a/tests/ui/test-attrs/test-panic-abort.rs
+++ b/tests/ui/test-attrs/test-panic-abort.rs
@@ -4,7 +4,7 @@
 //@ run-fail
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 //@ ignore-android #120567
 //@ ignore-wasm no panic or subprocess support

--- a/tests/ui/test-attrs/test-passed.rs
+++ b/tests/ui/test-attrs/test-passed.rs
@@ -3,7 +3,7 @@
 //@ run-flags: --test-threads=1
 //@ run-pass
 //@ check-run-results
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // Tests the output of the test harness with only passed tests.
 

--- a/tests/ui/test-attrs/test-thread-capture.rs
+++ b/tests/ui/test-attrs/test-thread-capture.rs
@@ -3,7 +3,7 @@
 //@ run-flags: --test-threads=1
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ ignore-emscripten no threads support
 //@ needs-unwind
 

--- a/tests/ui/test-attrs/test-thread-nocapture.rs
+++ b/tests/ui/test-attrs/test-thread-nocapture.rs
@@ -3,7 +3,7 @@
 //@ run-flags: --test-threads=1 --nocapture
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ ignore-emscripten no threads support
 //@ needs-unwind
 

--- a/tests/ui/test-attrs/test-type.rs
+++ b/tests/ui/test-attrs/test-type.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: --test -Zpanic-abort-tests
 //@ run-flags: --test-threads=1
 //@ check-run-results
-//@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ needs-threads
 //@ run-pass
 

--- a/tests/ui/track-diagnostics/track.rs
+++ b/tests/ui/track-diagnostics/track.rs
@@ -5,13 +5,13 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-//@ normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
-//@ normalize-stderr-test "note: rustc .+ running on .+" -> "note: rustc $$VERSION running on $$TARGET"
+//@ normalize-stderr-test: ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr-test: "note: rustc .+ running on .+" -> "note: rustc $$VERSION running on $$TARGET"
 
 // The test becomes too flaky if we care about exact args. If `-Z ui-testing`
 // from compiletest and `-Z track-diagnostics` from `// compile-flags` at the
 // top of this file are present, then assume all args are present.
-//@ normalize-stderr-test "note: compiler flags: .*-Z ui-testing.*-Z track-diagnostics" -> "note: compiler flags: ... -Z ui-testing ... -Z track-diagnostics"
+//@ normalize-stderr-test: "note: compiler flags: .*-Z ui-testing.*-Z track-diagnostics" -> "note: compiler flags: ... -Z ui-testing ... -Z track-diagnostics"
 
 fn main() {
     break rust

--- a/tests/ui/track-diagnostics/track2.rs
+++ b/tests/ui/track-diagnostics/track2.rs
@@ -3,7 +3,7 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-//@ normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr-test: ".rs:\d+:\d+" -> ".rs:LL:CC"
 
 fn main() {
     let _moved @ _from = String::from("foo");

--- a/tests/ui/track-diagnostics/track3.rs
+++ b/tests/ui/track-diagnostics/track3.rs
@@ -3,7 +3,7 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-//@ normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr-test: ".rs:\d+:\d+" -> ".rs:LL:CC"
 
 fn main() {
     let _unimported = Blah { field: u8 };

--- a/tests/ui/track-diagnostics/track4.rs
+++ b/tests/ui/track-diagnostics/track4.rs
@@ -3,7 +3,7 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-//@ normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr-test: ".rs:\d+:\d+" -> ".rs:LL:CC"
 
 pub onion {
     Owo(u8),

--- a/tests/ui/track-diagnostics/track5.rs
+++ b/tests/ui/track-diagnostics/track5.rs
@@ -3,6 +3,6 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-//@ normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr-test: ".rs:\d+:\d+" -> ".rs:LL:CC"
 
 }

--- a/tests/ui/track-diagnostics/track6.rs
+++ b/tests/ui/track-diagnostics/track6.rs
@@ -3,7 +3,7 @@
 
 // Normalize the emitted location so this doesn't need
 // updating everytime someone adds or removes a line.
-//@ normalize-stderr-test ".rs:\d+:\d+" -> ".rs:LL:CC"
+//@ normalize-stderr-test: ".rs:\d+:\d+" -> ".rs:LL:CC"
 
 
 pub trait Foo {

--- a/tests/ui/traits/trait-upcasting/illegal-upcast-to-impl-opaque.rs
+++ b/tests/ui/traits/trait-upcasting/illegal-upcast-to-impl-opaque.rs
@@ -2,10 +2,10 @@
 //@[next] compile-flags: -Znext-solver
 //@[next] failure-status: 101
 //@[next] known-bug: unknown
-//@[next] normalize-stderr-test "note: .*\n\n" -> ""
-//@[next] normalize-stderr-test "thread 'rustc' panicked.*\n.*\n" -> ""
-//@[next] normalize-stderr-test "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
-//@[next] normalize-stderr-test "delayed at .*" -> ""
+//@[next] normalize-stderr-test: "note: .*\n\n" -> ""
+//@[next] normalize-stderr-test: "thread 'rustc' panicked.*\n.*\n" -> ""
+//@[next] normalize-stderr-test: "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
+//@[next] normalize-stderr-test: "delayed at .*" -> ""
 //@[next] rustc-env:RUST_BACKTRACE=0
 //@ check-pass
 

--- a/tests/ui/transmute/transmute-different-sizes.rs
+++ b/tests/ui/transmute/transmute-different-sizes.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "\d+ bits" -> "N bits"
+//@ normalize-stderr-test: "\d+ bits" -> "N bits"
 
 // Tests that `transmute` cannot be called on types of different size.
 

--- a/tests/ui/transmute/transmute-fat-pointers.rs
+++ b/tests/ui/transmute/transmute-fat-pointers.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "\d+ bits" -> "N bits"
+//@ normalize-stderr-test: "\d+ bits" -> "N bits"
 
 // Tests that are conservative around thin/fat pointer mismatches.
 

--- a/tests/ui/transmute/transmute-impl.rs
+++ b/tests/ui/transmute/transmute-impl.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "\d+ bits" -> "N bits"
+//@ normalize-stderr-test: "\d+ bits" -> "N bits"
 
 // Tests that are conservative around thin/fat pointer mismatches.
 

--- a/tests/ui/treat-err-as-bug/err.rs
+++ b/tests/ui/treat-err-as-bug/err.rs
@@ -2,8 +2,8 @@
 //@ failure-status: 101
 //@ error-pattern: aborting due to `-Z treat-err-as-bug=1`
 //@ error-pattern: [eval_static_initializer] evaluating initializer of static `C`
-//@ normalize-stderr-test "note: .*\n\n" -> ""
-//@ normalize-stderr-test "thread 'rustc' panicked.*:\n.*\n" -> ""
+//@ normalize-stderr-test: "note: .*\n\n" -> ""
+//@ normalize-stderr-test: "thread 'rustc' panicked.*:\n.*\n" -> ""
 //@ rustc-env:RUST_BACKTRACE=0
 
 #![crate_type = "rlib"]

--- a/tests/ui/treat-err-as-bug/span_delayed_bug.rs
+++ b/tests/ui/treat-err-as-bug/span_delayed_bug.rs
@@ -2,8 +2,8 @@
 //@ failure-status: 101
 //@ error-pattern: aborting due to `-Z treat-err-as-bug=1`
 //@ error-pattern: [trigger_delayed_bug] triggering a delayed bug for testing incremental
-//@ normalize-stderr-test "note: .*\n\n" -> ""
-//@ normalize-stderr-test "thread 'rustc' panicked.*:\n.*\n" -> ""
+//@ normalize-stderr-test: "note: .*\n\n" -> ""
+//@ normalize-stderr-test: "thread 'rustc' panicked.*:\n.*\n" -> ""
 //@ rustc-env:RUST_BACKTRACE=0
 
 #![feature(rustc_attrs)]

--- a/tests/ui/type/pattern_types/range_patterns.rs
+++ b/tests/ui/type/pattern_types/range_patterns.rs
@@ -3,7 +3,7 @@
 #![feature(core_pattern_types)]
 #![allow(incomplete_features)]
 
-//@ normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$SOME_ALIGN"
+//@ normalize-stderr-test: "pref: Align\([1-8] bytes\)" -> "pref: $$SOME_ALIGN"
 
 use std::pat::pattern_type;
 

--- a/tests/ui/unknown-llvm-arg.rs
+++ b/tests/ui/unknown-llvm-arg.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Cllvm-args=-not-a-real-llvm-arg
-//@ normalize-stderr-test "--help" -> "-help"
-//@ normalize-stderr-test "\n(\n|.)*" -> ""
+//@ normalize-stderr-test: "--help" -> "-help"
+//@ normalize-stderr-test: "\n(\n|.)*" -> ""
 
 // I'm seeing "--help" locally, but "-help" in CI, so I'm normalizing it to just "-help".
 

--- a/tests/ui/unpretty/avoid-crash.rs
+++ b/tests/ui/unpretty/avoid-crash.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr-test "error `.*`" -> "$$ERROR_MESSAGE"
+//@ normalize-stderr-test: "error `.*`" -> "$$ERROR_MESSAGE"
 //@ compile-flags: -o. -Zunpretty=ast-tree
 
 fn main() {}


### PR DESCRIPTION
The previous parser for `//@ normalize-*` headers (before #126370) was so lax that it did not require `:` after the header name. As a result, the test suite contained a mix of with-colon and without-colon normalize headers, both numbering in the hundreds.

This PR updates the without-colon headers to add a colon (matching the style used by other headers), and then updates the parser to make the colon mandatory.

(Because the normalization parser only runs *after* the header system identifies a normalize header, this will detect and issue an error for relevant headers that lack the colon.)

Addresses one of the points of #126372.