### PR TITLE
Add `mem::{take, replace, swap}` to the prelude

### DIFF
--- a/library/core/src/prelude/common.rs
+++ b/library/core/src/prelude/common.rs
@@ -17,6 +17,9 @@ pub use crate::mem::drop;
 #[stable(feature = "size_of_prelude", since = "1.80.0")]
 #[doc(no_inline)]
 pub use crate::mem::{align_of, align_of_val, size_of, size_of_val};
+#[stable(feature = "mem_prelude", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::mem::{replace, swap, take};
 
 // Re-exported types and traits
 #[stable(feature = "core_prelude", since = "1.4.0")]

--- a/library/std/src/prelude/common.rs
+++ b/library/std/src/prelude/common.rs
@@ -17,6 +17,9 @@ pub use crate::mem::drop;
 #[stable(feature = "size_of_prelude", since = "1.80.0")]
 #[doc(no_inline)]
 pub use crate::mem::{align_of, align_of_val, size_of, size_of_val};
+#[stable(feature = "mem_prelude", since = "CURRENT_RUSTC_VERSION")]
+#[doc(no_inline)]
+pub use crate::mem::{replace, swap, take};
 
 // Re-exported types and traits
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -36,6 +36,13 @@
 //!   operations for both destructors and overloading `()`.
 //! * <code>[std::mem]::[drop]</code>, a convenience function for explicitly
 //!   dropping a value.
+//! * <code>[std::mem]::[replace]</code>, a convenience function for replacing
+//!   one value with another while returning the previous value.
+//! * <code>[std::mem]::[take]</code>, a convenience function for replacing a
+//!   value with the default value for its type while returning the previous
+//!   value.
+//! * <code>[std::mem]::[swap]</code>, a convenience function for swapping
+//!   two values.
 //! * <code>[std::mem]::{[size_of], [size_of_val]}</code>, to get the size of
 //!   a type or value.
 //! * <code>[std::mem]::{[align_of], [align_of_val]}</code>, to get the

--- a/src/tools/clippy/clippy_lints/src/booleans.rs
+++ b/src/tools/clippy/clippy_lints/src/booleans.rs
@@ -399,13 +399,13 @@ fn simple_negate(b: Bool) -> Bool {
         t @ Term(_) => Not(Box::new(t)),
         And(mut v) => {
             for el in &mut v {
-                *el = simple_negate(std::mem::replace(el, True));
+                *el = simple_negate(replace(el, True));
             }
             Or(v)
         },
         Or(mut v) => {
             for el in &mut v {
-                *el = simple_negate(std::mem::replace(el, True));
+                *el = simple_negate(replace(el, True));
             }
             And(v)
         },

--- a/src/tools/clippy/clippy_lints/src/dereference.rs
+++ b/src/tools/clippy/clippy_lints/src/dereference.rs
@@ -5,7 +5,6 @@ use clippy_utils::ty::{implements_trait, is_manually_drop, peel_mid_ty_refs};
 use clippy_utils::{
     expr_use_ctxt, get_parent_expr, is_block_like, is_lint_allowed, path_to_local, DefinedTy, ExprUseNode,
 };
-use core::mem;
 use rustc_ast::util::parser::{PREC_POSTFIX, PREC_PREFIX};
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_errors::Applicability;
@@ -714,7 +713,7 @@ fn try_parse_ref_op<'tcx>(
 // Checks if the adjustments contains a deref of `ManuallyDrop<_>`
 fn adjust_derefs_manually_drop<'tcx>(adjustments: &'tcx [Adjustment<'tcx>], mut ty: Ty<'tcx>) -> bool {
     adjustments.iter().any(|a| {
-        let ty = mem::replace(&mut ty, a.target);
+        let ty = replace(&mut ty, a.target);
         matches!(a.kind, Adjust::Deref(Some(ref op)) if op.mutbl == Mutability::Mut) && is_manually_drop(ty)
     })
 }

--- a/src/tools/clippy/clippy_lints/src/loops/needless_range_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/needless_range_loop.rs
@@ -13,7 +13,7 @@ use rustc_lint::LateContext;
 use rustc_middle::middle::region;
 use rustc_middle::ty::{self, Ty};
 use rustc_span::symbol::{sym, Symbol};
-use std::{iter, mem};
+use std::iter;
 
 /// Checks for looping over a range and then indexing a sequence with it.
 /// The iteratee must be a range literal.
@@ -135,7 +135,7 @@ pub(super) fn check<'tcx>(
                 let mut method_2 = skip;
 
                 if end_is_start_plus_val {
-                    mem::swap(&mut method_1, &mut method_2);
+                    swap(&mut method_1, &mut method_2);
                 }
 
                 if visitor.nonindex {

--- a/src/tools/clippy/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
@@ -222,7 +222,7 @@ impl<'a, 'tcx> SigDropHelper<'a, 'tcx> {
     fn find_sig_drop(&mut self, match_expr: &'tcx Expr<'_>) -> Vec<FoundSigDrop> {
         self.visit_expr(match_expr);
 
-        core::mem::take(&mut self.sig_drop_spans)
+        take(&mut self.sig_drop_spans)
     }
 
     fn replace_current_sig_drop(&mut self, found_span: Span, is_unit_return_val: bool, peel_ref_times: usize) {
@@ -376,8 +376,8 @@ impl<'a, 'tcx> Visitor<'tcx> for SigDropHelper<'a, 'tcx> {
 
         // These states are of neighborhood expressions. We save and clear them here, and we'll later merge
         // the states of the current expression with them at the end of the method.
-        let sig_drop_holder_before = core::mem::take(&mut self.sig_drop_holder);
-        let sig_drop_spans_before = core::mem::take(&mut self.sig_drop_spans);
+        let sig_drop_holder_before = take(&mut self.sig_drop_holder);
+        let sig_drop_spans_before = take(&mut self.sig_drop_spans);
         let parent_expr_before = self.parent_expr.replace(ex);
 
         match ex.kind {

--- a/src/tools/clippy/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -1,4 +1,3 @@
-use std::mem;
 use std::ops::ControlFlow;
 
 use clippy_utils::comparisons::{normalize_comparison, Rel};
@@ -290,7 +289,7 @@ fn check_assert<'hir>(cx: &LateContext<'_>, expr: &'hir Expr<'hir>, map: &mut Un
             {
                 *entry = IndexEntry::AssertWithIndex {
                     highest_index: *highest_index,
-                    indexes: mem::take(indexes),
+                    indexes: take(indexes),
                     slice,
                     assert_span: expr.span,
                     comparison,

--- a/src/tools/clippy/clippy_lints/src/redundant_else.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_else.rs
@@ -123,7 +123,7 @@ impl<'ast> Visitor<'ast> for BreakVisitor {
 impl BreakVisitor {
     fn check<T>(&mut self, item: T, visit: fn(&mut Self, T)) -> bool {
         visit(self, item);
-        std::mem::replace(&mut self.is_break, false)
+        replace(&mut self.is_break, false)
     }
 
     fn check_block(&mut self, block: &Block) -> bool {

--- a/src/tools/clippy/clippy_lints/src/unnested_or_patterns.rs
+++ b/src/tools/clippy/clippy_lints/src/unnested_or_patterns.rs
@@ -14,7 +14,6 @@ use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::impl_lint_pass;
 use rustc_span::DUMMY_SP;
 use std::cell::Cell;
-use std::mem;
 use thin_vec::{thin_vec, ThinVec};
 
 declare_clippy_lint! {
@@ -123,7 +122,7 @@ fn remove_all_parens(pat: &mut P<Pat>) {
         fn visit_pat(&mut self, pat: &mut P<Pat>) {
             noop_visit_pat(pat, self);
             let inner = match &mut pat.kind {
-                Paren(i) => mem::replace(&mut i.kind, Wild),
+                Paren(i) => replace(&mut i.kind, Wild),
                 _ => return,
             };
             pat.kind = inner;
@@ -170,7 +169,7 @@ fn unnest_or_patterns(pat: &mut P<Pat>) -> bool {
             let mut this_level_changed = false;
             while idx < alternatives.len() {
                 let inner = if let Or(ps) = &mut alternatives[idx].kind {
-                    mem::take(ps)
+                    take(ps)
                 } else {
                     idx += 1;
                     continue;
@@ -215,7 +214,7 @@ macro_rules! always_pat {
 /// in `alternatives[focus_idx + 1..]`.
 fn transform_with_focus_on_idx(alternatives: &mut ThinVec<P<Pat>>, focus_idx: usize) -> bool {
     // Extract the kind; we'll need to make some changes in it.
-    let mut focus_kind = mem::replace(&mut alternatives[focus_idx].kind, Wild);
+    let mut focus_kind = replace(&mut alternatives[focus_idx].kind, Wild);
     // We'll focus on `alternatives[focus_idx]`,
     // so we're draining from `alternatives[focus_idx + 1..]`.
     let start = focus_idx + 1;
@@ -359,7 +358,7 @@ fn take_pat(from: &mut Pat) -> Pat {
         span: DUMMY_SP,
         tokens: None,
     };
-    mem::replace(from, dummy)
+    replace(from, dummy)
 }
 
 /// Extend `target` as an or-pattern with the alternatives

--- a/src/tools/clippy/clippy_lints/src/utils/format_args_collector.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/format_args_collector.rs
@@ -8,7 +8,6 @@ use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::impl_lint_pass;
 use rustc_span::{hygiene, Span};
 use std::iter::once;
-use std::mem;
 
 /// Populates [`FormatArgsStorage`] with AST [`FormatArgs`] nodes
 pub struct FormatArgsCollector {
@@ -39,7 +38,7 @@ impl EarlyLintPass for FormatArgsCollector {
     }
 
     fn check_crate_post(&mut self, _: &EarlyContext<'_>, _: &Crate) {
-        self.storage.set(mem::take(&mut self.format_args));
+        self.storage.set(take(&mut self.format_args));
     }
 }
 

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -81,7 +81,6 @@ pub use self::hir_utils::{
     both, count_eq, eq_expr_value, hash_expr, hash_stmt, is_bool, over, HirEqInterExpr, SpanlessEq, SpanlessHash,
 };
 
-use core::mem;
 use core::ops::ControlFlow;
 use std::collections::hash_map::Entry;
 use std::hash::BuildHasherDefault;
@@ -3108,7 +3107,7 @@ pub fn is_never_expr<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> Option<
                     self.is_never = true;
                 },
                 ExprKind::If(cond, then, else_) => {
-                    let in_final_expr = mem::replace(&mut self.in_final_expr, false);
+                    let in_final_expr = replace(&mut self.in_final_expr, false);
                     self.visit_expr(cond);
                     self.in_final_expr = in_final_expr;
 
@@ -3119,7 +3118,7 @@ pub fn is_never_expr<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> Option<
                         }
                     } else {
                         self.visit_expr(then);
-                        let is_never = mem::replace(&mut self.is_never, false);
+                        let is_never = replace(&mut self.is_never, false);
                         if let Some(else_) = else_ {
                             self.visit_expr(else_);
                             self.is_never &= is_never;
@@ -3127,7 +3126,7 @@ pub fn is_never_expr<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> Option<
                     }
                 },
                 ExprKind::Match(scrutinee, arms, _) => {
-                    let in_final_expr = mem::replace(&mut self.in_final_expr, false);
+                    let in_final_expr = replace(&mut self.in_final_expr, false);
                     self.visit_expr(scrutinee);
                     self.in_final_expr = in_final_expr;
 
@@ -3140,7 +3139,7 @@ pub fn is_never_expr<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> Option<
                         for arm in arms {
                             self.is_never = false;
                             if let Some(guard) = arm.guard {
-                                let in_final_expr = mem::replace(&mut self.in_final_expr, false);
+                                let in_final_expr = replace(&mut self.in_final_expr, false);
                                 self.visit_expr(guard);
                                 self.in_final_expr = in_final_expr;
                                 // The compiler doesn't consider diverging guards as causing the arm to diverge.
@@ -3176,7 +3175,7 @@ pub fn is_never_expr<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> Option<
         }
 
         fn visit_block(&mut self, b: &'tcx Block<'_>) {
-            let in_final_expr = mem::replace(&mut self.in_final_expr, false);
+            let in_final_expr = replace(&mut self.in_final_expr, false);
             for s in b.stmts {
                 self.visit_stmt(s);
             }
@@ -3199,7 +3198,7 @@ pub fn is_never_expr<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> Option<
 
         fn visit_arm(&mut self, arm: &Arm<'tcx>) {
             if let Some(guard) = arm.guard {
-                let in_final_expr = mem::replace(&mut self.in_final_expr, false);
+                let in_final_expr = replace(&mut self.in_final_expr, false);
                 self.visit_expr(guard);
                 self.in_final_expr = in_final_expr;
             }

--- a/src/tools/clippy/clippy_utils/src/visitors.rs
+++ b/src/tools/clippy/clippy_utils/src/visitors.rs
@@ -208,7 +208,7 @@ where
 
     impl<F> RetFinder<F> {
         fn inside_stmt(&mut self, in_stmt: bool) -> WithStmtGuard<'_, F> {
-            let prev_in_stmt = std::mem::replace(&mut self.in_stmt, in_stmt);
+            let prev_in_stmt = replace(&mut self.in_stmt, in_stmt);
             WithStmtGuard {
                 val: self,
                 prev_in_stmt,


### PR DESCRIPTION
This adds the following 3 functions from `core::mem` to the prelude:
```rust
fn replace<T>(dest: &mut T, src: T) -> T;
fn take<T: Default>(dest: &mut T) -> T;
fn swap<T>(x: &mut T, y: &mut T);
```

The main goal is to make Rust easier to teach, while also making common code patterns easier to write. Many new Rust users coming from other languages find Rust's ownership system hard to use and a part of that is because it does not allow leaving values in an uninitialized state after moving them, even temporarily. While the tools to work around this are available in `core::mem`, they are not very discoverable for new users. By treating these functions more like keywords (similar to `drop`), we can encourage the inclusion of these functions in teaching materials and expose new Rust users to them.

These 3 functions are also very widely used in production Rust code so even experienced Rust users will benefit from this change. For example, in the Rust compiler there are:
- 74 uses of `mem::replace`.
- 94 uses of `mem::take`.
- 17 uses of `mem::swap`.