### PR TITLE
[fuchsia-test-runner] Remove usage of kw_only

### DIFF
--- a/src/ci/docker/scripts/fuchsia-test-runner.py
+++ b/src/ci/docker/scripts/fuchsia-test-runner.py
@@ -112,7 +112,7 @@ def atomic_link(link: Path, target: Path):
             os.remove(tmp_file)
 
 
-@dataclass(kw_only=True)
+@dataclass
 class TestEnvironment:
     rust_build_dir: Path
     sdk_dir: Path


### PR DESCRIPTION
We are still at Python 3.8 in Fuchsia infra. This was introduced at Python 3.10.

r? tmandry
r? erickt