### PR TITLE
Add a tidy rule to check that fluent messages and attrs don't end in `.`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5700,6 +5700,7 @@ name = "tidy"
 version = "0.1.0"
 dependencies = [
  "cargo_metadata 0.15.4",
+ "fluent-syntax",
  "ignore",
  "miropt-test-tools",
  "regex",

--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -78,7 +78,7 @@ ast_lowering_inline_asm_unsupported_target =
 ast_lowering_invalid_abi =
     invalid ABI: found `{$abi}`
     .label = invalid ABI
-    .note = invoke `{$command}` for a full list of supported calling conventions.
+    .note = invoke `{$command}` for a full list of supported calling conventions
 
 ast_lowering_invalid_abi_clobber_abi =
     invalid ABI for `clobber_abi`

--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -341,8 +341,7 @@ const_eval_unallowed_fn_pointer_call = function pointer calls are not allowed in
 const_eval_unallowed_heap_allocations =
     allocations are not allowed in {const_eval_const_context}s
     .label = allocation not allowed in {const_eval_const_context}s
-    .teach_note =
-        The value of statics and constants must be known at compile time, and they live for the entire lifetime of a program. Creating a boxed value allocates memory on the heap at runtime, and therefore cannot be done at compile time.
+    .teach_note = The value of statics and constants must be known at compile time, and they live for the entire lifetime of a program. Creating a boxed value allocates memory on the heap at runtime, and therefore cannot be done at compile time.
 
 const_eval_unallowed_inline_asm =
     inline assembly is not allowed in {const_eval_const_context}s

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -194,7 +194,7 @@ hir_analysis_inherent_ty_outside = cannot define inherent `impl` for a type outs
     .span_help = alternatively add `#[rustc_has_incoherent_inherent_impls]` to the type and `#[rustc_allow_incoherent_impl]` to the relevant impl items
 
 hir_analysis_inherent_ty_outside_new = cannot define inherent `impl` for a type outside of the crate where the type is defined
-    .label = impl for type defined outside of crate.
+    .label = impl for type defined outside of crate
     .note = define and implement a trait or new type instead
 
 hir_analysis_inherent_ty_outside_primitive = cannot define inherent `impl` for primitive types outside of `core`
@@ -544,7 +544,7 @@ hir_analysis_unrecognized_intrinsic_function =
 
 hir_analysis_unused_associated_type_bounds =
     unnecessary associated type bound for not object safe associated type
-    .note = this associated type has a `where Self: Sized` bound. Thus, while the associated type can be specified, it cannot be used in any way, because trait objects are not `Sized`.
+    .note = this associated type has a `where Self: Sized` bound, and while the associated type can be specified, it cannot be used because trait objects are never `Sized`
     .suggestion = remove this bound
 
 hir_analysis_unused_generic_parameter =

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -75,7 +75,7 @@ lint_builtin_deprecated_attr_default_suggestion = remove this attribute
 lint_builtin_deprecated_attr_link = use of deprecated attribute `{$name}`: {$reason}. See {$link}
     .msg_suggestion = {$msg}
     .default_suggestion = remove this attribute
-lint_builtin_deprecated_attr_used = use of deprecated attribute `{$name}`: no longer used.
+lint_builtin_deprecated_attr_used = use of deprecated attribute `{$name}`: no longer used
 lint_builtin_deref_nullptr = dereferencing a null pointer
     .label = this code causes undefined behavior when executed
 
@@ -213,7 +213,7 @@ lint_default_hash_types = prefer `{$preferred}` over `{$used}`, it has better pe
 lint_default_source = `forbid` lint level is the default for {$id}
 
 lint_deprecated_lint_name =
-    lint name `{$name}` is deprecated and may not have an effect in the future.
+    lint name `{$name}` is deprecated and may not have an effect in the future
     .suggestion = change it to
     .help = change it to {$replace}
 
@@ -244,11 +244,11 @@ lint_duplicate_matcher_binding = duplicate matcher binding
 
 lint_enum_intrinsics_mem_discriminant =
     the return value of `mem::discriminant` is unspecified when called with a non-enum type
-    .note = the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `{$ty_param}`, which is not an enum.
+    .note = the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `{$ty_param}`, which is not an enum
 
 lint_enum_intrinsics_mem_variant =
     the return value of `mem::variant_count` is unspecified when called with a non-enum type
-    .note = the type parameter of `variant_count` should be an enum, but it was instantiated with the type `{$ty_param}`, which is not an enum.
+    .note = the type parameter of `variant_count` should be an enum, but it was instantiated with the type `{$ty_param}`, which is not an enum
 
 lint_expectation = this lint expectation is unfulfilled
     .note = the `unfulfilled_lint_expectations` lint can't be expected and will always produce this message

--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -248,13 +248,13 @@ metadata_rustc_lib_required =
     .help = try adding `extern crate rustc_driver;` at the top level of this crate
 
 metadata_stable_crate_id_collision =
-    found crates (`{$crate_name0}` and `{$crate_name1}`) with colliding StableCrateId values.
+    found crates (`{$crate_name0}` and `{$crate_name1}`) with colliding StableCrateId values
 
 metadata_std_required =
     `std` is required by `{$current_crate}` because it does not declare `#![no_std]`
 
 metadata_symbol_conflicts_current =
-    the current crate is indistinguishable from one of its dependencies: it has the same crate-name `{$crate_name}` and was compiled with the same `-C metadata` arguments. This will result in symbol conflicts between the two.
+    the current crate is indistinguishable from one of its dependencies: it has the same crate-name `{$crate_name}` and was compiled with the same `-C metadata` arguments, so this will result in symbol conflicts between the two
 
 metadata_target_no_std_support =
     the `{$locator_triple}` target may not support the standard library

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -103,7 +103,7 @@ mir_build_deref_raw_pointer_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
     .note = raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
     .label = dereference of raw pointer
 
-mir_build_exceeds_mcdc_condition_limit = Number of conditions in decision ({$num_conditions}) exceeds limit ({$max_conditions}). MC/DC analysis will not count this expression.
+mir_build_exceeds_mcdc_condition_limit = number of conditions in decision ({$num_conditions}) exceeds limit ({$max_conditions}), so MC/DC analysis will not count this expression
 
 mir_build_extern_static_requires_unsafe =
     use of extern static is unsafe and requires unsafe block

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -14,7 +14,7 @@ passes_abi_of =
     fn_abi_of({$fn_name}) = {$fn_abi}
 
 passes_allow_incoherent_impl =
-    `rustc_allow_incoherent_impl` attribute should be applied to impl items.
+    `rustc_allow_incoherent_impl` attribute should be applied to impl items
     .label = the only currently supported targets are inherent methods
 
 passes_allow_internal_unstable =
@@ -253,8 +253,8 @@ passes_doc_test_unknown_spotlight =
     .no_op_note = `doc(spotlight)` is now a no-op
 
 passes_duplicate_diagnostic_item_in_crate =
-    duplicate diagnostic item in crate `{$crate_name}`: `{$name}`.
-    .note = the diagnostic item is first defined in crate `{$orig_crate_name}`.
+    duplicate diagnostic item in crate `{$crate_name}`: `{$name}`
+    .note = the diagnostic item is first defined in crate `{$orig_crate_name}`
 
 passes_duplicate_feature_err =
     the feature `{$feature}` has already been declared
@@ -263,27 +263,27 @@ passes_duplicate_lang_item =
     found duplicate lang item `{$lang_item_name}`
     .first_defined_span = the lang item is first defined here
     .first_defined_crate_depends = the lang item is first defined in crate `{$orig_crate_name}` (which `{$orig_dependency_of}` depends on)
-    .first_defined_crate = the lang item is first defined in crate `{$orig_crate_name}`.
+    .first_defined_crate = the lang item is first defined in crate `{$orig_crate_name}`
     .first_definition_local = first definition in the local crate (`{$orig_crate_name}`)
     .second_definition_local = second definition in the local crate (`{$crate_name}`)
     .first_definition_path = first definition in `{$orig_crate_name}` loaded from {$orig_path}
     .second_definition_path = second definition in `{$crate_name}` loaded from {$path}
 
 passes_duplicate_lang_item_crate =
-    duplicate lang item in crate `{$crate_name}`: `{$lang_item_name}`.
+    duplicate lang item in crate `{$crate_name}`: `{$lang_item_name}`
     .first_defined_span = the lang item is first defined here
     .first_defined_crate_depends = the lang item is first defined in crate `{$orig_crate_name}` (which `{$orig_dependency_of}` depends on)
-    .first_defined_crate = the lang item is first defined in crate `{$orig_crate_name}`.
+    .first_defined_crate = the lang item is first defined in crate `{$orig_crate_name}`
     .first_definition_local = first definition in the local crate (`{$orig_crate_name}`)
     .second_definition_local = second definition in the local crate (`{$crate_name}`)
     .first_definition_path = first definition in `{$orig_crate_name}` loaded from {$orig_path}
     .second_definition_path = second definition in `{$crate_name}` loaded from {$path}
 
 passes_duplicate_lang_item_crate_depends =
-    duplicate lang item in crate `{$crate_name}` (which `{$dependency_of}` depends on): `{$lang_item_name}`.
+    duplicate lang item in crate `{$crate_name}` (which `{$dependency_of}` depends on): `{$lang_item_name}`
     .first_defined_span = the lang item is first defined here
     .first_defined_crate_depends = the lang item is first defined in crate `{$orig_crate_name}` (which `{$orig_dependency_of}` depends on)
-    .first_defined_crate = the lang item is first defined in crate `{$orig_crate_name}`.
+    .first_defined_crate = the lang item is first defined in crate `{$orig_crate_name}`
     .first_definition_local = first definition in the local crate (`{$orig_crate_name}`)
     .second_definition_local = second definition in the local crate (`{$crate_name}`)
     .first_definition_path = first definition in `{$orig_crate_name}` loaded from {$orig_path}
@@ -315,7 +315,7 @@ passes_ffi_pure_invalid_target =
     `#[ffi_pure]` may only be used on foreign functions
 
 passes_has_incoherent_inherent_impl =
-    `rustc_has_incoherent_inherent_impls` attribute should be applied to types or traits.
+    `rustc_has_incoherent_inherent_impls` attribute should be applied to types or traits
     .label = only adts, extern types and traits are supported
 
 passes_ignored_attr =

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -240,7 +240,7 @@ resolve_label_with_similar_name_reachable =
 
 resolve_lending_iterator_report_error =
     associated type `Iterator::Item` is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type
-    .note = you can't create an `Iterator` that borrows each `Item` from itself, but you can instead create a new type that borrows your existing type and implement `Iterator` for that new type.
+    .note = you can't create an `Iterator` that borrows each `Item` from itself, but you can instead create a new type that borrows your existing type and implement `Iterator` for that new type
 
 resolve_lifetime_param_in_enum_discriminant =
     lifetime parameters may not be used in enum discriminant values

--- a/compiler/rustc_session/messages.ftl
+++ b/compiler/rustc_session/messages.ftl
@@ -82,9 +82,9 @@ session_octal_float_literal_not_supported = octal float literal is not supported
 
 session_optimization_fuel_exhausted = optimization-fuel-exhausted: {$msg}
 
-session_profile_sample_use_file_does_not_exist = file `{$path}` passed to `-C profile-sample-use` does not exist.
+session_profile_sample_use_file_does_not_exist = file `{$path}` passed to `-C profile-sample-use` does not exist
 
-session_profile_use_file_does_not_exist = file `{$path}` passed to `-C profile-use` does not exist.
+session_profile_use_file_does_not_exist = file `{$path}` passed to `-C profile-use` does not exist
 
 session_sanitizer_cfi_canonical_jump_tables_requires_cfi = `-Zsanitizer-cfi-canonical-jump-tables` requires `-Zsanitizer=cfi`
 

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -13,6 +13,7 @@ ignore = "0.4.18"
 semver = "1.0"
 termcolor = "1.1.3"
 rustc-hash = "1.1.0"
+fluent-syntax = "0.11.1"
 
 [[bin]]
 name = "rust-tidy"

--- a/src/tools/tidy/src/fluent_period.rs
+++ b/src/tools/tidy/src/fluent_period.rs
@@ -1,0 +1,84 @@
+//! Checks that no Fluent messages or attributes end in periods (except ellipses)
+
+use fluent_syntax::ast::{Entry, PatternElement};
+
+use crate::walk::{filter_dirs, walk};
+use std::path::Path;
+
+fn filter_fluent(path: &Path) -> bool {
+    if let Some(ext) = path.extension() { ext.to_str() != Some("ftl") } else { true }
+}
+
+/// Messages allowed to have `.` at their end.
+///
+/// These should probably be reworked eventually.
+const ALLOWLIST: &[&str] = &[
+    "const_eval_long_running",
+    "const_eval_validation_failure_note",
+    "driver_impl_ice",
+    "incremental_corrupt_file",
+    "mir_build_pointer_pattern",
+];
+
+fn check_period(filename: &str, contents: &str, bad: &mut bool) {
+    if filename.contains("codegen") {
+        // FIXME: Too many codegen messages have periods right now...
+        return;
+    }
+
+    let (Ok(parse) | Err((parse, _))) = fluent_syntax::parser::parse(contents);
+    for entry in &parse.body {
+        if let Entry::Message(m) = entry {
+            if ALLOWLIST.contains(&m.id.name) {
+                continue;
+            }
+
+            if let Some(pat) = &m.value {
+                if let Some(PatternElement::TextElement { value }) = pat.elements.last() {
+                    // We don't care about ellipses.
+                    if value.ends_with(".") && !value.ends_with("...") {
+                        let ll = find_line(contents, *value);
+                        let name = m.id.name;
+                        tidy_error!(bad, "{filename}:{ll}: message `{name}` ends in a period");
+                    }
+                }
+            }
+
+            for attr in &m.attributes {
+                // Teach notes usually have long messages.
+                if attr.id.name == "teach_note" {
+                    continue;
+                }
+
+                if let Some(PatternElement::TextElement { value }) = attr.value.elements.last() {
+                    if value.ends_with(".") && !value.ends_with("...") {
+                        let ll = find_line(contents, *value);
+                        let name = attr.id.name;
+                        tidy_error!(bad, "{filename}:{ll}: attr `{name}` ends in a period");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Evil cursed bad hack. Requires that `value` be a substr (in memory) of `contents`.
+fn find_line(haystack: &str, needle: &str) -> usize {
+    for (ll, line) in haystack.lines().enumerate() {
+        if line.as_ptr() > needle.as_ptr() {
+            return ll;
+        }
+    }
+
+    1
+}
+
+pub fn check(path: &Path, bad: &mut bool) {
+    walk(
+        path,
+        |path, is_dir| filter_dirs(path) || (!is_dir && filter_fluent(path)),
+        &mut |ent, contents| {
+            check_period(ent.path().to_str().unwrap(), contents, bad);
+        },
+    );
+}

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -72,6 +72,7 @@ pub mod ext_tool_checks;
 pub mod extdeps;
 pub mod features;
 pub mod fluent_alphabetical;
+pub mod fluent_period;
 mod fluent_used;
 pub(crate) mod iter_header;
 pub mod known_bug;

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -115,6 +115,7 @@ fn main() {
         // Checks that only make sense for the compiler.
         check!(error_codes, &root_path, &[&compiler_path, &librustdoc_path], verbose);
         check!(fluent_alphabetical, &compiler_path, bless);
+        check!(fluent_period, &compiler_path);
         check!(target_policy, &root_path);
 
         // Checks that only make sense for the std libs.

--- a/tests/ui/abi/abi-typo-unstable.stderr
+++ b/tests/ui/abi/abi-typo-unstable.stderr
@@ -4,7 +4,7 @@ error[E0703]: invalid ABI: found `rust-intrinsec`
 LL | extern "rust-intrinsec" fn rust_intrinsic() {}
    |        ^^^^^^^^^^^^^^^^ invalid ABI
    |
-   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions.
+   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
@@ -7,7 +7,7 @@ LL | extern "riscv-interrupt" fn isr() {}
    |        invalid ABI
    |        help: did you mean: `"riscv-interrupt-m"`
    |
-   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions.
+   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
    = note: please use one of riscv-interrupt-m or riscv-interrupt-s for machine- or supervisor-level interrupts, respectively
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
@@ -19,7 +19,7 @@ LL | extern "riscv-interrupt-u" fn isr_U() {}
    |        invalid ABI
    |        help: did you mean: `"riscv-interrupt-m"`
    |
-   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions.
+   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
    = note: user-mode interrupt handlers have been removed from LLVM pending standardization, see: https://reviews.llvm.org/D149314
 
 error: aborting due to 2 previous errors

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
@@ -7,7 +7,7 @@ LL | extern "riscv-interrupt" fn isr() {}
    |        invalid ABI
    |        help: did you mean: `"riscv-interrupt-m"`
    |
-   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions.
+   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
    = note: please use one of riscv-interrupt-m or riscv-interrupt-s for machine- or supervisor-level interrupts, respectively
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
@@ -19,7 +19,7 @@ LL | extern "riscv-interrupt-u" fn isr_U() {}
    |        invalid ABI
    |        help: did you mean: `"riscv-interrupt-m"`
    |
-   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions.
+   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
    = note: user-mode interrupt handlers have been removed from LLVM pending standardization, see: https://reviews.llvm.org/D149314
 
 error: aborting due to 2 previous errors

--- a/tests/ui/codemap_tests/unicode.normal.stderr
+++ b/tests/ui/codemap_tests/unicode.normal.stderr
@@ -4,7 +4,7 @@ error[E0703]: invalid ABI: found `路濫狼á́́`
 LL | extern "路濫狼á́́" fn foo() {}
    |        ^^^^^^^^^ invalid ABI
    |
-   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions.
+   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0116.stderr
+++ b/tests/ui/error-codes/E0116.stderr
@@ -2,7 +2,7 @@ error[E0116]: cannot define inherent `impl` for a type outside of the crate wher
   --> $DIR/E0116.rs:1:1
    |
 LL | impl Vec<u8> {}
-   | ^^^^^^^^^^^^ impl for type defined outside of crate.
+   | ^^^^^^^^^^^^ impl for type defined outside of crate
    |
    = note: define and implement a trait or new type instead
 

--- a/tests/ui/error-codes/E0519.stderr
+++ b/tests/ui/error-codes/E0519.stderr
@@ -1,4 +1,4 @@
-error[E0519]: the current crate is indistinguishable from one of its dependencies: it has the same crate-name `crateresolve1` and was compiled with the same `-C metadata` arguments. This will result in symbol conflicts between the two.
+error[E0519]: the current crate is indistinguishable from one of its dependencies: it has the same crate-name `crateresolve1` and was compiled with the same `-C metadata` arguments, so this will result in symbol conflicts between the two
   --> $DIR/E0519.rs:8:1
    |
 LL | extern crate crateresolve1;

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -186,7 +186,7 @@ warning: unknown lint: `x5100`
 LL |     #[deny(x5100)] impl S { }
    |            ^^^^^
 
-warning: use of deprecated attribute `crate_id`: no longer used.
+warning: use of deprecated attribute `crate_id`: no longer used
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:84:1
    |
 LL | #![crate_id = "10"]
@@ -194,7 +194,7 @@ LL | #![crate_id = "10"]
    |
    = note: `#[warn(deprecated)]` on by default
 
-warning: use of deprecated attribute `no_start`: no longer used.
+warning: use of deprecated attribute `no_start`: no longer used
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:94:1
    |
 LL | #![no_start]

--- a/tests/ui/incoherent-inherent-impls/no-attr-empty-impl.stderr
+++ b/tests/ui/incoherent-inherent-impls/no-attr-empty-impl.stderr
@@ -2,7 +2,7 @@ error[E0116]: cannot define inherent `impl` for a type outside of the crate wher
   --> $DIR/no-attr-empty-impl.rs:4:1
    |
 LL | impl extern_crate::StructWithAttr {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate
    |
    = note: define and implement a trait or new type instead
 
@@ -10,7 +10,7 @@ error[E0116]: cannot define inherent `impl` for a type outside of the crate wher
   --> $DIR/no-attr-empty-impl.rs:7:1
    |
 LL | impl extern_crate::StructNoAttr {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate
    |
    = note: define and implement a trait or new type instead
 
@@ -18,7 +18,7 @@ error[E0116]: cannot define inherent `impl` for a type outside of the crate wher
   --> $DIR/no-attr-empty-impl.rs:10:1
    |
 LL | impl extern_crate::EnumWithAttr {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate
    |
    = note: define and implement a trait or new type instead
 
@@ -26,7 +26,7 @@ error[E0116]: cannot define inherent `impl` for a type outside of the crate wher
   --> $DIR/no-attr-empty-impl.rs:13:1
    |
 LL | impl extern_crate::EnumNoAttr {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate
    |
    = note: define and implement a trait or new type instead
 

--- a/tests/ui/instrument-coverage/mcdc-condition-limit.bad.stderr
+++ b/tests/ui/instrument-coverage/mcdc-condition-limit.bad.stderr
@@ -1,4 +1,4 @@
-warning: Number of conditions in decision (7) exceeds limit (6). MC/DC analysis will not count this expression.
+warning: number of conditions in decision (7) exceeds limit (6), so MC/DC analysis will not count this expression
   --> $DIR/mcdc-condition-limit.rs:29:8
    |
 LL |     if a && b && c && d && e && f && g {

--- a/tests/ui/instrument-coverage/mcdc-condition-limit.rs
+++ b/tests/ui/instrument-coverage/mcdc-condition-limit.rs
@@ -26,7 +26,7 @@ fn main() {
 fn main() {
     // 7 conditions is too many, so issue a diagnostic.
     let [a, b, c, d, e, f, g] = <[bool; 7]>::default();
-    if a && b && c && d && e && f && g { //[bad]~ WARNING Number of conditions in decision
+    if a && b && c && d && e && f && g { //[bad]~ WARNING number of conditions in decision
         core::hint::black_box("hello");
     }
 }

--- a/tests/ui/lifetimes/no_lending_iterators.stderr
+++ b/tests/ui/lifetimes/no_lending_iterators.stderr
@@ -4,7 +4,7 @@ error: associated type `Iterator::Item` is declared without lifetime parameters,
 LL |     type Item = &str;
    |                 ^
    |
-note: you can't create an `Iterator` that borrows each `Item` from itself, but you can instead create a new type that borrows your existing type and implement `Iterator` for that new type.
+note: you can't create an `Iterator` that borrows each `Item` from itself, but you can instead create a new type that borrows your existing type and implement `Iterator` for that new type
   --> $DIR/no_lending_iterators.rs:3:19
    |
 LL | impl Iterator for Data {

--- a/tests/ui/lint/lint-attr-everywhere-late.stderr
+++ b/tests/ui/lint/lint-attr-everywhere-late.stderr
@@ -154,7 +154,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     fn assoc_fn() { discriminant::<i32>(&123); }
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum
   --> $DIR/lint-attr-everywhere-late.rs:96:41
    |
 LL |     fn assoc_fn() { discriminant::<i32>(&123); }
@@ -208,7 +208,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     let _ = discriminant::<i32>(&123);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum
   --> $DIR/lint-attr-everywhere-late.rs:139:33
    |
 LL |     let _ = discriminant::<i32>(&123);
@@ -237,7 +237,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |             discriminant::<i32>(&123);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum
   --> $DIR/lint-attr-everywhere-late.rs:155:33
    |
 LL |             discriminant::<i32>(&123);
@@ -254,7 +254,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |             discriminant::<i32>(&123);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum
   --> $DIR/lint-attr-everywhere-late.rs:161:33
    |
 LL |             discriminant::<i32>(&123);
@@ -283,7 +283,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |         discriminant::<i32>(&123);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum
   --> $DIR/lint-attr-everywhere-late.rs:173:29
    |
 LL |         discriminant::<i32>(&123);
@@ -300,7 +300,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |         discriminant::<i32>(&123);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum
   --> $DIR/lint-attr-everywhere-late.rs:177:29
    |
 LL |         discriminant::<i32>(&123);
@@ -317,7 +317,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     discriminant::<i32>(&123);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum
   --> $DIR/lint-attr-everywhere-late.rs:182:25
    |
 LL |     discriminant::<i32>(&123);
@@ -334,7 +334,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     [#[deny(enum_intrinsics_non_enums)] discriminant::<i32>(&123)];
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum
   --> $DIR/lint-attr-everywhere-late.rs:184:61
    |
 LL |     [#[deny(enum_intrinsics_non_enums)] discriminant::<i32>(&123)];
@@ -351,7 +351,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     (#[deny(enum_intrinsics_non_enums)] discriminant::<i32>(&123),);
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum
   --> $DIR/lint-attr-everywhere-late.rs:185:61
    |
 LL |     (#[deny(enum_intrinsics_non_enums)] discriminant::<i32>(&123),);
@@ -368,7 +368,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     call(#[deny(enum_intrinsics_non_enums)] discriminant::<i32>(&123));
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum
   --> $DIR/lint-attr-everywhere-late.rs:187:65
    |
 LL |     call(#[deny(enum_intrinsics_non_enums)] discriminant::<i32>(&123));
@@ -385,7 +385,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     TupleStruct(#[deny(enum_intrinsics_non_enums)] discriminant::<i32>(&123));
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `i32`, which is not an enum
   --> $DIR/lint-attr-everywhere-late.rs:189:72
    |
 LL |     TupleStruct(#[deny(enum_intrinsics_non_enums)] discriminant::<i32>(&123));

--- a/tests/ui/lint/lint-enum-intrinsics-non-enums.stderr
+++ b/tests/ui/lint/lint-enum-intrinsics-non-enums.stderr
@@ -4,7 +4,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     discriminant(&());
    |     ^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `()`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `()`, which is not an enum
   --> $DIR/lint-enum-intrinsics-non-enums.rs:26:18
    |
 LL |     discriminant(&());
@@ -17,7 +17,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     discriminant(&&SomeEnum::B);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `&SomeEnum`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `&SomeEnum`, which is not an enum
   --> $DIR/lint-enum-intrinsics-non-enums.rs:29:18
    |
 LL |     discriminant(&&SomeEnum::B);
@@ -29,7 +29,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     discriminant(&SomeStruct);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `SomeStruct`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `SomeStruct`, which is not an enum
   --> $DIR/lint-enum-intrinsics-non-enums.rs:32:18
    |
 LL |     discriminant(&SomeStruct);
@@ -41,7 +41,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     discriminant(&123u32);
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `u32`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `u32`, which is not an enum
   --> $DIR/lint-enum-intrinsics-non-enums.rs:35:18
    |
 LL |     discriminant(&123u32);
@@ -53,7 +53,7 @@ error: the return value of `mem::discriminant` is unspecified when called with a
 LL |     discriminant(&&123i8);
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `&i8`, which is not an enum.
+note: the argument to `discriminant` should be a reference to an enum, but it was passed a reference to a `&i8`, which is not an enum
   --> $DIR/lint-enum-intrinsics-non-enums.rs:38:18
    |
 LL |     discriminant(&&123i8);
@@ -65,7 +65,7 @@ error: the return value of `mem::variant_count` is unspecified when called with 
 LL |     variant_count::<&str>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the type parameter of `variant_count` should be an enum, but it was instantiated with the type `&str`, which is not an enum.
+   = note: the type parameter of `variant_count` should be an enum, but it was instantiated with the type `&str`, which is not an enum
 
 error: the return value of `mem::variant_count` is unspecified when called with a non-enum type
   --> $DIR/lint-enum-intrinsics-non-enums.rs:49:5
@@ -73,7 +73,7 @@ error: the return value of `mem::variant_count` is unspecified when called with 
 LL |     variant_count::<*const u8>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the type parameter of `variant_count` should be an enum, but it was instantiated with the type `*const u8`, which is not an enum.
+   = note: the type parameter of `variant_count` should be an enum, but it was instantiated with the type `*const u8`, which is not an enum
 
 error: the return value of `mem::variant_count` is unspecified when called with a non-enum type
   --> $DIR/lint-enum-intrinsics-non-enums.rs:52:5
@@ -81,7 +81,7 @@ error: the return value of `mem::variant_count` is unspecified when called with 
 LL |     variant_count::<()>();
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the type parameter of `variant_count` should be an enum, but it was instantiated with the type `()`, which is not an enum.
+   = note: the type parameter of `variant_count` should be an enum, but it was instantiated with the type `()`, which is not an enum
 
 error: the return value of `mem::variant_count` is unspecified when called with a non-enum type
   --> $DIR/lint-enum-intrinsics-non-enums.rs:55:5
@@ -89,7 +89,7 @@ error: the return value of `mem::variant_count` is unspecified when called with 
 LL |     variant_count::<&SomeEnum>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the type parameter of `variant_count` should be an enum, but it was instantiated with the type `&SomeEnum`, which is not an enum.
+   = note: the type parameter of `variant_count` should be an enum, but it was instantiated with the type `&SomeEnum`, which is not an enum
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.stderr
@@ -4,7 +4,7 @@ warning: unnecessary associated type bound for not object safe associated type
 LL | fn foo(_: &dyn Foo<Bar = ()>) {}
    |                    ^^^^^^^^ help: remove this bound
    |
-   = note: this associated type has a `where Self: Sized` bound. Thus, while the associated type can be specified, it cannot be used in any way, because trait objects are not `Sized`.
+   = note: this associated type has a `where Self: Sized` bound, and while the associated type can be specified, it cannot be used because trait objects are never `Sized`
    = note: `#[warn(unused_associated_type_bounds)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/parser/issues/issue-8537.stderr
+++ b/tests/ui/parser/issues/issue-8537.stderr
@@ -4,7 +4,7 @@ error[E0703]: invalid ABI: found `invalid-ab_isize`
 LL |   "invalid-ab_isize"
    |   ^^^^^^^^^^^^^^^^^^ invalid ABI
    |
-   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions.
+   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/abi-typo.stderr
+++ b/tests/ui/suggestions/abi-typo.stderr
@@ -7,7 +7,7 @@ LL | extern "cdedl" fn cdedl() {}
    |        invalid ABI
    |        help: did you mean: `"cdecl"`
    |
-   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions.
+   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/tool-attributes/duplicate-diagnostic.stderr
+++ b/tests/ui/tool-attributes/duplicate-diagnostic.stderr
@@ -1,14 +1,14 @@
-error: duplicate diagnostic item in crate `p2`: `Foo`.
+error: duplicate diagnostic item in crate `p2`: `Foo`
    |
-   = note: the diagnostic item is first defined in crate `p1`.
+   = note: the diagnostic item is first defined in crate `p1`
 
-error: duplicate diagnostic item in crate `duplicate_diagnostic`: `Foo`.
+error: duplicate diagnostic item in crate `duplicate_diagnostic`: `Foo`
   --> $DIR/duplicate-diagnostic.rs:12:1
    |
 LL | pub struct Foo {}
    | ^^^^^^^^^^^^^^
    |
-   = note: the diagnostic item is first defined in crate `p2`.
+   = note: the diagnostic item is first defined in crate `p2`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/trait-or-new-type-instead.stderr
+++ b/tests/ui/traits/trait-or-new-type-instead.stderr
@@ -2,7 +2,7 @@ error[E0116]: cannot define inherent `impl` for a type outside of the crate wher
   --> $DIR/trait-or-new-type-instead.rs:1:1
    |
 LL | impl<T> Option<T> {
-   | ^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
+   | ^^^^^^^^^^^^^^^^^ impl for type defined outside of crate
    |
    = note: define and implement a trait or new type instead
 


### PR DESCRIPTION
This adds a new dependency on `fluent-parse` to `tidy` -- we already rely on it in rustc so I feel like it's not that big of a deal.

This PR also adjusts many error messages that currently end in `.`; not all of them since I added an `ALLOWLIST`, excluded `rustc_codegen_*` ftl files, and `.teach_note` attributes.

r? @estebank @oli-obk 