### PR TITLE
Better handle suggestions for the already present code and fix some suggestions

### DIFF
--- a/src/tools/clippy/clippy_lints/src/unnecessary_wraps.rs
+++ b/src/tools/clippy/clippy_lints/src/unnecessary_wraps.rs
@@ -145,7 +145,9 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryWraps {
                 (
                     "this function's return value is unnecessary".to_string(),
                     "remove the return type...".to_string(),
-                    snippet(cx, fn_decl.output.span(), "..").to_string(),
+                    // FIXME: we should instead get the span including the `->` and suggest an
+                    // empty string for this case.
+                    "()".to_string(),
                     "...and then remove returned values",
                 )
             } else {

--- a/src/tools/clippy/tests/ui/unnecessary_literal_unwrap.stderr
+++ b/src/tools/clippy/tests/ui/unnecessary_literal_unwrap.stderr
@@ -63,7 +63,7 @@ LL |     let _val = None::<()>.expect("this always happens");
 help: remove the `None` and `expect()`
    |
 LL |     let _val = panic!("this always happens");
-   |                ~~~~~~~                     ~
+   |                ~~~~~~~
 
 error: used `unwrap_or_default()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap.rs:22:24
@@ -134,7 +134,7 @@ LL |     None::<()>.expect("this always happens");
 help: remove the `None` and `expect()`
    |
 LL |     panic!("this always happens");
-   |     ~~~~~~~                     ~
+   |     ~~~~~~~
 
 error: used `unwrap_or_default()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap.rs:30:5

--- a/src/tools/clippy/tests/ui/unnecessary_wraps.stderr
+++ b/src/tools/clippy/tests/ui/unnecessary_wraps.stderr
@@ -118,8 +118,8 @@ LL | | }
    |
 help: remove the return type...
    |
-LL | fn issue_6640_1(a: bool, b: bool) -> Option<()> {
-   |                                      ~~~~~~~~~~
+LL | fn issue_6640_1(a: bool, b: bool) -> () {
+   |                                      ~~
 help: ...and then remove returned values
    |
 LL ~         return ;
@@ -145,8 +145,8 @@ LL | | }
    |
 help: remove the return type...
    |
-LL | fn issue_6640_2(a: bool, b: bool) -> Result<(), i32> {
-   |                                      ~~~~~~~~~~~~~~~
+LL | fn issue_6640_2(a: bool, b: bool) -> () {
+   |                                      ~~
 help: ...and then remove returned values
    |
 LL ~         return ;

--- a/tests/ui/const-generics/generic_const_exprs/issue-105608.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105608.stderr
@@ -4,10 +4,6 @@ error[E0282]: type annotations needed
 LL |     Combination::<0>.and::<_>().and::<_>();
    |                      ^^^ cannot infer type of the type parameter `M` declared on the method `and`
    |
-help: consider specifying the generic argument
-   |
-LL |     Combination::<0>.and::<_>().and::<_>();
-   |                         ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-55884-2.stderr
+++ b/tests/ui/imports/issue-55884-2.stderr
@@ -24,10 +24,6 @@ note: ...and refers to the struct `ParseOptions` which is defined here
    |
 LL |     pub struct ParseOptions {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^ you could import this directly
-help: import `ParseOptions` through the re-export
-   |
-LL | pub use parser::ParseOptions;
-   |         ~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/wide_pointer_comparisons.stderr
+++ b/tests/ui/lint/wide_pointer_comparisons.stderr
@@ -74,7 +74,7 @@ LL |     let _ = PartialEq::eq(&a, &b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |     let _ = std::ptr::addr_eq(a, b);
-   |             ~~~~~~~~~~~~~~~~~~ ~  ~
+   |             ~~~~~~~~~~~~~~~~~~ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:35:13
@@ -85,7 +85,7 @@ LL |     let _ = PartialEq::ne(&a, &b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |     let _ = !std::ptr::addr_eq(a, b);
-   |             ~~~~~~~~~~~~~~~~~~~ ~  ~
+   |             ~~~~~~~~~~~~~~~~~~~ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:37:13
@@ -96,7 +96,7 @@ LL |     let _ = a.eq(&b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |     let _ = std::ptr::addr_eq(a, b);
-   |             ++++++++++++++++++ ~  ~
+   |             ++++++++++++++++++ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:39:13
@@ -107,7 +107,7 @@ LL |     let _ = a.ne(&b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |     let _ = !std::ptr::addr_eq(a, b);
-   |             +++++++++++++++++++ ~  ~
+   |             +++++++++++++++++++ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:41:13
@@ -283,7 +283,7 @@ LL |         let _ = PartialEq::eq(a, b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |         let _ = std::ptr::addr_eq(*a, *b);
-   |                 ~~~~~~~~~~~~~~~~~~~ ~~~ ~
+   |                 ~~~~~~~~~~~~~~~~~~~ ~~~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:85:17
@@ -294,7 +294,7 @@ LL |         let _ = PartialEq::ne(a, b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |         let _ = !std::ptr::addr_eq(*a, *b);
-   |                 ~~~~~~~~~~~~~~~~~~~~ ~~~ ~
+   |                 ~~~~~~~~~~~~~~~~~~~~ ~~~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:87:17
@@ -305,7 +305,7 @@ LL |         let _ = PartialEq::eq(&a, &b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |         let _ = std::ptr::addr_eq(*a, *b);
-   |                 ~~~~~~~~~~~~~~~~~~~ ~~~ ~
+   |                 ~~~~~~~~~~~~~~~~~~~ ~~~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:89:17
@@ -316,7 +316,7 @@ LL |         let _ = PartialEq::ne(&a, &b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |         let _ = !std::ptr::addr_eq(*a, *b);
-   |                 ~~~~~~~~~~~~~~~~~~~~ ~~~ ~
+   |                 ~~~~~~~~~~~~~~~~~~~~ ~~~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:91:17
@@ -327,7 +327,7 @@ LL |         let _ = a.eq(b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |         let _ = std::ptr::addr_eq(*a, *b);
-   |                 +++++++++++++++++++ ~~~ ~
+   |                 +++++++++++++++++++ ~~~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:93:17
@@ -338,7 +338,7 @@ LL |         let _ = a.ne(b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |         let _ = !std::ptr::addr_eq(*a, *b);
-   |                 ++++++++++++++++++++ ~~~ ~
+   |                 ++++++++++++++++++++ ~~~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:95:17
@@ -519,11 +519,11 @@ LL |         let _ = PartialEq::eq(&a, &b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |         let _ = std::ptr::addr_eq(a, b);
-   |                 ~~~~~~~~~~~~~~~~~~ ~  ~
+   |                 ~~~~~~~~~~~~~~~~~~ ~
 help: use explicit `std::ptr::eq` method to compare metadata and addresses
    |
 LL |         let _ = std::ptr::eq(a, b);
-   |                 ~~~~~~~~~~~~~ ~  ~
+   |                 ~~~~~~~~~~~~~ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:133:17
@@ -534,11 +534,11 @@ LL |         let _ = PartialEq::ne(&a, &b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |         let _ = !std::ptr::addr_eq(a, b);
-   |                 ~~~~~~~~~~~~~~~~~~~ ~  ~
+   |                 ~~~~~~~~~~~~~~~~~~~ ~
 help: use explicit `std::ptr::eq` method to compare metadata and addresses
    |
 LL |         let _ = !std::ptr::eq(a, b);
-   |                 ~~~~~~~~~~~~~~ ~  ~
+   |                 ~~~~~~~~~~~~~~ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:135:17
@@ -549,11 +549,11 @@ LL |         let _ = a.eq(&b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |         let _ = std::ptr::addr_eq(a, b);
-   |                 ++++++++++++++++++ ~  ~
+   |                 ++++++++++++++++++ ~
 help: use explicit `std::ptr::eq` method to compare metadata and addresses
    |
 LL |         let _ = std::ptr::eq(a, b);
-   |                 +++++++++++++ ~  ~
+   |                 +++++++++++++ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:137:17
@@ -564,11 +564,11 @@ LL |         let _ = a.ne(&b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |         let _ = !std::ptr::addr_eq(a, b);
-   |                 +++++++++++++++++++ ~  ~
+   |                 +++++++++++++++++++ ~
 help: use explicit `std::ptr::eq` method to compare metadata and addresses
    |
 LL |         let _ = !std::ptr::eq(a, b);
-   |                 ++++++++++++++ ~  ~
+   |                 ++++++++++++++ ~
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:142:9
@@ -594,7 +594,7 @@ LL |         cmp!(a, b);
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
 LL |         cmp!(std::ptr::addr_eq(a, b));
-   |              ++++++++++++++++++ ~  +
+   |              ++++++++++++++++++    +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:159:39

--- a/tests/ui/privacy/issue-75907.stderr
+++ b/tests/ui/privacy/issue-75907.stderr
@@ -14,7 +14,7 @@ LL |     let Bar(x, y, Foo(z)) = make_bar();
 help: consider making the fields publicly accessible
    |
 LL |     pub(crate) struct Bar(pub u8, pub u8, pub Foo);
-   |                           ~~~     ~~~     +++
+   |                                   ~~~     +++
 
 error[E0532]: cannot match against a tuple struct which contains private fields
   --> $DIR/issue-75907.rs:15:19

--- a/tests/ui/privacy/privacy5.stderr
+++ b/tests/ui/privacy/privacy5.stderr
@@ -53,7 +53,7 @@ LL |     pub struct C(pub isize, isize);
 help: consider making the fields publicly accessible
    |
 LL |     pub struct C(pub isize, pub isize);
-   |                  ~~~        +++
+   |                             +++
 
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:56:12
@@ -262,7 +262,7 @@ LL |     pub struct C(pub isize, isize);
 help: consider making the fields publicly accessible
    |
 LL |     pub struct C(pub isize, pub isize);
-   |                  ~~~        +++
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:69:12
@@ -281,7 +281,7 @@ LL |     pub struct C(pub isize, isize);
 help: consider making the fields publicly accessible
    |
 LL |     pub struct C(pub isize, pub isize);
-   |                  ~~~        +++
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:70:12
@@ -300,7 +300,7 @@ LL |     pub struct C(pub isize, isize);
 help: consider making the fields publicly accessible
    |
 LL |     pub struct C(pub isize, pub isize);
-   |                  ~~~        +++
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:71:12
@@ -319,7 +319,7 @@ LL |     pub struct C(pub isize, isize);
 help: consider making the fields publicly accessible
    |
 LL |     pub struct C(pub isize, pub isize);
-   |                  ~~~        +++
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:72:18
@@ -338,7 +338,7 @@ LL |     pub struct C(pub isize, isize);
 help: consider making the fields publicly accessible
    |
 LL |     pub struct C(pub isize, pub isize);
-   |                  ~~~        +++
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:73:18
@@ -357,7 +357,7 @@ LL |     pub struct C(pub isize, isize);
 help: consider making the fields publicly accessible
    |
 LL |     pub struct C(pub isize, pub isize);
-   |                  ~~~        +++
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:74:18
@@ -376,7 +376,7 @@ LL |     pub struct C(pub isize, isize);
 help: consider making the fields publicly accessible
    |
 LL |     pub struct C(pub isize, pub isize);
-   |                  ~~~        +++
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:75:18
@@ -395,7 +395,7 @@ LL |     pub struct C(pub isize, isize);
 help: consider making the fields publicly accessible
    |
 LL |     pub struct C(pub isize, pub isize);
-   |                  ~~~        +++
+   |                             +++
 
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:83:17
@@ -452,7 +452,7 @@ LL |     pub struct C(pub isize, isize);
 help: consider making the fields publicly accessible
    |
 LL |     pub struct C(pub isize, pub isize);
-   |                  ~~~        +++
+   |                             +++
 
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:90:20

--- a/tests/ui/span/issue-42234-unknown-receiver-type.full.stderr
+++ b/tests/ui/span/issue-42234-unknown-receiver-type.full.stderr
@@ -17,10 +17,6 @@ error[E0282]: type annotations needed
 LL |         .sum::<_>()
    |          ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
    |
-help: consider specifying the generic argument
-   |
-LL |         .sum::<_>()
-   |             ~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/recover-missing-turbofish-surrounding-angle-braket.stderr
+++ b/tests/ui/suggestions/recover-missing-turbofish-surrounding-angle-braket.stderr
@@ -40,7 +40,7 @@ LL |     let _ = vec![1, 2, 3].into_iter().collect::Vec<_>>();
 help: surround the type parameters with angle brackets
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<_>>();
-   |                                                +      ~
+   |                                                +
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
When a suggestion part is for code that is already present, skip it. If all the suggestion parts for a suggestion are for code that is already there, do not emit the suggestion.

Fix two suggestions that treat `span_suggestion` as if it were `span_help`.