### PR TITLE
make unsized_fn_params an internal feature

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -629,7 +629,7 @@ declare_features! (
     /// Allows unsafe on extern declarations and safety qualifiers over internal items.
     (unstable, unsafe_extern_blocks, "1.80.0", Some(123743)),
     /// Allows unsized fn parameters.
-    (unstable, unsized_fn_params, "1.49.0", Some(48055)),
+    (internal, unsized_fn_params, "1.49.0", Some(48055)),
     /// Allows unsized rvalues at arguments and parameters.
     (incomplete, unsized_locals, "1.30.0", Some(48055)),
     /// Allows unsized tuple coercion.


### PR DESCRIPTION
As suggested [here](https://github.com/rust-lang/rust/pull/123894#issuecomment-2054043053).
r? @compiler-errors 

Fixes https://github.com/rust-lang/rust/issues/123887 (kind of -- ICEs on internal features are considered acceptable so this issue is not-a-bug once this PR lands)