### PR TITLE
[`macro_metavar_expr_concat`] Add support for literals

### DIFF
--- a/tests/ui/macros/macro-metavar-expr-concat/allowed-operations.rs
+++ b/tests/ui/macros/macro-metavar-expr-concat/allowed-operations.rs
@@ -37,6 +37,16 @@ macro_rules! without_dollar_sign_is_an_ident {
     };
 }
 
+macro_rules! literals {
+    ($ident:ident) => {{
+        let ${concat(_a, "_b")}: () = ();
+        let ${concat("_b", _a)}: () = ();
+
+        let ${concat($ident, "_b")}: () = ();
+        let ${concat("_b", $ident)}: () = ();
+    }};
+}
+
 fn main() {
     create_things!(behold);
     behold_separated_idents_in_a_fn();
@@ -55,4 +65,6 @@ fn main() {
     without_dollar_sign_is_an_ident!(_123);
     assert_eq!(VARident, 1);
     assert_eq!(VAR_123, 2);
+
+    literals!(_hello);
 }

--- a/tests/ui/macros/macro-metavar-expr-concat/raw-identifiers.rs
+++ b/tests/ui/macros/macro-metavar-expr-concat/raw-identifiers.rs
@@ -26,14 +26,14 @@ macro_rules! idents_11 {
 macro_rules! no_params {
     () => {
         let ${concat(r#abc, abc)}: () = ();
-        //~^ ERROR `${concat(..)}` currently does not support raw identifiers
+        //~^ ERROR expected identifier or string literal
         //~| ERROR expected pattern, found `$`
 
         let ${concat(abc, r#abc)}: () = ();
-        //~^ ERROR `${concat(..)}` currently does not support raw identifiers
+        //~^ ERROR expected identifier or string literal
 
         let ${concat(r#abc, r#abc)}: () = ();
-        //~^ ERROR `${concat(..)}` currently does not support raw identifiers
+        //~^ ERROR expected identifier or string literal
     };
 }
 

--- a/tests/ui/macros/macro-metavar-expr-concat/raw-identifiers.stderr
+++ b/tests/ui/macros/macro-metavar-expr-concat/raw-identifiers.stderr
@@ -1,16 +1,16 @@
-error: `${concat(..)}` currently does not support raw identifiers
+error: expected identifier or string literal
   --> $DIR/raw-identifiers.rs:28:22
    |
 LL |         let ${concat(r#abc, abc)}: () = ();
    |                      ^^^^^
 
-error: `${concat(..)}` currently does not support raw identifiers
+error: expected identifier or string literal
   --> $DIR/raw-identifiers.rs:32:27
    |
 LL |         let ${concat(abc, r#abc)}: () = ();
    |                           ^^^^^
 
-error: `${concat(..)}` currently does not support raw identifiers
+error: expected identifier or string literal
   --> $DIR/raw-identifiers.rs:35:22
    |
 LL |         let ${concat(r#abc, r#abc)}: () = ();

--- a/tests/ui/macros/macro-metavar-expr-concat/syntax-errors.rs
+++ b/tests/ui/macros/macro-metavar-expr-concat/syntax-errors.rs
@@ -11,9 +11,6 @@ macro_rules! wrong_concat_declarations {
         ${concat(aaaa,)}
         //~^ ERROR expected identifier
 
-        ${concat(aaaa, 1)}
-        //~^ ERROR expected identifier
-
         ${concat(_, aaaa)}
 
         ${concat(aaaa aaaa)}
@@ -30,9 +27,6 @@ macro_rules! wrong_concat_declarations {
 
         ${concat($ex, aaaa,)}
         //~^ ERROR expected identifier
-
-        ${concat($ex, aaaa, 123)}
-        //~^ ERROR expected identifier
     };
 }
 
@@ -43,8 +37,80 @@ macro_rules! dollar_sign_without_referenced_ident {
     };
 }
 
+macro_rules! starting_number {
+    ($ident:ident) => {{
+        let ${concat("1", $ident)}: () = ();
+        //~^ ERROR `${concat(..)}` is not generating a valid identifier
+    }};
+}
+
+macro_rules! starting_valid_unicode {
+    ($ident:ident) => {{
+        let ${concat("Ý", $ident)}: () = ();
+    }};
+}
+
+macro_rules! starting_invalid_unicode {
+    ($ident:ident) => {{
+        let ${concat("\u{00BD}", $ident)}: () = ();
+        //~^ ERROR `${concat(..)}` is not generating a valid identifier
+    }};
+}
+
+macro_rules! ending_number {
+    ($ident:ident) => {{
+        let ${concat($ident, "1")}: () = ();
+    }};
+}
+
+macro_rules! ending_valid_unicode {
+    ($ident:ident) => {{
+        let ${concat($ident, "Ý")}: () = ();
+    }};
+}
+
+macro_rules! ending_invalid_unicode {
+    ($ident:ident) => {{
+        let ${concat($ident, "\u{00BD}")}: () = ();
+        //~^ ERROR `${concat(..)}` is not generating a valid identifier
+    }};
+}
+
+macro_rules! empty {
+    () => {{
+        let ${concat("", "")}: () = ();
+        //~^ ERROR `${concat(..)}` is not generating a valid identifier
+    }};
+}
+
+macro_rules! unsupported_literals {
+    ($ident:ident) => {{
+        let ${concat(_a, 'b')}: () = ();
+        //~^ ERROR expected identifier or string literal
+        //~| ERROR expected pattern
+        let ${concat(_a, 1)}: () = ();
+        //~^ ERROR expected identifier or string literal
+
+        let ${concat($ident, 'b')}: () = ();
+        //~^ ERROR expected identifier or string literal
+        let ${concat($ident, 1)}: () = ();
+        //~^ ERROR expected identifier or string literal
+    }};
+}
+
 fn main() {
     wrong_concat_declarations!(1);
 
     dollar_sign_without_referenced_ident!(VAR);
+
+    starting_number!(_abc);
+    starting_valid_unicode!(_abc);
+    starting_invalid_unicode!(_abc);
+
+    ending_number!(_abc);
+    ending_valid_unicode!(_abc);
+    ending_invalid_unicode!(_abc);
+    unsupported_literals!(_abc);
+
+    empty!();
 }

--- a/tests/ui/macros/macro-metavar-expr-concat/syntax-errors.stderr
+++ b/tests/ui/macros/macro-metavar-expr-concat/syntax-errors.stderr
@@ -1,4 +1,4 @@
-error: expected identifier
+error: expected identifier or string literal
   --> $DIR/syntax-errors.rs:5:10
    |
 LL |         ${concat()}
@@ -10,59 +10,126 @@ error: `concat` must have at least two elements
 LL |         ${concat(aaaa)}
    |           ^^^^^^
 
-error: expected identifier
+error: expected identifier or string literal
   --> $DIR/syntax-errors.rs:11:10
    |
 LL |         ${concat(aaaa,)}
    |          ^^^^^^^^^^^^^^^
 
-error: expected identifier, found `1`
-  --> $DIR/syntax-errors.rs:14:24
-   |
-LL |         ${concat(aaaa, 1)}
-   |                        ^ help: try removing `1`
-
 error: expected comma
-  --> $DIR/syntax-errors.rs:19:10
+  --> $DIR/syntax-errors.rs:16:10
    |
 LL |         ${concat(aaaa aaaa)}
    |          ^^^^^^^^^^^^^^^^^^^
 
 error: `concat` must have at least two elements
-  --> $DIR/syntax-errors.rs:22:11
+  --> $DIR/syntax-errors.rs:19:11
    |
 LL |         ${concat($ex)}
    |           ^^^^^^
 
 error: expected comma
-  --> $DIR/syntax-errors.rs:28:10
+  --> $DIR/syntax-errors.rs:25:10
    |
 LL |         ${concat($ex, aaaa 123)}
    |          ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected identifier
-  --> $DIR/syntax-errors.rs:31:10
+error: expected identifier or string literal
+  --> $DIR/syntax-errors.rs:28:10
    |
 LL |         ${concat($ex, aaaa,)}
    |          ^^^^^^^^^^^^^^^^^^^^
 
-error: expected identifier, found `123`
-  --> $DIR/syntax-errors.rs:34:29
+error: expected identifier or string literal
+  --> $DIR/syntax-errors.rs:88:26
    |
-LL |         ${concat($ex, aaaa, 123)}
-   |                             ^^^ help: try removing `123`
+LL |         let ${concat(_a, 'b')}: () = ();
+   |                          ^^^
+
+error: expected identifier or string literal
+  --> $DIR/syntax-errors.rs:91:26
+   |
+LL |         let ${concat(_a, 1)}: () = ();
+   |                          ^
+
+error: expected identifier or string literal
+  --> $DIR/syntax-errors.rs:94:30
+   |
+LL |         let ${concat($ident, 'b')}: () = ();
+   |                              ^^^
+
+error: expected identifier or string literal
+  --> $DIR/syntax-errors.rs:96:30
+   |
+LL |         let ${concat($ident, 1)}: () = ();
+   |                              ^
 
 error: `${concat(..)}` currently only accepts identifiers or meta-variables as parameters
-  --> $DIR/syntax-errors.rs:25:19
+  --> $DIR/syntax-errors.rs:22:19
    |
 LL |         ${concat($ex, aaaa)}
    |                   ^^
 
 error: variable `foo` is not recognized in meta-variable expression
-  --> $DIR/syntax-errors.rs:41:30
+  --> $DIR/syntax-errors.rs:35:30
    |
 LL |         const ${concat(FOO, $foo)}: i32 = 2;
    |                              ^^^
 
-error: aborting due to 11 previous errors
+error: `${concat(..)}` is not generating a valid identifier
+  --> $DIR/syntax-errors.rs:42:14
+   |
+LL |         let ${concat("1", $ident)}: () = ();
+   |              ^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     starting_number!(_abc);
+   |     ---------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `starting_number` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `${concat(..)}` is not generating a valid identifier
+  --> $DIR/syntax-errors.rs:55:14
+   |
+LL |         let ${concat("\u{00BD}", $ident)}: () = ();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     starting_invalid_unicode!(_abc);
+   |     ------------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `starting_invalid_unicode` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `${concat(..)}` is not generating a valid identifier
+  --> $DIR/syntax-errors.rs:74:14
+   |
+LL |         let ${concat($ident, "\u{00BD}")}: () = ();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     ending_invalid_unicode!(_abc);
+   |     ----------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `ending_invalid_unicode` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected pattern, found `$`
+  --> $DIR/syntax-errors.rs:88:13
+   |
+LL |         let ${concat(_a, 'b')}: () = ();
+   |             ^ expected pattern
+...
+LL |     unsupported_literals!(_abc);
+   |     --------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `unsupported_literals` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `${concat(..)}` is not generating a valid identifier
+  --> $DIR/syntax-errors.rs:81:14
+   |
+LL |         let ${concat("", "")}: () = ();
+   |              ^^^^^^^^^^^^^^^^
+...
+LL |     empty!();
+   |     -------- in this macro invocation
+   |
+   = note: this error originates in the macro `empty` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 18 previous errors
 

--- a/tests/ui/macros/macro-metavar-expr-concat/unicode-expansion.rs
+++ b/tests/ui/macros/macro-metavar-expr-concat/unicode-expansion.rs
@@ -1,0 +1,14 @@
+//@ run-pass
+
+#![feature(macro_metavar_expr_concat)]
+
+macro_rules! turn_to_page {
+    ($ident:ident) => {
+        const ${concat("Ḧ", $ident)}: i32 = 394;
+    };
+}
+
+fn main() {
+    turn_to_page!(P);
+    assert_eq!(ḦP, 394);
+}

--- a/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
@@ -190,7 +190,7 @@ error: unrecognized meta-variable expression
 LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
    |                                 ^^^^^^^^^^^^^^ help: supported expressions are count, ignore, index and len
 
-error: expected identifier
+error: expected identifier or string literal
   --> $DIR/syntax-errors.rs:118:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ {} } };


### PR DESCRIPTION
Adds support for things like `${concat($variable, 123)}` or `${concat("hello", "_world")}` .

cc #124225