### PR TITLE
Ignore run-make tests that use symlink on Windows and adjust symlink wrapper

### DIFF
--- a/tests/run-make/symlinked-extern/rmake.rs
+++ b/tests/run-make/symlinked-extern/rmake.rs
@@ -9,6 +9,7 @@
 // can result in successful compilation.
 
 //@ ignore-cross-compile
+//@ ignore-windows (symlink creation is priviledged on Windows)
 
 use run_make_support::{create_symlink, cwd, fs_wrapper, rustc};
 

--- a/tests/run-make/symlinked-libraries/rmake.rs
+++ b/tests/run-make/symlinked-libraries/rmake.rs
@@ -6,6 +6,7 @@
 // See https://github.com/rust-lang/rust/issues/12459
 
 //@ ignore-cross-compile
+//@ ignore-windows (symlink creation is priviledged on Windows)
 
 use run_make_support::{create_symlink, dynamic_lib_name, fs_wrapper, rustc};
 

--- a/tests/run-make/symlinked-rlib/rmake.rs
+++ b/tests/run-make/symlinked-rlib/rmake.rs
@@ -6,6 +6,7 @@
 // See https://github.com/rust-lang/rust/pull/32828
 
 //@ ignore-cross-compile
+//@ ignore-windows (symlink creation is priviledged on Windows)
 
 use run_make_support::{create_symlink, cwd, rustc};
 


### PR DESCRIPTION
Noticed in https://github.com/rust-lang/rust/pull/125674#issuecomment-2184047564.

> Symlink creation is a privileged operation ([`std::os::windows::fs::symlink_file`](https://doc.rust-lang.org/stable/std/os/windows/fs/fn.symlink_file.html#limitations)), it may be enabled on CI, but it's typically not enabled on user machines.

This PR does two things:

1. We change the support library's symlink wrapper to panic on Windows because user machines typically don't enable priviledged symlink operations. This can manifest in the test passing in CI but failing on a local machine, as is observed in the linked PR comment.
2. We update the tests {symlinked-extern, symlinked-rlib, symlinked-libraries} to `//@ ignore-windows` since they rely on symlink functionality (they were `//@ ignore-windows` originally).

cc @petrochenkov since you ran into the failing tests.