### PR TITLE
Also get `add nuw` from `uN::checked_add`

### DIFF
--- a/tests/codegen/checked_math.rs
+++ b/tests/codegen/checked_math.rs
@@ -84,3 +84,17 @@ pub fn checked_shr_signed(a: i32, b: u32) -> Option<i32> {
     // CHECK: ret { i32, i32 } %[[R1]]
     a.checked_shr(b)
 }
+
+// CHECK-LABEL: @checked_add_one_unwrap_unsigned
+// CHECK-SAME: (i32 noundef %x)
+#[no_mangle]
+pub fn checked_add_one_unwrap_unsigned(x: u32) -> u32 {
+    // CHECK: %[[IS_MAX:.+]] = icmp eq i32 %x, -1
+    // CHECK: br i1 %[[IS_MAX]], label %[[NONE_BB:.+]], label %[[SOME_BB:.+]]
+    // CHECK: [[SOME_BB]]:
+    // CHECK: %[[R:.+]] = add nuw i32 %x, 1
+    // CHECK: ret i32 %[[R]]
+    // CHECK: [[NONE_BB]]:
+    // CHECK: call {{.+}}unwrap_failed
+    x.checked_add(1).unwrap()
+}

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-abort.mir
@@ -11,15 +11,9 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
         scope 3 (inlined <u16 as Step>::forward_checked) {
             scope 4 {
                 scope 6 (inlined core::num::<impl u16>::checked_add) {
+                    let mut _5: (u16, bool);
+                    let mut _6: bool;
                     let mut _7: bool;
-                    scope 7 {
-                    }
-                    scope 8 (inlined core::num::<impl u16>::overflowing_add) {
-                        let mut _5: (u16, bool);
-                        let _6: bool;
-                        scope 9 {
-                        }
-                    }
                 }
             }
             scope 5 (inlined convert::num::ptr_try_from_impls::<impl TryFrom<usize> for u16>::try_from) {
@@ -27,11 +21,11 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
                 let mut _4: u16;
             }
         }
-        scope 10 (inlined Option::<u16>::is_none) {
-            scope 11 (inlined Option::<u16>::is_some) {
+        scope 7 (inlined Option::<u16>::is_none) {
+            scope 8 (inlined Option::<u16>::is_some) {
             }
         }
-        scope 12 (inlined core::num::<impl u16>::wrapping_add) {
+        scope 9 (inlined core::num::<impl u16>::wrapping_add) {
         }
     }
 
@@ -45,12 +39,11 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
     bb1: {
         _4 = _2 as u16 (IntToInt);
         StorageDead(_3);
+        StorageLive(_7);
         StorageLive(_6);
         StorageLive(_5);
         _5 = AddWithOverflow(_1, _4);
         _6 = (_5.1: bool);
-        StorageDead(_5);
-        StorageLive(_7);
         _7 = unlikely(move _6) -> [return: bb2, unwind unreachable];
     }
 
@@ -59,14 +52,16 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
     }
 
     bb3: {
-        StorageDead(_7);
+        StorageDead(_5);
         StorageDead(_6);
+        StorageDead(_7);
         goto -> bb7;
     }
 
     bb4: {
-        StorageDead(_7);
+        StorageDead(_5);
         StorageDead(_6);
+        StorageDead(_7);
         goto -> bb6;
     }
 

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-unwind.mir
@@ -11,15 +11,9 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
         scope 3 (inlined <u16 as Step>::forward_checked) {
             scope 4 {
                 scope 6 (inlined core::num::<impl u16>::checked_add) {
+                    let mut _5: (u16, bool);
+                    let mut _6: bool;
                     let mut _7: bool;
-                    scope 7 {
-                    }
-                    scope 8 (inlined core::num::<impl u16>::overflowing_add) {
-                        let mut _5: (u16, bool);
-                        let _6: bool;
-                        scope 9 {
-                        }
-                    }
                 }
             }
             scope 5 (inlined convert::num::ptr_try_from_impls::<impl TryFrom<usize> for u16>::try_from) {
@@ -27,11 +21,11 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
                 let mut _4: u16;
             }
         }
-        scope 10 (inlined Option::<u16>::is_none) {
-            scope 11 (inlined Option::<u16>::is_some) {
+        scope 7 (inlined Option::<u16>::is_none) {
+            scope 8 (inlined Option::<u16>::is_some) {
             }
         }
-        scope 12 (inlined core::num::<impl u16>::wrapping_add) {
+        scope 9 (inlined core::num::<impl u16>::wrapping_add) {
         }
     }
 
@@ -45,12 +39,11 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
     bb1: {
         _4 = _2 as u16 (IntToInt);
         StorageDead(_3);
+        StorageLive(_7);
         StorageLive(_6);
         StorageLive(_5);
         _5 = AddWithOverflow(_1, _4);
         _6 = (_5.1: bool);
-        StorageDead(_5);
-        StorageLive(_7);
         _7 = unlikely(move _6) -> [return: bb2, unwind unreachable];
     }
 
@@ -59,14 +52,16 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
     }
 
     bb3: {
-        StorageDead(_7);
+        StorageDead(_5);
         StorageDead(_6);
+        StorageDead(_7);
         goto -> bb7;
     }
 
     bb4: {
-        StorageDead(_7);
+        StorageDead(_5);
         StorageDead(_6);
+        StorageDead(_7);
         goto -> bb6;
     }
 


### PR DESCRIPTION
When I was doing this for `checked_{sub,shl,shr}`, it was mentioned https://github.com/rust-lang/rust/pull/124114#issuecomment-2066173305 that it'd be worth trying for `checked_add` too.

It makes a particularly-big difference for `x.checked_add(C)`, as doing this means that LLVM removes the intrinsic and does it as a normal `x <= MAX - C` instead.

cc @DianQK who had commented about `checked_add` related to https://github.com/rust-lang/hashbrown/issues/509 before

cc https://github.com/llvm/llvm-project/issues/80637 for how LLVM is unlikely to do this itself