### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -28,7 +28,7 @@ ast_passes_auto_super_lifetime = auto traits cannot have super traits or lifetim
     .label = {ast_passes_auto_super_lifetime}
     .suggestion = remove the super traits or lifetime bounds
 
-ast_passes_bad_c_variadic = only foreign or `unsafe extern "C"` functions may be C-variadic
+ast_passes_bad_c_variadic = only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 
 ast_passes_bare_fn_invalid_safety = function pointers cannot be declared with `safe` safety qualifier
     .suggestion = remove safe from this item

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -637,6 +637,7 @@ impl<'a> AstValidator<'a> {
             (Some(FnCtxt::Foreign), _) => return,
             (Some(FnCtxt::Free), Some(header)) => match header.ext {
                 Extern::Explicit(StrLit { symbol_unescaped: sym::C, .. }, _)
+                | Extern::Explicit(StrLit { symbol_unescaped: sym::C_dash_unwind, .. }, _)
                 | Extern::Implicit(_)
                     if matches!(header.safety, Safety::Unsafe(_)) =>
                 {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -167,6 +167,7 @@ symbols! {
         Break,
         C,
         CStr,
+        C_dash_unwind: "C-unwind",
         CallOnceFuture,
         CallRefFuture,
         Capture,

--- a/library/std/src/net/mod.rs
+++ b/library/std/src/net/mod.rs
@@ -27,7 +27,7 @@ use crate::io::{self, ErrorKind};
 pub use self::ip_addr::{IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::socket_addr::{SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
-#[unstable(feature = "tcplistener_into_incoming", issue = "88339")]
+#[unstable(feature = "tcplistener_into_incoming", issue = "88373")]
 pub use self::tcp::IntoIncoming;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::tcp::{Incoming, TcpListener, TcpStream};

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -105,7 +105,7 @@ pub struct Incoming<'a> {
 ///
 /// [`accept`]: TcpListener::accept
 #[derive(Debug)]
-#[unstable(feature = "tcplistener_into_incoming", issue = "88339")]
+#[unstable(feature = "tcplistener_into_incoming", issue = "88373")]
 pub struct IntoIncoming {
     listener: TcpListener,
 }
@@ -894,7 +894,7 @@ impl TcpListener {
     /// }
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
-    #[unstable(feature = "tcplistener_into_incoming", issue = "88339")]
+    #[unstable(feature = "tcplistener_into_incoming", issue = "88373")]
     pub fn into_incoming(self) -> IntoIncoming {
         IntoIncoming { listener: self }
     }
@@ -1033,7 +1033,7 @@ impl<'a> Iterator for Incoming<'a> {
 #[stable(feature = "tcp_listener_incoming_fused_iterator", since = "1.64.0")]
 impl FusedIterator for Incoming<'_> {}
 
-#[unstable(feature = "tcplistener_into_incoming", issue = "88339")]
+#[unstable(feature = "tcplistener_into_incoming", issue = "88373")]
 impl Iterator for IntoIncoming {
     type Item = io::Result<TcpStream>;
     fn next(&mut self) -> Option<io::Result<TcpStream>> {
@@ -1041,7 +1041,7 @@ impl Iterator for IntoIncoming {
     }
 }
 
-#[unstable(feature = "tcplistener_into_incoming", issue = "88339")]
+#[unstable(feature = "tcplistener_into_incoming", issue = "88373")]
 impl FusedIterator for IntoIncoming {}
 
 impl AsInner<net_imp::TcpListener> for TcpListener {

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -665,6 +665,10 @@ impl Step for Std {
     }
 }
 
+/// Tarball containing the compiler that gets downloaded and used by
+/// `rust.download-rustc`.
+///
+/// (Don't confuse this with [`RustDev`], without the `c`!)
 #[derive(Debug, PartialOrd, Ord, Clone, Hash, PartialEq, Eq)]
 pub struct RustcDev {
     pub compiler: Compiler,
@@ -2225,6 +2229,11 @@ impl Step for LlvmBitcodeLinker {
 /// Tarball intended for internal consumption to ease rustc/std development.
 ///
 /// Should not be considered stable by end users.
+///
+/// In practice, this is the tarball that gets downloaded and used by
+/// `llvm.download-ci-llvm`.
+///
+/// (Don't confuse this with [`RustcDev`], with a `c`!)
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RustDev {
     pub target: TargetSelection,

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -122,11 +122,14 @@ fn test_intersection() {
         PathSet::Set(paths.into_iter().map(|p| TaskPath { path: p.into(), kind: None }).collect())
     };
     let library_set = set(&["library/core", "library/alloc", "library/std"]);
-    let mut command_paths =
-        vec![Path::new("library/core"), Path::new("library/alloc"), Path::new("library/stdarch")];
+    let mut command_paths = vec![
+        PathBuf::from("library/core"),
+        PathBuf::from("library/alloc"),
+        PathBuf::from("library/stdarch"),
+    ];
     let subset = library_set.intersection_removing_matches(&mut command_paths, Kind::Build);
     assert_eq!(subset, set(&["library/core", "library/alloc"]),);
-    assert_eq!(command_paths, vec![Path::new("library/stdarch")]);
+    assert_eq!(command_paths, vec![PathBuf::from("library/stdarch")]);
 }
 
 #[test]

--- a/tests/run-make/branch-protection-check-IBT/Makefile
+++ b/tests/run-make/branch-protection-check-IBT/Makefile
@@ -7,6 +7,12 @@ include ../tools.mk
 
 # only-x86_64
 
+# ignore-test
+# FIXME(jieyouxu): This test never runs because the `ifeq` check on line 17
+# compares `x86` to `x86_64`, which always evaluates to false.
+# When the test does run, the compilation does not include `.note.gnu.property`.
+# See https://github.com/rust-lang/rust/pull/126720 for more information.
+
 all:
 ifeq ($(filter x86,$(LLVM_COMPONENTS)),x86_64)
 	$(RUSTC) --target x86_64-unknown-linux-gnu -Z cf-protection=branch -L$(TMPDIR) -C link-args='-nostartfiles'  -C save-temps  ./main.rs -o $(TMPDIR)/rsmain

--- a/tests/run-make/branch-protection-check-IBT/_rmake.rs
+++ b/tests/run-make/branch-protection-check-IBT/_rmake.rs
@@ -1,0 +1,31 @@
+// Check for GNU Property Note
+
+// How to run this
+// python3 x.py test --target x86_64-unknown-linux-gnu  tests/run-make/branch-protection-check-IBT/
+
+//@ only-x86_64
+
+//@ ignore-test
+// FIXME(jieyouxu): see the FIXME in the Makefile
+
+use run_make_support::llvm_readobj;
+use run_make_support::rustc;
+use run_make_support::{cwd, env_var};
+
+fn main() {
+    let llvm_components = env_var("LLVM_COMPONENTS");
+    if !format!(" {llvm_components} ").contains(" x86 ") {
+        return;
+    }
+
+    rustc()
+        .input("main.rs")
+        .target("x86_64-unknown-linux-gnu")
+        .arg("-Zcf-protection=branch")
+        .arg(format!("-L{}", cwd().display()))
+        .arg("-Clink-args=-nostartfiles")
+        .arg("-Csave-temps")
+        .run();
+
+    llvm_readobj().arg("-nW").input("main").run().assert_stdout_contains(".note.gnu.property");
+}

--- a/tests/ui/abi/variadic-ffi.rs
+++ b/tests/ui/abi/variadic-ffi.rs
@@ -14,6 +14,10 @@ pub unsafe extern "C" fn test_valist_forward(n: u64, mut ap: ...) -> f64 {
     rust_valist_interesting_average(n, ap.as_va_list())
 }
 
+pub unsafe extern "C-unwind" fn c_unwind_can_forward(n: u64, mut ap: ...) -> f64 {
+    rust_valist_interesting_average(n, ap.as_va_list())
+}
+
 pub unsafe extern "C" fn test_va_copy(_: u64, mut ap: ...) {
     let mut ap2 = ap.clone();
     assert_eq!(rust_valist_interesting_average(2, ap2.as_va_list()) as i64, 30);
@@ -70,6 +74,10 @@ pub fn main() {
 
     unsafe {
         assert_eq!(test_valist_forward(2, 10i64, 10f64, 20i64, 20f64) as i64, 30);
+    }
+
+    unsafe {
+        assert_eq!(c_unwind_can_forward(2, 10i64, 10f64, 20i64, 20f64) as i64, 30);
     }
 
     unsafe {

--- a/tests/ui/c-variadic/issue-86053-1.stderr
+++ b/tests/ui/c-variadic/issue-86053-1.stderr
@@ -46,7 +46,7 @@ error: `...` must be the last argument of a C-variadic function
 LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize ) {
    |            ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/issue-86053-1.rs:11:12
    |
 LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize ) {

--- a/tests/ui/mir/issue-83499-input-output-iteration-ice.rs
+++ b/tests/ui/mir/issue-83499-input-output-iteration-ice.rs
@@ -5,6 +5,6 @@
 fn main() {}
 
 fn foo(_: Bar, ...) -> impl {}
-//~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 //~| ERROR cannot find type `Bar` in this scope
 //~| ERROR at least one trait must be specified

--- a/tests/ui/mir/issue-83499-input-output-iteration-ice.stderr
+++ b/tests/ui/mir/issue-83499-input-output-iteration-ice.stderr
@@ -1,4 +1,4 @@
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/issue-83499-input-output-iteration-ice.rs:7:16
    |
 LL | fn foo(_: Bar, ...) -> impl {}

--- a/tests/ui/parser/variadic-ffi-semantic-restrictions.rs
+++ b/tests/ui/parser/variadic-ffi-semantic-restrictions.rs
@@ -4,29 +4,29 @@
 fn main() {}
 
 fn f1_1(x: isize, ...) {}
-//~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 
 fn f1_2(...) {}
-//~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 
 extern "C" fn f2_1(x: isize, ...) {}
-//~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 
 extern "C" fn f2_2(...) {}
-//~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 
 extern "C" fn f2_3(..., x: isize) {}
-//~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 //~| ERROR `...` must be the last argument of a C-variadic function
 
 extern "C" fn f3_1(x: isize, ...) {}
-//~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 
 extern "C" fn f3_2(...) {}
-//~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 
 extern "C" fn f3_3(..., x: isize) {}
-//~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 //~| ERROR `...` must be the last argument of a C-variadic function
 
 const unsafe extern "C" fn f4_1(x: isize, ...) {}
@@ -35,12 +35,12 @@ const unsafe extern "C" fn f4_1(x: isize, ...) {}
 
 const extern "C" fn f4_2(x: isize, ...) {}
 //~^ ERROR functions cannot be both `const` and C-variadic
-//~| ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~| ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 //~| ERROR destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
 
 const extern "C" fn f4_3(..., x: isize, ...) {}
 //~^ ERROR functions cannot be both `const` and C-variadic
-//~| ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~| ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
 //~| ERROR `...` must be the last argument of a C-variadic function
 
 extern "C" {
@@ -52,34 +52,34 @@ struct X;
 
 impl X {
     fn i_f1(x: isize, ...) {}
-    //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+    //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     fn i_f2(...) {}
-    //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+    //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     fn i_f3(..., x: isize, ...) {}
-    //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+    //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     //~| ERROR `...` must be the last argument of a C-variadic function
     fn i_f4(..., x: isize, ...) {}
-    //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+    //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     //~| ERROR `...` must be the last argument of a C-variadic function
     const fn i_f5(x: isize, ...) {}
-    //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+    //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     //~| ERROR functions cannot be both `const` and C-variadic
     //~| ERROR destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
 }
 
 trait T {
     fn t_f1(x: isize, ...) {}
-    //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+    //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     fn t_f2(x: isize, ...);
-    //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+    //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     fn t_f3(...) {}
-    //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+    //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     fn t_f4(...);
-    //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+    //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     fn t_f5(..., x: isize) {}
-    //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+    //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     //~| ERROR `...` must be the last argument of a C-variadic function
     fn t_f6(..., x: isize);
-    //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+    //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     //~| ERROR `...` must be the last argument of a C-variadic function
 }

--- a/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
+++ b/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
@@ -1,22 +1,22 @@
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:6:19
    |
 LL | fn f1_1(x: isize, ...) {}
    |                   ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:9:9
    |
 LL | fn f1_2(...) {}
    |         ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:12:30
    |
 LL | extern "C" fn f2_1(x: isize, ...) {}
    |                              ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:15:20
    |
 LL | extern "C" fn f2_2(...) {}
@@ -28,19 +28,19 @@ error: `...` must be the last argument of a C-variadic function
 LL | extern "C" fn f2_3(..., x: isize) {}
    |                    ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:18:20
    |
 LL | extern "C" fn f2_3(..., x: isize) {}
    |                    ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:22:30
    |
 LL | extern "C" fn f3_1(x: isize, ...) {}
    |                              ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:25:20
    |
 LL | extern "C" fn f3_2(...) {}
@@ -52,7 +52,7 @@ error: `...` must be the last argument of a C-variadic function
 LL | extern "C" fn f3_3(..., x: isize) {}
    |                    ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:28:20
    |
 LL | extern "C" fn f3_3(..., x: isize) {}
@@ -70,7 +70,7 @@ error: functions cannot be both `const` and C-variadic
 LL | const extern "C" fn f4_2(x: isize, ...) {}
    | ^^^^^ `const` because of this      ^^^ C-variadic because of this
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:36:36
    |
 LL | const extern "C" fn f4_2(x: isize, ...) {}
@@ -91,7 +91,7 @@ LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    | |                        C-variadic because of this
    | `const` because of this
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:41:26
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
@@ -103,13 +103,13 @@ error: `...` must be the last argument of a C-variadic function
 LL |     fn e_f2(..., x: isize);
    |             ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:54:23
    |
 LL |     fn i_f1(x: isize, ...) {}
    |                       ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:56:13
    |
 LL |     fn i_f2(...) {}
@@ -121,7 +121,7 @@ error: `...` must be the last argument of a C-variadic function
 LL |     fn i_f3(..., x: isize, ...) {}
    |             ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:58:13
    |
 LL |     fn i_f3(..., x: isize, ...) {}
@@ -133,7 +133,7 @@ error: `...` must be the last argument of a C-variadic function
 LL |     fn i_f4(..., x: isize, ...) {}
    |             ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:61:13
    |
 LL |     fn i_f4(..., x: isize, ...) {}
@@ -147,31 +147,31 @@ LL |     const fn i_f5(x: isize, ...) {}
    |     |
    |     `const` because of this
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:64:29
    |
 LL |     const fn i_f5(x: isize, ...) {}
    |                             ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:71:23
    |
 LL |     fn t_f1(x: isize, ...) {}
    |                       ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:73:23
    |
 LL |     fn t_f2(x: isize, ...);
    |                       ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:75:13
    |
 LL |     fn t_f3(...) {}
    |             ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:77:13
    |
 LL |     fn t_f4(...);
@@ -183,7 +183,7 @@ error: `...` must be the last argument of a C-variadic function
 LL |     fn t_f5(..., x: isize) {}
    |             ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:79:13
    |
 LL |     fn t_f5(..., x: isize) {}
@@ -195,7 +195,7 @@ error: `...` must be the last argument of a C-variadic function
 LL |     fn t_f6(..., x: isize);
    |             ^^^
 
-error: only foreign or `unsafe extern "C"` functions may be C-variadic
+error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
   --> $DIR/variadic-ffi-semantic-restrictions.rs:82:13
    |
 LL |     fn t_f6(..., x: isize);


### PR DESCRIPTION
Successful merges:

 - #126720 (Ignore `branch-protection-check-IBT` run-make test)
 - #126779 (Try to clarify the confusingly-named `RustDev` and `RustcDev` steps)
 - #126782 (Support absolute source paths in bootstrap)
 - #126783 (Fix issue number for the `tcplistener_into_incoming` feature)
 - #126843 (Allow "C-unwind" fn to have C variadics)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=126720,126779,126782,126783,126843)
<!-- homu-ignore:end -->