### PR TITLE
Lazify CRT objects fields initilization

### DIFF
--- a/compiler/rustc_target/src/lib.rs
+++ b/compiler/rustc_target/src/lib.rs
@@ -12,11 +12,13 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(assert_matches)]
+#![feature(fn_traits)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
 #![feature(min_exhaustive_patterns)]
 #![feature(rustc_attrs)]
 #![feature(rustdoc_internals)]
+#![feature(unboxed_closures)]
 // tidy-alphabetical-end
 
 use std::path::{Path, PathBuf};

--- a/compiler/rustc_target/src/spec/maybe_lazy.rs
+++ b/compiler/rustc_target/src/spec/maybe_lazy.rs
@@ -1,0 +1,144 @@
+//! A custom LazyLock+Cow suitable for holding borrowed, owned or lazy data.
+
+use std::borrow::{Borrow, Cow};
+use std::fmt::{Debug, Display};
+use std::ops::Deref;
+use std::sync::LazyLock;
+
+enum MaybeLazyInner<T: 'static + ToOwned + ?Sized, F> {
+    Lazy(LazyLock<T::Owned, F>),
+    Cow(Cow<'static, T>),
+}
+
+/// A custom LazyLock+Cow suitable for holding borrowed, owned or lazy data.
+///
+/// Technically this structure has 3 states: borrowed, owned and lazy
+/// They can all be constructed from the [`MaybeLazy::borrowed`], [`MaybeLazy::owned`] and
+/// [`MaybeLazy::lazy`] methods.
+#[repr(transparent)]
+pub struct MaybeLazy<T: 'static + ToOwned + ?Sized, F = fn() -> <T as ToOwned>::Owned> {
+    // Inner state.
+    //
+    // Not to be inlined since we may want in the future to
+    // make this struct usable to statics and we might need to
+    // workaround const-eval limitation (particulary around drop).
+    inner: MaybeLazyInner<T, F>,
+}
+
+impl<T: 'static + ?Sized + ToOwned, F: FnOnce() -> T::Owned> MaybeLazy<T, F> {
+    /// Create a [`MaybeLazy`] from an borrowed `T`.
+    #[inline]
+    pub const fn borrowed(a: &'static T) -> Self {
+        MaybeLazy { inner: MaybeLazyInner::Cow(Cow::Borrowed(a)) }
+    }
+
+    /// Create a [`MaybeLazy`] from an borrowed `T`.
+    #[inline]
+    pub const fn owned(a: T::Owned) -> Self {
+        MaybeLazy { inner: MaybeLazyInner::Cow(Cow::Owned(a)) }
+    }
+
+    /// Create a [`MaybeLazy`] from a function-able `F`.
+    #[inline]
+    pub const fn lazied(f: F) -> Self {
+        MaybeLazy { inner: MaybeLazyInner::Lazy(LazyLock::new(f)) }
+    }
+}
+
+impl<T: 'static + ?Sized + ToOwned> MaybeLazy<T> {
+    /// Create a [`MaybeLazy`] from a function pointer.
+    #[inline]
+    pub const fn lazy(a: fn() -> T::Owned) -> Self {
+        Self::lazied(a)
+    }
+}
+
+impl<T: 'static + ?Sized + ToOwned<Owned: Clone>, F: FnOnce() -> T::Owned> Clone
+    for MaybeLazy<T, F>
+{
+    #[inline]
+    fn clone(&self) -> Self {
+        MaybeLazy {
+            inner: MaybeLazyInner::Cow(match &self.inner {
+                MaybeLazyInner::Lazy(f) => Cow::Owned((*f).to_owned()),
+                MaybeLazyInner::Cow(c) => c.clone(),
+            }),
+        }
+    }
+}
+
+impl<T: 'static + ?Sized + ToOwned<Owned: Default>, F: FnOnce() -> T::Owned> Default
+    for MaybeLazy<T, F>
+{
+    #[inline]
+    fn default() -> MaybeLazy<T, F> {
+        MaybeLazy::owned(T::Owned::default())
+    }
+}
+
+// `Debug`, `Display` and other traits below are implemented in terms of this `Deref`
+impl<T: 'static + ?Sized + ToOwned<Owned: Borrow<T>>, F: FnOnce() -> T::Owned> Deref
+    for MaybeLazy<T, F>
+{
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        match &self.inner {
+            MaybeLazyInner::Lazy(f) => (&**f).borrow(),
+            MaybeLazyInner::Cow(c) => &*c,
+        }
+    }
+}
+
+impl<T: 'static + ?Sized + ToOwned<Owned: Debug> + Debug, F: FnOnce() -> T::Owned> Debug
+    for MaybeLazy<T, F>
+{
+    #[inline]
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&**self, fmt)
+    }
+}
+
+impl<T: 'static + ?Sized + ToOwned<Owned: Display> + Display, F: FnOnce() -> T::Owned> Display
+    for MaybeLazy<T, F>
+{
+    #[inline]
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&**self, fmt)
+    }
+}
+
+impl<T: 'static + ?Sized + ToOwned, F: FnOnce() -> T::Owned> AsRef<T> for MaybeLazy<T, F> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        &**self
+    }
+}
+
+impl<
+    T1: ?Sized + PartialEq<T2> + ToOwned,
+    T2: ?Sized + ToOwned,
+    F1: FnOnce() -> T1::Owned,
+    F2: FnOnce() -> T2::Owned,
+> PartialEq<MaybeLazy<T2, F2>> for MaybeLazy<T1, F1>
+{
+    #[inline]
+    fn eq(&self, other: &MaybeLazy<T2, F2>) -> bool {
+        PartialEq::eq(&**self, &**other)
+    }
+}
+
+impl<F: FnOnce() -> String> PartialEq<&str> for MaybeLazy<str, F> {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        &**self == *other
+    }
+}
+
+impl<F: FnOnce() -> String> From<&'static str> for MaybeLazy<str, F> {
+    #[inline]
+    fn from(s: &'static str) -> MaybeLazy<str, F> {
+        MaybeLazy::borrowed(s)
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -39,6 +39,7 @@ use crate::abi::{Endian, Integer, Size, TargetDataLayout, TargetDataLayoutErrors
 use crate::json::{Json, ToJson};
 use crate::spec::abi::Abi;
 use crate::spec::crt_objects::CrtObjects;
+use crate::spec::maybe_lazy::MaybeLazy;
 use rustc_fs_util::try_canonicalize;
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
@@ -55,6 +56,7 @@ use tracing::debug;
 
 pub mod abi;
 pub mod crt_objects;
+pub mod maybe_lazy;
 
 mod base;
 pub use base::apple::deployment_target as current_apple_deployment_target;

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -38,7 +38,7 @@ use crate::abi::call::Conv;
 use crate::abi::{Endian, Integer, Size, TargetDataLayout, TargetDataLayoutErrors};
 use crate::json::{Json, ToJson};
 use crate::spec::abi::Abi;
-use crate::spec::crt_objects::CrtObjects;
+use crate::spec::crt_objects::{CrtObjects, LazyCrtObjects};
 use crate::spec::maybe_lazy::MaybeLazy;
 use rustc_fs_util::try_canonicalize;
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
@@ -2016,11 +2016,11 @@ pub struct TargetOptions {
     linker_is_gnu_json: bool,
 
     /// Objects to link before and after all other object code.
-    pub pre_link_objects: CrtObjects,
-    pub post_link_objects: CrtObjects,
+    pub pre_link_objects: LazyCrtObjects,
+    pub post_link_objects: LazyCrtObjects,
     /// Same as `(pre|post)_link_objects`, but when self-contained linking mode is enabled.
-    pub pre_link_objects_self_contained: CrtObjects,
-    pub post_link_objects_self_contained: CrtObjects,
+    pub pre_link_objects_self_contained: LazyCrtObjects,
+    pub post_link_objects_self_contained: LazyCrtObjects,
     /// Behavior for the self-contained linking mode: inferred for some targets, or explicitly
     /// enabled (in bulk, or with individual components).
     pub link_self_contained: LinkSelfContainedDefault,
@@ -3097,7 +3097,7 @@ impl Target {
 
                         args.insert(kind, v);
                     }
-                    base.$key_name = args;
+                    base.$key_name = MaybeLazy::owned(args);
                 }
             } );
             ($key_name:ident = $json_name:expr, link_args) => ( {


### PR DESCRIPTION
This PR lazify the CRT objects by introducing `MaybeLazy`, a 3-way lazy container (borrowed, owned and lazied state). 

Split from https://github.com/rust-lang/rust/pull/122703
r? @petrochenkov
