### PR TITLE
Add needs-symlink directive to compiletest

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -875,6 +875,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "needs-sanitizer-shadow-call-stack",
     "needs-sanitizer-support",
     "needs-sanitizer-thread",
+    "needs-symlink",
     "needs-threads",
     "needs-unwind",
     "needs-wasmtime",

--- a/tests/run-make/symlinked-extern/rmake.rs
+++ b/tests/run-make/symlinked-extern/rmake.rs
@@ -9,6 +9,7 @@
 // can result in successful compilation.
 
 //@ ignore-cross-compile
+//@ needs-symlink
 
 use run_make_support::{create_symlink, cwd, fs_wrapper, rustc};
 

--- a/tests/run-make/symlinked-libraries/rmake.rs
+++ b/tests/run-make/symlinked-libraries/rmake.rs
@@ -6,6 +6,7 @@
 // See https://github.com/rust-lang/rust/issues/12459
 
 //@ ignore-cross-compile
+//@ needs-symlink
 
 use run_make_support::{create_symlink, dynamic_lib_name, fs_wrapper, rustc};
 

--- a/tests/run-make/symlinked-rlib/rmake.rs
+++ b/tests/run-make/symlinked-rlib/rmake.rs
@@ -6,6 +6,7 @@
 // See https://github.com/rust-lang/rust/pull/32828
 
 //@ ignore-cross-compile
+//@ needs-symlink
 
 use run_make_support::{create_symlink, cwd, rustc};
 


### PR DESCRIPTION
This is an alternative to #126846 that allows running symlink tests on Windows in CI but will ignore them locally if symlinks aren't available. A future improvement would be to check that the `needs-symlink` directive is used in rmake files that call `create_symlink` but this is just a quick PR to unblock Windows users who want to run tests locally without enabling symlinks.