### PR TITLE
Add `.ignore` file to make `config.toml` searchable in vscode

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+# Make vscode *not* count `config.toml` as ignored, so it is included in search
+!/config.toml

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -35,6 +35,7 @@ Files: compiler/*
        .gitignore
        .gitmodules
        .mailmap
+       .ignore
 Copyright: The Rust Project Developers (see https://thanks.rust-lang.org)
 License: MIT or Apache-2.0
 


### PR DESCRIPTION
Based on this answer on [Stack Overflow](https://stackoverflow.com/a/72059075).