### PR TITLE
Make `NEVER_TYPE_FALLBACK_FLOWING_INTO_UNSAFE` a deny-by-default lint in edition 2024

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4197,6 +4197,7 @@ declare_lint! {
         reason: FutureIncompatibilityReason::FutureReleaseSemanticsChange,
         reference: "issue #123748 <https://github.com/rust-lang/rust/issues/123748>",
     };
+    @edition Edition2024 => Deny;
     report_in_external_macro
 }
 

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
@@ -1,0 +1,107 @@
+warning: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:13:18
+   |
+LL |         unsafe { mem::zeroed() }
+   |                  ^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the type explicitly
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+
+warning: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:30:13
+   |
+LL |             core::mem::transmute(Zst)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the type explicitly
+
+warning: never type fallback affects this union access
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:47:18
+   |
+LL |         unsafe { Union { a: () }.b }
+   |                  ^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the type explicitly
+
+warning: never type fallback affects this raw pointer dereference
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:58:18
+   |
+LL |         unsafe { *ptr::from_ref(&()).cast() }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the type explicitly
+
+warning: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:79:18
+   |
+LL |         unsafe { internally_create(x) }
+   |                  ^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the type explicitly
+
+warning: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:97:18
+   |
+LL |         unsafe { zeroed() }
+   |                  ^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the type explicitly
+
+warning: never type fallback affects this `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:92:22
+   |
+LL |         let zeroed = mem::zeroed;
+   |                      ^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the type explicitly
+
+warning: never type fallback affects this `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:115:17
+   |
+LL |         let f = internally_create;
+   |                 ^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the type explicitly
+
+warning: never type fallback affects this call to an `unsafe` method
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:140:13
+   |
+LL |             S(marker::PhantomData).create_out_of_thin_air()
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the type explicitly
+
+warning: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:158:19
+   |
+LL |             match send_message::<_ /* ?0 */>() {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |         msg_send!();
+   |         ----------- in this macro invocation
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the type explicitly
+   = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 10 warnings emitted
+

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
@@ -1,5 +1,5 @@
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:8:18
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:13:18
    |
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
@@ -7,10 +7,10 @@ LL |         unsafe { mem::zeroed() }
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:23:13
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:30:13
    |
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,8 +19,8 @@ LL |             core::mem::transmute(Zst)
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
-warning: never type fallback affects this union access
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:39:18
+error: never type fallback affects this union access
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:47:18
    |
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
@@ -29,8 +29,8 @@ LL |         unsafe { Union { a: () }.b }
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
-warning: never type fallback affects this raw pointer dereference
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:49:18
+error: never type fallback affects this raw pointer dereference
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:58:18
    |
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,8 +39,8 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:67:18
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:79:18
    |
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
@@ -49,8 +49,8 @@ LL |         unsafe { internally_create(x) }
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:83:18
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:97:18
    |
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
@@ -59,8 +59,8 @@ LL |         unsafe { zeroed() }
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
-warning: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:79:22
+error: never type fallback affects this `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:92:22
    |
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
@@ -69,8 +69,8 @@ LL |         let zeroed = mem::zeroed;
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
-warning: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:98:17
+error: never type fallback affects this `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:115:17
    |
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
@@ -79,8 +79,8 @@ LL |         let f = internally_create;
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
-warning: never type fallback affects this call to an `unsafe` method
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:122:13
+error: never type fallback affects this call to an `unsafe` method
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:140:13
    |
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,8 +89,8 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
-warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:139:19
+error: never type fallback affects this call to an `unsafe` function
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:158:19
    |
 LL |             match send_message::<_ /* ?0 */>() {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -101,7 +101,16 @@ LL |         msg_send!();
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
-   = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: 10 warnings emitted
+warning: the type `!` does not permit zero-initialization
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:13:18
+   |
+LL |         unsafe { mem::zeroed() }
+   |                  ^^^^^^^^^^^^^ this code causes undefined behavior when executed
+   |
+   = note: the `!` type has no valid value
+   = note: `#[warn(invalid_value)]` on by default
+
+error: aborting due to 10 previous errors; 1 warning emitted
 

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
@@ -1,4 +1,9 @@
-//@ check-pass
+//@ revisions: e2015 e2024
+//@[e2015] check-pass
+//@[e2024] check-fail
+//@[e2024] edition:2024
+//@[e2024] compile-flags: -Zunstable-options
+
 use std::{marker, mem, ptr};
 
 fn main() {}
@@ -6,8 +11,10 @@ fn main() {}
 fn _zero() {
     if false {
         unsafe { mem::zeroed() }
-        //~^ warn: never type fallback affects this call to an `unsafe` function
+        //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
+        //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
         //~| warn: this will change its meaning in a future release!
+        //[e2024]~| warning: the type `!` does not permit zero-initialization
     } else {
         return;
     };
@@ -21,7 +28,8 @@ fn _trans() {
         unsafe {
             struct Zst;
             core::mem::transmute(Zst)
-            //~^ warn: never type fallback affects this call to an `unsafe` function
+            //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
+            //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
             //~| warn: this will change its meaning in a future release!
         }
     } else {
@@ -37,7 +45,8 @@ fn _union() {
         }
 
         unsafe { Union { a: () }.b }
-        //~^ warn: never type fallback affects this union access
+        //[e2015]~^ warn: never type fallback affects this union access
+        //[e2024]~^^ error: never type fallback affects this union access
         //~| warn: this will change its meaning in a future release!
     } else {
         return;
@@ -47,7 +56,8 @@ fn _union() {
 fn _deref() {
     if false {
         unsafe { *ptr::from_ref(&()).cast() }
-        //~^ warn: never type fallback affects this raw pointer dereference
+        //[e2015]~^ warn: never type fallback affects this raw pointer dereference
+        //[e2024]~^^ error: never type fallback affects this raw pointer dereference
         //~| warn: this will change its meaning in a future release!
     } else {
         return;
@@ -57,7 +67,9 @@ fn _deref() {
 fn _only_generics() {
     if false {
         unsafe fn internally_create<T>(_: Option<T>) {
-            let _ = mem::zeroed::<T>();
+            unsafe {
+                let _ = mem::zeroed::<T>();
+            }
         }
 
         // We need the option (and unwrap later) to call a function in a way,
@@ -65,7 +77,8 @@ fn _only_generics() {
         let x = None;
 
         unsafe { internally_create(x) }
-        //~^ warn: never type fallback affects this call to an `unsafe` function
+        //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
+        //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
         //~| warn: this will change its meaning in a future release!
 
         x.unwrap()
@@ -77,11 +90,13 @@ fn _only_generics() {
 fn _stored_function() {
     if false {
         let zeroed = mem::zeroed;
-        //~^ warn: never type fallback affects this `unsafe` function
+        //[e2015]~^ warn: never type fallback affects this `unsafe` function
+        //[e2024]~^^ error: never type fallback affects this `unsafe` function
         //~| warn: this will change its meaning in a future release!
 
         unsafe { zeroed() }
-        //~^ warn: never type fallback affects this call to an `unsafe` function
+        //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
+        //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
         //~| warn: this will change its meaning in a future release!
     } else {
         return;
@@ -91,12 +106,15 @@ fn _stored_function() {
 fn _only_generics_stored_function() {
     if false {
         unsafe fn internally_create<T>(_: Option<T>) {
-            let _ = mem::zeroed::<T>();
+            unsafe {
+                let _ = mem::zeroed::<T>();
+            }
         }
 
         let x = None;
         let f = internally_create;
-        //~^ warn: never type fallback affects this `unsafe` function
+        //[e2015]~^ warn: never type fallback affects this `unsafe` function
+        //[e2024]~^^ error: never type fallback affects this `unsafe` function
         //~| warn: this will change its meaning in a future release!
 
         unsafe { f(x) }
@@ -120,7 +138,8 @@ fn _method() {
     if false {
         unsafe {
             S(marker::PhantomData).create_out_of_thin_air()
-            //~^ warn: never type fallback affects this call to an `unsafe` method
+            //[e2015]~^ warn: never type fallback affects this call to an `unsafe` method
+            //[e2024]~^^ error: never type fallback affects this call to an `unsafe` method
             //~| warn: this will change its meaning in a future release!
         }
     } else {
@@ -137,7 +156,8 @@ fn _objc() {
     macro_rules! msg_send {
         () => {
             match send_message::<_ /* ?0 */>() {
-                //~^ warn: never type fallback affects this call to an `unsafe` function
+                //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
+                //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
                 //~| warn: this will change its meaning in a future release!
                 Ok(x) => x,
                 Err(_) => loop {},


### PR DESCRIPTION
I don't actually really care about this, but @traviscross asked me to do this, because lang team briefly discussed this before.

(TC here:)

Specifically, our original FCPed plan included this step:

- Add a lint against fallback affecting a generic that is passed to an `unsafe` function.
   - Perhaps make this lint `deny-by-default` or a hard error in Rust 2024.

That is, we had left as an open question strengthening this in Rust 2024, and had marked it as an open question on the tracking issue.  We're nominating here to address the open question.  (Closing the remaining open question helps us to fully mark this off for Rust 2024.)

r? @compiler-errors

Tracking:

- https://github.com/rust-lang/rust/issues/123748