### PR TITLE
Parenthesize break values containing leading label

### DIFF
--- a/tests/ui/unpretty/expanded-interpolation.rs
+++ b/tests/ui/unpretty/expanded-interpolation.rs
@@ -18,6 +18,26 @@ macro_rules! stmt {
     ($stmt:stmt) => { $stmt };
 }
 
+fn break_labeled_loop() {
+    let no_paren = 'outer: loop {
+        break 'outer expr!('inner: loop { break 'inner 1; } + 1);
+    };
+
+    let paren_around_break_value = 'outer: loop {
+        break expr!('inner: loop { break 'inner 1; } + 1);
+    };
+
+    macro_rules! breaking {
+        ($value:expr) => {
+            break $value
+        };
+    }
+
+    let paren_around_break_value = loop {
+        breaking!('inner: loop { break 'inner 1; } + 1);
+    };
+}
+
 fn if_let() {
     macro_rules! if_let {
         ($pat:pat, $expr:expr) => {

--- a/tests/ui/unpretty/expanded-interpolation.stdout
+++ b/tests/ui/unpretty/expanded-interpolation.stdout
@@ -20,6 +20,19 @@ macro_rules! expr { ($expr:expr) => { $expr }; }
 
 macro_rules! stmt { ($stmt:stmt) => { $stmt }; }
 
+fn break_labeled_loop() {
+    let no_paren =
+        'outer: loop { break 'outer 'inner: loop { break 'inner 1; } + 1; };
+
+    let paren_around_break_value =
+        'outer: loop { break 'inner: loop { break 'inner 1; } + 1; };
+
+    macro_rules! breaking { ($value:expr) => { break $value }; }
+
+    let paren_around_break_value =
+        loop { break 'inner: loop { break 'inner 1; } + 1; };
+}
+
 fn if_let() {
     macro_rules! if_let {
         ($pat:pat, $expr:expr) => { if let $pat = $expr {} };

--- a/tests/ui/unpretty/expanded-interpolation.stdout
+++ b/tests/ui/unpretty/expanded-interpolation.stdout
@@ -25,12 +25,12 @@ fn break_labeled_loop() {
         'outer: loop { break 'outer 'inner: loop { break 'inner 1; } + 1; };
 
     let paren_around_break_value =
-        'outer: loop { break 'inner: loop { break 'inner 1; } + 1; };
+        'outer: loop { break ('inner: loop { break 'inner 1; } + 1); };
 
     macro_rules! breaking { ($value:expr) => { break $value }; }
 
     let paren_around_break_value =
-        loop { break 'inner: loop { break 'inner 1; } + 1; };
+        loop { break ('inner: loop { break 'inner 1; } + 1); };
 }
 
 fn if_let() {


### PR DESCRIPTION
The AST pretty printer previously produced invalid syntax in the case of `break` expressions with a value that begins with a loop or block label.

```rust
macro_rules! expr {
    ($e:expr) => {
        $e
    };
}

fn main() {
    loop {
        break expr!('a: loop { break 'a 1; } + 1);
    };
}
```

`rustc -Zunpretty=expanded main.rs `:

```console
#![feature(prelude_import)]
#![no_std]
#[prelude_import]
use ::std::prelude::rust_2015::*;
#[macro_use]
extern crate std;
macro_rules! expr { ($e:expr) => { $e }; }

fn main() { loop { break 'a: loop { break 'a 1; } + 1; }; }
```

The expanded code is not valid Rust syntax. Printing invalid syntax is bad because it blocks `cargo expand` from being able to format the output as Rust syntax using rustfmt.

```console
error: parentheses are required around this expression to avoid confusion with a labeled break expression
 --> <anon>:9:26
  |
9 | fn main() { loop { break 'a: loop { break 'a 1; } + 1; }; }
  |                          ^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: wrap the expression in parentheses
  |
9 | fn main() { loop { break ('a: loop { break 'a 1; }) + 1; }; }
  |                          +                        +
```

This PR updates the AST pretty-printer to insert parentheses around the value of a `break` expression as required to avoid this edge case.