### PR TITLE
Do not ICE when suggesting dereferencing closure arg

### DIFF
--- a/tests/ui/regions/account-for-lifetimes-in-closure-suggestion.rs
+++ b/tests/ui/regions/account-for-lifetimes-in-closure-suggestion.rs
@@ -1,0 +1,19 @@
+// #125634
+struct Thing;
+
+// Invariant in 'a, Covariant in 'b
+struct TwoThings<'a, 'b>(*mut &'a (), &'b mut ());
+
+impl Thing {
+    fn enter_scope<'a>(self, _scope: impl for<'b> FnOnce(TwoThings<'a, 'b>)) {}
+}
+
+fn foo() {
+    Thing.enter_scope(|ctx| {
+        SameLifetime(ctx); //~ ERROR lifetime may not live long enough
+    });
+}
+
+struct SameLifetime<'a>(TwoThings<'a, 'a>);
+
+fn main() {}

--- a/tests/ui/regions/account-for-lifetimes-in-closure-suggestion.stderr
+++ b/tests/ui/regions/account-for-lifetimes-in-closure-suggestion.stderr
@@ -1,0 +1,17 @@
+error: lifetime may not live long enough
+  --> $DIR/account-for-lifetimes-in-closure-suggestion.rs:13:22
+   |
+LL |     Thing.enter_scope(|ctx| {
+   |                        ---
+   |                        |
+   |                        has type `TwoThings<'_, '1>`
+   |                        has type `TwoThings<'2, '_>`
+LL |         SameLifetime(ctx);
+   |                      ^^^ this usage requires that `'1` must outlive `'2`
+   |
+   = note: requirement occurs because of the type `TwoThings<'_, '_>`, which makes the generic argument `'_` invariant
+   = note: the struct `TwoThings<'a, 'b>` is invariant over the parameter `'a`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.rs
+++ b/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.rs
@@ -1,5 +1,4 @@
-//@ known-bug: rust-lang/rust#124563
-
+// #124563
 use std::marker::PhantomData;
 
 pub trait Trait {}
@@ -17,11 +16,11 @@ where
     T: Trait,
 {
     type Trait = T;
-    type Bar = BarImpl<'a, 'b, T>;
+    type Bar = BarImpl<'a, 'b, T>; //~ ERROR lifetime bound not satisfied
 
     fn foo(&mut self) {
-        self.enter_scope(|ctx| {
-            BarImpl(ctx);
+        self.enter_scope(|ctx| { //~ ERROR lifetime may not live long enough
+            BarImpl(ctx); //~ ERROR lifetime may not live long enough
         });
     }
 }
@@ -44,3 +43,5 @@ where
 {
     type Foo = FooImpl<'a, 'b, T>;
 }
+
+fn main() {}

--- a/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
+++ b/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
@@ -1,0 +1,49 @@
+error[E0478]: lifetime bound not satisfied
+  --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:19:16
+   |
+LL |     type Bar = BarImpl<'a, 'b, T>;
+   |                ^^^^^^^^^^^^^^^^^^
+   |
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
+  --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:14:6
+   |
+LL | impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
+   |      ^^
+note: but lifetime parameter must outlive the lifetime `'b` as defined here
+  --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:14:10
+   |
+LL | impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
+   |          ^^
+
+error: lifetime may not live long enough
+  --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:23:21
+   |
+LL |         self.enter_scope(|ctx| {
+   |                           ---
+   |                           |
+   |                           has type `&'1 mut FooImpl<'_, '_, T>`
+   |                           has type `&mut FooImpl<'2, '_, T>`
+LL |             BarImpl(ctx);
+   |                     ^^^ this usage requires that `'1` must outlive `'2`
+
+error: lifetime may not live long enough
+  --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:22:9
+   |
+LL |   impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
+   |        --  -- lifetime `'b` defined here
+   |        |
+   |        lifetime `'a` defined here
+...
+LL | /         self.enter_scope(|ctx| {
+LL | |             BarImpl(ctx);
+LL | |         });
+   | |__________^ argument requires that `'a` must outlive `'b`
+   |
+   = help: consider adding the following bound: `'a: 'b`
+   = note: requirement occurs because of a mutable reference to `FooImpl<'_, '_, T>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0478`.

--- a/tests/ui/regions/regions-escape-method.fixed
+++ b/tests/ui/regions/regions-escape-method.fixed
@@ -13,5 +13,5 @@ impl S {
 
 fn main() {
     let s = S;
-    s.f(|p| p) //~ ERROR lifetime may not live long enough
+    s.f(|p| *p) //~ ERROR lifetime may not live long enough
 }

--- a/tests/ui/regions/regions-escape-method.stderr
+++ b/tests/ui/regions/regions-escape-method.stderr
@@ -1,11 +1,16 @@
 error: lifetime may not live long enough
-  --> $DIR/regions-escape-method.rs:15:13
+  --> $DIR/regions-escape-method.rs:16:13
    |
 LL |     s.f(|p| p)
    |          -- ^ returning this value requires that `'1` must outlive `'2`
    |          ||
    |          |return type of closure is &'2 i32
    |          has type `&'1 i32`
+   |
+help: dereference the return value
+   |
+LL |     s.f(|p| *p)
+   |             +
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Account for `for` lifetimes when constructing closure to see if dereferencing the return value would be valid.

Fix #125634, fix #124563.