### PR TITLE
Remove stray println from rustfmt's `rewrite_static`

### DIFF
--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -1994,7 +1994,6 @@ fn rewrite_static(
     static_parts: &StaticParts<'_>,
     offset: Indent,
 ) -> Option<String> {
-    println!("rewriting static");
     let colon = colon_spaces(context.config);
     let mut prefix = format!(
         "{}{}{}{} {}{}{}",


### PR DESCRIPTION
r? @calebcartwright @ytmimi -- though anyone should probably r+ this so it gets into nightly sooner than later, since it's obviously wrong. 

This can just be fixed in-tree, since I don't think we want to wait until the next sync to fix this.

Fix https://github.com/rust-lang/rustfmt/issues/6210
Fix https://github.com/rust-lang/rust/issues/126887
Fix https://github.com/rust-lang/rust-analyzer/issues/17486