### PR TITLE
Don't suggest awaiting in closure patterns

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/suggest.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/suggest.rs
@@ -209,8 +209,10 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             }
             (Some(ty), _) if self.same_type_modulo_infer(ty, exp_found.found) => match cause.code()
             {
-                ObligationCauseCode::Pattern { span: Some(then_span), .. } => {
-                    Some(ConsiderAddingAwait::FutureSugg { span: then_span.shrink_to_hi() })
+                ObligationCauseCode::Pattern { span: Some(then_span), origin_expr, .. } => {
+                    origin_expr.then_some(ConsiderAddingAwait::FutureSugg {
+                        span: then_span.shrink_to_hi(),
+                    })
                 }
                 ObligationCauseCode::IfExpression(box IfExpressionCause { then_id, .. }) => {
                     let then_span = self.find_block_span_from_hir_id(*then_id);

--- a/tests/ui/async-await/suggest-missing-await.rs
+++ b/tests/ui/async-await/suggest-missing-await.rs
@@ -71,4 +71,11 @@ async fn suggest_await_in_generic_pattern() {
     }
 }
 
+// Issue #126903
+async fn do_async() {}
+fn dont_suggest_awaiting_closure_patterns() {
+    Some(do_async()).map(|()| {});
+    //~^ ERROR mismatched types [E0308]
+}
+
 fn main() {}

--- a/tests/ui/async-await/suggest-missing-await.stderr
+++ b/tests/ui/async-await/suggest-missing-await.stderr
@@ -133,6 +133,18 @@ help: consider `await`ing on the `Future`
 LL |     match dummy_result().await {
    |                         ++++++
 
-error: aborting due to 7 previous errors
+error[E0308]: mismatched types
+  --> $DIR/suggest-missing-await.rs:77:27
+   |
+LL |     Some(do_async()).map(|()| {});
+   |                           ^^
+   |                           |
+   |                           expected future, found `()`
+   |                           expected due to this
+   |
+   = note: expected opaque type `impl Future<Output = ()>`
+                found unit type `()`
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #126903.

For
```rust
async fn do_async() {}

fn main() {
    Some(do_async()).map(|()| {});
}
```
the error is now
```rust
error[E0308]: mismatched types
 --> src/main.rs:4:27
  |
4 |     Some(do_async()).map(|()| {});
  |                           ^^
  |                           |
  |                           expected future, found `()`
  |                           expected due to this
  |
  = note: expected opaque type `impl Future<Output = ()>`
               found unit type `()`
```

Ideally, if `main` were to be `async`, it should be
```rs
error[E0308]: mismatched types
 --> src/main.rs:4:27
  |
4 |     Some(do_async()).map(|()| {});
  |                           ^^
  |                           |
  |                           expected future, found `()`
  |                           expected due to this
  |
  = note: expected opaque type `impl Future<Output = ()>`
               found unit type `()`
help: consider `await`ing on the `Future`
  |
4 |     Some(do_async().await).map(|()| {});
  |                    ++++++
```
However, this would mean `FnCtx::check_pat_top` would have to be called with an `origin_expr` in `rustc_hir_typeck::check::check_fn`, and that expr would have to be somehow plumbed through `FnCtxt::check_expr_closure` and closure signature deduction. I'm willing to work on the plumbing but unsure how to start.
