### PR TITLE
Reduce `&'static str` -> `String` conversions in compiler/rustc_*

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -262,7 +262,7 @@ pub trait LayoutCalculator {
         let only_variant = &variants[VariantIdx::new(0)];
         for field in only_variant {
             if field.is_unsized() {
-                self.delayed_bug("unsized field in union".to_string());
+                self.delayed_bug("unsized field in union");
             }
 
             align = align.max(field.align);

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -31,7 +31,7 @@ pub struct InvalidAbi {
     #[label]
     pub span: Span,
     pub abi: Symbol,
-    pub command: String,
+    pub command: &'static str,
     #[subdiagnostic]
     pub explain: Option<InvalidAbiReason>,
     #[subdiagnostic]

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1410,7 +1410,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 span: abi.span,
                 suggestion: format!("\"{suggested_name}\""),
             }),
-            command: "rustc --print=calling-conventions".to_string(),
+            command: "rustc --print=calling-conventions",
         });
     }
 

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -277,10 +277,10 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, '_, 'tcx> {
                 DescribePlaceOpt { including_downcast: true, including_tuple_field: true },
             );
             let note_msg = match opt_name {
-                Some(name) => format!("`{name}`"),
-                None => "value".to_owned(),
+                Some(name) => &format!("`{name}`"),
+                None => "value",
             };
-            if self.suggest_borrow_fn_like(&mut err, ty, &move_site_vec, &note_msg)
+            if self.suggest_borrow_fn_like(&mut err, ty, &move_site_vec, note_msg)
                 || if let UseSpans::FnSelfUse { kind, .. } = use_spans
                     && let CallKind::FnCall { fn_trait_id, self_ty } = kind
                     && let ty::Param(_) = self_ty.kind()

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -180,15 +180,15 @@ impl<'tcx> BorrowExplanation<'tcx> {
                     // If type is an ADT that implements Drop, then
                     // simplify output by reporting just the ADT name.
                     ty::Adt(adt, _args) if adt.has_dtor(tcx) && !adt.is_box() => {
-                        ("`Drop` code", format!("type `{}`", tcx.def_path_str(adt.did())))
+                        ("`Drop` code", &*format!("type `{}`", tcx.def_path_str(adt.did())))
                     }
 
                     // Otherwise, just report the whole type (and use
                     // the intentionally fuzzy phrase "destructor")
-                    ty::Closure(..) => ("destructor", "closure".to_owned()),
-                    ty::Coroutine(..) => ("destructor", "coroutine".to_owned()),
+                    ty::Closure(..) => ("destructor", "closure"),
+                    ty::Coroutine(..) => ("destructor", "coroutine"),
 
-                    _ => ("destructor", format!("type `{}`", local_decl.ty)),
+                    _ => ("destructor", &*format!("type `{}`", local_decl.ty)),
                 };
 
                 match local_names[dropped_local] {

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -1,5 +1,7 @@
 //! Borrow checker diagnostics.
 
+use std::borrow::Cow;
+
 use crate::session_diagnostics::{
     CaptureArgLabel, CaptureReasonLabel, CaptureReasonNote, CaptureReasonSuggest, CaptureVarCause,
     CaptureVarKind, CaptureVarPathUseCause, OnClosureNote,
@@ -1018,8 +1020,8 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, '_, 'tcx> {
         if let UseSpans::FnSelfUse { var_span, fn_call_span, fn_span, kind } = move_spans {
             let place_name = self
                 .describe_place(moved_place.as_ref())
-                .map(|n| format!("`{n}`"))
-                .unwrap_or_else(|| "value".to_owned());
+                .map(|n| Cow::Owned(format!("`{n}`")))
+                .unwrap_or("value".into());
             match kind {
                 CallKind::FnCall { fn_trait_id, self_ty }
                     if self.infcx.tcx.is_lang_item(fn_trait_id, LangItem::FnOnce) =>
@@ -1138,7 +1140,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, '_, 'tcx> {
                         let func = tcx.def_path_str(method_did);
                         err.subdiagnostic(CaptureReasonNote::FuncTakeSelf {
                             func,
-                            place_name: place_name.clone(),
+                            place_name: &place_name,
                             span: self_arg.span,
                         });
                     }

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -585,7 +585,11 @@ impl UseSpans<'_> {
 
     /// Add a span label to the arguments of the closure, if it exists.
     #[allow(rustc::diagnostic_outside_of_impl)]
-    pub(super) fn args_subdiag(self, err: &mut Diag<'_>, f: impl FnOnce(Span) -> CaptureArgLabel) {
+    pub(super) fn args_subdiag<'a>(
+        self,
+        err: &mut Diag<'_>,
+        f: impl FnOnce(Span) -> CaptureArgLabel<'a>,
+    ) {
         if let UseSpans::ClosureUse { args_span, .. } = self {
             err.subdiagnostic(f(args_span));
         }

--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -571,8 +571,8 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, '_, 'tcx> {
                 if binds_to.is_empty() {
                     let place_ty = move_from.ty(self.body, self.infcx.tcx).ty;
                     let place_desc = match self.describe_place(move_from.as_ref()) {
-                        Some(desc) => format!("`{desc}`"),
-                        None => "value".to_string(),
+                        Some(desc) => &format!("`{desc}`"),
+                        None => "value",
                     };
 
                     if let Some(expr) = self.find_expr(span) {
@@ -603,8 +603,8 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, '_, 'tcx> {
                 let use_span = use_spans.var_or_use();
                 let place_ty = original_path.ty(self.body, self.infcx.tcx).ty;
                 let place_desc = match self.describe_place(original_path.as_ref()) {
-                    Some(desc) => format!("`{desc}`"),
-                    None => "value".to_string(),
+                    Some(desc) => &format!("`{desc}`"),
+                    None => "value",
                 };
 
                 if let Some(expr) = self.find_expr(use_span) {

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -873,7 +873,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, '_, 'tcx> {
                     self.infcx.tcx,
                     diag,
                     fn_returns,
-                    lifetime.to_string(),
+                    lifetime.as_str(),
                     Some(arg),
                     captures,
                     Some((param.param_ty_span, param.param_ty.to_string())),

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -863,8 +863,8 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, '_, 'tcx> {
             let lifetime = if f.has_name() { fr_name.name } else { kw::UnderscoreLifetime };
 
             let arg = match param.param.pat.simple_ident() {
-                Some(simple_ident) => format!("argument `{simple_ident}`"),
-                None => "the argument".to_string(),
+                Some(simple_ident) => &format!("argument `{simple_ident}`"),
+                None => "the argument",
             };
             let captures = format!("captures data from {arg}");
 

--- a/compiler/rustc_borrowck/src/region_infer/dump_mir.rs
+++ b/compiler/rustc_borrowck/src/region_infer/dump_mir.rs
@@ -79,7 +79,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 Locations::All(span) => {
                     ("All", tcx.sess.source_map().span_to_embeddable_string(*span))
                 }
-                Locations::Single(loc) => ("Single", format!("{loc:?}")),
+                Locations::Single(loc) => ("Single", format!("{loc:?}").into()),
             };
             with_msg(&format!("{sup:?}: {sub:?} due to {category:?} at {name}({arg}) ({span:?}"))?;
         }

--- a/compiler/rustc_borrowck/src/region_infer/graphviz.rs
+++ b/compiler/rustc_borrowck/src/region_infer/graphviz.rs
@@ -10,10 +10,10 @@ use itertools::Itertools;
 use rustc_graphviz as dot;
 use rustc_middle::ty::UniverseIndex;
 
-fn render_outlives_constraint(constraint: &OutlivesConstraint<'_>) -> String {
+fn render_outlives_constraint(constraint: &OutlivesConstraint<'_>) -> Cow<'static, str> {
     match constraint.locations {
-        Locations::All(_) => "All(...)".to_string(),
-        Locations::Single(loc) => format!("{loc:?}"),
+        Locations::All(_) => "All(...)".into(),
+        Locations::Single(loc) => format!("{loc:?}").into(),
     }
 }
 
@@ -80,7 +80,7 @@ impl<'a, 'this, 'tcx> dot::Labeller<'this> for RawConstraints<'a, 'tcx> {
         dot::LabelText::LabelStr(render_region_vid(*n, self.regioncx).into())
     }
     fn edge_label(&'this self, e: &OutlivesConstraint<'tcx>) -> dot::LabelText<'this> {
-        dot::LabelText::LabelStr(render_outlives_constraint(e).into())
+        dot::LabelText::LabelStr(render_outlives_constraint(e))
     }
 }
 
@@ -118,7 +118,7 @@ impl<'a, 'this, 'tcx> dot::Labeller<'this> for SccConstraints<'a, 'tcx> {
     type Edge = (ConstraintSccIndex, ConstraintSccIndex);
 
     fn graph_id(&'this self) -> dot::Id<'this> {
-        dot::Id::new("RegionInferenceContext".to_string()).unwrap()
+        dot::Id::new("RegionInferenceContext").unwrap()
     }
     fn node_id(&'this self, n: &ConstraintSccIndex) -> dot::Id<'this> {
         dot::Id::new(format!("r{}", n.index())).unwrap()

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::fmt::Write;
 use std::rc::Rc;
 
 use rustc_data_structures::binary_search_util;
@@ -335,7 +336,7 @@ fn sccs_info<'tcx>(infcx: &BorrowckInferCtxt<'tcx>, sccs: &ConstraintSccs) {
 
     let mut reg_vars_to_origins_str = "region variables to origins:\n".to_string();
     for (reg_var, origin) in var_to_origin_sorted.into_iter() {
-        reg_vars_to_origins_str.push_str(&format!("{reg_var:?}: {origin:?}\n"));
+        writeln!(reg_vars_to_origins_str, "{reg_var:?}: {origin:?}").unwrap();
     }
     debug!("{}", reg_vars_to_origins_str);
 
@@ -351,11 +352,13 @@ fn sccs_info<'tcx>(infcx: &BorrowckInferCtxt<'tcx>, sccs: &ConstraintSccs) {
     let mut components_str = "strongly connected components:".to_string();
     for (scc_idx, reg_vars_origins) in components.iter().enumerate() {
         let regions_info = reg_vars_origins.clone().into_iter().collect::<Vec<_>>();
-        components_str.push_str(&format!(
+        write!(
+            components_str,
             "{:?}: {:?},\n)",
             ConstraintSccIndex::from_usize(scc_idx),
             regions_info,
-        ))
+        )
+        .unwrap();
     }
     debug!("{}", components_str);
 

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -338,7 +338,7 @@ fn sccs_info<'tcx>(infcx: &BorrowckInferCtxt<'tcx>, sccs: &ConstraintSccs) {
     for (reg_var, origin) in var_to_origin_sorted.into_iter() {
         writeln!(reg_vars_to_origins_str, "{reg_var:?}: {origin:?}").unwrap();
     }
-    debug!("{}", reg_vars_to_origins_str);
+    debug!("{reg_vars_to_origins_str}");
 
     let num_components = sccs.num_sccs();
     let mut components = vec![FxIndexSet::default(); num_components];

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -426,7 +426,7 @@ pub(crate) enum CaptureReasonSuggest<'tcx> {
 }
 
 #[derive(Subdiagnostic)]
-pub(crate) enum CaptureArgLabel {
+pub(crate) enum CaptureArgLabel<'a> {
     #[label(borrowck_value_capture_here)]
     Capture {
         is_within: bool,
@@ -435,7 +435,7 @@ pub(crate) enum CaptureArgLabel {
     },
     #[label(borrowck_move_out_place_here)]
     MoveOutPlace {
-        place: String,
+        place: &'a str,
         #[primary_span]
         args_span: Span,
     },

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -375,7 +375,7 @@ pub(crate) enum CaptureReasonLabel<'a> {
 }
 
 #[derive(Subdiagnostic)]
-pub(crate) enum CaptureReasonNote {
+pub(crate) enum CaptureReasonNote<'a> {
     #[note(borrowck_moved_a_fn_once_in_call)]
     FnOnceMoveInCall {
         #[primary_span]
@@ -394,7 +394,7 @@ pub(crate) enum CaptureReasonNote {
     #[note(borrowck_func_take_self_moved_place)]
     FuncTakeSelf {
         func: String,
-        place_name: String,
+        place_name: &'a str,
         #[primary_span]
         span: Span,
     },

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use rustc_errors::{
     codes::*, Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, MultiSpan,
     SingleLabelManySpans, SubdiagMessageOp, Subdiagnostic,
@@ -508,8 +510,8 @@ pub(crate) struct InvalidFormatString {
     #[primary_span]
     #[label]
     pub(crate) span: Span,
-    pub(crate) desc: String,
-    pub(crate) label1: String,
+    pub(crate) desc: Cow<'static, str>,
+    pub(crate) label1: Cow<'static, str>,
     #[subdiagnostic]
     pub(crate) note_: Option<InvalidFormatStringNote>,
     #[subdiagnostic]
@@ -521,7 +523,7 @@ pub(crate) struct InvalidFormatString {
 #[derive(Subdiagnostic)]
 #[note(builtin_macros_note)]
 pub(crate) struct InvalidFormatStringNote {
-    pub(crate) note: String,
+    pub(crate) note: Cow<'static, str>,
 }
 
 #[derive(Subdiagnostic)]
@@ -529,7 +531,7 @@ pub(crate) struct InvalidFormatStringNote {
 pub(crate) struct InvalidFormatStringLabel {
     #[primary_span]
     pub(crate) span: Span,
-    pub(crate) label: String,
+    pub(crate) label: Cow<'static, str>,
 }
 
 #[derive(Subdiagnostic)]
@@ -629,11 +631,11 @@ pub(crate) struct FormatUnusedArgs {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_format_pos_mismatch)]
-pub(crate) struct FormatPositionalMismatch {
+pub(crate) struct FormatPositionalMismatch<'a> {
     #[primary_span]
     pub(crate) span: MultiSpan,
     pub(crate) n: usize,
-    pub(crate) desc: String,
+    pub(crate) desc: &'a str,
     #[subdiagnostic]
     pub(crate) highlight: SingleLabelManySpans,
 }

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -195,9 +195,9 @@ fn make_format_args(
                                 );
                             } else {
                                 let sugg_fmt = match args.explicit_args().len() {
-                                    0 => "{}".to_string(),
+                                    0 => "{}",
                                     _ => {
-                                        format!("{}{{}}", "{} ".repeat(args.explicit_args().len()))
+                                        &format!("{}{{}}", "{} ".repeat(args.explicit_args().len()))
                                     }
                                 };
                                 err.span_suggestion(
@@ -811,9 +811,9 @@ fn report_invalid_references(
     parser: parse::Parser<'_>,
 ) {
     let num_args_desc = match args.explicit_args().len() {
-        0 => "no arguments were given".to_string(),
-        1 => "there is 1 argument".to_string(),
-        n => format!("there are {n} arguments"),
+        0 => "no arguments were given",
+        1 => "there is 1 argument",
+        n => &format!("there are {n} arguments"),
     };
 
     let mut e;

--- a/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
+++ b/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
@@ -55,7 +55,7 @@ pub fn inject(
     is_test_crate: bool,
     dcx: DiagCtxtHandle<'_>,
 ) {
-    let ecfg = ExpansionConfig::default("proc_macro".to_string(), features);
+    let ecfg = ExpansionConfig::default("proc_macro", features);
     let mut cx = ExtCtxt::new(sess, ecfg, resolver, None);
 
     let mut collect = CollectProcMacros {

--- a/compiler/rustc_builtin_macros/src/standard_library_imports.rs
+++ b/compiler/rustc_builtin_macros/src/standard_library_imports.rs
@@ -41,7 +41,7 @@ pub fn inject(
     let span = DUMMY_SP.with_def_site_ctxt(expn_id.to_expn_id());
     let call_site = DUMMY_SP.with_call_site_ctxt(expn_id.to_expn_id());
 
-    let ecfg = ExpansionConfig::default("std_lib_injection".to_string(), features);
+    let ecfg = ExpansionConfig::default("std_lib_injection", features);
     let cx = ExtCtxt::new(sess, ecfg, resolver, None);
 
     // .rev() to preserve ordering above in combination with insert(0, ...)

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -438,11 +438,11 @@ fn get_location_info(cx: &ExtCtxt<'_>, item: &ast::Item) -> (Symbol, usize, usiz
         cx.sess.source_map().span_to_location_info(span);
 
     let file_name = match source_file {
-        Some(sf) => sf.name.display(FileNameDisplayPreference::Remapped).to_string(),
-        None => "no-location".to_string(),
+        Some(sf) => &sf.name.display(FileNameDisplayPreference::Remapped).to_string(),
+        None => "no-location",
     };
 
-    (Symbol::intern(&file_name), lo_line, lo_col, hi_line, hi_col)
+    (Symbol::intern(file_name), lo_line, lo_col, hi_line, hi_col)
 }
 
 fn item_path(mod_path: &[Ident], item_ident: &Ident) -> String {

--- a/compiler/rustc_builtin_macros/src/test_harness.rs
+++ b/compiler/rustc_builtin_macros/src/test_harness.rs
@@ -237,7 +237,7 @@ fn generate_test_harness(
     panic_strategy: PanicStrategy,
     test_runner: Option<ast::Path>,
 ) {
-    let econfig = ExpansionConfig::default("test".to_string(), features);
+    let econfig = ExpansionConfig::default("test", features);
     let ext_cx = ExtCtxt::new(sess, econfig, resolver, None);
 
     let expn_id = ext_cx.resolver.expansion_for_ast_pass(

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1414,19 +1414,19 @@ fn build_vtable_type_di_node<'ll, 'tcx>(
                 .filter_map(|(index, vtable_entry)| {
                     let (field_name, field_type_di_node) = match vtable_entry {
                         ty::VtblEntry::MetadataDropInPlace => {
-                            ("drop_in_place".to_string(), void_pointer_type_di_node)
+                            ("drop_in_place", void_pointer_type_di_node)
                         }
                         ty::VtblEntry::Method(_) => {
                             // Note: This code does not try to give a proper name to each method
                             //       because their might be multiple methods with the same name
                             //       (coming from different traits).
-                            (format!("__method{index}"), void_pointer_type_di_node)
+                            (&*format!("__method{index}"), void_pointer_type_di_node)
                         }
                         ty::VtblEntry::TraitVPtr(_) => {
-                            (format!("__super_trait_ptr{index}"), void_pointer_type_di_node)
+                            (&*format!("__super_trait_ptr{index}"), void_pointer_type_di_node)
                         }
-                        ty::VtblEntry::MetadataAlign => ("align".to_string(), usize_di_node),
-                        ty::VtblEntry::MetadataSize => ("size".to_string(), usize_di_node),
+                        ty::VtblEntry::MetadataAlign => ("align", usize_di_node),
+                        ty::VtblEntry::MetadataSize => ("size", usize_di_node),
                         ty::VtblEntry::Vacant => return None,
                     };
 

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -680,16 +680,13 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
     ) -> &mut Self {
         let expected_label = expected_label.to_string();
         let expected_label = if expected_label.is_empty() {
-            "expected".to_string()
+            "expected"
         } else {
-            format!("expected {expected_label}")
+            &format!("expected {expected_label}")
         };
         let found_label = found_label.to_string();
-        let found_label = if found_label.is_empty() {
-            "found".to_string()
-        } else {
-            format!("found {found_label}")
-        };
+        let found_label =
+            if found_label.is_empty() { "found" } else { &format!("found {found_label}") };
         let (found_padding, expected_padding) = if expected_label.len() > found_label.len() {
             (expected_label.len() - found_label.len(), 0)
         } else {

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1404,8 +1404,8 @@ fn pretty_printing_compatibility_hack(item: &Item, sess: &Session) {
             // FIXME: make this translatable
             #[allow(rustc::untranslatable_diagnostic)]
             sess.dcx().emit_fatal(errors::ProcMacroBackCompat {
-                crate_name: "rental".to_string(),
-                fixed_version: "0.5.6".to_string(),
+                crate_name: "rental",
+                fixed_version: "0.5.6",
             });
         }
     }

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -462,6 +462,6 @@ pub(crate) struct GlobDelegationTraitlessQpath {
 #[diag(expand_proc_macro_back_compat)]
 #[note]
 pub struct ProcMacroBackCompat {
-    pub crate_name: String,
-    pub fixed_version: String,
+    pub crate_name: &'static str,
+    pub fixed_version: &'static str,
 }

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -37,6 +37,7 @@ use rustc_span::symbol::{sym, Ident};
 use rustc_span::{ErrorGuaranteed, FileName, LocalExpnId, Span};
 
 use smallvec::SmallVec;
+use std::borrow::Cow;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -2207,7 +2208,7 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
 }
 
 pub struct ExpansionConfig<'feat> {
-    pub crate_name: String,
+    pub crate_name: Cow<'static, str>,
     pub features: &'feat Features,
     pub recursion_limit: Limit,
     pub trace_mac: bool,
@@ -2220,9 +2221,12 @@ pub struct ExpansionConfig<'feat> {
 }
 
 impl ExpansionConfig<'_> {
-    pub fn default(crate_name: String, features: &Features) -> ExpansionConfig<'_> {
+    pub fn default(
+        crate_name: impl Into<Cow<'static, str>>,
+        features: &Features,
+    ) -> ExpansionConfig<'_> {
         ExpansionConfig {
-            crate_name,
+            crate_name: crate_name.into(),
             features,
             recursion_limit: Limit::new(1024),
             trace_mac: false,

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -963,10 +963,10 @@ fn report_trait_method_mismatch<'tcx>(
         {
             let ty = trait_sig.inputs()[0];
             let sugg = match ExplicitSelf::determine(ty, |ty| ty == impl_trait_ref.self_ty()) {
-                ExplicitSelf::ByValue => "self".to_owned(),
-                ExplicitSelf::ByReference(_, hir::Mutability::Not) => "&self".to_owned(),
-                ExplicitSelf::ByReference(_, hir::Mutability::Mut) => "&mut self".to_owned(),
-                _ => format!("self: {ty}"),
+                ExplicitSelf::ByValue => "self",
+                ExplicitSelf::ByReference(_, hir::Mutability::Not) => "&self",
+                ExplicitSelf::ByReference(_, hir::Mutability::Mut) => "&mut self",
+                _ => &format!("self: {ty}"),
             };
 
             // When the `impl` receiver is an arbitrary self type, like `self: Box<Self>`, the
@@ -1182,10 +1182,10 @@ fn compare_self_type<'tcx>(
         let self_arg_ty = tcx.liberate_late_bound_regions(method.def_id, self_arg_ty);
         let can_eq_self = |ty| infcx.can_eq(param_env, untransformed_self_ty, ty);
         match ExplicitSelf::determine(self_arg_ty, can_eq_self) {
-            ExplicitSelf::ByValue => "self".to_owned(),
-            ExplicitSelf::ByReference(_, hir::Mutability::Not) => "&self".to_owned(),
-            ExplicitSelf::ByReference(_, hir::Mutability::Mut) => "&mut self".to_owned(),
-            _ => format!("self: {self_arg_ty}"),
+            ExplicitSelf::ByValue => "self".into(),
+            ExplicitSelf::ByReference(_, hir::Mutability::Not) => "&self".into(),
+            ExplicitSelf::ByReference(_, hir::Mutability::Mut) => "&mut self".into(),
+            _ => Cow::Owned(format!("self: {self_arg_ty}")),
         }
     };
 

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -513,7 +513,7 @@ fn suggestion_signature<'tcx>(
                 .build()
                 .err_ctxt()
                 .ty_kind_suggestion(tcx.param_env(assoc.def_id), ty)
-                .unwrap_or_else(|| "value".to_string());
+                .unwrap_or_else(|| "value".into());
             format!("const {}: {} = {};", assoc.name, ty, val)
         }
     }

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2415,9 +2415,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         for br in referenced_regions.difference(&constrained_regions) {
             let br_name = match *br {
                 ty::BrNamed(_, kw::UnderscoreLifetime) | ty::BrAnon | ty::BrEnv => {
-                    "an anonymous lifetime".to_string()
+                    "an anonymous lifetime"
                 }
-                ty::BrNamed(_, name) => format!("lifetime `{name}`"),
+                ty::BrNamed(_, name) => &format!("lifetime `{name}`"),
             };
 
             let mut err = generate_err(&br_name);

--- a/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/structured_errors/wrong_number_of_generic_args.rs
@@ -358,7 +358,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                     matches!(fn_decl.output, hir::FnRetTy::Return(ty) if ty.hir_id == ty_id);
 
                 if in_arg || (in_ret && fn_decl.lifetime_elision_allowed) {
-                    return std::iter::repeat("'_".to_owned())
+                    return std::iter::repeat("'_")
                         .take(num_params_to_take)
                         .collect::<Vec<_>>()
                         .join(", ");
@@ -384,7 +384,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
             })
             | hir::Node::AnonConst(..) = node
             {
-                return std::iter::repeat("'static".to_owned())
+                return std::iter::repeat("'static")
                     .take(num_params_to_take.saturating_sub(ret.len()))
                     .collect::<Vec<_>>()
                     .join(", ");

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -531,12 +531,12 @@ pub struct NoAssociatedItem {
 
 #[derive(Subdiagnostic)]
 #[note(hir_typeck_candidate_trait_note)]
-pub struct CandidateTraitNote {
+pub struct CandidateTraitNote<'a> {
     #[primary_span]
     pub span: Span,
     pub trait_name: String,
     pub item_name: Ident,
-    pub action_or_ty: String,
+    pub action_or_ty: Cow<'a, str>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -992,18 +992,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         let mut sp = MultiSpan::from_span(path_segment.ident.span);
+        let reciever = match rcvr.kind {
+            ExprKind::Path(QPath::Resolved(None, hir::Path { segments: [segment], .. })) => {
+                &format!("`{}`", segment.ident)
+            }
+            _ => "its receiver",
+        };
+
         sp.push_span_label(
             path_segment.ident.span,
-            format!(
-                "this call modifies {} in-place",
-                match rcvr.kind {
-                    ExprKind::Path(QPath::Resolved(
-                        None,
-                        hir::Path { segments: [segment], .. },
-                    )) => format!("`{}`", segment.ident),
-                    _ => "its receiver".to_string(),
-                }
-            ),
+            format!("this call modifies {reciever} in-place",),
         );
 
         let modifies_rcvr_note =

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -126,11 +126,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             let msg = match def_id_or_name {
                 DefIdOrName::DefId(def_id) => match self.tcx.def_kind(def_id) {
-                    DefKind::Ctor(CtorOf::Struct, _) => "construct this tuple struct".to_string(),
-                    DefKind::Ctor(CtorOf::Variant, _) => "construct this tuple variant".to_string(),
-                    kind => format!("call this {}", self.tcx.def_kind_descr(kind, def_id)),
+                    DefKind::Ctor(CtorOf::Struct, _) => "construct this tuple struct",
+                    DefKind::Ctor(CtorOf::Variant, _) => "construct this tuple variant",
+                    kind => &format!("call this {}", self.tcx.def_kind_descr(kind, def_id)),
                 },
-                DefIdOrName::Name(name) => format!("call this {name}"),
+                DefIdOrName::Name(name) => &format!("call this {name}"),
             };
 
             let sugg = match expr.kind {
@@ -1229,8 +1229,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .must_apply_modulo_regions()
         {
             let suggestion = match self.tcx.hir().maybe_get_struct_pattern_shorthand_field(expr) {
-                Some(ident) => format!(": {ident}.clone()"),
-                None => ".clone()".to_string(),
+                Some(ident) => &format!(": {ident}.clone()"),
+                None => ".clone()",
             };
 
             diag.span_suggestion_verbose(
@@ -1394,8 +1394,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         let suggestion = match self.tcx.hir().maybe_get_struct_pattern_shorthand_field(expr) {
-            Some(ident) => format!(": {ident}.is_some()"),
-            None => ".is_some()".to_string(),
+            Some(ident) => &format!(": {ident}.is_some()"),
+            None => ".is_some()",
         };
 
         diag.span_suggestion_verbose(
@@ -2035,12 +2035,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let span = expr.span;
 
             let (msg, suggestion) = if expected.is_never() {
-                (
-                    "consider adding a diverging expression here",
-                    "`loop {}` or `panic!(\"...\")`".to_string(),
-                )
+                ("consider adding a diverging expression here", "`loop {}` or `panic!(\"...\")`")
             } else {
-                ("consider returning a value here", format!("`{expected}` value"))
+                ("consider returning a value here", &*format!("`{expected}` value"))
             };
 
             let src_map = self.tcx.sess.source_map();

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -2196,8 +2196,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 };
 
                 let (open, close) = match ctor_kind {
-                    Some(CtorKind::Fn) => ("(".to_owned(), ")"),
-                    None => (format!(" {{ {field_name}: "), " }"),
+                    Some(CtorKind::Fn) => ("(", ")"),
+                    None => (&*format!(" {{ {field_name}: "), " }"),
 
                     Some(CtorKind::Const) => unreachable!("unit variants don't have fields"),
                 };

--- a/compiler/rustc_hir_typeck/src/method/prelude_edition_lints.rs
+++ b/compiler/rustc_hir_typeck/src/method/prelude_edition_lints.rs
@@ -387,14 +387,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             Some(probe::AutorefOrPtrAdjustment::ToConstPtr) | None => "",
         };
 
+        let expr_text_owned;
         let (expr_text, precise) = if let Some(expr_text) = expr
             .span
             .find_ancestor_inside(outer)
             .and_then(|span| self.sess().source_map().span_to_snippet(span).ok())
         {
-            (expr_text, true)
+            expr_text_owned = expr_text;
+            (&*expr_text_owned, true)
         } else {
-            ("(..)".to_string(), false)
+            ("(..)", false)
         };
 
         let adjusted_text = if let Some(probe::AutorefOrPtrAdjustment::ToConstPtr) =

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -6,6 +6,7 @@
 use crate::errors::{self, CandidateTraitNote, NoAssociatedItem};
 use crate::Expectation;
 use crate::FnCtxt;
+use core::fmt::Write;
 use core::ops::ControlFlow;
 use hir::Expr;
 use rustc_ast::ast::Mutability;
@@ -4047,17 +4048,17 @@ fn print_disambiguation_help<'tcx>(
             .collect::<Vec<_>>()
             .join(", ");
 
-            let args = format!("({}{})", rcvr_ref, args);
-            let candidate = if let Some(candidate) = candidate_idx {
-                &format!("candidate #{candidate}")
-            } else {
-                "the candidate"
-            };
+            let mut candidate_msg = format!("disambiguate the {def_kind_descr} for ");
+            match candidate_idx {
+                Some(candidate) => write!(candidate_msg, "candidate #{candidate}"),
+                None => write!(candidate_msg, "the candidate"),
+            }
+            .unwrap();
 
             err.span_suggestion_verbose(
                 span,
-                format!("disambiguate the {def_kind_descr} for {candidate}",),
-                format!("{trait_ref}::{item_name}{args}"),
+                candidate_msg,
+                format!("{trait_ref}::{item_name}({rcvr_ref}{args})"),
                 Applicability::HasPlaceholders,
             );
             return None;

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2201,7 +2201,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                     args.iter().collect()
                 };
-                format!(
+                &format!(
                     "({}{})",
                     first_arg.unwrap_or(""),
                     explicit_args
@@ -2211,16 +2211,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             .sess
                             .source_map()
                             .span_to_snippet(arg.span)
+                            .map(Cow::Owned)
                             .unwrap_or_else(|_| {
                                 applicability = Applicability::HasPlaceholders;
-                                "_".to_owned()
+                                "_".into()
                             }))
                         .collect::<Vec<_>>()
                         .join(", "),
                 )
             } else {
                 applicability = Applicability::HasPlaceholders;
-                "(...)".to_owned()
+                "(...)"
             };
             err.span_suggestion(
                 sugg_span,
@@ -2436,7 +2437,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         .sess
                         .source_map()
                         .span_to_snippet(lit.span)
-                        .unwrap_or_else(|_| "<numeric literal>".to_owned());
+                        .map(Cow::Owned)
+                        .unwrap_or("<numeric literal>".into());
 
                     // If this is a floating point literal that ends with '.',
                     // get rid of it to stop this from becoming a member access.
@@ -4036,7 +4038,11 @@ fn print_disambiguation_help<'tcx>(
             .into_iter()
             .chain(args)
             .map(|arg| {
-                tcx.sess.source_map().span_to_snippet(arg.span).unwrap_or_else(|_| "_".to_owned())
+                tcx.sess
+                    .source_map()
+                    .span_to_snippet(arg.span)
+                    .map(Cow::Owned)
+                    .unwrap_or("_".into())
             })
             .collect::<Vec<_>>()
             .join(", ");

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -21,6 +21,7 @@ use crate::infer::error_reporting::{
     ObligationCauseAsDiagArg,
 };
 
+use std::borrow::Cow;
 use std::path::PathBuf;
 
 pub mod note_and_explain;
@@ -153,7 +154,7 @@ pub enum SourceKindSubdiag<'a> {
         #[primary_span]
         span: Span,
         arg_count: usize,
-        args: String,
+        args: Cow<'static, str>,
     },
 }
 

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -995,7 +995,7 @@ impl Subdiagnostic for MoreTargeted {
 
 #[derive(Diagnostic)]
 #[diag(infer_but_needs_to_satisfy, code = E0759)]
-pub struct ButNeedsToSatisfy {
+pub struct ButNeedsToSatisfy<'a> {
     #[primary_span]
     pub sp: Span,
     #[label(infer_influencer)]
@@ -1016,7 +1016,7 @@ pub struct ButNeedsToSatisfy {
     pub param_name: String,
     pub spans_empty: bool,
     pub has_lifetime: bool,
-    pub lifetime: String,
+    pub lifetime: &'a str,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -345,7 +345,7 @@ pub fn unexpected_hidden_region_diagnostic<'tcx>(
                     tcx,
                     &mut err,
                     fn_returns,
-                    hidden_region.to_string(),
+                    &hidden_region.to_string(),
                     None,
                     format!("captures `{hidden_region}`"),
                     None,

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -531,7 +531,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 let args = if self.tcx.get_diagnostic_item(sym::iterator_collect_fn)
                     == Some(generics_def_id)
                 {
-                    "Vec<_>".to_string()
+                    "Vec<_>".into()
                 } else {
                     let mut printer = fmt_printer(self, Namespace::TypeNS);
                     printer
@@ -547,7 +547,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             }
                         }))
                         .unwrap();
-                    printer.into_buffer()
+                    printer.into_buffer().into()
                 };
 
                 if !have_turbofish {

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -98,7 +98,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         let return_sp = sub_origin.span();
         let param = self.find_param_with_region(*sup_r, *sub_r)?;
         let simple_ident = param.param.pat.simple_ident();
-        let lifetime_name = if sup_r.has_name() { sup_r.to_string() } else { "'_".to_owned() };
+        let lifetime_name = if sup_r.has_name() { &sup_r.to_string() } else { "'_" };
 
         let (mention_influencer, influencer_point) =
             if sup_origin.span().overlaps(param.param_ty_span) {
@@ -187,7 +187,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             req_introduces_loc: subdiag,
 
             has_lifetime: sup_r.has_name(),
-            lifetime: lifetime_name.clone(),
+            lifetime: lifetime_name,
             has_param_name: simple_ident.is_some(),
             param_name: simple_ident.map(|x| x.to_string()).unwrap_or_default(),
             spans_empty,
@@ -262,7 +262,7 @@ pub fn suggest_new_region_bound(
     tcx: TyCtxt<'_>,
     err: &mut Diag<'_>,
     fn_returns: Vec<&rustc_hir::Ty<'_>>,
-    lifetime_name: String,
+    lifetime_name: &str,
     arg: Option<&str>,
     captures: String,
     param: Option<(Span, String)>,
@@ -319,7 +319,7 @@ pub fn suggest_new_region_bound(
                 } else if opaque.bounds.iter().any(|arg| {
                     matches!(arg,
                         GenericBound::Outlives(Lifetime { ident, .. })
-                        if ident.name.to_string() == lifetime_name )
+                        if ident.name.as_str() == lifetime_name )
                 }) {
                 } else {
                     // get a lifetime name of existing named lifetimes if any

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -238,8 +238,8 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         }
 
         let arg = match param.param.pat.simple_ident() {
-            Some(simple_ident) => format!("argument `{simple_ident}`"),
-            None => "the argument".to_string(),
+            Some(simple_ident) => &format!("argument `{simple_ident}`"),
+            None => "the argument",
         };
         let captures = format!("captures data from {arg}");
         suggest_new_region_bound(
@@ -263,7 +263,7 @@ pub fn suggest_new_region_bound(
     err: &mut Diag<'_>,
     fn_returns: Vec<&rustc_hir::Ty<'_>>,
     lifetime_name: String,
-    arg: Option<String>,
+    arg: Option<&str>,
     captures: String,
     param: Option<(Span, String)>,
     scope_def_id: Option<LocalDefId>,

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -194,7 +194,7 @@ fn configure_and_expand(
         // Create the config for macro expansion
         let recursion_limit = get_recursion_limit(pre_configured_attrs, sess);
         let cfg = rustc_expand::expand::ExpansionConfig {
-            crate_name: crate_name.to_string(),
+            crate_name: crate_name.to_string().into(),
             features,
             recursion_limit,
             trace_mac: sess.opts.unstable_opts.trace_macros,

--- a/compiler/rustc_lint/src/context/diagnostics.rs
+++ b/compiler/rustc_lint/src/context/diagnostics.rs
@@ -133,11 +133,11 @@ pub(super) fn decorate_lint(sess: &Session, diagnostic: BuiltinLintDiag, diag: &
         } => {
             let sub = suggestion.map(|suggestion| stability::DeprecationSuggestion {
                 span: suggestion_span,
-                kind: "macro".to_owned(),
+                kind: "macro",
                 suggestion,
             });
 
-            stability::Deprecated { sub, kind: "macro".to_owned(), path, note, since_kind }
+            stability::Deprecated { sub, kind: "macro", path, note, since_kind }
                 .decorate_lint(diag);
         }
         BuiltinLintDiag::UnusedDocComment(attr_span) => {
@@ -215,9 +215,9 @@ pub(super) fn decorate_lint(sess: &Session, diagnostic: BuiltinLintDiag, diag: &
             let suggestion = if let Some(deletion_span) = deletion_span {
                 let (use_span, replace_lt) = if elide {
                     let use_span = sess.source_map().span_extend_while_whitespace(use_span);
-                    (use_span, String::new())
+                    (use_span, "")
                 } else {
-                    (use_span, "'_".to_owned())
+                    (use_span, "'_")
                 };
                 debug!(?deletion_span, ?use_span);
 

--- a/compiler/rustc_lint/src/let_underscore.rs
+++ b/compiler/rustc_lint/src/let_underscore.rs
@@ -160,7 +160,7 @@ impl<'tcx> LateLintPass<'tcx> for LetUnderscore {
                 let mut span = MultiSpan::from_span(pat.span);
                 span.push_span_label(
                     pat.span,
-                    "this lock is not assigned to a binding and is immediately dropped".to_string(),
+                    "this lock is not assigned to a binding and is immediately dropped",
                 );
                 cx.emit_span_lint(LET_UNDERSCORE_LOCK, span, NonBindingLet::SyncLock { sub });
             // Only emit let_underscore_drop for top-level `_` patterns.

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2772,7 +2772,7 @@ pub struct SingleUseLifetimeSugg {
     #[suggestion_part(code = "{replace_lt}")]
     pub use_span: Span,
 
-    pub replace_lt: String,
+    pub replace_lt: &'static str,
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1,6 +1,6 @@
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
-use std::num::NonZero;
+use std::{borrow::Cow, num::NonZero};
 
 use crate::errors::RequestedLevel;
 use crate::fluent_generated as fluent;
@@ -880,7 +880,7 @@ pub struct MappingToUnit {
     pub map_label: Span,
     #[suggestion(style = "verbose", code = "{replace}", applicability = "maybe-incorrect")]
     pub suggestion: Span,
-    pub replace: String,
+    pub replace: &'static str,
 }
 
 // internal.rs
@@ -2887,8 +2887,8 @@ pub struct RedundantImportVisibility {
     #[help]
     pub help: (),
 
-    pub import_vis: String,
-    pub max_vis: String,
+    pub import_vis: Cow<'static, str>,
+    pub max_vis: Cow<'static, str>,
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_lint/src/map_unit_fn.rs
+++ b/compiler/rustc_lint/src/map_unit_fn.rs
@@ -73,7 +73,7 @@ impl<'tcx> LateLintPass<'tcx> for MapUnitFn {
                                     argument_label: args[0].span,
                                     map_label: arg_ty.default_span(cx.tcx),
                                     suggestion: path.ident.span,
-                                    replace: "for_each".to_string(),
+                                    replace: "for_each",
                                 },
                             )
                         }
@@ -92,7 +92,7 @@ impl<'tcx> LateLintPass<'tcx> for MapUnitFn {
                                     argument_label: args[0].span,
                                     map_label: arg_ty.default_span(cx.tcx),
                                     suggestion: path.ident.span,
-                                    replace: "for_each".to_string(),
+                                    replace: "for_each",
                                 },
                             )
                         }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 pub use self::Level::*;
 use rustc_ast::node_id::NodeId;
 use rustc_ast::{AttrId, Attribute};
@@ -557,7 +559,7 @@ pub struct AmbiguityErrorDiag {
     pub msg: String,
     pub span: Span,
     pub label_span: Span,
-    pub label_msg: String,
+    pub label_msg: &'static str,
     pub note_msg: String,
     pub b1_span: Span,
     pub b1_note_msg: String,
@@ -702,8 +704,8 @@ pub enum BuiltinLintDiag {
     },
     RedundantImportVisibility {
         span: Span,
-        max_vis: String,
-        import_vis: String,
+        max_vis: Cow<'static, str>,
+        import_vis: Cow<'static, str>,
     },
     UnknownDiagnosticAttribute {
         span: Span,

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     io::Error,
     path::{Path, PathBuf},
 };
@@ -597,7 +598,7 @@ pub struct InvalidMetadataFiles {
     pub span: Span,
     pub crate_name: Symbol,
     pub add_info: String,
-    pub crate_rejections: Vec<String>,
+    pub crate_rejections: Vec<Cow<'static, str>>,
 }
 
 impl<G: EmissionGuarantee> Diagnostic<'_, G> for InvalidMetadataFiles {
@@ -622,7 +623,7 @@ pub struct CannotFindCrate {
     pub crate_name: Symbol,
     pub add_info: String,
     pub missing_core: bool,
-    pub current_crate: String,
+    pub current_crate: Cow<'static, str>,
     pub is_nightly_build: bool,
     pub profiler_runtime: Symbol,
     pub locator_triple: TargetTriple,

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -949,7 +949,7 @@ enum MetadataError<'a> {
     /// The file was present and invalid.
     LoadFailure(String),
     /// The file was present, but compiled with a different rustc version.
-    VersionMismatch { expected_version: String, found_version: String },
+    VersionMismatch { expected_version: String, found_version: Cow<'static, str> },
 }
 
 impl fmt::Display for MetadataError<'_> {

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -1,4 +1,4 @@
-use std::cmp;
+use std::{borrow::Cow, cmp};
 
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::sorted_map::SortedMap;
@@ -367,21 +367,21 @@ pub fn lint_level(
                 | FutureIncompatibilityReason::FutureReleaseErrorReportInDeps => {
                     "this was previously accepted by the compiler but is being phased out; \
                          it will become a hard error in a future release!"
-                        .to_owned()
+                        .into()
                 }
                 FutureIncompatibilityReason::FutureReleaseSemanticsChange => {
-                    "this will change its meaning in a future release!".to_owned()
+                    "this will change its meaning in a future release!".into()
                 }
                 FutureIncompatibilityReason::EditionError(edition) => {
                     let current_edition = sess.edition();
                     format!(
                         "this is accepted in the current edition (Rust {current_edition}) but is a hard error in Rust {edition}!"
-                    )
+                    ).into()
                 }
                 FutureIncompatibilityReason::EditionSemanticsChange(edition) => {
-                    format!("this changes meaning in Rust {edition}")
+                    format!("this changes meaning in Rust {edition}").into()
                 }
-                FutureIncompatibilityReason::Custom(reason) => reason.to_owned(),
+                FutureIncompatibilityReason::Custom(reason) => Cow::Borrowed(reason),
             };
 
             if future_incompatible.explain_reason {

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -141,21 +141,21 @@ pub struct DeprecationSuggestion {
     #[primary_span]
     pub span: Span,
 
-    pub kind: String,
+    pub kind: &'static str,
     pub suggestion: Symbol,
 }
 
-pub struct Deprecated {
+pub struct Deprecated<'a> {
     pub sub: Option<DeprecationSuggestion>,
 
     // FIXME: make this translatable
-    pub kind: String,
+    pub kind: &'a str,
     pub path: String,
     pub note: Option<Symbol>,
     pub since_kind: DeprecatedSinceKind,
 }
 
-impl<'a, G: EmissionGuarantee> rustc_errors::LintDiagnostic<'a, G> for Deprecated {
+impl<'a, G: EmissionGuarantee> rustc_errors::LintDiagnostic<'a, G> for Deprecated<'_> {
     fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, G>) {
         diag.primary_message(match &self.since_kind {
             DeprecatedSinceKind::InEffect => crate::fluent_generated::middle_deprecated,
@@ -243,10 +243,10 @@ fn late_report_deprecation(
     let diag = Deprecated {
         sub: suggestion.map(|suggestion| DeprecationSuggestion {
             span: method_span,
-            kind: def_kind.to_owned(),
+            kind: def_kind,
             suggestion,
         }),
-        kind: def_kind.to_owned(),
+        kind: def_kind,
         path: def_path,
         note: depr.note,
         since_kind: deprecated_since_kind(is_in_effect, depr.since),

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -105,7 +105,7 @@ pub fn report_unstable(
     feature: Symbol,
     reason: Option<Symbol>,
     issue: Option<NonZero<u32>>,
-    suggestion: Option<(Span, String, String, Applicability)>,
+    suggestion: Option<(Span, &'static str, String, Applicability)>,
     is_soft: bool,
     span: Span,
     soft_handler: impl FnOnce(&'static Lint, Span, String),
@@ -265,7 +265,7 @@ pub enum EvalResult {
         feature: Symbol,
         reason: Option<Symbol>,
         issue: Option<NonZero<u32>>,
-        suggestion: Option<(Span, String, String, Applicability)>,
+        suggestion: Option<(Span, &'static str, String, Applicability)>,
         is_soft: bool,
     },
     /// The item does not have the `#[stable]` or `#[unstable]` marker assigned.
@@ -294,7 +294,7 @@ fn suggestion_for_allocator_api(
     def_id: DefId,
     span: Span,
     feature: Symbol,
-) -> Option<(Span, String, String, Applicability)> {
+) -> Option<(Span, &'static str, String, Applicability)> {
     if feature == sym::allocator_api {
         if let Some(trait_) = tcx.opt_parent(def_id) {
             if tcx.is_diagnostic_item(sym::Vec, trait_) {
@@ -303,7 +303,7 @@ fn suggestion_for_allocator_api(
                 if let Ok(snippet) = sm.span_to_snippet(inner_types) {
                     return Some((
                         inner_types,
-                        "consider wrapping the inner types in tuple".to_string(),
+                        "consider wrapping the inner types in tuple",
                         format!("({snippet})"),
                         Applicability::MaybeIncorrect,
                     ));

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -64,6 +64,7 @@ use tracing::{debug, instrument};
 pub use vtable::*;
 
 use std::assert_matches::assert_matches;
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
@@ -296,18 +297,18 @@ pub enum Visibility<Id = LocalDefId> {
 }
 
 impl Visibility {
-    pub fn to_string(self, def_id: LocalDefId, tcx: TyCtxt<'_>) -> String {
+    pub fn to_string(self, def_id: LocalDefId, tcx: TyCtxt<'_>) -> Cow<'static, str> {
         match self {
             ty::Visibility::Restricted(restricted_id) => {
                 if restricted_id.is_top_level_module() {
-                    "pub(crate)".to_string()
+                    "pub(crate)".into()
                 } else if restricted_id == tcx.parent_module_from_def_id(def_id).to_local_def_id() {
-                    "pub(self)".to_string()
+                    "pub(self)".into()
                 } else {
-                    format!("pub({})", tcx.item_name(restricted_id.to_def_id()))
+                    format!("pub({})", tcx.item_name(restricted_id.to_def_id())).into()
                 }
             }
-            ty::Visibility::Public => "pub".to_string(),
+            ty::Visibility::Public => "pub".into(),
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::ty::GenericArg;
 use crate::ty::{self, Ty, TyCtxt};
 
@@ -330,12 +332,12 @@ impl<'tcx, P: Printer<'tcx>> Print<'tcx, P> for ty::Const<'tcx> {
 }
 
 // This is only used by query descriptions
-pub fn describe_as_module(def_id: impl Into<LocalDefId>, tcx: TyCtxt<'_>) -> String {
+pub fn describe_as_module(def_id: impl Into<LocalDefId>, tcx: TyCtxt<'_>) -> Cow<'static, str> {
     let def_id = def_id.into();
     if def_id.is_top_level_module() {
-        "top-level module".to_string()
+        "top-level module".into()
     } else {
-        format!("module `{}`", tcx.def_path_str(def_id))
+        format!("module `{}`", tcx.def_path_str(def_id)).into()
     }
 }
 

--- a/compiler/rustc_mir_build/src/build/custom/mod.rs
+++ b/compiler/rustc_mir_build/src/build/custom/mod.rs
@@ -149,8 +149,8 @@ struct ParseCtxt<'tcx, 'body> {
 
 struct ParseError {
     span: Span,
-    item_description: String,
-    expected: String,
+    item_description: std::borrow::Cow<'static, str>,
+    expected: &'static str,
 }
 
 impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
@@ -158,8 +158,8 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
         let expr = &self.thir[expr];
         ParseError {
             span: expr.span,
-            item_description: format!("{:?}", expr.kind),
-            expected: expected.to_string(),
+            item_description: format!("{:?}", expr.kind).into(),
+            expected,
         }
     }
 
@@ -169,11 +169,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
             StmtKind::Expr { expr, .. } => self.thir[expr].span,
             StmtKind::Let { span, .. } => span,
         };
-        ParseError {
-            span,
-            item_description: format!("{:?}", stmt.kind),
-            expected: expected.to_string(),
-        }
+        ParseError { span, item_description: format!("{:?}", stmt.kind).into(), expected }
     }
 }
 

--- a/compiler/rustc_mir_build/src/build/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse.rs
@@ -84,8 +84,8 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
             kind @ StmtKind::Let { pattern, .. } => {
                 return Err(ParseError {
                     span: pattern.span,
-                    item_description: format!("{kind:?}"),
-                    expected: "expression".to_string(),
+                    item_description: format!("{kind:?}").into(),
+                    expected: "expression",
                 });
             }
         }
@@ -100,8 +100,8 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
                     _ => {
                         return Err(ParseError {
                             span: pat.span,
-                            item_description: format!("{:?}", pat.kind),
-                            expected: "local".to_string(),
+                            item_description: format!("{:?}", pat.kind).into(),
+                            expected: "local",
                         });
                     }
                 }
@@ -234,8 +234,8 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
                 StmtKind::Let { span, .. } => {
                     return Err(ParseError {
                         span,
-                        item_description: format!("{:?}", stmt),
-                        expected: "debuginfo".to_string(),
+                        item_description: format!("{:?}", stmt).into(),
+                        expected: "debuginfo",
                     });
                 }
                 StmtKind::Expr { expr, .. } => expr,
@@ -252,8 +252,8 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
             let Some(name) = name.node.str() else {
                 return Err(ParseError {
                     span,
-                    item_description: format!("{:?}", name),
-                    expected: "string".to_string(),
+                    item_description: format!("{:?}", name).into(),
+                    expected: "string",
                 });
             };
             let operand = self.parse_operand(operand)?;
@@ -296,8 +296,8 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
                 _ => {
                     break Err(ParseError {
                         span: pat.span,
-                        item_description: format!("{:?}", pat.kind),
-                        expected: "local".to_string(),
+                        item_description: format!("{:?}", pat.kind).into(),
+                        expected: "local",
                     });
                 }
             }

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -121,8 +121,8 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
         let Some((otherwise, rest)) = arms.split_last() else {
             return Err(ParseError {
                 span,
-                item_description: "no arms".to_string(),
-                expected: "at least one arm".to_string(),
+                item_description: "no arms".into(),
+                expected: "at least one arm",
             });
         };
 
@@ -130,8 +130,8 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
         let PatKind::Wild = otherwise.pattern.kind else {
             return Err(ParseError {
                 span: otherwise.span,
-                item_description: format!("{:?}", otherwise.pattern.kind),
-                expected: "wildcard pattern".to_string(),
+                item_description: format!("{:?}", otherwise.pattern.kind).into(),
+                expected: "wildcard pattern",
             });
         };
         let otherwise = self.parse_block(otherwise.body)?;
@@ -143,8 +143,8 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
             let PatKind::Constant { value } = arm.pattern.kind else {
                 return Err(ParseError {
                     span: arm.pattern.span,
-                    item_description: format!("{:?}", arm.pattern.kind),
-                    expected: "constant pattern".to_string(),
+                    item_description: format!("{:?}", arm.pattern.kind).into(),
+                    expected: "constant pattern",
                 });
             };
             values.push(value.eval_bits(self.tcx, self.param_env));

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -537,9 +537,9 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for NonExhaustivePatternsTypeNo
             // Get the span for the empty match body `{}`.
             let (indentation, more) = if let Some(snippet) = sm.indentation_before(self.scrut_span)
             {
-                (format!("\n{snippet}"), "    ")
+                (&*format!("\n{snippet}"), "    ")
             } else {
-                (" ".to_string(), "")
+                (" ", "")
             };
             diag.span_suggestion_verbose(
                 braces_span,

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::errors::*;
 
 use rustc_arena::{DroplessArena, TypedArena};
@@ -1052,9 +1054,9 @@ fn report_non_exhaustive_match<'p, 'tcx>(
         [] if let Some(braces_span) = braces_span => {
             // Get the span for the empty match body `{}`.
             let (indentation, more) = if let Some(snippet) = sm.indentation_before(sp) {
-                (format!("\n{snippet}"), "    ")
+                (&*format!("\n{snippet}"), "    ")
             } else {
-                (" ".to_string(), "")
+                (" ", "")
             };
             suggestion = Some((
                 braces_span,
@@ -1069,9 +1071,9 @@ fn report_non_exhaustive_match<'p, 'tcx>(
                     sm.span_extend_while(only.span, |c| c.is_whitespace() || c == ',')
                 && sm.is_multiline(with_trailing)
             {
-                (format!("\n{snippet}"), true)
+                (&*format!("\n{snippet}"), true)
             } else {
-                (" ".to_string(), false)
+                (" ", false)
             };
             let only_body = &thir[only.body];
             let comma = if matches!(only_body.kind, ExprKind::Block { .. })
@@ -1100,9 +1102,9 @@ fn report_non_exhaustive_match<'p, 'tcx>(
                     ","
                 };
                 let spacing = if sm.is_multiline(prev.span.between(last.span)) {
-                    sm.indentation_before(last.span).map(|indent| format!("\n{indent}"))
+                    sm.indentation_before(last.span).map(|indent| format!("\n{indent}").into())
                 } else {
-                    Some(" ".to_string())
+                    Some(Cow::Borrowed(" "))
                 };
                 if let Some(spacing) = spacing {
                     suggestion = Some((

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -92,6 +92,7 @@
 //! source-level module, functions from the same module will be available for
 //! inlining, even when they are not marked `#[inline]`.
 
+use std::borrow::Cow;
 use std::cmp;
 use std::collections::hash_map::Entry;
 use std::fs::{self, File};
@@ -1031,10 +1032,10 @@ fn debug_dump<'a, 'tcx: 'a>(tcx: TyCtxt<'tcx>, label: &str, cgus: &[CodegenUnit<
 
         // Converts a slice to a string, capturing repetitions to save space.
         // E.g. `[4, 4, 4, 3, 2, 1, 1, 1, 1, 1]` -> "[4 (x3), 3, 2, 1 (x5)]".
-        fn list(ns: &[usize]) -> String {
+        fn list(ns: &[usize]) -> Cow<'static, str> {
             let mut v = Vec::new();
             if ns.is_empty() {
-                return "[]".to_string();
+                return "[]".into();
             }
 
             let mut elem = |curr, curr_count| {
@@ -1059,7 +1060,7 @@ fn debug_dump<'a, 'tcx: 'a>(tcx: TyCtxt<'tcx>, label: &str, cgus: &[CodegenUnit<
             }
             elem(curr, curr_count);
 
-            format!("[{}]", v.join(", "))
+            format!("[{}]", v.join(", ")).into()
         }
     };
 

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -321,16 +321,16 @@ enum TokenType {
 }
 
 impl TokenType {
-    fn to_string(&self) -> String {
+    fn to_string(&self) -> std::borrow::Cow<'static, str> {
         match self {
-            TokenType::Token(t) => format!("`{}`", pprust::token_kind_to_string(t)),
-            TokenType::Keyword(kw) => format!("`{kw}`"),
-            TokenType::Operator => "an operator".to_string(),
-            TokenType::Lifetime => "lifetime".to_string(),
-            TokenType::Ident => "identifier".to_string(),
-            TokenType::Path => "path".to_string(),
-            TokenType::Type => "type".to_string(),
-            TokenType::Const => "a const expression".to_string(),
+            TokenType::Token(t) => format!("`{}`", pprust::token_kind_to_string(t)).into(),
+            TokenType::Keyword(kw) => format!("`{kw}`").into(),
+            TokenType::Operator => "an operator".into(),
+            TokenType::Lifetime => "lifetime".into(),
+            TokenType::Ident => "identifier".into(),
+            TokenType::Path => "path".into(),
+            TokenType::Type => "type".into(),
+            TokenType::Const => "a const expression".into(),
         }
     }
 }

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -294,8 +294,10 @@ impl<'a> Parser<'a> {
                         colon_sp,
                         format!(
                             "while parsing the type for {}",
-                            pat.descr()
-                                .map_or_else(|| "the binding".to_string(), |n| format!("`{n}`"))
+                            pat.descr().map_or_else(
+                                || "the binding".into(),
+                                |n| Cow::Owned(format!("`{n}`"))
+                            )
                         ),
                     );
                     // we use noexpect here because we don't actually expect Eq to be here
@@ -770,8 +772,8 @@ impl<'a> Parser<'a> {
                                 format!(
                                     "while parsing the type for {}",
                                     local.pat.descr().map_or_else(
-                                        || "the binding".to_string(),
-                                        |n| format!("`{n}`")
+                                        || "the binding".into(),
+                                        |n| Cow::Owned(format!("`{n}`"))
                                     )
                                 ),
                             );

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -294,10 +294,8 @@ impl<'a> Parser<'a> {
                         colon_sp,
                         format!(
                             "while parsing the type for {}",
-                            pat.descr().map_or_else(
-                                || "the binding".into(),
-                                |n| Cow::Owned(format!("`{n}`"))
-                            )
+                            pat.descr()
+                                .map_or("the binding".into(), |n| Cow::Owned(format!("`{n}`")))
                         ),
                     );
                     // we use noexpect here because we don't actually expect Eq to be here
@@ -771,10 +769,9 @@ impl<'a> Parser<'a> {
                                 colon_sp,
                                 format!(
                                     "while parsing the type for {}",
-                                    local.pat.descr().map_or_else(
-                                        || "the binding".into(),
-                                        |n| Cow::Owned(format!("`{n}`"))
-                                    )
+                                    local.pat.descr().map_or("the binding".into(), |n| Cow::Owned(
+                                        format!("`{n}`")
+                                    ))
                                 ),
                             );
                             let suggest_eq = if self.token.kind == token::Dot

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -461,11 +461,15 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             for p in generics.params {
                 let hir::GenericParamKind::Type { .. } = p.kind else { continue };
                 let default = tcx.object_lifetime_default(p.def_id);
+                let item_name;
                 let repr = match default {
-                    ObjectLifetimeDefault::Empty => "BaseDefault".to_owned(),
-                    ObjectLifetimeDefault::Static => "'static".to_owned(),
-                    ObjectLifetimeDefault::Param(def_id) => tcx.item_name(def_id).to_string(),
-                    ObjectLifetimeDefault::Ambiguous => "Ambiguous".to_owned(),
+                    ObjectLifetimeDefault::Empty => "BaseDefault",
+                    ObjectLifetimeDefault::Static => "'static",
+                    ObjectLifetimeDefault::Param(def_id) => {
+                        item_name = tcx.item_name(def_id);
+                        item_name.as_str()
+                    }
+                    ObjectLifetimeDefault::Ambiguous => "Ambiguous",
                 };
                 tcx.dcx().emit_err(errors::ObjectLifetimeErr { span: p.span, repr });
             }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1377,10 +1377,10 @@ pub struct OnlyHasEffectOn {
 
 #[derive(Diagnostic)]
 #[diag(passes_object_lifetime_err)]
-pub struct ObjectLifetimeErr {
+pub struct ObjectLifetimeErr<'a> {
     #[primary_span]
     pub span: Span,
-    pub repr: String,
+    pub repr: &'a str,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -126,15 +126,15 @@ enum LiveNodeKind {
     ErrNode,
 }
 
-fn live_node_kind_to_string(lnk: LiveNodeKind, tcx: TyCtxt<'_>) -> String {
+fn live_node_kind_to_string(lnk: LiveNodeKind, tcx: TyCtxt<'_>) -> std::borrow::Cow<'static, str> {
     let sm = tcx.sess.source_map();
     match lnk {
-        UpvarNode(s) => format!("Upvar node [{}]", sm.span_to_diagnostic_string(s)),
-        ExprNode(s, _) => format!("Expr node [{}]", sm.span_to_diagnostic_string(s)),
-        VarDefNode(s, _) => format!("Var def node [{}]", sm.span_to_diagnostic_string(s)),
-        ClosureNode => "Closure node".to_owned(),
-        ExitNode => "Exit node".to_owned(),
-        ErrNode => "Error node".to_owned(),
+        UpvarNode(s) => format!("Upvar node [{}]", sm.span_to_diagnostic_string(s)).into(),
+        ExprNode(s, _) => format!("Expr node [{}]", sm.span_to_diagnostic_string(s)).into(),
+        VarDefNode(s, _) => format!("Var def node [{}]", sm.span_to_diagnostic_string(s)).into(),
+        ClosureNode => "Closure node".into(),
+        ExitNode => "Exit node".into(),
+        ErrNode => "Error node".into(),
     }
 }
 

--- a/compiler/rustc_query_system/src/error.rs
+++ b/compiler/rustc_query_system/src/error.rs
@@ -72,9 +72,9 @@ pub struct Reentrant;
 #[help]
 #[note(query_system_increment_compilation_note1)]
 #[note(query_system_increment_compilation_note2)]
-pub struct IncrementCompilation {
-    pub run_cmd: String,
-    pub dep_node: String,
+pub struct IncrementCompilation<'a> {
+    pub run_cmd: &'a str,
+    pub dep_node: &'a str,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -713,15 +713,15 @@ fn incremental_verify_ich_failed<Tcx>(
         tcx.sess().dcx().emit_err(crate::error::Reentrant);
     } else {
         let run_cmd = if let Some(crate_name) = &tcx.sess().opts.crate_name {
-            format!("`cargo clean -p {crate_name}` or `cargo clean`")
+            &format!("`cargo clean -p {crate_name}` or `cargo clean`")
         } else {
-            "`cargo clean`".to_string()
+            "`cargo clean`"
         };
 
         let dep_node = tcx.dep_graph().data().unwrap().prev_node_of(prev_index);
         tcx.sess().dcx().emit_err(crate::error::IncrementCompilation {
             run_cmd,
-            dep_node: format!("{dep_node:?}"),
+            dep_node: &format!("{dep_node:?}"),
         });
         panic!("Found unstable fingerprints for {dep_node:?}: {}", result());
     }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1479,7 +1479,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             let head_span = source_map.guess_head_span(span);
             err.subdiagnostic(ConsiderAddingADerive {
                 span: head_span.shrink_to_lo(),
-                suggestion: "#[derive(Default)]\n".to_string(),
+                suggestion: "#[derive(Default)]\n",
             });
         }
         for ns in [Namespace::MacroNS, Namespace::TypeNS, Namespace::ValueNS] {
@@ -1492,23 +1492,21 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 None,
             ) {
                 let desc = match binding.res() {
-                    Res::Def(DefKind::Macro(MacroKind::Bang), _) => {
-                        "a function-like macro".to_string()
-                    }
+                    Res::Def(DefKind::Macro(MacroKind::Bang), _) => "a function-like macro",
                     Res::Def(DefKind::Macro(MacroKind::Attr), _) | Res::NonMacroAttr(..) => {
-                        format!("an attribute: `#[{ident}]`")
+                        &format!("an attribute: `#[{ident}]`")
                     }
                     Res::Def(DefKind::Macro(MacroKind::Derive), _) => {
-                        format!("a derive macro: `#[derive({ident})]`")
+                        &format!("a derive macro: `#[derive({ident})]`")
                     }
                     Res::ToolMod => {
                         // Don't confuse the user with tool modules.
                         continue;
                     }
                     Res::Def(DefKind::Trait, _) if macro_kind == MacroKind::Derive => {
-                        "only a trait, without a derive macro".to_string()
+                        "only a trait, without a derive macro"
                     }
-                    res => format!(
+                    res => &format!(
                         "{} {}, not {} {}",
                         res.article(),
                         res.descr(),
@@ -1532,7 +1530,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 }
                 let note = errors::IdentInScopeButItIsDesc {
                     imported_ident: ident,
-                    imported_ident_desc: &desc,
+                    imported_ident_desc: desc,
                 };
                 err.subdiagnostic(note);
                 return;
@@ -1706,7 +1704,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             msg: format!("`{ident}` is ambiguous"),
             span: ident.span,
             label_span: ident.span,
-            label_msg: "ambiguous name".to_string(),
+            label_msg: "ambiguous name",
             note_msg: format!("ambiguous because of {}", kind.descr()),
             b1_span,
             b1_note_msg,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2022,10 +2022,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 // ::foo is mounted at the crate root for 2015, and is the extern
                 // prelude for 2018+
                 kw::PathRoot if self.tcx.sess.edition() > Edition::Edition2015 => {
-                    "the list of imported crates".to_owned()
+                    "the list of imported crates"
                 }
-                kw::PathRoot | kw::Crate => "the crate root".to_owned(),
-                _ => format!("`{parent}`"),
+                kw::PathRoot | kw::Crate => "the crate root",
+                _ => &format!("`{parent}`"),
             };
 
             let mut msg = format!("could not find `{ident}` in {parent}");

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -683,7 +683,7 @@ pub(crate) struct AddedMacroUse;
 pub(crate) struct ConsiderAddingADerive {
     #[primary_span]
     pub(crate) span: Span,
-    pub(crate) suggestion: String,
+    pub(crate) suggestion: &'static str,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1498,11 +1498,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             // Report special messages for path segment keywords in wrong positions.
             if ident.is_path_segment_keyword() && segment_idx != 0 {
                 return PathResult::failed(ident, false, finalize.is_some(), module, || {
-                    let name_str = if name == kw::PathRoot {
-                        "crate root".to_string()
-                    } else {
-                        format!("`{name}`")
-                    };
+                    let name_str =
+                        if name == kw::PathRoot { "crate root" } else { &format!("`{name}`") };
                     let label = if segment_idx == 1 && path[0].ident.name == kw::PathRoot {
                         format!("global paths cannot start with {name_str}")
                     } else {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -627,9 +627,9 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                 // (that it's a variant) for E0573 "expected type, found variant".
                 let preamble = if res.is_none() {
                     let others = match enum_candidates.len() {
-                        1 => String::new(),
-                        2 => " and 1 other".to_owned(),
-                        n => format!(" and {n} others"),
+                        1 => "",
+                        2 => " and 1 other",
+                        n => &format!(" and {n} others"),
                     };
                     format!("there is an enum variant `{}`{}; ", enum_candidates[0].0, others)
                 } else {

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/encode.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/encode.rs
@@ -752,11 +752,11 @@ fn encode_ty_name(tcx: TyCtxt<'_>, def_id: DefId) -> String {
 
 /// Converts a number to a disambiguator (see
 /// <https://rust-lang.github.io/rfcs/2603-rust-symbol-name-mangling-v0.html>).
-fn to_disambiguator(num: u64) -> String {
+fn to_disambiguator(num: u64) -> std::borrow::Cow<'static, str> {
     if let Some(num) = num.checked_sub(1) {
-        format!("s{}_", num.to_base(ALPHANUMERIC_ONLY))
+        format!("s{}_", num.to_base(ALPHANUMERIC_ONLY)).into()
     } else {
-        "s_".to_string()
+        "s_".into()
     }
 }
 

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -99,7 +99,7 @@ pub(crate) struct TargetRequiresUnwindTables;
 #[derive(Diagnostic)]
 #[diag(session_instrumentation_not_supported)]
 pub(crate) struct InstrumentationNotSupported {
-    pub(crate) us: String,
+    pub(crate) us: &'static str,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1303,7 +1303,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     }
 
     if sess.opts.unstable_opts.instrument_xray.is_some() && !sess.target.options.supports_xray {
-        sess.dcx().emit_err(errors::InstrumentationNotSupported { us: "XRay".to_string() });
+        sess.dcx().emit_err(errors::InstrumentationNotSupported { us: "XRay" });
     }
 
     if let Some(flavor) = sess.opts.cg.linker_flavor {

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -228,7 +228,7 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         }
     }
 
-    fn span_to_string(&self, span: stable_mir::ty::Span) -> String {
+    fn span_to_string(&self, span: stable_mir::ty::Span) -> std::borrow::Cow<'static, str> {
         let tables = self.0.borrow();
         tables.tcx.sess.source_map().span_to_diagnostic_string(tables[span])
     }

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -400,12 +400,12 @@ impl SourceMap {
         &self,
         sp: Span,
         filename_display_pref: FileNameDisplayPreference,
-    ) -> String {
+    ) -> Cow<'static, str> {
         let (source_file, lo_line, lo_col, hi_line, hi_col) = self.span_to_location_info(sp);
 
-        let file_name = match source_file {
-            Some(sf) => sf.name.display(filename_display_pref).to_string(),
-            None => return "no-location".to_string(),
+        let file_name = match source_file.as_ref() {
+            Some(sf) => sf.name.display(filename_display_pref),
+            None => return "no-location".into(),
         };
 
         format!(
@@ -416,6 +416,7 @@ impl SourceMap {
                 format!(": {hi_line}:{hi_col}")
             }
         )
+        .into()
     }
 
     pub fn span_to_location_info(
@@ -432,14 +433,14 @@ impl SourceMap {
     }
 
     /// Format the span location suitable for embedding in build artifacts
-    pub fn span_to_embeddable_string(&self, sp: Span) -> String {
+    pub fn span_to_embeddable_string(&self, sp: Span) -> Cow<'static, str> {
         self.span_to_string(sp, FileNameDisplayPreference::Remapped)
     }
 
     /// Format the span location to be printed in diagnostics. Must not be emitted
     /// to build artifacts as this may leak local file paths. Use span_to_embeddable_string
     /// for string suitable for embedding.
-    pub fn span_to_diagnostic_string(&self, sp: Span) -> String {
+    pub fn span_to_diagnostic_string(&self, sp: Span) -> Cow<'static, str> {
         self.span_to_string(sp, self.path_mapping.filename_display_for_diagnostics)
     }
 

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::fluent_generated as fluent;
 use rustc_errors::{
     codes::*, Applicability, Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level,
@@ -62,7 +64,10 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for NegativePositiveConflict<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let mut diag = Diag::new(dcx, level, fluent::trait_selection_negative_positive_conflict);
         diag.arg("trait_desc", self.trait_desc.print_only_trait_path().to_string());
-        diag.arg("self_desc", self.self_ty.map_or_else(|| "none".to_string(), |ty| ty.to_string()));
+        diag.arg(
+            "self_desc",
+            self.self_ty.map_or_else(|| Cow::Borrowed("none"), |ty| ty.to_string().into()),
+        );
         diag.span(self.impl_span);
         diag.code(E0751);
         match self.negative_impl_span {

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -66,7 +66,7 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for NegativePositiveConflict<'_> {
         diag.arg("trait_desc", self.trait_desc.print_only_trait_path().to_string());
         diag.arg(
             "self_desc",
-            self.self_ty.map_or_else(|| Cow::Borrowed("none"), |ty| ty.to_string().into()),
+            self.self_ty.map_or(Cow::Borrowed("none"), |ty| ty.to_string().into()),
         );
         diag.span(self.impl_span);
         diag.code(E0751);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/infer_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/infer_ctxt_ext.rs
@@ -165,10 +165,10 @@ impl<'tcx> InferCtxt<'tcx> {
                     found_args
                         .iter()
                         .map(|arg| match arg {
-                            ArgKind::Arg(name, _) => name.to_owned(),
-                            _ => "_".to_owned(),
+                            ArgKind::Arg(name, _) => &*name,
+                            _ => "_",
                         })
-                        .collect::<Vec<String>>()
+                        .collect::<Vec<_>>()
                         .join(", "),
                     // add type annotations if available
                     if found_args.iter().any(|arg| match arg {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
@@ -18,6 +18,7 @@ use rustc_parse_format::{ParseMode, Parser, Piece, Position};
 use rustc_session::lint::builtin::UNKNOWN_OR_MALFORMED_DIAGNOSTIC_ATTRIBUTES;
 use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::Span;
+use std::borrow::Cow;
 use std::iter;
 use std::path::PathBuf;
 
@@ -385,8 +386,8 @@ pub struct InvalidFormatSpecifier;
 #[derive(LintDiagnostic)]
 #[diag(trait_selection_wrapped_parser_error)]
 pub struct WrappedParserError {
-    description: String,
-    label: String,
+    description: Cow<'static, str>,
+    label: Cow<'static, str>,
 }
 
 impl<'tcx> OnUnimplementedDirective {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -4859,9 +4859,9 @@ pub(super) fn get_explanation_based_on_obligation<'tcx>(
     obligation: &PredicateObligation<'tcx>,
     trait_predicate: ty::PolyTraitPredicate<'tcx>,
     pre_message: String,
-) -> String {
+) -> Cow<'static, str> {
     if let ObligationCauseCode::MainFunctionType = obligation.cause.code() {
-        "consider using `()`, or a `Result`".to_owned()
+        "consider using `()`, or a `Result`".into()
     } else {
         let ty_desc = match trait_predicate.self_ty().skip_binder().kind() {
             ty::FnDef(_, _) => Some("fn item"),
@@ -4896,6 +4896,7 @@ pub(super) fn get_explanation_based_on_obligation<'tcx>(
             // FIXME: add note explaining explicit negative trait bounds.
             format!("{pre_message}the trait bound `{trait_predicate}` is not satisfied{post}")
         }
+        .into()
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2536,7 +2536,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                                 (
                                     "use the fully-qualified path to the only available \
                                      implementation",
-                                    format!(
+                                    &*format!(
                                         "{}",
                                         self.tcx.type_of(impl_def_id).instantiate_identity()
                                     ),
@@ -2545,7 +2545,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                                 (
                                     "use a fully-qualified path to a specific available \
                                      implementation",
-                                    "/* self type */".to_string(),
+                                    "/* self type */",
                                 )
                             };
                             let mut suggestions =
@@ -3444,11 +3444,9 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         def_id: DefId,
     ) -> ErrorGuaranteed {
         let name = match self.tcx.opaque_type_origin(def_id.expect_local()) {
-            hir::OpaqueTyOrigin::FnReturn(_) | hir::OpaqueTyOrigin::AsyncFn(_) => {
-                "opaque type".to_string()
-            }
+            hir::OpaqueTyOrigin::FnReturn(_) | hir::OpaqueTyOrigin::AsyncFn(_) => "opaque type",
             hir::OpaqueTyOrigin::TyAlias { .. } => {
-                format!("`{}`", self.tcx.def_path_debug_str(def_id))
+                &format!("`{}`", self.tcx.def_path_debug_str(def_id))
             }
         };
         let mut err = self.dcx().struct_span_err(

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -56,7 +56,7 @@ pub trait Context {
     fn def_name(&self, def_id: DefId, trimmed: bool) -> Symbol;
 
     /// Returns printable, human readable form of `Span`
-    fn span_to_string(&self, span: Span) -> String;
+    fn span_to_string(&self, span: Span) -> std::borrow::Cow<'static, str>;
 
     /// Return filename from given `Span`, for diagnostic purposes
     fn get_filename(&self, span: &Span) -> Filename;

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -1046,7 +1046,7 @@ impl ProjectionElem {
                 let len = size - from - to;
                 Ty::try_new_array(inner, len)
             }
-            _ => Err(Error(format!("Cannot subslice non-array type: `{ty_kind:?}`"))),
+            _ => Err(Error::new(format!("Cannot subslice non-array type: `{ty_kind:?}`"))),
         }
     }
 

--- a/compiler/stable_mir/src/mir/mono.rs
+++ b/compiler/stable_mir/src/mir/mono.rs
@@ -200,7 +200,7 @@ impl TryFrom<CrateItem> for Instance {
             if !context.requires_monomorphization(def_id) {
                 Ok(context.mono_instance(def_id))
             } else {
-                Err(Error::new("Item requires monomorphization".to_string()))
+                Err(Error::new("Item requires monomorphization"))
             }
         })
     }

--- a/src/tools/rustfmt/src/parse/session.rs
+++ b/src/tools/rustfmt/src/parse/session.rs
@@ -250,7 +250,7 @@ impl ParseSess {
         self.line_of_byte_pos(a) == self.line_of_byte_pos(b)
     }
 
-    pub(crate) fn span_to_debug_info(&self, span: Span) -> String {
+    pub(crate) fn span_to_debug_info(&self, span: Span) -> std::borrow::Cow<'static, str> {
         self.raw_psess.source_map().span_to_diagnostic_string(span)
     }
 


### PR DESCRIPTION
This PR removes unnecessary `String` allocations when the `&'static str` is perfectly fine. This is possible for a couple of reasons:
- The new lifetime extension rules allow "may return `String`" style expressions to return `&str` and have the `String` lifetime extended.
- `Cow<'static, str>` can be used for cases where lifetime extension isn't possible, and does not incur any overhead due to somewhat recent niche optimizations
-  A couple of places were just allocating for the sake of it, and those were removed.

Most of these allocations are on cold paths, but even cold path allocations contribute to binary size and may lead to worse inlining decisions, as well as being utterly avoidable.

I have tried to minimize the diff caused, but if any specific change is too disruptive I'm okay to just revert that section, as I don't want this to get stuck in review and therefore need lots of rebasing.