### PR TITLE
Remove `__rust_force_expr`.

### DIFF
--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -41,18 +41,18 @@
 #[allow_internal_unstable(rustc_attrs, liballoc_internals)]
 macro_rules! vec {
     () => (
-        $crate::__rust_force_expr!($crate::vec::Vec::new())
+        $crate::vec::Vec::new()
     );
     ($elem:expr; $n:expr) => (
-        $crate::__rust_force_expr!($crate::vec::from_elem($elem, $n))
+        $crate::vec::from_elem($elem, $n)
     );
     ($($x:expr),+ $(,)?) => (
-        $crate::__rust_force_expr!(<[_]>::into_vec(
+        <[_]>::into_vec(
             // This rustc_box is not required, but it produces a dramatic improvement in compile
             // time when constructing arrays with many elements.
             #[rustc_box]
             $crate::boxed::Box::new([$($x),+])
-        ))
+        )
     );
 }
 
@@ -125,14 +125,4 @@ macro_rules! format {
         let res = $crate::fmt::format($crate::__export::format_args!($($arg)*));
         res
     }}
-}
-
-/// Force AST node to an expression to improve diagnostics in pattern position.
-#[doc(hidden)]
-#[macro_export]
-#[unstable(feature = "liballoc_internals", issue = "none", reason = "implementation detail")]
-macro_rules! __rust_force_expr {
-    ($e:expr) => {
-        $e
-    };
 }

--- a/tests/ui/macros/vec-macro-in-pattern.rs
+++ b/tests/ui/macros/vec-macro-in-pattern.rs
@@ -4,7 +4,7 @@
 
 fn main() {
     match Some(vec![42]) {
-        Some(vec![43]) => {} //~ ERROR arbitrary expressions aren't allowed in patterns
+        Some(vec![43]) => {} //~ ERROR expected pattern, found `#`
         _ => {}
     }
 }

--- a/tests/ui/macros/vec-macro-in-pattern.stderr
+++ b/tests/ui/macros/vec-macro-in-pattern.stderr
@@ -1,10 +1,13 @@
-error: arbitrary expressions aren't allowed in patterns
+error: expected pattern, found `#`
   --> $DIR/vec-macro-in-pattern.rs:7:14
    |
 LL |         Some(vec![43]) => {}
    |              ^^^^^^^^
+   |              |
+   |              expected pattern
+   |              in this macro invocation
+   |              this macro call doesn't expand to a pattern
    |
-   = note: the `expr` fragment specifier forces the metavariable's content to be an expression
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
This was added (with a different name) to improve an error message. It is no longer needed -- removing it changes the error message, but overall I think the new message is no worse:
- the mention of `#` in the first line is a little worse,
- but the extra context makes it very clear what the problem is, perhaps even clearer than the old message,
- and the removal of the note about the `expr` fragment (an internal detail of `__rust_force_expr`) is an improvement.

Overall I think the error is quite clear and still far better than the old message that prompted #61933, which didn't even mention patterns.

The motivation for this is #124141, which will cause pasted metavariables to be tokenized and reparsed instead of the AST node being cached. This change in behaviour occasionally has a non-zero perf cost, and `__rust_force_expr` causes the tokenize/reparse step to occur twice. Removing `__rust_force_expr` greatly reduces the extra overhead for the `deep-vector` benchmark.

r? @oli-obk