### PR TITLE
std: separate TLS key creation from TLS access

### DIFF
--- a/library/std/src/sys/thread_local/guard/key.rs
+++ b/library/std/src/sys/thread_local/guard/key.rs
@@ -4,15 +4,15 @@
 
 use crate::ptr;
 use crate::sys::thread_local::destructors;
-use crate::sys::thread_local::key::StaticKey;
+use crate::sys::thread_local::key::{set, LazyKey};
 
 pub fn enable() {
-    static DTORS: StaticKey = StaticKey::new(Some(run));
+    static DTORS: LazyKey = LazyKey::new(Some(run));
 
     // Setting the key value to something other than NULL will result in the
     // destructor being run at thread exit.
     unsafe {
-        DTORS.set(ptr::without_provenance_mut(1));
+        set(DTORS.force(), ptr::without_provenance_mut(1));
     }
 
     unsafe extern "C" fn run(_: *mut u8) {

--- a/library/std/src/sys/thread_local/key/tests.rs
+++ b/library/std/src/sys/thread_local/key/tests.rs
@@ -1,18 +1,25 @@
-use super::StaticKey;
+use super::{get, set, LazyKey};
 use crate::ptr;
 
 #[test]
 fn smoke() {
-    static K1: StaticKey = StaticKey::new(None);
-    static K2: StaticKey = StaticKey::new(None);
+    static K1: LazyKey = LazyKey::new(None);
+    static K2: LazyKey = LazyKey::new(None);
+
+    let k1 = K1.force();
+    let k2 = K2.force();
+    assert_ne!(k1, k2);
+
+    assert_eq!(K1.force(), k1);
+    assert_eq!(K2.force(), k2);
 
     unsafe {
-        assert!(K1.get().is_null());
-        assert!(K2.get().is_null());
-        K1.set(ptr::without_provenance_mut(1));
-        K2.set(ptr::without_provenance_mut(2));
-        assert_eq!(K1.get() as usize, 1);
-        assert_eq!(K2.get() as usize, 2);
+        assert!(get(k1).is_null());
+        assert!(get(k2).is_null());
+        set(k1, ptr::without_provenance_mut(1));
+        set(k2, ptr::without_provenance_mut(2));
+        assert_eq!(get(k1) as usize, 1);
+        assert_eq!(get(k2) as usize, 2);
     }
 }
 
@@ -26,25 +33,27 @@ fn destructors() {
         drop(unsafe { Arc::from_raw(ptr as *const ()) });
     }
 
-    static KEY: StaticKey = StaticKey::new(Some(destruct));
+    static KEY: LazyKey = LazyKey::new(Some(destruct));
 
     let shared1 = Arc::new(());
     let shared2 = Arc::clone(&shared1);
 
+    let key = KEY.force();
     unsafe {
-        assert!(KEY.get().is_null());
-        KEY.set(Arc::into_raw(shared1) as *mut u8);
+        assert!(get(key).is_null());
+        set(key, Arc::into_raw(shared1) as *mut u8);
     }
 
     thread::spawn(move || unsafe {
-        assert!(KEY.get().is_null());
-        KEY.set(Arc::into_raw(shared2) as *mut u8);
+        let key = KEY.force();
+        assert!(get(key).is_null());
+        set(key, Arc::into_raw(shared2) as *mut u8);
     })
     .join()
     .unwrap();
 
     // Leak the Arc, let the TLS destructor clean it up.
-    let shared1 = unsafe { ManuallyDrop::new(Arc::from_raw(KEY.get() as *const ())) };
+    let shared1 = unsafe { ManuallyDrop::new(Arc::from_raw(get(key) as *const ())) };
     assert_eq!(
         Arc::strong_count(&shared1),
         1,

--- a/library/std/src/sys/thread_local/key/unix.rs
+++ b/library/std/src/sys/thread_local/key/unix.rs
@@ -16,6 +16,7 @@ pub unsafe fn set(key: Key, value: *mut u8) {
 }
 
 #[inline]
+#[cfg(any(not(target_thread_local), test))]
 pub unsafe fn get(key: Key) -> *mut u8 {
     unsafe { libc::pthread_getspecific(key) as *mut u8 }
 }

--- a/library/std/src/sys/thread_local/key/xous.rs
+++ b/library/std/src/sys/thread_local/key/xous.rs
@@ -30,7 +30,7 @@
 //! really.
 //!
 //! Perhaps one day we can fold the `Box` here into a static allocation,
-//! expanding the `StaticKey` structure to contain not only a slot for the TLS
+//! expanding the `LazyKey` structure to contain not only a slot for the TLS
 //! key but also a slot for the destructor queue on windows. An optimization for
 //! another day!
 

--- a/library/std/src/sys/thread_local/os.rs
+++ b/library/std/src/sys/thread_local/os.rs
@@ -2,7 +2,7 @@ use super::abort_on_dtor_unwind;
 use crate::cell::Cell;
 use crate::marker::PhantomData;
 use crate::ptr;
-use crate::sys::thread_local::key::StaticKey as OsKey;
+use crate::sys::thread_local::key::{get, set, Key, LazyKey};
 
 #[doc(hidden)]
 #[allow_internal_unstable(thread_local_internals)]
@@ -22,12 +22,12 @@ pub macro thread_local_inner {
 
         unsafe {
             use $crate::thread::LocalKey;
-            use $crate::thread::local_impl::Key;
+            use $crate::thread::local_impl::Storage;
 
             // Inlining does not work on windows-gnu due to linking errors around
             // dllimports. See https://github.com/rust-lang/rust/issues/109797.
             LocalKey::new(#[cfg_attr(windows, inline(never))] |init| {
-                static VAL: Key<$t> = Key::new();
+                static VAL: Storage<$t> = Storage::new();
                 VAL.get(init, __init)
             })
         }
@@ -41,22 +41,22 @@ pub macro thread_local_inner {
 /// Use a regular global static to store this key; the state provided will then be
 /// thread-local.
 #[allow(missing_debug_implementations)]
-pub struct Key<T> {
-    os: OsKey,
+pub struct Storage<T> {
+    key: LazyKey,
     marker: PhantomData<Cell<T>>,
 }
 
-unsafe impl<T> Sync for Key<T> {}
+unsafe impl<T> Sync for Storage<T> {}
 
 struct Value<T: 'static> {
     value: T,
-    key: &'static Key<T>,
+    key: Key,
 }
 
-impl<T: 'static> Key<T> {
+impl<T: 'static> Storage<T> {
     #[rustc_const_unstable(feature = "thread_local_internals", issue = "none")]
-    pub const fn new() -> Key<T> {
-        Key { os: OsKey::new(Some(destroy_value::<T>)), marker: PhantomData }
+    pub const fn new() -> Storage<T> {
+        Storage { key: LazyKey::new(Some(destroy_value::<T>)), marker: PhantomData }
     }
 
     /// Get a pointer to the TLS value, potentially initializing it with the
@@ -66,19 +66,19 @@ impl<T: 'static> Key<T> {
     /// The resulting pointer may not be used after reentrant inialialization
     /// or thread destruction has occurred.
     pub fn get(&'static self, i: Option<&mut Option<T>>, f: impl FnOnce() -> T) -> *const T {
-        // SAFETY: (FIXME: get should actually be safe)
-        let ptr = unsafe { self.os.get() as *mut Value<T> };
+        let key = self.key.force();
+        let ptr = unsafe { get(key) as *mut Value<T> };
         if ptr.addr() > 1 {
             // SAFETY: the check ensured the pointer is safe (its destructor
             // is not running) + it is coming from a trusted source (self).
             unsafe { &(*ptr).value }
         } else {
-            self.try_initialize(ptr, i, f)
+            unsafe { Self::try_initialize(key, ptr, i, f) }
         }
     }
 
-    fn try_initialize(
-        &'static self,
+    unsafe fn try_initialize(
+        key: Key,
         ptr: *mut Value<T>,
         i: Option<&mut Option<T>>,
         f: impl FnOnce() -> T,
@@ -88,13 +88,13 @@ impl<T: 'static> Key<T> {
             return ptr::null();
         }
 
-        let value = i.and_then(Option::take).unwrap_or_else(f);
-        let ptr = Box::into_raw(Box::new(Value { value, key: self }));
-        // SAFETY: (FIXME: get should actually be safe)
-        let old = unsafe { self.os.get() as *mut Value<T> };
+        let value = Box::new(Value { value: i.and_then(Option::take).unwrap_or_else(f), key });
+        let ptr = Box::into_raw(value);
+
+        let old = unsafe { get(key) as *mut Value<T> };
         // SAFETY: `ptr` is a correct pointer that can be destroyed by the key destructor.
         unsafe {
-            self.os.set(ptr as *mut u8);
+            set(key, ptr as *mut u8);
         }
         if !old.is_null() {
             // If the variable was recursively initialized, drop the old value.
@@ -123,8 +123,8 @@ unsafe extern "C" fn destroy_value<T: 'static>(ptr: *mut u8) {
     abort_on_dtor_unwind(|| {
         let ptr = unsafe { Box::from_raw(ptr as *mut Value<T>) };
         let key = ptr.key;
-        unsafe { key.os.set(ptr::without_provenance_mut(1)) };
+        unsafe { set(key, ptr::without_provenance_mut(1)) };
         drop(ptr);
-        unsafe { key.os.set(ptr::null_mut()) };
+        unsafe { set(key, ptr::null_mut()) };
     });
 }


### PR DESCRIPTION
Currently, `std` performs an atomic load to get the OS key on every access to `StaticKey` even when the key is already known. This PR thus replaces `StaticKey` with the platform-specific `get` and `set` function and a new `LazyKey` type that acts as a `LazyLock<Key>`, allowing the reuse of the retreived key for multiple accesses.

Related to #110897.
