### PR TITLE
Improve error message in tidy

### DIFF
--- a/src/tools/tidy/src/ext_tool_checks.rs
+++ b/src/tools/tidy/src/ext_tool_checks.rs
@@ -267,11 +267,10 @@ fn create_venv_at_path(path: &Path) -> Result<(), Error> {
 
     let stderr = String::from_utf8_lossy(&out.stderr);
     let err = if stderr.contains("No module named virtualenv") {
-        Error::Generic(
+        Error::Generic(format!(
             "virtualenv not found: you may need to install it \
-                               (`python3 -m pip install venv`)"
-                .to_owned(),
-        )
+                               (`{sys_py} -m pip install virtualenv`)"
+        ))
     } else {
         Error::Generic(format!(
             "failed to create venv at '{}' using {sys_py}: {stderr}",


### PR DESCRIPTION
The old error message was wrong (there is no `venv` Python package on PyPi), and we did not specify the correct Python path in the error message.