### PR TITLE
Add `tap` as doc alias for `Iterator::inspect`

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1847,6 +1847,7 @@ pub trait Iterator {
     /// Sum: 3
     /// ```
     #[inline]
+    #[doc(alias = "tap")]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_do_not_const_check]
     fn inspect<F>(self, f: F) -> Inspect<Self, F>


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

Today I have spent 15 minutes looking for `inspect` method in `itertools` crate and the standard library.
I have tried to use many words:

- `tee` (as `coreutils` tee, but this method is already used in itertools for a slightly different purpose)
- `tap` (plumbing tap, wiretap, `tap` crate)
- `on_each` (like `for-each`, but not consuming the iterator)
- `peek` (Java's `Stream` has `peek` method with the same purpose)
- `look`... `process`... `emit`... `branch`... I was just desperate for an answer.

To avoid conflicts with `itertools` `tee`, or with `peek` from `PeekableIterator` I decided to add one word from what I have searched, with hope that it might help someone one day with the discoverability of `inspect`.
