### PR TITLE
Don't ICE during RPITIT refinement checking for resolution errors after normalization

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
@@ -171,10 +171,10 @@ pub(super) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
     }
     // Resolve any lifetime variables that may have been introduced during normalization.
     let Ok((trait_bounds, impl_bounds)) = infcx.fully_resolve((trait_bounds, impl_bounds)) else {
-        // This code path is not reached in any tests, but may be reachable. If
-        // this is triggered, it should be converted to `delayed_bug` and the
-        // triggering case turned into a test.
-        tcx.dcx().bug("encountered errors when checking RPITIT refinement (resolution)");
+        // If resolution didn't fully complete, we cannot continue checking RPITIT refinement, and
+        // delay a bug as the original code contains load-bearing errors.
+        tcx.dcx().delayed_bug("encountered errors when checking RPITIT refinement (resolution)");
+        return;
     };
 
     // For quicker lookup, use an `IndexSet` (we don't use one earlier because

--- a/tests/ui/impl-trait/in-trait/refine-resolution-errors.rs
+++ b/tests/ui/impl-trait/in-trait/refine-resolution-errors.rs
@@ -1,0 +1,23 @@
+// This is a non-regression test for issue #126670 where RPITIT refinement checking encountered
+// errors during resolution and ICEd.
+
+//@ edition: 2018
+
+pub trait Mirror {
+    type Assoc;
+}
+impl<T: ?Sized> Mirror for () {
+    //~^ ERROR the type parameter `T` is not constrained
+    type Assoc = T;
+}
+
+pub trait First {
+    async fn first() -> <() as Mirror>::Assoc;
+    //~^ ERROR type annotations needed
+}
+
+impl First for () {
+    async fn first() {}
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/refine-resolution-errors.stderr
+++ b/tests/ui/impl-trait/in-trait/refine-resolution-errors.stderr
@@ -1,0 +1,16 @@
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/refine-resolution-errors.rs:9:6
+   |
+LL | impl<T: ?Sized> Mirror for () {
+   |      ^ unconstrained type parameter
+
+error[E0282]: type annotations needed
+  --> $DIR/refine-resolution-errors.rs:15:5
+   |
+LL |     async fn first() -> <() as Mirror>::Assoc;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0282.
+For more information about an error, try `rustc --explain E0207`.


### PR DESCRIPTION
#126670 shows a case where resolution errors after normalization can happen during RPITIT refinement checking. Our tests didn't reach this path before, and we explicitly ICEd until we had a test. We can now delay a bug since we're sure it is reachable and have the test from the isue.

The comment I added likely still needs more expert wordsmithing.

r? @compiler-errors who's making me work during vacation (j/k).
Fixes #126670