### PR TITLE
Remove `f16` and `f128` ICE paths from smir

### DIFF
--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -188,8 +188,10 @@ impl RustcInternal for FloatTy {
 
     fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
+            FloatTy::F16 => rustc_ty::FloatTy::F16,
             FloatTy::F32 => rustc_ty::FloatTy::F32,
             FloatTy::F64 => rustc_ty::FloatTy::F64,
+            FloatTy::F128 => rustc_ty::FloatTy::F128,
         }
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
@@ -304,10 +304,10 @@ impl<'tcx> Stable<'tcx> for ty::FloatTy {
 
     fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         match self {
-            ty::FloatTy::F16 => unimplemented!("f16_f128"),
+            ty::FloatTy::F16 => FloatTy::F16,
             ty::FloatTy::F32 => FloatTy::F32,
             ty::FloatTy::F64 => FloatTy::F64,
-            ty::FloatTy::F128 => unimplemented!("f16_f128"),
+            ty::FloatTy::F128 => FloatTy::F128,
         }
     }
 }

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -608,8 +608,10 @@ impl UintTy {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FloatTy {
+    F16,
     F32,
     F64,
+    F128,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Just chasing down some possible ICE paths. @compiler-errors mentioned in https://github.com/rust-lang/rust/pull/121728#discussion_r1506133496 that it is okay not to support these in smir, but this change seems pretty trivial?

r? @celinval since you reviewed https://github.com/rust-lang/rust/pull/114607#pullrequestreview-1771673591