### PR TITLE
Improve slice::binary_search_by

### DIFF
--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -69,13 +69,13 @@ fn test_binary_search() {
     assert_eq!(b.binary_search(&8), Err(5));
 
     let b = [(); usize::MAX];
-    assert_eq!(b.binary_search(&()), Ok(usize::MAX / 2));
+    assert_eq!(b.binary_search(&()), Ok(0));
 }
 
 #[test]
 fn test_binary_search_by_overflow() {
     let b = [(); usize::MAX];
-    assert_eq!(b.binary_search_by(|_| Ordering::Equal), Ok(usize::MAX / 2));
+    assert_eq!(b.binary_search_by(|_| Ordering::Equal), Ok(0));
     assert_eq!(b.binary_search_by(|_| Ordering::Greater), Err(0));
     assert_eq!(b.binary_search_by(|_| Ordering::Less), Err(usize::MAX));
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR aims to improve the performances of std::slice::binary_search.

**EDIT: The proposed implementation changed so the rest of this comment is outdated. See https://github.com/rust-lang/rust/pull/127007#issuecomment-2194126792 for an up to date presentation of the PR.**

It reduces the total instruction count for the `u32` monomorphization, but maybe more remarkably, removes 2 of the 12 instructions of the main loop (on x86).

It changes `test_binary_search_implementation_details()` so may warrant a crater run. 

I will document it much more if this is shown to be interesting on benchmarks. Could we start with a timer run first?
 
**Before the PR**

```asm
        mov     eax, 1
        test    rsi, rsi
        je      .LBB0_1
        mov     rcx, rdx
        mov     rdx, rsi
        mov     ecx, dword ptr [rcx]
        xor     esi, esi
        mov     r8, rdx
.LBB0_3:
        shr     rdx
        add     rdx, rsi
        mov     r9d, dword ptr [rdi + 4*rdx]
        cmp     r9d, ecx
        je      .LBB0_4
        lea     r10, [rdx + 1]
        cmp     r9d, ecx
        cmova   r8, rdx
        cmovb   rsi, r10
        mov     rdx, r8
        sub     rdx, rsi
        ja      .LBB0_3
        mov     rdx, rsi
        ret
.LBB0_1:
        xor     edx, edx
        ret
.LBB0_4:
        xor     eax, eax
        ret
```
 
**After the PR**

```asm
        mov     ecx, dword ptr [rdx]
        xor     eax, eax
        xor     edx, edx
.LBB1_1:
        cmp     rsi, 1
        jbe     .LBB1_2
        mov     r9, rsi
        shr     r9
        lea     r8, [r9 + rdx]
        sub     rsi, r9
        cmp     dword ptr [rdi + 4*r8], ecx
        cmovb   rdx, r8
        cmova   rsi, r9
        jne     .LBB1_1
        mov     rdx, r8
        ret
.LBB1_2:
        test    rsi, rsi
        je      .LBB1_3
        xor     eax, eax
        cmp     dword ptr [rdi + 4*rdx], ecx
        setne   al
        adc     rdx, 0
        ret
.LBB1_3:
        mov     eax, 1
        ret
```
