### PR TITLE
Switch back `non_local_definitions` lint to allow-by-default

### DIFF
--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -50,7 +50,7 @@ declare_lint! {
     /// All nested bodies (functions, enum discriminant, array length, consts) (expect for
     /// `const _: Ty = { ... }` in top-level module, which is still undecided) are checked.
     pub NON_LOCAL_DEFINITIONS,
-    Warn,
+    Allow,
     "checks for non-local definitions",
     report_in_external_macro
 }

--- a/tests/rustdoc-ui/doctest/non_local_defs.rs
+++ b/tests/rustdoc-ui/doctest/non_local_defs.rs
@@ -4,6 +4,8 @@
 //@ normalize-stderr-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 
+#![doc(test(attr(warn(non_local_definitions))))]
+
 //! ```
 //! #[macro_export]
 //! macro_rules! a_macro { () => {} }

--- a/tests/rustdoc-ui/doctest/non_local_defs.stderr
+++ b/tests/rustdoc-ui/doctest/non_local_defs.stderr
@@ -1,5 +1,5 @@
 warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
-  --> $DIR/non_local_defs.rs:9:1
+  --> $DIR/non_local_defs.rs:11:1
    |
 LL | macro_rules! a_macro { () => {} }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,11 @@ LL | macro_rules! a_macro { () => {} }
    = help: remove the `#[macro_export]` or make this doc-test a standalone test with its own `fn main() { ... }`
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/non_local_defs.rs:8:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/rustdoc-ui/doctest/non_local_defs.stdout
+++ b/tests/rustdoc-ui/doctest/non_local_defs.stdout
@@ -1,6 +1,6 @@
 
 running 1 test
-test $DIR/non_local_defs.rs - (line 7) ... ok
+test $DIR/non_local_defs.rs - (line 9) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/ui/lint/non-local-defs/cargo-update.rs
+++ b/tests/ui/lint/non-local-defs/cargo-update.rs
@@ -10,6 +10,8 @@
 // of the `cargo update` suggestion we assert it here.
 //@ error-pattern: `cargo update -p non_local_macro`
 
+#![warn(non_local_definitions)]
+
 extern crate non_local_macro;
 
 struct LocalStruct;

--- a/tests/ui/lint/non-local-defs/cargo-update.stderr
+++ b/tests/ui/lint/non-local-defs/cargo-update.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/cargo-update.rs:17:1
+  --> $DIR/cargo-update.rs:19:1
    |
 LL | non_local_macro::non_local_impl!(LocalStruct);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -14,7 +14,11 @@ LL | non_local_macro::non_local_impl!(LocalStruct);
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/cargo-update.rs:13:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
    = note: this warning originates in the macro `non_local_macro::non_local_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted

--- a/tests/ui/lint/non-local-defs/consts.rs
+++ b/tests/ui/lint/non-local-defs/consts.rs
@@ -2,6 +2,8 @@
 //@ edition:2021
 //@ rustc-env:CARGO_CRATE_NAME=non_local_def
 
+#![warn(non_local_definitions)]
+
 struct Test;
 
 trait Uto {}

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:13:5
+  --> $DIR/consts.rs:15:5
    |
 LL | const Z: () = {
    | -----------
@@ -17,10 +17,14 @@ LL |     impl Uto for &Test {}
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/consts.rs:5:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:24:5
+  --> $DIR/consts.rs:26:5
    |
 LL | static A: u32 = {
    | ------------- move the `impl` block outside of this static `A`
@@ -36,7 +40,7 @@ LL |     impl Uto2 for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:32:5
+  --> $DIR/consts.rs:34:5
    |
 LL | const B: u32 = {
    | ------------ move the `impl` block outside of this constant `B`
@@ -52,7 +56,7 @@ LL |     impl Uto3 for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:43:5
+  --> $DIR/consts.rs:45:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -65,7 +69,7 @@ LL |     impl Test {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:50:9
+  --> $DIR/consts.rs:52:9
    |
 LL |       const {
    |  ___________-
@@ -84,7 +88,7 @@ LL | |     };
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:59:9
+  --> $DIR/consts.rs:61:9
    |
 LL |     const _: u32 = {
    |     ------------ move the `impl` block outside of this constant `_` and up 2 bodies
@@ -98,7 +102,7 @@ LL |         impl Test {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:72:9
+  --> $DIR/consts.rs:74:9
    |
 LL |     let _a = || {
    |              -- move the `impl` block outside of this closure `<unnameable>` and up 2 bodies
@@ -113,7 +117,7 @@ LL |         impl Uto9 for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:79:9
+  --> $DIR/consts.rs:81:9
    |
 LL |       type A = [u32; {
    |  ____________________-

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.rs
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 struct Dog;
 
 fn main() {

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:7:5
+  --> $DIR/exhaustive-trait.rs:9:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -12,10 +12,14 @@ LL |     impl PartialEq<()> for Dog {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive-trait.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:14:5
+  --> $DIR/exhaustive-trait.rs:16:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -31,7 +35,7 @@ LL |     impl PartialEq<()> for &Dog {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:21:5
+  --> $DIR/exhaustive-trait.rs:23:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -47,7 +51,7 @@ LL |     impl PartialEq<Dog> for () {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:28:5
+  --> $DIR/exhaustive-trait.rs:30:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -63,7 +67,7 @@ LL |     impl PartialEq<&Dog> for () {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:35:5
+  --> $DIR/exhaustive-trait.rs:37:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -79,7 +83,7 @@ LL |     impl PartialEq<Dog> for &Dog {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:42:5
+  --> $DIR/exhaustive-trait.rs:44:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`

--- a/tests/ui/lint/non-local-defs/exhaustive.rs
+++ b/tests/ui/lint/non-local-defs/exhaustive.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 use std::fmt::Display;
 
 trait Trait {}

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:10:5
+  --> $DIR/exhaustive.rs:12:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -10,10 +10,14 @@ LL |     impl Test {
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:15:5
+  --> $DIR/exhaustive.rs:17:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -29,7 +33,7 @@ LL |     impl Display for Test {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:22:5
+  --> $DIR/exhaustive.rs:24:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -43,7 +47,7 @@ LL |     impl dyn Trait {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:25:5
+  --> $DIR/exhaustive.rs:27:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -59,7 +63,7 @@ LL |     impl<T: Trait> Trait for Vec<T> { }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:28:5
+  --> $DIR/exhaustive.rs:30:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -75,7 +79,7 @@ LL |     impl Trait for &dyn Trait {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:31:5
+  --> $DIR/exhaustive.rs:33:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -91,7 +95,7 @@ LL |     impl Trait for *mut Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:34:5
+  --> $DIR/exhaustive.rs:36:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -107,7 +111,7 @@ LL |     impl Trait for *mut [Test] {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:37:5
+  --> $DIR/exhaustive.rs:39:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -123,7 +127,7 @@ LL |     impl Trait for [Test; 8] {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:40:5
+  --> $DIR/exhaustive.rs:42:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -139,7 +143,7 @@ LL |     impl Trait for (Test,) {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:43:5
+  --> $DIR/exhaustive.rs:45:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -155,7 +159,7 @@ LL |     impl Trait for fn(Test) -> () {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:46:5
+  --> $DIR/exhaustive.rs:48:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -171,7 +175,7 @@ LL |     impl Trait for fn() -> Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:50:9
+  --> $DIR/exhaustive.rs:52:9
    |
 LL |     let _a = || {
    |              -- move the `impl` block outside of this closure `<unnameable>` and up 2 bodies
@@ -186,7 +190,7 @@ LL |         impl Trait for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:58:5
+  --> $DIR/exhaustive.rs:60:5
    |
 LL |     impl Trait for *mut InsideMain {}
    |     ^^^^^-----^^^^^---------------
@@ -198,28 +202,7 @@ LL |     impl Trait for *mut InsideMain {}
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
-   |
-LL | fn main() {
-   | ^^^^^^^^^
-...
-LL |     struct InsideMain;
-   |     ----------------- may need to be moved as well
-   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-
-warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:60:5
-   |
-LL |     impl Trait for *mut [InsideMain] {}
-   |     ^^^^^-----^^^^^-----------------
-   |          |         |
-   |          |         `*mut [InsideMain]` is not local
-   |          `Trait` is not local
-   |
-   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
-   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
+  --> $DIR/exhaustive.rs:11:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -231,16 +214,16 @@ LL |     struct InsideMain;
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:62:5
    |
-LL |     impl Trait for [InsideMain; 8] {}
-   |     ^^^^^-----^^^^^---------------
+LL |     impl Trait for *mut [InsideMain] {}
+   |     ^^^^^-----^^^^^-----------------
    |          |         |
-   |          |         `[InsideMain; 8]` is not local
+   |          |         `*mut [InsideMain]` is not local
    |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
+  --> $DIR/exhaustive.rs:11:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -252,16 +235,16 @@ LL |     struct InsideMain;
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:64:5
    |
-LL |     impl Trait for (InsideMain,) {}
-   |     ^^^^^-----^^^^^-------------
+LL |     impl Trait for [InsideMain; 8] {}
+   |     ^^^^^-----^^^^^---------------
    |          |         |
-   |          |         `(InsideMain,)` is not local
+   |          |         `[InsideMain; 8]` is not local
    |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
+  --> $DIR/exhaustive.rs:11:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -273,16 +256,16 @@ LL |     struct InsideMain;
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:66:5
    |
-LL |     impl Trait for fn(InsideMain) -> () {}
-   |     ^^^^^-----^^^^^--------------------
+LL |     impl Trait for (InsideMain,) {}
+   |     ^^^^^-----^^^^^-------------
    |          |         |
-   |          |         `fn(: InsideMain) -> ()` is not local
+   |          |         `(InsideMain,)` is not local
    |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
+  --> $DIR/exhaustive.rs:11:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -294,16 +277,16 @@ LL |     struct InsideMain;
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:68:5
    |
-LL |     impl Trait for fn() -> InsideMain {}
-   |     ^^^^^-----^^^^^------------------
+LL |     impl Trait for fn(InsideMain) -> () {}
+   |     ^^^^^-----^^^^^--------------------
    |          |         |
-   |          |         `fn() -> InsideMain` is not local
+   |          |         `fn(: InsideMain) -> ()` is not local
    |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
+  --> $DIR/exhaustive.rs:11:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -313,7 +296,28 @@ LL |     struct InsideMain;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:72:9
+  --> $DIR/exhaustive.rs:70:5
+   |
+LL |     impl Trait for fn() -> InsideMain {}
+   |     ^^^^^-----^^^^^------------------
+   |          |         |
+   |          |         `fn() -> InsideMain` is not local
+   |          `Trait` is not local
+   |
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move the `impl` block outside of this function `main`
+  --> $DIR/exhaustive.rs:11:1
+   |
+LL | fn main() {
+   | ^^^^^^^^^
+...
+LL |     struct InsideMain;
+   |     ----------------- may need to be moved as well
+   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
+
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
+  --> $DIR/exhaustive.rs:74:9
    |
 LL |     fn inside_inside() {
    |     ------------------ move the `impl` block outside of this function `inside_inside` and up 2 bodies
@@ -328,7 +332,7 @@ LL |         impl Display for InsideMain {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:79:9
+  --> $DIR/exhaustive.rs:81:9
    |
 LL |     fn inside_inside() {
    |     ------------------ move the `impl` block outside of this function `inside_inside` and up 2 bodies

--- a/tests/ui/lint/non-local-defs/from-local-for-global.rs
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 struct Cat;
 struct Wrap<T>(T);
 

--- a/tests/ui/lint/non-local-defs/from-local-for-global.stderr
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/from-local-for-global.rs:8:5
+  --> $DIR/from-local-for-global.rs:10:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -12,10 +12,14 @@ LL |     impl From<Cat> for () {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/from-local-for-global.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/from-local-for-global.rs:18:5
+  --> $DIR/from-local-for-global.rs:20:5
    |
 LL |     impl From<Wrap<Wrap<Elephant>>> for () {
    |     ^^^^^----^^^^^^^^^^^^^^^^^^^^^^^^^^^--
@@ -25,7 +29,7 @@ LL |     impl From<Wrap<Wrap<Elephant>>> for () {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/from-local-for-global.rs:7:1
+  --> $DIR/from-local-for-global.rs:9:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -35,7 +39,7 @@ LL |     struct Elephant;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/from-local-for-global.rs:32:5
+  --> $DIR/from-local-for-global.rs:34:5
    |
 LL |     impl StillNonLocal for &Foo {}
    |     ^^^^^-------------^^^^^----
@@ -47,7 +51,7 @@ LL |     impl StillNonLocal for &Foo {}
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `only_global`
-  --> $DIR/from-local-for-global.rs:30:1
+  --> $DIR/from-local-for-global.rs:32:1
    |
 LL | fn only_global() {
    | ^^^^^^^^^^^^^^^^
@@ -56,7 +60,7 @@ LL |     struct Foo;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/from-local-for-global.rs:40:5
+  --> $DIR/from-local-for-global.rs:42:5
    |
 LL |     impl From<Local1> for GlobalSameFunction {
    |     ^^^^^----^^^^^^^^^^^^^------------------
@@ -67,7 +71,7 @@ LL |     impl From<Local1> for GlobalSameFunction {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `same_function`
-  --> $DIR/from-local-for-global.rs:38:1
+  --> $DIR/from-local-for-global.rs:40:1
    |
 LL | fn same_function() {
    | ^^^^^^^^^^^^^^^^^^
@@ -76,7 +80,7 @@ LL |     struct Local1(GlobalSameFunction);
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/from-local-for-global.rs:48:5
+  --> $DIR/from-local-for-global.rs:50:5
    |
 LL |     impl From<Local2> for GlobalSameFunction {
    |     ^^^^^----^^^^^^^^^^^^^------------------
@@ -87,7 +91,7 @@ LL |     impl From<Local2> for GlobalSameFunction {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `same_function`
-  --> $DIR/from-local-for-global.rs:38:1
+  --> $DIR/from-local-for-global.rs:40:1
    |
 LL | fn same_function() {
    | ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-local-defs/generics.rs
+++ b/tests/ui/lint/non-local-defs/generics.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 trait Global {}
 
 fn main() {

--- a/tests/ui/lint/non-local-defs/generics.stderr
+++ b/tests/ui/lint/non-local-defs/generics.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:9:5
+  --> $DIR/generics.rs:11:5
    |
 LL |     impl<T: Local> Global for Vec<T> { }
    |     ^^^^^^^^^^^^^^^------^^^^^---^^^
@@ -10,17 +10,21 @@ LL |     impl<T: Local> Global for Vec<T> { }
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/generics.rs:6:1
+  --> $DIR/generics.rs:8:1
    |
 LL | fn main() {
    | ^^^^^^^^^
 LL |     trait Local {};
    |     ----------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/generics.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:20:5
+  --> $DIR/generics.rs:22:5
    |
 LL |     impl Uto7 for Test where Local: std::any::Any {}
    |     ^^^^^----^^^^^----
@@ -31,7 +35,7 @@ LL |     impl Uto7 for Test where Local: std::any::Any {}
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `bad`
-  --> $DIR/generics.rs:18:1
+  --> $DIR/generics.rs:20:1
    |
 LL | fn bad() {
    | ^^^^^^^^
@@ -40,7 +44,7 @@ LL |     struct Local;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:23:5
+  --> $DIR/generics.rs:25:5
    |
 LL | fn bad() {
    | -------- move the `impl` block outside of this function `bad`
@@ -56,7 +60,7 @@ LL |     impl<T> Uto8 for T {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:32:5
+  --> $DIR/generics.rs:34:5
    |
 LL |     impl Default for UwU<OwO> {
    |     ^^^^^-------^^^^^---^^^^^
@@ -67,7 +71,7 @@ LL |     impl Default for UwU<OwO> {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `fun`
-  --> $DIR/generics.rs:29:1
+  --> $DIR/generics.rs:31:1
    |
 LL | fn fun() {
    | ^^^^^^^^
@@ -77,7 +81,7 @@ LL |     struct OwO;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:43:5
+  --> $DIR/generics.rs:45:5
    |
 LL |     impl AsRef<Cat> for () {
    |     ^^^^^-----^^^^^^^^^^--
@@ -88,7 +92,7 @@ LL |     impl AsRef<Cat> for () {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `meow`
-  --> $DIR/generics.rs:40:1
+  --> $DIR/generics.rs:42:1
    |
 LL | fn meow() {
    | ^^^^^^^^^
@@ -98,7 +102,7 @@ LL |     struct Cat;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:54:5
+  --> $DIR/generics.rs:56:5
    |
 LL |     impl PartialEq<B> for G {
    |     ^^^^^---------^^^^^^^^-
@@ -109,7 +113,7 @@ LL |     impl PartialEq<B> for G {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `fun2`
-  --> $DIR/generics.rs:51:1
+  --> $DIR/generics.rs:53:1
    |
 LL | fn fun2() {
    | ^^^^^^^^^
@@ -119,7 +123,7 @@ LL |     struct B;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:69:5
+  --> $DIR/generics.rs:71:5
    |
 LL |     impl From<Wrap<Wrap<Lion>>> for () {
    |     ^^^^^----^^^^^^^^^^^^^^^^^^^^^^^--
@@ -129,7 +133,7 @@ LL |     impl From<Wrap<Wrap<Lion>>> for () {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `rawr`
-  --> $DIR/generics.rs:66:1
+  --> $DIR/generics.rs:68:1
    |
 LL | fn rawr() {
    | ^^^^^^^^^
@@ -138,7 +142,7 @@ LL |     struct Lion;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:76:5
+  --> $DIR/generics.rs:78:5
    |
 LL |     impl From<()> for Wrap<Lion> {
    |     ^^^^^----^^^^^^^^^----^^^^^^
@@ -149,7 +153,7 @@ LL |     impl From<()> for Wrap<Lion> {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `rawr`
-  --> $DIR/generics.rs:66:1
+  --> $DIR/generics.rs:68:1
    |
 LL | fn rawr() {
    | ^^^^^^^^^

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.rs
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 macro_rules! m {
     () => {
         trait MacroTrait {}

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/inside-macro_rules.rs:9:13
+  --> $DIR/inside-macro_rules.rs:11:13
    |
 LL |         fn my_func() {
    |         ------------ move the `impl` block outside of this function `my_func`
@@ -16,7 +16,11 @@ LL | m!();
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/inside-macro_rules.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
    = note: this warning originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted

--- a/tests/ui/lint/non-local-defs/local.rs
+++ b/tests/ui/lint/non-local-defs/local.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 use std::fmt::Debug;
 
 trait GlobalTrait {}

--- a/tests/ui/lint/non-local-defs/macro_rules.rs
+++ b/tests/ui/lint/non-local-defs/macro_rules.rs
@@ -3,6 +3,8 @@
 //@ aux-build:non_local_macro.rs
 //@ rustc-env:CARGO_CRATE_NAME=non_local_def
 
+#![warn(non_local_definitions)]
+
 extern crate non_local_macro;
 
 const B: u32 = {

--- a/tests/ui/lint/non-local-defs/macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/macro_rules.stderr
@@ -1,5 +1,5 @@
 warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
-  --> $DIR/macro_rules.rs:10:5
+  --> $DIR/macro_rules.rs:12:5
    |
 LL |     macro_rules! m0 { () => { } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,10 +7,14 @@ LL |     macro_rules! m0 { () => { } };
    = help: remove the `#[macro_export]` or move this `macro_rules!` outside the of the current constant `B`
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/macro_rules.rs:6:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
-  --> $DIR/macro_rules.rs:16:1
+  --> $DIR/macro_rules.rs:18:1
    |
 LL | non_local_macro::non_local_macro_rules!(my_macro);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +26,7 @@ LL | non_local_macro::non_local_macro_rules!(my_macro);
    = note: this warning originates in the macro `non_local_macro::non_local_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
-  --> $DIR/macro_rules.rs:21:5
+  --> $DIR/macro_rules.rs:23:5
    |
 LL |     macro_rules! m { () => { } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +36,7 @@ LL |     macro_rules! m { () => { } };
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
-  --> $DIR/macro_rules.rs:29:13
+  --> $DIR/macro_rules.rs:31:13
    |
 LL |             macro_rules! m2 { () => { } };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-local-defs/suggest-moving-inner.rs
+++ b/tests/ui/lint/non-local-defs/suggest-moving-inner.rs
@@ -1,5 +1,7 @@
 //@ check-pass
 
+#![warn(non_local_definitions)]
+
 trait Trait<T> {}
 
 fn main() {

--- a/tests/ui/lint/non-local-defs/suggest-moving-inner.stderr
+++ b/tests/ui/lint/non-local-defs/suggest-moving-inner.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/suggest-moving-inner.rs:12:5
+  --> $DIR/suggest-moving-inner.rs:14:5
    |
 LL |     impl<T> Trait<InsideMain> for &Vec<below::Type<(InsideMain, T)>>
    |     ^^^^^^^^-----^^^^^^^^^^^^^^^^^----------------------------------
@@ -10,7 +10,7 @@ LL |     impl<T> Trait<InsideMain> for &Vec<below::Type<(InsideMain, T)>>
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/suggest-moving-inner.rs:5:1
+  --> $DIR/suggest-moving-inner.rs:7:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -23,7 +23,11 @@ LL |     struct InsideMain;
 LL |     trait HasFoo {}
    |     ------------ may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/suggest-moving-inner.rs:3:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.rs
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.rs
@@ -3,6 +3,8 @@
 
 // https://github.com/rust-lang/rust/issues/123573#issue-2229428739
 
+#![warn(non_local_definitions)]
+
 pub trait Test {}
 
 impl<'a, T: 'a> Test for &[T] where &'a T: Test {}

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/trait-solver-overflow-123573.rs:12:5
+  --> $DIR/trait-solver-overflow-123573.rs:14:5
    |
 LL |     impl Test for &Local {}
    |     ^^^^^----^^^^^------
@@ -11,14 +11,18 @@ LL |     impl Test for &Local {}
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/trait-solver-overflow-123573.rs:10:1
+  --> $DIR/trait-solver-overflow-123573.rs:12:1
    |
 LL | fn main() {
    | ^^^^^^^^^
 LL |     struct Local {}
    |     ------------ may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/trait-solver-overflow-123573.rs:6:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/non-local-defs/weird-exprs.rs
+++ b/tests/ui/lint/non-local-defs/weird-exprs.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 trait Uto {}
 struct Test;
 

--- a/tests/ui/lint/non-local-defs/weird-exprs.stderr
+++ b/tests/ui/lint/non-local-defs/weird-exprs.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:8:5
+  --> $DIR/weird-exprs.rs:10:5
    |
 LL |   type A = [u32; {
    |  ________________-
@@ -16,10 +16,14 @@ LL | | }];
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/weird-exprs.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:16:9
+  --> $DIR/weird-exprs.rs:18:9
    |
 LL |       Discr = {
    |  _____________-
@@ -38,7 +42,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:25:9
+  --> $DIR/weird-exprs.rs:27:9
    |
 LL |       let _array = [0i32; {
    |  _________________________-
@@ -57,7 +61,7 @@ LL | |     }];
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:34:9
+  --> $DIR/weird-exprs.rs:36:9
    |
 LL |       type A = [u32; {
    |  ____________________-
@@ -76,7 +80,7 @@ LL | |     }];
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:41:9
+  --> $DIR/weird-exprs.rs:43:9
    |
 LL |       fn a(_: [u32; {
    |  ___________________-
@@ -95,7 +99,7 @@ LL | |     }]) {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:48:9
+  --> $DIR/weird-exprs.rs:50:9
    |
 LL |       fn b() -> [u32; {
    |  _____________________-


### PR DESCRIPTION
This PR switch back (again) the `non_local_definitions` lint to allow-by-default as T-lang is requesting some (major) changes in the lint inner workings in https://github.com/rust-lang/rust/issues/126768#issuecomment-2192634762.

This PR will need to be beta-backported, as the lint is currently warn-by-default in beta.

Tracking:

- https://github.com/rust-lang/rust/issues/120363