### PR TITLE
docs: check if the disambiguator matches its suffix

### DIFF
--- a/tests/rustdoc-ui/disambiguator-endswith-named-suffix.rs
+++ b/tests/rustdoc-ui/disambiguator-endswith-named-suffix.rs
@@ -1,0 +1,110 @@
+//@ check-pass
+
+//! [struct@m!()]   //~ WARN: unmatched disambiguator `struct` and suffix `!()`
+//! [struct@m!{}]
+//! [struct@m![]]
+//! [struct@f()]    //~ WARN: unmatched disambiguator `struct` and suffix `()`
+//! [struct@m!]     //~ WARN: unmatched disambiguator `struct` and suffix `!`
+//!
+//! [enum@m!()]     //~ WARN: unmatched disambiguator `enum` and suffix `!()`
+//! [enum@m!{}]
+//! [enum@m![]]
+//! [enum@f()]      //~ WARN: unmatched disambiguator `enum` and suffix `()`
+//! [enum@m!]       //~ WARN: unmatched disambiguator `enum` and suffix `!`
+//!
+//! [trait@m!()]    //~ WARN: unmatched disambiguator `trait` and suffix `!()`
+//! [trait@m!{}]
+//! [trait@m![]]
+//! [trait@f()]     //~ WARN: unmatched disambiguator `trait` and suffix `()`
+//! [trait@m!]      //~ WARN: unmatched disambiguator `trait` and suffix `!`
+//!
+//! [module@m!()]   //~ WARN: unmatched disambiguator `module` and suffix `!()`
+//! [module@m!{}]
+//! [module@m![]]
+//! [module@f()]    //~ WARN: unmatched disambiguator `module` and suffix `()`
+//! [module@m!]     //~ WARN: unmatched disambiguator `module` and suffix `!`
+//!
+//! [mod@m!()]      //~ WARN: unmatched disambiguator `mod` and suffix `!()`
+//! [mod@m!{}]
+//! [mod@m![]]
+//! [mod@f()]       //~ WARN: unmatched disambiguator `mod` and suffix `()`
+//! [mod@m!]        //~ WARN: unmatched disambiguator `mod` and suffix `!`
+//!
+//! [const@m!()]    //~ WARN: unmatched disambiguator `const` and suffix `!()`
+//! [const@m!{}]
+//! [const@m![]]
+//! [const@f()]     //~ WARN: incompatible link kind for `f`
+//! [const@m!]      //~ WARN: unmatched disambiguator `const` and suffix `!`
+//!
+//! [constant@m!()]   //~ WARN: unmatched disambiguator `constant` and suffix `!()`
+//! [constant@m!{}]
+//! [constant@m![]]
+//! [constant@f()]    //~ WARN: incompatible link kind for `f`
+//! [constant@m!]     //~ WARN: unmatched disambiguator `constant` and suffix `!`
+//!
+//! [static@m!()]   //~ WARN: unmatched disambiguator `static` and suffix `!()`
+//! [static@m!{}]
+//! [static@m![]]
+//! [static@f()]    //~ WARN: incompatible link kind for `f`
+//! [static@m!]     //~ WARN: unmatched disambiguator `static` and suffix `!`
+//!
+//! [function@m!()]   //~ WARN: unmatched disambiguator `function` and suffix `!()`
+//! [function@m!{}]
+//! [function@m![]]
+//! [function@f()]
+//! [function@m!]     //~ WARN: unmatched disambiguator `function` and suffix `!`
+//!
+//! [fn@m!()]   //~ WARN: unmatched disambiguator `fn` and suffix `!()`
+//! [fn@m!{}]
+//! [fn@m![]]
+//! [fn@f()]
+//! [fn@m!]     //~ WARN: unmatched disambiguator `fn` and suffix `!`
+//!
+//! [method@m!()]   //~ WARN: unmatched disambiguator `method` and suffix `!()`
+//! [method@m!{}]
+//! [method@m![]]
+//! [method@f()]
+//! [method@m!]     //~ WARN: unmatched disambiguator `method` and suffix `!`
+//!
+//! [derive@m!()]   //~ WARN: incompatible link kind for `m`
+//! [derive@m!{}]   //~ WARN: incompatible link kind for `m`
+//! [derive@m![]]
+//! [derive@f()]    //~ WARN: unmatched disambiguator `derive` and suffix `()`
+//! [derive@m!]     //~ WARN: incompatible link kind for `m`
+//!
+//! [type@m!()]   //~ WARN: unmatched disambiguator `type` and suffix `!()`
+//! [type@m!{}]
+//! [type@m![]]
+//! [type@f()]    //~ WARN: unmatched disambiguator `type` and suffix `()`
+//! [type@m!]     //~ WARN: unmatched disambiguator `type` and suffix `!`
+//!
+//! [value@m!()]   //~ WARN: unmatched disambiguator `value` and suffix `!()`
+//! [value@m!{}]
+//! [value@m![]]
+//! [value@f()]
+//! [value@m!]     //~ WARN: unmatched disambiguator `value` and suffix `!`
+//!
+//! [macro@m!()]
+//! [macro@m!{}]
+//! [macro@m![]]
+//! [macro@f()]    //~ WARN: unmatched disambiguator `macro` and suffix `()`
+//! [macro@m!]
+//!
+//! [prim@m!()]   //~ WARN: unmatched disambiguator `prim` and suffix `!()`
+//! [prim@m!{}]
+//! [prim@m![]]
+//! [prim@f()]    //~ WARN: unmatched disambiguator `prim` and suffix `()`
+//! [prim@m!]     //~ WARN: unmatched disambiguator `prim` and suffix `!`
+//!
+//! [primitive@m!()]   //~ WARN: unmatched disambiguator `primitive` and suffix `!()`
+//! [primitive@m!{}]
+//! [primitive@m![]]
+//! [primitive@f()]    //~ WARN: unmatched disambiguator `primitive` and suffix `()`
+//! [primitive@m!]     //~ WARN: unmatched disambiguator `primitive` and suffix `!`
+
+#[macro_export]
+macro_rules! m {
+    () => {};
+}
+
+pub fn f() {}

--- a/tests/rustdoc-ui/disambiguator-endswith-named-suffix.rs
+++ b/tests/rustdoc-ui/disambiguator-endswith-named-suffix.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@ normalize-stderr-test: "nightly|beta|1\.[0-9][0-9]\.[0-9]" -> "$$CHANNEL"
 
 //! [struct@m!()]   //~ WARN: unmatched disambiguator `struct` and suffix `!()`
 //! [struct@m!{}]

--- a/tests/rustdoc-ui/disambiguator-endswith-named-suffix.stderr
+++ b/tests/rustdoc-ui/disambiguator-endswith-named-suffix.stderr
@@ -1,0 +1,395 @@
+warning: unmatched disambiguator `struct` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:3:6
+   |
+LL | //! [struct@m!()]
+   |      ^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
+
+warning: unmatched disambiguator `struct` and suffix `()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:6:6
+   |
+LL | //! [struct@f()]
+   |      ^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `struct` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:7:6
+   |
+LL | //! [struct@m!]
+   |      ^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `enum` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:9:6
+   |
+LL | //! [enum@m!()]
+   |      ^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `enum` and suffix `()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:12:6
+   |
+LL | //! [enum@f()]
+   |      ^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `enum` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:13:6
+   |
+LL | //! [enum@m!]
+   |      ^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `trait` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:15:6
+   |
+LL | //! [trait@m!()]
+   |      ^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `trait` and suffix `()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:18:6
+   |
+LL | //! [trait@f()]
+   |      ^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `trait` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:19:6
+   |
+LL | //! [trait@m!]
+   |      ^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `module` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:21:6
+   |
+LL | //! [module@m!()]
+   |      ^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `module` and suffix `()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:24:6
+   |
+LL | //! [module@f()]
+   |      ^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `module` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:25:6
+   |
+LL | //! [module@m!]
+   |      ^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `mod` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:27:6
+   |
+LL | //! [mod@m!()]
+   |      ^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `mod` and suffix `()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:30:6
+   |
+LL | //! [mod@f()]
+   |      ^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `mod` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:31:6
+   |
+LL | //! [mod@m!]
+   |      ^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `const` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:33:6
+   |
+LL | //! [const@m!()]
+   |      ^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: incompatible link kind for `f`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:36:6
+   |
+LL | //! [const@f()]
+   |      ^^^^^^^^^ this link resolved to a function, which is not a constant
+   |
+help: to link to the function, add parentheses
+   |
+LL - //! [const@f()]
+LL + //! [f()]
+   |
+
+warning: unmatched disambiguator `const` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:37:6
+   |
+LL | //! [const@m!]
+   |      ^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `constant` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:39:6
+   |
+LL | //! [constant@m!()]
+   |      ^^^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: incompatible link kind for `f`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:42:6
+   |
+LL | //! [constant@f()]
+   |      ^^^^^^^^^^^^ this link resolved to a function, which is not a constant
+   |
+help: to link to the function, add parentheses
+   |
+LL - //! [constant@f()]
+LL + //! [f()]
+   |
+
+warning: unmatched disambiguator `constant` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:43:6
+   |
+LL | //! [constant@m!]
+   |      ^^^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `static` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:45:6
+   |
+LL | //! [static@m!()]
+   |      ^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: incompatible link kind for `f`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:48:6
+   |
+LL | //! [static@f()]
+   |      ^^^^^^^^^^ this link resolved to a function, which is not a static
+   |
+help: to link to the function, add parentheses
+   |
+LL - //! [static@f()]
+LL + //! [f()]
+   |
+
+warning: unmatched disambiguator `static` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:49:6
+   |
+LL | //! [static@m!]
+   |      ^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `function` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:51:6
+   |
+LL | //! [function@m!()]
+   |      ^^^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `function` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:55:6
+   |
+LL | //! [function@m!]
+   |      ^^^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `fn` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:57:6
+   |
+LL | //! [fn@m!()]
+   |      ^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `fn` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:61:6
+   |
+LL | //! [fn@m!]
+   |      ^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `method` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:63:6
+   |
+LL | //! [method@m!()]
+   |      ^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `method` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:67:6
+   |
+LL | //! [method@m!]
+   |      ^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: incompatible link kind for `m`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:69:6
+   |
+LL | //! [derive@m!()]
+   |      ^^^^^^^^^^^ this link resolved to a macro, which is not a derive macro
+   |
+help: to link to the macro, add an exclamation mark
+   |
+LL - //! [derive@m!()]
+LL + //! [m!!()]
+   |
+
+warning: incompatible link kind for `m`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:70:6
+   |
+LL | //! [derive@m!{}]
+   |      ^^^^^^^^^^^ this link resolved to a macro, which is not a derive macro
+   |
+help: to link to the macro, add an exclamation mark
+   |
+LL - //! [derive@m!{}]
+LL + //! [m!!{}]
+   |
+
+warning: unmatched disambiguator `derive` and suffix `()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:72:6
+   |
+LL | //! [derive@f()]
+   |      ^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: incompatible link kind for `m`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:73:6
+   |
+LL | //! [derive@m!]
+   |      ^^^^^^^^^ this link resolved to a macro, which is not a derive macro
+   |
+help: to link to the macro, add an exclamation mark
+   |
+LL - //! [derive@m!]
+LL + //! [m!!]
+   |
+
+warning: unmatched disambiguator `type` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:75:6
+   |
+LL | //! [type@m!()]
+   |      ^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `type` and suffix `()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:78:6
+   |
+LL | //! [type@f()]
+   |      ^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `type` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:79:6
+   |
+LL | //! [type@m!]
+   |      ^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `value` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:81:6
+   |
+LL | //! [value@m!()]
+   |      ^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `value` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:85:6
+   |
+LL | //! [value@m!]
+   |      ^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `macro` and suffix `()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:90:6
+   |
+LL | //! [macro@f()]
+   |      ^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `prim` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:93:6
+   |
+LL | //! [prim@m!()]
+   |      ^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `prim` and suffix `()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:96:6
+   |
+LL | //! [prim@f()]
+   |      ^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `prim` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:97:6
+   |
+LL | //! [prim@m!]
+   |      ^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `primitive` and suffix `!()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:99:6
+   |
+LL | //! [primitive@m!()]
+   |      ^^^^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `primitive` and suffix `()`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:102:6
+   |
+LL | //! [primitive@f()]
+   |      ^^^^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: unmatched disambiguator `primitive` and suffix `!`
+  --> $DIR/disambiguator-endswith-named-suffix.rs:103:6
+   |
+LL | //! [primitive@m!]
+   |      ^^^^^^^^^
+   |
+   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+
+warning: 46 warnings emitted
+

--- a/tests/rustdoc-ui/disambiguator-endswith-named-suffix.stderr
+++ b/tests/rustdoc-ui/disambiguator-endswith-named-suffix.stderr
@@ -1,134 +1,134 @@
 warning: unmatched disambiguator `struct` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:3:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:4:6
    |
 LL | //! [struct@m!()]
    |      ^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
 
 warning: unmatched disambiguator `struct` and suffix `()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:6:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:7:6
    |
 LL | //! [struct@f()]
    |      ^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `struct` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:7:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:8:6
    |
 LL | //! [struct@m!]
    |      ^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `enum` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:9:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:10:6
    |
 LL | //! [enum@m!()]
    |      ^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `enum` and suffix `()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:12:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:13:6
    |
 LL | //! [enum@f()]
    |      ^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `enum` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:13:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:14:6
    |
 LL | //! [enum@m!]
    |      ^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `trait` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:15:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:16:6
    |
 LL | //! [trait@m!()]
    |      ^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `trait` and suffix `()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:18:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:19:6
    |
 LL | //! [trait@f()]
    |      ^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `trait` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:19:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:20:6
    |
 LL | //! [trait@m!]
    |      ^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `module` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:21:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:22:6
    |
 LL | //! [module@m!()]
    |      ^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `module` and suffix `()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:24:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:25:6
    |
 LL | //! [module@f()]
    |      ^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `module` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:25:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:26:6
    |
 LL | //! [module@m!]
    |      ^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `mod` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:27:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:28:6
    |
 LL | //! [mod@m!()]
    |      ^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `mod` and suffix `()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:30:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:31:6
    |
 LL | //! [mod@f()]
    |      ^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `mod` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:31:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:32:6
    |
 LL | //! [mod@m!]
    |      ^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `const` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:33:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:34:6
    |
 LL | //! [const@m!()]
    |      ^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: incompatible link kind for `f`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:36:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:37:6
    |
 LL | //! [const@f()]
    |      ^^^^^^^^^ this link resolved to a function, which is not a constant
@@ -140,23 +140,23 @@ LL + //! [f()]
    |
 
 warning: unmatched disambiguator `const` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:37:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:38:6
    |
 LL | //! [const@m!]
    |      ^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `constant` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:39:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:40:6
    |
 LL | //! [constant@m!()]
    |      ^^^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: incompatible link kind for `f`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:42:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:43:6
    |
 LL | //! [constant@f()]
    |      ^^^^^^^^^^^^ this link resolved to a function, which is not a constant
@@ -168,23 +168,23 @@ LL + //! [f()]
    |
 
 warning: unmatched disambiguator `constant` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:43:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:44:6
    |
 LL | //! [constant@m!]
    |      ^^^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `static` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:45:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:46:6
    |
 LL | //! [static@m!()]
    |      ^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: incompatible link kind for `f`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:48:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:49:6
    |
 LL | //! [static@f()]
    |      ^^^^^^^^^^ this link resolved to a function, which is not a static
@@ -196,63 +196,63 @@ LL + //! [f()]
    |
 
 warning: unmatched disambiguator `static` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:49:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:50:6
    |
 LL | //! [static@m!]
    |      ^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `function` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:51:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:52:6
    |
 LL | //! [function@m!()]
    |      ^^^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `function` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:55:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:56:6
    |
 LL | //! [function@m!]
    |      ^^^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `fn` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:57:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:58:6
    |
 LL | //! [fn@m!()]
    |      ^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `fn` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:61:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:62:6
    |
 LL | //! [fn@m!]
    |      ^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `method` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:63:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:64:6
    |
 LL | //! [method@m!()]
    |      ^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `method` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:67:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:68:6
    |
 LL | //! [method@m!]
    |      ^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: incompatible link kind for `m`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:69:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:70:6
    |
 LL | //! [derive@m!()]
    |      ^^^^^^^^^^^ this link resolved to a macro, which is not a derive macro
@@ -264,7 +264,7 @@ LL + //! [m!!()]
    |
 
 warning: incompatible link kind for `m`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:70:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:71:6
    |
 LL | //! [derive@m!{}]
    |      ^^^^^^^^^^^ this link resolved to a macro, which is not a derive macro
@@ -276,15 +276,15 @@ LL + //! [m!!{}]
    |
 
 warning: unmatched disambiguator `derive` and suffix `()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:72:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:73:6
    |
 LL | //! [derive@f()]
    |      ^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: incompatible link kind for `m`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:73:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:74:6
    |
 LL | //! [derive@m!]
    |      ^^^^^^^^^ this link resolved to a macro, which is not a derive macro
@@ -296,100 +296,100 @@ LL + //! [m!!]
    |
 
 warning: unmatched disambiguator `type` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:75:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:76:6
    |
 LL | //! [type@m!()]
    |      ^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `type` and suffix `()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:78:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:79:6
    |
 LL | //! [type@f()]
    |      ^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `type` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:79:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:80:6
    |
 LL | //! [type@m!]
    |      ^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `value` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:81:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:82:6
    |
 LL | //! [value@m!()]
    |      ^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `value` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:85:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:86:6
    |
 LL | //! [value@m!]
    |      ^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `macro` and suffix `()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:90:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:91:6
    |
 LL | //! [macro@f()]
    |      ^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `prim` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:93:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:94:6
    |
 LL | //! [prim@m!()]
    |      ^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `prim` and suffix `()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:96:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:97:6
    |
 LL | //! [prim@f()]
    |      ^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `prim` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:97:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:98:6
    |
 LL | //! [prim@m!]
    |      ^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `primitive` and suffix `!()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:99:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:100:6
    |
 LL | //! [primitive@m!()]
    |      ^^^^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `primitive` and suffix `()`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:102:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:103:6
    |
 LL | //! [primitive@f()]
    |      ^^^^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: unmatched disambiguator `primitive` and suffix `!`
-  --> $DIR/disambiguator-endswith-named-suffix.rs:103:6
+  --> $DIR/disambiguator-endswith-named-suffix.rs:104:6
    |
 LL | //! [primitive@m!]
    |      ^^^^^^^^^
    |
-   = note: see https://doc.rust-lang.org/nightly/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
+   = note: see https://doc.rust-lang.org/$CHANNEL/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators for more info about disambiguators
 
 warning: 46 warnings emitted
 

--- a/tests/rustdoc-ui/disambiguator-macro-endswith-exclamatory.rs
+++ b/tests/rustdoc-ui/disambiguator-macro-endswith-exclamatory.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+
+//! [macro@m!] //~ WARN: unresolved link to `m`
+
+//issue#126986
+
+macro_rules! m {
+    () => {};
+}
+
+fn main() {}

--- a/tests/rustdoc-ui/disambiguator-macro-endswith-exclamatory.stderr
+++ b/tests/rustdoc-ui/disambiguator-macro-endswith-exclamatory.stderr
@@ -1,0 +1,11 @@
+warning: unresolved link to `m`
+  --> $DIR/disambiguator-macro-endswith-exclamatory.rs:3:6
+   |
+LL | //! [macro@m!]
+   |      ^^^^^^^^ no item named `m` in scope
+   |
+   = note: `macro_rules` named `m` exists in this crate, but it is not in scope at this link's location
+   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes #126986

This PR makes it will not continue resolving when its disambiguator doesn't match the suffix format.