### PR TITLE
[DO NOT MERGE] llvm-wrapper: adapt for LLVM 19 API change #126582

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1562,11 +1562,11 @@ LLVMRustGetInstrProfMCDCTVBitmapUpdateIntrinsic(LLVMModuleRef M) {
 
 extern "C" LLVMValueRef
 LLVMRustGetInstrProfMCDCCondBitmapIntrinsic(LLVMModuleRef M) {
-#if LLVM_VERSION_GE(18, 0)
+#if LLVM_VERSION_GE(18, 0) && LLVM_VERSION_LT(19, 0)
   return wrap(llvm::Intrinsic::getDeclaration(
       unwrap(M), llvm::Intrinsic::instrprof_mcdc_condbitmap_update));
 #else
-  report_fatal_error("LLVM 18.0 is required for mcdc intrinsic functions");
+  report_fatal_error("The instrprof_mcdc_condbitmap_update only exists in LLVM 18");
 #endif
 }
 


### PR DESCRIPTION
No functional changes intended.

The instrprof_mcdc_condbitmap_update intrinsic was dropped recently:

https://github.com/llvm/llvm-project/commit/85a7bba7d28365ff98dae74f20ebf9f53d42023a

This is incomplete; https://github.com/rust-lang/rust/issues/126672 to track the proper fix.

@rustbot label: +llvm-main
