### PR TITLE
Cleanup bootstrap check-cfg

### DIFF
--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -47,8 +47,6 @@ optimize_for_size = ["core/optimize_for_size"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-# x.py uses beta cargo, so `check-cfg` entries do not yet take effect
-# for rust-lang/rust. But for users of `-Zbuild-std` it does.
 check-cfg = [
     'cfg(bootstrap)',
     'cfg(no_global_oom_handling)',

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -39,8 +39,6 @@ debug_refcell = []
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-# x.py uses beta cargo, so `check-cfg` entries do not yet take effect
-# for rust-lang/rust. But for users of `-Zbuild-std` it does.
 check-cfg = [
     'cfg(bootstrap)',
     'cfg(no_fp_fmt_parse)',

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -100,8 +100,6 @@ test = true
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-# x.py uses beta cargo, so `check-cfg` entries do not yet take effect
-# for rust-lang/rust. But for users of `-Zbuild-std` it does.
 check-cfg = [
     'cfg(bootstrap)',
     'cfg(target_arch, values("xtensa"))',

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -74,7 +74,7 @@ const LLVM_TOOLS: &[&str] = &[
 /// LLD file names for all flavors.
 const LLD_FILE_NAMES: &[&str] = &["ld.lld", "ld64.lld", "lld-link", "wasm-ld"];
 
-/// Extra --check-cfg to add when building
+/// Extra `--check-cfg` to add when building the compiler or tools
 /// (Mode restriction, config name, config values (if any))
 #[allow(clippy::type_complexity)] // It's fine for hard-coded list and type is explained above.
 const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
@@ -84,38 +84,9 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
     (Some(Mode::ToolRustc), "rust_analyzer", None),
     (Some(Mode::ToolStd), "rust_analyzer", None),
     (Some(Mode::Codegen), "parallel_compiler", None),
-    // NOTE: consider updating `check-cfg` entries in `std/Cargo.toml` too.
-    // cfg(bootstrap) remove these once the bootstrap compiler supports
-    // `lints.rust.unexpected_cfgs.check-cfg`
-    (Some(Mode::Std), "stdarch_intel_sde", None),
-    (Some(Mode::Std), "no_fp_fmt_parse", None),
-    (Some(Mode::Std), "no_global_oom_handling", None),
-    (Some(Mode::Std), "no_rc", None),
-    (Some(Mode::Std), "no_sync", None),
-    /* Extra values not defined in the built-in targets yet, but used in std */
-    (Some(Mode::Std), "target_env", Some(&["libnx", "p2"])),
-    (Some(Mode::Std), "target_os", Some(&["visionos"])),
-    (Some(Mode::Std), "target_arch", Some(&["arm64ec", "spirv", "nvptx", "xtensa"])),
-    (Some(Mode::ToolStd), "target_os", Some(&["visionos"])),
-    /* Extra names used by dependencies */
-    // FIXME: Used by serde_json, but we should not be triggering on external dependencies.
-    (Some(Mode::Rustc), "no_btreemap_remove_entry", None),
-    (Some(Mode::ToolRustc), "no_btreemap_remove_entry", None),
-    // FIXME: Used by crossbeam-utils, but we should not be triggering on external dependencies.
-    (Some(Mode::Rustc), "crossbeam_loom", None),
-    (Some(Mode::ToolRustc), "crossbeam_loom", None),
-    // FIXME: Used by proc-macro2, but we should not be triggering on external dependencies.
-    (Some(Mode::Rustc), "span_locations", None),
-    (Some(Mode::ToolRustc), "span_locations", None),
-    // FIXME: Used by rustix, but we should not be triggering on external dependencies.
-    (Some(Mode::Rustc), "rustix_use_libc", None),
-    (Some(Mode::ToolRustc), "rustix_use_libc", None),
-    // FIXME: Used by filetime, but we should not be triggering on external dependencies.
-    (Some(Mode::Rustc), "emulate_second_only_system", None),
-    (Some(Mode::ToolRustc), "emulate_second_only_system", None),
-    // Needed to avoid the need to copy windows.lib into the sysroot.
-    (Some(Mode::Rustc), "windows_raw_dylib", None),
-    (Some(Mode::ToolRustc), "windows_raw_dylib", None),
+    // Any library specific cfgs like `target_os`, `target_arch` should be put in
+    // priority the `[lints.rust.unexpected_cfgs.check-cfg]` table
+    // in the appropriate `library/{std,alloc,core}/Cargo.toml`
 ];
 
 /// A structure representing a Rust compiler.


### PR DESCRIPTION
This PR cleanup many custom `check-cfg` in bootstrap that have been accumulated over the years.

As well as updating some outdated comments.