### PR TITLE
Fix regression in the MIR lowering of or-patterns

### DIFF
--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1411,6 +1411,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     break;
                 }
             }
+            if expand_until != 0 {
+                expand_until = i + 1;
+            }
         }
         let (candidates_to_expand, remaining_candidates) = candidates.split_at_mut(expand_until);
 

--- a/tests/mir-opt/building/match/simple_match.match_enum.built.after.mir
+++ b/tests/mir-opt/building/match/simple_match.match_enum.built.after.mir
@@ -4,12 +4,11 @@ fn match_enum(_1: E1) -> bool {
     debug x => _1;
     let mut _0: bool;
     let mut _2: isize;
-    let mut _3: isize;
 
     bb0: {
         PlaceMention(_1);
         _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb3, 1: bb5, otherwise: bb2];
+        switchInt(move _2) -> [0: bb3, 1: bb5, 2: bb7, otherwise: bb2];
     }
 
     bb1: {
@@ -18,12 +17,11 @@ fn match_enum(_1: E1) -> bool {
     }
 
     bb2: {
-        _3 = discriminant(_1);
-        switchInt(move _3) -> [2: bb8, otherwise: bb1];
+        goto -> bb1;
     }
 
     bb3: {
-        goto -> bb7;
+        goto -> bb9;
     }
 
     bb4: {
@@ -31,7 +29,7 @@ fn match_enum(_1: E1) -> bool {
     }
 
     bb5: {
-        goto -> bb7;
+        goto -> bb9;
     }
 
     bb6: {
@@ -39,16 +37,16 @@ fn match_enum(_1: E1) -> bool {
     }
 
     bb7: {
-        falseEdge -> [real: bb10, imaginary: bb2];
-    }
-
-    bb8: {
         _0 = const false;
         goto -> bb11;
     }
 
+    bb8: {
+        goto -> bb2;
+    }
+
     bb9: {
-        goto -> bb1;
+        falseEdge -> [real: bb10, imaginary: bb7];
     }
 
     bb10: {

--- a/tests/mir-opt/building/match/simple_match.match_enum.built.after.mir
+++ b/tests/mir-opt/building/match/simple_match.match_enum.built.after.mir
@@ -1,0 +1,62 @@
+// MIR for `match_enum` after built
+
+fn match_enum(_1: E1) -> bool {
+    debug x => _1;
+    let mut _0: bool;
+    let mut _2: isize;
+    let mut _3: isize;
+
+    bb0: {
+        PlaceMention(_1);
+        _2 = discriminant(_1);
+        switchInt(move _2) -> [0: bb3, 1: bb5, otherwise: bb2];
+    }
+
+    bb1: {
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
+    }
+
+    bb2: {
+        _3 = discriminant(_1);
+        switchInt(move _3) -> [2: bb8, otherwise: bb1];
+    }
+
+    bb3: {
+        goto -> bb7;
+    }
+
+    bb4: {
+        goto -> bb2;
+    }
+
+    bb5: {
+        goto -> bb7;
+    }
+
+    bb6: {
+        goto -> bb2;
+    }
+
+    bb7: {
+        falseEdge -> [real: bb10, imaginary: bb2];
+    }
+
+    bb8: {
+        _0 = const false;
+        goto -> bb11;
+    }
+
+    bb9: {
+        goto -> bb1;
+    }
+
+    bb10: {
+        _0 = const true;
+        goto -> bb11;
+    }
+
+    bb11: {
+        return;
+    }
+}

--- a/tests/mir-opt/building/match/simple_match.rs
+++ b/tests/mir-opt/building/match/simple_match.rs
@@ -9,4 +9,18 @@ fn match_bool(x: bool) -> usize {
     }
 }
 
+pub enum E1 {
+    V1,
+    V2,
+    V3,
+}
+
+// EMIT_MIR simple_match.match_enum.built.after.mir
+pub fn match_enum(x: E1) -> bool {
+    match x {
+        E1::V1 | E1::V2 => true,
+        E1::V3 => false,
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/126553 I made a silly indexing mistake and regressed the MIR lowering of or-patterns. This fixes it.

r? @compiler-errors because I'd like this to be merged quickly :pray: 