### PR TITLE
Tighten `fn_decl_span` for async blocks

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1454,7 +1454,10 @@ pub enum ExprKind {
     Block(P<Block>, Option<Label>),
     /// An `async` block (`async move { ... }`),
     /// or a `gen` block (`gen move { ... }`)
-    Gen(CaptureBy, P<Block>, GenBlockKind),
+    ///
+    /// The span is the "decl", which is the header before the body `{ }`
+    /// including the `asyng`/`gen` keywords and possibly `move`.
+    Gen(CaptureBy, P<Block>, GenBlockKind, Span),
     /// An await expression (`my_future.await`). Span is of await keyword.
     Await(P<Expr>, Span),
 

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1528,8 +1528,9 @@ pub fn noop_visit_expr<T: MutVisitor>(
             visit_opt(label, |label| vis.visit_label(label));
             vis.visit_block(blk);
         }
-        ExprKind::Gen(_capture_by, body, _kind) => {
+        ExprKind::Gen(_capture_by, body, _kind, decl_span) => {
             vis.visit_block(body);
+            vis.visit_span(decl_span);
         }
         ExprKind::Await(expr, await_kw_span) => {
             vis.visit_expr(expr);

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -1122,7 +1122,7 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) -> V
             visit_opt!(visitor, visit_label, opt_label);
             try_visit!(visitor.visit_block(block));
         }
-        ExprKind::Gen(_capt, body, _kind) => try_visit!(visitor.visit_block(body)),
+        ExprKind::Gen(_capt, body, _kind, _decl_span) => try_visit!(visitor.visit_block(body)),
         ExprKind::Await(expr, _span) => try_visit!(visitor.visit_expr(expr)),
         ExprKind::Assign(lhs, rhs, _span) => {
             try_visit!(visitor.visit_expr(lhs));

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -227,7 +227,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         *fn_arg_span,
                     ),
                 },
-                ExprKind::Gen(capture_clause, block, genblock_kind) => {
+                ExprKind::Gen(capture_clause, block, genblock_kind, decl_span) => {
                     let desugaring_kind = match genblock_kind {
                         GenBlockKind::Async => hir::CoroutineDesugaring::Async,
                         GenBlockKind::Gen => hir::CoroutineDesugaring::Gen,
@@ -237,6 +237,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         *capture_clause,
                         e.id,
                         None,
+                        *decl_span,
                         e.span,
                         desugaring_kind,
                         hir::CoroutineSource::Block,
@@ -616,6 +617,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         capture_clause: CaptureBy,
         closure_node_id: NodeId,
         return_ty: Option<hir::FnRetTy<'hir>>,
+        fn_decl_span: Span,
         span: Span,
         desugaring_kind: hir::CoroutineDesugaring,
         coroutine_source: hir::CoroutineSource,
@@ -692,7 +694,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             bound_generic_params: &[],
             fn_decl,
             body,
-            fn_decl_span: self.lower_span(span),
+            fn_decl_span: self.lower_span(fn_decl_span),
             fn_arg_span: None,
             kind: hir::ClosureKind::Coroutine(coroutine_kind),
             constness: hir::Constness::NotConst,
@@ -1083,6 +1085,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let (parameters, expr) = this.lower_coroutine_body_with_moved_arguments(
                     &inner_decl,
                     |this| this.with_new_scopes(fn_decl_span, |this| this.lower_expr_mut(body)),
+                    fn_decl_span,
                     body.span,
                     coroutine_kind,
                     hir::CoroutineSource::Closure,

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -211,6 +211,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     // declaration (decl), not the return types.
                     let coroutine_kind = header.coroutine_kind;
                     let body_id = this.lower_maybe_coroutine_body(
+                        *fn_sig_span,
                         span,
                         hir_id,
                         decl,
@@ -799,6 +800,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             }
             AssocItemKind::Fn(box Fn { sig, generics, body: Some(body), .. }) => {
                 let body_id = self.lower_maybe_coroutine_body(
+                    sig.span,
                     i.span,
                     hir_id,
                     &sig.decl,
@@ -915,6 +917,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             ),
             AssocItemKind::Fn(box Fn { sig, generics, body, .. }) => {
                 let body_id = self.lower_maybe_coroutine_body(
+                    sig.span,
                     i.span,
                     hir_id,
                     &sig.decl,
@@ -1111,6 +1114,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     /// `gen {}` block as appropriate.
     fn lower_maybe_coroutine_body(
         &mut self,
+        fn_decl_span: Span,
         span: Span,
         fn_id: hir::HirId,
         decl: &FnDecl,
@@ -1124,6 +1128,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             let (parameters, expr) = this.lower_coroutine_body_with_moved_arguments(
                 decl,
                 |this| this.lower_block_expr(body),
+                fn_decl_span,
                 body.span,
                 coroutine_kind,
                 hir::CoroutineSource::Fn,
@@ -1145,6 +1150,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         &mut self,
         decl: &FnDecl,
         lower_body: impl FnOnce(&mut LoweringContext<'_, 'hir>) -> hir::Expr<'hir>,
+        fn_decl_span: Span,
         body_span: Span,
         coroutine_kind: CoroutineKind,
         coroutine_source: hir::CoroutineSource,
@@ -1315,13 +1321,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
         };
         let closure_id = coroutine_kind.closure_id();
 
-        let span = if let FnRetTy::Default(span) = decl.output
-            && matches!(coroutine_source, rustc_hir::CoroutineSource::Closure)
-        {
-            body_span.with_lo(span.lo())
-        } else {
-            body_span
-        };
         let coroutine_expr = self.make_desugared_coroutine_expr(
             // The default capture mode here is by-ref. Later on during upvar analysis,
             // we will force the captured arguments to by-move, but for async closures,
@@ -1330,7 +1329,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
             CaptureBy::Ref,
             closure_id,
             None,
-            span,
+            fn_decl_span,
+            body_span,
             desugaring_kind,
             coroutine_source,
             mkbody,

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -540,7 +540,7 @@ impl<'a> State<'a> {
                 self.ibox(0);
                 self.print_block_with_attrs(blk, attrs);
             }
-            ast::ExprKind::Gen(capture_clause, blk, kind) => {
+            ast::ExprKind::Gen(capture_clause, blk, kind, _decl_span) => {
                 self.word_nbsp(kind.modifier());
                 self.print_capture_clause(*capture_clause);
                 // cbox/ibox in analogy to the `ExprKind::Block` arm above

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -298,7 +298,7 @@ impl<'cx, 'a> Context<'cx, 'a> {
             // sync with the `rfc-2011-nicer-assert-messages/all-expr-kinds.rs` test.
             ExprKind::Assign(_, _, _)
             | ExprKind::AssignOp(_, _, _)
-            | ExprKind::Gen(_, _, _)
+            | ExprKind::Gen(_, _, _, _)
             | ExprKind::Await(_, _)
             | ExprKind::Block(_, _)
             | ExprKind::Break(_, _)

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3432,8 +3432,9 @@ impl<'a> Parser<'a> {
             }
         }
         let capture_clause = self.parse_capture_clause()?;
+        let decl_span = lo.to(self.prev_token.span);
         let (attrs, body) = self.parse_inner_attrs_and_block()?;
-        let kind = ExprKind::Gen(capture_clause, body, kind);
+        let kind = ExprKind::Gen(capture_clause, body, kind, decl_span);
         Ok(self.mk_expr_with_attrs(lo.to(self.prev_token.span), kind, attrs))
     }
 
@@ -4022,7 +4023,7 @@ impl MutVisitor for CondChecker<'_> {
             | ExprKind::Match(_, _, _)
             | ExprKind::Closure(_)
             | ExprKind::Block(_, _)
-            | ExprKind::Gen(_, _, _)
+            | ExprKind::Gen(_, _, _, _)
             | ExprKind::TryBlock(_)
             | ExprKind::Underscore
             | ExprKind::Path(_, _)

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -334,7 +334,7 @@ impl<'a, 'b, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'b, 'tcx> {
                     None => closure_def,
                 }
             }
-            ExprKind::Gen(_, _, _) => {
+            ExprKind::Gen(_, _, _, _) => {
                 self.create_def(expr.id, kw::Empty, DefKind::Closure, expr.span)
             }
             ExprKind::ConstBlock(ref constant) => {

--- a/src/tools/clippy/clippy_lints/src/suspicious_operation_groupings.rs
+++ b/src/tools/clippy/clippy_lints/src/suspicious_operation_groupings.rs
@@ -549,7 +549,7 @@ fn ident_difference_expr_with_base_location(
         | (Assign(_, _, _), Assign(_, _, _))
         | (TryBlock(_), TryBlock(_))
         | (Await(_, _), Await(_, _))
-        | (Gen(_, _, _), Gen(_, _, _))
+        | (Gen(_, _, _, _), Gen(_, _, _, _))
         | (Block(_, _), Block(_, _))
         | (Closure(_), Closure(_))
         | (Match(_, _, _), Match(_, _, _))

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -226,7 +226,7 @@ pub fn eq_expr(l: &Expr, r: &Expr) -> bool {
                 && eq_fn_decl(lf, rf)
                 && eq_expr(le, re)
         },
-        (Gen(lc, lb, lk), Gen(rc, rb, rk)) => lc == rc && eq_block(lb, rb) && lk == rk,
+        (Gen(lc, lb, lk, _), Gen(rc, rb, rk, _)) => lc == rc && eq_block(lb, rb) && lk == rk,
         (Range(lf, lt, ll), Range(rf, rt, rl)) => ll == rl && eq_expr_opt(lf, rf) && eq_expr_opt(lt, rt),
         (AddrOf(lbk, lm, le), AddrOf(rbk, rm, re)) => lbk == rbk && lm == rm && eq_expr(le, re),
         (Path(lq, lp), Path(rq, rp)) => both(lq, rq, eq_qself) && eq_path(lp, rp),

--- a/src/tools/rustfmt/src/expr.rs
+++ b/src/tools/rustfmt/src/expr.rs
@@ -372,7 +372,7 @@ pub(crate) fn format_expr(
                 ))
             }
         }
-        ast::ExprKind::Gen(capture_by, ref block, ref kind) => {
+        ast::ExprKind::Gen(capture_by, ref block, ref kind, _) => {
             let mover = if matches!(capture_by, ast::CaptureBy::Value { .. }) {
                 "move "
             } else {

--- a/tests/ui/async-await/async-block-control-flow-static-semantics.stderr
+++ b/tests/ui/async-await/async-block-control-flow-static-semantics.stderr
@@ -1,20 +1,18 @@
 error[E0267]: `break` inside `async` block
   --> $DIR/async-block-control-flow-static-semantics.rs:32:9
    |
-LL | /     async {
-LL | |         break 0u8;
-   | |         ^^^^^^^^^ cannot `break` inside `async` block
-LL | |     };
-   | |_____- enclosing `async` block
+LL |     async {
+   |     ----- enclosing `async` block
+LL |         break 0u8;
+   |         ^^^^^^^^^ cannot `break` inside `async` block
 
 error[E0267]: `break` inside `async` block
   --> $DIR/async-block-control-flow-static-semantics.rs:39:13
    |
-LL | /         async {
-LL | |             break 0u8;
-   | |             ^^^^^^^^^ cannot `break` inside `async` block
-LL | |         };
-   | |_________- enclosing `async` block
+LL |         async {
+   |         ----- enclosing `async` block
+LL |             break 0u8;
+   |             ^^^^^^^^^ cannot `break` inside `async` block
 
 error[E0308]: mismatched types
   --> $DIR/async-block-control-flow-static-semantics.rs:21:58
@@ -29,13 +27,13 @@ LL | |
 LL | | }
    | |_^ expected `u8`, found `()`
 
-error[E0271]: expected `{async block@$DIR/async-block-control-flow-static-semantics.rs:23:17: 25:6}` to be a future that resolves to `()`, but it resolves to `u8`
+error[E0271]: expected `{async block@$DIR/async-block-control-flow-static-semantics.rs:23:17: 23:22}` to be a future that resolves to `()`, but it resolves to `u8`
   --> $DIR/async-block-control-flow-static-semantics.rs:26:39
    |
 LL |     let _: &dyn Future<Output = ()> = &block;
    |                                       ^^^^^^ expected `()`, found `u8`
    |
-   = note: required for the cast from `&{async block@$DIR/async-block-control-flow-static-semantics.rs:23:17: 25:6}` to `&dyn Future<Output = ()>`
+   = note: required for the cast from `&{async block@$DIR/async-block-control-flow-static-semantics.rs:23:17: 23:22}` to `&dyn Future<Output = ()>`
 
 error[E0308]: mismatched types
   --> $DIR/async-block-control-flow-static-semantics.rs:12:43
@@ -45,13 +43,13 @@ LL | fn return_targets_async_block_not_fn() -> u8 {
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 
-error[E0271]: expected `{async block@$DIR/async-block-control-flow-static-semantics.rs:14:17: 16:6}` to be a future that resolves to `()`, but it resolves to `u8`
+error[E0271]: expected `{async block@$DIR/async-block-control-flow-static-semantics.rs:14:17: 14:22}` to be a future that resolves to `()`, but it resolves to `u8`
   --> $DIR/async-block-control-flow-static-semantics.rs:17:39
    |
 LL |     let _: &dyn Future<Output = ()> = &block;
    |                                       ^^^^^^ expected `()`, found `u8`
    |
-   = note: required for the cast from `&{async block@$DIR/async-block-control-flow-static-semantics.rs:14:17: 16:6}` to `&dyn Future<Output = ()>`
+   = note: required for the cast from `&{async block@$DIR/async-block-control-flow-static-semantics.rs:14:17: 14:22}` to `&dyn Future<Output = ()>`
 
 error[E0308]: mismatched types
   --> $DIR/async-block-control-flow-static-semantics.rs:49:44

--- a/tests/ui/async-await/async-borrowck-escaping-block-error.stderr
+++ b/tests/ui/async-await/async-borrowck-escaping-block-error.stderr
@@ -2,9 +2,8 @@ error[E0373]: async block may outlive the current function, but it borrows `x`, 
   --> $DIR/async-borrowck-escaping-block-error.rs:6:14
    |
 LL |     Box::new(async { x } )
-   |              ^^^^^^^^-^^
-   |              |       |
-   |              |       `x` is borrowed here
+   |              ^^^^^   - `x` is borrowed here
+   |              |
    |              may outlive borrowed value `x`
    |
 note: async block is returned here
@@ -21,9 +20,8 @@ error[E0373]: async block may outlive the current function, but it borrows `x`, 
   --> $DIR/async-borrowck-escaping-block-error.rs:11:5
    |
 LL |     async { *x }
-   |     ^^^^^^^^--^^
-   |     |       |
-   |     |       `x` is borrowed here
+   |     ^^^^^   -- `x` is borrowed here
+   |     |
    |     may outlive borrowed value `x`
    |
 note: async block is returned here

--- a/tests/ui/async-await/async-closures/wrong-fn-kind.stderr
+++ b/tests/ui/async-await/async-closures/wrong-fn-kind.stderr
@@ -22,20 +22,18 @@ LL | fn needs_async_fn(_: impl async Fn()) {}
 error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
   --> $DIR/wrong-fn-kind.rs:9:20
    |
-LL |   fn needs_async_fn(_: impl async Fn()) {}
-   |                        --------------- change this to accept `FnMut` instead of `Fn`
+LL | fn needs_async_fn(_: impl async Fn()) {}
+   |                      --------------- change this to accept `FnMut` instead of `Fn`
 ...
-LL |       needs_async_fn(async || {
-   |       -------------- ^-------
-   |       |              |
-   |  _____|______________in this closure
-   | |     |
-   | |     expects `Fn` instead of `FnMut`
-LL | |
-LL | |         x += 1;
-   | |         - mutable borrow occurs due to use of `x` in closure
-LL | |     });
-   | |_____^ cannot borrow as mutable
+LL |     needs_async_fn(async || {
+   |     -------------- ^^^^^^^^
+   |     |              |
+   |     |              cannot borrow as mutable
+   |     |              in this closure
+   |     expects `Fn` instead of `FnMut`
+LL |
+LL |         x += 1;
+   |         - mutable borrow occurs due to use of `x` in closure
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/async-is-unwindsafe.stderr
+++ b/tests/ui/async-await/async-is-unwindsafe.stderr
@@ -1,20 +1,19 @@
 error[E0277]: the type `&mut Context<'_>` may not be safely transferred across an unwind boundary
   --> $DIR/async-is-unwindsafe.rs:12:5
    |
-LL |        is_unwindsafe(async {
-   |  ______^             -
-   | | ___________________|
-LL | ||
-LL | ||         use std::ptr::null;
-LL | ||         use std::task::{Context, RawWaker, RawWakerVTable, Waker};
-...  ||
-LL | ||         drop(cx_ref);
-LL | ||     });
-   | ||_____-^ `&mut Context<'_>` may not be safely transferred across an unwind boundary
-   |  |_____|
-   |        within this `{async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6}`
+LL |       is_unwindsafe(async {
+   |       ^             ----- within this `{async block@$DIR/async-is-unwindsafe.rs:12:19: 12:24}`
+   |  _____|
+   | |
+LL | |
+LL | |         use std::ptr::null;
+LL | |         use std::task::{Context, RawWaker, RawWakerVTable, Waker};
+...  |
+LL | |         drop(cx_ref);
+LL | |     });
+   | |______^ `&mut Context<'_>` may not be safely transferred across an unwind boundary
    |
-   = help: within `{async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6}`, the trait `UnwindSafe` is not implemented for `&mut Context<'_>`, which is required by `{async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6}: UnwindSafe`
+   = help: within `{async block@$DIR/async-is-unwindsafe.rs:12:19: 12:24}`, the trait `UnwindSafe` is not implemented for `&mut Context<'_>`, which is required by `{async block@$DIR/async-is-unwindsafe.rs:12:19: 12:24}: UnwindSafe`
    = note: `UnwindSafe` is implemented for `&Context<'_>`, but not for `&mut Context<'_>`
 note: future does not implement `UnwindSafe` as this value is used across an await
   --> $DIR/async-is-unwindsafe.rs:25:18

--- a/tests/ui/async-await/coroutine-desc.stderr
+++ b/tests/ui/async-await/coroutine-desc.stderr
@@ -8,8 +8,8 @@ LL |     fun(async {}, async {});
    |     |   expected all arguments to be this `async` block type because they need to match the type of this parameter
    |     arguments to this function are incorrect
    |
-   = note: expected `async` block `{async block@$DIR/coroutine-desc.rs:10:9: 10:17}`
-              found `async` block `{async block@$DIR/coroutine-desc.rs:10:19: 10:27}`
+   = note: expected `async` block `{async block@$DIR/coroutine-desc.rs:10:9: 10:14}`
+              found `async` block `{async block@$DIR/coroutine-desc.rs:10:19: 10:24}`
    = note: no two async blocks, even if identical, have the same type
    = help: consider pinning your async block and casting it to a trait object
 note: function defined here

--- a/tests/ui/async-await/coroutine-not-future.stderr
+++ b/tests/ui/async-await/coroutine-not-future.stderr
@@ -26,11 +26,11 @@ note: required by a bound in `takes_coroutine`
 LL | fn takes_coroutine<ResumeTy>(_g: impl Coroutine<ResumeTy, Yield = (), Return = ()>) {}
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_coroutine`
 
-error[E0277]: the trait bound `{async block@$DIR/coroutine-not-future.rs:39:21: 39:29}: Coroutine<_>` is not satisfied
+error[E0277]: the trait bound `{async block@$DIR/coroutine-not-future.rs:39:21: 39:26}: Coroutine<_>` is not satisfied
   --> $DIR/coroutine-not-future.rs:39:21
    |
 LL |     takes_coroutine(async {});
-   |     --------------- ^^^^^^^^ the trait `Coroutine<_>` is not implemented for `{async block@$DIR/coroutine-not-future.rs:39:21: 39:29}`
+   |     --------------- ^^^^^^^^ the trait `Coroutine<_>` is not implemented for `{async block@$DIR/coroutine-not-future.rs:39:21: 39:26}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/async-await/issue-67252-unnamed-future.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.stderr
@@ -8,7 +8,7 @@ LL | |         let _a = a;
 LL | |     });
    | |______^ future created by async block is not `Send`
    |
-   = help: within `{async block@$DIR/issue-67252-unnamed-future.rs:18:11: 22:6}`, the trait `Send` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-67252-unnamed-future.rs:18:11: 22:6}: Send`
+   = help: within `{async block@$DIR/issue-67252-unnamed-future.rs:18:11: 18:16}`, the trait `Send` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-67252-unnamed-future.rs:18:11: 18:16}: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-67252-unnamed-future.rs:20:17
    |

--- a/tests/ui/async-await/issue-68112.stderr
+++ b/tests/ui/async-await/issue-68112.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     require_send(send_fut);
    |     ^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{async block@$DIR/issue-68112.rs:29:20: 33:6}: Send`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{async block@$DIR/issue-68112.rs:29:20: 29:25}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/issue-68112.rs:31:17
@@ -23,7 +23,7 @@ error: future cannot be sent between threads safely
 LL |     require_send(send_fut);
    |     ^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{async block@$DIR/issue-68112.rs:39:20: 42:6}: Send`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{async block@$DIR/issue-68112.rs:39:20: 39:25}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/issue-68112.rs:40:17
@@ -42,7 +42,7 @@ error[E0277]: `RefCell<i32>` cannot be shared between threads safely
 LL |     require_send(send_fut);
    |     ^^^^^^^^^^^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{async block@$DIR/issue-68112.rs:57:20: 61:6}: Send`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{async block@$DIR/issue-68112.rs:57:20: 57:25}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
    = note: required for `Arc<RefCell<i32>>` to implement `Send`
 note: required because it's used within this `async` fn body
@@ -61,13 +61,8 @@ LL | fn make_non_send_future2() -> impl Future<Output = Arc<RefCell<i32>>> {
 note: required because it's used within this `async` block
   --> $DIR/issue-68112.rs:57:20
    |
-LL |       let send_fut = async {
-   |  ____________________^
-LL | |         let non_send_fut = make_non_send_future2();
-LL | |         let _ = non_send_fut.await;
-LL | |         ready(0).await;
-LL | |     };
-   | |_____^
+LL |     let send_fut = async {
+   |                    ^^^^^
 note: required by a bound in `require_send`
   --> $DIR/issue-68112.rs:11:25
    |

--- a/tests/ui/async-await/issue-70935-complex-spans.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.stderr
@@ -4,7 +4,7 @@ error[E0277]: `*mut ()` cannot be shared between threads safely
 LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
-   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-70935-complex-spans.rs:18:5: 22:6}: Send`
+   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-70935-complex-spans.rs:18:5: 18:15}: Send`
 note: required because it appears within the type `PhantomData<*mut ()>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `NotSync`
@@ -28,12 +28,8 @@ LL | | }
 note: required because it's used within this `async` block
   --> $DIR/issue-70935-complex-spans.rs:18:5
    |
-LL | /     async move {
-LL | |         baz(|| async {
-LL | |             foo(x.clone());
-LL | |         }).await;
-LL | |     }
-   | |_____^
+LL |     async move {
+   |     ^^^^^^^^^^
 
 error[E0277]: `*mut ()` cannot be shared between threads safely
   --> $DIR/issue-70935-complex-spans.rs:15:23
@@ -41,7 +37,7 @@ error[E0277]: `*mut ()` cannot be shared between threads safely
 LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
-   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-70935-complex-spans.rs:18:5: 22:6}: Send`
+   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-70935-complex-spans.rs:18:5: 18:15}: Send`
 note: required because it appears within the type `PhantomData<*mut ()>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `NotSync`
@@ -65,12 +61,8 @@ LL | | }
 note: required because it's used within this `async` block
   --> $DIR/issue-70935-complex-spans.rs:18:5
    |
-LL | /     async move {
-LL | |         baz(|| async {
-LL | |             foo(x.clone());
-LL | |         }).await;
-LL | |     }
-   | |_____^
+LL |     async move {
+   |     ^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
+++ b/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
@@ -13,14 +13,15 @@ LL |     y
 error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:18:9
    |
+LL |     (async move || {
+   |                  - return type of async closure is &'1 i32
+...
 LL |         let y = &*x;
    |                 --- `*x` is borrowed here
 LL |         *x += 1;
    |         ^^^^^^^ `*x` is assigned to here but it was already borrowed
 LL |         y
    |         - returning this value requires that `*x` is borrowed for `'1`
-LL |     })()
-   |     - return type of async closure is &'1 i32
 
 error: lifetime may not live long enough
   --> $DIR/issue-74072-lifetime-name-annotations.rs:14:20
@@ -61,14 +62,15 @@ LL |    }
 error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:28:9
    |
+LL |     (async move || -> &i32 {
+   |                          - return type of async closure is &'1 i32
+...
 LL |         let y = &*x;
    |                 --- `*x` is borrowed here
 LL |         *x += 1;
    |         ^^^^^^^ `*x` is assigned to here but it was already borrowed
 LL |         y
    |         - returning this value requires that `*x` is borrowed for `'1`
-LL |     })()
-   |     - return type of async closure is &'1 i32
 
 error: lifetime may not live long enough
   --> $DIR/issue-74072-lifetime-name-annotations.rs:24:28
@@ -109,14 +111,14 @@ LL |    }
 error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:36:9
    |
+LL |     async move {
+   |              - return type of async block is &'1 i32
 LL |         let y = &*x;
    |                 --- `*x` is borrowed here
 LL |         *x += 1;
    |         ^^^^^^^ `*x` is assigned to here but it was already borrowed
 LL |         y
    |         - returning this value requires that `*x` is borrowed for `'1`
-LL |     }
-   |     - return type of async block is &'1 i32
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/async-await/issue-86507.stderr
+++ b/tests/ui/async-await/issue-86507.stderr
@@ -13,7 +13,7 @@ note: captured value is not `Send` because `&` references cannot be sent unless 
    |
 LL |                     let x = x;
    |                             ^ has type `&T` which is not `Send`, because `T` is not `Sync`
-   = note: required for the cast from `Pin<Box<{async block@$DIR/issue-86507.rs:18:17: 20:18}>>` to `Pin<Box<(dyn Future<Output = ()> + Send + 'async_trait)>>`
+   = note: required for the cast from `Pin<Box<{async block@$DIR/issue-86507.rs:18:17: 18:27}>>` to `Pin<Box<(dyn Future<Output = ()> + Send + 'async_trait)>>`
 help: consider further restricting this bound
    |
 LL |     fn bar<'me, 'async_trait, T: Send + std::marker::Sync>(x: &'me T)

--- a/tests/ui/async-await/issues/issue-78938-async-block.stderr
+++ b/tests/ui/async-await/issues/issue-78938-async-block.stderr
@@ -1,12 +1,10 @@
 error[E0373]: async block may outlive the current function, but it borrows `room_ref`, which is owned by the current function
   --> $DIR/issue-78938-async-block.rs:8:33
    |
-LL |       let gameloop_handle = spawn(async {
-   |  _________________________________^
-LL | |         game_loop(Arc::clone(&room_ref))
-   | |                               -------- `room_ref` is borrowed here
-LL | |     });
-   | |_____^ may outlive borrowed value `room_ref`
+LL |     let gameloop_handle = spawn(async {
+   |                                 ^^^^^ may outlive borrowed value `room_ref`
+LL |         game_loop(Arc::clone(&room_ref))
+   |                               -------- `room_ref` is borrowed here
    |
    = note: async blocks are not executed immediately and must either take a reference or ownership of outside variables they use
 help: to force the async block to take ownership of `room_ref` (and any other referenced variables), use the `move` keyword

--- a/tests/ui/async-await/track-caller/async-closure-gate.afn.stderr
+++ b/tests/ui/async-await/track-caller/async-closure-gate.afn.stderr
@@ -72,7 +72,7 @@ LL | |     }
    | |_____^ expected `()`, found `async` block
    |
    = note:  expected unit type `()`
-           found `async` block `{async block@$DIR/async-closure-gate.rs:27:5: 32:6}`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:27:5: 27:10}`
 
 error[E0308]: mismatched types
   --> $DIR/async-closure-gate.rs:44:5
@@ -89,7 +89,7 @@ LL | |     }
    | |_____^ expected `()`, found `async` block
    |
    = note:  expected unit type `()`
-           found `async` block `{async block@$DIR/async-closure-gate.rs:44:5: 51:6}`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:44:5: 44:10}`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/async-await/track-caller/async-closure-gate.nofeat.stderr
+++ b/tests/ui/async-await/track-caller/async-closure-gate.nofeat.stderr
@@ -72,7 +72,7 @@ LL | |     }
    | |_____^ expected `()`, found `async` block
    |
    = note:  expected unit type `()`
-           found `async` block `{async block@$DIR/async-closure-gate.rs:27:5: 32:6}`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:27:5: 27:10}`
 
 error[E0308]: mismatched types
   --> $DIR/async-closure-gate.rs:44:5
@@ -89,7 +89,7 @@ LL | |     }
    | |_____^ expected `()`, found `async` block
    |
    = note:  expected unit type `()`
-           found `async` block `{async block@$DIR/async-closure-gate.rs:44:5: 51:6}`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:44:5: 44:10}`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/async-await/try-on-option-in-async.stderr
+++ b/tests/ui/async-await/try-on-option-in-async.stderr
@@ -1,13 +1,11 @@
 error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-on-option-in-async.rs:8:10
    |
-LL | /     async {
-LL | |         let x: Option<u32> = None;
-LL | |         x?;
-   | |          ^ cannot use the `?` operator in an async block that returns `{integer}`
-LL | |         22
-LL | |     }
-   | |_____- this function should return `Result` or `Option` to accept `?`
+LL |     async {
+   |     ----- this function should return `Result` or `Option` to accept `?`
+LL |         let x: Option<u32> = None;
+LL |         x?;
+   |          ^ cannot use the `?` operator in an async block that returns `{integer}`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `{integer}`
 

--- a/tests/ui/borrowck/cloning-in-async-block-121547.stderr
+++ b/tests/ui/borrowck/cloning-in-async-block-121547.stderr
@@ -1,16 +1,14 @@
 error[E0382]: use of moved value: `value`
   --> $DIR/cloning-in-async-block-121547.rs:5:9
    |
-LL |   async fn clone_async_block(value: String) {
-   |                              ----- move occurs because `value` has type `String`, which does not implement the `Copy` trait
-LL |       for _ in 0..10 {
-   |       -------------- inside of this loop
-LL | /         async {
-LL | |             drop(value);
-   | |                  ----- use occurs due to use in coroutine
-LL | |
-LL | |         }.await
-   | |_________^ value moved here, in previous iteration of loop
+LL | async fn clone_async_block(value: String) {
+   |                            ----- move occurs because `value` has type `String`, which does not implement the `Copy` trait
+LL |     for _ in 0..10 {
+   |     -------------- inside of this loop
+LL |         async {
+   |         ^^^^^ value moved here, in previous iteration of loop
+LL |             drop(value);
+   |                  ----- use occurs due to use in coroutine
    |
 help: consider cloning the value if the performance cost is acceptable
    |

--- a/tests/ui/coroutine/break-inside-coroutine-issue-124495.stderr
+++ b/tests/ui/coroutine/break-inside-coroutine-issue-124495.stderr
@@ -1,67 +1,57 @@
 error[E0267]: `break` inside `async` function
   --> $DIR/break-inside-coroutine-issue-124495.rs:8:5
    |
-LL |   async fn async_fn() {
-   |  _____________________-
-LL | |     break;
-   | |     ^^^^^ cannot `break` inside `async` function
-LL | | }
-   | |_- enclosing `async` function
+LL | async fn async_fn() {
+   | ------------------- enclosing `async` function
+LL |     break;
+   |     ^^^^^ cannot `break` inside `async` function
 
 error[E0267]: `break` inside `gen` function
   --> $DIR/break-inside-coroutine-issue-124495.rs:12:5
    |
-LL |   gen fn gen_fn() {
-   |  _________________-
-LL | |     break;
-   | |     ^^^^^ cannot `break` inside `gen` function
-LL | | }
-   | |_- enclosing `gen` function
+LL | gen fn gen_fn() {
+   | --------------- enclosing `gen` function
+LL |     break;
+   |     ^^^^^ cannot `break` inside `gen` function
 
 error[E0267]: `break` inside `async gen` function
   --> $DIR/break-inside-coroutine-issue-124495.rs:16:5
    |
-LL |   async gen fn async_gen_fn() {
-   |  _____________________________-
-LL | |     break;
-   | |     ^^^^^ cannot `break` inside `async gen` function
-LL | | }
-   | |_- enclosing `async gen` function
+LL | async gen fn async_gen_fn() {
+   | --------------------------- enclosing `async gen` function
+LL |     break;
+   |     ^^^^^ cannot `break` inside `async gen` function
 
 error[E0267]: `break` inside `async` block
   --> $DIR/break-inside-coroutine-issue-124495.rs:20:21
    |
 LL |     let _ = async { break; };
-   |             --------^^^^^---
-   |             |       |
-   |             |       cannot `break` inside `async` block
+   |             -----   ^^^^^ cannot `break` inside `async` block
+   |             |
    |             enclosing `async` block
 
 error[E0267]: `break` inside `async` closure
   --> $DIR/break-inside-coroutine-issue-124495.rs:22:24
    |
 LL |     let _ = async || { break; };
-   |             -----------^^^^^---
-   |             |          |
-   |             |          cannot `break` inside `async` closure
+   |             --------   ^^^^^ cannot `break` inside `async` closure
+   |             |
    |             enclosing `async` closure
 
 error[E0267]: `break` inside `gen` block
   --> $DIR/break-inside-coroutine-issue-124495.rs:24:19
    |
 LL |     let _ = gen { break; };
-   |             ------^^^^^---
-   |             |     |
-   |             |     cannot `break` inside `gen` block
+   |             ---   ^^^^^ cannot `break` inside `gen` block
+   |             |
    |             enclosing `gen` block
 
 error[E0267]: `break` inside `async gen` block
   --> $DIR/break-inside-coroutine-issue-124495.rs:26:25
    |
 LL |     let _ = async gen { break; };
-   |             ------------^^^^^---
-   |             |           |
-   |             |           cannot `break` inside `async gen` block
+   |             ---------   ^^^^^ cannot `break` inside `async gen` block
+   |             |
    |             enclosing `async gen` block
 
 error: aborting due to 7 previous errors

--- a/tests/ui/coroutine/clone-impl-async.stderr
+++ b/tests/ui/coroutine/clone-impl-async.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:12:27: 16:6}: Copy` is not satisfied
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:12:27: 12:32}: Copy` is not satisfied
   --> $DIR/clone-impl-async.rs:17:16
    |
 LL |     check_copy(&inner_non_clone);
-   |     ---------- ^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:12:27: 16:6}`
+   |     ---------- ^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:12:27: 12:32}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -12,11 +12,11 @@ note: required by a bound in `check_copy`
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:12:27: 16:6}: Clone` is not satisfied
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:12:27: 12:32}: Clone` is not satisfied
   --> $DIR/clone-impl-async.rs:19:17
    |
 LL |     check_clone(&inner_non_clone);
-   |     ----------- ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:12:27: 16:6}`
+   |     ----------- ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:12:27: 12:32}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -26,11 +26,11 @@ note: required by a bound in `check_clone`
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`
 
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:23:27: 25:6}: Copy` is not satisfied
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:23:27: 23:37}: Copy` is not satisfied
   --> $DIR/clone-impl-async.rs:26:16
    |
 LL |     check_copy(&outer_non_clone);
-   |     ---------- ^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:23:27: 25:6}`
+   |     ---------- ^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:23:27: 23:37}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -40,11 +40,11 @@ note: required by a bound in `check_copy`
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:23:27: 25:6}: Clone` is not satisfied
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:23:27: 23:37}: Clone` is not satisfied
   --> $DIR/clone-impl-async.rs:28:17
    |
 LL |     check_clone(&outer_non_clone);
-   |     ----------- ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:23:27: 25:6}`
+   |     ----------- ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:23:27: 23:37}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -54,11 +54,11 @@ note: required by a bound in `check_clone`
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`
 
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:31:28: 31:41}: Copy` is not satisfied
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:31:28: 31:38}: Copy` is not satisfied
   --> $DIR/clone-impl-async.rs:32:16
    |
 LL |     check_copy(&maybe_copy_clone);
-   |     ---------- ^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:31:28: 31:41}`
+   |     ---------- ^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:31:28: 31:38}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -68,11 +68,11 @@ note: required by a bound in `check_copy`
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:31:28: 31:41}: Clone` is not satisfied
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:31:28: 31:38}: Clone` is not satisfied
   --> $DIR/clone-impl-async.rs:34:17
    |
 LL |     check_clone(&maybe_copy_clone);
-   |     ----------- ^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:31:28: 31:41}`
+   |     ----------- ^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:31:28: 31:38}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/coroutine/gen_block_is_coro.stderr
+++ b/tests/ui/coroutine/gen_block_is_coro.stderr
@@ -1,20 +1,20 @@
-error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:7:5: 7:21}: Coroutine` is not satisfied
+error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:7:5: 7:8}: Coroutine` is not satisfied
   --> $DIR/gen_block_is_coro.rs:6:13
    |
 LL | fn foo() -> impl Coroutine<Yield = u32, Return = ()> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:7:5: 7:21}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:7:5: 7:8}`
 
-error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:11:5: 11:21}: Coroutine` is not satisfied
+error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:11:5: 11:8}: Coroutine` is not satisfied
   --> $DIR/gen_block_is_coro.rs:10:13
    |
 LL | fn bar() -> impl Coroutine<Yield = i64, Return = ()> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:11:5: 11:21}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:11:5: 11:8}`
 
-error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:15:5: 15:21}: Coroutine` is not satisfied
+error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:15:5: 15:8}: Coroutine` is not satisfied
   --> $DIR/gen_block_is_coro.rs:14:13
    |
 LL | fn baz() -> impl Coroutine<Yield = i32, Return = ()> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:15:5: 15:21}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:15:5: 15:8}`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/coroutine/gen_block_is_no_future.stderr
+++ b/tests/ui/coroutine/gen_block_is_no_future.stderr
@@ -1,10 +1,10 @@
-error[E0277]: `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:21}` is not a future
+error[E0277]: `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:8}` is not a future
   --> $DIR/gen_block_is_no_future.rs:4:13
    |
 LL | fn foo() -> impl std::future::Future {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:21}` is not a future
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:8}` is not a future
    |
-   = help: the trait `Future` is not implemented for `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:21}`
+   = help: the trait `Future` is not implemented for `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:8}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coroutine/gen_block_move.stderr
+++ b/tests/ui/coroutine/gen_block_move.stderr
@@ -1,14 +1,11 @@
 error[E0373]: gen block may outlive the current function, but it borrows `x`, which is owned by the current function
   --> $DIR/gen_block_move.rs:7:5
    |
-LL | /     gen {
-LL | |         yield 42;
-LL | |         if x == "foo" { return }
-LL | |         x.clear();
-   | |         - `x` is borrowed here
-LL | |         for x in 3..6 { yield x }
-LL | |     }
-   | |_____^ may outlive borrowed value `x`
+LL |     gen {
+   |     ^^^ may outlive borrowed value `x`
+...
+LL |         x.clear();
+   |         - `x` is borrowed here
    |
 note: gen block is returned here
   --> $DIR/gen_block_move.rs:7:5

--- a/tests/ui/generic-associated-types/issue-90014-tait.stderr
+++ b/tests/ui/generic-associated-types/issue-90014-tait.stderr
@@ -10,7 +10,7 @@ LL |         async { () }
    |         ^^^^^^^^^^^^ expected future, found `async` block
    |
    = note: expected opaque type `Foo<'_>::Fut<'a>`
-            found `async` block `{async block@$DIR/issue-90014-tait.rs:18:9: 18:21}`
+            found `async` block `{async block@$DIR/issue-90014-tait.rs:18:9: 18:14}`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
   --> $DIR/issue-90014-tait.rs:17:8
    |

--- a/tests/ui/impl-trait/issue-55872-3.stderr
+++ b/tests/ui/impl-trait/issue-55872-3.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `{async block@$DIR/issue-55872-3.rs:15:9: 15:17}: Copy` is not satisfied
+error[E0277]: the trait bound `{async block@$DIR/issue-55872-3.rs:15:9: 15:14}: Copy` is not satisfied
   --> $DIR/issue-55872-3.rs:13:20
    |
 LL |     fn foo<T>() -> Self::E {
-   |                    ^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/issue-55872-3.rs:15:9: 15:17}`
+   |                    ^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/issue-55872-3.rs:15:9: 15:14}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/issues/issue-78722-2.stderr
+++ b/tests/ui/impl-trait/issues/issue-78722-2.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `{async block@$DIR/issue-78722-2.rs:13:13: 13:21}` to be a future that resolves to `u8`, but it resolves to `()`
+error[E0271]: expected `{async block@$DIR/issue-78722-2.rs:13:13: 13:18}` to be a future that resolves to `u8`, but it resolves to `()`
   --> $DIR/issue-78722-2.rs:11:30
    |
 LL |         fn concrete_use() -> F {
@@ -16,7 +16,7 @@ LL |         let f: F = async { 1 };
    |                expected due to this
    |
    = note: expected opaque type `F`
-            found `async` block `{async block@$DIR/issue-78722-2.rs:16:20: 16:31}`
+            found `async` block `{async block@$DIR/issue-78722-2.rs:16:20: 16:25}`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/issues/issue-78722.stderr
+++ b/tests/ui/impl-trait/issues/issue-78722.stderr
@@ -8,7 +8,7 @@ LL |         let f: F = async { 1 };
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0271]: expected `{async block@$DIR/issue-78722.rs:10:13: 10:21}` to be a future that resolves to `u8`, but it resolves to `()`
+error[E0271]: expected `{async block@$DIR/issue-78722.rs:10:13: 10:18}` to be a future that resolves to `u8`, but it resolves to `()`
   --> $DIR/issue-78722.rs:8:30
    |
 LL |         fn concrete_use() -> F {

--- a/tests/ui/impl-trait/nested-return-type4.stderr
+++ b/tests/ui/impl-trait/nested-return-type4.stderr
@@ -4,7 +4,7 @@ error[E0700]: hidden type for `impl Future<Output = impl Sized>` captures lifeti
 LL | fn test<'s: 's>(s: &'s str) -> impl std::future::Future<Output = impl Sized> {
    |         --                     --------------------------------------------- opaque type defined here
    |         |
-   |         hidden type `{async block@$DIR/nested-return-type4.rs:4:5: 4:31}` captures the lifetime `'s` as defined here
+   |         hidden type `{async block@$DIR/nested-return-type4.rs:4:5: 4:15}` captures the lifetime `'s` as defined here
 LL |     async move { let _s = s; }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
+++ b/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
@@ -52,13 +52,13 @@ error[E0308]: mismatched types
   --> $DIR/mismatch-sugg-for-shorthand-field.rs:57:20
    |
 LL |     let a = async { 42 };
-   |             ------------ the found `async` block
+   |             ----- the found `async` block
 ...
 LL |     let s = Demo { a };
    |                    ^ expected `Pin<Box<...>>`, found `async` block
    |
    = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
-           found `async` block `{async block@$DIR/mismatch-sugg-for-shorthand-field.rs:53:13: 53:25}`
+           found `async` block `{async block@$DIR/mismatch-sugg-for-shorthand-field.rs:53:13: 53:18}`
 help: you need to pin and box this expression
    |
 LL |     let s = Demo { a: Box::pin(a) };

--- a/tests/ui/pattern/non-structural-match-types.stderr
+++ b/tests/ui/pattern/non-structural-match-types.stderr
@@ -4,7 +4,7 @@ error: `{closure@$DIR/non-structural-match-types.rs:9:17: 9:19}` cannot be used 
 LL |         const { || {} } => {}
    |         ^^^^^^^^^^^^^^^
 
-error: `{async block@$DIR/non-structural-match-types.rs:12:17: 12:25}` cannot be used in patterns
+error: `{async block@$DIR/non-structural-match-types.rs:12:17: 12:22}` cannot be used in patterns
   --> $DIR/non-structural-match-types.rs:12:9
    |
 LL |         const { async {} } => {}

--- a/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -79,7 +79,7 @@ LL | |     }
    | |_____^ expected `Pin<Box<...>>`, found `async` block
    |
    = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
-           found `async` block `{async block@$DIR/expected-boxed-future-isnt-pinned.rs:28:5: 30:6}`
+           found `async` block `{async block@$DIR/expected-boxed-future-isnt-pinned.rs:28:5: 28:10}`
 help: you need to pin and box this expression
    |
 LL ~     Box::pin(async {

--- a/tests/ui/traits/next-solver/async.fail.stderr
+++ b/tests/ui/traits/next-solver/async.fail.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<{async block@$DIR/async.rs:12:17: 12:25} as Future>::Output == i32`
+error[E0271]: type mismatch resolving `<{async block@$DIR/async.rs:12:17: 12:22} as Future>::Output == i32`
   --> $DIR/async.rs:12:17
    |
 LL |     needs_async(async {});

--- a/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.stderr
+++ b/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.stderr
@@ -2,9 +2,7 @@ error[E0733]: recursion in an async block requires boxing
   --> $DIR/indirect-recursion-issue-112047.rs:22:9
    |
 LL |         async move { recur(self).await; }
-   |         ^^^^^^^^^^^^^-----------------^^^
-   |                      |
-   |                      recursive call here
+   |         ^^^^^^^^^^   ----------------- recursive call here
    |
 note: which leads to this async fn
   --> $DIR/indirect-recursion-issue-112047.rs:14:1


### PR DESCRIPTION
Tightens the span of `async {}` blocks in diagnostics, and subsequently async closures and async fns, by actually setting the `fn_decl_span` correctly. This is kinda a follow-up on #125078, but it fixes the problem in a more general way.

I think the diagnostics are significantly improved, since we no longer have a bunch of overlapping spans. I'll point out one caveat where I think the diagnostic may get a bit more confusing, but where I don't think it matters.

r? @estebank or @oli-obk or someone else on wg-diag or compiler i dont really care lol