### PR TITLE
add inner methods to peekable

### DIFF
--- a/library/core/src/iter/adapters/peekable.rs
+++ b/library/core/src/iter/adapters/peekable.rs
@@ -316,6 +316,18 @@ impl<I: Iterator> Peekable<I> {
     {
         self.next_if(|next| next == expected)
     }
+
+    pub fn into_inner(self) -> I {
+        self.iter
+    }
+
+    pub fn inner(&self) -> &I {
+        &self.iter
+    }
+
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.iter
+    }
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]


### PR DESCRIPTION
r? rust-lang/libs
You have no way to access the inner methods when you create a Peekable.

Use case: I'd like to do something like
```rs
"my str".chars()
  .peekable()
  .inner_ref()
  .as_str();
```