### PR TITLE
Warn when passing pointers to asm! with nomem/readonly options

### DIFF
--- a/tests/ui/asm/x86_64/passing-pointer-nomem-readonly.rs
+++ b/tests/ui/asm/x86_64/passing-pointer-nomem-readonly.rs
@@ -1,0 +1,34 @@
+//@ only-x86_64
+//@ needs-asm-support
+//@ build-pass
+
+#![crate_type = "lib"]
+#![no_std]
+
+unsafe fn nomem_bad(p: &i32) {
+    core::arch::asm!("mov {p}, {p}", p = in(reg) p, options(nomem, nostack, preserves_flags));
+    //~^ WARNING passing a pointer to asm! block with 'nomem' option.
+}
+
+unsafe fn readonly_bad(p: &mut i32) {
+    core::arch::asm!("mov {p}, {p}", p = in(reg) p, options(readonly, nostack, preserves_flags));
+    //~^ WARNING passing a mutable pointer to asm! block with 'readonly' option.
+}
+
+unsafe fn nomem_good(p: &i32) {
+    core::arch::asm!("mov {p}, {p}", p = in(reg) p, options(readonly, nostack, preserves_flags));
+    let p = p as *const i32 as usize;
+    core::arch::asm!("mov {p}, {p}", p = in(reg) p, options(nomem, nostack, preserves_flags));
+}
+
+unsafe fn readonly_good(p: &mut i32) {
+    core::arch::asm!("mov {p}, {p}", p = in(reg) p, options(nostack, preserves_flags));
+    core::arch::asm!("mov {p}, {p}", p = in(reg) &*p, options(readonly, nostack, preserves_flags));
+    let p = p as *const i32;
+    core::arch::asm!("mov {p}, {p}", p = in(reg) p, options(readonly, nostack, preserves_flags));
+}
+
+unsafe fn nomem_bad2(p: &mut i32) {
+    core::arch::asm!("mov {p}, {p}", p = in(reg) p, options(nomem, nostack, preserves_flags));
+    //~^ WARNING passing a pointer to asm! block with 'nomem' option.
+}

--- a/tests/ui/asm/x86_64/passing-pointer-nomem-readonly.stderr
+++ b/tests/ui/asm/x86_64/passing-pointer-nomem-readonly.stderr
@@ -1,0 +1,32 @@
+warning: passing a pointer to asm! block with 'nomem' option.
+  --> $DIR/passing-pointer-nomem-readonly.rs:9:50
+   |
+LL |     core::arch::asm!("mov {p}, {p}", p = in(reg) p, options(nomem, nostack, preserves_flags));
+   |                                                  ^
+   |
+   = note: `nomem` means that no memory write or read happens inside the asm! block.
+   = note: This is not limited to global variables, it also includes passed pointers.
+   = note: If passing this pointer is intentional, replace the `nomem` attribute with `readonly` or remove it completely.
+
+warning: passing a mutable pointer to asm! block with 'readonly' option.
+  --> $DIR/passing-pointer-nomem-readonly.rs:14:50
+   |
+LL |     core::arch::asm!("mov {p}, {p}", p = in(reg) p, options(readonly, nostack, preserves_flags));
+   |                                                  ^
+   |
+   = note: `readonly` means that no memory write happens inside the asm! block.
+   = note: This is not limited to global variables, it also includes passed pointers.
+   = note: If passing this mutable pointer is intentional, remove the `readonly` attribute.
+
+warning: passing a pointer to asm! block with 'nomem' option.
+  --> $DIR/passing-pointer-nomem-readonly.rs:32:50
+   |
+LL |     core::arch::asm!("mov {p}, {p}", p = in(reg) p, options(nomem, nostack, preserves_flags));
+   |                                                  ^
+   |
+   = note: `nomem` means that no memory write or read happens inside the asm! block.
+   = note: This is not limited to global variables, it also includes passed pointers.
+   = note: If passing this pointer is intentional, replace the `nomem` attribute with `readonly` or remove it completely.
+
+warning: 3 warnings emitted
+


### PR DESCRIPTION
I think these warnings would help a lot finding weird bugs caused by improper `options` inside `asm!`, while allowing existing code to compile.