### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5254,6 +5254,7 @@ name = "stable_mir"
 version = "0.1.0-preview"
 dependencies = [
  "scoped-tls",
+ "serde",
 ]
 
 [[package]]

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -2,8 +2,15 @@
 //!
 //! This pass intends to check that the constructed AST is *syntactically valid* to allow the rest
 //! of the compiler to assume that the AST is valid. These checks cannot be performed during parsing
-//! because attribute macros are allowed to accept certain pieces of invalid syntax such as `async
-//! fn` within a trait (before async-fn-in-trait was introduced).
+//! because attribute macros are allowed to accept certain pieces of invalid syntax such as a
+//! function without body outside of a trait definition:
+//!
+//! ```ignore (illustrative)
+//! #[my_attribute]
+//! mod foo {
+//!     fn missing_body();
+//! }
+//! ```
 //!
 //! These checks are run post-expansion, after AST is frozen, to be able to check for erroneous
 //! constructions produced by proc macros. This pass is only intended for simple checks that do not

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1,10 +1,13 @@
-// Validate AST before lowering it to HIR.
-//
-// This pass is supposed to catch things that fit into AST data structures,
-// but not permitted by the language. It runs after expansion when AST is frozen,
-// so it can check for erroneous constructions produced by syntax extensions.
-// This pass is supposed to perform only simple checks not requiring name resolution
-// or type checking or some other kind of complex analysis.
+//! Validate AST before lowering it to HIR.
+//!
+//! This pass intends to check that the constructed AST is *syntactically valid* to allow the rest
+//! of the compiler to assume that the AST is valid. These checks cannot be performed during parsing
+//! because attribute macros are allowed to accept certain pieces of invalid syntax such as `async
+//! fn` within a trait (before async-fn-in-trait was introduced).
+//!
+//! These checks are run post-expansion, after AST is frozen, to be able to check for erroneous
+//! constructions produced by proc macros. This pass is only intended for simple checks that do not
+//! require name resolution or type checking, or other kinds of complex analysis.
 
 use itertools::{Either, Itertools};
 use rustc_ast::ptr::P;

--- a/compiler/rustc_codegen_gcc/src/context.rs
+++ b/compiler/rustc_codegen_gcc/src/context.rs
@@ -27,7 +27,6 @@ use crate::callee::get_fn;
 use crate::common::SignType;
 
 pub struct CodegenCx<'gcc, 'tcx> {
-    pub check_overflow: bool,
     pub codegen_unit: &'tcx CodegenUnit<'tcx>,
     pub context: &'gcc Context<'gcc>,
 
@@ -134,8 +133,6 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
         tcx: TyCtxt<'tcx>,
         supports_128bit_integers: bool,
     ) -> Self {
-        let check_overflow = tcx.sess.overflow_checks();
-
         let create_type = |ctype, rust_type| {
             let layout = tcx.layout_of(ParamEnv::reveal_all().and(rust_type)).unwrap();
             let align = layout.align.abi.bytes();
@@ -271,7 +268,6 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
         }
 
         let mut cx = Self {
-            check_overflow,
             codegen_unit,
             context,
             current_func: RefCell::new(None),
@@ -509,10 +505,6 @@ impl<'gcc, 'tcx> MiscMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
 
     fn sess(&self) -> &Session {
         &self.tcx.sess
-    }
-
-    fn check_overflow(&self) -> bool {
-        self.check_overflow
     }
 
     fn codegen_unit(&self) -> &'tcx CodegenUnit<'tcx> {

--- a/compiler/rustc_codegen_llvm/src/common.rs
+++ b/compiler/rustc_codegen_llvm/src/common.rs
@@ -329,10 +329,6 @@ impl<'ll, 'tcx> ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         const_alloc_to_llvm(self, alloc, /*static*/ false)
     }
 
-    fn const_bitcast(&self, val: &'ll Value, ty: &'ll Type) -> &'ll Value {
-        self.const_bitcast(val, ty)
-    }
-
     fn const_ptr_byte_offset(&self, base_addr: Self::Value, offset: abi::Size) -> Self::Value {
         unsafe {
             llvm::LLVMConstInBoundsGEP2(

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -44,7 +44,6 @@ use std::str;
 /// All other LLVM data structures in the `CodegenCx` are tied to that `llvm::Context`.
 pub struct CodegenCx<'ll, 'tcx> {
     pub tcx: TyCtxt<'tcx>,
-    pub check_overflow: bool,
     pub use_dll_storage_attrs: bool,
     pub tls_model: llvm::ThreadLocalMode,
 
@@ -442,8 +441,6 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
         // start) and then strongly recommending static linkage on Windows!
         let use_dll_storage_attrs = tcx.sess.target.is_like_windows;
 
-        let check_overflow = tcx.sess.overflow_checks();
-
         let tls_model = to_llvm_tls_model(tcx.sess.tls_model());
 
         let (llcx, llmod) = (&*llvm_module.llcx, llvm_module.llmod());
@@ -467,7 +464,6 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
 
         CodegenCx {
             tcx,
-            check_overflow,
             use_dll_storage_attrs,
             tls_model,
             llmod,
@@ -604,10 +600,6 @@ impl<'ll, 'tcx> MiscMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
     fn sess(&self) -> &Session {
         self.tcx.sess
-    }
-
-    fn check_overflow(&self) -> bool {
-        self.check_overflow
     }
 
     fn codegen_unit(&self) -> &'tcx CodegenUnit<'tcx> {

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -3,6 +3,7 @@ use crate::back::write::to_llvm_code_model;
 use crate::callee::get_fn;
 use crate::coverageinfo;
 use crate::debuginfo;
+use crate::debuginfo::metadata::apply_vcall_visibility_metadata;
 use crate::llvm;
 use crate::llvm_util;
 use crate::type_::Type;
@@ -520,6 +521,15 @@ impl<'ll, 'tcx> MiscMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     ) -> &RefCell<FxHashMap<(Ty<'tcx>, Option<ty::PolyExistentialTraitRef<'tcx>>), &'ll Value>>
     {
         &self.vtables
+    }
+
+    fn apply_vcall_visibility_metadata(
+        &self,
+        ty: Ty<'tcx>,
+        poly_trait_ref: Option<ty::PolyExistentialTraitRef<'tcx>>,
+        vtable: &'ll Value,
+    ) {
+        apply_vcall_visibility_metadata(self, ty, poly_trait_ref, vtable);
     }
 
     fn get_fn(&self, instance: Instance<'tcx>) -> &'ll Value {

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -274,10 +274,11 @@ impl CodegenBackend for LlvmCodegenBackend {
             |tcx, ()| llvm_util::global_llvm_features(tcx.sess, true)
     }
 
-    fn print(&self, req: &PrintRequest, out: &mut dyn PrintBackendInfo, sess: &Session) {
+    fn print(&self, req: &PrintRequest, out: &mut String, sess: &Session) {
+        use std::fmt::Write;
         match req.kind {
             PrintKind::RelocationModels => {
-                writeln!(out, "Available relocation models:");
+                writeln!(out, "Available relocation models:").unwrap();
                 for name in &[
                     "static",
                     "pic",
@@ -288,25 +289,25 @@ impl CodegenBackend for LlvmCodegenBackend {
                     "ropi-rwpi",
                     "default",
                 ] {
-                    writeln!(out, "    {name}");
+                    writeln!(out, "    {name}").unwrap();
                 }
-                writeln!(out);
+                writeln!(out).unwrap();
             }
             PrintKind::CodeModels => {
-                writeln!(out, "Available code models:");
+                writeln!(out, "Available code models:").unwrap();
                 for name in &["tiny", "small", "kernel", "medium", "large"] {
-                    writeln!(out, "    {name}");
+                    writeln!(out, "    {name}").unwrap();
                 }
-                writeln!(out);
+                writeln!(out).unwrap();
             }
             PrintKind::TlsModels => {
-                writeln!(out, "Available TLS models:");
+                writeln!(out, "Available TLS models:").unwrap();
                 for name in
                     &["global-dynamic", "local-dynamic", "initial-exec", "local-exec", "emulated"]
                 {
-                    writeln!(out, "    {name}");
+                    writeln!(out, "    {name}").unwrap();
                 }
-                writeln!(out);
+                writeln!(out).unwrap();
             }
             PrintKind::StackProtectorStrategies => {
                 writeln!(
@@ -332,7 +333,8 @@ impl CodegenBackend for LlvmCodegenBackend {
     none
         Do not generate stack canaries.
 "#
-                );
+                )
+                .unwrap();
             }
             _other => llvm_util::print(req, out, sess),
         }

--- a/compiler/rustc_codegen_llvm/src/type_.rs
+++ b/compiler/rustc_codegen_llvm/src/type_.rs
@@ -127,13 +127,24 @@ impl<'ll> CodegenCx<'ll, '_> {
     pub(crate) fn type_variadic_func(&self, args: &[&'ll Type], ret: &'ll Type) -> &'ll Type {
         unsafe { llvm::LLVMFunctionType(ret, args.as_ptr(), args.len() as c_uint, True) }
     }
-}
 
-impl<'ll, 'tcx> BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
-    fn type_i1(&self) -> &'ll Type {
+    pub(crate) fn type_i1(&self) -> &'ll Type {
         unsafe { llvm::LLVMInt1TypeInContext(self.llcx) }
     }
 
+    pub(crate) fn type_struct(&self, els: &[&'ll Type], packed: bool) -> &'ll Type {
+        unsafe {
+            llvm::LLVMStructTypeInContext(
+                self.llcx,
+                els.as_ptr(),
+                els.len() as c_uint,
+                packed as Bool,
+            )
+        }
+    }
+}
+
+impl<'ll, 'tcx> BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     fn type_i8(&self) -> &'ll Type {
         unsafe { llvm::LLVMInt8TypeInContext(self.llcx) }
     }
@@ -176,17 +187,6 @@ impl<'ll, 'tcx> BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
     fn type_func(&self, args: &[&'ll Type], ret: &'ll Type) -> &'ll Type {
         unsafe { llvm::LLVMFunctionType(ret, args.as_ptr(), args.len() as c_uint, False) }
-    }
-
-    fn type_struct(&self, els: &[&'ll Type], packed: bool) -> &'ll Type {
-        unsafe {
-            llvm::LLVMStructTypeInContext(
-                self.llcx,
-                els.as_ptr(),
-                els.len() as c_uint,
-                packed as Bool,
-            )
-        }
     }
 
     fn type_kind(&self, ty: &'ll Type) -> TypeKind {

--- a/compiler/rustc_codegen_ssa/src/meth.rs
+++ b/compiler/rustc_codegen_ssa/src/meth.rs
@@ -133,6 +133,7 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
     let align = cx.data_layout().pointer_align.abi;
     let vtable = cx.static_addr_of(vtable_const, align, Some("vtable"));
 
+    cx.apply_vcall_visibility_metadata(ty, trait_ref, vtable);
     cx.create_vtable_debuginfo(ty, trait_ref, vtable);
     cx.vtables().borrow_mut().insert((ty, trait_ref), vtable);
     vtable

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -658,7 +658,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         // with #[rustc_inherit_overflow_checks] and inlined from
         // another crate (mostly core::num generic/#[inline] fns),
         // while the current crate doesn't use overflow checks.
-        if !bx.cx().check_overflow() && msg.is_optional_overflow_check() {
+        if !bx.sess().overflow_checks() && msg.is_optional_overflow_check() {
             const_cond = Some(expected);
         }
 

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -751,7 +751,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         &mut self,
         helper: &TerminatorCodegenHelper<'tcx>,
         bx: &mut Bx,
-        intrinsic: Option<ty::IntrinsicDef>,
+        intrinsic: ty::IntrinsicDef,
         instance: Option<Instance<'tcx>>,
         source_info: mir::SourceInfo,
         target: Option<mir::BasicBlock>,
@@ -761,8 +761,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         // Emit a panic or a no-op for `assert_*` intrinsics.
         // These are intrinsics that compile to panics so that we can get a message
         // which mentions the offending type, even from a const context.
-        let panic_intrinsic = intrinsic.and_then(|i| ValidityRequirement::from_intrinsic(i.name));
-        if let Some(requirement) = panic_intrinsic {
+        if let Some(requirement) = ValidityRequirement::from_intrinsic(intrinsic.name) {
             let ty = instance.unwrap().args.type_at(0);
 
             let do_panic = !bx
@@ -869,12 +868,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         let sig = callee.layout.ty.fn_sig(bx.tcx());
         let abi = sig.abi();
 
-        // Handle intrinsics old codegen wants Expr's for, ourselves.
-        let intrinsic = match def {
-            Some(ty::InstanceKind::Intrinsic(def_id)) => Some(bx.tcx().intrinsic(def_id).unwrap()),
-            _ => None,
-        };
-
         let extra_args = &args[sig.inputs().skip_binder().len()..];
         let extra_args = bx.tcx().mk_type_list_from_iter(extra_args.iter().map(|op_arg| {
             let op_ty = op_arg.node.ty(self.mir, bx.tcx());
@@ -886,25 +879,25 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             None => bx.fn_abi_of_fn_ptr(sig, extra_args),
         };
 
-        if let Some(merging_succ) = self.codegen_panic_intrinsic(
-            &helper,
-            bx,
-            intrinsic,
-            instance,
-            source_info,
-            target,
-            unwind,
-            mergeable_succ,
-        ) {
-            return merging_succ;
-        }
-
         // The arguments we'll be passing. Plus one to account for outptr, if used.
         let arg_count = fn_abi.args.len() + fn_abi.ret.is_indirect() as usize;
 
-        let instance = match intrinsic {
-            None => instance,
-            Some(intrinsic) => {
+        let instance = match def {
+            Some(ty::InstanceKind::Intrinsic(def_id)) => {
+                let intrinsic = bx.tcx().intrinsic(def_id).unwrap();
+                if let Some(merging_succ) = self.codegen_panic_intrinsic(
+                    &helper,
+                    bx,
+                    intrinsic,
+                    instance,
+                    source_info,
+                    target,
+                    unwind,
+                    mergeable_succ,
+                ) {
+                    return merging_succ;
+                }
+
                 let mut llargs = Vec::with_capacity(1);
                 let ret_dest = self.make_return_dest(
                     bx,
@@ -984,6 +977,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     }
                 }
             }
+            _ => instance,
         };
 
         let mut llargs = Vec::with_capacity(arg_count);

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -22,8 +22,6 @@ use rustc_session::{
 use rustc_span::symbol::Symbol;
 use rustc_target::abi::call::FnAbi;
 
-use std::fmt;
-
 pub trait BackendTypes {
     type Value: CodegenObject;
     type Function: CodegenObject;
@@ -62,7 +60,7 @@ pub trait CodegenBackend {
     fn locale_resource(&self) -> &'static str;
 
     fn init(&self, _sess: &Session) {}
-    fn print(&self, _req: &PrintRequest, _out: &mut dyn PrintBackendInfo, _sess: &Session) {}
+    fn print(&self, _req: &PrintRequest, _out: &mut String, _sess: &Session) {}
     fn target_features(&self, _sess: &Session, _allow_unstable: bool) -> Vec<Symbol> {
         vec![]
     }
@@ -148,21 +146,5 @@ pub trait ExtraBackendMethods:
         T: Send + 'static,
     {
         std::thread::Builder::new().name(name).spawn(f)
-    }
-}
-
-pub trait PrintBackendInfo {
-    fn infallible_write_fmt(&mut self, args: fmt::Arguments<'_>);
-}
-
-impl PrintBackendInfo for String {
-    fn infallible_write_fmt(&mut self, args: fmt::Arguments<'_>) {
-        fmt::Write::write_fmt(self, args).unwrap();
-    }
-}
-
-impl dyn PrintBackendInfo + '_ {
-    pub fn write_fmt(&mut self, args: fmt::Arguments<'_>) {
-        self.infallible_write_fmt(args);
     }
 }

--- a/compiler/rustc_codegen_ssa/src/traits/consts.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/consts.rs
@@ -37,6 +37,5 @@ pub trait ConstMethods<'tcx>: BackendTypes {
 
     fn scalar_to_backend(&self, cv: Scalar, layout: abi::Scalar, llty: Self::Type) -> Self::Value;
 
-    fn const_bitcast(&self, val: Self::Value, ty: Self::Type) -> Self::Value;
     fn const_ptr_byte_offset(&self, val: Self::Value, offset: abi::Size) -> Self::Value;
 }

--- a/compiler/rustc_codegen_ssa/src/traits/misc.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/misc.rs
@@ -16,7 +16,6 @@ pub trait MiscMethods<'tcx>: BackendTypes {
         _vtable: Self::Value,
     ) {
     }
-    fn check_overflow(&self) -> bool;
     fn get_fn(&self, instance: Instance<'tcx>) -> Self::Function;
     fn get_fn_addr(&self, instance: Instance<'tcx>) -> Self::Value;
     fn eh_personality(&self) -> Self::Value;

--- a/compiler/rustc_codegen_ssa/src/traits/misc.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/misc.rs
@@ -9,6 +9,13 @@ pub trait MiscMethods<'tcx>: BackendTypes {
     fn vtables(
         &self,
     ) -> &RefCell<FxHashMap<(Ty<'tcx>, Option<ty::PolyExistentialTraitRef<'tcx>>), Self::Value>>;
+    fn apply_vcall_visibility_metadata(
+        &self,
+        _ty: Ty<'tcx>,
+        _poly_trait_ref: Option<ty::PolyExistentialTraitRef<'tcx>>,
+        _vtable: Self::Value,
+    ) {
+    }
     fn check_overflow(&self) -> bool;
     fn get_fn(&self, instance: Instance<'tcx>) -> Self::Function;
     fn get_fn_addr(&self, instance: Instance<'tcx>) -> Self::Value;

--- a/compiler/rustc_codegen_ssa/src/traits/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/mod.rs
@@ -30,9 +30,7 @@ mod write;
 
 pub use self::abi::AbiBuilderMethods;
 pub use self::asm::{AsmBuilderMethods, AsmMethods, GlobalAsmOperandRef, InlineAsmOperandRef};
-pub use self::backend::{
-    Backend, BackendTypes, CodegenBackend, ExtraBackendMethods, PrintBackendInfo,
-};
+pub use self::backend::{Backend, BackendTypes, CodegenBackend, ExtraBackendMethods};
 pub use self::builder::{BuilderMethods, OverflowOp};
 pub use self::consts::ConstMethods;
 pub use self::coverageinfo::CoverageInfoBuilderMethods;

--- a/compiler/rustc_codegen_ssa/src/traits/type_.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/type_.rs
@@ -113,8 +113,8 @@ pub trait LayoutTypeMethods<'tcx>: Backend<'tcx> {
     /// The backend type used for a rust type when it's in an SSA register.
     ///
     /// For nearly all types this is the same as the [`Self::backend_type`], however
-    /// `bool` (and other `0`-or-`1` values) are kept as [`BaseTypeMethods::type_i1`]
-    /// in registers but as [`BaseTypeMethods::type_i8`] in memory.
+    /// `bool` (and other `0`-or-`1` values) are kept as `i1` in registers but as
+    /// [`BaseTypeMethods::type_i8`] in memory.
     ///
     /// Converting values between the two different backend types is done using
     /// [`from_immediate`](super::BuilderMethods::from_immediate) and

--- a/compiler/rustc_codegen_ssa/src/traits/type_.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/type_.rs
@@ -12,7 +12,6 @@ use rustc_target::abi::{AddressSpace, Float, Integer};
 // This depends on `Backend` and not `BackendTypes`, because consumers will probably want to use
 // `LayoutOf` or `HasTyCtxt`. This way, they don't have to add a constraint on it themselves.
 pub trait BaseTypeMethods<'tcx>: Backend<'tcx> {
-    fn type_i1(&self) -> Self::Type;
     fn type_i8(&self) -> Self::Type;
     fn type_i16(&self) -> Self::Type;
     fn type_i32(&self) -> Self::Type;
@@ -27,7 +26,6 @@ pub trait BaseTypeMethods<'tcx>: Backend<'tcx> {
 
     fn type_array(&self, ty: Self::Type, len: u64) -> Self::Type;
     fn type_func(&self, args: &[Self::Type], ret: Self::Type) -> Self::Type;
-    fn type_struct(&self, els: &[Self::Type], packed: bool) -> Self::Type;
     fn type_kind(&self, ty: Self::Type) -> TypeKind;
     fn type_ptr(&self) -> Self::Type;
     fn type_ptr_ext(&self, address_space: AddressSpace) -> Self::Type;

--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -50,7 +50,7 @@ declare_lint! {
     /// All nested bodies (functions, enum discriminant, array length, consts) (expect for
     /// `const _: Ty = { ... }` in top-level module, which is still undecided) are checked.
     pub NON_LOCAL_DEFINITIONS,
-    Warn,
+    Allow,
     "checks for non-local definitions",
     report_in_external_macro
 }

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -2491,14 +2491,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 true,
             );
             // This block is for the failure case
-            let failure = this.bind_pattern(
-                this.source_info(else_block_span),
-                wildcard,
-                &[],
-                initializer_span,
-                None,
-                true,
-            );
+            let failure = wildcard.pre_binding_block.unwrap();
 
             // If branch coverage is enabled, record this branch.
             this.visit_coverage_conditional_let(pattern, matching, failure);

--- a/compiler/rustc_mir_build/src/build/matches/util.rs
+++ b/compiler/rustc_mir_build/src/build/matches/util.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::build::expr::as_place::{PlaceBase, PlaceBuilder};
 use crate::build::matches::{Binding, Candidate, FlatPat, MatchPair, TestCase};
 use crate::build::Builder;
@@ -267,18 +269,6 @@ impl<'pat, 'tcx> MatchPair<'pat, 'tcx> {
     }
 }
 
-pub(super) struct FakeBorrowCollector<'a, 'b, 'tcx> {
-    cx: &'a mut Builder<'b, 'tcx>,
-    /// Base of the scrutinee place. Used to distinguish bindings inside the scrutinee place from
-    /// bindings inside deref patterns.
-    scrutinee_base: PlaceBase,
-    /// Store for each place the kind of borrow to take. In case of conflicts, we take the strongest
-    /// borrow (i.e. Deep > Shallow).
-    /// Invariant: for any place in `fake_borrows`, all the prefixes of this place that are
-    /// dereferences are also borrowed with the same of stronger borrow kind.
-    fake_borrows: FxIndexMap<Place<'tcx>, FakeBorrowKind>,
-}
-
 /// Determine the set of places that have to be stable across match guards.
 ///
 /// Returns a list of places that need a fake borrow along with a local to store it.
@@ -340,6 +330,18 @@ pub(super) fn collect_fake_borrows<'tcx>(
             (*matched_place, fake_borrow_temp, *borrow_kind)
         })
         .collect()
+}
+
+pub(super) struct FakeBorrowCollector<'a, 'b, 'tcx> {
+    cx: &'a mut Builder<'b, 'tcx>,
+    /// Base of the scrutinee place. Used to distinguish bindings inside the scrutinee place from
+    /// bindings inside deref patterns.
+    scrutinee_base: PlaceBase,
+    /// Store for each place the kind of borrow to take. In case of conflicts, we take the strongest
+    /// borrow (i.e. Deep > Shallow).
+    /// Invariant: for any place in `fake_borrows`, all the prefixes of this place that are
+    /// dereferences are also borrowed with the same of stronger borrow kind.
+    fake_borrows: FxIndexMap<Place<'tcx>, FakeBorrowKind>,
 }
 
 impl<'a, 'b, 'tcx> FakeBorrowCollector<'a, 'b, 'tcx> {
@@ -452,6 +454,57 @@ impl<'a, 'b, 'tcx> FakeBorrowCollector<'a, 'b, 'tcx> {
         //     x => (),
         // }
         self.fake_borrow_deref_prefixes(*source, FakeBorrowKind::Shallow);
+    }
+}
+
+/// Visit all the bindings of these candidates. Because or-alternatives bind the same variables, we
+/// only explore the first one of each or-pattern.
+pub(super) fn visit_bindings<'tcx>(
+    candidates: &[&mut Candidate<'_, 'tcx>],
+    f: impl FnMut(&Binding<'tcx>),
+) {
+    let mut visitor = BindingsVisitor { f, phantom: PhantomData };
+    for candidate in candidates.iter() {
+        visitor.visit_candidate(candidate);
+    }
+}
+
+pub(super) struct BindingsVisitor<'tcx, F> {
+    f: F,
+    phantom: PhantomData<&'tcx ()>,
+}
+
+impl<'tcx, F> BindingsVisitor<'tcx, F>
+where
+    F: FnMut(&Binding<'tcx>),
+{
+    fn visit_candidate(&mut self, candidate: &Candidate<'_, 'tcx>) {
+        for binding in &candidate.extra_data.bindings {
+            (self.f)(binding)
+        }
+        for match_pair in &candidate.match_pairs {
+            self.visit_match_pair(match_pair);
+        }
+    }
+
+    fn visit_flat_pat(&mut self, flat_pat: &FlatPat<'_, 'tcx>) {
+        for binding in &flat_pat.extra_data.bindings {
+            (self.f)(binding)
+        }
+        for match_pair in &flat_pat.match_pairs {
+            self.visit_match_pair(match_pair);
+        }
+    }
+
+    fn visit_match_pair(&mut self, match_pair: &MatchPair<'_, 'tcx>) {
+        if let TestCase::Or { pats, .. } = &match_pair.test_case {
+            // All the or-alternatives should bind the same locals, so we only visit the first one.
+            self.visit_flat_pat(&pats[0])
+        } else {
+            for subpair in &match_pair.subpairs {
+                self.visit_match_pair(subpair);
+            }
+        }
     }
 }
 

--- a/compiler/stable_mir/Cargo.toml
+++ b/compiler/stable_mir/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 scoped-tls = "1.0"
+serde = { version = "1.0.125", features = [ "derive" ] }

--- a/compiler/stable_mir/src/abi.rs
+++ b/compiler/stable_mir/src/abi.rs
@@ -5,12 +5,13 @@ use crate::target::{MachineInfo, MachineSize as Size};
 use crate::ty::{Align, IndexedVal, Ty, VariantIdx};
 use crate::Error;
 use crate::Opaque;
+use serde::Serialize;
 use std::fmt::{self, Debug};
 use std::num::NonZero;
 use std::ops::RangeInclusive;
 
 /// A function ABI definition.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct FnAbi {
     /// The types of each argument.
     pub args: Vec<ArgAbi>,
@@ -31,7 +32,7 @@ pub struct FnAbi {
 }
 
 /// Information about the ABI of a function's argument, or return value.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct ArgAbi {
     pub ty: Ty,
     pub layout: Layout,
@@ -39,7 +40,7 @@ pub struct ArgAbi {
 }
 
 /// How a function argument should be passed in to the target function.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum PassMode {
     /// Ignore the argument.
     ///
@@ -60,14 +61,14 @@ pub enum PassMode {
 }
 
 /// The layout of a type, alongside the type itself.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct TyAndLayout {
     pub ty: Ty,
     pub layout: Layout,
 }
 
 /// The layout of a type in memory.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct LayoutShape {
     /// The fields location withing the layout
     pub fields: FieldsShape,
@@ -108,7 +109,7 @@ impl LayoutShape {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct Layout(usize);
 
 impl Layout {
@@ -127,7 +128,7 @@ impl IndexedVal for Layout {
 }
 
 /// Describes how the fields of a type are shaped in memory.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum FieldsShape {
     /// Scalar primitives and `!`, which never have fields.
     Primitive,
@@ -177,7 +178,7 @@ impl FieldsShape {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum VariantsShape {
     /// Single enum variants, structs/tuples, unions, and all non-ADTs.
     Single { index: VariantIdx },
@@ -196,7 +197,7 @@ pub enum VariantsShape {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum TagEncoding {
     /// The tag directly stores the discriminant, but possibly with a smaller layout
     /// (so converting the tag to the discriminant can require sign extension).
@@ -221,7 +222,7 @@ pub enum TagEncoding {
 
 /// Describes how values of the type are passed by target ABIs,
 /// in terms of categories of C types there are ABI rules for.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum ValueAbi {
     Uninhabited,
     Scalar(Scalar),
@@ -250,7 +251,7 @@ impl ValueAbi {
 }
 
 /// Information about one scalar component of a Rust type.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize)]
 pub enum Scalar {
     Initialized {
         /// The primitive type used to represent this value.
@@ -280,7 +281,7 @@ impl Scalar {
 }
 
 /// Fundamental unit of memory access and layout.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize)]
 pub enum Primitive {
     /// The `bool` is the signedness of the `Integer` type.
     ///
@@ -310,7 +311,7 @@ impl Primitive {
 }
 
 /// Enum representing the existing integer lengths.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize)]
 pub enum IntegerLength {
     I8,
     I16,
@@ -320,7 +321,7 @@ pub enum IntegerLength {
 }
 
 /// Enum representing the existing float lengths.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize)]
 pub enum FloatLength {
     F16,
     F32,
@@ -354,7 +355,7 @@ impl FloatLength {
 /// An identifier that specifies the address space that some operation
 /// should operate on. Special address spaces have an effect on code generation,
 /// depending on the target and the address spaces it implements.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct AddressSpace(pub u32);
 
 impl AddressSpace {
@@ -369,7 +370,7 @@ impl AddressSpace {
 /// sequence:
 ///
 ///    254 (-2), 255 (-1), 0, 1, 2
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub struct WrappingRange {
     pub start: u128,
     pub end: u128,
@@ -420,7 +421,7 @@ impl Debug for WrappingRange {
 }
 
 /// General language calling conventions.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum CallConvention {
     C,
     Rust,

--- a/compiler/stable_mir/src/crate_def.rs
+++ b/compiler/stable_mir/src/crate_def.rs
@@ -3,9 +3,10 @@
 
 use crate::ty::{GenericArgs, Span, Ty};
 use crate::{with, Crate, Symbol};
+use serde::Serialize;
 
 /// A unique identification number for each item accessible for the current compilation unit.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub struct DefId(pub(crate) usize);
 
 /// A trait for retrieving information about a particular definition.

--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -27,6 +27,7 @@ pub use crate::error::*;
 use crate::mir::Body;
 use crate::mir::Mutability;
 use crate::ty::{ForeignModuleDef, ImplDef, IndexedVal, Span, TraitDef, Ty};
+use serde::Serialize;
 
 pub mod abi;
 #[macro_use]
@@ -74,7 +75,7 @@ pub type TraitDecls = Vec<TraitDef>;
 pub type ImplTraitDecls = Vec<ImplDef>;
 
 /// Holds information about a crate.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize)]
 pub struct Crate {
     pub id: CrateNum,
     pub name: Symbol,
@@ -98,7 +99,7 @@ impl Crate {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Serialize)]
 pub enum ItemKind {
     Fn,
     Static,
@@ -106,7 +107,7 @@ pub enum ItemKind {
     Ctor(CtorKind),
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Serialize)]
 pub enum CtorKind {
     Const,
     Fn,
@@ -116,6 +117,7 @@ pub type Filename = String;
 
 crate_def_with_ty! {
     /// Holds information about an item in a crate.
+    #[derive(Serialize)]
     pub CrateItem;
 }
 
@@ -188,7 +190,7 @@ pub fn all_trait_impls() -> ImplTraitDecls {
 }
 
 /// A type that provides internal information but that can still be used for debug purpose.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct Opaque(String);
 
 impl std::fmt::Display for Opaque {

--- a/compiler/stable_mir/src/mir/alloc.rs
+++ b/compiler/stable_mir/src/mir/alloc.rs
@@ -4,11 +4,12 @@ use crate::mir::mono::{Instance, StaticDef};
 use crate::target::{Endian, MachineInfo};
 use crate::ty::{Allocation, Binder, ExistentialTraitRef, IndexedVal, Ty};
 use crate::{with, Error};
+use serde::Serialize;
 use std::io::Read;
 
 /// An allocation in the SMIR global memory can be either a function pointer,
 /// a static, or a "real" allocation with some data in it.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub enum GlobalAlloc {
     /// The alloc ID is used as a function pointer.
     Function(Instance),
@@ -41,7 +42,7 @@ impl GlobalAlloc {
 }
 
 /// A unique identification number for each provenance
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize)]
 pub struct AllocId(usize);
 
 impl IndexedVal for AllocId {

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -5,10 +5,11 @@ use crate::ty::{
     TyConst, TyKind, VariantIdx,
 };
 use crate::{Error, Opaque, Span, Symbol};
+use serde::Serialize;
 use std::io;
 
 /// The SMIR representation of a single function.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct Body {
     pub blocks: Vec<BasicBlock>,
 
@@ -104,20 +105,20 @@ impl Body {
 
 type LocalDecls = Vec<LocalDecl>;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct LocalDecl {
     pub ty: Ty,
     pub span: Span,
     pub mutability: Mutability,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize)]
 pub struct BasicBlock {
     pub statements: Vec<Statement>,
     pub terminator: Terminator,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Terminator {
     pub kind: TerminatorKind,
     pub span: Span,
@@ -131,7 +132,7 @@ impl Terminator {
 
 pub type Successors = Vec<BasicBlockIdx>;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum TerminatorKind {
     Goto {
         target: BasicBlockIdx,
@@ -221,7 +222,7 @@ impl TerminatorKind {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct InlineAsmOperand {
     pub in_value: Option<Operand>,
     pub out_place: Option<Place>,
@@ -230,7 +231,7 @@ pub struct InlineAsmOperand {
     pub raw_rpr: String,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum UnwindAction {
     Continue,
     Unreachable,
@@ -238,7 +239,7 @@ pub enum UnwindAction {
     Cleanup(BasicBlockIdx),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum AssertMessage {
     BoundsCheck { len: Operand, index: Operand },
     Overflow(BinOp, Operand, Operand),
@@ -307,7 +308,7 @@ impl AssertMessage {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum BinOp {
     Add,
     AddUnchecked,
@@ -342,7 +343,7 @@ impl BinOp {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum UnOp {
     Not,
     Neg,
@@ -357,20 +358,20 @@ impl UnOp {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum CoroutineKind {
     Desugared(CoroutineDesugaring, CoroutineSource),
     Coroutine(Movability),
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum CoroutineSource {
     Block,
     Closure,
     Fn,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum CoroutineDesugaring {
     Async,
 
@@ -386,7 +387,7 @@ pub(crate) type LocalDefId = Opaque;
 pub(crate) type Coverage = Opaque;
 
 /// The FakeReadCause describes the type of pattern why a FakeRead statement exists.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum FakeReadCause {
     ForMatchGuard,
     ForMatchedPlace(LocalDefId),
@@ -396,7 +397,7 @@ pub enum FakeReadCause {
 }
 
 /// Describes what kind of retag is to be performed
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize)]
 pub enum RetagKind {
     FnEntry,
     TwoPhase,
@@ -404,7 +405,7 @@ pub enum RetagKind {
     Default,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize)]
 pub enum Variance {
     Covariant,
     Invariant,
@@ -412,26 +413,26 @@ pub enum Variance {
     Bivariant,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CopyNonOverlapping {
     pub src: Operand,
     pub dst: Operand,
     pub count: Operand,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum NonDivergingIntrinsic {
     Assume(Operand),
     CopyNonOverlapping(CopyNonOverlapping),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Statement {
     pub kind: StatementKind,
     pub span: Span,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum StatementKind {
     Assign(Place, Rvalue),
     FakeRead(FakeReadCause, Place),
@@ -448,7 +449,7 @@ pub enum StatementKind {
     Nop,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum Rvalue {
     /// Creates a pointer with the indicated mutability to the place.
     ///
@@ -622,7 +623,7 @@ impl Rvalue {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum AggregateKind {
     Array(Ty),
     Tuple,
@@ -633,14 +634,14 @@ pub enum AggregateKind {
     RawPtr(Ty, Mutability),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum Operand {
     Copy(Place),
     Move(Place),
     Constant(ConstOperand),
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Serialize)]
 pub struct Place {
     pub local: Local,
     /// projection out of a place (access a field, deref a pointer, etc)
@@ -653,7 +654,7 @@ impl From<Local> for Place {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ConstOperand {
     pub span: Span,
     pub user_ty: Option<UserTypeAnnotationIndex>,
@@ -661,7 +662,7 @@ pub struct ConstOperand {
 }
 
 /// Debug information pertaining to a user variable.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct VarDebugInfo {
     /// The variable name.
     pub name: Symbol,
@@ -703,19 +704,19 @@ impl VarDebugInfo {
 
 pub type SourceScope = u32;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct SourceInfo {
     pub span: Span,
     pub scope: SourceScope,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct VarDebugInfoFragment {
     pub ty: Ty,
     pub projection: Vec<ProjectionElem>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum VarDebugInfoContents {
     Place(Place),
     Const(ConstOperand),
@@ -726,7 +727,7 @@ pub enum VarDebugInfoContents {
 // ProjectionElem<Local, Ty>) and user-provided type annotations (for which the projection elements
 // are of type ProjectionElem<(), ()>). In SMIR we don't need this generality, so we just use
 // ProjectionElem for Places.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum ProjectionElem {
     /// Dereference projections (e.g. `*_1`) project to the address referenced by the base place.
     Deref,
@@ -800,7 +801,7 @@ pub enum ProjectionElem {
     Subtype(Ty),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct UserTypeProjection {
     pub base: UserTypeAnnotationIndex,
 
@@ -830,7 +831,7 @@ pub type FieldIdx = usize;
 type UserTypeAnnotationIndex = usize;
 
 /// The possible branch sites of a [TerminatorKind::SwitchInt].
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct SwitchTargets {
     /// The conditional branches where the first element represents the value that guards this
     /// branch, and the second element is the branch target.
@@ -867,7 +868,7 @@ impl SwitchTargets {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum BorrowKind {
     /// Data must be immutable and is aliasable.
     Shared,
@@ -894,14 +895,14 @@ impl BorrowKind {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum MutBorrowKind {
     Default,
     TwoPhaseBorrow,
     ClosureCapture,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum FakeBorrowKind {
     /// A shared (deep) borrow. Data must be immutable and is aliasable.
     Deep,
@@ -912,19 +913,19 @@ pub enum FakeBorrowKind {
     Shallow,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum Mutability {
     Not,
     Mut,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum Safety {
     Safe,
     Unsafe,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum PointerCoercion {
     /// Go from a fn-item type to a fn-pointer type.
     ReifyFnPointer,
@@ -951,7 +952,7 @@ pub enum PointerCoercion {
     Unsize,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum CastKind {
     // FIXME(smir-rename): rename this to PointerExposeProvenance
     PointerExposeAddress,
@@ -967,7 +968,7 @@ pub enum CastKind {
     Transmute,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum NullOp {
     /// Returns the size of a value of that type.
     SizeOf,

--- a/compiler/stable_mir/src/mir/mono.rs
+++ b/compiler/stable_mir/src/mir/mono.rs
@@ -3,17 +3,18 @@ use crate::crate_def::CrateDef;
 use crate::mir::Body;
 use crate::ty::{Allocation, ClosureDef, ClosureKind, FnDef, GenericArgs, IndexedVal, Ty};
 use crate::{with, CrateItem, DefId, Error, ItemKind, Opaque, Symbol};
+use serde::Serialize;
 use std::fmt::{Debug, Formatter};
 use std::io;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum MonoItem {
     Fn(Instance),
     Static(StaticDef),
     GlobalAsm(Opaque),
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct Instance {
     /// The type of instance.
     pub kind: InstanceKind,
@@ -22,7 +23,7 @@ pub struct Instance {
     pub def: InstanceDef,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum InstanceKind {
     /// A user defined item.
     Item,
@@ -240,7 +241,7 @@ impl From<StaticDef> for CrateItem {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct InstanceDef(usize);
 
 impl CrateDef for InstanceDef {
@@ -251,6 +252,7 @@ impl CrateDef for InstanceDef {
 
 crate_def! {
     /// Holds information about a static variable definition.
+    #[derive(Serialize)]
     pub StaticDef;
 }
 

--- a/compiler/stable_mir/src/target.rs
+++ b/compiler/stable_mir/src/target.rs
@@ -1,9 +1,10 @@
 //! Provide information about the machine that this is being compiled into.
 
 use crate::compiler_interface::with;
+use serde::Serialize;
 
 /// The properties of the target machine being compiled into.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize)]
 pub struct MachineInfo {
     pub endian: Endian,
     pub pointer_width: MachineSize,
@@ -23,14 +24,14 @@ impl MachineInfo {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Serialize)]
 pub enum Endian {
     Little,
     Big,
 }
 
 /// Represent the size of a component.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize)]
 pub struct MachineSize {
     num_bits: usize,
 }

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -8,10 +8,11 @@ use crate::mir::alloc::{read_target_int, read_target_uint, AllocId};
 use crate::mir::mono::StaticDef;
 use crate::target::MachineInfo;
 use crate::{Filename, Opaque};
+use serde::Serialize;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::Range;
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize)]
 pub struct Ty(usize);
 
 impl Debug for Ty {
@@ -100,13 +101,13 @@ impl Ty {
 }
 
 /// Represents a pattern in the type system
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum Pattern {
     Range { start: Option<TyConst>, end: Option<TyConst>, include_end: bool },
 }
 
 /// Represents a constant in the type system
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TyConst {
     pub(crate) kind: TyConstKind,
     pub id: TyConstId,
@@ -133,7 +134,7 @@ impl TyConst {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum TyConstKind {
     Param(ParamConst),
     Bound(DebruijnIndex, BoundVar),
@@ -144,11 +145,11 @@ pub enum TyConstKind {
     ZSTValue(Ty),
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TyConstId(usize);
 
 /// Represents a constant in MIR
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct MirConst {
     /// The constant kind.
     pub(crate) kind: ConstantKind,
@@ -205,17 +206,17 @@ impl MirConst {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub struct MirConstId(usize);
 
 type Ident = Opaque;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Region {
     pub kind: RegionKind,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum RegionKind {
     ReEarlyParam(EarlyParamRegion),
     ReBound(DebruijnIndex, BoundRegion),
@@ -226,7 +227,7 @@ pub enum RegionKind {
 
 pub(crate) type DebruijnIndex = u32;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct EarlyParamRegion {
     pub index: u32,
     pub name: Symbol,
@@ -234,7 +235,7 @@ pub struct EarlyParamRegion {
 
 pub(crate) type BoundVar = u32;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct BoundRegion {
     pub var: BoundVar,
     pub kind: BoundRegionKind,
@@ -242,13 +243,13 @@ pub struct BoundRegion {
 
 pub(crate) type UniverseIndex = u32;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Placeholder<T> {
     pub universe: UniverseIndex,
     pub bound: T,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct Span(usize);
 
 impl Debug for Span {
@@ -272,7 +273,7 @@ impl Span {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize)]
 /// Information you get from `Span` in a struct form.
 /// Line and col start from 1.
 pub struct LineInfo {
@@ -282,7 +283,7 @@ pub struct LineInfo {
     pub end_col: usize,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum TyKind {
     RigidTy(RigidTy),
     Alias(AliasKind, AliasTy),
@@ -521,7 +522,7 @@ pub struct TypeAndMut {
     pub mutability: Mutability,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum RigidTy {
     Bool,
     Char,
@@ -560,7 +561,7 @@ impl From<RigidTy> for TyKind {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub enum IntTy {
     Isize,
     I8,
@@ -583,7 +584,7 @@ impl IntTy {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub enum UintTy {
     Usize,
     U8,
@@ -606,19 +607,20 @@ impl UintTy {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub enum FloatTy {
     F32,
     F64,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub enum Movability {
     Static,
     Movable,
 }
 
 crate_def! {
+    #[derive(Serialize)]
     pub ForeignModuleDef;
 }
 
@@ -641,6 +643,7 @@ impl ForeignModule {
 
 crate_def_with_ty! {
     /// Hold information about a ForeignItem in a crate.
+    #[derive(Serialize)]
     pub ForeignDef;
 }
 
@@ -650,7 +653,7 @@ impl ForeignDef {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize)]
 pub enum ForeignItemKind {
     Fn(FnDef),
     Static(StaticDef),
@@ -659,6 +662,7 @@ pub enum ForeignItemKind {
 
 crate_def_with_ty! {
     /// Hold information about a function definition in a crate.
+    #[derive(Serialize)]
     pub FnDef;
 }
 
@@ -692,6 +696,7 @@ impl FnDef {
 }
 
 crate_def_with_ty! {
+    #[derive(Serialize)]
     pub IntrinsicDef;
 }
 
@@ -716,26 +721,31 @@ impl From<IntrinsicDef> for FnDef {
 }
 
 crate_def! {
+    #[derive(Serialize)]
     pub ClosureDef;
 }
 
 crate_def! {
+    #[derive(Serialize)]
     pub CoroutineDef;
 }
 
 crate_def! {
+    #[derive(Serialize)]
     pub ParamDef;
 }
 
 crate_def! {
+    #[derive(Serialize)]
     pub BrNamedDef;
 }
 
-crate_def_with_ty! {
+crate_def! {
+    #[derive(Serialize)]
     pub AdtDef;
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize)]
 pub enum AdtKind {
     Enum,
     Union,
@@ -789,7 +799,7 @@ impl AdtDef {
 }
 
 /// Definition of a variant, which can be either a struct / union field or an enum variant.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct VariantDef {
     /// The variant index.
     ///
@@ -818,7 +828,7 @@ impl VariantDef {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct FieldDef {
     /// The field definition.
     ///
@@ -869,11 +879,13 @@ impl AdtKind {
 }
 
 crate_def! {
+    #[derive(Serialize)]
     pub AliasDef;
 }
 
 crate_def! {
     /// A trait's definition.
+    #[derive(Serialize)]
     pub TraitDef;
 }
 
@@ -884,15 +896,18 @@ impl TraitDef {
 }
 
 crate_def! {
+    #[derive(Serialize)]
     pub GenericDef;
 }
 
 crate_def_with_ty! {
+    #[derive(Serialize)]
     pub ConstDef;
 }
 
 crate_def! {
     /// A trait impl definition.
+    #[derive(Serialize)]
     pub ImplDef;
 }
 
@@ -904,15 +919,17 @@ impl ImplDef {
 }
 
 crate_def! {
+    #[derive(Serialize)]
     pub RegionDef;
 }
 
 crate_def! {
+    #[derive(Serialize)]
     pub CoroutineWitnessDef;
 }
 
 /// A list of generic arguments.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct GenericArgs(pub Vec<GenericArgKind>);
 
 impl std::ops::Index<ParamTy> for GenericArgs {
@@ -931,7 +948,7 @@ impl std::ops::Index<ParamConst> for GenericArgs {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum GenericArgKind {
     Lifetime(Region),
     Type(Ty),
@@ -968,13 +985,13 @@ impl GenericArgKind {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum TermKind {
     Type(Ty),
     Const(TyConst),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum AliasKind {
     Projection,
     Inherent,
@@ -982,13 +999,13 @@ pub enum AliasKind {
     Weak,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct AliasTy {
     pub def_id: AliasDef,
     pub args: GenericArgs,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct AliasTerm {
     pub def_id: AliasDef,
     pub args: GenericArgs,
@@ -1006,7 +1023,7 @@ impl PolyFnSig {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct FnSig {
     pub inputs_and_output: Vec<Ty>,
     pub c_variadic: bool,
@@ -1024,7 +1041,7 @@ impl FnSig {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize)]
 pub enum Abi {
     Rust,
     C { unwind: bool },
@@ -1054,7 +1071,7 @@ pub enum Abi {
 }
 
 /// A binder represents a possibly generic type and its bound vars.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Binder<T> {
     pub value: T,
     pub bound_vars: Vec<BoundVariableKind>,
@@ -1094,38 +1111,38 @@ impl<T> Binder<T> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct EarlyBinder<T> {
     pub value: T,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum BoundVariableKind {
     Ty(BoundTyKind),
     Region(BoundRegionKind),
     Const,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize)]
 pub enum BoundTyKind {
     Anon,
     Param(ParamDef, String),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum BoundRegionKind {
     BrAnon,
     BrNamed(BrNamedDef, String),
     BrEnv,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum DynKind {
     Dyn,
     DynStar,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum ExistentialPredicate {
     Trait(ExistentialTraitRef),
     Projection(ExistentialProjection),
@@ -1135,7 +1152,7 @@ pub enum ExistentialPredicate {
 /// An existential reference to a trait where `Self` is not included.
 ///
 /// The `generic_args` will include any other known argument.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ExistentialTraitRef {
     pub def_id: TraitDef,
     pub generic_args: GenericArgs,
@@ -1153,20 +1170,20 @@ impl ExistentialTraitRef {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ExistentialProjection {
     pub def_id: TraitDef,
     pub generic_args: GenericArgs,
     pub term: TermKind,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ParamTy {
     pub index: u32,
     pub name: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct BoundTy {
     pub var: usize,
     pub kind: BoundTyKind,
@@ -1177,7 +1194,7 @@ pub type Bytes = Vec<Option<u8>>;
 /// Size in bytes.
 pub type Size = usize;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize)]
 pub struct Prov(pub AllocId);
 
 pub type Align = u64;
@@ -1185,14 +1202,14 @@ pub type Promoted = u32;
 pub type InitMaskMaterialized = Vec<u64>;
 
 /// Stores the provenance information of pointers stored in memory.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize)]
 pub struct ProvenanceMap {
     /// Provenance in this map applies from the given offset for an entire pointer-size worth of
     /// bytes. Two entries in this map are always at least a pointer size apart.
     pub ptrs: Vec<(Size, Prov)>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize)]
 pub struct Allocation {
     pub bytes: Bytes,
     pub provenance: ProvenanceMap,
@@ -1268,7 +1285,7 @@ impl Allocation {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum ConstantKind {
     Ty(TyConst),
     Allocated(Allocation),
@@ -1279,27 +1296,27 @@ pub enum ConstantKind {
     ZeroSized,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ParamConst {
     pub index: u32,
     pub name: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct UnevaluatedConst {
     pub def: ConstDef,
     pub args: GenericArgs,
     pub promoted: Option<Promoted>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub enum TraitSpecializationKind {
     None,
     Marker,
     AlwaysApplicable,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TraitDecl {
     pub def_id: TraitDef,
     pub safety: Safety,
@@ -1332,7 +1349,7 @@ impl TraitDecl {
 pub type ImplTrait = EarlyBinder<TraitRef>;
 
 /// A complete reference to a trait, i.e., one where `Self` is known.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TraitRef {
     pub def_id: TraitDef,
     /// The generic arguments for this definition.
@@ -1366,7 +1383,7 @@ impl TraitRef {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Generics {
     pub parent: Option<GenericDef>,
     pub parent_count: usize,
@@ -1377,14 +1394,14 @@ pub struct Generics {
     pub host_effect_index: Option<usize>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum GenericParamDefKind {
     Lifetime,
     Type { has_default: bool, synthetic: bool },
     Const { has_default: bool },
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct GenericParamDef {
     pub name: super::Symbol,
     pub def_id: GenericDef,
@@ -1398,7 +1415,7 @@ pub struct GenericPredicates {
     pub predicates: Vec<(PredicateKind, Span)>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum PredicateKind {
     Clause(ClauseKind),
     ObjectSafe(TraitDef),
@@ -1409,7 +1426,7 @@ pub enum PredicateKind {
     AliasRelate(TermKind, TermKind, AliasRelationDirection),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum ClauseKind {
     Trait(TraitPredicate),
     RegionOutlives(RegionOutlivesPredicate),
@@ -1420,57 +1437,57 @@ pub enum ClauseKind {
     ConstEvaluatable(TyConst),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum ClosureKind {
     Fn,
     FnMut,
     FnOnce,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct SubtypePredicate {
     pub a: Ty,
     pub b: Ty,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CoercePredicate {
     pub a: Ty,
     pub b: Ty,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum AliasRelationDirection {
     Equate,
     Subtype,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TraitPredicate {
     pub trait_ref: TraitRef,
     pub polarity: PredicatePolarity,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct OutlivesPredicate<A, B>(pub A, pub B);
 
 pub type RegionOutlivesPredicate = OutlivesPredicate<Region, Region>;
 pub type TypeOutlivesPredicate = OutlivesPredicate<Ty, Region>;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ProjectionPredicate {
     pub projection_term: AliasTerm,
     pub term: TermKind,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum ImplPolarity {
     Positive,
     Negative,
     Reservation,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum PredicatePolarity {
     Positive,
     Negative,
@@ -1513,7 +1530,7 @@ index_impl!(Span);
 /// `a` is in the variant with the `VariantIdx` of `0`,
 /// `c` is in the variant with the `VariantIdx` of `1`, and
 /// `g` is in the variant with the `VariantIdx` of `0`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct VariantIdx(usize);
 
 index_impl!(VariantIdx);

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -168,12 +168,12 @@ target | std | notes
 `i686-unknown-freebsd` | ✓ | 32-bit FreeBSD [^x86_32-floats-return-ABI]
 `i686-unknown-linux-musl` | ✓ | 32-bit Linux with musl 1.2.3 [^x86_32-floats-return-ABI]
 [`i686-unknown-uefi`](platform-support/unknown-uefi.md) | ? | 32-bit UEFI
-[`loongarch64-unknown-none`](platform-support/loongarch-none.md) | * |  | LoongArch64 Bare-metal (LP64D ABI)
-[`loongarch64-unknown-none-softfloat`](platform-support/loongarch-none.md) | * |  | LoongArch64 Bare-metal (LP64S ABI)
+[`loongarch64-unknown-none`](platform-support/loongarch-none.md) | * | LoongArch64 Bare-metal (LP64D ABI)
+[`loongarch64-unknown-none-softfloat`](platform-support/loongarch-none.md) | * | LoongArch64 Bare-metal (LP64S ABI)
 [`nvptx64-nvidia-cuda`](platform-support/nvptx64-nvidia-cuda.md) | * | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
 [`riscv32imac-unknown-none-elf`](platform-support/riscv32-unknown-none-elf.md) | * | Bare RISC-V (RV32IMAC ISA)
 [`riscv32i-unknown-none-elf`](platform-support/riscv32-unknown-none-elf.md) | * | Bare RISC-V (RV32I ISA)
-[`riscv32im-unknown-none-elf`](platform-support/riscv32-unknown-none-elf.md) | * |  | Bare RISC-V (RV32IM ISA)
+[`riscv32im-unknown-none-elf`](platform-support/riscv32-unknown-none-elf.md) | * | Bare RISC-V (RV32IM ISA)
 [`riscv32imc-unknown-none-elf`](platform-support/riscv32-unknown-none-elf.md) | * | Bare RISC-V (RV32IMC ISA)
 [`riscv32imafc-unknown-none-elf`](platform-support/riscv32-unknown-none-elf.md) | * | Bare RISC-V (RV32IMAFC ISA)
 `riscv64gc-unknown-none-elf` | * | Bare RISC-V (RV64IMAFDC ISA)
@@ -193,7 +193,7 @@ target | std | notes
 `wasm32-unknown-unknown` | ✓ | WebAssembly
 `wasm32-wasi` | ✓ | WebAssembly with WASI (undergoing a [rename to `wasm32-wasip1`][wasi-rename])
 [`wasm32-wasip1`](platform-support/wasm32-wasip1.md) | ✓ | WebAssembly with WASI
-[`wasm32-wasip1-threads`](platform-support/wasm32-wasip1-threads.md) | ✓ |  | WebAssembly with WASI Preview 1 and threads
+[`wasm32-wasip1-threads`](platform-support/wasm32-wasip1-threads.md) | ✓ | WebAssembly with WASI Preview 1 and threads
 [`x86_64-apple-ios`](platform-support/apple-ios.md) | ✓ | 64-bit x86 iOS
 [`x86_64-fortanix-unknown-sgx`](platform-support/x86_64-fortanix-unknown-sgx.md) | ✓ | [Fortanix ABI] for 64-bit Intel SGX
 `x86_64-fuchsia` | ✓ | Alias for `x86_64-unknown-fuchsia`

--- a/tests/mir-opt/building/issue_101867.main.built.after.mir
+++ b/tests/mir-opt/building/issue_101867.main.built.after.mir
@@ -27,13 +27,13 @@ fn main() -> () {
         StorageLive(_5);
         PlaceMention(_1);
         _6 = discriminant(_1);
-        switchInt(move _6) -> [1: bb6, otherwise: bb4];
+        switchInt(move _6) -> [1: bb4, otherwise: bb3];
     }
 
     bb1: {
         StorageLive(_3);
         StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> bb10;
+        _4 = begin_panic::<&str>(const "explicit panic") -> bb8;
     }
 
     bb2: {
@@ -43,12 +43,11 @@ fn main() -> () {
     }
 
     bb3: {
-        FakeRead(ForMatchedPlace(None), _1);
-        unreachable;
+        goto -> bb7;
     }
 
     bb4: {
-        goto -> bb9;
+        falseEdge -> [real: bb6, imaginary: bb3];
     }
 
     bb5: {
@@ -56,14 +55,6 @@ fn main() -> () {
     }
 
     bb6: {
-        falseEdge -> [real: bb8, imaginary: bb4];
-    }
-
-    bb7: {
-        goto -> bb4;
-    }
-
-    bb8: {
         _5 = ((_1 as Some).0: u8);
         _0 = const ();
         StorageDead(_5);
@@ -71,12 +62,12 @@ fn main() -> () {
         return;
     }
 
-    bb9: {
+    bb7: {
         StorageDead(_5);
         goto -> bb1;
     }
 
-    bb10 (cleanup): {
+    bb8 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/logical_or_in_conditional.test_complex.built.after.mir
+++ b/tests/mir-opt/building/logical_or_in_conditional.test_complex.built.after.mir
@@ -19,22 +19,21 @@ fn test_complex() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = E::f() -> [return: bb1, unwind: bb38];
+        _2 = E::f() -> [return: bb1, unwind: bb34];
     }
 
     bb1: {
         PlaceMention(_2);
         _3 = discriminant(_2);
-        switchInt(move _3) -> [0: bb5, otherwise: bb3];
+        switchInt(move _3) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
-        FakeRead(ForMatchedPlace(None), _2);
-        unreachable;
+        goto -> bb21;
     }
 
     bb3: {
-        goto -> bb23;
+        falseEdge -> [real: bb5, imaginary: bb2];
     }
 
     bb4: {
@@ -42,175 +41,158 @@ fn test_complex() -> () {
     }
 
     bb5: {
-        falseEdge -> [real: bb7, imaginary: bb3];
+        StorageLive(_4);
+        _4 = always_true() -> [return: bb6, unwind: bb34];
     }
 
     bb6: {
-        goto -> bb3;
+        switchInt(move _4) -> [0: bb8, otherwise: bb7];
     }
 
     bb7: {
-        StorageLive(_4);
-        _4 = always_true() -> [return: bb8, unwind: bb38];
-    }
-
-    bb8: {
-        switchInt(move _4) -> [0: bb10, otherwise: bb9];
-    }
-
-    bb9: {
         StorageLive(_5);
         StorageLive(_6);
         StorageLive(_7);
         _7 = Droppy(const 0_u8);
         _6 = (_7.0: u8);
         _5 = Gt(move _6, const 0_u8);
-        switchInt(move _5) -> [0: bb12, otherwise: bb11];
+        switchInt(move _5) -> [0: bb10, otherwise: bb9];
+    }
+
+    bb8: {
+        goto -> bb14;
+    }
+
+    bb9: {
+        drop(_7) -> [return: bb11, unwind: bb34];
     }
 
     bb10: {
-        goto -> bb16;
+        goto -> bb12;
     }
 
     bb11: {
-        drop(_7) -> [return: bb13, unwind: bb38];
+        StorageDead(_7);
+        StorageDead(_6);
+        goto -> bb18;
     }
 
     bb12: {
-        goto -> bb14;
+        drop(_7) -> [return: bb13, unwind: bb34];
     }
 
     bb13: {
         StorageDead(_7);
         StorageDead(_6);
-        goto -> bb20;
+        goto -> bb14;
     }
 
     bb14: {
-        drop(_7) -> [return: bb15, unwind: bb38];
-    }
-
-    bb15: {
-        StorageDead(_7);
-        StorageDead(_6);
-        goto -> bb16;
-    }
-
-    bb16: {
         StorageLive(_8);
         StorageLive(_9);
         StorageLive(_10);
         _10 = Droppy(const 1_u8);
         _9 = (_10.0: u8);
         _8 = Gt(move _9, const 1_u8);
-        switchInt(move _8) -> [0: bb18, otherwise: bb17];
+        switchInt(move _8) -> [0: bb16, otherwise: bb15];
+    }
+
+    bb15: {
+        drop(_10) -> [return: bb17, unwind: bb34];
+    }
+
+    bb16: {
+        goto -> bb19;
     }
 
     bb17: {
-        drop(_10) -> [return: bb19, unwind: bb38];
+        StorageDead(_10);
+        StorageDead(_9);
+        goto -> bb18;
     }
 
     bb18: {
-        goto -> bb21;
+        _1 = const ();
+        goto -> bb22;
     }
 
     bb19: {
-        StorageDead(_10);
-        StorageDead(_9);
-        goto -> bb20;
+        drop(_10) -> [return: bb20, unwind: bb34];
     }
 
     bb20: {
-        _1 = const ();
-        goto -> bb24;
+        StorageDead(_10);
+        StorageDead(_9);
+        goto -> bb21;
     }
 
     bb21: {
-        drop(_10) -> [return: bb22, unwind: bb38];
+        _1 = const ();
+        goto -> bb22;
     }
 
     bb22: {
-        StorageDead(_10);
-        StorageDead(_9);
-        goto -> bb23;
-    }
-
-    bb23: {
-        _1 = const ();
-        goto -> bb24;
-    }
-
-    bb24: {
         StorageDead(_8);
         StorageDead(_5);
         StorageDead(_4);
         StorageDead(_2);
         StorageDead(_1);
         StorageLive(_11);
-        _11 = always_true() -> [return: bb25, unwind: bb38];
+        _11 = always_true() -> [return: bb23, unwind: bb34];
+    }
+
+    bb23: {
+        switchInt(move _11) -> [0: bb25, otherwise: bb24];
+    }
+
+    bb24: {
+        goto -> bb32;
     }
 
     bb25: {
-        switchInt(move _11) -> [0: bb27, otherwise: bb26];
+        goto -> bb26;
     }
 
     bb26: {
-        goto -> bb36;
+        StorageLive(_12);
+        _12 = E::f() -> [return: bb27, unwind: bb34];
     }
 
     bb27: {
-        goto -> bb28;
+        PlaceMention(_12);
+        _13 = discriminant(_12);
+        switchInt(move _13) -> [1: bb29, otherwise: bb28];
     }
 
     bb28: {
-        StorageLive(_12);
-        _12 = E::f() -> [return: bb29, unwind: bb38];
+        goto -> bb32;
     }
 
     bb29: {
-        PlaceMention(_12);
-        _13 = discriminant(_12);
-        switchInt(move _13) -> [1: bb33, otherwise: bb31];
+        falseEdge -> [real: bb31, imaginary: bb28];
     }
 
     bb30: {
-        FakeRead(ForMatchedPlace(None), _12);
-        unreachable;
+        goto -> bb28;
     }
 
     bb31: {
-        goto -> bb36;
+        _0 = const ();
+        goto -> bb33;
     }
 
     bb32: {
-        goto -> bb30;
+        _0 = const ();
+        goto -> bb33;
     }
 
     bb33: {
-        falseEdge -> [real: bb35, imaginary: bb31];
-    }
-
-    bb34: {
-        goto -> bb31;
-    }
-
-    bb35: {
-        _0 = const ();
-        goto -> bb37;
-    }
-
-    bb36: {
-        _0 = const ();
-        goto -> bb37;
-    }
-
-    bb37: {
         StorageDead(_11);
         StorageDead(_12);
         return;
     }
 
-    bb38 (cleanup): {
+    bb34 (cleanup): {
         resume;
     }
 }

--- a/tests/rustdoc-ui/doctest/non_local_defs.rs
+++ b/tests/rustdoc-ui/doctest/non_local_defs.rs
@@ -4,6 +4,8 @@
 //@ normalize-stderr-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 
+#![doc(test(attr(warn(non_local_definitions))))]
+
 //! ```
 //! #[macro_export]
 //! macro_rules! a_macro { () => {} }

--- a/tests/rustdoc-ui/doctest/non_local_defs.stderr
+++ b/tests/rustdoc-ui/doctest/non_local_defs.stderr
@@ -1,5 +1,5 @@
 warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
-  --> $DIR/non_local_defs.rs:9:1
+  --> $DIR/non_local_defs.rs:11:1
    |
 LL | macro_rules! a_macro { () => {} }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,11 @@ LL | macro_rules! a_macro { () => {} }
    = help: remove the `#[macro_export]` or make this doc-test a standalone test with its own `fn main() { ... }`
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/non_local_defs.rs:8:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/rustdoc-ui/doctest/non_local_defs.stdout
+++ b/tests/rustdoc-ui/doctest/non_local_defs.stdout
@@ -1,6 +1,6 @@
 
 running 1 test
-test $DIR/non_local_defs.rs - (line 7) ... ok
+test $DIR/non_local_defs.rs - (line 9) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/ui-fulldeps/stable-mir/smir_serde.rs
+++ b/tests/ui-fulldeps/stable-mir/smir_serde.rs
@@ -1,0 +1,75 @@
+//@ run-pass
+//! Test that users are able to use serialize stable MIR constructs.
+
+//@ ignore-stage1
+//@ ignore-cross-compile
+//@ ignore-remote
+//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
+//@ edition: 2021
+
+#![feature(rustc_private)]
+#![feature(assert_matches)]
+#![feature(control_flow_enum)]
+
+#[macro_use]
+extern crate rustc_smir;
+extern crate rustc_driver;
+extern crate rustc_interface;
+extern crate rustc_middle;
+extern crate stable_mir;
+extern crate serde;
+extern crate serde_json;
+
+use rustc_middle::ty::TyCtxt;
+use rustc_smir::rustc_internal;
+use stable_mir::mir::Body;
+use std::io::{Write, BufWriter};
+use std::ops::ControlFlow;
+use serde_json::to_string;
+
+
+const CRATE_NAME: &str = "input";
+
+fn serialize_to_json(_tcx: TyCtxt<'_>) -> ControlFlow<()> {
+    let path = "output.json";
+    let mut writer = BufWriter::new(std::fs::File::create(path)
+        .expect("Failed to create path"));
+    let local_crate = stable_mir::local_crate();
+    let items: Vec<Body> = stable_mir::all_local_items()
+        .iter()
+        .map(|item| { item.body() })
+        .collect();
+    let crate_data = ( local_crate.name, items );
+    writer.write_all(to_string(&crate_data)
+        .expect("serde_json failed")
+        .as_bytes()).expect("JSON serialization failed");
+    ControlFlow::Continue(())
+}
+
+/// This test will generate and analyze a dummy crate using the stable mir.
+/// For that, it will first write the dummy crate into a file.
+/// Then it will create a `StableMir` using custom arguments and then
+/// it will run the compiler.
+fn main() {
+    let path = "internal_input.rs";
+    generate_input(&path).unwrap();
+    let args = vec![
+        "rustc".to_string(),
+        "--crate-name".to_string(),
+        CRATE_NAME.to_string(),
+        path.to_string(),
+    ];
+    run_with_tcx!(args, serialize_to_json).unwrap();
+}
+
+fn generate_input(path: &str) -> std::io::Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    write!(
+        file,
+        r#"
+    pub fn main() {{
+    }}
+    "#
+    )?;
+    Ok(())
+}

--- a/tests/ui/lint/non-local-defs/cargo-update.rs
+++ b/tests/ui/lint/non-local-defs/cargo-update.rs
@@ -10,6 +10,8 @@
 // of the `cargo update` suggestion we assert it here.
 //@ error-pattern: `cargo update -p non_local_macro`
 
+#![warn(non_local_definitions)]
+
 extern crate non_local_macro;
 
 struct LocalStruct;

--- a/tests/ui/lint/non-local-defs/cargo-update.stderr
+++ b/tests/ui/lint/non-local-defs/cargo-update.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/cargo-update.rs:17:1
+  --> $DIR/cargo-update.rs:19:1
    |
 LL | non_local_macro::non_local_impl!(LocalStruct);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -14,7 +14,11 @@ LL | non_local_macro::non_local_impl!(LocalStruct);
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/cargo-update.rs:13:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
    = note: this warning originates in the macro `non_local_macro::non_local_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted

--- a/tests/ui/lint/non-local-defs/consts.rs
+++ b/tests/ui/lint/non-local-defs/consts.rs
@@ -2,6 +2,8 @@
 //@ edition:2021
 //@ rustc-env:CARGO_CRATE_NAME=non_local_def
 
+#![warn(non_local_definitions)]
+
 struct Test;
 
 trait Uto {}

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:13:5
+  --> $DIR/consts.rs:15:5
    |
 LL | const Z: () = {
    | -----------
@@ -17,10 +17,14 @@ LL |     impl Uto for &Test {}
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/consts.rs:5:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:24:5
+  --> $DIR/consts.rs:26:5
    |
 LL | static A: u32 = {
    | ------------- move the `impl` block outside of this static `A`
@@ -36,7 +40,7 @@ LL |     impl Uto2 for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:32:5
+  --> $DIR/consts.rs:34:5
    |
 LL | const B: u32 = {
    | ------------ move the `impl` block outside of this constant `B`
@@ -52,7 +56,7 @@ LL |     impl Uto3 for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:43:5
+  --> $DIR/consts.rs:45:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -65,7 +69,7 @@ LL |     impl Test {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:50:9
+  --> $DIR/consts.rs:52:9
    |
 LL |       const {
    |  ___________-
@@ -84,7 +88,7 @@ LL | |     };
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:59:9
+  --> $DIR/consts.rs:61:9
    |
 LL |     const _: u32 = {
    |     ------------ move the `impl` block outside of this constant `_` and up 2 bodies
@@ -98,7 +102,7 @@ LL |         impl Test {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:72:9
+  --> $DIR/consts.rs:74:9
    |
 LL |     let _a = || {
    |              -- move the `impl` block outside of this closure `<unnameable>` and up 2 bodies
@@ -113,7 +117,7 @@ LL |         impl Uto9 for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:79:9
+  --> $DIR/consts.rs:81:9
    |
 LL |       type A = [u32; {
    |  ____________________-

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.rs
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 struct Dog;
 
 fn main() {

--- a/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive-trait.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:7:5
+  --> $DIR/exhaustive-trait.rs:9:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -12,10 +12,14 @@ LL |     impl PartialEq<()> for Dog {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive-trait.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:14:5
+  --> $DIR/exhaustive-trait.rs:16:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -31,7 +35,7 @@ LL |     impl PartialEq<()> for &Dog {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:21:5
+  --> $DIR/exhaustive-trait.rs:23:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -47,7 +51,7 @@ LL |     impl PartialEq<Dog> for () {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:28:5
+  --> $DIR/exhaustive-trait.rs:30:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -63,7 +67,7 @@ LL |     impl PartialEq<&Dog> for () {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:35:5
+  --> $DIR/exhaustive-trait.rs:37:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -79,7 +83,7 @@ LL |     impl PartialEq<Dog> for &Dog {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive-trait.rs:42:5
+  --> $DIR/exhaustive-trait.rs:44:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`

--- a/tests/ui/lint/non-local-defs/exhaustive.rs
+++ b/tests/ui/lint/non-local-defs/exhaustive.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 use std::fmt::Display;
 
 trait Trait {}

--- a/tests/ui/lint/non-local-defs/exhaustive.stderr
+++ b/tests/ui/lint/non-local-defs/exhaustive.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:10:5
+  --> $DIR/exhaustive.rs:12:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -10,10 +10,14 @@ LL |     impl Test {
    |
    = note: methods and associated constants are still usable outside the current expression, only `impl Local` and `impl dyn Local` can ever be private, and only if the type is nested in the same item as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/exhaustive.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:15:5
+  --> $DIR/exhaustive.rs:17:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -29,7 +33,7 @@ LL |     impl Display for Test {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:22:5
+  --> $DIR/exhaustive.rs:24:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -43,7 +47,7 @@ LL |     impl dyn Trait {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:25:5
+  --> $DIR/exhaustive.rs:27:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -59,7 +63,7 @@ LL |     impl<T: Trait> Trait for Vec<T> { }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:28:5
+  --> $DIR/exhaustive.rs:30:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -75,7 +79,7 @@ LL |     impl Trait for &dyn Trait {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:31:5
+  --> $DIR/exhaustive.rs:33:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -91,7 +95,7 @@ LL |     impl Trait for *mut Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:34:5
+  --> $DIR/exhaustive.rs:36:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -107,7 +111,7 @@ LL |     impl Trait for *mut [Test] {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:37:5
+  --> $DIR/exhaustive.rs:39:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -123,7 +127,7 @@ LL |     impl Trait for [Test; 8] {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:40:5
+  --> $DIR/exhaustive.rs:42:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -139,7 +143,7 @@ LL |     impl Trait for (Test,) {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:43:5
+  --> $DIR/exhaustive.rs:45:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -155,7 +159,7 @@ LL |     impl Trait for fn(Test) -> () {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:46:5
+  --> $DIR/exhaustive.rs:48:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -171,7 +175,7 @@ LL |     impl Trait for fn() -> Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:50:9
+  --> $DIR/exhaustive.rs:52:9
    |
 LL |     let _a = || {
    |              -- move the `impl` block outside of this closure `<unnameable>` and up 2 bodies
@@ -186,7 +190,7 @@ LL |         impl Trait for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:58:5
+  --> $DIR/exhaustive.rs:60:5
    |
 LL |     impl Trait for *mut InsideMain {}
    |     ^^^^^-----^^^^^---------------
@@ -198,28 +202,7 @@ LL |     impl Trait for *mut InsideMain {}
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
-   |
-LL | fn main() {
-   | ^^^^^^^^^
-...
-LL |     struct InsideMain;
-   |     ----------------- may need to be moved as well
-   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-
-warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:60:5
-   |
-LL |     impl Trait for *mut [InsideMain] {}
-   |     ^^^^^-----^^^^^-----------------
-   |          |         |
-   |          |         `*mut [InsideMain]` is not local
-   |          `Trait` is not local
-   |
-   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
-   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
-help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
+  --> $DIR/exhaustive.rs:11:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -231,16 +214,16 @@ LL |     struct InsideMain;
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:62:5
    |
-LL |     impl Trait for [InsideMain; 8] {}
-   |     ^^^^^-----^^^^^---------------
+LL |     impl Trait for *mut [InsideMain] {}
+   |     ^^^^^-----^^^^^-----------------
    |          |         |
-   |          |         `[InsideMain; 8]` is not local
+   |          |         `*mut [InsideMain]` is not local
    |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
+  --> $DIR/exhaustive.rs:11:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -252,16 +235,16 @@ LL |     struct InsideMain;
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:64:5
    |
-LL |     impl Trait for (InsideMain,) {}
-   |     ^^^^^-----^^^^^-------------
+LL |     impl Trait for [InsideMain; 8] {}
+   |     ^^^^^-----^^^^^---------------
    |          |         |
-   |          |         `(InsideMain,)` is not local
+   |          |         `[InsideMain; 8]` is not local
    |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
+  --> $DIR/exhaustive.rs:11:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -273,16 +256,16 @@ LL |     struct InsideMain;
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:66:5
    |
-LL |     impl Trait for fn(InsideMain) -> () {}
-   |     ^^^^^-----^^^^^--------------------
+LL |     impl Trait for (InsideMain,) {}
+   |     ^^^^^-----^^^^^-------------
    |          |         |
-   |          |         `fn(: InsideMain) -> ()` is not local
+   |          |         `(InsideMain,)` is not local
    |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
+  --> $DIR/exhaustive.rs:11:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -294,16 +277,16 @@ LL |     struct InsideMain;
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
   --> $DIR/exhaustive.rs:68:5
    |
-LL |     impl Trait for fn() -> InsideMain {}
-   |     ^^^^^-----^^^^^------------------
+LL |     impl Trait for fn(InsideMain) -> () {}
+   |     ^^^^^-----^^^^^--------------------
    |          |         |
-   |          |         `fn() -> InsideMain` is not local
+   |          |         `fn(: InsideMain) -> ()` is not local
    |          `Trait` is not local
    |
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/exhaustive.rs:9:1
+  --> $DIR/exhaustive.rs:11:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -313,7 +296,28 @@ LL |     struct InsideMain;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:72:9
+  --> $DIR/exhaustive.rs:70:5
+   |
+LL |     impl Trait for fn() -> InsideMain {}
+   |     ^^^^^-----^^^^^------------------
+   |          |         |
+   |          |         `fn() -> InsideMain` is not local
+   |          `Trait` is not local
+   |
+   = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+help: move the `impl` block outside of this function `main`
+  --> $DIR/exhaustive.rs:11:1
+   |
+LL | fn main() {
+   | ^^^^^^^^^
+...
+LL |     struct InsideMain;
+   |     ----------------- may need to be moved as well
+   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
+
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
+  --> $DIR/exhaustive.rs:74:9
    |
 LL |     fn inside_inside() {
    |     ------------------ move the `impl` block outside of this function `inside_inside` and up 2 bodies
@@ -328,7 +332,7 @@ LL |         impl Display for InsideMain {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/exhaustive.rs:79:9
+  --> $DIR/exhaustive.rs:81:9
    |
 LL |     fn inside_inside() {
    |     ------------------ move the `impl` block outside of this function `inside_inside` and up 2 bodies

--- a/tests/ui/lint/non-local-defs/from-local-for-global.rs
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 struct Cat;
 struct Wrap<T>(T);
 

--- a/tests/ui/lint/non-local-defs/from-local-for-global.stderr
+++ b/tests/ui/lint/non-local-defs/from-local-for-global.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/from-local-for-global.rs:8:5
+  --> $DIR/from-local-for-global.rs:10:5
    |
 LL | fn main() {
    | --------- move the `impl` block outside of this function `main`
@@ -12,10 +12,14 @@ LL |     impl From<Cat> for () {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/from-local-for-global.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/from-local-for-global.rs:18:5
+  --> $DIR/from-local-for-global.rs:20:5
    |
 LL |     impl From<Wrap<Wrap<Elephant>>> for () {
    |     ^^^^^----^^^^^^^^^^^^^^^^^^^^^^^^^^^--
@@ -25,7 +29,7 @@ LL |     impl From<Wrap<Wrap<Elephant>>> for () {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/from-local-for-global.rs:7:1
+  --> $DIR/from-local-for-global.rs:9:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -35,7 +39,7 @@ LL |     struct Elephant;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/from-local-for-global.rs:32:5
+  --> $DIR/from-local-for-global.rs:34:5
    |
 LL |     impl StillNonLocal for &Foo {}
    |     ^^^^^-------------^^^^^----
@@ -47,7 +51,7 @@ LL |     impl StillNonLocal for &Foo {}
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `only_global`
-  --> $DIR/from-local-for-global.rs:30:1
+  --> $DIR/from-local-for-global.rs:32:1
    |
 LL | fn only_global() {
    | ^^^^^^^^^^^^^^^^
@@ -56,7 +60,7 @@ LL |     struct Foo;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/from-local-for-global.rs:40:5
+  --> $DIR/from-local-for-global.rs:42:5
    |
 LL |     impl From<Local1> for GlobalSameFunction {
    |     ^^^^^----^^^^^^^^^^^^^------------------
@@ -67,7 +71,7 @@ LL |     impl From<Local1> for GlobalSameFunction {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `same_function`
-  --> $DIR/from-local-for-global.rs:38:1
+  --> $DIR/from-local-for-global.rs:40:1
    |
 LL | fn same_function() {
    | ^^^^^^^^^^^^^^^^^^
@@ -76,7 +80,7 @@ LL |     struct Local1(GlobalSameFunction);
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/from-local-for-global.rs:48:5
+  --> $DIR/from-local-for-global.rs:50:5
    |
 LL |     impl From<Local2> for GlobalSameFunction {
    |     ^^^^^----^^^^^^^^^^^^^------------------
@@ -87,7 +91,7 @@ LL |     impl From<Local2> for GlobalSameFunction {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `same_function`
-  --> $DIR/from-local-for-global.rs:38:1
+  --> $DIR/from-local-for-global.rs:40:1
    |
 LL | fn same_function() {
    | ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-local-defs/generics.rs
+++ b/tests/ui/lint/non-local-defs/generics.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 trait Global {}
 
 fn main() {

--- a/tests/ui/lint/non-local-defs/generics.stderr
+++ b/tests/ui/lint/non-local-defs/generics.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:9:5
+  --> $DIR/generics.rs:11:5
    |
 LL |     impl<T: Local> Global for Vec<T> { }
    |     ^^^^^^^^^^^^^^^------^^^^^---^^^
@@ -10,17 +10,21 @@ LL |     impl<T: Local> Global for Vec<T> { }
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/generics.rs:6:1
+  --> $DIR/generics.rs:8:1
    |
 LL | fn main() {
    | ^^^^^^^^^
 LL |     trait Local {};
    |     ----------- may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/generics.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:20:5
+  --> $DIR/generics.rs:22:5
    |
 LL |     impl Uto7 for Test where Local: std::any::Any {}
    |     ^^^^^----^^^^^----
@@ -31,7 +35,7 @@ LL |     impl Uto7 for Test where Local: std::any::Any {}
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `bad`
-  --> $DIR/generics.rs:18:1
+  --> $DIR/generics.rs:20:1
    |
 LL | fn bad() {
    | ^^^^^^^^
@@ -40,7 +44,7 @@ LL |     struct Local;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:23:5
+  --> $DIR/generics.rs:25:5
    |
 LL | fn bad() {
    | -------- move the `impl` block outside of this function `bad`
@@ -56,7 +60,7 @@ LL |     impl<T> Uto8 for T {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:32:5
+  --> $DIR/generics.rs:34:5
    |
 LL |     impl Default for UwU<OwO> {
    |     ^^^^^-------^^^^^---^^^^^
@@ -67,7 +71,7 @@ LL |     impl Default for UwU<OwO> {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `fun`
-  --> $DIR/generics.rs:29:1
+  --> $DIR/generics.rs:31:1
    |
 LL | fn fun() {
    | ^^^^^^^^
@@ -77,7 +81,7 @@ LL |     struct OwO;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:43:5
+  --> $DIR/generics.rs:45:5
    |
 LL |     impl AsRef<Cat> for () {
    |     ^^^^^-----^^^^^^^^^^--
@@ -88,7 +92,7 @@ LL |     impl AsRef<Cat> for () {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `meow`
-  --> $DIR/generics.rs:40:1
+  --> $DIR/generics.rs:42:1
    |
 LL | fn meow() {
    | ^^^^^^^^^
@@ -98,7 +102,7 @@ LL |     struct Cat;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:54:5
+  --> $DIR/generics.rs:56:5
    |
 LL |     impl PartialEq<B> for G {
    |     ^^^^^---------^^^^^^^^-
@@ -109,7 +113,7 @@ LL |     impl PartialEq<B> for G {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `fun2`
-  --> $DIR/generics.rs:51:1
+  --> $DIR/generics.rs:53:1
    |
 LL | fn fun2() {
    | ^^^^^^^^^
@@ -119,7 +123,7 @@ LL |     struct B;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:69:5
+  --> $DIR/generics.rs:71:5
    |
 LL |     impl From<Wrap<Wrap<Lion>>> for () {
    |     ^^^^^----^^^^^^^^^^^^^^^^^^^^^^^--
@@ -129,7 +133,7 @@ LL |     impl From<Wrap<Wrap<Lion>>> for () {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `rawr`
-  --> $DIR/generics.rs:66:1
+  --> $DIR/generics.rs:68:1
    |
 LL | fn rawr() {
    | ^^^^^^^^^
@@ -138,7 +142,7 @@ LL |     struct Lion;
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/generics.rs:76:5
+  --> $DIR/generics.rs:78:5
    |
 LL |     impl From<()> for Wrap<Lion> {
    |     ^^^^^----^^^^^^^^^----^^^^^^
@@ -149,7 +153,7 @@ LL |     impl From<()> for Wrap<Lion> {
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `rawr`
-  --> $DIR/generics.rs:66:1
+  --> $DIR/generics.rs:68:1
    |
 LL | fn rawr() {
    | ^^^^^^^^^

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.rs
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 macro_rules! m {
     () => {
         trait MacroTrait {}

--- a/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/inside-macro_rules.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/inside-macro_rules.rs:9:13
+  --> $DIR/inside-macro_rules.rs:11:13
    |
 LL |         fn my_func() {
    |         ------------ move the `impl` block outside of this function `my_func`
@@ -16,7 +16,11 @@ LL | m!();
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/inside-macro_rules.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
    = note: this warning originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted

--- a/tests/ui/lint/non-local-defs/local.rs
+++ b/tests/ui/lint/non-local-defs/local.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 use std::fmt::Debug;
 
 trait GlobalTrait {}

--- a/tests/ui/lint/non-local-defs/macro_rules.rs
+++ b/tests/ui/lint/non-local-defs/macro_rules.rs
@@ -3,6 +3,8 @@
 //@ aux-build:non_local_macro.rs
 //@ rustc-env:CARGO_CRATE_NAME=non_local_def
 
+#![warn(non_local_definitions)]
+
 extern crate non_local_macro;
 
 const B: u32 = {

--- a/tests/ui/lint/non-local-defs/macro_rules.stderr
+++ b/tests/ui/lint/non-local-defs/macro_rules.stderr
@@ -1,5 +1,5 @@
 warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
-  --> $DIR/macro_rules.rs:10:5
+  --> $DIR/macro_rules.rs:12:5
    |
 LL |     macro_rules! m0 { () => { } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,10 +7,14 @@ LL |     macro_rules! m0 { () => { } };
    = help: remove the `#[macro_export]` or move this `macro_rules!` outside the of the current constant `B`
    = note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/macro_rules.rs:6:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
-  --> $DIR/macro_rules.rs:16:1
+  --> $DIR/macro_rules.rs:18:1
    |
 LL | non_local_macro::non_local_macro_rules!(my_macro);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +26,7 @@ LL | non_local_macro::non_local_macro_rules!(my_macro);
    = note: this warning originates in the macro `non_local_macro::non_local_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
-  --> $DIR/macro_rules.rs:21:5
+  --> $DIR/macro_rules.rs:23:5
    |
 LL |     macro_rules! m { () => { } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +36,7 @@ LL |     macro_rules! m { () => { } };
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
-  --> $DIR/macro_rules.rs:29:13
+  --> $DIR/macro_rules.rs:31:13
    |
 LL |             macro_rules! m2 { () => { } };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-local-defs/suggest-moving-inner.rs
+++ b/tests/ui/lint/non-local-defs/suggest-moving-inner.rs
@@ -1,5 +1,7 @@
 //@ check-pass
 
+#![warn(non_local_definitions)]
+
 trait Trait<T> {}
 
 fn main() {

--- a/tests/ui/lint/non-local-defs/suggest-moving-inner.stderr
+++ b/tests/ui/lint/non-local-defs/suggest-moving-inner.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/suggest-moving-inner.rs:12:5
+  --> $DIR/suggest-moving-inner.rs:14:5
    |
 LL |     impl<T> Trait<InsideMain> for &Vec<below::Type<(InsideMain, T)>>
    |     ^^^^^^^^-----^^^^^^^^^^^^^^^^^----------------------------------
@@ -10,7 +10,7 @@ LL |     impl<T> Trait<InsideMain> for &Vec<below::Type<(InsideMain, T)>>
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/suggest-moving-inner.rs:5:1
+  --> $DIR/suggest-moving-inner.rs:7:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -23,7 +23,11 @@ LL |     struct InsideMain;
 LL |     trait HasFoo {}
    |     ------------ may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/suggest-moving-inner.rs:3:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.rs
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.rs
@@ -3,6 +3,8 @@
 
 // https://github.com/rust-lang/rust/issues/123573#issue-2229428739
 
+#![warn(non_local_definitions)]
+
 pub trait Test {}
 
 impl<'a, T: 'a> Test for &[T] where &'a T: Test {}

--- a/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
+++ b/tests/ui/lint/non-local-defs/trait-solver-overflow-123573.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/trait-solver-overflow-123573.rs:12:5
+  --> $DIR/trait-solver-overflow-123573.rs:14:5
    |
 LL |     impl Test for &Local {}
    |     ^^^^^----^^^^^------
@@ -11,14 +11,18 @@ LL |     impl Test for &Local {}
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 help: move the `impl` block outside of this function `main`
-  --> $DIR/trait-solver-overflow-123573.rs:10:1
+  --> $DIR/trait-solver-overflow-123573.rs:12:1
    |
 LL | fn main() {
    | ^^^^^^^^^
 LL |     struct Local {}
    |     ------------ may need to be moved as well
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/trait-solver-overflow-123573.rs:6:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/non-local-defs/weird-exprs.rs
+++ b/tests/ui/lint/non-local-defs/weird-exprs.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![warn(non_local_definitions)]
+
 trait Uto {}
 struct Test;
 

--- a/tests/ui/lint/non-local-defs/weird-exprs.stderr
+++ b/tests/ui/lint/non-local-defs/weird-exprs.stderr
@@ -1,5 +1,5 @@
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:8:5
+  --> $DIR/weird-exprs.rs:10:5
    |
 LL |   type A = [u32; {
    |  ________________-
@@ -16,10 +16,14 @@ LL | | }];
    = note: `impl` may be usable in bounds, etc. from outside the expression, which might e.g. make something constructible that previously wasn't, because it's still on a publicly-visible type
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
-   = note: `#[warn(non_local_definitions)]` on by default
+note: the lint level is defined here
+  --> $DIR/weird-exprs.rs:4:9
+   |
+LL | #![warn(non_local_definitions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:16:9
+  --> $DIR/weird-exprs.rs:18:9
    |
 LL |       Discr = {
    |  _____________-
@@ -38,7 +42,7 @@ LL | |     }
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:25:9
+  --> $DIR/weird-exprs.rs:27:9
    |
 LL |       let _array = [0i32; {
    |  _________________________-
@@ -57,7 +61,7 @@ LL | |     }];
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:34:9
+  --> $DIR/weird-exprs.rs:36:9
    |
 LL |       type A = [u32; {
    |  ____________________-
@@ -76,7 +80,7 @@ LL | |     }];
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:41:9
+  --> $DIR/weird-exprs.rs:43:9
    |
 LL |       fn a(_: [u32; {
    |  ___________________-
@@ -95,7 +99,7 @@ LL | |     }]) {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/weird-exprs.rs:48:9
+  --> $DIR/weird-exprs.rs:50:9
    |
 LL |       fn b() -> [u32; {
    |  _____________________-

--- a/tests/ui/mir/auxiliary/static_fnptr.rs
+++ b/tests/ui/mir/auxiliary/static_fnptr.rs
@@ -1,0 +1,10 @@
+//@ compile-flags:-O
+
+fn foo() {}
+
+pub static ADDR: fn() = foo;
+
+#[inline(always)]
+pub fn bar(x: fn()) -> bool {
+    x == ADDR
+}

--- a/tests/ui/mir/auxiliary/static_fnptr.rs
+++ b/tests/ui/mir/auxiliary/static_fnptr.rs
@@ -1,5 +1,6 @@
 //@ compile-flags:-O
 
+#[inline]
 fn foo() {}
 
 pub static ADDR: fn() = foo;

--- a/tests/ui/mir/static_fnptr.rs
+++ b/tests/ui/mir/static_fnptr.rs
@@ -1,3 +1,10 @@
+//! Verify that we correctly handle fn pointer provenance in MIR optimizations.
+//! By asking to inline `static_fnptr::bar`, we have two copies of `static_fnptr::foo`, one in the
+//! auxiliary crate and one in the local crate CGU.
+//! `baz` must only consider the versions from upstream crate, and not try to compare with the
+//! address of the CGU-local copy.
+//! Related issue: #123670
+
 //@ run-pass
 //@ compile-flags:-Cno-prepopulate-passes -Copt-level=0
 //@ aux-build:static_fnptr.rs

--- a/tests/ui/mir/static_fnptr.rs
+++ b/tests/ui/mir/static_fnptr.rs
@@ -1,0 +1,14 @@
+//@ run-pass
+//@ compile-flags:-Cno-prepopulate-passes -Copt-level=0
+//@ aux-build:static_fnptr.rs
+
+extern crate static_fnptr;
+use static_fnptr::{ADDR, bar};
+
+fn baz() -> bool {
+    bar(ADDR)
+}
+
+fn main() {
+    assert!(baz())
+}


### PR DESCRIPTION
Successful merges:

 - #123237 (Various rustc_codegen_ssa cleanups)
 - #123714 (Add test for fn pointer duplication.)
 - #124091 (Update AST validation module docs)
 - #126835 (Simplifications in match lowering)
 - #126963 (Add basic Serde serialization capabilities to Stable MIR)
 - #127015 (Switch back `non_local_definitions` lint to allow-by-default)
 - #127029 (Fix Markdown tables in platform-support.md)
 - #127032 (Enable const casting for `f16` and `f128`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=123237,123714,124091,126835,126963,127015,127029,127032)
<!-- homu-ignore:end -->