### PR TITLE
Hide deprecated alias LayoutErr

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -466,14 +466,6 @@ impl Layout {
     }
 }
 
-#[stable(feature = "alloc_layout", since = "1.28.0")]
-#[deprecated(
-    since = "1.52.0",
-    note = "Name does not follow std convention, use LayoutError",
-    suggestion = "LayoutError"
-)]
-pub type LayoutErr = LayoutError;
-
 /// The parameters given to `Layout::from_size_align`
 /// or some other `Layout` constructor
 /// do not satisfy its documented constraints.
@@ -485,7 +477,6 @@ pub struct LayoutError;
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 impl Error for LayoutError {}
 
-// (we need this for downstream impl of trait Error)
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 impl fmt::Display for LayoutError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -9,17 +9,17 @@ mod layout;
 pub use self::global::GlobalAlloc;
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 pub use self::layout::Layout;
+#[stable(feature = "alloc_layout_error", since = "1.50.0")]
+pub use self::layout::LayoutError;
+
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 #[deprecated(
     since = "1.52.0",
     note = "Name does not follow std convention, use LayoutError",
     suggestion = "LayoutError"
 )]
-#[allow(deprecated, deprecated_in_future)]
-pub use self::layout::LayoutErr;
-
-#[stable(feature = "alloc_layout_error", since = "1.50.0")]
-pub use self::layout::LayoutError;
+#[doc(hidden)]
+pub type LayoutErr = LayoutError;
 
 use crate::error::Error;
 use crate::fmt;


### PR DESCRIPTION
Does not need to be featured in rustdoc.

@rustbot label +T-libs-api