### PR TITLE
rustc_data_structures: Explicitly check for 64-bit atomics support

### DIFF
--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -50,7 +50,7 @@ libc = "0.2"
 memmap2 = "0.2.1"
 # tidy-alphabetical-end
 
-[target.'cfg(any(target_arch = "mips", target_arch = "powerpc", target_arch = "sparc"))'.dependencies]
+[target.'cfg(not(target_has_atomic = "64"))'.dependencies]
 portable-atomic = "1.5.1"
 
 [features]

--- a/compiler/rustc_data_structures/src/marker.rs
+++ b/compiler/rustc_data_structures/src/marker.rs
@@ -147,14 +147,13 @@ cfg_match! {
             [crate::owned_slice::OwnedSlice]
         );
 
-        // MIPS, PowerPC and SPARC platforms with 32-bit pointers do not
-        // have AtomicU64 type.
-        #[cfg(not(any(target_arch = "powerpc", target_arch = "powerpc", target_arch = "sparc")))]
+        // Use portable AtomicU64 for targets without native 64-bit atomics
+        #[cfg(target_has_atomic = "64")]
         already_sync!(
             [std::sync::atomic::AtomicU64]
         );
 
-        #[cfg(any(target_arch = "mips", target_arch = "powerpc", target_arch = "sparc"))]
+        #[cfg(not(target_has_atomic = "64"))]
         already_sync!(
             [portable_atomic::AtomicU64]
         );

--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -270,12 +270,11 @@ cfg_match! {
 
         pub use std::sync::atomic::{AtomicBool, AtomicUsize, AtomicU32};
 
-        // MIPS, PowerPC and SPARC platforms with 32-bit pointers do not
-        // have AtomicU64 type.
-        #[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "sparc")))]
+        // Use portable AtomicU64 for targets without native 64-bit atomics
+        #[cfg(target_has_atomic = "64")]
         pub use std::sync::atomic::AtomicU64;
 
-        #[cfg(any(target_arch = "mips", target_arch = "powerpc", target_arch = "sparc"))]
+        #[cfg(not(target_has_atomic = "64"))]
         pub use portable_atomic::AtomicU64;
 
         pub use std::sync::Arc as Lrc;


### PR DESCRIPTION
Instead of keeping a list of architectures which have native support
for 64-bit atomics, just use #[cfg(target_has_atomic = "64")] and its
inverted counterpart to determine whether we need to use portable
AtomicU64 on the target architecture.