### PR TITLE
Enable full tools and profiler for LoongArch Linux targets

### DIFF
--- a/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
@@ -25,5 +25,10 @@ ENV CC_loongarch64_unknown_linux_gnu=loongarch64-unknown-linux-gnu-gcc \
 
 ENV HOSTS=loongarch64-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
+ENV RUST_CONFIGURE_ARGS \
+      --enable-extended \
+      --enable-full-tools \
+      --enable-profiler \
+      --disable-docs
+
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/host-x86_64/dist-loongarch64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-loongarch64-musl/Dockerfile
@@ -27,7 +27,8 @@ ENV HOSTS=loongarch64-unknown-linux-musl
 
 ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
-      --enable-lld \
+      --enable-full-tools \
+      --enable-profiler \
       --disable-docs \
       --set target.loongarch64-unknown-linux-musl.crt-static=false \
       --musl-root-loongarch64=/x-tools/loongarch64-unknown-linux-musl/loongarch64-unknown-linux-musl/sysroot/usr


### PR DESCRIPTION
When the LoongArch targets were first introduced, the LLVM support was still immature and various tools were not supported on LoongArch. Nowadays most infra is in place, so it is time to enable them on LoongArch to provide a better experience for users of these targets. Plus, the profiler support is needed by Chromium, so better provide it in the official artifacts.

cc @heiher

try-job: dist-loongarch64-linux
try-job: dist-loongarch64-musl