### PR TITLE
[WIP] Benchmark span combining changes

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
@@ -56,7 +56,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             ));
         }
 
-        if self_ty.span.edition().at_least_rust_2021() {
+        if tcx.hir().span_in_context(self_ty.hir_id).edition().at_least_rust_2021() {
             let msg = "trait objects must include the `dyn` keyword";
             let label = "add `dyn` keyword before this trait";
             let mut diag =

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2454,7 +2454,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ExprKind::Path(QPath::Resolved(_, path)) => {
                     // local binding
                     if let hir::def::Res::Local(hir_id) = path.res {
-                        let span = tcx.hir().span(hir_id);
+                        let span = tcx.hir().span_in_context(hir_id);
                         let filename = tcx.sess.source_map().span_to_filename(span);
 
                         let parent_node = self.tcx.parent_hir_node(hir_id);

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -718,8 +718,9 @@ fn lint_wide_pointer<'tcx>(
         return;
     };
 
+    let (l_span, r_span) = (l.span.with_neighbor(e.span), r.span.with_neighbor(e.span));
     let (Some(l_span), Some(r_span)) =
-        (l.span.find_ancestor_inside(e.span), r.span.find_ancestor_inside(e.span))
+        (l_span.find_ancestor_inside(e.span), r_span.find_ancestor_inside(e.span))
     else {
         return cx.emit_span_lint(
             AMBIGUOUS_WIDE_POINTER_COMPARISONS,

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -935,6 +935,11 @@ impl<'hir> Map<'hir> {
         }
     }
 
+    pub fn span_in_context(self, hir_id: HirId) -> Span {
+        let parent_span = self.span(self.tcx.parent_hir_id(hir_id));
+        self.span(hir_id).with_neighbor(parent_span)
+    }
+
     /// Get a representation of this `id` for debugging purposes.
     /// NOTE: Do NOT use this in diagnostics!
     pub fn node_to_string(self, id: HirId) -> String {

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -687,9 +687,9 @@ impl<'a> Parser<'a> {
         self.is_keyword_ahead(0, &[kw::Const])
             && self.look_ahead(1, |t| match &t.kind {
                 // async closures do not work with const closures, so we do not parse that here.
-                token::Ident(kw::Move | kw::Static, _) | token::OrOr | token::BinOp(token::Or) => {
-                    true
-                }
+                token::Ident(kw::Move | kw::Static, IdentIsRaw::No)
+                | token::OrOr
+                | token::BinOp(token::Or) => true,
                 _ => false,
             })
     }

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -876,6 +876,7 @@ impl Span {
 
     /// Check if you can select metavar spans for the given spans to get matching contexts.
     fn try_metavars(a: SpanData, b: SpanData, a_orig: Span, b_orig: Span) -> (SpanData, SpanData) {
+        let (a_orig, b_orig) = (a_orig.with_parent(None), b_orig.with_parent(None));
         let get = |mspans: &FxHashMap<_, _>, s| mspans.get(&s).copied();
         match with_metavar_spans(|mspans| (get(mspans, a_orig), get(mspans, b_orig))) {
             (None, None) => {}
@@ -938,7 +939,7 @@ impl Span {
     pub fn with_neighbor(self, neighbor: Span) -> Span {
         match Span::prepare_to_combine(self, neighbor) {
             Ok((this, ..)) => this.span(),
-            Err(_) => self,
+            Err(fallback) => self.with_ctxt(fallback.ctxt()),
         }
     }
 

--- a/tests/ui/consts/const-float-classify.stderr
+++ b/tests/ui/consts/const-float-classify.stderr
@@ -29,7 +29,7 @@ error[E0284]: type annotations needed
   --> $DIR/const-float-classify.rs:21:35
    |
 LL |               const _: () = assert!($a == $b);
-   |                                     ^^ cannot infer the value of the constant `_`
+   |                                     ^^^^^ cannot infer the value of the constant `_`
 ...
 LL | / suite! {
 LL | |                    [is_nan, is_infinite, is_finite, is_normal, is_sign_positive, is_sign_negative]
@@ -53,7 +53,7 @@ error[E0284]: type annotations needed
   --> $DIR/const-float-classify.rs:21:35
    |
 LL |               const _: () = assert!($a == $b);
-   |                                     ^^ cannot infer the value of the constant `_`
+   |                                     ^^^^^ cannot infer the value of the constant `_`
 ...
 LL | / suite! {
 LL | |                    [is_nan, is_infinite, is_finite, is_normal, is_sign_positive, is_sign_negative]
@@ -77,7 +77,7 @@ error[E0284]: type annotations needed
   --> $DIR/const-float-classify.rs:21:35
    |
 LL |               const _: () = assert!($a == $b);
-   |                                     ^^ cannot infer the value of the constant `_`
+   |                                     ^^^^^ cannot infer the value of the constant `_`
 ...
 LL | / suite! {
 LL | |                    [is_nan, is_infinite, is_finite, is_normal, is_sign_positive, is_sign_negative]
@@ -101,7 +101,7 @@ error[E0284]: type annotations needed
   --> $DIR/const-float-classify.rs:21:35
    |
 LL |               const _: () = assert!($a == $b);
-   |                                     ^^ cannot infer the value of the constant `_`
+   |                                     ^^^^^ cannot infer the value of the constant `_`
 ...
 LL | / suite! {
 LL | |                    [is_nan, is_infinite, is_finite, is_normal, is_sign_positive, is_sign_negative]
@@ -125,7 +125,7 @@ error[E0284]: type annotations needed
   --> $DIR/const-float-classify.rs:21:35
    |
 LL |               const _: () = assert!($a == $b);
-   |                                     ^^ cannot infer the value of the constant `_`
+   |                                     ^^^^^ cannot infer the value of the constant `_`
 ...
 LL | / suite! {
 LL | |                    [is_nan, is_infinite, is_finite, is_normal, is_sign_positive, is_sign_negative]
@@ -149,7 +149,7 @@ error[E0284]: type annotations needed
   --> $DIR/const-float-classify.rs:21:35
    |
 LL |               const _: () = assert!($a == $b);
-   |                                     ^^ cannot infer the value of the constant `_`
+   |                                     ^^^^^ cannot infer the value of the constant `_`
 ...
 LL | / suite! {
 LL | |                    [is_nan, is_infinite, is_finite, is_normal, is_sign_positive, is_sign_negative]
@@ -173,7 +173,7 @@ error[E0284]: type annotations needed
   --> $DIR/const-float-classify.rs:21:35
    |
 LL |               const _: () = assert!($a == $b);
-   |                                     ^^ cannot infer the value of the constant `_`
+   |                                     ^^^^^ cannot infer the value of the constant `_`
 ...
 LL | / suite! {
 LL | |                    [is_nan, is_infinite, is_finite, is_normal, is_sign_positive, is_sign_negative]
@@ -197,7 +197,7 @@ error[E0284]: type annotations needed
   --> $DIR/const-float-classify.rs:21:35
    |
 LL |               const _: () = assert!($a == $b);
-   |                                     ^^ cannot infer the value of the constant `_`
+   |                                     ^^^^^ cannot infer the value of the constant `_`
 ...
 LL | / suite! {
 LL | |                    [is_nan, is_infinite, is_finite, is_normal, is_sign_positive, is_sign_negative]

--- a/tests/ui/lint/wide_pointer_comparisons.rs
+++ b/tests/ui/lint/wide_pointer_comparisons.rs
@@ -146,12 +146,10 @@ fn main() {
     {
         macro_rules! cmp {
             ($a:tt, $b:tt) => { $a == $b }
+            //~^ WARN ambiguous wide pointer comparison
         }
 
-        // FIXME: This lint uses some custom span combination logic.
-        // Rewrite it to adapt to the new metavariable span rules.
         cmp!(a, b);
-        //~^ WARN ambiguous wide pointer comparison
     }
 
     {

--- a/tests/ui/lint/wide_pointer_comparisons.stderr
+++ b/tests/ui/lint/wide_pointer_comparisons.stderr
@@ -586,18 +586,22 @@ LL |         std::ptr::eq(*a, *b)
    |         ~~~~~~~~~~~~~  ~   +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:153:14
+  --> $DIR/wide_pointer_comparisons.rs:148:33
    |
+LL |             ($a:tt, $b:tt) => { $a == $b }
+   |                                 ^^^^^^^^
+...
 LL |         cmp!(a, b);
-   |              ^^^^
+   |         ---------- in this macro invocation
    |
+   = note: this warning originates in the macro `cmp` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
-LL |         cmp!(std::ptr::addr_eq(a, b));
-   |              ++++++++++++++++++ ~  +
+LL |             ($a:tt, $b:tt) => { std::ptr::addr_eq($a, $b) }
+   |                                 ++++++++++++++++++  ~   +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:159:39
+  --> $DIR/wide_pointer_comparisons.rs:157:39
    |
 LL |             ($a:ident, $b:ident) => { $a == $b }
    |                                       ^^^^^^^^
@@ -612,10 +616,10 @@ LL |             ($a:ident, $b:ident) => { std::ptr::addr_eq($a, $b) }
    |                                       ++++++++++++++++++  ~   +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:169:37
+  --> $DIR/wide_pointer_comparisons.rs:167:37
    |
 LL |             ($a:expr, $b:expr) => { $a == $b }
-   |                                     ^^
+   |                                     ^^^^^
 ...
 LL |         cmp!(&a, &b);
    |         ------------ in this macro invocation

--- a/tests/ui/methods/method-on-ambiguous-numeric-type.stderr
+++ b/tests/ui/methods/method-on-ambiguous-numeric-type.stderr
@@ -47,8 +47,8 @@ LL |     local_bar_tt.pow(2);
    |
 help: you must specify a type for this binding, like `i32`
    |
-LL |     local_mac_tt!(local_bar_tt: i32);
-   |                               +++++
+LL |     ($tt:tt) => { let $tt: i32 = 42; }
+   |                          +++++
 
 error[E0689]: can't call method `pow` on ambiguous numeric type `{integer}`
   --> $DIR/method-on-ambiguous-numeric-type.rs:37:9


### PR DESCRIPTION
This is the part of https://github.com/rust-lang/rust/pull/119412 that doesn't include the actual removal of `NtIdent`.