### PR TITLE
Change return-type-notation to use `(..)`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -176,6 +176,8 @@ pub enum GenericArgs {
     AngleBracketed(AngleBracketedArgs),
     /// The `(A, B)` and `C` in `Foo(A, B) -> C`.
     Parenthesized(ParenthesizedArgs),
+    /// `(..)` in return type notation
+    ParenthesizedElided(Span),
 }
 
 impl GenericArgs {
@@ -187,6 +189,7 @@ impl GenericArgs {
         match self {
             AngleBracketed(data) => data.span,
             Parenthesized(data) => data.span,
+            ParenthesizedElided(span) => *span,
         }
     }
 }
@@ -2051,7 +2054,7 @@ impl UintTy {
 /// * the `A: Bound` in `Trait<A: Bound>`
 /// * the `RetTy` in `Trait(ArgTy, ArgTy) -> RetTy`
 /// * the `C = { Ct }` in `Trait<C = { Ct }>` (feature `associated_const_equality`)
-/// * the `f(): Bound` in `Trait<f(): Bound>` (feature `return_type_notation`)
+/// * the `f(..): Bound` in `Trait<f(..): Bound>` (feature `return_type_notation`)
 #[derive(Clone, Encodable, Decodable, Debug)]
 pub struct AssocItemConstraint {
     pub id: NodeId,

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -582,6 +582,7 @@ fn noop_visit_generic_args<T: MutVisitor>(generic_args: &mut GenericArgs, vis: &
     match generic_args {
         GenericArgs::AngleBracketed(data) => vis.visit_angle_bracketed_parameter_data(data),
         GenericArgs::Parenthesized(data) => vis.visit_parenthesized_parameter_data(data),
+        GenericArgs::ParenthesizedElided(span) => vis.visit_span(span),
     }
 }
 

--- a/compiler/rustc_ast/src/util/classify.rs
+++ b/compiler/rustc_ast/src/util/classify.rs
@@ -234,6 +234,6 @@ fn path_return_type(path: &ast::Path) -> Option<&ast::Ty> {
             ast::FnRetTy::Default(_) => None,
             ast::FnRetTy::Ty(ret) => Some(ret),
         },
-        ast::GenericArgs::AngleBracketed(_) => None,
+        ast::GenericArgs::AngleBracketed(_) | ast::GenericArgs::ParenthesizedElided(_) => None,
     }
 }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -609,6 +609,7 @@ where
             walk_list!(visitor, visit_ty, inputs);
             try_visit!(visitor.visit_fn_ret_ty(output));
         }
+        GenericArgs::ParenthesizedElided(_span) => {}
     }
     V::Result::output()
 }

--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -43,6 +43,8 @@ ast_lowering_bad_return_type_notation_output =
     return type not allowed with return type notation
     .suggestion = remove the return type
 
+ast_lowering_bad_return_type_notation_position = return type notation not allowed in this position yet
+
 ast_lowering_base_expression_double_dot =
     base expression required after `..`
     .suggestion = add a base expression here

--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -36,6 +36,9 @@ ast_lowering_bad_return_type_notation_inputs =
     argument types not allowed with return type notation
     .suggestion = remove the input types
 
+ast_lowering_bad_return_type_notation_needs_dots = return type notation arguments must be elided with `..`
+    .suggestion = add `..`
+
 ast_lowering_bad_return_type_notation_output =
     return type not allowed with return type notation
     .suggestion = remove the return type

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -399,6 +399,11 @@ pub enum BadReturnTypeNotation {
         #[suggestion(code = "(..)", applicability = "maybe-incorrect")]
         span: Span,
     },
+    #[diag(ast_lowering_bad_return_type_notation_position)]
+    Position {
+        #[primary_span]
+        span: Span,
+    },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -393,6 +393,12 @@ pub enum BadReturnTypeNotation {
         #[suggestion(code = "", applicability = "maybe-incorrect")]
         span: Span,
     },
+    #[diag(ast_lowering_bad_return_type_notation_needs_dots)]
+    NeedsDots {
+        #[primary_span]
+        #[suggestion(code = "(..)", applicability = "maybe-incorrect")]
+        span: Span,
+    },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -979,20 +979,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     self.lower_angle_bracketed_parameter_data(data, ParamMode::Explicit, itctx).0
                 }
                 GenericArgs::Parenthesized(data) => {
-                    if data.inputs.is_empty() && matches!(data.output, FnRetTy::Default(..)) {
-                        let parenthesized = if self.tcx.features().return_type_notation {
-                            hir::GenericArgsParentheses::ReturnTypeNotation
-                        } else {
-                            self.emit_bad_parenthesized_trait_in_assoc_ty(data);
-                            hir::GenericArgsParentheses::No
-                        };
-                        GenericArgsCtor {
-                            args: Default::default(),
-                            constraints: &[],
-                            parenthesized,
-                            span: data.inputs_span,
-                        }
-                    } else if let Some(first_char) = constraint.ident.as_str().chars().next()
+                    if let Some(first_char) = constraint.ident.as_str().chars().next()
                         && first_char.is_ascii_lowercase()
                     {
                         let mut err = if !data.inputs.is_empty() {
@@ -1004,7 +991,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                 span: data.inputs_span.shrink_to_hi().to(ty.span),
                             })
                         } else {
-                            unreachable!("inputs are empty and return type is not provided")
+                            self.dcx().create_err(errors::BadReturnTypeNotation::NeedsDots {
+                                span: data.inputs_span,
+                            })
                         };
                         if !self.tcx.features().return_type_notation
                             && self.tcx.sess.is_nightly_build()
@@ -1034,6 +1023,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         .0
                     }
                 }
+                GenericArgs::ParenthesizedElided(span) => GenericArgsCtor {
+                    args: Default::default(),
+                    constraints: &[],
+                    parenthesized: hir::GenericArgsParentheses::ReturnTypeNotation,
+                    span: *span,
+                },
             };
             gen_args_ctor.into_generic_args(self)
         } else {

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -1,7 +1,8 @@
 use crate::ImplTraitPosition;
 
 use super::errors::{
-    AsyncBoundNotOnTrait, AsyncBoundOnlyForFnTraits, GenericTypeWithParentheses, UseAngleBrackets,
+    AsyncBoundNotOnTrait, AsyncBoundOnlyForFnTraits, BadReturnTypeNotation,
+    GenericTypeWithParentheses, UseAngleBrackets,
 };
 use super::ResolverAstLoweringExt;
 use super::{GenericArgsCtor, LifetimeRes, ParenthesizedGenericArgs};
@@ -276,8 +277,17 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         )
                     }
                 },
-                GenericArgs::ParenthesizedElided(_span) => {
-                    todo!()
+                GenericArgs::ParenthesizedElided(span) => {
+                    self.dcx().emit_err(BadReturnTypeNotation::Position { span: *span });
+                    (
+                        GenericArgsCtor {
+                            args: Default::default(),
+                            constraints: &[],
+                            parenthesized: hir::GenericArgsParentheses::ReturnTypeNotation,
+                            span: *span,
+                        },
+                        false,
+                    )
                 }
             }
         } else {

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -276,6 +276,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         )
                     }
                 },
+                GenericArgs::ParenthesizedElided(_span) => {
+                    todo!()
+                }
             }
         } else {
             (

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1289,6 +1289,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     self.with_impl_trait(None, |this| this.visit_ty(ty));
                 }
             }
+            GenericArgs::ParenthesizedElided(_span) => {}
         }
     }
 
@@ -1445,7 +1446,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                                 span: args.span,
                             });
                         }
-                        None => {}
+                        Some(ast::GenericArgs::ParenthesizedElided(_)) | None => {}
                     }
                 }
             }
@@ -1693,7 +1694,9 @@ fn deny_equality_constraints(
                 // Add `<Bar = RhsTy>` to `Foo`.
                 match &mut assoc_path.segments[len].args {
                     Some(args) => match args.deref_mut() {
-                        GenericArgs::Parenthesized(_) => continue,
+                        GenericArgs::Parenthesized(_) | GenericArgs::ParenthesizedElided(..) => {
+                            continue;
+                        }
                         GenericArgs::AngleBracketed(args) => {
                             args.args.push(arg);
                         }

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1060,6 +1060,11 @@ impl<'a> PrintState<'a> for State<'a> {
                 self.word(")");
                 self.print_fn_ret_ty(&data.output);
             }
+            ast::GenericArgs::ParenthesizedElided(_) => {
+                self.word("(");
+                self.word("..");
+                self.word(")");
+            }
         }
     }
 }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2413,7 +2413,7 @@ pub enum ImplItemKind<'hir> {
 /// * the `A: Bound` in `Trait<A: Bound>`
 /// * the `RetTy` in `Trait(ArgTy, ArgTy) -> RetTy`
 /// * the `C = { Ct }` in `Trait<C = { Ct }>` (feature `associated_const_equality`)
-/// * the `f(): Bound` in `Trait<f(): Bound>` (feature `return_type_notation`)
+/// * the `f(..): Bound` in `Trait<f(..): Bound>` (feature `return_type_notation`)
 #[derive(Debug, Clone, Copy, HashStable_Generic)]
 pub struct AssocItemConstraint<'hir> {
     pub hir_id: HirId,

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -45,10 +45,6 @@ parse_bad_assoc_type_bounds = bounds on associated types do not belong here
 parse_bad_item_kind = {$descr} is not supported in {$ctx}
     .help = consider moving the {$descr} out to a nearby module scope
 
-parse_bad_return_type_notation_dotdot =
-    return type notation uses `()` instead of `(..)` for elided arguments
-    .suggestion = remove the `..`
-
 parse_bad_return_type_notation_output =
     return type not allowed with return type notation
     .suggestion = remove the return type

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2568,14 +2568,6 @@ pub(crate) struct BadReturnTypeNotationOutput {
 }
 
 #[derive(Diagnostic)]
-#[diag(parse_bad_return_type_notation_dotdot)]
-pub(crate) struct BadReturnTypeNotationDotDot {
-    #[primary_span]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(parse_bad_assoc_type_bounds)]
 pub(crate) struct BadAssocTypeBounds {
     #[primary_span]

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -695,7 +695,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
     fn visit_generic_args(&mut self, g: &'v ast::GenericArgs) {
         record_variants!(
             (self, g, g, Id::None, ast, GenericArgs, GenericArgs),
-            [AngleBracketed, Parenthesized]
+            [AngleBracketed, Parenthesized, ParenthesizedElided]
         );
         ast_visit::walk_generic_args(self, g)
     }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1221,6 +1221,7 @@ impl<'a: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast,
                         }
                     }
                 }
+                GenericArgs::ParenthesizedElided(_) => {}
             }
         }
     }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -350,6 +350,7 @@ impl<'a> From<&'a ast::PathSegment> for Segment {
                     (args.span, found_lifetimes)
                 }
                 GenericArgs::Parenthesized(args) => (args.span, true),
+                GenericArgs::ParenthesizedElided(span) => (*span, true),
             }
         } else {
             (DUMMY_SP, false)

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2557,7 +2557,7 @@ pub(crate) struct ProcMacro {
 /// * the `A: Bound` in `Trait<A: Bound>`
 /// * the `RetTy` in `Trait(ArgTy, ArgTy) -> RetTy`
 /// * the `C = { Ct }` in `Trait<C = { Ct }>` (feature `associated_const_equality`)
-/// * the `f(): Bound` in `Trait<f(): Bound>` (feature `return_type_notation`)
+/// * the `f(..): Bound` in `Trait<f(..): Bound>` (feature `return_type_notation`)
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub(crate) struct AssocItemConstraint {
     pub(crate) assoc: PathSegment,

--- a/src/tools/rustfmt/src/types.rs
+++ b/src/tools/rustfmt/src/types.rs
@@ -484,21 +484,25 @@ fn rewrite_generic_args(
     span: Span,
 ) -> Option<String> {
     match gen_args {
-        ast::GenericArgs::AngleBracketed(ref data) if !data.args.is_empty() => {
-            let args = data
-                .args
-                .iter()
-                .map(|x| match x {
-                    ast::AngleBracketedArg::Arg(generic_arg) => {
-                        SegmentParam::from_generic_arg(generic_arg)
-                    }
-                    ast::AngleBracketedArg::Constraint(constraint) => {
-                        SegmentParam::Binding(constraint)
-                    }
-                })
-                .collect::<Vec<_>>();
+        ast::GenericArgs::AngleBracketed(ref data) => {
+            if data.args.is_empty() {
+                Some("".to_owned())
+            } else {
+                let args = data
+                    .args
+                    .iter()
+                    .map(|x| match x {
+                        ast::AngleBracketedArg::Arg(generic_arg) => {
+                            SegmentParam::from_generic_arg(generic_arg)
+                        }
+                        ast::AngleBracketedArg::Constraint(constraint) => {
+                            SegmentParam::Binding(constraint)
+                        }
+                    })
+                    .collect::<Vec<_>>();
 
-            overflow::rewrite_with_angle_brackets(context, "", args.iter(), shape, span)
+                overflow::rewrite_with_angle_brackets(context, "", args.iter(), shape, span)
+            }
         }
         ast::GenericArgs::Parenthesized(ref data) => format_function_type(
             data.inputs.iter().map(|x| &**x),
@@ -508,7 +512,7 @@ fn rewrite_generic_args(
             context,
             shape,
         ),
-        _ => Some("".to_owned()),
+        ast::GenericArgs::ParenthesizedElided(..) => Some("(..)".to_owned()),
     }
 }
 

--- a/src/tools/rustfmt/tests/target/return-type-notation.rs
+++ b/src/tools/rustfmt/tests/target/return-type-notation.rs
@@ -1,0 +1,10 @@
+fn rtn()
+where
+    T: Trait<method(..): Send + 'static>,
+    T::method(..): Send + 'static,
+{
+}
+
+fn test() {
+    let x: T::method(..);
+}

--- a/tests/crashes/125249.rs
+++ b/tests/crashes/125249.rs
@@ -2,7 +2,7 @@
 #![feature(return_position_impl_trait_in_trait, return_type_notation)]
 
 trait IntFactory {
-    fn stream(&self) -> impl IntFactory<stream(): IntFactory<stream(): Send> + Send>;
+    fn stream(&self) -> impl IntFactory<stream(..): IntFactory<stream(..): Send> + Send>;
 }
 
 pub fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
@@ -13,7 +13,7 @@ fn foo<T: Trait<method(i32): Send>>() {}
 fn bar<T: Trait<method() -> (): Send>>() {}
 //~^ ERROR return type not allowed with return type notation
 
-fn baz<T: Trait<method(..): Send>>() {}
-//~^ ERROR return type notation uses `()` instead of `(..)` for elided arguments
+fn baz<T: Trait<method(): Send>>() {}
+//~^ ERROR return type notation arguments must be elided with `..`
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
@@ -1,9 +1,3 @@
-error: return type notation uses `()` instead of `(..)` for elided arguments
-  --> $DIR/bad-inputs-and-output.rs:16:24
-   |
-LL | fn baz<T: Trait<method(..): Send>>() {}
-   |                        ^^ help: remove the `..`
-
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/bad-inputs-and-output.rs:3:12
    |
@@ -24,6 +18,12 @@ error: return type not allowed with return type notation
    |
 LL | fn bar<T: Trait<method() -> (): Send>>() {}
    |                         ^^^^^^ help: remove the return type
+
+error: return type notation arguments must be elided with `..`
+  --> $DIR/bad-inputs-and-output.rs:16:23
+   |
+LL | fn baz<T: Trait<method(): Send>>() {}
+   |                       ^^ help: add `..`: `(..)`
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/tests/ui/associated-type-bounds/return-type-notation/bare-path.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/bare-path.rs
@@ -1,0 +1,26 @@
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Tr {
+    const CONST: usize;
+
+    fn method() -> impl Sized;
+}
+
+fn foo<T: Tr>()
+where
+    T::method(..): Send,
+    //~^ ERROR return type notation not allowed in this position yet
+    //~| ERROR expected type, found function
+    <T as Tr>::method(..): Send,
+    //~^ ERROR return type notation not allowed in this position yet
+    //~| ERROR expected associated type, found associated function `Tr::method`
+{
+    let _ = T::CONST::(..);
+    //~^ ERROR return type notation not allowed in this position yet
+    let _: T::method(..);
+    //~^ ERROR return type notation not allowed in this position yet
+    //~| ERROR expected type, found function
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/bare-path.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bare-path.stderr
@@ -1,0 +1,66 @@
+error[E0575]: expected associated type, found associated function `Tr::method`
+  --> $DIR/bare-path.rs:15:5
+   |
+LL |     <T as Tr>::method(..): Send,
+   |     ^^^^^^^^^^^^^^^^^^^^^ not a associated type
+
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/bare-path.rs:1:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: return type notation not allowed in this position yet
+  --> $DIR/bare-path.rs:19:23
+   |
+LL |     let _ = T::CONST::(..);
+   |                       ^^^^
+
+error: return type notation not allowed in this position yet
+  --> $DIR/bare-path.rs:21:21
+   |
+LL |     let _: T::method(..);
+   |                     ^^^^
+
+error: return type notation not allowed in this position yet
+  --> $DIR/bare-path.rs:12:14
+   |
+LL |     T::method(..): Send,
+   |              ^^^^
+
+error: return type notation not allowed in this position yet
+  --> $DIR/bare-path.rs:15:22
+   |
+LL |     <T as Tr>::method(..): Send,
+   |                      ^^^^
+
+error: expected type, found function
+  --> $DIR/bare-path.rs:12:8
+   |
+LL |     T::method(..): Send,
+   |        ^^^^^^ unexpected function
+   |
+note: the associated function is defined here
+  --> $DIR/bare-path.rs:7:5
+   |
+LL |     fn method() -> impl Sized;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected type, found function
+  --> $DIR/bare-path.rs:21:15
+   |
+LL |     let _: T::method(..);
+   |               ^^^^^^ unexpected function
+   |
+note: the associated function is defined here
+  --> $DIR/bare-path.rs:7:5
+   |
+LL |     fn method() -> impl Sized;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0575`.

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.rs
@@ -17,7 +17,7 @@ async fn foo<T: Foo>() -> Result<(), ()> {
 fn is_send(_: impl Send) {}
 
 fn test<
-    #[cfg(with)] T: Foo<method(): Send>,
+    #[cfg(with)] T: Foo<method(..): Send>,
     #[cfg(without)] T: Foo,
 >() {
     is_send(foo::<T>());

--- a/tests/ui/associated-type-bounds/return-type-notation/equality.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/equality.rs
@@ -9,7 +9,7 @@ trait Trait {
     async fn method() {}
 }
 
-fn test<T: Trait<method() = Box<dyn Future<Output = ()>>>>() {}
+fn test<T: Trait<method(..) = Box<dyn Future<Output = ()>>>>() {}
 //~^ ERROR return type notation is not allowed to use type equality
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/equality.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/equality.stderr
@@ -10,8 +10,8 @@ LL | #![feature(return_type_notation)]
 error: return type notation is not allowed to use type equality
   --> $DIR/equality.rs:12:18
    |
-LL | fn test<T: Trait<method() = Box<dyn Future<Output = ()>>>>() {}
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test<T: Trait<method(..) = Box<dyn Future<Output = ()>>>>() {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/associated-type-bounds/return-type-notation/issue-120208-higher-ranked-const.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/issue-120208-higher-ranked-const.rs
@@ -9,7 +9,7 @@ trait HealthCheck {
 
 async fn do_health_check_par<HC>(hc: HC)
 where
-    HC: HealthCheck<check(): Send> + Send + 'static,
+    HC: HealthCheck<check(..): Send> + Send + 'static,
     //~^ ERROR return type notation is not allowed for functions that have const parameters
 {
 }

--- a/tests/ui/associated-type-bounds/return-type-notation/issue-120208-higher-ranked-const.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/issue-120208-higher-ranked-const.stderr
@@ -13,8 +13,8 @@ error: return type notation is not allowed for functions that have const paramet
 LL |     async fn check<const N: usize>() -> bool;
    |                    -------------- const parameter declared here
 ...
-LL |     HC: HealthCheck<check(): Send> + Send + 'static,
-   |                     ^^^^^^^^^^^^^
+LL |     HC: HealthCheck<check(..): Send> + Send + 'static,
+   |                     ^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/associated-type-bounds/return-type-notation/missing.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/missing.rs
@@ -7,7 +7,7 @@ trait Trait {
     async fn method() {}
 }
 
-fn bar<T: Trait<methid(): Send>>() {}
+fn bar<T: Trait<methid(..): Send>>() {}
 //~^ ERROR associated function `methid` not found for `Trait`
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/missing.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/missing.stderr
@@ -10,7 +10,7 @@ LL | #![feature(return_type_notation)]
 error[E0220]: associated function `methid` not found for `Trait`
   --> $DIR/missing.rs:10:17
    |
-LL | fn bar<T: Trait<methid(): Send>>() {}
+LL | fn bar<T: Trait<methid(..): Send>>() {}
    |                 ^^^^^^ help: there is an associated function with a similar name: `method`
 
 error: aborting due to 1 previous error; 1 warning emitted

--- a/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.rs
@@ -5,7 +5,7 @@ trait Trait {
     fn method() {}
 }
 
-fn test<T: Trait<method(): Send>>() {}
+fn test<T: Trait<method(..): Send>>() {}
 //~^ ERROR  return type notation used on function that is not `async` and does not return `impl Trait`
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.stderr
@@ -13,8 +13,8 @@ error: return type notation used on function that is not `async` and does not re
 LL |     fn method() {}
    |     ----------- this function must be `async` or return `impl Trait`
 ...
-LL | fn test<T: Trait<method(): Send>>() {}
-   |                  ^^^^^^^^^^^^^^
+LL | fn test<T: Trait<method(..): Send>>() {}
+   |                  ^^^^^^^^^^^^^^^^
    |
    = note: function returns `()`, which is not compatible with associated type return bounds
 

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.rs
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.rs
@@ -9,7 +9,7 @@ trait HealthCheck {
 
 async fn do_health_check_par<HC>(hc: HC)
 where
-    HC: HealthCheck<check(): Send> + Send + 'static,
+    HC: HealthCheck<check(..): Send> + Send + 'static,
 {
     spawn(async move {
         let mut hc = hc;

--- a/tests/ui/async-await/return-type-notation/issue-110963-late.rs
+++ b/tests/ui/async-await/return-type-notation/issue-110963-late.rs
@@ -10,7 +10,7 @@ trait HealthCheck {
 
 async fn do_health_check_par<HC>(hc: HC)
 where
-    HC: HealthCheck<check(): Send> + Send + 'static,
+    HC: HealthCheck<check(..): Send> + Send + 'static,
 {
     spawn(async move {
         let mut hc = hc;

--- a/tests/ui/async-await/return-type-notation/normalizing-self-auto-trait-issue-109924.rs
+++ b/tests/ui/async-await/return-type-notation/normalizing-self-auto-trait-issue-109924.rs
@@ -16,7 +16,7 @@ impl Foo for Bar {
     async fn bar(&self) {}
 }
 
-fn build<T>(_: T) where T: Foo<bar(): Send> {}
+fn build<T>(_: T) where T: Foo<bar(..): Send> {}
 
 fn main() {
     build(Bar);

--- a/tests/ui/async-await/return-type-notation/rtn-implied-in-supertrait.rs
+++ b/tests/ui/async-await/return-type-notation/rtn-implied-in-supertrait.rs
@@ -16,7 +16,7 @@ trait Foo {
     async fn bar(&self) -> i32;
 }
 
-trait SendFoo: Foo<bar(): Send> + Send {}
+trait SendFoo: Foo<bar(..): Send> + Send {}
 
 fn foobar(foo: impl SendFoo) -> JoinHandle<i32> {
     spawn(async move {

--- a/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.rs
+++ b/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.rs
@@ -7,7 +7,7 @@ trait Super1<'a> {
     fn bar<'b>() -> bool;
 }
 
-impl Super1<'_, bar(): Send> for () {}
+impl Super1<'_, bar(..): Send> for () {}
 //~^ ERROR associated item constraints are not allowed here
 //~| ERROR not all trait items implemented
 

--- a/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
+++ b/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
@@ -10,13 +10,13 @@ LL | #![feature(return_type_notation)]
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/rtn-in-impl-signature.rs:10:17
    |
-LL | impl Super1<'_, bar(): Send> for () {}
-   |                 ^^^^^^^^^^^ associated item constraint not allowed here
+LL | impl Super1<'_, bar(..): Send> for () {}
+   |                 ^^^^^^^^^^^^^ associated item constraint not allowed here
    |
 help: consider removing this associated item constraint
    |
-LL | impl Super1<'_, bar(): Send> for () {}
-   |               ~~~~~~~~~~~~~
+LL | impl Super1<'_, bar(..): Send> for () {}
+   |               ~~~~~~~~~~~~~~~
 
 error[E0046]: not all trait items implemented, missing: `bar`
   --> $DIR/rtn-in-impl-signature.rs:10:1
@@ -24,8 +24,8 @@ error[E0046]: not all trait items implemented, missing: `bar`
 LL |     fn bar<'b>() -> bool;
    |     --------------------- `bar` from trait
 ...
-LL | impl Super1<'_, bar(): Send> for () {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `bar` in implementation
+LL | impl Super1<'_, bar(..): Send> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `bar` in implementation
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/async-await/return-type-notation/super-method-bound-ambig.rs
+++ b/tests/ui/async-await/return-type-notation/super-method-bound-ambig.rs
@@ -22,7 +22,7 @@ impl Foo for () {}
 
 fn test<T>()
 where
-    T: Foo<test(): Send>,
+    T: Foo<test(..): Send>,
     //~^ ERROR ambiguous associated function `test` in bounds of `Foo`
 {
 }

--- a/tests/ui/async-await/return-type-notation/super-method-bound-ambig.stderr
+++ b/tests/ui/async-await/return-type-notation/super-method-bound-ambig.stderr
@@ -16,8 +16,8 @@ LL |     async fn test();
 LL |     async fn test();
    |     ---------------- ambiguous `test` from `Super2`
 ...
-LL |     T: Foo<test(): Send>,
-   |            ^^^^^^^^^^^^ ambiguous associated function `test`
+LL |     T: Foo<test(..): Send>,
+   |            ^^^^^^^^^^^^^^ ambiguous associated function `test`
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/async-await/return-type-notation/super-method-bound.rs
+++ b/tests/ui/async-await/return-type-notation/super-method-bound.rs
@@ -16,7 +16,7 @@ impl Foo for () {}
 
 fn test<T>()
 where
-    T: Foo<test(): Send>,
+    T: Foo<test(..): Send>,
 {
 }
 

--- a/tests/ui/async-await/return-type-notation/supertrait-bound.rs
+++ b/tests/ui/async-await/return-type-notation/supertrait-bound.rs
@@ -6,6 +6,6 @@
 trait IntFactory {
     fn stream(&self) -> impl Iterator<Item = i32>;
 }
-trait SendIntFactory: IntFactory<stream(): Send> + Send {}
+trait SendIntFactory: IntFactory<stream(..): Send> + Send {}
 
 fn main() {}

--- a/tests/ui/async-await/return-type-notation/ty-or-ct-params.rs
+++ b/tests/ui/async-await/return-type-notation/ty-or-ct-params.rs
@@ -11,7 +11,7 @@ trait Foo {
 
 fn test<T>()
 where
-    T: Foo<bar(): Send, baz(): Send>,
+    T: Foo<bar(..): Send, baz(..): Send>,
     //~^ ERROR return type notation is not allowed for functions that have const parameters
     //~| ERROR return type notation is not allowed for functions that have type parameters
 {

--- a/tests/ui/async-await/return-type-notation/ty-or-ct-params.stderr
+++ b/tests/ui/async-await/return-type-notation/ty-or-ct-params.stderr
@@ -13,17 +13,17 @@ error: return type notation is not allowed for functions that have type paramete
 LL |     async fn bar<T>() {}
    |                  - type parameter declared here
 ...
-LL |     T: Foo<bar(): Send, baz(): Send>,
-   |            ^^^^^^^^^^^
+LL |     T: Foo<bar(..): Send, baz(..): Send>,
+   |            ^^^^^^^^^^^^^
 
 error: return type notation is not allowed for functions that have const parameters
-  --> $DIR/ty-or-ct-params.rs:14:25
+  --> $DIR/ty-or-ct-params.rs:14:27
    |
 LL |     async fn baz<const N: usize>() {}
    |                  -------------- const parameter declared here
 ...
-LL |     T: Foo<bar(): Send, baz(): Send>,
-   |                         ^^^^^^^^^^^
+LL |     T: Foo<bar(..): Send, baz(..): Send>,
+   |                           ^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/borrowck/alias-liveness/rtn-static.rs
+++ b/tests/ui/borrowck/alias-liveness/rtn-static.rs
@@ -7,7 +7,7 @@ trait Foo {
     fn borrow(&mut self) -> impl Sized + '_;
 }
 
-fn live_past_borrow<T: Foo<borrow(): 'static>>(mut t: T) {
+fn live_past_borrow<T: Foo<borrow(..): 'static>>(mut t: T) {
     let x = t.borrow();
     drop(t);
     drop(x);
@@ -15,7 +15,7 @@ fn live_past_borrow<T: Foo<borrow(): 'static>>(mut t: T) {
 
 // Test that the `'_` item bound in `borrow` does not cause us to
 // overlook the `'static` RTN bound.
-fn overlapping_mut<T: Foo<borrow(): 'static>>(mut t: T) {
+fn overlapping_mut<T: Foo<borrow(..): 'static>>(mut t: T) {
     let x = t.borrow();
     let x = t.borrow();
 }

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.cfg.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.cfg.stderr
@@ -1,33 +1,13 @@
 error[E0658]: return type notation is experimental
-  --> $DIR/feature-gate-return_type_notation.rs:14:17
+  --> $DIR/feature-gate-return_type_notation.rs:10:18
    |
-LL | fn foo<T: Trait<m(): Send>>() {}
-   |                 ^^^^^^^^^
+LL | fn foo<T: Trait<m(..): Send>>() {}
+   |                  ^^^^
    |
    = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
    = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: parenthesized generic arguments cannot be used in associated type constraints
-  --> $DIR/feature-gate-return_type_notation.rs:14:17
-   |
-LL | fn foo<T: Trait<m(): Send>>() {}
-   |                 ^--
-   |                  |
-   |                  help: remove these parentheses
-
-error: expected type, found function
-  --> $DIR/feature-gate-return_type_notation.rs:14:17
-   |
-LL | fn foo<T: Trait<m(): Send>>() {}
-   |                 ^ unexpected function
-   |
-note: the associated function is defined here
-  --> $DIR/feature-gate-return_type_notation.rs:10:5
-   |
-LL |     async fn m();
-   |     ^^^^^^^^^^^^^
-
-error: aborting due to 3 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.no.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.no.stderr
@@ -1,14 +1,13 @@
-warning: return type notation is experimental
-  --> $DIR/feature-gate-return_type_notation.rs:14:17
+error[E0658]: return type notation is experimental
+  --> $DIR/feature-gate-return_type_notation.rs:10:18
    |
-LL | fn foo<T: Trait<m(): Send>>() {}
-   |                 ^^^^^^^^^
+LL | fn foo<T: Trait<m(..): Send>>() {}
+   |                  ^^^^
    |
    = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
    = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.rs
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.rs
@@ -1,21 +1,13 @@
 //@ edition: 2021
 //@ revisions: cfg no
 
-//@ [no] check-pass
-// Since we're not adding new syntax, `cfg`'d out RTN must pass.
-
-
 trait Trait {
     #[allow(async_fn_in_trait)]
     async fn m();
 }
 
 #[cfg(cfg)]
-fn foo<T: Trait<m(): Send>>() {}
-//[cfg]~^ ERROR return type notation is experimental
-//[cfg]~| ERROR parenthesized generic arguments cannot be used in associated type constraints
-//[cfg]~| ERROR expected type, found function
-//[no]~^^^^ WARN return type notation is experimental
-//[no]~| WARN unstable syntax can change at any point in the future, causing a hard error!
+fn foo<T: Trait<m(..): Send>>() {}
+//~^ ERROR return type notation is experimental
 
 fn main() {}


### PR DESCRIPTION
Aligns the syntax with the current wording of [RFC 3654](https://github.com/rust-lang/rfcs/pull/3654). Also implements rustfmt support (along with making a match exhaustive).

Tracking:
* https://github.com/rust-lang/rust/issues/109417