### PR TITLE
Move binder and polarity parsing into `parse_generic_ty_bound`

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2327,7 +2327,7 @@ impl<'a> Parser<'a> {
         let before = self.prev_token.clone();
         let binder = if self.check_keyword(kw::For) {
             let lo = self.token.span;
-            let lifetime_defs = self.parse_late_bound_lifetime_defs()?;
+            let (lifetime_defs, _) = self.parse_late_bound_lifetime_defs()?;
             let span = lo.to(self.prev_token.span);
 
             self.psess.gated_spans.gate(sym::closure_lifetime_binder, span);

--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -457,7 +457,7 @@ impl<'a> Parser<'a> {
         // * `for<'a> Trait1<'a>: Trait2<'a /* ok */>`
         // * `(for<'a> Trait1<'a>): Trait2<'a /* not ok */>`
         // * `for<'a> for<'b> Trait1<'a, 'b>: Trait2<'a /* ok */, 'b /* not ok */>`
-        let lifetime_defs = self.parse_late_bound_lifetime_defs()?;
+        let (lifetime_defs, _) = self.parse_late_bound_lifetime_defs()?;
 
         // Parse type with mandatory colon and (possibly empty) bounds,
         // or with mandatory equality sign and the second type.

--- a/tests/ui/higher-ranked/erroneous-lifetime-bound.rs
+++ b/tests/ui/higher-ranked/erroneous-lifetime-bound.rs
@@ -1,0 +1,5 @@
+fn foo<T>() where T: for<'a> 'a {}
+//~^ ERROR `for<...>` may only modify trait bounds, not lifetime bounds
+//~| ERROR use of undeclared lifetime name `'a` [E0261]
+
+fn main() {}

--- a/tests/ui/higher-ranked/erroneous-lifetime-bound.stderr
+++ b/tests/ui/higher-ranked/erroneous-lifetime-bound.stderr
@@ -1,0 +1,25 @@
+error: `for<...>` may only modify trait bounds, not lifetime bounds
+  --> $DIR/erroneous-lifetime-bound.rs:1:25
+   |
+LL | fn foo<T>() where T: for<'a> 'a {}
+   |                         ^^^^
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/erroneous-lifetime-bound.rs:1:30
+   |
+LL | fn foo<T>() where T: for<'a> 'a {}
+   |                              ^^ undeclared lifetime
+   |
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL | fn foo<T>() where for<'a> T: for<'a> 'a {}
+   |                   +++++++
+help: consider introducing lifetime `'a` here
+   |
+LL | fn foo<'a, T>() where T: for<'a> 'a {}
+   |        +++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0261`.

--- a/tests/ui/impl-trait/precise-capturing/bound-modifiers.rs
+++ b/tests/ui/impl-trait/precise-capturing/bound-modifiers.rs
@@ -1,0 +1,25 @@
+//@ edition: 2021
+
+#![feature(precise_capturing)]
+
+fn polarity() -> impl Sized + ?use<> {}
+//~^ ERROR expected identifier, found keyword `use`
+//~| ERROR cannot find trait `r#use` in this scope
+//~| WARN relaxing a default bound only does something for `?Sized`
+//~| WARN relaxing a default bound only does something for `?Sized`
+
+fn asyncness() -> impl Sized + async use<> {}
+//~^ ERROR expected identifier, found keyword `use`
+//~| ERROR cannot find trait `r#use` in this scope
+//~| ERROR async closures are unstable
+
+fn constness() -> impl Sized + const use<> {}
+//~^ ERROR expected identifier, found keyword `use`
+//~| ERROR cannot find trait `r#use` in this scope
+//~| ERROR const trait impls are experimental
+
+fn binder() -> impl Sized + for<'a> use<> {}
+//~^ ERROR expected identifier, found keyword `use`
+//~| ERROR cannot find trait `r#use` in this scope
+
+fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/bound-modifiers.stderr
+++ b/tests/ui/impl-trait/precise-capturing/bound-modifiers.stderr
@@ -1,0 +1,87 @@
+error: expected identifier, found keyword `use`
+  --> $DIR/bound-modifiers.rs:5:32
+   |
+LL | fn polarity() -> impl Sized + ?use<> {}
+   |                                ^^^ expected identifier, found keyword
+
+error: expected identifier, found keyword `use`
+  --> $DIR/bound-modifiers.rs:11:38
+   |
+LL | fn asyncness() -> impl Sized + async use<> {}
+   |                                      ^^^ expected identifier, found keyword
+
+error: expected identifier, found keyword `use`
+  --> $DIR/bound-modifiers.rs:16:38
+   |
+LL | fn constness() -> impl Sized + const use<> {}
+   |                                      ^^^ expected identifier, found keyword
+
+error: expected identifier, found keyword `use`
+  --> $DIR/bound-modifiers.rs:21:37
+   |
+LL | fn binder() -> impl Sized + for<'a> use<> {}
+   |                                     ^^^ expected identifier, found keyword
+
+error[E0405]: cannot find trait `r#use` in this scope
+  --> $DIR/bound-modifiers.rs:5:32
+   |
+LL | fn polarity() -> impl Sized + ?use<> {}
+   |                                ^^^ not found in this scope
+
+error[E0405]: cannot find trait `r#use` in this scope
+  --> $DIR/bound-modifiers.rs:11:38
+   |
+LL | fn asyncness() -> impl Sized + async use<> {}
+   |                                      ^^^ not found in this scope
+
+error[E0405]: cannot find trait `r#use` in this scope
+  --> $DIR/bound-modifiers.rs:16:38
+   |
+LL | fn constness() -> impl Sized + const use<> {}
+   |                                      ^^^ not found in this scope
+
+error[E0405]: cannot find trait `r#use` in this scope
+  --> $DIR/bound-modifiers.rs:21:37
+   |
+LL | fn binder() -> impl Sized + for<'a> use<> {}
+   |                                     ^^^ not found in this scope
+
+error[E0658]: async closures are unstable
+  --> $DIR/bound-modifiers.rs:11:32
+   |
+LL | fn asyncness() -> impl Sized + async use<> {}
+   |                                ^^^^^
+   |
+   = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
+   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: to use an async block, remove the `||`: `async {`
+
+error[E0658]: const trait impls are experimental
+  --> $DIR/bound-modifiers.rs:16:32
+   |
+LL | fn constness() -> impl Sized + const use<> {}
+   |                                ^^^^^
+   |
+   = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
+  --> $DIR/bound-modifiers.rs:5:31
+   |
+LL | fn polarity() -> impl Sized + ?use<> {}
+   |                               ^^^^^^
+
+warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
+  --> $DIR/bound-modifiers.rs:5:31
+   |
+LL | fn polarity() -> impl Sized + ?use<> {}
+   |                               ^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 10 previous errors; 2 warnings emitted
+
+Some errors have detailed explanations: E0405, E0658.
+For more information about an error, try `rustc --explain E0405`.


### PR DESCRIPTION
Let's pull out the parts of #127054 which just:
1. Make the parsing code less confusing
2. Fix `?use<>` (to correctly be denied)
3. Improve `T: for<'a> 'a` diagnostics

This should have no user-facing effects on stable parsing.

r? fmease