### PR TITLE
Improve unsafe extern blocks diagnostics

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1088,7 +1088,15 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                             }
                         }
                     } else if let &Safety::Unsafe(span) = safety {
-                        this.dcx().emit_err(errors::UnsafeItem { span, kind: "extern block" });
+                        let mut diag = this
+                            .dcx()
+                            .create_err(errors::UnsafeItem { span, kind: "extern block" });
+                        rustc_session::parse::add_feature_diagnostics(
+                            &mut diag,
+                            self.session,
+                            sym::unsafe_extern_blocks,
+                        );
+                        diag.emit();
                     }
 
                     if abi.is_none() {

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -459,13 +459,18 @@ impl<'a> AstValidator<'a> {
     fn check_item_safety(&self, span: Span, safety: Safety) {
         match self.extern_mod_safety {
             Some(extern_safety) => {
-                if matches!(safety, Safety::Unsafe(_) | Safety::Safe(_))
-                    && (extern_safety == Safety::Default || !self.features.unsafe_extern_blocks)
-                {
-                    self.dcx().emit_err(errors::InvalidSafetyOnExtern {
-                        item_span: span,
-                        block: self.current_extern_span().shrink_to_lo(),
-                    });
+                if matches!(safety, Safety::Unsafe(_) | Safety::Safe(_)) {
+                    if extern_safety == Safety::Default {
+                        self.dcx().emit_err(errors::InvalidSafetyOnExtern {
+                            item_span: span,
+                            block: Some(self.current_extern_span().shrink_to_lo()),
+                        });
+                    } else if !self.features.unsafe_extern_blocks {
+                        self.dcx().emit_err(errors::InvalidSafetyOnExtern {
+                            item_span: span,
+                            block: None,
+                        });
+                    }
                 }
             }
             None => {

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -222,7 +222,7 @@ pub struct InvalidSafetyOnExtern {
     #[primary_span]
     pub item_span: Span,
     #[suggestion(code = "unsafe ", applicability = "machine-applicable", style = "verbose")]
-    pub block: Span,
+    pub block: Option<Span>,
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui/feature-gates/feature-gate-unsafe-extern-blocks.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsafe-extern-blocks.stderr
@@ -3,6 +3,10 @@ error: extern block cannot be declared unsafe
    |
 LL | unsafe extern "C" {
    | ^^^^^^
+   |
+   = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
+   = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `unsafe extern {}` blocks and `safe` keyword are experimental
   --> $DIR/feature-gate-unsafe-extern-blocks.rs:9:5

--- a/tests/ui/parser/unsafe-foreign-mod-2.stderr
+++ b/tests/ui/parser/unsafe-foreign-mod-2.stderr
@@ -19,11 +19,6 @@ error: items in unadorned `extern` blocks cannot have safety qualifiers
    |
 LL |     unsafe fn foo();
    |     ^^^^^^^^^^^^^^^^
-   |
-help: add unsafe to this `extern` block
-   |
-LL | unsafe extern "C" unsafe {
-   | ++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/unsafe-foreign-mod-2.stderr
+++ b/tests/ui/parser/unsafe-foreign-mod-2.stderr
@@ -9,6 +9,10 @@ error: extern block cannot be declared unsafe
    |
 LL | extern "C" unsafe {
    |            ^^^^^^
+   |
+   = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
+   = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: items in unadorned `extern` blocks cannot have safety qualifiers
   --> $DIR/unsafe-foreign-mod-2.rs:4:5

--- a/tests/ui/parser/unsafe-foreign-mod.stderr
+++ b/tests/ui/parser/unsafe-foreign-mod.stderr
@@ -3,6 +3,10 @@ error: extern block cannot be declared unsafe
    |
 LL | unsafe extern "C" {
    | ^^^^^^
+   |
+   = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
+   = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Closes #126327

For this code:

```rust
extern {
    pub fn foo();
    pub safe fn bar();
}
```

We get ...

```
error: items in unadorned `extern` blocks cannot have safety qualifiers
 --> test.rs:3:5
  |
3 |     pub safe fn bar();
  |     ^^^^^^^^^^^^^^^^^^
  |
help: add unsafe to this `extern` block
  |
1 | unsafe extern {
  | ++++++

error[E0658]: `unsafe extern {}` blocks and `safe` keyword are experimental
 --> test.rs:3:9
  |
3 |     pub safe fn bar();
  |         ^^^^
  |
  = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
  = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0658`.
```

And then making the extern block unsafe, we get ...

```
error: extern block cannot be declared unsafe
 --> test.rs:1:1
  |
1 | unsafe extern {
  | ^^^^^^
  |
  = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
  = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable

error: items in unadorned `extern` blocks cannot have safety qualifiers
 --> test.rs:3:5
  |
3 |     pub safe fn bar();
  |     ^^^^^^^^^^^^^^^^^^

error[E0658]: `unsafe extern {}` blocks and `safe` keyword are experimental
 --> test.rs:3:9
  |
3 |     pub safe fn bar();
  |         ^^^^
  |
  = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
  = help: add `#![feature(unsafe_extern_blocks)]` to the crate attributes to enable

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0658`.
```

r? @compiler-errors 