### PR TITLE
Fix a error suggestion for E0121 when using placeholder _ as return types on function signature.

### DIFF
--- a/tests/ui/return/infer-return-ty-for-fn-sig-issue-125488.fixed
+++ b/tests/ui/return/infer-return-ty-for-fn-sig-issue-125488.fixed
@@ -1,0 +1,33 @@
+//@ run-rustfix
+
+#[allow(dead_code)]
+
+fn main() {
+    struct S<'a>(&'a ());
+
+    fn f1(s: S<'_>) -> S<'_> {
+        //~^ ERROR the placeholder `_` is not allowed
+        s
+    }
+
+    fn f2(s: S<'_>) -> S<'_> {
+        //~^ ERROR the placeholder `_` is not allowed
+        let x = true;
+        if x {
+            s
+        } else {
+            s
+        }
+    }
+
+    fn f3(s: S<'_>) -> S<'_> {
+        //~^ ERROR the placeholder `_` is not allowed
+        return s;
+    }
+
+    fn f4(s: S<'_>) -> S<'_> {
+        //~^ ERROR the placeholder `_` is not allowed
+        let _x = 1;
+        return s;
+    }
+}

--- a/tests/ui/return/infer-return-ty-for-fn-sig-issue-125488.rs
+++ b/tests/ui/return/infer-return-ty-for-fn-sig-issue-125488.rs
@@ -1,0 +1,33 @@
+//@ run-rustfix
+
+#[allow(dead_code)]
+
+fn main() {
+    struct S<'a>(&'a ());
+
+    fn f1(s: S<'_>) -> _ {
+        //~^ ERROR the placeholder `_` is not allowed
+        s
+    }
+
+    fn f2(s: S<'_>) -> _ {
+        //~^ ERROR the placeholder `_` is not allowed
+        let x = true;
+        if x {
+            s
+        } else {
+            s
+        }
+    }
+
+    fn f3(s: S<'_>) -> _ {
+        //~^ ERROR the placeholder `_` is not allowed
+        return s;
+    }
+
+    fn f4(s: S<'_>) -> _ {
+        //~^ ERROR the placeholder `_` is not allowed
+        let _x = 1;
+        return s;
+    }
+}

--- a/tests/ui/return/infer-return-ty-for-fn-sig-issue-125488.stderr
+++ b/tests/ui/return/infer-return-ty-for-fn-sig-issue-125488.stderr
@@ -1,0 +1,39 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/infer-return-ty-for-fn-sig-issue-125488.rs:8:24
+   |
+LL |     fn f1(s: S<'_>) -> _ {
+   |                        ^
+   |                        |
+   |                        not allowed in type signatures
+   |                        help: replace with the correct return type: `S<'_>`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/infer-return-ty-for-fn-sig-issue-125488.rs:13:24
+   |
+LL |     fn f2(s: S<'_>) -> _ {
+   |                        ^
+   |                        |
+   |                        not allowed in type signatures
+   |                        help: replace with the correct return type: `S<'_>`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/infer-return-ty-for-fn-sig-issue-125488.rs:23:24
+   |
+LL |     fn f3(s: S<'_>) -> _ {
+   |                        ^
+   |                        |
+   |                        not allowed in type signatures
+   |                        help: replace with the correct return type: `S<'_>`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/infer-return-ty-for-fn-sig-issue-125488.rs:28:24
+   |
+LL |     fn f4(s: S<'_>) -> _ {
+   |                        ^
+   |                        |
+   |                        not allowed in type signatures
+   |                        help: replace with the correct return type: `S<'_>`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/typeck/typeck_type_placeholder_item.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item.rs
@@ -47,7 +47,7 @@ impl Test9 {
 
 fn test11(x: &usize) -> &_ {
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
-    &x //~ ERROR cannot return reference to function parameter
+    &x
 }
 
 unsafe fn test12(x: *const usize) -> *const *const _ {

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -158,7 +158,7 @@ LL | fn test11(x: &usize) -> &_ {
    |                         -^
    |                         ||
    |                         |not allowed in type signatures
-   |                         help: replace with the correct return type: `&'static &'static usize`
+   |                         help: replace with the correct return type: `&&usize`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:53:52
@@ -687,13 +687,7 @@ help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 LL + #![feature(const_trait_impl)]
    |
 
-error[E0515]: cannot return reference to function parameter `x`
-  --> $DIR/typeck_type_placeholder_item.rs:50:5
-   |
-LL |     &x
-   |     ^^ returns a reference to data owned by the current function
+error: aborting due to 74 previous errors
 
-error: aborting due to 75 previous errors
-
-Some errors have detailed explanations: E0015, E0046, E0121, E0282, E0403, E0515.
+Some errors have detailed explanations: E0015, E0046, E0121, E0282, E0403.
 For more information about an error, try `rustc --explain E0015`.


### PR DESCRIPTION
Recommit after refactoring based on comment:
https://github.com/rust-lang/rust/pull/126017#issuecomment-2189149361

But when changing return type's lifetime to `ReError` will affect the subsequent borrow check process and cause test11 in typeck_type_placeholder_item.rs to lost E0515 message.
```rust
fn test11(x: &usize) -> &_ {
//~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
    &x //~ ERROR cannot return reference to function parameter(this E0515 msg will disappear)
}
```

fixes #125488

r? @pnkfelix 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
