### PR TITLE
Bootstrap: Don't get output if `lldb --version` errors

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -7,6 +7,7 @@ use std::env;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fs;
+use std::io::ErrorKind;
 use std::iter;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -1830,6 +1831,9 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         let lldb_version = Command::new(&lldb_exe)
             .arg("--version")
             .output()
+            .and_then(|output| {
+                if output.status.success() { Ok(output) } else { Err(ErrorKind::Other.into()) }
+            })
             .map(|output| String::from_utf8_lossy(&output.stdout).to_string())
             .ok();
         if let Some(ref vers) = lldb_version {


### PR DESCRIPTION
fixes #126892

`Command` can error in two ways: the OS can fail to run the binary at all or else the binary can return an error exit code. Unfortunately the distinction between the two is not clear cut. The OS may succeed in starting the binary but it may still error before `main` (e.g. if a necessary library fails to load) and this will be reported via the exit code.

Fortunately this case is simpler. We can assume that `lldb --version` will only ever error if there's a startup issue of some kind. so both kinds of errors are caused by the OS. Thus it's safe for us to treat them equally for the sake of this specific check.