### PR TITLE
fix: prefer `(*p).clone` to `p.clone` if the `p` is a raw pointer

### DIFF
--- a/tests/ui/borrowck/borrowck-move-from-unsafe-ptr.stderr
+++ b/tests/ui/borrowck/borrowck-move-from-unsafe-ptr.stderr
@@ -4,16 +4,10 @@ error[E0507]: cannot move out of `*x` which is behind a raw pointer
 LL |     let y = *x;
    |             ^^ move occurs because `*x` has type `Box<isize>`, which does not implement the `Copy` trait
    |
-help: consider removing the dereference here
-   |
-LL -     let y = *x;
-LL +     let y = x;
-   |
 help: consider cloning the value if the performance cost is acceptable
    |
-LL -     let y = *x;
-LL +     let y = x.clone();
-   |
+LL |     let y = (*x).clone();
+   |             +  +++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-20801.stderr
+++ b/tests/ui/borrowck/issue-20801.stderr
@@ -67,11 +67,6 @@ LL | struct T(u8);
 ...
 LL |     let c = unsafe { *mut_ptr() };
    |                      ---------- you could clone this value
-help: consider removing the dereference here
-   |
-LL -     let c = unsafe { *mut_ptr() };
-LL +     let c = unsafe { mut_ptr() };
-   |
 
 error[E0507]: cannot move out of a raw pointer
   --> $DIR/issue-20801.rs:36:22
@@ -87,11 +82,6 @@ LL | struct T(u8);
 ...
 LL |     let d = unsafe { *const_ptr() };
    |                      ------------ you could clone this value
-help: consider removing the dereference here
-   |
-LL -     let d = unsafe { *const_ptr() };
-LL +     let d = unsafe { const_ptr() };
-   |
 
 error: aborting due to 4 previous errors; 1 warning emitted
 

--- a/tests/ui/borrowck/move-from-union-field-issue-66500.stderr
+++ b/tests/ui/borrowck/move-from-union-field-issue-66500.stderr
@@ -30,9 +30,8 @@ LL |     *u.c
    |
 help: consider cloning the value if the performance cost is acceptable
    |
-LL -     *u.c
-LL +     u.c.clone()
-   |
+LL |     (*u.c).clone()
+   |     +    +++++++++
 
 error[E0507]: cannot move out of `*u.d` which is behind a raw pointer
   --> $DIR/move-from-union-field-issue-66500.rs:24:5
@@ -42,9 +41,8 @@ LL |     *u.d
    |
 help: consider cloning the value if the performance cost is acceptable
    |
-LL -     *u.d
-LL +     u.d.clone()
-   |
+LL |     (*u.d).clone()
+   |     +    +++++++++
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/126863


I wonder if there is a better way to solve the regression problem of this test case:
`tests/ui/borrowck/issue-20801.rs`.
It's okay to drop the dereference symbol in this scenario.

But it's not correct in https://github.com/rust-lang/rust/issues/126863

```
help: consider removing the dereference here
  |
5 -         let inner: String = *p;
5 +         let inner: String = p;
```

I haven't found out how to tell if clone pointer is allowed, i.e. no type mismatch occurs