### PR TITLE
Migrate `run-make/return-non-c-like-enum` to `rmake.rs`

### DIFF
--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -147,7 +147,6 @@ run-make/remap-path-prefix/Makefile
 run-make/reproducible-build-2/Makefile
 run-make/reproducible-build/Makefile
 run-make/return-non-c-like-enum-from-c/Makefile
-run-make/return-non-c-like-enum/Makefile
 run-make/rlib-chain/Makefile
 run-make/rlib-format-packed-bundled-libs-2/Makefile
 run-make/rlib-format-packed-bundled-libs-3/Makefile

--- a/tests/run-make/return-non-c-like-enum/Makefile
+++ b/tests/run-make/return-non-c-like-enum/Makefile
@@ -1,8 +1,0 @@
-# ignore-cross-compile
-include ../tools.mk
-
-all:
-	$(RUSTC) --crate-type=staticlib nonclike.rs
-	$(CC) test.c $(call STATICLIB,nonclike) $(call OUT_EXE,test) \
-		$(EXTRACFLAGS) $(EXTRACXXFLAGS)
-	$(call RUN,test)

--- a/tests/run-make/return-non-c-like-enum/rmake.rs
+++ b/tests/run-make/return-non-c-like-enum/rmake.rs
@@ -1,0 +1,18 @@
+// Check that we treat enum variants like union members in call ABIs.
+// Added in #68443.
+// Original issue: #68190.
+
+//@ ignore-cross-compile
+
+use run_make_support::{cc, extra_c_flags, extra_cxx_flags, run, rustc, static_lib_name};
+
+fn main() {
+    rustc().crate_type("staticlib").input("nonclike.rs").run();
+    cc().input("test.c")
+        .arg(&static_lib_name("nonclike"))
+        .out_exe("test")
+        .args(&extra_c_flags())
+        .args(&extra_cxx_flags())
+        .run();
+    run("test");
+}


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/121876.

r? @Kobzol 