### PR TITLE
Show `used attribute`'s kind for user when find it isn't applied to a `static` variable.

### DIFF
--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -786,6 +786,7 @@ passes_used_compiler_linker =
 
 passes_used_static =
     attribute must be applied to a `static` variable
+    .label = but this is a {$target}
 
 passes_useless_assignment =
     useless assignment of {$is_field_assign ->

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -278,7 +278,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         }
 
         self.check_repr(attrs, span, target, item, hir_id);
-        self.check_used(attrs, target);
+        self.check_used(attrs, target, span);
     }
 
     fn inline_attr_str_error_with_macro_def(&self, hir_id: HirId, attr: &Attribute, sym: &str) {
@@ -1978,12 +1978,16 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         }
     }
 
-    fn check_used(&self, attrs: &[Attribute], target: Target) {
+    fn check_used(&self, attrs: &[Attribute], target: Target, target_span: Span) {
         let mut used_linker_span = None;
         let mut used_compiler_span = None;
         for attr in attrs.iter().filter(|attr| attr.has_name(sym::used)) {
             if target != Target::Static {
-                self.dcx().emit_err(errors::UsedStatic { span: attr.span });
+                self.dcx().emit_err(errors::UsedStatic {
+                    attr_span: attr.span,
+                    span: target_span,
+                    target: target.name(),
+                });
             }
             let inner = attr.meta_item_list();
             match inner.as_deref() {

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -563,7 +563,10 @@ pub struct ReprConflictingLint;
 #[diag(passes_used_static)]
 pub struct UsedStatic {
     #[primary_span]
+    pub attr_span: Span,
+    #[label]
     pub span: Span,
+    pub target: &'static str,
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui/attributes/used-issue-126789.rs
+++ b/tests/ui/attributes/used-issue-126789.rs
@@ -1,0 +1,6 @@
+extern "C" {
+    #[used] //~ ERROR attribute must be applied to a `static` variable
+    static FOO: i32;
+}
+
+fn main() {}

--- a/tests/ui/attributes/used-issue-126789.stderr
+++ b/tests/ui/attributes/used-issue-126789.stderr
@@ -1,0 +1,10 @@
+error: attribute must be applied to a `static` variable
+  --> $DIR/used-issue-126789.rs:2:5
+   |
+LL |     #[used]
+   |     ^^^^^^^
+LL |     static FOO: i32;
+   |     ---------------- but this is a foreign static item
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/used.stderr
+++ b/tests/ui/used.stderr
@@ -3,24 +3,32 @@ error: attribute must be applied to a `static` variable
    |
 LL | #[used]
    | ^^^^^^^
+LL | fn foo() {}
+   | ----------- but this is a function
 
 error: attribute must be applied to a `static` variable
   --> $DIR/used.rs:7:1
    |
 LL | #[used]
    | ^^^^^^^
+LL | struct Foo {}
+   | ------------- but this is a struct
 
 error: attribute must be applied to a `static` variable
   --> $DIR/used.rs:10:1
    |
 LL | #[used]
    | ^^^^^^^
+LL | trait Bar {}
+   | ------------ but this is a trait
 
 error: attribute must be applied to a `static` variable
   --> $DIR/used.rs:13:1
    |
 LL | #[used]
    | ^^^^^^^
+LL | impl Bar for Foo {}
+   | ------------------- but this is a implementation block
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
For example :
```rust
extern "C" {
    #[used] //~ ERROR attribute must be applied to a `static` variable
    static FOO: i32; // show the kind of this item to help user understand why the error is reported.
}
```

fixes #126789


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
