### PR TITLE
Remove uneccessary condition in `div_ceil`

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2726,7 +2726,7 @@ macro_rules! uint_impl {
         pub const fn div_ceil(self, rhs: Self) -> Self {
             let d = self / rhs;
             let r = self % rhs;
-            if r > 0 && rhs > 0 {
+            if r > 0 {
                 d + 1
             } else {
                 d


### PR DESCRIPTION
Previously, `div_ceil` for unsigned integers had a `rhs > 0` for rounding. That condition however is always fulfilled, since `rhs == 0` would mean a division by zero earlier.