### PR TITLE
add useful terminal control escape sequences

### DIFF
--- a/compiler/rustc_lexer/src/unescape.rs
+++ b/compiler/rustc_lexer/src/unescape.rs
@@ -243,6 +243,11 @@ fn scan_escape<T: From<char> + From<u8>>(
         '\\' => '\\',
         '\'' => '\'',
         '0' => '\0',
+        'a' => '\x07',
+        'f' => '\x0c',
+        'v' => '\x0b',
+        'b' => '\x08',
+        'e' => '\x1b',
         'x' => {
             // Parse hexadecimal character code.
 

--- a/compiler/rustc_lexer/src/unescape/tests.rs
+++ b/compiler/rustc_lexer/src/unescape/tests.rs
@@ -26,7 +26,7 @@ fn test_unescape_char_bad() {
     check(r"\u{0}x", EscapeError::MoreThanOneChar);
     check(r"\u{1F63b}}", EscapeError::MoreThanOneChar);
 
-    check(r"\v", EscapeError::InvalidEscape);
+    check(r"\c", EscapeError::InvalidEscape);
     check(r"\💩", EscapeError::InvalidEscape);
     check(r"\●", EscapeError::InvalidEscape);
     check("\\\r", EscapeError::InvalidEscape);
@@ -81,6 +81,11 @@ fn test_unescape_char_good() {
     check(r"\\", '\\');
     check(r"\'", '\'');
     check(r"\0", '\0');
+    check(r"\a", 7 as char);
+    check(r"\f", 12 as char);
+    check(r"\v", 11 as char);
+    check(r"\b", 8 as char);
+    check(r"\e", 27 as char);
 
     check(r"\x00", '\0');
     check(r"\x5a", 'Z');
@@ -167,7 +172,7 @@ fn test_unescape_byte_bad() {
     check(r"\'a", EscapeError::MoreThanOneChar);
     check(r"\0a", EscapeError::MoreThanOneChar);
 
-    check(r"\v", EscapeError::InvalidEscape);
+    check(r"\c", EscapeError::InvalidEscape);
     check(r"\💩", EscapeError::InvalidEscape);
     check(r"\●", EscapeError::InvalidEscape);
 
@@ -227,6 +232,11 @@ fn test_unescape_byte_good() {
     check(r"\\", b'\\');
     check(r"\'", b'\'');
     check(r"\0", b'\0');
+    check(r"\a", 7);
+    check(r"\f", 12);
+    check(r"\v", 11);
+    check(r"\b", 8);
+    check(r"\e", 27);
 
     check(r"\x00", b'\0');
     check(r"\x5a", b'Z');

--- a/tests/ui/parser/byte-literals.rs
+++ b/tests/ui/parser/byte-literals.rs
@@ -1,9 +1,9 @@
 // ignore-tidy-tab
 
-static FOO: u8 = b'\f';  //~ ERROR unknown byte escape
+static FOO: u8 = b'\c';  //~ ERROR unknown byte escape
 
 pub fn main() {
-    b'\f';  //~ ERROR unknown byte escape
+    b'\c';  //~ ERROR unknown byte escape
     b'\x0Z';  //~ ERROR invalid character in numeric character escape: `Z`
     b'	';  //~ ERROR byte constant must be escaped
     b''';  //~ ERROR byte constant must be escaped

--- a/tests/ui/parser/byte-literals.stderr
+++ b/tests/ui/parser/byte-literals.stderr
@@ -1,15 +1,15 @@
-error: unknown byte escape: `f`
+error: unknown byte escape: `c`
   --> $DIR/byte-literals.rs:3:21
    |
-LL | static FOO: u8 = b'\f';
+LL | static FOO: u8 = b'\c';
    |                     ^ unknown byte escape
    |
    = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
 
-error: unknown byte escape: `f`
+error: unknown byte escape: `c`
   --> $DIR/byte-literals.rs:6:8
    |
-LL |     b'\f';
+LL |     b'\c';
    |        ^ unknown byte escape
    |
    = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>

--- a/tests/ui/parser/byte-string-literals.rs
+++ b/tests/ui/parser/byte-string-literals.rs
@@ -1,7 +1,7 @@
-static FOO: &'static [u8] = b"\f";  //~ ERROR unknown byte escape
+static FOO: &'static [u8] = b"\c";  //~ ERROR unknown byte escape
 
 pub fn main() {
-    b"\f";  //~ ERROR unknown byte escape
+    b"\c";  //~ ERROR unknown byte escape
     b"\x0Z";  //~ ERROR invalid character in numeric character escape: `Z`
     b"é";  //~ ERROR non-ASCII character in byte string literal
     br##"é"##;  //~ ERROR non-ASCII character in raw byte string literal

--- a/tests/ui/parser/byte-string-literals.stderr
+++ b/tests/ui/parser/byte-string-literals.stderr
@@ -1,15 +1,15 @@
-error: unknown byte escape: `f`
+error: unknown byte escape: `c`
   --> $DIR/byte-string-literals.rs:1:32
    |
-LL | static FOO: &'static [u8] = b"\f";
+LL | static FOO: &'static [u8] = b"\c";
    |                                ^ unknown byte escape
    |
    = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
 
-error: unknown byte escape: `f`
+error: unknown byte escape: `c`
   --> $DIR/byte-string-literals.rs:4:8
    |
-LL |     b"\f";
+LL |     b"\c";
    |        ^ unknown byte escape
    |
    = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>


### PR DESCRIPTION
Hi folks,
This PR adds support for useful terminal control escape sequences.  The lack of support for these has on more than one occasion caused me to use magic numbers that are easy to mistype (`\x2b` instead of `\x1b` for example), and somewhat hard to catch.

The full list of escape sequences that this PR adds are: `\v` for vertical tab, `\f` for form-feed (page break), `\a` to ring the terminal's bell, `\b` for backspace, and `\e` for escape.

Tests referencing `\f` and `\v` have been modified to instead look for `\c`, and the commit's tests and tidy checks all pass.

If I need to add any documentation or anything else, please let me know.

Thanks,
Ren