### PR TITLE
Bootstrap: Retry copying/linking

### DIFF
--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -34,7 +34,7 @@ use filetime::FileTime;
 use sha2::digest::Digest;
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 use utils::channel::GitInfo;
-use utils::helpers::hex_encode;
+use utils::helpers::{hex_encode, retry};
 
 use crate::core::builder;
 use crate::core::builder::Kind;
@@ -1676,7 +1676,7 @@ impl Build {
         if src == dst {
             return;
         }
-        let _ = fs::remove_file(dst);
+        let _ = retry(60, || fs::remove_file(dst));
         let metadata = t!(src.symlink_metadata(), format!("src = {}", src.display()));
         let mut src = src.to_path_buf();
         if metadata.file_type().is_symlink() {

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -517,3 +517,19 @@ pub fn git(source_dir: Option<&Path>) -> Command {
 
     git
 }
+
+/// Retry a function up to n times, returning the last call to fun.
+/// Stops early if the function returns `Ok`.
+pub fn retry<T, E>(n: usize, mut fun: impl FnMut() -> Result<T, E>) -> Result<T, E> {
+    let mut retries = 0;
+    loop {
+        retries += 1;
+
+        let result = fun();
+        if result.is_ok() || retries == n {
+            return result;
+        }
+        // wait an arbitrary length of time.
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}


### PR DESCRIPTION
May be a workaround for #127126. But it's hard to know if this works due to the error only appearing some times.

This just adds a retry loop with a fairly long pause between retries so as to give time to whatever is locking the file to give up its lock.

try-job: x86_64-msvc-ext