### PR TITLE
match lowering: Hide `Candidate` from outside the lowering algorithm

### DIFF
--- a/compiler/rustc_mir_build/src/build/matches/util.rs
+++ b/compiler/rustc_mir_build/src/build/matches/util.rs
@@ -70,7 +70,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 ///    a MIR pass run after borrow checking.
 pub(super) fn collect_fake_borrows<'tcx>(
     cx: &mut Builder<'_, 'tcx>,
-    candidates: &[&mut Candidate<'_, 'tcx>],
+    candidates: &[Candidate<'_, 'tcx>],
     temp_span: Span,
     scrutinee_base: PlaceBase,
 ) -> Vec<(Place<'tcx>, Local, FakeBorrowKind)> {

--- a/compiler/rustc_mir_build/src/build/matches/util.rs
+++ b/compiler/rustc_mir_build/src/build/matches/util.rs
@@ -72,6 +72,10 @@ pub(super) fn collect_fake_borrows<'tcx>(
     temp_span: Span,
     scrutinee_base: PlaceBase,
 ) -> Vec<(Place<'tcx>, Local, FakeBorrowKind)> {
+    if candidates.iter().all(|candidate| !candidate.has_guard) {
+        // Fake borrows are only used when there is a guard.
+        return Vec::new();
+    }
     let mut collector =
         FakeBorrowCollector { cx, scrutinee_base, fake_borrows: FxIndexMap::default() };
     for candidate in candidates.iter() {

--- a/compiler/rustc_mir_build/src/build/matches/util.rs
+++ b/compiler/rustc_mir_build/src/build/matches/util.rs
@@ -18,18 +18,17 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         &mut self,
         from_block: BasicBlock,
         real_target: BasicBlock,
-        imaginary_target: Option<BasicBlock>,
+        imaginary_target: BasicBlock,
         source_info: SourceInfo,
     ) {
-        match imaginary_target {
-            Some(target) if target != real_target => {
-                self.cfg.terminate(
-                    from_block,
-                    source_info,
-                    TerminatorKind::FalseEdge { real_target, imaginary_target: target },
-                );
-            }
-            _ => self.cfg.goto(from_block, source_info, real_target),
+        if imaginary_target != real_target {
+            self.cfg.terminate(
+                from_block,
+                source_info,
+                TerminatorKind::FalseEdge { real_target, imaginary_target },
+            );
+        } else {
+            self.cfg.goto(from_block, source_info, real_target)
         }
     }
 }

--- a/tests/mir-opt/building/match/match_false_edges.full_tested_match.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.full_tested_match.built.after.mir
@@ -37,11 +37,11 @@ fn full_tested_match() -> () {
     }
 
     bb2: {
-        falseEdge -> [real: bb7, imaginary: bb3];
+        falseEdge -> [real: bb8, imaginary: bb3];
     }
 
     bb3: {
-        falseEdge -> [real: bb12, imaginary: bb5];
+        falseEdge -> [real: bb7, imaginary: bb5];
     }
 
     bb4: {
@@ -50,7 +50,7 @@ fn full_tested_match() -> () {
 
     bb5: {
         _1 = (const 3_i32, const 3_i32);
-        goto -> bb13;
+        goto -> bb14;
     }
 
     bb6: {
@@ -58,18 +58,33 @@ fn full_tested_match() -> () {
     }
 
     bb7: {
+        StorageLive(_9);
+        _9 = ((_2 as Some).0: i32);
+        StorageLive(_10);
+        _10 = _9;
+        _1 = (const 2_i32, move _10);
+        StorageDead(_10);
+        StorageDead(_9);
+        goto -> bb14;
+    }
+
+    bb8: {
         StorageLive(_6);
         _6 = &((_2 as Some).0: i32);
         _3 = &fake shallow _2;
         StorageLive(_7);
-        _7 = guard() -> [return: bb8, unwind: bb15];
-    }
-
-    bb8: {
-        switchInt(move _7) -> [0: bb10, otherwise: bb9];
+        _7 = guard() -> [return: bb10, unwind: bb16];
     }
 
     bb9: {
+        goto -> bb3;
+    }
+
+    bb10: {
+        switchInt(move _7) -> [0: bb12, otherwise: bb11];
+    }
+
+    bb11: {
         StorageDead(_7);
         FakeRead(ForMatchGuard, _3);
         FakeRead(ForGuardBinding, _6);
@@ -81,31 +96,20 @@ fn full_tested_match() -> () {
         StorageDead(_8);
         StorageDead(_5);
         StorageDead(_6);
-        goto -> bb13;
-    }
-
-    bb10: {
-        goto -> bb11;
-    }
-
-    bb11: {
-        StorageDead(_7);
-        StorageDead(_6);
-        goto -> bb3;
+        goto -> bb14;
     }
 
     bb12: {
-        StorageLive(_9);
-        _9 = ((_2 as Some).0: i32);
-        StorageLive(_10);
-        _10 = _9;
-        _1 = (const 2_i32, move _10);
-        StorageDead(_10);
-        StorageDead(_9);
         goto -> bb13;
     }
 
     bb13: {
+        StorageDead(_7);
+        StorageDead(_6);
+        goto -> bb9;
+    }
+
+    bb14: {
         PlaceMention(_1);
         StorageDead(_2);
         StorageDead(_1);
@@ -113,12 +117,12 @@ fn full_tested_match() -> () {
         return;
     }
 
-    bb14: {
+    bb15: {
         FakeRead(ForMatchedPlace(None), _1);
         unreachable;
     }
 
-    bb15 (cleanup): {
+    bb16 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/match_false_edges.full_tested_match2.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.full_tested_match2.built.after.mir
@@ -37,7 +37,7 @@ fn full_tested_match2() -> () {
     }
 
     bb2: {
-        falseEdge -> [real: bb7, imaginary: bb5];
+        falseEdge -> [real: bb8, imaginary: bb5];
     }
 
     bb3: {
@@ -48,7 +48,7 @@ fn full_tested_match2() -> () {
         _1 = (const 2_i32, move _10);
         StorageDead(_10);
         StorageDead(_9);
-        goto -> bb13;
+        goto -> bb14;
     }
 
     bb4: {
@@ -56,7 +56,7 @@ fn full_tested_match2() -> () {
     }
 
     bb5: {
-        falseEdge -> [real: bb12, imaginary: bb3];
+        falseEdge -> [real: bb7, imaginary: bb3];
     }
 
     bb6: {
@@ -64,18 +64,27 @@ fn full_tested_match2() -> () {
     }
 
     bb7: {
+        _1 = (const 3_i32, const 3_i32);
+        goto -> bb14;
+    }
+
+    bb8: {
         StorageLive(_6);
         _6 = &((_2 as Some).0: i32);
         _3 = &fake shallow _2;
         StorageLive(_7);
-        _7 = guard() -> [return: bb8, unwind: bb15];
-    }
-
-    bb8: {
-        switchInt(move _7) -> [0: bb10, otherwise: bb9];
+        _7 = guard() -> [return: bb10, unwind: bb16];
     }
 
     bb9: {
+        falseEdge -> [real: bb3, imaginary: bb5];
+    }
+
+    bb10: {
+        switchInt(move _7) -> [0: bb12, otherwise: bb11];
+    }
+
+    bb11: {
         StorageDead(_7);
         FakeRead(ForMatchGuard, _3);
         FakeRead(ForGuardBinding, _6);
@@ -87,25 +96,20 @@ fn full_tested_match2() -> () {
         StorageDead(_8);
         StorageDead(_5);
         StorageDead(_6);
-        goto -> bb13;
-    }
-
-    bb10: {
-        goto -> bb11;
-    }
-
-    bb11: {
-        StorageDead(_7);
-        StorageDead(_6);
-        falseEdge -> [real: bb3, imaginary: bb5];
+        goto -> bb14;
     }
 
     bb12: {
-        _1 = (const 3_i32, const 3_i32);
         goto -> bb13;
     }
 
     bb13: {
+        StorageDead(_7);
+        StorageDead(_6);
+        goto -> bb9;
+    }
+
+    bb14: {
         PlaceMention(_1);
         StorageDead(_2);
         StorageDead(_1);
@@ -113,12 +117,12 @@ fn full_tested_match2() -> () {
         return;
     }
 
-    bb14: {
+    bb15: {
         FakeRead(ForMatchedPlace(None), _1);
         unreachable;
     }
 
-    bb15 (cleanup): {
+    bb16 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/match_false_edges.main.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.main.built.after.mir
@@ -43,11 +43,11 @@ fn main() -> () {
     }
 
     bb1: {
-        falseEdge -> [real: bb14, imaginary: bb4];
+        falseEdge -> [real: bb11, imaginary: bb4];
     }
 
     bb2: {
-        falseEdge -> [real: bb9, imaginary: bb1];
+        falseEdge -> [real: bb12, imaginary: bb1];
     }
 
     bb3: {
@@ -64,11 +64,11 @@ fn main() -> () {
         _14 = _2;
         _1 = const 4_i32;
         StorageDead(_14);
-        goto -> bb20;
+        goto -> bb22;
     }
 
     bb6: {
-        falseEdge -> [real: bb15, imaginary: bb5];
+        falseEdge -> [real: bb9, imaginary: bb5];
     }
 
     bb7: {
@@ -81,18 +81,44 @@ fn main() -> () {
     }
 
     bb9: {
+        StorageLive(_11);
+        _11 = &((_2 as Some).0: i32);
+        _3 = &fake shallow _2;
+        StorageLive(_12);
+        StorageLive(_13);
+        _13 = (*_11);
+        _12 = guard2(move _13) -> [return: bb18, unwind: bb24];
+    }
+
+    bb10: {
+        falseEdge -> [real: bb7, imaginary: bb5];
+    }
+
+    bb11: {
+        StorageLive(_9);
+        _9 = _2;
+        _1 = const 2_i32;
+        StorageDead(_9);
+        goto -> bb22;
+    }
+
+    bb12: {
         StorageLive(_7);
         _7 = &((_2 as Some).0: i32);
         _3 = &fake shallow _2;
         StorageLive(_8);
-        _8 = guard() -> [return: bb10, unwind: bb22];
+        _8 = guard() -> [return: bb14, unwind: bb24];
     }
 
-    bb10: {
-        switchInt(move _8) -> [0: bb12, otherwise: bb11];
+    bb13: {
+        falseEdge -> [real: bb3, imaginary: bb1];
     }
 
-    bb11: {
+    bb14: {
+        switchInt(move _8) -> [0: bb16, otherwise: bb15];
+    }
+
+    bb15: {
         StorageDead(_8);
         FakeRead(ForMatchGuard, _3);
         FakeRead(ForGuardBinding, _7);
@@ -101,42 +127,24 @@ fn main() -> () {
         _1 = const 1_i32;
         StorageDead(_6);
         StorageDead(_7);
-        goto -> bb20;
-    }
-
-    bb12: {
-        goto -> bb13;
-    }
-
-    bb13: {
-        StorageDead(_8);
-        StorageDead(_7);
-        falseEdge -> [real: bb3, imaginary: bb1];
-    }
-
-    bb14: {
-        StorageLive(_9);
-        _9 = _2;
-        _1 = const 2_i32;
-        StorageDead(_9);
-        goto -> bb20;
-    }
-
-    bb15: {
-        StorageLive(_11);
-        _11 = &((_2 as Some).0: i32);
-        _3 = &fake shallow _2;
-        StorageLive(_12);
-        StorageLive(_13);
-        _13 = (*_11);
-        _12 = guard2(move _13) -> [return: bb16, unwind: bb22];
+        goto -> bb22;
     }
 
     bb16: {
-        switchInt(move _12) -> [0: bb18, otherwise: bb17];
+        goto -> bb17;
     }
 
     bb17: {
+        StorageDead(_8);
+        StorageDead(_7);
+        goto -> bb13;
+    }
+
+    bb18: {
+        switchInt(move _12) -> [0: bb20, otherwise: bb19];
+    }
+
+    bb19: {
         StorageDead(_13);
         StorageDead(_12);
         FakeRead(ForMatchGuard, _3);
@@ -146,21 +154,21 @@ fn main() -> () {
         _1 = const 3_i32;
         StorageDead(_10);
         StorageDead(_11);
-        goto -> bb20;
-    }
-
-    bb18: {
-        goto -> bb19;
-    }
-
-    bb19: {
-        StorageDead(_13);
-        StorageDead(_12);
-        StorageDead(_11);
-        falseEdge -> [real: bb7, imaginary: bb5];
+        goto -> bb22;
     }
 
     bb20: {
+        goto -> bb21;
+    }
+
+    bb21: {
+        StorageDead(_13);
+        StorageDead(_12);
+        StorageDead(_11);
+        goto -> bb10;
+    }
+
+    bb22: {
         PlaceMention(_1);
         StorageDead(_2);
         StorageDead(_1);
@@ -168,12 +176,12 @@ fn main() -> () {
         return;
     }
 
-    bb21: {
+    bb23: {
         FakeRead(ForMatchedPlace(None), _1);
         unreachable;
     }
 
-    bb22 (cleanup): {
+    bb24 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/sort_candidates.constant_eq.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/building/match/sort_candidates.constant_eq.SimplifyCfg-initial.after.mir
@@ -31,7 +31,7 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
     }
 
     bb2: {
-        falseEdge -> [real: bb12, imaginary: bb5];
+        falseEdge -> [real: bb15, imaginary: bb5];
     }
 
     bb3: {
@@ -39,7 +39,7 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
     }
 
     bb4: {
-        falseEdge -> [real: bb16, imaginary: bb1];
+        falseEdge -> [real: bb13, imaginary: bb1];
     }
 
     bb5: {
@@ -51,7 +51,7 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
     }
 
     bb7: {
-        falseEdge -> [real: bb15, imaginary: bb3];
+        falseEdge -> [real: bb14, imaginary: bb3];
     }
 
     bb8: {
@@ -68,18 +68,33 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
     }
 
     bb11: {
-        falseEdge -> [real: bb17, imaginary: bb10];
+        falseEdge -> [real: bb12, imaginary: bb10];
     }
 
     bb12: {
+        _0 = const 4_u32;
+        goto -> bb18;
+    }
+
+    bb13: {
+        _0 = const 3_u32;
+        goto -> bb18;
+    }
+
+    bb14: {
+        _0 = const 2_u32;
+        goto -> bb18;
+    }
+
+    bb15: {
         _6 = &fake shallow (_3.0: &str);
         _7 = &fake shallow (_3.1: bool);
         StorageLive(_10);
         _10 = const true;
-        switchInt(move _10) -> [0: bb14, otherwise: bb13];
+        switchInt(move _10) -> [0: bb17, otherwise: bb16];
     }
 
-    bb13: {
+    bb16: {
         StorageDead(_10);
         FakeRead(ForMatchGuard, _6);
         FakeRead(ForMatchGuard, _7);
@@ -87,24 +102,9 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
         goto -> bb18;
     }
 
-    bb14: {
+    bb17: {
         StorageDead(_10);
         falseEdge -> [real: bb3, imaginary: bb5];
-    }
-
-    bb15: {
-        _0 = const 2_u32;
-        goto -> bb18;
-    }
-
-    bb16: {
-        _0 = const 3_u32;
-        goto -> bb18;
-    }
-
-    bb17: {
-        _0 = const 4_u32;
-        goto -> bb18;
     }
 
     bb18: {

--- a/tests/mir-opt/building/match/sort_candidates.disjoint_ranges.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/building/match/sort_candidates.disjoint_ranges.SimplifyCfg-initial.after.mir
@@ -23,7 +23,7 @@ fn disjoint_ranges(_1: i32, _2: bool) -> u32 {
     }
 
     bb2: {
-        falseEdge -> [real: bb9, imaginary: bb3];
+        falseEdge -> [real: bb11, imaginary: bb3];
     }
 
     bb3: {
@@ -32,7 +32,7 @@ fn disjoint_ranges(_1: i32, _2: bool) -> u32 {
     }
 
     bb4: {
-        falseEdge -> [real: bb12, imaginary: bb5];
+        falseEdge -> [real: bb10, imaginary: bb5];
     }
 
     bb5: {
@@ -40,7 +40,7 @@ fn disjoint_ranges(_1: i32, _2: bool) -> u32 {
     }
 
     bb6: {
-        falseEdge -> [real: bb13, imaginary: bb1];
+        falseEdge -> [real: bb9, imaginary: bb1];
     }
 
     bb7: {
@@ -54,32 +54,32 @@ fn disjoint_ranges(_1: i32, _2: bool) -> u32 {
     }
 
     bb9: {
-        _3 = &fake shallow _1;
-        StorageLive(_8);
-        _8 = _2;
-        switchInt(move _8) -> [0: bb11, otherwise: bb10];
+        _0 = const 2_u32;
+        goto -> bb14;
     }
 
     bb10: {
+        _0 = const 1_u32;
+        goto -> bb14;
+    }
+
+    bb11: {
+        _3 = &fake shallow _1;
+        StorageLive(_8);
+        _8 = _2;
+        switchInt(move _8) -> [0: bb13, otherwise: bb12];
+    }
+
+    bb12: {
         StorageDead(_8);
         FakeRead(ForMatchGuard, _3);
         _0 = const 0_u32;
         goto -> bb14;
     }
 
-    bb11: {
+    bb13: {
         StorageDead(_8);
         falseEdge -> [real: bb1, imaginary: bb3];
-    }
-
-    bb12: {
-        _0 = const 1_u32;
-        goto -> bb14;
-    }
-
-    bb13: {
-        _0 = const 2_u32;
-        goto -> bb14;
     }
 
     bb14: {

--- a/tests/mir-opt/coverage/branch_match_arms.main.InstrumentCoverage.diff
+++ b/tests/mir-opt/coverage/branch_match_arms.main.InstrumentCoverage.diff
@@ -55,17 +55,17 @@
   
       bb2: {
 +         Coverage::CounterIncrement(3);
-          falseEdge -> [real: bb6, imaginary: bb3];
+          falseEdge -> [real: bb8, imaginary: bb3];
       }
   
       bb3: {
 +         Coverage::CounterIncrement(2);
-          falseEdge -> [real: bb8, imaginary: bb4];
+          falseEdge -> [real: bb7, imaginary: bb4];
       }
   
       bb4: {
 +         Coverage::CounterIncrement(1);
-          falseEdge -> [real: bb10, imaginary: bb5];
+          falseEdge -> [real: bb6, imaginary: bb5];
       }
   
       bb5: {
@@ -78,39 +78,39 @@
       }
   
       bb6: {
-          StorageLive(_3);
-          _3 = ((_1 as D).0: u32);
-          StorageLive(_4);
-          _4 = _3;
-          _0 = consume(move _4) -> [return: bb7, unwind: bb14];
-      }
-  
-      bb7: {
-          StorageDead(_4);
-          StorageDead(_3);
-          goto -> bb13;
-      }
-  
-      bb8: {
-          StorageLive(_5);
-          _5 = ((_1 as C).0: u32);
-          StorageLive(_6);
-          _6 = _5;
-          _0 = consume(move _6) -> [return: bb9, unwind: bb14];
-      }
-  
-      bb9: {
-          StorageDead(_6);
-          StorageDead(_5);
-          goto -> bb13;
-      }
-  
-      bb10: {
           StorageLive(_7);
           _7 = ((_1 as B).0: u32);
           StorageLive(_8);
           _8 = _7;
           _0 = consume(move _8) -> [return: bb11, unwind: bb14];
+      }
+  
+      bb7: {
+          StorageLive(_5);
+          _5 = ((_1 as C).0: u32);
+          StorageLive(_6);
+          _6 = _5;
+          _0 = consume(move _6) -> [return: bb10, unwind: bb14];
+      }
+  
+      bb8: {
+          StorageLive(_3);
+          _3 = ((_1 as D).0: u32);
+          StorageLive(_4);
+          _4 = _3;
+          _0 = consume(move _4) -> [return: bb9, unwind: bb14];
+      }
+  
+      bb9: {
+          StorageDead(_4);
+          StorageDead(_3);
+          goto -> bb13;
+      }
+  
+      bb10: {
+          StorageDead(_6);
+          StorageDead(_5);
+          goto -> bb13;
       }
   
       bb11: {

--- a/tests/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.panic-abort.diff
+++ b/tests/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.panic-abort.diff
@@ -33,7 +33,7 @@
           _8 = const 3_usize;
           _9 = Ge(move _7, move _8);
 -         switchInt(move _9) -> [0: bb7, otherwise: bb8];
-+         switchInt(move _9) -> [0: bb10, otherwise: bb7];
++         switchInt(move _9) -> [0: bb11, otherwise: bb7];
       }
   
       bb3: {
@@ -49,48 +49,48 @@
       }
   
       bb6: {
--         switchInt((*_2)[3 of 4]) -> [47: bb11, otherwise: bb2];
-+         switchInt((*_2)[3 of 4]) -> [47: bb10, otherwise: bb2];
+-         switchInt((*_2)[3 of 4]) -> [47: bb13, otherwise: bb2];
++         switchInt((*_2)[3 of 4]) -> [47: bb11, otherwise: bb2];
       }
   
       bb7: {
 -         _0 = const false;
 -         goto -> bb14;
-+         switchInt((*_2)[0 of 3]) -> [47: bb8, otherwise: bb10];
++         switchInt((*_2)[0 of 3]) -> [47: bb8, otherwise: bb11];
       }
   
       bb8: {
 -         switchInt((*_2)[0 of 3]) -> [47: bb9, otherwise: bb7];
-+         switchInt((*_2)[1 of 3]) -> [47: bb9, otherwise: bb10];
++         switchInt((*_2)[1 of 3]) -> [47: bb9, otherwise: bb11];
       }
   
       bb9: {
 -         switchInt((*_2)[1 of 3]) -> [47: bb10, otherwise: bb7];
-+         switchInt((*_2)[2 of 3]) -> [47: bb11, 33: bb11, otherwise: bb10];
++         switchInt((*_2)[2 of 3]) -> [47: bb10, 33: bb10, otherwise: bb11];
       }
   
       bb10: {
--         switchInt((*_2)[2 of 3]) -> [47: bb12, 33: bb13, otherwise: bb7];
+-         switchInt((*_2)[2 of 3]) -> [47: bb12, 33: bb11, otherwise: bb7];
 -     }
 - 
 -     bb11: {
-          _0 = const false;
--         goto -> bb14;
-+         goto -> bb12;
-      }
-  
--     bb12: {
-+     bb11: {
           _0 = const true;
 -         goto -> bb14;
 +         goto -> bb12;
       }
   
--     bb13: {
+-     bb12: {
 -         _0 = const true;
 -         goto -> bb14;
 -     }
 - 
+-     bb13: {
++     bb11: {
+          _0 = const false;
+-         goto -> bb14;
++         goto -> bb12;
+      }
+  
 -     bb14: {
 +     bb12: {
           StorageDead(_2);

--- a/tests/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.panic-unwind.diff
+++ b/tests/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.panic-unwind.diff
@@ -33,7 +33,7 @@
           _8 = const 3_usize;
           _9 = Ge(move _7, move _8);
 -         switchInt(move _9) -> [0: bb7, otherwise: bb8];
-+         switchInt(move _9) -> [0: bb10, otherwise: bb7];
++         switchInt(move _9) -> [0: bb11, otherwise: bb7];
       }
   
       bb3: {
@@ -49,48 +49,48 @@
       }
   
       bb6: {
--         switchInt((*_2)[3 of 4]) -> [47: bb11, otherwise: bb2];
-+         switchInt((*_2)[3 of 4]) -> [47: bb10, otherwise: bb2];
+-         switchInt((*_2)[3 of 4]) -> [47: bb13, otherwise: bb2];
++         switchInt((*_2)[3 of 4]) -> [47: bb11, otherwise: bb2];
       }
   
       bb7: {
 -         _0 = const false;
 -         goto -> bb14;
-+         switchInt((*_2)[0 of 3]) -> [47: bb8, otherwise: bb10];
++         switchInt((*_2)[0 of 3]) -> [47: bb8, otherwise: bb11];
       }
   
       bb8: {
 -         switchInt((*_2)[0 of 3]) -> [47: bb9, otherwise: bb7];
-+         switchInt((*_2)[1 of 3]) -> [47: bb9, otherwise: bb10];
++         switchInt((*_2)[1 of 3]) -> [47: bb9, otherwise: bb11];
       }
   
       bb9: {
 -         switchInt((*_2)[1 of 3]) -> [47: bb10, otherwise: bb7];
-+         switchInt((*_2)[2 of 3]) -> [47: bb11, 33: bb11, otherwise: bb10];
++         switchInt((*_2)[2 of 3]) -> [47: bb10, 33: bb10, otherwise: bb11];
       }
   
       bb10: {
--         switchInt((*_2)[2 of 3]) -> [47: bb12, 33: bb13, otherwise: bb7];
+-         switchInt((*_2)[2 of 3]) -> [47: bb12, 33: bb11, otherwise: bb7];
 -     }
 - 
 -     bb11: {
-          _0 = const false;
--         goto -> bb14;
-+         goto -> bb12;
-      }
-  
--     bb12: {
-+     bb11: {
           _0 = const true;
 -         goto -> bb14;
 +         goto -> bb12;
       }
   
--     bb13: {
+-     bb12: {
 -         _0 = const true;
 -         goto -> bb14;
 -     }
 - 
+-     bb13: {
++     bb11: {
+          _0 = const false;
+-         goto -> bb14;
++         goto -> bb12;
+      }
+  
 -     bb14: {
 +     bb12: {
           StorageDead(_2);

--- a/tests/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
@@ -38,15 +38,20 @@
   
       bb2: {
           _6 = discriminant((_3.1: std::option::Option<u32>));
-          switchInt(move _6) -> [1: bb4, 0: bb1, otherwise: bb7];
+          switchInt(move _6) -> [1: bb5, 0: bb1, otherwise: bb7];
       }
   
       bb3: {
           _7 = discriminant((_3.1: std::option::Option<u32>));
-          switchInt(move _7) -> [0: bb5, 1: bb1, otherwise: bb7];
+          switchInt(move _7) -> [0: bb4, 1: bb1, otherwise: bb7];
       }
   
       bb4: {
+          _0 = const 2_u32;
+          goto -> bb6;
+      }
+  
+      bb5: {
           StorageLive(_9);
           _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32);
           StorageLive(_10);
@@ -54,11 +59,6 @@
           _0 = const 0_u32;
           StorageDead(_10);
           StorageDead(_9);
-          goto -> bb6;
-      }
-  
-      bb5: {
-          _0 = const 2_u32;
           goto -> bb6;
       }
   

--- a/tests/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
@@ -49,7 +49,7 @@
   
       bb2: {
 -         _6 = discriminant((_3.1: Option2<bool>));
--         switchInt(move _6) -> [0: bb5, otherwise: bb1];
+-         switchInt(move _6) -> [0: bb7, otherwise: bb1];
 -     }
 - 
 -     bb3: {
@@ -59,17 +59,11 @@
 - 
 -     bb4: {
 -         _8 = discriminant((_3.1: Option2<bool>));
--         switchInt(move _8) -> [2: bb7, otherwise: bb1];
+-         switchInt(move _8) -> [2: bb5, otherwise: bb1];
 -     }
 - 
 -     bb5: {
-          StorageLive(_10);
-          _10 = (((_3.0: Option2<u32>) as Some).0: u32);
-          StorageLive(_11);
-          _11 = (((_3.1: Option2<bool>) as Some).0: bool);
-          _0 = const 0_u32;
-          StorageDead(_11);
-          StorageDead(_10);
+          _0 = const 3_u32;
 -         goto -> bb8;
 +         goto -> bb5;
       }
@@ -83,7 +77,13 @@
   
 -     bb7: {
 +     bb4: {
-          _0 = const 3_u32;
+          StorageLive(_10);
+          _10 = (((_3.0: Option2<u32>) as Some).0: u32);
+          StorageLive(_11);
+          _11 = (((_3.1: Option2<bool>) as Some).0: bool);
+          _0 = const 0_u32;
+          StorageDead(_11);
+          StorageDead(_10);
 -         goto -> bb8;
 +         goto -> bb5;
       }
@@ -101,7 +101,7 @@
 + 
 +     bb7: {
 +         StorageDead(_13);
-+         switchInt(_9) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb6];
++         switchInt(_9) -> [0: bb4, 1: bb3, 2: bb2, otherwise: bb6];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch.opt4.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt4.EarlyOtherwiseBranch.diff
@@ -49,7 +49,7 @@
   
       bb2: {
 -         _6 = discriminant((_3.1: Option2<u32>));
--         switchInt(move _6) -> [0: bb5, otherwise: bb1];
+-         switchInt(move _6) -> [0: bb7, otherwise: bb1];
 -     }
 - 
 -     bb3: {
@@ -59,17 +59,11 @@
 - 
 -     bb4: {
 -         _8 = discriminant((_3.1: Option2<u32>));
--         switchInt(move _8) -> [2: bb7, otherwise: bb1];
+-         switchInt(move _8) -> [2: bb5, otherwise: bb1];
 -     }
 - 
 -     bb5: {
-          StorageLive(_10);
-          _10 = (((_3.0: Option2<u32>) as Some).0: u32);
-          StorageLive(_11);
-          _11 = (((_3.1: Option2<u32>) as Some).0: u32);
-          _0 = const 0_u32;
-          StorageDead(_11);
-          StorageDead(_10);
+          _0 = const 3_u32;
 -         goto -> bb8;
 +         goto -> bb5;
       }
@@ -83,7 +77,13 @@
   
 -     bb7: {
 +     bb4: {
-          _0 = const 3_u32;
+          StorageLive(_10);
+          _10 = (((_3.0: Option2<u32>) as Some).0: u32);
+          StorageLive(_11);
+          _11 = (((_3.1: Option2<u32>) as Some).0: u32);
+          _0 = const 0_u32;
+          StorageDead(_11);
+          StorageDead(_10);
 -         goto -> bb8;
 +         goto -> bb5;
       }
@@ -101,7 +101,7 @@
 + 
 +     bb7: {
 +         StorageDead(_13);
-+         switchInt(_9) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb6];
++         switchInt(_9) -> [0: bb4, 1: bb3, 2: bb2, otherwise: bb6];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
@@ -52,7 +52,7 @@
   
       bb3: {
           _8 = discriminant((_4.2: std::option::Option<u32>));
-          switchInt(move _8) -> [1: bb6, 0: bb1, otherwise: bb9];
+          switchInt(move _8) -> [1: bb7, 0: bb1, otherwise: bb9];
       }
   
       bb4: {
@@ -62,10 +62,15 @@
   
       bb5: {
           _10 = discriminant((_4.2: std::option::Option<u32>));
-          switchInt(move _10) -> [0: bb7, 1: bb1, otherwise: bb9];
+          switchInt(move _10) -> [0: bb6, 1: bb1, otherwise: bb9];
       }
   
       bb6: {
+          _0 = const 2_u32;
+          goto -> bb8;
+      }
+  
+      bb7: {
           StorageLive(_13);
           _13 = (((_4.0: std::option::Option<u32>) as Some).0: u32);
           StorageLive(_14);
@@ -76,11 +81,6 @@
           StorageDead(_15);
           StorageDead(_14);
           StorageDead(_13);
-          goto -> bb8;
-      }
-  
-      bb7: {
-          _0 = const 2_u32;
           goto -> bb8;
       }
   

--- a/tests/mir-opt/early_otherwise_branch_3_element_tuple.opt2.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_3_element_tuple.opt2.EarlyOtherwiseBranch.diff
@@ -64,8 +64,8 @@
 - 
 -     bb3: {
           _8 = discriminant((_4.2: Option2<u32>));
--         switchInt(move _8) -> [0: bb8, otherwise: bb1];
-+         switchInt(move _8) -> [0: bb5, otherwise: bb1];
+-         switchInt(move _8) -> [0: bb10, otherwise: bb1];
++         switchInt(move _8) -> [0: bb7, otherwise: bb1];
       }
   
 -     bb4: {
@@ -88,22 +88,13 @@
 -     bb7: {
 +     bb4: {
           _12 = discriminant((_4.2: Option2<u32>));
--         switchInt(move _12) -> [2: bb10, otherwise: bb1];
-+         switchInt(move _12) -> [2: bb7, otherwise: bb1];
+-         switchInt(move _12) -> [2: bb8, otherwise: bb1];
++         switchInt(move _12) -> [2: bb5, otherwise: bb1];
       }
   
 -     bb8: {
 +     bb5: {
-          StorageLive(_15);
-          _15 = (((_4.0: Option2<u32>) as Some).0: u32);
-          StorageLive(_16);
-          _16 = (((_4.1: Option2<u32>) as Some).0: u32);
-          StorageLive(_17);
-          _17 = (((_4.2: Option2<u32>) as Some).0: u32);
-          _0 = const 0_u32;
-          StorageDead(_17);
-          StorageDead(_16);
-          StorageDead(_15);
+          _0 = const 3_u32;
 -         goto -> bb11;
 +         goto -> bb8;
       }
@@ -117,7 +108,16 @@
   
 -     bb10: {
 +     bb7: {
-          _0 = const 3_u32;
+          StorageLive(_15);
+          _15 = (((_4.0: Option2<u32>) as Some).0: u32);
+          StorageLive(_16);
+          _16 = (((_4.1: Option2<u32>) as Some).0: u32);
+          StorageLive(_17);
+          _17 = (((_4.2: Option2<u32>) as Some).0: u32);
+          _0 = const 0_u32;
+          StorageDead(_17);
+          StorageDead(_16);
+          StorageDead(_15);
 -         goto -> bb11;
 +         goto -> bb8;
       }

--- a/tests/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -94,78 +94,56 @@
       bb2: {
           _35 = deref_copy (_4.1: &ViewportPercentageLength);
           _7 = discriminant((*_35));
-          switchInt(move _7) -> [0: bb6, otherwise: bb1];
+          switchInt(move _7) -> [0: bb9, otherwise: bb1];
       }
   
       bb3: {
           _36 = deref_copy (_4.1: &ViewportPercentageLength);
           _8 = discriminant((*_36));
-          switchInt(move _8) -> [1: bb7, otherwise: bb1];
+          switchInt(move _8) -> [1: bb8, otherwise: bb1];
       }
   
       bb4: {
           _37 = deref_copy (_4.1: &ViewportPercentageLength);
           _9 = discriminant((*_37));
-          switchInt(move _9) -> [2: bb8, otherwise: bb1];
+          switchInt(move _9) -> [2: bb7, otherwise: bb1];
       }
   
       bb5: {
           _38 = deref_copy (_4.1: &ViewportPercentageLength);
           _10 = discriminant((*_38));
-          switchInt(move _10) -> [3: bb9, otherwise: bb1];
+          switchInt(move _10) -> [3: bb6, otherwise: bb1];
       }
   
       bb6: {
-          StorageLive(_12);
+          StorageLive(_27);
           _39 = deref_copy (_4.0: &ViewportPercentageLength);
-          _12 = (((*_39) as Vw).0: f32);
-          StorageLive(_13);
+          _27 = (((*_39) as Vmax).0: f32);
+          StorageLive(_28);
           _40 = deref_copy (_4.1: &ViewportPercentageLength);
-          _13 = (((*_40) as Vw).0: f32);
-          StorageLive(_14);
-          StorageLive(_15);
-          _15 = _12;
-          StorageLive(_16);
-          _16 = _13;
-          _14 = Add(move _15, move _16);
-          StorageDead(_16);
-          StorageDead(_15);
-          _3 = ViewportPercentageLength::Vw(move _14);
-          StorageDead(_14);
-          StorageDead(_13);
-          StorageDead(_12);
+          _28 = (((*_40) as Vmax).0: f32);
+          StorageLive(_29);
+          StorageLive(_30);
+          _30 = _27;
+          StorageLive(_31);
+          _31 = _28;
+          _29 = Add(move _30, move _31);
+          StorageDead(_31);
+          StorageDead(_30);
+          _3 = ViewportPercentageLength::Vmax(move _29);
+          StorageDead(_29);
+          StorageDead(_28);
+          StorageDead(_27);
           goto -> bb10;
       }
   
       bb7: {
-          StorageLive(_17);
-          _41 = deref_copy (_4.0: &ViewportPercentageLength);
-          _17 = (((*_41) as Vh).0: f32);
-          StorageLive(_18);
-          _42 = deref_copy (_4.1: &ViewportPercentageLength);
-          _18 = (((*_42) as Vh).0: f32);
-          StorageLive(_19);
-          StorageLive(_20);
-          _20 = _17;
-          StorageLive(_21);
-          _21 = _18;
-          _19 = Add(move _20, move _21);
-          StorageDead(_21);
-          StorageDead(_20);
-          _3 = ViewportPercentageLength::Vh(move _19);
-          StorageDead(_19);
-          StorageDead(_18);
-          StorageDead(_17);
-          goto -> bb10;
-      }
-  
-      bb8: {
           StorageLive(_22);
-          _43 = deref_copy (_4.0: &ViewportPercentageLength);
-          _22 = (((*_43) as Vmin).0: f32);
+          _41 = deref_copy (_4.0: &ViewportPercentageLength);
+          _22 = (((*_41) as Vmin).0: f32);
           StorageLive(_23);
-          _44 = deref_copy (_4.1: &ViewportPercentageLength);
-          _23 = (((*_44) as Vmin).0: f32);
+          _42 = deref_copy (_4.1: &ViewportPercentageLength);
+          _23 = (((*_42) as Vmin).0: f32);
           StorageLive(_24);
           StorageLive(_25);
           _25 = _22;
@@ -181,25 +159,47 @@
           goto -> bb10;
       }
   
+      bb8: {
+          StorageLive(_17);
+          _43 = deref_copy (_4.0: &ViewportPercentageLength);
+          _17 = (((*_43) as Vh).0: f32);
+          StorageLive(_18);
+          _44 = deref_copy (_4.1: &ViewportPercentageLength);
+          _18 = (((*_44) as Vh).0: f32);
+          StorageLive(_19);
+          StorageLive(_20);
+          _20 = _17;
+          StorageLive(_21);
+          _21 = _18;
+          _19 = Add(move _20, move _21);
+          StorageDead(_21);
+          StorageDead(_20);
+          _3 = ViewportPercentageLength::Vh(move _19);
+          StorageDead(_19);
+          StorageDead(_18);
+          StorageDead(_17);
+          goto -> bb10;
+      }
+  
       bb9: {
-          StorageLive(_27);
+          StorageLive(_12);
           _45 = deref_copy (_4.0: &ViewportPercentageLength);
-          _27 = (((*_45) as Vmax).0: f32);
-          StorageLive(_28);
+          _12 = (((*_45) as Vw).0: f32);
+          StorageLive(_13);
           _46 = deref_copy (_4.1: &ViewportPercentageLength);
-          _28 = (((*_46) as Vmax).0: f32);
-          StorageLive(_29);
-          StorageLive(_30);
-          _30 = _27;
-          StorageLive(_31);
-          _31 = _28;
-          _29 = Add(move _30, move _31);
-          StorageDead(_31);
-          StorageDead(_30);
-          _3 = ViewportPercentageLength::Vmax(move _29);
-          StorageDead(_29);
-          StorageDead(_28);
-          StorageDead(_27);
+          _13 = (((*_46) as Vw).0: f32);
+          StorageLive(_14);
+          StorageLive(_15);
+          _15 = _12;
+          StorageLive(_16);
+          _16 = _13;
+          _14 = Add(move _15, move _16);
+          StorageDead(_16);
+          StorageDead(_15);
+          _3 = ViewportPercentageLength::Vw(move _14);
+          StorageDead(_14);
+          StorageDead(_13);
+          StorageDead(_12);
           goto -> bb10;
       }
   

--- a/tests/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
@@ -45,12 +45,12 @@
   
       bb2: {
           _6 = discriminant((_3.1: std::option::Option<u32>));
-          switchInt(move _6) -> [0: bb6, 1: bb5, otherwise: bb1];
+          switchInt(move _6) -> [0: bb6, 1: bb7, otherwise: bb1];
       }
   
       bb3: {
           _7 = discriminant((_3.1: std::option::Option<u32>));
-          switchInt(move _7) -> [0: bb4, 1: bb7, otherwise: bb1];
+          switchInt(move _7) -> [0: bb4, 1: bb5, otherwise: bb1];
       }
   
       bb4: {
@@ -59,13 +59,10 @@
       }
   
       bb5: {
-          StorageLive(_9);
-          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32);
-          StorageLive(_10);
-          _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32);
-          _0 = const 0_u32;
-          StorageDead(_10);
-          StorageDead(_9);
+          StorageLive(_12);
+          _12 = (((_3.1: std::option::Option<u32>) as Some).0: u32);
+          _0 = const 2_u32;
+          StorageDead(_12);
           goto -> bb8;
       }
   
@@ -78,10 +75,13 @@
       }
   
       bb7: {
-          StorageLive(_12);
-          _12 = (((_3.1: std::option::Option<u32>) as Some).0: u32);
-          _0 = const 2_u32;
-          StorageDead(_12);
+          StorageLive(_9);
+          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32);
+          StorageLive(_10);
+          _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32);
+          _0 = const 0_u32;
+          StorageDead(_10);
+          StorageDead(_9);
           goto -> bb8;
       }
   

--- a/tests/mir-opt/jump_threading.dfa.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.dfa.JumpThreading.panic-abort.diff
@@ -24,7 +24,7 @@
   
       bb1: {
           _4 = discriminant(_1);
-          switchInt(move _4) -> [0: bb4, 1: bb5, 2: bb6, 3: bb3, otherwise: bb2];
+          switchInt(move _4) -> [0: bb6, 1: bb5, 2: bb4, 3: bb3, otherwise: bb2];
       }
   
       bb2: {
@@ -39,11 +39,11 @@
       }
   
       bb4: {
-          StorageLive(_5);
-          _5 = DFA::B;
-          _1 = move _5;
+          StorageLive(_7);
+          _7 = DFA::D;
+          _1 = move _7;
           _3 = const ();
-          StorageDead(_5);
+          StorageDead(_7);
           goto -> bb1;
       }
   
@@ -57,11 +57,11 @@
       }
   
       bb6: {
-          StorageLive(_7);
-          _7 = DFA::D;
-          _1 = move _7;
+          StorageLive(_5);
+          _5 = DFA::B;
+          _1 = move _5;
           _3 = const ();
-          StorageDead(_7);
+          StorageDead(_5);
           goto -> bb1;
       }
   }

--- a/tests/mir-opt/jump_threading.dfa.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.dfa.JumpThreading.panic-unwind.diff
@@ -24,7 +24,7 @@
   
       bb1: {
           _4 = discriminant(_1);
-          switchInt(move _4) -> [0: bb4, 1: bb5, 2: bb6, 3: bb3, otherwise: bb2];
+          switchInt(move _4) -> [0: bb6, 1: bb5, 2: bb4, 3: bb3, otherwise: bb2];
       }
   
       bb2: {
@@ -39,11 +39,11 @@
       }
   
       bb4: {
-          StorageLive(_5);
-          _5 = DFA::B;
-          _1 = move _5;
+          StorageLive(_7);
+          _7 = DFA::D;
+          _1 = move _7;
           _3 = const ();
-          StorageDead(_5);
+          StorageDead(_7);
           goto -> bb1;
       }
   
@@ -57,11 +57,11 @@
       }
   
       bb6: {
-          StorageLive(_7);
-          _7 = DFA::D;
-          _1 = move _7;
+          StorageLive(_5);
+          _5 = DFA::B;
+          _1 = move _5;
           _3 = const ();
-          StorageDead(_7);
+          StorageDead(_5);
           goto -> bb1;
       }
   }

--- a/tests/mir-opt/jump_threading.rs
+++ b/tests/mir-opt/jump_threading.rs
@@ -93,19 +93,19 @@ fn dfa() {
     // CHECK:     {{_.*}} = DFA::A;
     // CHECK:     goto -> bb1;
     // CHECK: bb1: {
-    // CHECK:     switchInt({{.*}}) -> [0: bb4, 1: bb5, 2: bb6, 3: bb3, otherwise: bb2];
+    // CHECK:     switchInt({{.*}}) -> [0: bb6, 1: bb5, 2: bb4, 3: bb3, otherwise: bb2];
     // CHECK: bb2: {
     // CHECK:     unreachable;
     // CHECK: bb3: {
     // CHECK:     return;
     // CHECK: bb4: {
-    // CHECK:     {{_.*}} = DFA::B;
+    // CHECK:     {{_.*}} = DFA::D;
     // CHECK:     goto -> bb1;
     // CHECK: bb5: {
     // CHECK:     {{_.*}} = DFA::C;
     // CHECK:     goto -> bb1;
     // CHECK: bb6: {
-    // CHECK:     {{_.*}} = DFA::D;
+    // CHECK:     {{_.*}} = DFA::B;
     // CHECK:     goto -> bb1;
     let mut state = DFA::A;
     loop {

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -33,17 +33,17 @@
       bb0: {
           PlaceMention(_2);
 -         switchInt((_2.0: bool)) -> [0: bb2, otherwise: bb1];
-+         switchInt((_2.0: bool)) -> [0: bb5, otherwise: bb1];
++         switchInt((_2.0: bool)) -> [0: bb6, otherwise: bb1];
       }
   
       bb1: {
 -         switchInt((_2.1: bool)) -> [0: bb4, otherwise: bb3];
-+         switchInt((_2.1: bool)) -> [0: bb10, otherwise: bb2];
++         switchInt((_2.1: bool)) -> [0: bb5, otherwise: bb2];
       }
   
       bb2: {
--         falseEdge -> [real: bb8, imaginary: bb1];
-+         switchInt((_2.0: bool)) -> [0: bb3, otherwise: bb17];
+-         falseEdge -> [real: bb9, imaginary: bb1];
++         switchInt((_2.0: bool)) -> [0: bb3, otherwise: bb4];
       }
   
       bb3: {
@@ -51,11 +51,11 @@
 -     }
 - 
 -     bb4: {
--         falseEdge -> [real: bb13, imaginary: bb3];
+-         falseEdge -> [real: bb8, imaginary: bb3];
 -     }
 - 
 -     bb5: {
--         falseEdge -> [real: bb20, imaginary: bb6];
+-         falseEdge -> [real: bb7, imaginary: bb6];
 -     }
 - 
 -     bb6: {
@@ -63,19 +63,37 @@
           _15 = (_2.1: bool);
           StorageLive(_16);
           _16 = move (_2.2: std::string::String);
--         goto -> bb19;
-+         goto -> bb16;
+-         goto -> bb20;
++         goto -> bb17;
       }
   
 -     bb7: {
 +     bb4: {
-          _0 = const 1_i32;
--         drop(_7) -> [return: bb18, unwind: bb25];
-+         drop(_7) -> [return: bb15, unwind: bb22];
+          StorageLive(_15);
+          _15 = (_2.1: bool);
+          StorageLive(_16);
+          _16 = move (_2.2: std::string::String);
+-         goto -> bb20;
++         goto -> bb17;
       }
   
 -     bb8: {
 +     bb5: {
+          StorageLive(_6);
+          _6 = &(_2.0: bool);
+          StorageLive(_8);
+          _8 = &(_2.2: std::string::String);
+-         _3 = &fake shallow (_2.0: bool);
+-         _4 = &fake shallow (_2.1: bool);
+          StorageLive(_12);
+          StorageLive(_13);
+          _13 = _1;
+-         switchInt(move _13) -> [0: bb16, otherwise: bb15];
++         switchInt(move _13) -> [0: bb13, otherwise: bb12];
+      }
+  
+-     bb9: {
++     bb6: {
           StorageLive(_6);
           _6 = &(_2.1: bool);
           StorageLive(_8);
@@ -85,12 +103,19 @@
           StorageLive(_9);
           StorageLive(_10);
           _10 = _1;
--         switchInt(move _10) -> [0: bb10, otherwise: bb9];
-+         switchInt(move _10) -> [0: bb7, otherwise: bb6];
+-         switchInt(move _10) -> [0: bb12, otherwise: bb11];
++         switchInt(move _10) -> [0: bb9, otherwise: bb8];
       }
   
--     bb9: {
-+     bb6: {
+-     bb10: {
++     bb7: {
+          _0 = const 1_i32;
+-         drop(_7) -> [return: bb19, unwind: bb25];
++         drop(_7) -> [return: bb16, unwind: bb22];
+      }
+  
+-     bb11: {
++     bb8: {
           _0 = const 3_i32;
           StorageDead(_10);
           StorageDead(_9);
@@ -98,15 +123,15 @@
 +         goto -> bb20;
       }
   
--     bb10: {
-+     bb7: {
+-     bb12: {
++     bb9: {
           _9 = (*_6);
--         switchInt(move _9) -> [0: bb12, otherwise: bb11];
-+         switchInt(move _9) -> [0: bb9, otherwise: bb8];
+-         switchInt(move _9) -> [0: bb14, otherwise: bb13];
++         switchInt(move _9) -> [0: bb11, otherwise: bb10];
       }
   
--     bb11: {
-+     bb8: {
+-     bb13: {
++     bb10: {
           StorageDead(_10);
           StorageDead(_9);
 -         FakeRead(ForMatchGuard, _3);
@@ -117,12 +142,12 @@
           _5 = (_2.1: bool);
           StorageLive(_7);
           _7 = move (_2.2: std::string::String);
--         goto -> bb7;
-+         goto -> bb4;
+-         goto -> bb10;
++         goto -> bb7;
       }
   
--     bb12: {
-+     bb9: {
+-     bb14: {
++     bb11: {
           StorageDead(_10);
           StorageDead(_9);
           StorageDead(_8);
@@ -131,23 +156,8 @@
 +         goto -> bb1;
       }
   
--     bb13: {
-+     bb10: {
-          StorageLive(_6);
-          _6 = &(_2.0: bool);
-          StorageLive(_8);
-          _8 = &(_2.2: std::string::String);
--         _3 = &fake shallow (_2.0: bool);
--         _4 = &fake shallow (_2.1: bool);
-          StorageLive(_12);
-          StorageLive(_13);
-          _13 = _1;
--         switchInt(move _13) -> [0: bb15, otherwise: bb14];
-+         switchInt(move _13) -> [0: bb12, otherwise: bb11];
-      }
-  
--     bb14: {
-+     bb11: {
+-     bb15: {
++     bb12: {
           _0 = const 3_i32;
           StorageDead(_13);
           StorageDead(_12);
@@ -155,15 +165,15 @@
 +         goto -> bb20;
       }
   
--     bb15: {
-+     bb12: {
-          _12 = (*_6);
--         switchInt(move _12) -> [0: bb17, otherwise: bb16];
-+         switchInt(move _12) -> [0: bb14, otherwise: bb13];
-      }
-  
 -     bb16: {
 +     bb13: {
+          _12 = (*_6);
+-         switchInt(move _12) -> [0: bb18, otherwise: bb17];
++         switchInt(move _12) -> [0: bb15, otherwise: bb14];
+      }
+  
+-     bb17: {
++     bb14: {
           StorageDead(_13);
           StorageDead(_12);
 -         FakeRead(ForMatchGuard, _3);
@@ -174,12 +184,12 @@
           _5 = (_2.0: bool);
           StorageLive(_7);
           _7 = move (_2.2: std::string::String);
--         goto -> bb7;
-+         goto -> bb4;
+-         goto -> bb10;
++         goto -> bb7;
       }
   
--     bb17: {
-+     bb14: {
+-     bb18: {
++     bb15: {
           StorageDead(_13);
           StorageDead(_12);
           StorageDead(_8);
@@ -188,8 +198,8 @@
 +         goto -> bb2;
       }
   
--     bb18: {
-+     bb15: {
+-     bb19: {
++     bb16: {
           StorageDead(_7);
           StorageDead(_5);
           StorageDead(_8);
@@ -198,21 +208,11 @@
 +         goto -> bb19;
       }
   
--     bb19: {
-+     bb16: {
+-     bb20: {
++     bb17: {
           _0 = const 2_i32;
 -         drop(_16) -> [return: bb21, unwind: bb25];
 +         drop(_16) -> [return: bb18, unwind: bb22];
-      }
-  
--     bb20: {
-+     bb17: {
-          StorageLive(_15);
-          _15 = (_2.1: bool);
-          StorageLive(_16);
-          _16 = move (_2.2: std::string::String);
--         goto -> bb19;
-+         goto -> bb16;
       }
   
 -     bb21: {

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -33,17 +33,17 @@
       bb0: {
           PlaceMention(_2);
 -         switchInt((_2.0: bool)) -> [0: bb2, otherwise: bb1];
-+         switchInt((_2.0: bool)) -> [0: bb5, otherwise: bb1];
++         switchInt((_2.0: bool)) -> [0: bb6, otherwise: bb1];
       }
   
       bb1: {
 -         switchInt((_2.1: bool)) -> [0: bb4, otherwise: bb3];
-+         switchInt((_2.1: bool)) -> [0: bb10, otherwise: bb2];
++         switchInt((_2.1: bool)) -> [0: bb5, otherwise: bb2];
       }
   
       bb2: {
--         falseEdge -> [real: bb8, imaginary: bb1];
-+         switchInt((_2.0: bool)) -> [0: bb3, otherwise: bb17];
+-         falseEdge -> [real: bb9, imaginary: bb1];
++         switchInt((_2.0: bool)) -> [0: bb3, otherwise: bb4];
       }
   
       bb3: {
@@ -51,11 +51,11 @@
 -     }
 - 
 -     bb4: {
--         falseEdge -> [real: bb13, imaginary: bb3];
+-         falseEdge -> [real: bb8, imaginary: bb3];
 -     }
 - 
 -     bb5: {
--         falseEdge -> [real: bb20, imaginary: bb6];
+-         falseEdge -> [real: bb7, imaginary: bb6];
 -     }
 - 
 -     bb6: {
@@ -63,19 +63,37 @@
           _15 = (_2.1: bool);
           StorageLive(_16);
           _16 = move (_2.2: std::string::String);
--         goto -> bb19;
-+         goto -> bb16;
+-         goto -> bb20;
++         goto -> bb17;
       }
   
 -     bb7: {
 +     bb4: {
-          _0 = const 1_i32;
--         drop(_7) -> [return: bb18, unwind: bb25];
-+         drop(_7) -> [return: bb15, unwind: bb22];
+          StorageLive(_15);
+          _15 = (_2.1: bool);
+          StorageLive(_16);
+          _16 = move (_2.2: std::string::String);
+-         goto -> bb20;
++         goto -> bb17;
       }
   
 -     bb8: {
 +     bb5: {
+          StorageLive(_6);
+          _6 = &(_2.0: bool);
+          StorageLive(_8);
+          _8 = &(_2.2: std::string::String);
+-         _3 = &fake shallow (_2.0: bool);
+-         _4 = &fake shallow (_2.1: bool);
+          StorageLive(_12);
+          StorageLive(_13);
+          _13 = _1;
+-         switchInt(move _13) -> [0: bb16, otherwise: bb15];
++         switchInt(move _13) -> [0: bb13, otherwise: bb12];
+      }
+  
+-     bb9: {
++     bb6: {
           StorageLive(_6);
           _6 = &(_2.1: bool);
           StorageLive(_8);
@@ -85,12 +103,19 @@
           StorageLive(_9);
           StorageLive(_10);
           _10 = _1;
--         switchInt(move _10) -> [0: bb10, otherwise: bb9];
-+         switchInt(move _10) -> [0: bb7, otherwise: bb6];
+-         switchInt(move _10) -> [0: bb12, otherwise: bb11];
++         switchInt(move _10) -> [0: bb9, otherwise: bb8];
       }
   
--     bb9: {
-+     bb6: {
+-     bb10: {
++     bb7: {
+          _0 = const 1_i32;
+-         drop(_7) -> [return: bb19, unwind: bb25];
++         drop(_7) -> [return: bb16, unwind: bb22];
+      }
+  
+-     bb11: {
++     bb8: {
           _0 = const 3_i32;
           StorageDead(_10);
           StorageDead(_9);
@@ -98,15 +123,15 @@
 +         goto -> bb20;
       }
   
--     bb10: {
-+     bb7: {
+-     bb12: {
++     bb9: {
           _9 = (*_6);
--         switchInt(move _9) -> [0: bb12, otherwise: bb11];
-+         switchInt(move _9) -> [0: bb9, otherwise: bb8];
+-         switchInt(move _9) -> [0: bb14, otherwise: bb13];
++         switchInt(move _9) -> [0: bb11, otherwise: bb10];
       }
   
--     bb11: {
-+     bb8: {
+-     bb13: {
++     bb10: {
           StorageDead(_10);
           StorageDead(_9);
 -         FakeRead(ForMatchGuard, _3);
@@ -117,12 +142,12 @@
           _5 = (_2.1: bool);
           StorageLive(_7);
           _7 = move (_2.2: std::string::String);
--         goto -> bb7;
-+         goto -> bb4;
+-         goto -> bb10;
++         goto -> bb7;
       }
   
--     bb12: {
-+     bb9: {
+-     bb14: {
++     bb11: {
           StorageDead(_10);
           StorageDead(_9);
           StorageDead(_8);
@@ -131,23 +156,8 @@
 +         goto -> bb1;
       }
   
--     bb13: {
-+     bb10: {
-          StorageLive(_6);
-          _6 = &(_2.0: bool);
-          StorageLive(_8);
-          _8 = &(_2.2: std::string::String);
--         _3 = &fake shallow (_2.0: bool);
--         _4 = &fake shallow (_2.1: bool);
-          StorageLive(_12);
-          StorageLive(_13);
-          _13 = _1;
--         switchInt(move _13) -> [0: bb15, otherwise: bb14];
-+         switchInt(move _13) -> [0: bb12, otherwise: bb11];
-      }
-  
--     bb14: {
-+     bb11: {
+-     bb15: {
++     bb12: {
           _0 = const 3_i32;
           StorageDead(_13);
           StorageDead(_12);
@@ -155,15 +165,15 @@
 +         goto -> bb20;
       }
   
--     bb15: {
-+     bb12: {
-          _12 = (*_6);
--         switchInt(move _12) -> [0: bb17, otherwise: bb16];
-+         switchInt(move _12) -> [0: bb14, otherwise: bb13];
-      }
-  
 -     bb16: {
 +     bb13: {
+          _12 = (*_6);
+-         switchInt(move _12) -> [0: bb18, otherwise: bb17];
++         switchInt(move _12) -> [0: bb15, otherwise: bb14];
+      }
+  
+-     bb17: {
++     bb14: {
           StorageDead(_13);
           StorageDead(_12);
 -         FakeRead(ForMatchGuard, _3);
@@ -174,12 +184,12 @@
           _5 = (_2.0: bool);
           StorageLive(_7);
           _7 = move (_2.2: std::string::String);
--         goto -> bb7;
-+         goto -> bb4;
+-         goto -> bb10;
++         goto -> bb7;
       }
   
--     bb17: {
-+     bb14: {
+-     bb18: {
++     bb15: {
           StorageDead(_13);
           StorageDead(_12);
           StorageDead(_8);
@@ -188,8 +198,8 @@
 +         goto -> bb2;
       }
   
--     bb18: {
-+     bb15: {
+-     bb19: {
++     bb16: {
           StorageDead(_7);
           StorageDead(_5);
           StorageDead(_8);
@@ -198,21 +208,11 @@
 +         goto -> bb19;
       }
   
--     bb19: {
-+     bb16: {
+-     bb20: {
++     bb17: {
           _0 = const 2_i32;
 -         drop(_16) -> [return: bb21, unwind: bb25];
 +         drop(_16) -> [return: bb18, unwind: bb22];
-      }
-  
--     bb20: {
-+     bb17: {
-          StorageLive(_15);
-          _15 = (_2.1: bool);
-          StorageLive(_16);
-          _16 = move (_2.2: std::string::String);
--         goto -> bb19;
-+         goto -> bb16;
       }
   
 -     bb21: {

--- a/tests/mir-opt/matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [1: bb3, 2: bb4, 3: bb5, 340282366920938463463374607431768211455: bb2, otherwise: bb1];
+          switchInt(move _2) -> [1: bb5, 2: bb4, 3: bb3, 340282366920938463463374607431768211455: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -21,7 +21,7 @@
       }
   
       bb3: {
-          _0 = const 1_u128;
+          _0 = const 3_u128;
           goto -> bb6;
       }
   
@@ -31,7 +31,7 @@
       }
   
       bb5: {
-          _0 = const 3_u128;
+          _0 = const 1_u128;
           goto -> bb6;
       }
   

--- a/tests/mir-opt/matches_reduce_branches.match_i16_i8.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i16_i8.MatchBranchSimplification.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [65535: bb3, 2: bb4, 65533: bb2, otherwise: bb1];
+          switchInt(move _2) -> [65535: bb4, 2: bb3, 65533: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -21,12 +21,12 @@
       }
   
       bb3: {
-          _0 = const -1_i8;
+          _0 = const 2_i8;
           goto -> bb5;
       }
   
       bb4: {
-          _0 = const 2_i8;
+          _0 = const -1_i8;
           goto -> bb5;
       }
   

--- a/tests/mir-opt/matches_reduce_branches.match_i8_i16.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i8_i16.MatchBranchSimplification.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [255: bb3, 2: bb4, 253: bb2, otherwise: bb1];
+          switchInt(move _2) -> [255: bb4, 2: bb3, 253: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -21,12 +21,12 @@
       }
   
       bb3: {
-          _0 = const -1_i16;
+          _0 = const 2_i16;
           goto -> bb5;
       }
   
       bb4: {
-          _0 = const 2_i16;
+          _0 = const -1_i16;
           goto -> bb5;
       }
   

--- a/tests/mir-opt/matches_reduce_branches.match_i8_i16_failed.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i8_i16_failed.MatchBranchSimplification.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [255: bb3, 2: bb4, 253: bb2, otherwise: bb1];
+          switchInt(move _2) -> [255: bb4, 2: bb3, 253: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -21,12 +21,12 @@
       }
   
       bb3: {
-          _0 = const -1_i16;
+          _0 = const 2_i16;
           goto -> bb5;
       }
   
       bb4: {
-          _0 = const 2_i16;
+          _0 = const -1_i16;
           goto -> bb5;
       }
   

--- a/tests/mir-opt/matches_reduce_branches.match_u8_i16_fallback.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_i16_fallback.MatchBranchSimplification.diff
@@ -6,7 +6,7 @@
       let mut _0: i16;
   
       bb0: {
-          switchInt(_1) -> [1: bb2, 2: bb3, otherwise: bb1];
+          switchInt(_1) -> [1: bb3, 2: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -15,12 +15,12 @@
       }
   
       bb2: {
-          _0 = const 1_i16;
+          _0 = const 2_i16;
           goto -> bb4;
       }
   
       bb3: {
-          _0 = const 2_i16;
+          _0 = const 1_i16;
           goto -> bb4;
       }
   

--- a/tests/mir-opt/matches_reduce_branches.match_u8_u16.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_u16.MatchBranchSimplification.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [1: bb3, 2: bb4, 5: bb2, otherwise: bb1];
+          switchInt(move _2) -> [1: bb4, 2: bb3, 5: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -21,12 +21,12 @@
       }
   
       bb3: {
-          _0 = const 1_u16;
+          _0 = const 2_u16;
           goto -> bb5;
       }
   
       bb4: {
-          _0 = const 2_u16;
+          _0 = const 1_u16;
           goto -> bb5;
       }
   

--- a/tests/mir-opt/or_pattern.shortcut_second_or.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/or_pattern.shortcut_second_or.SimplifyCfg-initial.after.mir
@@ -39,7 +39,7 @@ fn shortcut_second_or() -> () {
     }
 
     bb5: {
-        falseEdge -> [real: bb10, imaginary: bb6];
+        falseEdge -> [real: bb12, imaginary: bb6];
     }
 
     bb6: {
@@ -47,18 +47,19 @@ fn shortcut_second_or() -> () {
     }
 
     bb7: {
-        falseEdge -> [real: bb12, imaginary: bb8];
+        falseEdge -> [real: bb10, imaginary: bb8];
     }
 
     bb8: {
-        falseEdge -> [real: bb13, imaginary: bb3];
+        falseEdge -> [real: bb9, imaginary: bb3];
     }
 
     bb9: {
-        _0 = const ();
-        StorageDead(_4);
-        StorageDead(_3);
-        goto -> bb14;
+        StorageLive(_3);
+        _3 = (_1.0: (i32, i32));
+        StorageLive(_4);
+        _4 = (_1.1: i32);
+        goto -> bb13;
     }
 
     bb10: {
@@ -66,7 +67,7 @@ fn shortcut_second_or() -> () {
         _3 = (_1.0: (i32, i32));
         StorageLive(_4);
         _4 = (_1.1: i32);
-        goto -> bb9;
+        goto -> bb13;
     }
 
     bb11: {
@@ -74,7 +75,7 @@ fn shortcut_second_or() -> () {
         _3 = (_1.0: (i32, i32));
         StorageLive(_4);
         _4 = (_1.1: i32);
-        goto -> bb9;
+        goto -> bb13;
     }
 
     bb12: {
@@ -82,15 +83,14 @@ fn shortcut_second_or() -> () {
         _3 = (_1.0: (i32, i32));
         StorageLive(_4);
         _4 = (_1.1: i32);
-        goto -> bb9;
+        goto -> bb13;
     }
 
     bb13: {
-        StorageLive(_3);
-        _3 = (_1.0: (i32, i32));
-        StorageLive(_4);
-        _4 = (_1.1: i32);
-        goto -> bb9;
+        _0 = const ();
+        StorageDead(_4);
+        StorageDead(_3);
+        goto -> bb14;
     }
 
     bb14: {

--- a/tests/mir-opt/or_pattern.single_switchint.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/or_pattern.single_switchint.SimplifyCfg-initial.after.mir
@@ -22,7 +22,7 @@ fn single_switchint() -> () {
     }
 
     bb3: {
-        falseEdge -> [real: bb9, imaginary: bb4];
+        falseEdge -> [real: bb12, imaginary: bb4];
     }
 
     bb4: {
@@ -30,11 +30,11 @@ fn single_switchint() -> () {
     }
 
     bb5: {
-        falseEdge -> [real: bb10, imaginary: bb6];
+        falseEdge -> [real: bb11, imaginary: bb6];
     }
 
     bb6: {
-        falseEdge -> [real: bb11, imaginary: bb1];
+        falseEdge -> [real: bb10, imaginary: bb1];
     }
 
     bb7: {
@@ -43,26 +43,26 @@ fn single_switchint() -> () {
     }
 
     bb8: {
-        falseEdge -> [real: bb12, imaginary: bb7];
+        falseEdge -> [real: bb9, imaginary: bb7];
     }
 
     bb9: {
-        _1 = const 1_i32;
+        _1 = const 4_i32;
         goto -> bb13;
     }
 
     bb10: {
-        _1 = const 2_i32;
-        goto -> bb13;
-    }
-
-    bb11: {
         _1 = const 3_i32;
         goto -> bb13;
     }
 
+    bb11: {
+        _1 = const 2_i32;
+        goto -> bb13;
+    }
+
     bb12: {
-        _1 = const 4_i32;
+        _1 = const 1_i32;
         goto -> bb13;
     }
 

--- a/tests/mir-opt/single_use_consts.match_const.SingleUseConsts.panic-abort.diff
+++ b/tests/mir-opt/single_use_consts.match_const.SingleUseConsts.panic-abort.diff
@@ -8,9 +8,9 @@
       bb0: {
           StorageLive(_1);
 -         _1 = const <T as MyTrait>::ASSOC_INT;
--         switchInt(_1) -> [7: bb2, 42: bb3, otherwise: bb1];
+-         switchInt(_1) -> [7: bb3, 42: bb2, otherwise: bb1];
 +         nop;
-+         switchInt(const <T as MyTrait>::ASSOC_INT) -> [7: bb2, 42: bb3, otherwise: bb1];
++         switchInt(const <T as MyTrait>::ASSOC_INT) -> [7: bb3, 42: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -19,12 +19,12 @@
       }
   
       bb2: {
-          _0 = const "hello";
+          _0 = const "towel";
           goto -> bb4;
       }
   
       bb3: {
-          _0 = const "towel";
+          _0 = const "hello";
           goto -> bb4;
       }
   

--- a/tests/mir-opt/single_use_consts.match_const.SingleUseConsts.panic-unwind.diff
+++ b/tests/mir-opt/single_use_consts.match_const.SingleUseConsts.panic-unwind.diff
@@ -8,9 +8,9 @@
       bb0: {
           StorageLive(_1);
 -         _1 = const <T as MyTrait>::ASSOC_INT;
--         switchInt(_1) -> [7: bb2, 42: bb3, otherwise: bb1];
+-         switchInt(_1) -> [7: bb3, 42: bb2, otherwise: bb1];
 +         nop;
-+         switchInt(const <T as MyTrait>::ASSOC_INT) -> [7: bb2, 42: bb3, otherwise: bb1];
++         switchInt(const <T as MyTrait>::ASSOC_INT) -> [7: bb3, 42: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -19,12 +19,12 @@
       }
   
       bb2: {
-          _0 = const "hello";
+          _0 = const "towel";
           goto -> bb4;
       }
   
       bb3: {
-          _0 = const "towel";
+          _0 = const "hello";
           goto -> bb4;
       }
   

--- a/tests/mir-opt/single_use_consts.match_const_debug.SingleUseConsts.panic-abort.diff
+++ b/tests/mir-opt/single_use_consts.match_const_debug.SingleUseConsts.panic-abort.diff
@@ -20,8 +20,8 @@
   
       bb1: {
           StorageDead(_2);
--         switchInt(_1) -> [7: bb3, 42: bb4, otherwise: bb2];
-+         switchInt(const <T as MyTrait>::ASSOC_INT) -> [7: bb3, 42: bb4, otherwise: bb2];
+-         switchInt(_1) -> [7: bb4, 42: bb3, otherwise: bb2];
++         switchInt(const <T as MyTrait>::ASSOC_INT) -> [7: bb4, 42: bb3, otherwise: bb2];
       }
   
       bb2: {
@@ -30,12 +30,12 @@
       }
   
       bb3: {
-          _0 = const "hello";
+          _0 = const "towel";
           goto -> bb5;
       }
   
       bb4: {
-          _0 = const "towel";
+          _0 = const "hello";
           goto -> bb5;
       }
   

--- a/tests/mir-opt/single_use_consts.match_const_debug.SingleUseConsts.panic-unwind.diff
+++ b/tests/mir-opt/single_use_consts.match_const_debug.SingleUseConsts.panic-unwind.diff
@@ -20,8 +20,8 @@
   
       bb1: {
           StorageDead(_2);
--         switchInt(_1) -> [7: bb3, 42: bb4, otherwise: bb2];
-+         switchInt(const <T as MyTrait>::ASSOC_INT) -> [7: bb3, 42: bb4, otherwise: bb2];
+-         switchInt(_1) -> [7: bb4, 42: bb3, otherwise: bb2];
++         switchInt(const <T as MyTrait>::ASSOC_INT) -> [7: bb4, 42: bb3, otherwise: bb2];
       }
   
       bb2: {
@@ -30,12 +30,12 @@
       }
   
       bb3: {
-          _0 = const "hello";
+          _0 = const "towel";
           goto -> bb5;
       }
   
       bb4: {
-          _0 = const "towel";
+          _0 = const "hello";
           goto -> bb5;
       }
   

--- a/tests/mir-opt/uninhabited_fallthrough_elimination.eliminate_fallthrough.UnreachableEnumBranching.diff
+++ b/tests/mir-opt/uninhabited_fallthrough_elimination.eliminate_fallthrough.UnreachableEnumBranching.diff
@@ -8,8 +8,8 @@
   
       bb0: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [1: bb3, 2: bb2, otherwise: bb1];
-+         switchInt(move _2) -> [1: bb3, 2: bb2, otherwise: bb5];
+-         switchInt(move _2) -> [1: bb2, 2: bb3, otherwise: bb1];
++         switchInt(move _2) -> [1: bb2, 2: bb3, otherwise: bb5];
       }
   
       bb1: {
@@ -18,12 +18,12 @@
       }
   
       bb2: {
-          _0 = const 1_u32;
+          _0 = const 2_u32;
           goto -> bb4;
       }
   
       bb3: {
-          _0 = const 2_u32;
+          _0 = const 1_u32;
           goto -> bb4;
       }
   

--- a/tests/mir-opt/uninhabited_fallthrough_elimination.keep_fallthrough.UnreachableEnumBranching.diff
+++ b/tests/mir-opt/uninhabited_fallthrough_elimination.keep_fallthrough.UnreachableEnumBranching.diff
@@ -8,8 +8,8 @@
   
       bb0: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [0: bb2, 1: bb3, otherwise: bb1];
-+         switchInt(move _2) -> [0: bb5, 1: bb3, 2: bb1, otherwise: bb5];
+-         switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
++         switchInt(move _2) -> [0: bb5, 1: bb2, 2: bb1, otherwise: bb5];
       }
   
       bb1: {
@@ -18,12 +18,12 @@
       }
   
       bb2: {
-          _0 = const 1_u32;
+          _0 = const 2_u32;
           goto -> bb4;
       }
   
       bb3: {
-          _0 = const 2_u32;
+          _0 = const 1_u32;
           goto -> bb4;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.byref.UnreachableEnumBranching.panic-abort.diff
+++ b/tests/mir-opt/unreachable_enum_branching.byref.UnreachableEnumBranching.panic-abort.diff
@@ -30,8 +30,8 @@
           StorageLive(_4);
           _4 = &(_1.1: Test3);
           _5 = discriminant((*_4));
--         switchInt(move _5) -> [0: bb3, 1: bb4, 2: bb5, 3: bb2, otherwise: bb1];
-+         switchInt(move _5) -> [0: bb1, 1: bb1, 2: bb5, 3: bb2, otherwise: bb1];
+-         switchInt(move _5) -> [0: bb5, 1: bb4, 2: bb3, 3: bb2, otherwise: bb1];
++         switchInt(move _5) -> [0: bb1, 1: bb1, 2: bb3, 3: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -47,7 +47,10 @@
       }
   
       bb3: {
-          _3 = const "A(Empty)";
+          StorageLive(_7);
+          _7 = const "C";
+          _3 = &(*_7);
+          StorageDead(_7);
           goto -> bb6;
       }
   
@@ -60,10 +63,7 @@
       }
   
       bb5: {
-          StorageLive(_7);
-          _7 = const "C";
-          _3 = &(*_7);
-          StorageDead(_7);
+          _3 = const "A(Empty)";
           goto -> bb6;
       }
   
@@ -72,8 +72,8 @@
           StorageDead(_3);
           StorageLive(_9);
           _10 = discriminant((_1.1: Test3));
--         switchInt(move _10) -> [0: bb8, 1: bb9, 2: bb10, 3: bb7, otherwise: bb1];
-+         switchInt(move _10) -> [0: bb1, 1: bb1, 2: bb10, 3: bb7, otherwise: bb1];
+-         switchInt(move _10) -> [0: bb10, 1: bb9, 2: bb8, 3: bb7, otherwise: bb1];
++         switchInt(move _10) -> [0: bb1, 1: bb1, 2: bb8, 3: bb7, otherwise: bb1];
       }
   
       bb7: {
@@ -85,7 +85,10 @@
       }
   
       bb8: {
-          _9 = const "A(Empty)";
+          StorageLive(_12);
+          _12 = const "C";
+          _9 = &(*_12);
+          StorageDead(_12);
           goto -> bb11;
       }
   
@@ -98,10 +101,7 @@
       }
   
       bb10: {
-          StorageLive(_12);
-          _12 = const "C";
-          _9 = &(*_12);
-          StorageDead(_12);
+          _9 = const "A(Empty)";
           goto -> bb11;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.byref.UnreachableEnumBranching.panic-unwind.diff
+++ b/tests/mir-opt/unreachable_enum_branching.byref.UnreachableEnumBranching.panic-unwind.diff
@@ -30,8 +30,8 @@
           StorageLive(_4);
           _4 = &(_1.1: Test3);
           _5 = discriminant((*_4));
--         switchInt(move _5) -> [0: bb3, 1: bb4, 2: bb5, 3: bb2, otherwise: bb1];
-+         switchInt(move _5) -> [0: bb1, 1: bb1, 2: bb5, 3: bb2, otherwise: bb1];
+-         switchInt(move _5) -> [0: bb5, 1: bb4, 2: bb3, 3: bb2, otherwise: bb1];
++         switchInt(move _5) -> [0: bb1, 1: bb1, 2: bb3, 3: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -47,7 +47,10 @@
       }
   
       bb3: {
-          _3 = const "A(Empty)";
+          StorageLive(_7);
+          _7 = const "C";
+          _3 = &(*_7);
+          StorageDead(_7);
           goto -> bb6;
       }
   
@@ -60,10 +63,7 @@
       }
   
       bb5: {
-          StorageLive(_7);
-          _7 = const "C";
-          _3 = &(*_7);
-          StorageDead(_7);
+          _3 = const "A(Empty)";
           goto -> bb6;
       }
   
@@ -72,8 +72,8 @@
           StorageDead(_3);
           StorageLive(_9);
           _10 = discriminant((_1.1: Test3));
--         switchInt(move _10) -> [0: bb8, 1: bb9, 2: bb10, 3: bb7, otherwise: bb1];
-+         switchInt(move _10) -> [0: bb1, 1: bb1, 2: bb10, 3: bb7, otherwise: bb1];
+-         switchInt(move _10) -> [0: bb10, 1: bb9, 2: bb8, 3: bb7, otherwise: bb1];
++         switchInt(move _10) -> [0: bb1, 1: bb1, 2: bb8, 3: bb7, otherwise: bb1];
       }
   
       bb7: {
@@ -85,7 +85,10 @@
       }
   
       bb8: {
-          _9 = const "A(Empty)";
+          StorageLive(_12);
+          _12 = const "C";
+          _9 = &(*_12);
+          StorageDead(_12);
           goto -> bb11;
       }
   
@@ -98,10 +101,7 @@
       }
   
       bb10: {
-          StorageLive(_12);
-          _12 = const "C";
-          _9 = &(*_12);
-          StorageDead(_12);
+          _9 = const "A(Empty)";
           goto -> bb11;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t1.UnreachableEnumBranching.panic-abort.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t1.UnreachableEnumBranching.panic-abort.diff
@@ -14,7 +14,7 @@
           StorageLive(_2);
           _2 = Test1::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
+-         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
 +         switchInt(move _3) -> [0: bb5, 1: bb5, 2: bb1, otherwise: bb5];
       }
   
@@ -27,15 +27,15 @@
       }
   
       bb2: {
-          _1 = const "A(Empty)";
-          goto -> bb4;
-      }
-  
-      bb3: {
           StorageLive(_4);
           _4 = const "B(Empty)";
           _1 = &(*_4);
           StorageDead(_4);
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _1 = const "A(Empty)";
           goto -> bb4;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t1.UnreachableEnumBranching.panic-unwind.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t1.UnreachableEnumBranching.panic-unwind.diff
@@ -14,7 +14,7 @@
           StorageLive(_2);
           _2 = Test1::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
+-         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
 +         switchInt(move _3) -> [0: bb5, 1: bb5, 2: bb1, otherwise: bb5];
       }
   
@@ -27,15 +27,15 @@
       }
   
       bb2: {
-          _1 = const "A(Empty)";
-          goto -> bb4;
-      }
-  
-      bb3: {
           StorageLive(_4);
           _4 = const "B(Empty)";
           _1 = &(*_4);
           StorageDead(_4);
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _1 = const "A(Empty)";
           goto -> bb4;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t3.UnreachableEnumBranching.panic-abort.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t3.UnreachableEnumBranching.panic-abort.diff
@@ -14,7 +14,7 @@
           StorageLive(_2);
           _2 = Test3::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
+-         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
 +         switchInt(move _3) -> [0: bb5, 1: bb5, otherwise: bb1];
       }
   
@@ -27,15 +27,15 @@
       }
   
       bb2: {
-          _1 = const "A(Empty)";
-          goto -> bb4;
-      }
-  
-      bb3: {
           StorageLive(_4);
           _4 = const "B(Empty)";
           _1 = &(*_4);
           StorageDead(_4);
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _1 = const "A(Empty)";
           goto -> bb4;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t3.UnreachableEnumBranching.panic-unwind.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t3.UnreachableEnumBranching.panic-unwind.diff
@@ -14,7 +14,7 @@
           StorageLive(_2);
           _2 = Test3::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
+-         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
 +         switchInt(move _3) -> [0: bb5, 1: bb5, otherwise: bb1];
       }
   
@@ -27,15 +27,15 @@
       }
   
       bb2: {
-          _1 = const "A(Empty)";
-          goto -> bb4;
-      }
-  
-      bb3: {
           StorageLive(_4);
           _4 = const "B(Empty)";
           _1 = &(*_4);
           StorageDead(_4);
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _1 = const "A(Empty)";
           goto -> bb4;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t4.UnreachableEnumBranching.panic-abort.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t4.UnreachableEnumBranching.panic-abort.diff
@@ -14,7 +14,7 @@
           StorageLive(_2);
           _2 = Test4::C;
           _3 = discriminant(_2);
-          switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
+          switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -26,15 +26,15 @@
       }
   
       bb2: {
-          _1 = const "A(i32)";
-          goto -> bb4;
-      }
-  
-      bb3: {
           StorageLive(_4);
           _4 = const "B(i32)";
           _1 = &(*_4);
           StorageDead(_4);
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _1 = const "A(i32)";
           goto -> bb4;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t4.UnreachableEnumBranching.panic-unwind.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t4.UnreachableEnumBranching.panic-unwind.diff
@@ -14,7 +14,7 @@
           StorageLive(_2);
           _2 = Test4::C;
           _3 = discriminant(_2);
-          switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
+          switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -26,15 +26,15 @@
       }
   
       bb2: {
-          _1 = const "A(i32)";
-          goto -> bb4;
-      }
-  
-      bb3: {
           StorageLive(_4);
           _4 = const "B(i32)";
           _1 = &(*_4);
           StorageDead(_4);
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _1 = const "A(i32)";
           goto -> bb4;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t4_unreachable_default.UnreachableEnumBranching.panic-abort.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t4_unreachable_default.UnreachableEnumBranching.panic-abort.diff
@@ -15,8 +15,8 @@
           StorageLive(_2);
           _2 = Test4::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb1];
-+         switchInt(move _3) -> [0: bb2, 1: bb3, 2: bb4, 3: bb1, otherwise: bb6];
+-         switchInt(move _3) -> [0: bb4, 1: bb3, 2: bb2, otherwise: bb1];
++         switchInt(move _3) -> [0: bb4, 1: bb3, 2: bb2, 3: bb1, otherwise: bb6];
       }
   
       bb1: {
@@ -28,7 +28,10 @@
       }
   
       bb2: {
-          _1 = const "A(i32)";
+          StorageLive(_5);
+          _5 = const "C";
+          _1 = &(*_5);
+          StorageDead(_5);
           goto -> bb5;
       }
   
@@ -41,10 +44,7 @@
       }
   
       bb4: {
-          StorageLive(_5);
-          _5 = const "C";
-          _1 = &(*_5);
-          StorageDead(_5);
+          _1 = const "A(i32)";
           goto -> bb5;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t4_unreachable_default.UnreachableEnumBranching.panic-unwind.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t4_unreachable_default.UnreachableEnumBranching.panic-unwind.diff
@@ -15,8 +15,8 @@
           StorageLive(_2);
           _2 = Test4::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb1];
-+         switchInt(move _3) -> [0: bb2, 1: bb3, 2: bb4, 3: bb1, otherwise: bb6];
+-         switchInt(move _3) -> [0: bb4, 1: bb3, 2: bb2, otherwise: bb1];
++         switchInt(move _3) -> [0: bb4, 1: bb3, 2: bb2, 3: bb1, otherwise: bb6];
       }
   
       bb1: {
@@ -28,7 +28,10 @@
       }
   
       bb2: {
-          _1 = const "A(i32)";
+          StorageLive(_5);
+          _5 = const "C";
+          _1 = &(*_5);
+          StorageDead(_5);
           goto -> bb5;
       }
   
@@ -41,10 +44,7 @@
       }
   
       bb4: {
-          StorageLive(_5);
-          _5 = const "C";
-          _1 = &(*_5);
-          StorageDead(_5);
+          _1 = const "A(i32)";
           goto -> bb5;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t4_unreachable_default_2.UnreachableEnumBranching.panic-abort.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t4_unreachable_default_2.UnreachableEnumBranching.panic-abort.diff
@@ -16,8 +16,8 @@
           StorageLive(_2);
           _2 = Test4::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb2, 1: bb5, 2: bb6, otherwise: bb1];
-+         switchInt(move _3) -> [0: bb2, 1: bb5, 2: bb6, 3: bb1, otherwise: bb8];
+-         switchInt(move _3) -> [0: bb2, 1: bb4, 2: bb3, otherwise: bb1];
++         switchInt(move _3) -> [0: bb2, 1: bb4, 2: bb3, 3: bb1, otherwise: bb8];
       }
   
       bb1: {
@@ -29,23 +29,18 @@
       }
   
       bb2: {
-          switchInt(((_2 as A).0: i32)) -> [1: bb3, 2: bb4, otherwise: bb1];
+          switchInt(((_2 as A).0: i32)) -> [1: bb6, 2: bb5, otherwise: bb1];
       }
   
       bb3: {
-          _1 = const "A(1)";
+          StorageLive(_6);
+          _6 = const "C";
+          _1 = &(*_6);
+          StorageDead(_6);
           goto -> bb7;
       }
   
       bb4: {
-          StorageLive(_4);
-          _4 = const "A(2)";
-          _1 = &(*_4);
-          StorageDead(_4);
-          goto -> bb7;
-      }
-  
-      bb5: {
           StorageLive(_5);
           _5 = const "B(i32)";
           _1 = &(*_5);
@@ -53,11 +48,16 @@
           goto -> bb7;
       }
   
+      bb5: {
+          StorageLive(_4);
+          _4 = const "A(2)";
+          _1 = &(*_4);
+          StorageDead(_4);
+          goto -> bb7;
+      }
+  
       bb6: {
-          StorageLive(_6);
-          _6 = const "C";
-          _1 = &(*_6);
-          StorageDead(_6);
+          _1 = const "A(1)";
           goto -> bb7;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t4_unreachable_default_2.UnreachableEnumBranching.panic-unwind.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t4_unreachable_default_2.UnreachableEnumBranching.panic-unwind.diff
@@ -16,8 +16,8 @@
           StorageLive(_2);
           _2 = Test4::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb2, 1: bb5, 2: bb6, otherwise: bb1];
-+         switchInt(move _3) -> [0: bb2, 1: bb5, 2: bb6, 3: bb1, otherwise: bb8];
+-         switchInt(move _3) -> [0: bb2, 1: bb4, 2: bb3, otherwise: bb1];
++         switchInt(move _3) -> [0: bb2, 1: bb4, 2: bb3, 3: bb1, otherwise: bb8];
       }
   
       bb1: {
@@ -29,23 +29,18 @@
       }
   
       bb2: {
-          switchInt(((_2 as A).0: i32)) -> [1: bb3, 2: bb4, otherwise: bb1];
+          switchInt(((_2 as A).0: i32)) -> [1: bb6, 2: bb5, otherwise: bb1];
       }
   
       bb3: {
-          _1 = const "A(1)";
+          StorageLive(_6);
+          _6 = const "C";
+          _1 = &(*_6);
+          StorageDead(_6);
           goto -> bb7;
       }
   
       bb4: {
-          StorageLive(_4);
-          _4 = const "A(2)";
-          _1 = &(*_4);
-          StorageDead(_4);
-          goto -> bb7;
-      }
-  
-      bb5: {
           StorageLive(_5);
           _5 = const "B(i32)";
           _1 = &(*_5);
@@ -53,11 +48,16 @@
           goto -> bb7;
       }
   
+      bb5: {
+          StorageLive(_4);
+          _4 = const "A(2)";
+          _1 = &(*_4);
+          StorageDead(_4);
+          goto -> bb7;
+      }
+  
       bb6: {
-          StorageLive(_6);
-          _6 = const "C";
-          _1 = &(*_6);
-          StorageDead(_6);
+          _1 = const "A(1)";
           goto -> bb7;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t5_unreachable_default.UnreachableEnumBranching.panic-abort.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t5_unreachable_default.UnreachableEnumBranching.panic-abort.diff
@@ -15,8 +15,8 @@
           StorageLive(_2);
           _2 = Test5::<T>::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [255: bb2, 0: bb3, 5: bb4, otherwise: bb1];
-+         switchInt(move _3) -> [255: bb2, 0: bb3, 5: bb4, 3: bb1, otherwise: bb7];
+-         switchInt(move _3) -> [255: bb4, 0: bb3, 5: bb2, otherwise: bb1];
++         switchInt(move _3) -> [255: bb4, 0: bb3, 5: bb2, 3: bb1, otherwise: bb7];
       }
   
       bb1: {
@@ -28,7 +28,10 @@
       }
   
       bb2: {
-          _1 = const "A(T)";
+          StorageLive(_5);
+          _5 = const "C";
+          _1 = &(*_5);
+          StorageDead(_5);
           goto -> bb5;
       }
   
@@ -41,10 +44,7 @@
       }
   
       bb4: {
-          StorageLive(_5);
-          _5 = const "C";
-          _1 = &(*_5);
-          StorageDead(_5);
+          _1 = const "A(T)";
           goto -> bb5;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.otherwise_t5_unreachable_default.UnreachableEnumBranching.panic-unwind.diff
+++ b/tests/mir-opt/unreachable_enum_branching.otherwise_t5_unreachable_default.UnreachableEnumBranching.panic-unwind.diff
@@ -15,8 +15,8 @@
           StorageLive(_2);
           _2 = Test5::<T>::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [255: bb2, 0: bb3, 5: bb4, otherwise: bb1];
-+         switchInt(move _3) -> [255: bb2, 0: bb3, 5: bb4, 3: bb1, otherwise: bb8];
+-         switchInt(move _3) -> [255: bb4, 0: bb3, 5: bb2, otherwise: bb1];
++         switchInt(move _3) -> [255: bb4, 0: bb3, 5: bb2, 3: bb1, otherwise: bb8];
       }
   
       bb1: {
@@ -28,7 +28,10 @@
       }
   
       bb2: {
-          _1 = const "A(T)";
+          StorageLive(_5);
+          _5 = const "C";
+          _1 = &(*_5);
+          StorageDead(_5);
           goto -> bb5;
       }
   
@@ -41,10 +44,7 @@
       }
   
       bb4: {
-          StorageLive(_5);
-          _5 = const "C";
-          _1 = &(*_5);
-          StorageDead(_5);
+          _1 = const "A(T)";
           goto -> bb5;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.rs
+++ b/tests/mir-opt/unreachable_enum_branching.rs
@@ -120,7 +120,7 @@ fn otherwise_t3() {
 fn otherwise_t4_unreachable_default() {
     // CHECK-LABEL: fn otherwise_t4_unreachable_default(
     // CHECK: [[discr:_.*]] = discriminant(
-    // CHECK: switchInt(move [[discr]]) -> [0: bb2, 1: bb3, 2: bb4, 3: bb1, otherwise: [[unreachable:bb.*]]];
+    // CHECK: switchInt(move [[discr]]) -> [0: {{bb.*}}, 1: {{bb.*}}, 2: {{bb.*}}, 3: {{bb.*}}, otherwise: [[unreachable:bb.*]]];
     // CHECK: [[unreachable]]: {
     // CHECK-NEXT: unreachable;
     match Test4::C {
@@ -135,7 +135,7 @@ fn otherwise_t4_unreachable_default() {
 fn otherwise_t4_unreachable_default_2() {
     // CHECK-LABEL: fn otherwise_t4_unreachable_default_2(
     // CHECK: [[discr:_.*]] = discriminant(
-    // CHECK: switchInt(move [[discr]]) -> [0: bb2, 1: bb5, 2: bb6, 3: bb1, otherwise: [[unreachable:bb.*]]];
+    // CHECK: switchInt(move [[discr]]) -> [0: {{bb.*}}, 1: {{bb.*}}, 2: {{bb.*}}, 3: {{bb.*}}, otherwise: [[unreachable:bb.*]]];
     // CHECK: [[unreachable]]: {
     // CHECK-NEXT: unreachable;
     match Test4::C {
@@ -151,7 +151,7 @@ fn otherwise_t4_unreachable_default_2() {
 fn otherwise_t4() {
     // CHECK-LABEL: fn otherwise_t4(
     // CHECK: [[discr:_.*]] = discriminant(
-    // CHECK: switchInt(move [[discr]]) -> [0: bb2, 1: bb3, otherwise: [[unreachable:bb.*]]];
+    // CHECK: switchInt(move [[discr]]) -> [0: {{bb.*}}, 1: {{bb.*}}, otherwise: [[unreachable:bb.*]]];
     // CHECK: [[unreachable]]: {
     // CHECK-NOT: unreachable;
     // CHECK: }
@@ -166,7 +166,7 @@ fn otherwise_t4() {
 fn otherwise_t5_unreachable_default<T>() {
     // CHECK-LABEL: fn otherwise_t5_unreachable_default(
     // CHECK: [[discr:_.*]] = discriminant(
-    // CHECK: switchInt(move [[discr]]) -> [255: bb2, 0: bb3, 5: bb4, 3: bb1, otherwise: [[unreachable:bb.*]]];
+    // CHECK: switchInt(move [[discr]]) -> [255: {{bb.*}}, 0: {{bb.*}}, 5: {{bb.*}}, 3: {{bb.*}}, otherwise: [[unreachable:bb.*]]];
     // CHECK: [[unreachable]]: {
     // CHECK-NEXT: unreachable;
     match Test5::<T>::C {
@@ -183,7 +183,7 @@ fn byref() {
     let plop = Plop { xx: 51, test3: Test3::C };
 
     // CHECK: [[ref_discr:_.*]] = discriminant((*
-    // CHECK: switchInt(move [[ref_discr]]) -> [0: [[unreachable:bb.*]], 1: [[unreachable]], 2: bb5, 3: bb2, otherwise: [[unreachable]]];
+    // CHECK: switchInt(move [[ref_discr]]) -> [0: [[unreachable:bb.*]], 1: [[unreachable]], 2: {{bb.*}}, 3: {{bb.*}}, otherwise: [[unreachable]]];
     match &plop.test3 {
         Test3::A(_) => "A(Empty)",
         Test3::B(_) => "B(Empty)",
@@ -195,7 +195,7 @@ fn byref() {
     // CHECK-NEXT: unreachable;
 
     // CHECK: [[discr:_.*]] = discriminant(
-    // CHECK: switchInt(move [[discr]]) -> [0: [[unreachable]], 1: [[unreachable]], 2: bb10, 3: bb7, otherwise: [[unreachable]]];
+    // CHECK: switchInt(move [[discr]]) -> [0: [[unreachable]], 1: [[unreachable]], 2: {{bb.*}}, 3: {{bb.*}}, otherwise: [[unreachable]]];
     match plop.test3 {
         Test3::A(_) => "A(Empty)",
         Test3::B(_) => "B(Empty)",

--- a/tests/mir-opt/unreachable_enum_branching.simple.UnreachableEnumBranching.panic-abort.diff
+++ b/tests/mir-opt/unreachable_enum_branching.simple.UnreachableEnumBranching.panic-abort.diff
@@ -14,7 +14,7 @@
           StorageLive(_2);
           _2 = Test1::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb3, 1: bb4, 2: bb2, otherwise: bb1];
+-         switchInt(move _3) -> [0: bb4, 1: bb3, 2: bb2, otherwise: bb1];
 +         switchInt(move _3) -> [0: bb1, 1: bb1, 2: bb2, otherwise: bb1];
       }
   
@@ -31,15 +31,15 @@
       }
   
       bb3: {
-          _1 = const "A(Empty)";
-          goto -> bb5;
-      }
-  
-      bb4: {
           StorageLive(_4);
           _4 = const "B(Empty)";
           _1 = &(*_4);
           StorageDead(_4);
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _1 = const "A(Empty)";
           goto -> bb5;
       }
   

--- a/tests/mir-opt/unreachable_enum_branching.simple.UnreachableEnumBranching.panic-unwind.diff
+++ b/tests/mir-opt/unreachable_enum_branching.simple.UnreachableEnumBranching.panic-unwind.diff
@@ -14,7 +14,7 @@
           StorageLive(_2);
           _2 = Test1::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb3, 1: bb4, 2: bb2, otherwise: bb1];
+-         switchInt(move _3) -> [0: bb4, 1: bb3, 2: bb2, otherwise: bb1];
 +         switchInt(move _3) -> [0: bb1, 1: bb1, 2: bb2, otherwise: bb1];
       }
   
@@ -31,15 +31,15 @@
       }
   
       bb3: {
-          _1 = const "A(Empty)";
-          goto -> bb5;
-      }
-  
-      bb4: {
           StorageLive(_4);
           _4 = const "B(Empty)";
           _1 = &(*_4);
           StorageDead(_4);
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _1 = const "A(Empty)";
           goto -> bb5;
       }
   

--- a/tests/ui/stable-mir-print/basic_function.stdout
+++ b/tests/ui/stable-mir-print/basic_function.stdout
@@ -44,14 +44,14 @@ fn demux(_1: u8) -> u8 {
     let mut _0: u8;
     debug input => _1;
     bb0: {
-        switchInt(_1) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb1];
+        switchInt(_1) -> [0: bb4, 1: bb3, 2: bb2, otherwise: bb1];
     }
     bb1: {
         _0 = 0_u8;
         goto -> bb5;
     }
     bb2: {
-        _0 = 10_u8;
+        _0 = 8_u8;
         goto -> bb5;
     }
     bb3: {
@@ -59,7 +59,7 @@ fn demux(_1: u8) -> u8 {
         goto -> bb5;
     }
     bb4: {
-        _0 = 8_u8;
+        _0 = 10_u8;
         goto -> bb5;
     }
     bb5: {


### PR DESCRIPTION
The internals of `Candidate` are tricky and a source of confusion. This PR makes it so we don't expose `Candidate`s outside the lowering algorithm. Now:
- false edges are handled in `lower_match_tree`;
- `lower_match_tree` takes a list of patterns as input;
- `lower_match_tree` returns a flat datastructure that contains only the necessary information.

r? @matthewjasper

try-job: x86_64-rust-for-linux