### PR TITLE
Add a regression test for #123630

### DIFF
--- a/tests/ui/suggestions/types/dont-suggest-path-names.rs
+++ b/tests/ui/suggestions/types/dont-suggest-path-names.rs
@@ -1,0 +1,17 @@
+// This is a regression test for #123630
+//
+// Prior to #123703 this was resulting in compiler suggesting add a type signature
+// for `lit` containing path to a file containing `Select` - something obviously invalid.
+
+struct Select<F, I>(F, I);
+fn select<F, I>(filter: F) -> Select<F, I> {}
+//~^ 7:31: 7:43: mismatched types [E0308]
+
+fn parser1() {
+    let lit = select(|x| match x {
+        //~^ 11:23: 11:24: type annotations needed [E0282]
+        _ => (),
+    });
+}
+
+fn main() {}

--- a/tests/ui/suggestions/types/dont-suggest-path-names.stderr
+++ b/tests/ui/suggestions/types/dont-suggest-path-names.stderr
@@ -1,0 +1,26 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-path-names.rs:7:31
+   |
+LL | fn select<F, I>(filter: F) -> Select<F, I> {}
+   |    ------                     ^^^^^^^^^^^^ expected `Select<F, I>`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression
+   |
+   = note: expected struct `Select<F, I>`
+           found unit type `()`
+
+error[E0282]: type annotations needed
+  --> $DIR/dont-suggest-path-names.rs:11:23
+   |
+LL |     let lit = select(|x| match x {
+   |                       ^        - type must be known at this point
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     let lit = select(|x: /* Type */| match x {
+   |                        ++++++++++++
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0282, E0308.
+For more information about an error, try `rustc --explain E0282`.


### PR DESCRIPTION
Fixes #123630

compiler should not suggest nonsensical signatures, original suggestion was

```
error[E0308]: mismatched types
 --> src/lib.rs:3:31
  |
3 | fn select<F, I>(filter: F) -> Select<F, I> {
  |    ------                     ^^^^^^^^^^^^ expected `Select<F, I>`, found `()`
  |    |
  |    implicitly returns `()` as its body has no tail or `return` expression
  |
  = note: expected struct `Select<F, I>`
          found unit type `()`

error[E0282]: type annotations needed for `Select<{closure@src/lib.rs:8:22: 8:25}, I>`
 --> src/lib.rs:8:9
  |
8 |     let lit = select(|x| match x {
  |         ^^^
  |
help: consider giving `lit` an explicit type, where the type for type parameter `I` is specified
  |
8 |     let lit: Select<{closure@src/lib.rs:8:22: 8:25}, I> = select(|x| match x {
  |            ++++++++++++++++++++++++++++++++++++++++++++

Some errors have detailed explanations: E0282, E0308. For more information about an error, try `rustc --explain E0282`.
```
