### PR TITLE
Improve `run-make-support` library `args` API

### DIFF
--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -525,11 +525,12 @@ macro_rules! impl_common_helpers {
             /// Generic command arguments provider. Prefer specific helper methods if possible.
             /// Note that for some executables, arguments might be platform specific. For C/C++
             /// compilers, arguments might be platform *and* compiler specific.
-            pub fn args<S>(&mut self, args: &[S]) -> &mut Self
+            pub fn args<V, S>(&mut self, args: V) -> &mut Self
             where
+                V: AsRef<[S]>,
                 S: AsRef<::std::ffi::OsStr>,
             {
-                self.cmd.args(args);
+                self.cmd.args(args.as_ref());
                 self
             }
 

--- a/tests/run-make/arguments-non-c-like-enum/rmake.rs
+++ b/tests/run-make/arguments-non-c-like-enum/rmake.rs
@@ -10,8 +10,8 @@ pub fn main() {
     cc().input("test.c")
         .input(static_lib_name("nonclike"))
         .out_exe("test")
-        .args(&extra_c_flags())
-        .args(&extra_cxx_flags())
+        .args(extra_c_flags())
+        .args(extra_cxx_flags())
         .inspect(|cmd| eprintln!("{cmd:?}"))
         .run();
     run("test");

--- a/tests/run-make/c-link-to-rust-staticlib/rmake.rs
+++ b/tests/run-make/c-link-to-rust-staticlib/rmake.rs
@@ -9,7 +9,7 @@ use std::fs;
 
 fn main() {
     rustc().input("foo.rs").run();
-    cc().input("bar.c").input(static_lib_name("foo")).out_exe("bar").args(&extra_c_flags()).run();
+    cc().input("bar.c").input(static_lib_name("foo")).out_exe("bar").args(extra_c_flags()).run();
     run("bar");
     remove_file(static_lib_name("foo"));
     run("bar");

--- a/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
+++ b/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
@@ -12,7 +12,7 @@ fn main() {
     cc().input("test.c")
         .input(static_lib_name("checkrust"))
         .out_exe("test")
-        .args(&extra_c_flags())
+        .args(extra_c_flags())
         .run();
     run("test");
 }

--- a/tests/run-make/glibc-staticlib-args/rmake.rs
+++ b/tests/run-make/glibc-staticlib-args/rmake.rs
@@ -11,8 +11,8 @@ fn main() {
     cc().input("program.c")
         .arg(static_lib_name("library"))
         .out_exe("program")
-        .args(&extra_c_flags())
-        .args(&extra_cxx_flags())
+        .args(extra_c_flags())
+        .args(extra_cxx_flags())
         .run();
     run(&bin_name("program"));
 }

--- a/tests/run-make/print-check-cfg/rmake.rs
+++ b/tests/run-make/print-check-cfg/rmake.rs
@@ -86,12 +86,8 @@ fn main() {
 }
 
 fn check(CheckCfg { args, contains }: CheckCfg) {
-    let output = rustc()
-        .input("lib.rs")
-        .arg("-Zunstable-options")
-        .arg("--print=check-cfg")
-        .args(&*args)
-        .run();
+    let output =
+        rustc().input("lib.rs").arg("-Zunstable-options").arg("--print=check-cfg").args(args).run();
 
     let stdout = output.stdout_utf8();
 

--- a/tests/run-make/return-non-c-like-enum/rmake.rs
+++ b/tests/run-make/return-non-c-like-enum/rmake.rs
@@ -11,8 +11,8 @@ fn main() {
     cc().input("test.c")
         .arg(&static_lib_name("nonclike"))
         .out_exe("test")
-        .args(&extra_c_flags())
-        .args(&extra_cxx_flags())
+        .args(extra_c_flags())
+        .args(extra_cxx_flags())
         .run();
     run("test");
 }

--- a/tests/run-make/textrel-on-minimal-lib/rmake.rs
+++ b/tests/run-make/textrel-on-minimal-lib/rmake.rs
@@ -20,8 +20,8 @@ fn main() {
         .out_exe(&dynamic_lib_name("bar"))
         .arg("-fPIC")
         .arg("-shared")
-        .args(&extra_c_flags())
-        .args(&extra_cxx_flags())
+        .args(extra_c_flags())
+        .args(extra_cxx_flags())
         .run();
     llvm_readobj()
         .input(dynamic_lib_name("bar"))


### PR DESCRIPTION
It allows to pass both `Vec` and slices, which makes it much better (for me at least :wink:).

r? @Kobzol 