### PR TITLE
Process alias-relate obligations when proving `receiver_is_valid`

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -767,6 +767,8 @@ impl<'tcx> InferCtxt<'tcx> {
             .collect()
     }
 
+    // FIXME(-Znext-solver): Get rid of this method, it's never correct. Either that,
+    // or we need to process the obligations.
     pub fn can_sub<T>(&self, param_env: ty::ParamEnv<'tcx>, expected: T, actual: T) -> bool
     where
         T: at::ToTrace<'tcx>,
@@ -779,6 +781,8 @@ impl<'tcx> InferCtxt<'tcx> {
         })
     }
 
+    // FIXME(-Znext-solver): Get rid of this method, it's never correct. Either that,
+    // or we need to process the obligations.
     pub fn can_eq<T>(&self, param_env: ty::ParamEnv<'tcx>, a: T, b: T) -> bool
     where
         T: at::ToTrace<'tcx>,

--- a/tests/ui/traits/next-solver/typeck/receiver-self-ty-check-eq.rs
+++ b/tests/ui/traits/next-solver/typeck/receiver-self-ty-check-eq.rs
@@ -1,0 +1,23 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Fixes a regression in `receiver_is_valid` in wfcheck where we were using
+// `InferCtxt::can_eq` instead of processing alias-relate goals, leading to false
+// positives, not deref'ing enough steps to check the receiver is valid.
+
+trait Mirror {
+    type Mirror: ?Sized;
+}
+impl<T: ?Sized> Mirror for T {
+    type Mirror = T;
+}
+
+trait Foo {
+    fn foo(&self) {}
+}
+
+impl Foo for <() as Mirror>::Mirror {
+    fn foo(&self) {}
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/method_resolution3.current.stderr
+++ b/tests/ui/type-alias-impl-trait/method_resolution3.current.stderr
@@ -8,7 +8,7 @@ LL |     fn bar(self: Bar<u32>) {
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0307]: invalid `self` parameter type: `&Bar<u32>`
-  --> $DIR/method_resolution3.rs:21:18
+  --> $DIR/method_resolution3.rs:20:18
    |
 LL |     fn baz(self: &Bar<u32>) {
    |                  ^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/method_resolution3.next.stderr
+++ b/tests/ui/type-alias-impl-trait/method_resolution3.next.stderr
@@ -1,15 +1,21 @@
-error[E0271]: type mismatch resolving `Foo == u32`
+error[E0307]: invalid `self` parameter type: `Bar<u32>`
   --> $DIR/method_resolution3.rs:16:18
    |
 LL |     fn bar(self: Bar<u32>) {
-   |                  ^^^^^^^^ types differ
+   |                  ^^^^^^^^
+   |
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error[E0271]: type mismatch resolving `Foo == u32`
-  --> $DIR/method_resolution3.rs:21:18
+error[E0307]: invalid `self` parameter type: `&Bar<u32>`
+  --> $DIR/method_resolution3.rs:20:18
    |
 LL |     fn baz(self: &Bar<u32>) {
-   |                  ^^^^^^^^^ types differ
+   |                  ^^^^^^^^^
+   |
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0307`.

--- a/tests/ui/type-alias-impl-trait/method_resolution3.rs
+++ b/tests/ui/type-alias-impl-trait/method_resolution3.rs
@@ -14,13 +14,11 @@ struct Bar<T>(T);
 
 impl Bar<Foo> {
     fn bar(self: Bar<u32>) {
-        //[current]~^ ERROR: invalid `self` parameter
-        //[next]~^^ ERROR: type mismatch resolving `Foo == u32`
+        //~^ ERROR: invalid `self` parameter
         self.foo()
     }
     fn baz(self: &Bar<u32>) {
-        //[current]~^ ERROR: invalid `self` parameter
-        //[next]~^^ ERROR: type mismatch resolving `Foo == u32`
+        //~^ ERROR: invalid `self` parameter
         self.foo()
     }
 }

--- a/tests/ui/type-alias-impl-trait/method_resolution4.current.stderr
+++ b/tests/ui/type-alias-impl-trait/method_resolution4.current.stderr
@@ -8,7 +8,7 @@ LL |     fn foo(self: Bar<Foo>) {
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0307]: invalid `self` parameter type: `&Bar<Foo>`
-  --> $DIR/method_resolution4.rs:32:20
+  --> $DIR/method_resolution4.rs:31:20
    |
 LL |     fn foomp(self: &Bar<Foo>) {
    |                    ^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/method_resolution4.next.stderr
+++ b/tests/ui/type-alias-impl-trait/method_resolution4.next.stderr
@@ -1,15 +1,21 @@
-error[E0271]: type mismatch resolving `u32 == Foo`
+error[E0307]: invalid `self` parameter type: `Bar<Foo>`
   --> $DIR/method_resolution4.rs:27:18
    |
 LL |     fn foo(self: Bar<Foo>) {
-   |                  ^^^^^^^^ types differ
+   |                  ^^^^^^^^
+   |
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error[E0271]: type mismatch resolving `u32 == Foo`
-  --> $DIR/method_resolution4.rs:32:20
+error[E0307]: invalid `self` parameter type: `&Bar<Foo>`
+  --> $DIR/method_resolution4.rs:31:20
    |
 LL |     fn foomp(self: &Bar<Foo>) {
-   |                    ^^^^^^^^^ types differ
+   |                    ^^^^^^^^^
+   |
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0307`.

--- a/tests/ui/type-alias-impl-trait/method_resolution4.rs
+++ b/tests/ui/type-alias-impl-trait/method_resolution4.rs
@@ -25,13 +25,11 @@ impl Bar<Foo> {
 
 impl Bar<u32> {
     fn foo(self: Bar<Foo>) {
-        //[current]~^ ERROR: invalid `self` parameter
-        //[next]~^^ ERROR: type mismatch resolving `u32 == Foo`
+        //~^ ERROR: invalid `self` parameter
         self.bar()
     }
     fn foomp(self: &Bar<Foo>) {
-        //[current]~^ ERROR: invalid `self` parameter
-        //[next]~^^ ERROR: type mismatch resolving `u32 == Foo`
+        //~^ ERROR: invalid `self` parameter
         self.bar()
     }
 }


### PR DESCRIPTION
Fixes #127149

This is a somewhat targetted fix. I will investigate eliminating `can_eq` altogether.

r? lcnr