### PR TITLE
Mangle rustc_std_internal_symbols functions

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -26,6 +26,7 @@ extern crate rustc_index;
 extern crate rustc_metadata;
 extern crate rustc_session;
 extern crate rustc_span;
+extern crate rustc_symbol_mangling;
 extern crate rustc_target;
 #[macro_use]
 extern crate tracing;

--- a/compiler/rustc_codegen_gcc/src/allocator.rs
+++ b/compiler/rustc_codegen_gcc/src/allocator.rs
@@ -8,6 +8,7 @@ use rustc_ast::expand::allocator::{
 use rustc_middle::bug;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::config::OomStrategy;
+use rustc_symbol_mangling::mangle_internal_symbol;
 
 use crate::GccContext;
 #[cfg(feature = "master")]
@@ -53,8 +54,8 @@ pub(crate) unsafe fn codegen(
                     panic!("invalid allocator output")
                 }
             };
-            let from_name = global_fn_name(method.name);
-            let to_name = default_fn_name(method.name);
+            let from_name = mangle_internal_symbol(tcx, &global_fn_name(method.name));
+            let to_name = mangle_internal_symbol(tcx, &default_fn_name(method.name));
 
             create_wrapper_function(tcx, context, &from_name, &to_name, &types, output);
         }
@@ -64,13 +65,13 @@ pub(crate) unsafe fn codegen(
     create_wrapper_function(
         tcx,
         context,
-        "__rust_alloc_error_handler",
-        alloc_error_handler_name(alloc_error_handler_kind),
+        &mangle_internal_symbol(tcx, "__rust_alloc_error_handler"),
+        &mangle_internal_symbol(tcx, alloc_error_handler_name(alloc_error_handler_kind)),
         &[usize, usize],
         None,
     );
 
-    let name = OomStrategy::SYMBOL.to_string();
+    let name = mangle_internal_symbol(tcx, OomStrategy::SYMBOL);
     let global = context.new_global(None, GlobalKind::Exported, i8, name);
     #[cfg(feature = "master")]
     global.add_attribute(VarAttribute::Visibility(symbol_visibility_to_gcc(
@@ -80,7 +81,7 @@ pub(crate) unsafe fn codegen(
     let value = context.new_rvalue_from_int(i8, value as i32);
     global.global_set_initializer_rvalue(value);
 
-    let name = NO_ALLOC_SHIM_IS_UNSTABLE.to_string();
+    let name = mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE);
     let global = context.new_global(None, GlobalKind::Exported, i8, name);
     #[cfg(feature = "master")]
     global.add_attribute(VarAttribute::Visibility(symbol_visibility_to_gcc(

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -52,6 +52,7 @@ extern crate rustc_metadata;
 extern crate rustc_middle;
 extern crate rustc_session;
 extern crate rustc_span;
+extern crate rustc_symbol_mangling;
 extern crate rustc_target;
 
 // This prevents duplicating functions and statics that are already part of the host rustc process.

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -27,6 +27,7 @@ use rustc_session::config::{
 };
 use rustc_span::source_map::Spanned;
 use rustc_span::{DUMMY_SP, Span};
+use rustc_symbol_mangling::mangle_internal_symbol;
 use rustc_target::spec::{HasTargetSpec, RelocModel, SmallDataThresholdSupport, Target, TlsModel};
 use smallvec::SmallVec;
 
@@ -1199,7 +1200,7 @@ impl<'ll> CodegenCx<'ll, '_> {
             Some(def_id) => self.get_static(def_id),
             _ => {
                 let ty = self.type_struct(&[self.type_ptr(), self.type_ptr()], false);
-                self.declare_global("rust_eh_catch_typeinfo", ty)
+                self.declare_global(&mangle_internal_symbol(self.tcx, "rust_eh_catch_typeinfo"), ty)
             }
         };
         self.eh_catch_typeinfo.set(Some(eh_catch_typeinfo));

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -14,6 +14,7 @@ use rustc_middle::ty::layout::{FnAbiOf, HasTyCtxt, HasTypingEnv, LayoutOf};
 use rustc_middle::ty::{self, GenericArgsRef, Ty};
 use rustc_middle::{bug, span_bug};
 use rustc_span::{Span, Symbol, sym};
+use rustc_symbol_mangling::mangle_internal_symbol;
 use rustc_target::callconv::{FnAbi, PassMode};
 use rustc_target::spec::{HasTargetSpec, PanicStrategy};
 use tracing::debug;
@@ -812,7 +813,10 @@ fn codegen_msvc_try<'ll>(
         let type_name = bx.const_bytes(b"rust_panic\0");
         let type_info =
             bx.const_struct(&[type_info_vtable, bx.const_null(bx.type_ptr()), type_name], false);
-        let tydesc = bx.declare_global("__rust_panic_type_info", bx.val_ty(type_info));
+        let tydesc = bx.declare_global(
+            &mangle_internal_symbol(bx.tcx, "__rust_panic_type_info"),
+            bx.val_ty(type_info),
+        );
 
         llvm::set_linkage(tydesc, llvm::Linkage::LinkOnceODRLinkage);
         if bx.cx.tcx.sess.target.supports_comdat() {

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -174,6 +174,7 @@ impl CodegenFnAttrs {
     /// * `#[linkage]` is present
     pub fn contains_extern_indicator(&self) -> bool {
         self.flags.contains(CodegenFnAttrFlags::NO_MANGLE)
+            || self.flags.contains(CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL)
             || self.export_name.is_some()
             || match self.linkage {
                 // These are private, so make sure we don't try to consider

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -2203,7 +2203,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
 
     fn check_rustc_std_internal_symbol(&self, attr: &Attribute, span: Span, target: Target) {
         match target {
-            Target::Fn | Target::Static => {}
+            Target::Fn | Target::Static | Target::ForeignFn | Target::ForeignStatic => {}
             _ => {
                 self.tcx
                     .dcx()

--- a/compiler/rustc_passes/src/reachable.rs
+++ b/compiler/rustc_passes/src/reachable.rs
@@ -184,9 +184,7 @@ impl<'tcx> ReachableContext<'tcx> {
                 CodegenFnAttrs::EMPTY
             };
             let is_extern = codegen_attrs.contains_extern_indicator();
-            let std_internal =
-                codegen_attrs.flags.contains(CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL);
-            if is_extern || std_internal {
+            if is_extern {
                 self.reachable_symbols.insert(search_item);
             }
         } else {
@@ -426,7 +424,6 @@ fn has_custom_linkage(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     }
     let codegen_attrs = tcx.codegen_fn_attrs(def_id);
     codegen_attrs.contains_extern_indicator()
-        || codegen_attrs.flags.contains(CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL)
         // FIXME(nbdd0121): `#[used]` are marked as reachable here so it's picked up by
         // `linked_symbols` in cg_ssa. They won't be exported in binary or cdylib due to their
         // `SymbolExportLevel::Rust` export level but may end up being exported in dylibs.

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::hash::Hasher;
 use std::iter;
 use std::ops::Range;
 
@@ -6,6 +7,8 @@ use rustc_abi::{ExternAbi, Integer};
 use rustc_data_structures::base_n::ToBaseN;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::intern::Interned;
+use rustc_data_structures::stable_hasher::StableHasher;
+use rustc_hashes::Hash64;
 use rustc_hir as hir;
 use rustc_hir::def::CtorKind;
 use rustc_hir::def_id::{CrateNum, DefId};
@@ -67,6 +70,45 @@ pub(super) fn mangle<'tcx>(
     if let Some(instantiating_crate) = instantiating_crate {
         cx.print_def_path(instantiating_crate.as_def_id(), &[]).unwrap();
     }
+    std::mem::take(&mut cx.out)
+}
+
+pub fn mangle_internal_symbol<'tcx>(tcx: TyCtxt<'tcx>, item_name: &str) -> String {
+    let prefix = "_R";
+    let mut cx: SymbolMangler<'_> = SymbolMangler {
+        tcx,
+        start_offset: prefix.len(),
+        paths: FxHashMap::default(),
+        types: FxHashMap::default(),
+        consts: FxHashMap::default(),
+        binders: vec![],
+        out: String::from(prefix),
+    };
+
+    cx.path_append_ns(
+        |cx| {
+            cx.push("C");
+            cx.push_disambiguator({
+                let mut hasher = StableHasher::new();
+                // Incorporate the rustc version to ensure #[rustc_std_internal_symbol] functions
+                // get a different symbol name depending on the rustc version.
+                //
+                // RUSTC_FORCE_RUSTC_VERSION is ignored here as otherwise different we would get an
+                // abi incompatibility with the standard library.
+                hasher.write(tcx.sess.cfg_version.as_bytes());
+
+                let hash: Hash64 = hasher.finish();
+                hash.as_u64()
+            });
+            cx.push_ident("__rustc");
+            Ok(())
+        },
+        'v',
+        0,
+        item_name,
+    )
+    .unwrap();
+
     std::mem::take(&mut cx.out)
 }
 

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -74,6 +74,15 @@ pub(super) fn mangle<'tcx>(
 }
 
 pub fn mangle_internal_symbol<'tcx>(tcx: TyCtxt<'tcx>, item_name: &str) -> String {
+    if item_name == "rust_eh_personality" {
+        // rust_eh_personality must not be renamed as LLVM hard-codes the name
+        return "rust_eh_personality".to_owned();
+    } else if item_name == "__rust_no_alloc_shim_is_unstable" {
+        // Temporary back compat hack to give people the chance to migrate to
+        // include #[rustc_std_internal_symbol].
+        return "__rust_no_alloc_shim_is_unstable".to_owned();
+    }
+
     let prefix = "_R";
     let mut cx: SymbolMangler<'_> = SymbolMangler {
         tcx,

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -10,25 +10,28 @@ use core::ptr::{self, NonNull};
 
 unsafe extern "Rust" {
     // These are the magic symbols to call the global allocator. rustc generates
-    // them to call `__rg_alloc` etc. if there is a `#[global_allocator]` attribute
+    // them to call the global allocator if there is a `#[global_allocator]` attribute
     // (the code expanding that attribute macro generates those functions), or to call
     // the default implementations in std (`__rdl_alloc` etc. in `library/std/src/alloc.rs`)
     // otherwise.
-    // The rustc fork of LLVM 14 and earlier also special-cases these function names to be able to optimize them
-    // like `malloc`, `realloc`, and `free`, respectively.
     #[rustc_allocator]
     #[rustc_nounwind]
+    #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
     fn __rust_alloc(size: usize, align: usize) -> *mut u8;
     #[rustc_deallocator]
     #[rustc_nounwind]
+    #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
     #[rustc_reallocator]
     #[rustc_nounwind]
+    #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
     fn __rust_realloc(ptr: *mut u8, old_size: usize, align: usize, new_size: usize) -> *mut u8;
     #[rustc_allocator_zeroed]
     #[rustc_nounwind]
+    #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
     fn __rust_alloc_zeroed(size: usize, align: usize) -> *mut u8;
 
+    #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
     static __rust_no_alloc_shim_is_unstable: u8;
 }
 
@@ -357,6 +360,7 @@ unsafe extern "Rust" {
     // This is the magic symbol to call the global alloc error handler. rustc generates
     // it to call `__rg_oom` if there is a `#[alloc_error_handler]`, or to call the
     // default implementations below (`__rdl_oom`) otherwise.
+    #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
     fn __rust_alloc_error_handler(size: usize, align: usize) -> !;
 }
 
@@ -423,6 +427,7 @@ pub mod __alloc_error_handler {
         unsafe extern "Rust" {
             // This symbol is emitted by rustc next to __rust_alloc_error_handler.
             // Its value depends on the -Zoom={panic,abort} compiler option.
+            #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
             static __rust_alloc_error_handler_should_panic: u8;
         }
 

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -79,9 +79,11 @@ cfg_if::cfg_if! {
 unsafe extern "C" {
     /// Handler in std called when a panic object is dropped outside of
     /// `catch_unwind`.
+    #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
     fn __rust_drop_panic() -> !;
 
     /// Handler in std called when a foreign exception is caught.
+    #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
     fn __rust_foreign_exception() -> !;
 }
 

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -348,6 +348,7 @@ fn default_alloc_error_hook(layout: Layout) {
     unsafe extern "Rust" {
         // This symbol is emitted by rustc next to __rust_alloc_error_handler.
         // Its value depends on the -Zoom={panic,abort} compiler option.
+        #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
         static __rust_alloc_error_handler_should_panic: u8;
     }
 

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -55,12 +55,14 @@ pub static EMPTY_PANIC: fn(&'static str) -> ! =
 // hook up these functions, but it is not this day!
 #[allow(improper_ctypes)]
 unsafe extern "C" {
+    #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
     fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static);
 }
 
 unsafe extern "Rust" {
     /// `PanicPayload` lazily performs allocation only when needed (this avoids
     /// allocations when using the "abort" panic runtime).
+    #[cfg_attr(not(bootstrap), rustc_std_internal_symbol)]
     fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32;
 }
 

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -71,6 +71,7 @@ extern crate rustc_index;
 extern crate rustc_middle;
 extern crate rustc_session;
 extern crate rustc_span;
+extern crate rustc_symbol_mangling;
 extern crate rustc_target;
 // Linking `rustc_driver` pulls in the required  object code as the rest of the rustc crates are
 // shipped only as rmeta files.

--- a/src/tools/miri/src/shims/extern_static.rs
+++ b/src/tools/miri/src/shims/extern_static.rs
@@ -1,5 +1,7 @@
 //! Provides the `extern static` that this platform expects.
 
+use rustc_symbol_mangling::mangle_internal_symbol;
+
 use crate::*;
 
 impl<'tcx> MiriMachine<'tcx> {
@@ -50,7 +52,11 @@ impl<'tcx> MiriMachine<'tcx> {
         // "__rust_alloc_error_handler_should_panic"
         let val = ecx.tcx.sess.opts.unstable_opts.oom.should_panic();
         let val = ImmTy::from_int(val, ecx.machine.layouts.u8);
-        Self::alloc_extern_static(ecx, "__rust_alloc_error_handler_should_panic", val)?;
+        Self::alloc_extern_static(
+            ecx,
+            &mangle_internal_symbol(*ecx.tcx, "__rust_alloc_error_handler_should_panic"),
+            val,
+        )?;
 
         if ecx.target_os_is_unix() {
             // "environ" is mandated by POSIX.

--- a/src/tools/miri/tests/fail/alloc/too_large.rs
+++ b/src/tools/miri/tests/fail/alloc/too_large.rs
@@ -1,4 +1,7 @@
+#![feature(rustc_attrs)]
+
 extern "Rust" {
+    #[rustc_std_internal_symbol]
     fn __rust_alloc(size: usize, align: usize) -> *mut u8;
 }
 

--- a/src/tools/miri/tests/fail/alloc/unsupported_big_alignment.rs
+++ b/src/tools/miri/tests/fail/alloc/unsupported_big_alignment.rs
@@ -2,7 +2,10 @@
 // because rustc does not support alignments that large.
 // https://github.com/rust-lang/miri/issues/3687
 
+#![feature(rustc_attrs)]
+
 extern "Rust" {
+    #[rustc_std_internal_symbol]
     fn __rust_alloc(size: usize, align: usize) -> *mut u8;
 }
 

--- a/src/tools/miri/tests/fail/alloc/unsupported_non_power_two_alignment.rs
+++ b/src/tools/miri/tests/fail/alloc/unsupported_non_power_two_alignment.rs
@@ -1,5 +1,9 @@
 // Test non-power-of-two alignment.
+
+#![feature(rustc_attrs)]
+
 extern "Rust" {
+    #[rustc_std_internal_symbol]
     fn __rust_alloc(size: usize, align: usize) -> *mut u8;
 }
 

--- a/src/tools/miri/tests/fail/data_race/dealloc_read_race1.rs
+++ b/src/tools/miri/tests/fail/data_race/dealloc_read_race1.rs
@@ -3,6 +3,8 @@
 // Avoid accidental synchronization via address reuse inside `thread::spawn`.
 //@compile-flags: -Zmiri-address-reuse-cross-thread-rate=0
 
+#![feature(rustc_attrs)]
+
 use std::thread::spawn;
 
 #[derive(Copy, Clone)]
@@ -12,6 +14,7 @@ unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
 extern "Rust" {
+    #[rustc_std_internal_symbol]
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
 }
 

--- a/src/tools/miri/tests/fail/data_race/dealloc_read_race2.rs
+++ b/src/tools/miri/tests/fail/data_race/dealloc_read_race2.rs
@@ -3,6 +3,8 @@
 // Avoid accidental synchronization via address reuse inside `thread::spawn`.
 //@compile-flags: -Zmiri-address-reuse-cross-thread-rate=0
 
+#![feature(rustc_attrs)]
+
 use std::thread::spawn;
 
 #[derive(Copy, Clone)]
@@ -12,6 +14,7 @@ unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
 extern "Rust" {
+    #[rustc_std_internal_symbol]
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
 }
 

--- a/src/tools/miri/tests/fail/data_race/dealloc_write_race1.rs
+++ b/src/tools/miri/tests/fail/data_race/dealloc_write_race1.rs
@@ -3,6 +3,8 @@
 // Avoid accidental synchronization via address reuse inside `thread::spawn`.
 //@compile-flags: -Zmiri-address-reuse-cross-thread-rate=0
 
+#![feature(rustc_attrs)]
+
 use std::thread::spawn;
 
 #[derive(Copy, Clone)]
@@ -12,6 +14,7 @@ unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
 extern "Rust" {
+    #[rustc_std_internal_symbol]
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
 }
 pub fn main() {

--- a/src/tools/miri/tests/fail/data_race/dealloc_write_race2.rs
+++ b/src/tools/miri/tests/fail/data_race/dealloc_write_race2.rs
@@ -3,6 +3,8 @@
 // Avoid accidental synchronization via address reuse inside `thread::spawn`.
 //@compile-flags: -Zmiri-address-reuse-cross-thread-rate=0
 
+#![feature(rustc_attrs)]
+
 use std::thread::spawn;
 
 #[derive(Copy, Clone)]
@@ -12,6 +14,7 @@ unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
 extern "Rust" {
+    #[rustc_std_internal_symbol]
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
 }
 pub fn main() {

--- a/src/tools/miri/tests/pass/function_calls/exported_symbol.rs
+++ b/src/tools/miri/tests/pass/function_calls/exported_symbol.rs
@@ -40,6 +40,7 @@ fn main() {
 
         extern "Rust" {
             fn bar() -> i32;
+            #[rustc_std_internal_symbol]
             fn baz() -> i32;
             fn qux() -> i32;
         }
@@ -63,6 +64,7 @@ fn main() {
 
             extern "C" {
                 fn bar() -> i32;
+                #[rustc_std_internal_symbol]
                 fn baz() -> i32;
                 fn qux() -> i32;
             }

--- a/tests/codegen/alloc-optimisation.rs
+++ b/tests/codegen/alloc-optimisation.rs
@@ -5,7 +5,7 @@
 pub fn alloc_test(data: u32) {
     // CHECK-LABEL: @alloc_test
     // CHECK-NEXT: start:
-    // CHECK-NEXT: {{.*}} load volatile i8, ptr @__rust_no_alloc_shim_is_unstable, align 1
+    // CHECK-NEXT: {{.*}} load volatile i8, ptr @{{.*}}__rust_no_alloc_shim_is_unstable, align 1
     // CHECK-NEXT: ret void
     let x = Box::new(data);
     drop(x);

--- a/tests/codegen/box-uninit-bytes.rs
+++ b/tests/codegen/box-uninit-bytes.rs
@@ -41,6 +41,6 @@ pub fn box_lotsa_padding() -> Box<LotsaPadding> {
 
 // Hide the `allocalign` attribute in the declaration of __rust_alloc
 // from the CHECK-NOT above, and also verify the attributes got set reasonably.
-// CHECK: declare {{(dso_local )?}}noalias noundef ptr @__rust_alloc(i{{[0-9]+}} noundef, i{{[0-9]+}} allocalign noundef) unnamed_addr [[RUST_ALLOC_ATTRS:#[0-9]+]]
+// CHECK: declare {{(dso_local )?}}noalias noundef ptr @{{.*}}__rust_alloc(i{{[0-9]+}} noundef, i{{[0-9]+}} allocalign noundef) unnamed_addr [[RUST_ALLOC_ATTRS:#[0-9]+]]
 
 // CHECK-DAG: attributes [[RUST_ALLOC_ATTRS]] = { {{.*}} allockind("alloc,uninitialized,aligned") allocsize(0) {{(uwtable )?}}"alloc-family"="__rust_alloc" {{.*}} }

--- a/tests/codegen/dealloc-no-unwind.rs
+++ b/tests/codegen/dealloc-no-unwind.rs
@@ -18,7 +18,7 @@ impl Drop for A {
 #[no_mangle]
 pub fn a(a: Box<i32>) {
     // CHECK-LABEL: define{{.*}}void @a
-    // CHECK: call void @__rust_dealloc
+    // CHECK: call void @{{.*}}__rust_dealloc
     // CHECK-NEXT: call void @foo
     let _a = A;
     drop(a);

--- a/tests/codegen/iter-repeat-n-trivial-drop.rs
+++ b/tests/codegen/iter-repeat-n-trivial-drop.rs
@@ -47,7 +47,7 @@ pub fn iter_repeat_n_next(it: &mut std::iter::RepeatN<NotCopy>) -> Option<NotCop
 #[no_mangle]
 // CHECK-LABEL: @vec_extend_via_iter_repeat_n
 pub fn vec_extend_via_iter_repeat_n() -> Vec<u8> {
-    // CHECK: %[[ADDR:.+]] = tail call {{(noalias )?}}noundef dereferenceable_or_null(1234) ptr @__rust_alloc(i64 noundef {{(range\(i64 1, 0\) )?}}1234, i64 noundef {{(range\(i64 1, -9223372036854775807\) )?}}1)
+    // CHECK: %[[ADDR:.+]] = tail call {{(noalias )?}}noundef dereferenceable_or_null(1234) ptr @{{.*}}__rust_alloc(i64 noundef {{(range\(i64 1, 0\) )?}}1234, i64 noundef {{(range\(i64 1, -9223372036854775807\) )?}}1)
     // CHECK: tail call void @llvm.memset.p0.i64(ptr noundef nonnull align 1 dereferenceable(1234) %[[ADDR]], i8 42, i64 1234,
 
     let n = 1234_usize;

--- a/tests/codegen/vec-calloc.rs
+++ b/tests/codegen/vec-calloc.rs
@@ -177,6 +177,6 @@ pub fn vec_option_i32(n: usize) -> Vec<Option<i32>> {
 }
 
 // Ensure that __rust_alloc_zeroed gets the right attributes for LLVM to optimize it away.
-// CHECK: declare noalias noundef ptr @__rust_alloc_zeroed(i64 noundef, i64 allocalign noundef) unnamed_addr [[RUST_ALLOC_ZEROED_ATTRS:#[0-9]+]]
+// CHECK: declare noalias noundef ptr @{{.*}}__rust_alloc_zeroed(i64 noundef, i64 allocalign noundef) unnamed_addr [[RUST_ALLOC_ZEROED_ATTRS:#[0-9]+]]
 
 // CHECK-DAG: attributes [[RUST_ALLOC_ZEROED_ATTRS]] = { {{.*}} allockind("alloc,zeroed,aligned") allocsize(0) uwtable "alloc-family"="__rust_alloc" {{.*}} }

--- a/tests/codegen/vec-optimizes-away.rs
+++ b/tests/codegen/vec-optimizes-away.rs
@@ -5,7 +5,7 @@
 pub fn sum_me() -> i32 {
     // CHECK-LABEL: @sum_me
     // CHECK-NEXT: {{^.*:$}}
-    // CHECK-NEXT: {{.*}} load volatile i8, ptr @__rust_no_alloc_shim_is_unstable, align 1
+    // CHECK-NEXT: {{.*}} load volatile i8, ptr @{{.*}}__rust_no_alloc_shim_is_unstable, align 1
     // CHECK-NEXT: ret i32 6
     vec![1, 2, 3].iter().sum::<i32>()
 }

--- a/tests/run-make/symbols-all-mangled/a_lib.rs
+++ b/tests/run-make/symbols-all-mangled/a_lib.rs
@@ -1,0 +1,1 @@
+pub fn public_rust_function() {}

--- a/tests/run-make/symbols-all-mangled/an_executable.rs
+++ b/tests/run-make/symbols-all-mangled/an_executable.rs
@@ -1,0 +1,3 @@
+pub fn public_rust_function_from_exe() {}
+
+fn main() {}

--- a/tests/run-make/symbols-all-mangled/rmake.rs
+++ b/tests/run-make/symbols-all-mangled/rmake.rs
@@ -1,4 +1,5 @@
 // Check that all symbols in cdylibs, staticlibs and bins are mangled
+//@ only-elf some object file formats create multiple symbols for each function with different names
 
 use run_make_support::object::read::{Object, ObjectSymbol};
 use run_make_support::{bin_name, dynamic_lib_name, object, rfs, rustc, static_lib_name};

--- a/tests/run-make/symbols-all-mangled/rmake.rs
+++ b/tests/run-make/symbols-all-mangled/rmake.rs
@@ -59,20 +59,19 @@ fn symbols_check(path: &str) {
             continue; // Correctly mangled
         }
 
+        if !name.contains("rust") {
+            // Assume that this symbol doesn't originate from rustc. This may
+            // be wrong, but even if so symbol_check_archive will likely
+            // catch it.
+            continue;
+        }
+
         if name == "__rust_no_alloc_shim_is_unstable" {
             continue; // FIXME remove exception once we mangle this symbol
         }
 
         if name.contains("rust_eh_personality") {
             continue; // Unfortunately LLVM doesn't allow us to mangle this symbol
-        }
-
-        if ["_start", "__dso_handle", "_init", "_fini", "__TMC_END__"].contains(&name) {
-            continue; // Part of the libc crt object
-        }
-
-        if name == "main" {
-            continue; // The main symbol has to be unmangled for the crt object to find it
         }
 
         panic!("Unmangled symbol found: {name}");

--- a/tests/run-make/symbols-all-mangled/rmake.rs
+++ b/tests/run-make/symbols-all-mangled/rmake.rs
@@ -1,0 +1,84 @@
+// Check that all symbols in cdylibs, staticlibs and bins are mangled
+
+use run_make_support::object::read::{Object, ObjectSymbol};
+use run_make_support::{bin_name, dynamic_lib_name, object, rfs, rustc, static_lib_name};
+
+fn main() {
+    let staticlib_name = static_lib_name("a_lib");
+    let cdylib_name = dynamic_lib_name("a_lib");
+    let exe_name = bin_name("an_executable");
+    rustc().crate_type("cdylib").input("a_lib.rs").run();
+    rustc().crate_type("staticlib").input("a_lib.rs").run();
+    rustc().crate_type("bin").input("an_executable.rs").run();
+
+    symbols_check_archive(&staticlib_name);
+    symbols_check(&cdylib_name);
+    symbols_check(&exe_name);
+}
+
+fn symbols_check_archive(path: &str) {
+    let binary_data = rfs::read(path);
+    let file = object::read::archive::ArchiveFile::parse(&*binary_data).unwrap();
+    for symbol in file.symbols().unwrap().unwrap() {
+        let symbol = symbol.unwrap();
+        let name = strip_underscore_if_apple(std::str::from_utf8(symbol.name()).unwrap());
+        if name.starts_with("_ZN") || name.starts_with("_R") {
+            continue; // Correctly mangled
+        }
+
+        let member_name =
+            std::str::from_utf8(file.member(symbol.offset()).unwrap().name()).unwrap();
+        if !member_name.ends_with(".rcgu.o") || member_name.contains("compiler_builtins") {
+            continue; // All compiler-builtins symbols must remain unmangled
+        }
+
+        if name == "__rust_no_alloc_shim_is_unstable" {
+            continue; // FIXME remove exception once we mangle this symbol
+        }
+
+        if name.contains("rust_eh_personality") {
+            continue; // Unfortunately LLVM doesn't allow us to mangle this symbol
+        }
+
+        panic!("Unmangled symbol found: {name}");
+    }
+}
+
+fn symbols_check(path: &str) {
+    let binary_data = rfs::read(path);
+    let file = object::File::parse(&*binary_data).unwrap();
+    for symbol in file.symbols() {
+        if !symbol.is_definition() || !symbol.is_global() {
+            continue;
+        }
+        if symbol.is_weak() {
+            continue; // Likely an intrinsic from compiler-builtins
+        }
+        let name = strip_underscore_if_apple(symbol.name().unwrap());
+        if name.starts_with("_ZN") || name.starts_with("_R") {
+            continue; // Correctly mangled
+        }
+
+        if name == "__rust_no_alloc_shim_is_unstable" {
+            continue; // FIXME remove exception once we mangle this symbol
+        }
+
+        if name.contains("rust_eh_personality") {
+            continue; // Unfortunately LLVM doesn't allow us to mangle this symbol
+        }
+
+        if ["_start", "__dso_handle", "_init", "_fini", "__TMC_END__"].contains(&name) {
+            continue; // Part of the libc crt object
+        }
+
+        if name == "main" {
+            continue; // The main symbol has to be unmangled for the crt object to find it
+        }
+
+        panic!("Unmangled symbol found: {name}");
+    }
+}
+
+fn strip_underscore_if_apple(symbol: &str) -> &str {
+    if cfg!(target_vendor = "apple") { symbol.strip_prefix("_").unwrap() } else { symbol }
+}


### PR DESCRIPTION
This reduces the risk of issues when using a staticlib or rust dylib compiled with a different rustc version in a rust program. Currently this will either (in the case of staticlib) cause a linker error due to duplicate symbol definitions, or (in the case of rust dylibs) cause rustc_std_internal_symbols functions to be silently overridden. As rust gets more commonly used inside the implementation of libraries consumed with a C interface (like Spidermonkey, Ruby YJIT (curently has to do partial linking of all rust code to hide all symbols not part of the C api), the Rusticl OpenCL implementation in mesa) this is becoming much more of an issue. With this PR the only symbols remaining with an unmangled name are rust_eh_personality (LLVM doesn't allow renaming it) and `__rust_no_alloc_shim_is_unstable`.

Helps mitigate https://github.com/rust-lang/rust/issues/104707

try-job: aarch64-gnu-debug
try-job: aarch64-apple
try-job: x86_64-apple-1
try-job: x86_64-mingw-1
try-job: i686-mingw-1
try-job: x86_64-msvc-1
try-job: i686-msvc-1
try-job: test-various
try-job: armhf-gnu