### PR TITLE
Compiletest: Panic on Invalid Source File

### DIFF
--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -324,6 +324,11 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
 
     assert!(opts.fail_fast || st.current_test_count() == st.total);
 
+    // Check if any filter is applied to an invalid test file (e.g .stderr)
+    if !opts.filters.is_empty() && st.total == 0 {
+        panic!("\nno tests were run for the given filters: {:?}\n", opts.filters);
+    }
+
     out.write_run_finish(&st)
 }
 


### PR DESCRIPTION
Fixes  #126601

This PR makes compiletest print a warning message when a non `.rs` file is passed as argument.

This warning applies to not just UI tests because other (e.g.: coverage test) tests have non `.rs` files too.

Also, decided to not return an error because `rustc` accepts non `.rs` files with valid source code.

Please let me know if I should add some kind of test for this.