### PR TITLE
Print `TypeId` as hex for debugging

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -673,7 +673,7 @@ impl hash::Hash for TypeId {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for TypeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.debug_tuple("TypeId").field(&self.as_u128()).finish()
+        write!(f, "TypeId({:#034x})", self.as_u128())
     }
 }
 


### PR DESCRIPTION
In <https://github.com/rust-lang/rust/pull/127134>, the `Debug` impl for `TypeId` was changed to print a single integer rather than a tuple. Change this again to print as hex for more concise and consistent formatting, as was suggested.

Result:

    TypeId(0x1378bb1c0a0202683eb65e7c11f2e4d7)

<!-- homu-ignore:start -->
r? @Nilstrieb 
<!-- homu-ignore:end -->
