### PR TITLE
Preserve UTF-8 + UTF-8 = UTF-8 for Wtf8Buf

### DIFF
--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -474,13 +474,11 @@ impl Wtf8Buf {
         Wtf8Buf { bytes: bytes.into_vec(), is_known_utf8: false }
     }
 
-    /// Provides plumbing to core `Vec::extend_from_slice`.
-    /// More well behaving alternative to allowing outer types
-    /// full mutable access to the core `Vec`.
+    /// Push bytes into a Wtf8Buf, checking if the result is still UTF-8
     #[inline]
     pub(crate) fn extend_from_slice(&mut self, other: &[u8]) {
+        self.is_known_utf8 = self.is_known_utf8 && str::from_utf8(other).is_ok();
         self.bytes.extend_from_slice(other);
-        self.is_known_utf8 = false;
     }
 }
 

--- a/library/std/src/sys_common/wtf8/tests.rs
+++ b/library/std/src/sys_common/wtf8/tests.rs
@@ -757,3 +757,11 @@ fn unwobbly_wtf8_plus_wobbled_bytes_isnt_utf8() {
     string.extend_from_slice(b"\xED\xa0\x80");
     assert!(!string.is_known_utf8);
 }
+
+#[test]
+fn unwobbly_wtf8_plus_unwobbly_bytes_is_utf8() {
+    let mut string: Wtf8Buf = Wtf8Buf::from_str("hello world");
+    assert!(string.is_known_utf8);
+    string.extend_from_slice(b"some utf-8");
+    assert!(string.is_known_utf8);
+}

--- a/library/std/src/sys_common/wtf8/tests.rs
+++ b/library/std/src/sys_common/wtf8/tests.rs
@@ -743,9 +743,17 @@ fn wobbled_wtf8_plus_str_isnt_utf8() {
 }
 
 #[test]
-fn unwobbly_wtf8_plus_utf8_is_utf8() {
+fn unwobbly_wtf8_plus_str_is_utf8() {
     let mut string: Wtf8Buf = Wtf8Buf::from_str("hello world");
     assert!(string.is_known_utf8);
     string.push_str("some utf-8");
     assert!(string.is_known_utf8);
+}
+
+#[test]
+fn unwobbly_wtf8_plus_wobbled_bytes_isnt_utf8() {
+    let mut string: Wtf8Buf = Wtf8Buf::from_str("hello world");
+    assert!(string.is_known_utf8);
+    string.extend_from_slice(b"\xED\xa0\x80");
+    assert!(!string.is_known_utf8);
 }


### PR DESCRIPTION
When using `extend_from_slice` to add UTF-8 bytes that aren't statically verified as UTF-8 (by being `str`) to Wtf8Buf, this should make `is_known_utf8` remain `true` if the addition is also UTF-8.

r? @ghost

try-job: x86_64-msvc