### PR TITLE
Fallback on unix filesystem's remove_dir_impl for target vxworks

### DIFF
--- a/library/std/src/sys/pal/unix/fs.rs
+++ b/library/std/src/sys/pal/unix/fs.rs
@@ -1976,13 +1976,14 @@ pub fn chroot(dir: &Path) -> io::Result<()> {
 
 pub use remove_dir_impl::remove_dir_all;
 
-// Fallback for REDOX, ESP-ID, Horizon, Vita and Miri
+// Fallback for REDOX, ESP-ID, Horizon, Vita, Vxworks and Miri
 #[cfg(any(
     target_os = "redox",
     target_os = "espidf",
     target_os = "horizon",
     target_os = "vita",
     target_os = "nto",
+    target_os = "vxworks",
     miri
 ))]
 mod remove_dir_impl {
@@ -1996,6 +1997,7 @@ mod remove_dir_impl {
     target_os = "horizon",
     target_os = "vita",
     target_os = "nto",
+    target_os = "vxworks",
     miri
 )))]
 mod remove_dir_impl {


### PR DESCRIPTION
Hi all, 
I'm skipping the unix filesystem remove_dir_impl for target vxworks. As seen in the error #127084, remove_dir_impl need libc imports fdopendir, openat, unlinkat. These need to be introduced in libc and tested for vxworks. Thus we are temporarily falling back on remove_dir_impl as our priority is to get a successful build on vxworks.

Thank you.