### PR TITLE
coverage: Extract hole spans from HIR instead of MIR

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -8,7 +8,7 @@ use rustc_span::Span;
 use crate::coverage::graph::{BasicCoverageBlock, CoverageGraph};
 use crate::coverage::mappings;
 use crate::coverage::spans::from_mir::{
-    extract_covspans_and_holes_from_mir, ExtractedCovspans, Hole, SpanFromMir,
+    extract_covspans_from_mir, ExtractedCovspans, Hole, SpanFromMir,
 };
 use crate::coverage::ExtractedHirInfo;
 
@@ -20,8 +20,8 @@ pub(super) fn extract_refined_covspans(
     basic_coverage_blocks: &CoverageGraph,
     code_mappings: &mut impl Extend<mappings::CodeMapping>,
 ) {
-    let ExtractedCovspans { mut covspans, mut holes } =
-        extract_covspans_and_holes_from_mir(mir_body, hir_info, basic_coverage_blocks);
+    let ExtractedCovspans { mut covspans } =
+        extract_covspans_from_mir(mir_body, hir_info, basic_coverage_blocks);
 
     // First, perform the passes that need macro information.
     covspans.sort_by(|a, b| basic_coverage_blocks.cmp_in_dominator_order(a.bcb, b.bcb));
@@ -45,6 +45,7 @@ pub(super) fn extract_refined_covspans(
     covspans.dedup_by(|b, a| a.span.source_equal(b.span));
 
     // Sort the holes, and merge overlapping/adjacent holes.
+    let mut holes = hir_info.hole_spans.iter().map(|&span| Hole { span }).collect::<Vec<_>>();
     holes.sort_by(|a, b| compare_spans(a.span, b.span));
     holes.dedup_by(|b, a| a.merge_if_overlapping_or_adjacent(b));
 

--- a/tests/coverage-run-rustdoc/doctest.coverage
+++ b/tests/coverage-run-rustdoc/doctest.coverage
@@ -34,10 +34,10 @@ $DIR/doctest.rs:
    LL|       |//!
    LL|       |//! doctest returning a result:
    LL|      1|//! ```
-   LL|      1|//! #[derive(Debug, PartialEq)]
-   LL|      1|//! struct SomeError {
-   LL|      1|//!     msg: String,
-   LL|      1|//! }
+   LL|       |//! #[derive(Debug, PartialEq)]
+   LL|       |//! struct SomeError {
+   LL|       |//!     msg: String,
+   LL|       |//! }
    LL|      1|//! let mut res = Err(SomeError { msg: String::from("a message") });
    LL|      1|//! if res.is_ok() {
    LL|      0|//!     res?;

--- a/tests/coverage/async.cov-map
+++ b/tests/coverage/async.cov-map
@@ -167,15 +167,16 @@ Number of file 0 mappings: 14
     = ((c6 + c7) + c8)
 
 Function name: async::j
-Raw bytes (53): 0x[01, 01, 02, 07, 0d, 05, 09, 09, 01, 35, 01, 13, 0c, 05, 14, 09, 00, 0a, 01, 00, 0e, 00, 1b, 05, 00, 1f, 00, 27, 09, 01, 09, 00, 0a, 11, 00, 0e, 00, 1a, 09, 00, 1e, 00, 20, 0d, 01, 0e, 00, 10, 03, 02, 01, 00, 02]
+Raw bytes (58): 0x[01, 01, 02, 07, 0d, 05, 09, 0a, 01, 35, 01, 00, 0d, 01, 0b, 0b, 00, 0c, 05, 01, 09, 00, 0a, 01, 00, 0e, 00, 1b, 05, 00, 1f, 00, 27, 09, 01, 09, 00, 0a, 11, 00, 0e, 00, 1a, 09, 00, 1e, 00, 20, 0d, 01, 0e, 00, 10, 03, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 2
 - expression 0 operands: lhs = Expression(1, Add), rhs = Counter(3)
 - expression 1 operands: lhs = Counter(1), rhs = Counter(2)
-Number of file 0 mappings: 9
-- Code(Counter(0)) at (prev + 53, 1) to (start + 19, 12)
-- Code(Counter(1)) at (prev + 20, 9) to (start + 0, 10)
+Number of file 0 mappings: 10
+- Code(Counter(0)) at (prev + 53, 1) to (start + 0, 13)
+- Code(Counter(0)) at (prev + 11, 11) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 10)
 - Code(Counter(0)) at (prev + 0, 14) to (start + 0, 27)
 - Code(Counter(1)) at (prev + 0, 31) to (start + 0, 39)
 - Code(Counter(2)) at (prev + 1, 9) to (start + 0, 10)
@@ -186,7 +187,7 @@ Number of file 0 mappings: 9
     = ((c1 + c2) + c3)
 
 Function name: async::j::c
-Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 37, 05, 01, 12, 05, 02, 0d, 00, 0e, 02, 0a, 0d, 00, 0e, 01, 02, 05, 00, 06]
+Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 37, 05, 01, 12, 05, 02, 0d, 00, 0e, 02, 02, 0d, 00, 0e, 01, 02, 05, 00, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
@@ -194,40 +195,40 @@ Number of expressions: 1
 Number of file 0 mappings: 4
 - Code(Counter(0)) at (prev + 55, 5) to (start + 1, 18)
 - Code(Counter(1)) at (prev + 2, 13) to (start + 0, 14)
-- Code(Expression(0, Sub)) at (prev + 10, 13) to (start + 0, 14)
+- Code(Expression(0, Sub)) at (prev + 2, 13) to (start + 0, 14)
     = (c0 - c1)
 - Code(Counter(0)) at (prev + 2, 5) to (start + 0, 6)
 
 Function name: async::j::d
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 46, 05, 00, 17]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 3e, 05, 00, 17]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 70, 5) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 62, 5) to (start + 0, 23)
 
 Function name: async::j::f
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 47, 05, 00, 17]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 3f, 05, 00, 17]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 71, 5) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 63, 5) to (start + 0, 23)
 
 Function name: async::k (unused)
-Raw bytes (29): 0x[01, 01, 00, 05, 00, 4f, 01, 01, 0c, 00, 02, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
+Raw bytes (29): 0x[01, 01, 00, 05, 00, 47, 01, 01, 0c, 00, 02, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 5
-- Code(Zero) at (prev + 79, 1) to (start + 1, 12)
+- Code(Zero) at (prev + 71, 1) to (start + 1, 12)
 - Code(Zero) at (prev + 2, 14) to (start + 0, 16)
 - Code(Zero) at (prev + 1, 14) to (start + 0, 16)
 - Code(Zero) at (prev + 1, 14) to (start + 0, 16)
 - Code(Zero) at (prev + 2, 1) to (start + 0, 2)
 
 Function name: async::l
-Raw bytes (37): 0x[01, 01, 04, 01, 07, 05, 09, 0f, 02, 09, 05, 05, 01, 57, 01, 01, 0c, 02, 02, 0e, 00, 10, 05, 01, 0e, 00, 10, 09, 01, 0e, 00, 10, 0b, 02, 01, 00, 02]
+Raw bytes (37): 0x[01, 01, 04, 01, 07, 05, 09, 0f, 02, 09, 05, 05, 01, 4f, 01, 01, 0c, 02, 02, 0e, 00, 10, 05, 01, 0e, 00, 10, 09, 01, 0e, 00, 10, 0b, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 4
@@ -236,7 +237,7 @@ Number of expressions: 4
 - expression 2 operands: lhs = Expression(3, Add), rhs = Expression(0, Sub)
 - expression 3 operands: lhs = Counter(2), rhs = Counter(1)
 Number of file 0 mappings: 5
-- Code(Counter(0)) at (prev + 87, 1) to (start + 1, 12)
+- Code(Counter(0)) at (prev + 79, 1) to (start + 1, 12)
 - Code(Expression(0, Sub)) at (prev + 2, 14) to (start + 0, 16)
     = (c0 - (c1 + c2))
 - Code(Counter(1)) at (prev + 1, 14) to (start + 0, 16)
@@ -245,26 +246,26 @@ Number of file 0 mappings: 5
     = ((c2 + c1) + (c0 - (c1 + c2)))
 
 Function name: async::m
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 5f, 01, 00, 19]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 57, 01, 00, 19]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 95, 1) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 87, 1) to (start + 0, 25)
 
 Function name: async::m::{closure#0} (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 5f, 19, 00, 22]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 57, 19, 00, 22]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 95, 25) to (start + 0, 34)
+- Code(Zero) at (prev + 87, 25) to (start + 0, 34)
 
 Function name: async::main
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 61, 01, 08, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 59, 01, 08, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 97, 1) to (start + 8, 2)
+- Code(Counter(0)) at (prev + 89, 1) to (start + 8, 2)
 

--- a/tests/coverage/async.coverage
+++ b/tests/coverage/async.coverage
@@ -53,25 +53,15 @@
    LL|      1|}
    LL|       |
    LL|      1|fn j(x: u8) {
-   LL|      1|    // non-async versions of `c()`, `d()`, and `f()` to make it similar to async `i()`.
+   LL|       |    // non-async versions of `c()`, `d()`, and `f()` to make it similar to async `i()`.
    LL|      1|    fn c(x: u8) -> u8 {
    LL|      1|        if x == 8 {
-   LL|      1|            1 // This line appears covered, but the 1-character expression span covering the `1`
-                          ^0
-   LL|      1|              // is not executed. (`llvm-cov show` displays a `^0` below the `1` ). This is because
-   LL|      1|              // `fn j()` executes the open brace for the function body, followed by the function's
-   LL|      1|              // first executable statement, `match x`. Inner function declarations are not
-   LL|      1|              // "visible" to the MIR for `j()`, so the code region counts all lines between the
-   LL|      1|              // open brace and the first statement as executed, which is, in a sense, true.
-   LL|      1|              // `llvm-cov show` overcomes this kind of situation by showing the actual counts
-   LL|      1|              // of the enclosed coverages, (that is, the `1` expression was not executed, and
-   LL|      1|              // accurately displays a `0`).
-   LL|      1|        } else {
+   LL|      0|            1
+   LL|       |        } else {
    LL|      1|            0
-   LL|      1|        }
+   LL|       |        }
    LL|      1|    }
-   LL|      1|    fn d() -> u8 { 1 } // inner function is defined in-line, but the function is not executed
-                  ^0
+   LL|      0|    fn d() -> u8 { 1 } // inner function is defined in-line, but the function is not executed
    LL|      1|    fn f() -> u8 { 1 }
    LL|      1|    match x {
    LL|      1|        y if c(x) == y + 1 => { d(); }

--- a/tests/coverage/async.rs
+++ b/tests/coverage/async.rs
@@ -54,15 +54,7 @@ fn j(x: u8) {
     // non-async versions of `c()`, `d()`, and `f()` to make it similar to async `i()`.
     fn c(x: u8) -> u8 {
         if x == 8 {
-            1 // This line appears covered, but the 1-character expression span covering the `1`
-              // is not executed. (`llvm-cov show` displays a `^0` below the `1` ). This is because
-              // `fn j()` executes the open brace for the function body, followed by the function's
-              // first executable statement, `match x`. Inner function declarations are not
-              // "visible" to the MIR for `j()`, so the code region counts all lines between the
-              // open brace and the first statement as executed, which is, in a sense, true.
-              // `llvm-cov show` overcomes this kind of situation by showing the actual counts
-              // of the enclosed coverages, (that is, the `1` expression was not executed, and
-              // accurately displays a `0`).
+            1
         } else {
             0
         }

--- a/tests/coverage/attr/nested.cov-map
+++ b/tests/coverage/attr/nested.cov-map
@@ -1,18 +1,18 @@
 Function name: nested::closure_expr
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 44, 01, 01, 0f, 01, 0b, 05, 01, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 3f, 01, 01, 0f, 01, 0b, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 68, 1) to (start + 1, 15)
+- Code(Counter(0)) at (prev + 63, 1) to (start + 1, 15)
 - Code(Counter(0)) at (prev + 11, 5) to (start + 1, 2)
 
 Function name: nested::closure_tail
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 53, 01, 01, 0f, 01, 11, 05, 01, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 4e, 01, 01, 0f, 01, 11, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 83, 1) to (start + 1, 15)
+- Code(Counter(0)) at (prev + 78, 1) to (start + 1, 15)
 - Code(Counter(0)) at (prev + 17, 5) to (start + 1, 2)
 

--- a/tests/coverage/attr/nested.coverage
+++ b/tests/coverage/attr/nested.coverage
@@ -4,11 +4,6 @@
    LL|       |// Demonstrates the interaction between #[coverage(off)] and various kinds of
    LL|       |// nested function.
    LL|       |
-   LL|       |// FIXME(#126625): Coverage attributes should apply recursively to nested functions.
-   LL|       |// FIXME(#126626): When an inner (non-closure) function has `#[coverage(off)]`,
-   LL|       |// its lines can still be marked with misleading execution counts from its enclosing
-   LL|       |// function.
-   LL|       |
    LL|       |#[coverage(off)]
    LL|       |fn do_stuff() {}
    LL|       |

--- a/tests/coverage/attr/nested.rs
+++ b/tests/coverage/attr/nested.rs
@@ -4,11 +4,6 @@
 // Demonstrates the interaction between #[coverage(off)] and various kinds of
 // nested function.
 
-// FIXME(#126625): Coverage attributes should apply recursively to nested functions.
-// FIXME(#126626): When an inner (non-closure) function has `#[coverage(off)]`,
-// its lines can still be marked with misleading execution counts from its enclosing
-// function.
-
 #[coverage(off)]
 fn do_stuff() {}
 

--- a/tests/coverage/attr/off-on-sandwich.cov-map
+++ b/tests/coverage/attr/off-on-sandwich.cov-map
@@ -1,24 +1,27 @@
 Function name: off_on_sandwich::dense_a::dense_b
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 14, 05, 07, 06]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 0f, 05, 02, 12, 01, 07, 05, 00, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 20, 5) to (start + 7, 6)
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 15, 5) to (start + 2, 18)
+- Code(Counter(0)) at (prev + 7, 5) to (start + 0, 6)
 
 Function name: off_on_sandwich::sparse_a::sparse_b::sparse_c
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 26, 09, 0b, 0a]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 21, 09, 02, 17, 01, 0b, 09, 00, 0a]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 38, 9) to (start + 11, 10)
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 33, 9) to (start + 2, 23)
+- Code(Counter(0)) at (prev + 11, 9) to (start + 0, 10)
 
 Function name: off_on_sandwich::sparse_a::sparse_b::sparse_c::sparse_d
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 29, 0d, 07, 0e]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 24, 0d, 02, 1b, 01, 07, 0d, 00, 0e]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 41, 13) to (start + 7, 14)
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 36, 13) to (start + 2, 27)
+- Code(Counter(0)) at (prev + 7, 13) to (start + 0, 14)
 

--- a/tests/coverage/attr/off-on-sandwich.coverage
+++ b/tests/coverage/attr/off-on-sandwich.coverage
@@ -4,11 +4,6 @@
    LL|       |// Demonstrates the interaction of `#[coverage(off)]` and `#[coverage(on)]`
    LL|       |// in nested functions.
    LL|       |
-   LL|       |// FIXME(#126625): Coverage attributes should apply recursively to nested functions.
-   LL|       |// FIXME(#126626): When an inner (non-closure) function has `#[coverage(off)]`,
-   LL|       |// its lines can still be marked with misleading execution counts from its enclosing
-   LL|       |// function.
-   LL|       |
    LL|       |#[coverage(off)]
    LL|       |fn do_stuff() {}
    LL|       |
@@ -20,10 +15,10 @@
    LL|      2|    fn dense_b() {
    LL|      2|        dense_c();
    LL|      2|        dense_c();
-   LL|      2|        #[coverage(off)]
-   LL|      2|        fn dense_c() {
-   LL|      2|            do_stuff();
-   LL|      2|        }
+   LL|       |        #[coverage(off)]
+   LL|       |        fn dense_c() {
+   LL|       |            do_stuff();
+   LL|       |        }
    LL|      2|    }
    LL|       |}
    LL|       |
@@ -41,10 +36,10 @@
    LL|      8|            fn sparse_d() {
    LL|      8|                sparse_e();
    LL|      8|                sparse_e();
-   LL|      8|                #[coverage(off)]
-   LL|      8|                fn sparse_e() {
-   LL|      8|                    do_stuff();
-   LL|      8|                }
+   LL|       |                #[coverage(off)]
+   LL|       |                fn sparse_e() {
+   LL|       |                    do_stuff();
+   LL|       |                }
    LL|      8|            }
    LL|      4|        }
    LL|       |    }

--- a/tests/coverage/attr/off-on-sandwich.rs
+++ b/tests/coverage/attr/off-on-sandwich.rs
@@ -4,11 +4,6 @@
 // Demonstrates the interaction of `#[coverage(off)]` and `#[coverage(on)]`
 // in nested functions.
 
-// FIXME(#126625): Coverage attributes should apply recursively to nested functions.
-// FIXME(#126626): When an inner (non-closure) function has `#[coverage(off)]`,
-// its lines can still be marked with misleading execution counts from its enclosing
-// function.
-
 #[coverage(off)]
 fn do_stuff() {}
 

--- a/tests/coverage/closure_macro.cov-map
+++ b/tests/coverage/closure_macro.cov-map
@@ -7,15 +7,16 @@ Number of file 0 mappings: 1
 - Code(Counter(0)) at (prev + 29, 1) to (start + 2, 2)
 
 Function name: closure_macro::main
-Raw bytes (31): 0x[01, 01, 01, 01, 05, 05, 01, 21, 01, 01, 21, 02, 02, 09, 00, 0f, 05, 00, 54, 00, 55, 02, 02, 09, 02, 0b, 01, 03, 01, 00, 02]
+Raw bytes (36): 0x[01, 01, 01, 01, 05, 06, 01, 21, 01, 01, 21, 02, 02, 09, 00, 0f, 01, 00, 12, 00, 54, 05, 00, 54, 00, 55, 02, 02, 09, 02, 0b, 01, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 5
+Number of file 0 mappings: 6
 - Code(Counter(0)) at (prev + 33, 1) to (start + 1, 33)
 - Code(Expression(0, Sub)) at (prev + 2, 9) to (start + 0, 15)
     = (c0 - c1)
+- Code(Counter(0)) at (prev + 0, 18) to (start + 0, 84)
 - Code(Counter(1)) at (prev + 0, 84) to (start + 0, 85)
 - Code(Expression(0, Sub)) at (prev + 2, 9) to (start + 2, 11)
     = (c0 - c1)

--- a/tests/coverage/closure_macro_async.cov-map
+++ b/tests/coverage/closure_macro_async.cov-map
@@ -15,15 +15,16 @@ Number of file 0 mappings: 1
 - Code(Counter(0)) at (prev + 35, 1) to (start + 0, 43)
 
 Function name: closure_macro_async::test::{closure#0}
-Raw bytes (31): 0x[01, 01, 01, 01, 05, 05, 01, 23, 2b, 01, 21, 02, 02, 09, 00, 0f, 05, 00, 54, 00, 55, 02, 02, 09, 02, 0b, 01, 03, 01, 00, 02]
+Raw bytes (36): 0x[01, 01, 01, 01, 05, 06, 01, 23, 2b, 01, 21, 02, 02, 09, 00, 0f, 01, 00, 12, 00, 54, 05, 00, 54, 00, 55, 02, 02, 09, 02, 0b, 01, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 5
+Number of file 0 mappings: 6
 - Code(Counter(0)) at (prev + 35, 43) to (start + 1, 33)
 - Code(Expression(0, Sub)) at (prev + 2, 9) to (start + 0, 15)
     = (c0 - c1)
+- Code(Counter(0)) at (prev + 0, 18) to (start + 0, 84)
 - Code(Counter(1)) at (prev + 0, 84) to (start + 0, 85)
 - Code(Expression(0, Sub)) at (prev + 2, 9) to (start + 2, 11)
     = (c0 - c1)

--- a/tests/coverage/holes.cov-map
+++ b/tests/coverage/holes.cov-map
@@ -7,14 +7,19 @@ Number of file 0 mappings: 1
 - Code(Zero) at (prev + 37, 9) to (start + 0, 29)
 
 Function name: holes::main
-Raw bytes (19): 0x[01, 01, 00, 03, 01, 08, 01, 06, 11, 01, 0f, 05, 24, 0f, 01, 2b, 05, 01, 02]
+Raw bytes (44): 0x[01, 01, 00, 08, 01, 08, 01, 06, 11, 01, 0f, 05, 00, 12, 01, 04, 05, 00, 12, 01, 07, 05, 00, 12, 01, 06, 05, 00, 12, 01, 06, 05, 03, 0f, 01, 0a, 05, 03, 0f, 01, 0a, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
-Number of file 0 mappings: 3
+Number of file 0 mappings: 8
 - Code(Counter(0)) at (prev + 8, 1) to (start + 6, 17)
-- Code(Counter(0)) at (prev + 15, 5) to (start + 36, 15)
-- Code(Counter(0)) at (prev + 43, 5) to (start + 1, 2)
+- Code(Counter(0)) at (prev + 15, 5) to (start + 0, 18)
+- Code(Counter(0)) at (prev + 4, 5) to (start + 0, 18)
+- Code(Counter(0)) at (prev + 7, 5) to (start + 0, 18)
+- Code(Counter(0)) at (prev + 6, 5) to (start + 0, 18)
+- Code(Counter(0)) at (prev + 6, 5) to (start + 3, 15)
+- Code(Counter(0)) at (prev + 10, 5) to (start + 3, 15)
+- Code(Counter(0)) at (prev + 10, 5) to (start + 1, 2)
 
 Function name: holes::main::_unused_fn (unused)
 Raw bytes (9): 0x[01, 01, 00, 01, 00, 19, 05, 00, 17]

--- a/tests/coverage/holes.cov-map
+++ b/tests/coverage/holes.cov-map
@@ -1,0 +1,42 @@
+Function name: <holes::main::MyStruct>::_method (unused)
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 25, 09, 00, 1d]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Zero) at (prev + 37, 9) to (start + 0, 29)
+
+Function name: holes::main
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 08, 01, 06, 11, 01, 0f, 05, 24, 0f, 01, 2b, 05, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 8, 1) to (start + 6, 17)
+- Code(Counter(0)) at (prev + 15, 5) to (start + 36, 15)
+- Code(Counter(0)) at (prev + 43, 5) to (start + 1, 2)
+
+Function name: holes::main::_unused_fn (unused)
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 19, 05, 00, 17]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Zero) at (prev + 25, 5) to (start + 0, 23)
+
+Function name: holes::main::{closure#0} (unused)
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 12, 09, 02, 0a]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Zero) at (prev + 18, 9) to (start + 2, 10)
+
+Function name: holes::main::{closure#1} (unused)
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 3d, 09, 02, 0a]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Zero) at (prev + 61, 9) to (start + 2, 10)
+

--- a/tests/coverage/holes.coverage
+++ b/tests/coverage/holes.coverage
@@ -21,40 +21,38 @@
    LL|       |        ;
    LL|       |
    LL|      1|    black_box(());
-   LL|      1|
-   LL|      1|    fn _unused_fn() {}
-                  ^0
-   LL|      1|
+   LL|       |
+   LL|      0|    fn _unused_fn() {}
+   LL|       |
    LL|      1|    black_box(());
-   LL|      1|
-   LL|      1|    struct MyStruct {
-   LL|      1|        _x: u32,
-   LL|      1|        _y: u32,
-   LL|      1|    }
-   LL|      1|
+   LL|       |
+   LL|       |    struct MyStruct {
+   LL|       |        _x: u32,
+   LL|       |        _y: u32,
+   LL|       |    }
+   LL|       |
    LL|      1|    black_box(());
-   LL|      1|
-   LL|      1|    impl MyStruct {
-   LL|      1|        fn _method(&self) {}
-                      ^0
-   LL|      1|    }
-   LL|      1|
+   LL|       |
+   LL|       |    impl MyStruct {
+   LL|      0|        fn _method(&self) {}
+   LL|       |    }
+   LL|       |
    LL|      1|    black_box(());
-   LL|      1|
-   LL|      1|    macro_rules! _my_macro {
-   LL|      1|        () => {};
-   LL|      1|    }
-   LL|      1|
+   LL|       |
+   LL|       |    macro_rules! _my_macro {
+   LL|       |        () => {};
+   LL|       |    }
+   LL|       |
    LL|      1|    black_box(());
    LL|      1|
    LL|      1|    #[rustfmt::skip]
    LL|      1|    let _const =
-   LL|      1|        const
-   LL|      1|        {
-   LL|      1|            7 + 4
-   LL|      1|        }
-   LL|      1|        ;
-   LL|      1|
+   LL|       |        const
+   LL|       |        {
+   LL|       |            7 + 4
+   LL|       |        }
+   LL|       |        ;
+   LL|       |
    LL|      1|    black_box(());
    LL|      1|
    LL|      1|    #[rustfmt::skip]

--- a/tests/coverage/holes.coverage
+++ b/tests/coverage/holes.coverage
@@ -1,0 +1,70 @@
+   LL|       |//@ edition: 2021
+   LL|       |
+   LL|       |// Nested items/closures should be treated as "holes", so that their spans are
+   LL|       |// not displayed as executable code in the enclosing function.
+   LL|       |
+   LL|       |use core::hint::black_box;
+   LL|       |
+   LL|      1|fn main() {
+   LL|      1|    black_box(());
+   LL|      1|
+   LL|      1|    // Splitting this across multiple lines makes it easier to see where the
+   LL|      1|    // coverage mapping regions begin and end.
+   LL|      1|    #[rustfmt::skip]
+   LL|      1|    let _closure =
+   LL|       |        |
+   LL|       |            _arg: (),
+   LL|       |        |
+   LL|      0|        {
+   LL|      0|            black_box(());
+   LL|      0|        }
+   LL|       |        ;
+   LL|       |
+   LL|      1|    black_box(());
+   LL|      1|
+   LL|      1|    fn _unused_fn() {}
+                  ^0
+   LL|      1|
+   LL|      1|    black_box(());
+   LL|      1|
+   LL|      1|    struct MyStruct {
+   LL|      1|        _x: u32,
+   LL|      1|        _y: u32,
+   LL|      1|    }
+   LL|      1|
+   LL|      1|    black_box(());
+   LL|      1|
+   LL|      1|    impl MyStruct {
+   LL|      1|        fn _method(&self) {}
+                      ^0
+   LL|      1|    }
+   LL|      1|
+   LL|      1|    black_box(());
+   LL|      1|
+   LL|      1|    macro_rules! _my_macro {
+   LL|      1|        () => {};
+   LL|      1|    }
+   LL|      1|
+   LL|      1|    black_box(());
+   LL|      1|
+   LL|      1|    #[rustfmt::skip]
+   LL|      1|    let _const =
+   LL|      1|        const
+   LL|      1|        {
+   LL|      1|            7 + 4
+   LL|      1|        }
+   LL|      1|        ;
+   LL|      1|
+   LL|      1|    black_box(());
+   LL|      1|
+   LL|      1|    #[rustfmt::skip]
+   LL|      1|    let _async =
+   LL|       |        async
+   LL|      0|        {
+   LL|      0|            7 + 4
+   LL|      0|        }
+   LL|       |        ;
+   LL|       |
+   LL|      1|    black_box(());
+   LL|      1|}
+

--- a/tests/coverage/holes.rs
+++ b/tests/coverage/holes.rs
@@ -1,0 +1,67 @@
+//@ edition: 2021
+
+// Nested items/closures should be treated as "holes", so that their spans are
+// not displayed as executable code in the enclosing function.
+
+use core::hint::black_box;
+
+fn main() {
+    black_box(());
+
+    // Splitting this across multiple lines makes it easier to see where the
+    // coverage mapping regions begin and end.
+    #[rustfmt::skip]
+    let _closure =
+        |
+            _arg: (),
+        |
+        {
+            black_box(());
+        }
+        ;
+
+    black_box(());
+
+    fn _unused_fn() {}
+
+    black_box(());
+
+    struct MyStruct {
+        _x: u32,
+        _y: u32,
+    }
+
+    black_box(());
+
+    impl MyStruct {
+        fn _method(&self) {}
+    }
+
+    black_box(());
+
+    macro_rules! _my_macro {
+        () => {};
+    }
+
+    black_box(());
+
+    #[rustfmt::skip]
+    let _const =
+        const
+        {
+            7 + 4
+        }
+        ;
+
+    black_box(());
+
+    #[rustfmt::skip]
+    let _async =
+        async
+        {
+            7 + 4
+        }
+        ;
+
+    black_box(());
+}

--- a/tests/coverage/no_cov_crate.cov-map
+++ b/tests/coverage/no_cov_crate.cov-map
@@ -31,20 +31,22 @@ Number of file 0 mappings: 1
 - Code(Counter(0)) at (prev + 77, 1) to (start + 11, 2)
 
 Function name: no_cov_crate::nested_fns::outer
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 31, 05, 0c, 06]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 31, 05, 02, 23, 01, 0c, 05, 00, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 49, 5) to (start + 12, 6)
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 49, 5) to (start + 2, 35)
+- Code(Counter(0)) at (prev + 12, 5) to (start + 0, 6)
 
 Function name: no_cov_crate::nested_fns::outer_both_covered
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 3f, 05, 0b, 06]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 3f, 05, 02, 17, 01, 0b, 05, 00, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 63, 5) to (start + 11, 6)
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 63, 5) to (start + 2, 23)
+- Code(Counter(0)) at (prev + 11, 5) to (start + 0, 6)
 
 Function name: no_cov_crate::nested_fns::outer_both_covered::inner
 Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 43, 09, 01, 17, 05, 01, 18, 02, 0e, 02, 02, 14, 02, 0e, 01, 03, 09, 00, 0a]

--- a/tests/coverage/no_cov_crate.coverage
+++ b/tests/coverage/no_cov_crate.coverage
@@ -49,21 +49,21 @@
    LL|      1|    pub fn outer(is_true: bool) {
    LL|      1|        println!("called and covered");
    LL|      1|        inner_not_covered(is_true);
-   LL|      1|
-   LL|      1|        #[coverage(off)]
-   LL|      1|        fn inner_not_covered(is_true: bool) {
-   LL|      1|            if is_true {
-   LL|      1|                println!("called but not covered");
-   LL|      1|            } else {
-   LL|      1|                println!("absolutely not covered");
-   LL|      1|            }
-   LL|      1|        }
+   LL|       |
+   LL|       |        #[coverage(off)]
+   LL|       |        fn inner_not_covered(is_true: bool) {
+   LL|       |            if is_true {
+   LL|       |                println!("called but not covered");
+   LL|       |            } else {
+   LL|       |                println!("absolutely not covered");
+   LL|       |            }
+   LL|       |        }
    LL|      1|    }
    LL|       |
    LL|      1|    pub fn outer_both_covered(is_true: bool) {
    LL|      1|        println!("called and covered");
    LL|      1|        inner(is_true);
-   LL|      1|
+   LL|       |
    LL|      1|        fn inner(is_true: bool) {
    LL|      1|            if is_true {
    LL|      1|                println!("called and covered");


### PR DESCRIPTION
This makes it possible to treat more kinds of nested item/code as holes, instead of being restricted to closures.

(It also potentially opens up the possibility of using HIR holes to modify branch or MC/DC spans, though we currently don't actually do this.)

Thus, this new implementation treats the following as holes:
- Closures (as before, including `async` and coroutines)
- All nested items
- Inline `const` (because why not)

This gives more accurate coverage reports, because lines occupied by holes don't show the execution count from the enclosing function.

Fixes #126626.

---

[Representative example of the improved coverage instrumentation for functions containing nested items.](https://github.com/rust-lang/rust/pull/127199/commits/63c04f05e60ce27311fc1b874907188616beb558#diff-63049890796abe7dade4458e3961d536e3a6a9cd5451df834008cc8b0531825c)
