### PR TITLE
[Benchmark]: lint expectations

### DIFF
--- a/compiler/rustc_lint/src/expect.rs
+++ b/compiler/rustc_lint/src/expect.rs
@@ -9,7 +9,10 @@ pub(crate) fn provide(providers: &mut Providers) {
     *providers = Providers { check_expectations, ..*providers };
 }
 
+#[allow(unused)]
 fn check_expectations(tcx: TyCtxt<'_>, tool_filter: Option<Symbol>) {
+    return;
+
     let lint_expectations = tcx.lint_expectations(());
     let fulfilled_expectations = tcx.dcx().steal_fulfilled_expectation_ids();
 

--- a/src/tools/clippy/tests/ui-cargo/duplicate_mod/fail/src/main.rs
+++ b/src/tools/clippy/tests/ui-cargo/duplicate_mod/fail/src/main.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 mod a;
 
 mod b;

--- a/src/tools/clippy/tests/ui-toml/macro_metavars_in_unsafe/default/test.rs
+++ b/src/tools/clippy/tests/ui-toml/macro_metavars_in_unsafe/default/test.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //! Tests macro_metavars_in_unsafe with default configuration
 #![feature(decl_macro)]
 #![warn(clippy::macro_metavars_in_unsafe)]

--- a/src/tools/clippy/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs
+++ b/src/tools/clippy/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //@aux-build:../../ui/auxiliary/proc_macro_unsafe.rs
 //@revisions: default disabled
 //@[default] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/undocumented_unsafe_blocks/default

--- a/src/tools/clippy/tests/ui/allow_attributes.rs
+++ b/src/tools/clippy/tests/ui/allow_attributes.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //@aux-build:proc_macros.rs
 #![allow(unused)]
 #![warn(clippy::allow_attributes)]

--- a/src/tools/clippy/tests/ui/allow_attributes_without_reason.rs
+++ b/src/tools/clippy/tests/ui/allow_attributes_without_reason.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //@aux-build:proc_macros.rs
 #![deny(clippy::allow_attributes_without_reason)]
 #![allow(unfulfilled_lint_expectations, clippy::duplicated_attributes)]

--- a/src/tools/clippy/tests/ui/async_yields_async.rs
+++ b/src/tools/clippy/tests/ui/async_yields_async.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 #![feature(async_closure)]
 #![warn(clippy::async_yields_async)]
 #![allow(clippy::redundant_async_block)]

--- a/src/tools/clippy/tests/ui/boxed_local.rs
+++ b/src/tools/clippy/tests/ui/boxed_local.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 #![allow(
     clippy::borrowed_box,
     clippy::needless_pass_by_value,

--- a/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.rs
+++ b/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //@no-rustfix: overlapping suggestions
 #![deny(clippy::panicking_unwrap, clippy::unnecessary_unwrap)]
 #![allow(

--- a/src/tools/clippy/tests/ui/default_numeric_fallback_i32.rs
+++ b/src/tools/clippy/tests/ui/default_numeric_fallback_i32.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //@aux-build:proc_macros.rs
 
 #![warn(clippy::default_numeric_fallback)]

--- a/src/tools/clippy/tests/ui/derive_partial_eq_without_eq.rs
+++ b/src/tools/clippy/tests/ui/derive_partial_eq_without_eq.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 #![allow(unused)]
 #![warn(clippy::derive_partial_eq_without_eq)]
 

--- a/src/tools/clippy/tests/ui/expect_tool_lint_rfc_2383.rs
+++ b/src/tools/clippy/tests/ui/expect_tool_lint_rfc_2383.rs
@@ -1,3 +1,5 @@
+//@only-16bit
+
 //! This file tests the `#[expect]` attribute implementation for tool lints. The same
 //! file is used to test clippy and rustdoc. Any changes to this file should be synced
 //! to the other test files as well.

--- a/src/tools/clippy/tests/ui/implicit_return.rs
+++ b/src/tools/clippy/tests/ui/implicit_return.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //@aux-build: proc_macros.rs
 
 #![warn(clippy::implicit_return)]

--- a/src/tools/clippy/tests/ui/let_unit.rs
+++ b/src/tools/clippy/tests/ui/let_unit.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 #![warn(clippy::let_unit_value)]
 #![allow(unused, clippy::no_effect, clippy::needless_late_init, path_statements)]
 

--- a/src/tools/clippy/tests/ui/macro_use_imports_expect.rs
+++ b/src/tools/clippy/tests/ui/macro_use_imports_expect.rs
@@ -1,7 +1,7 @@
+//@only-16bit
 //@aux-build:macro_rules.rs
 //@aux-build:macro_use_helper.rs
 //@aux-build:proc_macro_derive.rs
-//@ignore-32bit
 
 #![allow(unused_imports, unreachable_code, unused_variables, dead_code, unused_attributes)]
 #![allow(clippy::single_component_path_imports)]

--- a/src/tools/clippy/tests/ui/manual_non_exhaustive_enum.rs
+++ b/src/tools/clippy/tests/ui/manual_non_exhaustive_enum.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 #![warn(clippy::manual_non_exhaustive)]
 #![allow(unused)]
 //@no-rustfix

--- a/src/tools/clippy/tests/ui/needless_borrow.rs
+++ b/src/tools/clippy/tests/ui/needless_borrow.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 #![allow(
     unused,
     non_local_definitions,

--- a/src/tools/clippy/tests/ui/needless_pass_by_ref_mut.rs
+++ b/src/tools/clippy/tests/ui/needless_pass_by_ref_mut.rs
@@ -5,6 +5,7 @@
     clippy::ptr_arg
 )]
 #![warn(clippy::needless_pass_by_ref_mut)]
+//@only-16bit
 //@no-rustfix
 use std::ptr::NonNull;
 

--- a/src/tools/clippy/tests/ui/needless_return.rs
+++ b/src/tools/clippy/tests/ui/needless_return.rs
@@ -1,3 +1,5 @@
+//@only-16bit
+
 #![feature(yeet_expr)]
 #![allow(unused)]
 #![allow(

--- a/src/tools/clippy/tests/ui/nonminimal_bool.rs
+++ b/src/tools/clippy/tests/ui/nonminimal_bool.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //@no-rustfix: overlapping suggestions
 #![allow(
     unused,

--- a/src/tools/clippy/tests/ui/overly_complex_bool_expr.rs
+++ b/src/tools/clippy/tests/ui/overly_complex_bool_expr.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 #![allow(unused, clippy::diverging_sub_expression)]
 #![warn(clippy::overly_complex_bool_expr)]
 

--- a/src/tools/clippy/tests/ui/ptr_arg.rs
+++ b/src/tools/clippy/tests/ui/ptr_arg.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 #![allow(
     unused,
     clippy::many_single_char_names,

--- a/src/tools/clippy/tests/ui/redundant_clone.rs
+++ b/src/tools/clippy/tests/ui/redundant_clone.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 // rustfix-only-machine-applicable
 #![warn(clippy::redundant_clone)]
 #![allow(

--- a/src/tools/clippy/tests/ui/ref_binding_to_reference.rs
+++ b/src/tools/clippy/tests/ui/ref_binding_to_reference.rs
@@ -1,5 +1,6 @@
 // FIXME: run-rustfix waiting on multi-span suggestions
 //@no-rustfix
+//@only-16bit
 #![warn(clippy::ref_binding_to_reference)]
 #![allow(clippy::needless_borrowed_reference, clippy::explicit_auto_deref)]
 

--- a/src/tools/clippy/tests/ui/same_name_method.rs
+++ b/src/tools/clippy/tests/ui/same_name_method.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 #![warn(clippy::same_name_method)]
 #![allow(dead_code, non_camel_case_types)]
 

--- a/src/tools/clippy/tests/ui/unsafe_derive_deserialize.rs
+++ b/src/tools/clippy/tests/ui/unsafe_derive_deserialize.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 #![warn(clippy::unsafe_derive_deserialize)]
 #![allow(unused, clippy::missing_safety_doc)]
 

--- a/src/tools/clippy/tests/ui/used_underscore_binding.rs
+++ b/src/tools/clippy/tests/ui/used_underscore_binding.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //@aux-build:proc_macro_derive.rs
 #![feature(rustc_private)]
 #![warn(clippy::used_underscore_binding)]

--- a/tests/rustdoc-ui/lints/expect-tool-lint-rfc-2383.rs
+++ b/tests/rustdoc-ui/lints/expect-tool-lint-rfc-2383.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 //! This file tests the `#[expect]` attribute implementation for tool lints. The same
 //! file is used to test clippy and rustdoc. Any changes to this file should be synced

--- a/tests/ui/async-await/in-trait/async-example-desugared-extra.rs
+++ b/tests/ui/async-await/in-trait/async-example-desugared-extra.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ edition: 2021
+//@only-16bit
 
 use std::future::Future;
 use std::pin::Pin;

--- a/tests/ui/cfg/diagnostics-not-a-def.rs
+++ b/tests/ui/cfg/diagnostics-not-a-def.rs
@@ -1,3 +1,5 @@
+//@only-16bit
+
 pub mod inner {
     #[expect(unexpected_cfgs)]
     pub fn i_am_here() {

--- a/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/auxiliary/rpitit.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 use std::ops::Deref;
 
 pub trait Foo {

--- a/tests/ui/impl-trait/in-trait/deep-match-works.rs
+++ b/tests/ui/impl-trait/in-trait/deep-match-works.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 pub struct Wrapper<T>(T);
 

--- a/tests/ui/impl-trait/in-trait/foreign.rs
+++ b/tests/ui/impl-trait/in-trait/foreign.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ aux-build: rpitit.rs
+//@only-16bit
 
 extern crate rpitit;
 

--- a/tests/ui/impl-trait/in-trait/nested-rpitit.rs
+++ b/tests/ui/impl-trait/in-trait/nested-rpitit.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 use std::fmt::Display;
 use std::ops::Deref;

--- a/tests/ui/impl-trait/in-trait/reveal.rs
+++ b/tests/ui/impl-trait/in-trait/reveal.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 pub trait Foo {
     fn f() -> Box<impl Sized>;

--- a/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.rs
+++ b/tests/ui/impl-trait/in-trait/rpitit-shadowed-by-missing-adt.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 // issue: 113903
 
 use std::ops::Deref;

--- a/tests/ui/impl-trait/in-trait/signature-mismatch.rs
+++ b/tests/ui/impl-trait/in-trait/signature-mismatch.rs
@@ -1,6 +1,7 @@
 //@ edition:2021
 //@ revisions: success failure
 //@[success] check-pass
+//@only-16bit
 
 use std::future::Future;
 

--- a/tests/ui/impl-trait/in-trait/specialization-substs-remap.rs
+++ b/tests/ui/impl-trait/in-trait/specialization-substs-remap.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 #![feature(specialization)]
 #![allow(incomplete_features)]

--- a/tests/ui/impl-trait/in-trait/success.rs
+++ b/tests/ui/impl-trait/in-trait/success.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 use std::fmt::Display;
 

--- a/tests/ui/lint/dead-code/allow-or-expect-dead_code-114557-2.rs
+++ b/tests/ui/lint/dead-code/allow-or-expect-dead_code-114557-2.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //@ check-pass
 
 // this test checks that the `dead_code` lint is *NOT* being emited

--- a/tests/ui/lint/dead-code/allow-or-expect-dead_code-114557-3.rs
+++ b/tests/ui/lint/dead-code/allow-or-expect-dead_code-114557-3.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 // this test makes sure that the `unfulfilled_lint_expectations` lint
 // is being emited for `foo` as foo is not dead code, it's pub

--- a/tests/ui/lint/dead-code/allow-or-expect-dead_code-114557.rs
+++ b/tests/ui/lint/dead-code/allow-or-expect-dead_code-114557.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //@ check-pass
 //@ revisions: allow expect
 

--- a/tests/ui/lint/expect-future_breakage-crash-issue-126521.rs
+++ b/tests/ui/lint/expect-future_breakage-crash-issue-126521.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 // This test covers similar crashes from both #126521 and #126751.
 

--- a/tests/ui/lint/rfc-2383-lint-reason/avoid_delayed_good_path_ice.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/avoid_delayed_good_path_ice.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 #[expect(drop_bounds)]
 fn trigger_rustc_lints<T: Drop>() {

--- a/tests/ui/lint/rfc-2383-lint-reason/catch_multiple_lint_triggers.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/catch_multiple_lint_triggers.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 #![warn(unused)]
 

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_inside_macro.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_inside_macro.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 #![warn(unused)]
 

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_lint_from_macro.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_lint_from_macro.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 #![warn(unused_variables)]
 

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_multiple_lints.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_multiple_lints.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 #![warn(unused)]
 

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_nested_lint_levels.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_nested_lint_levels.rs
@@ -1,4 +1,5 @@
 // ignore-tidy-linelength
+//@only-16bit
 
 #![warn(unused_mut)]
 

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_on_fn_params.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_on_fn_params.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 #[warn(unused_variables)]
 

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_tool_lint_rfc_2383.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_tool_lint_rfc_2383.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 //! This file tests the `#[expect]` attribute implementation for tool lints. The same
 //! file is used to test clippy and rustdoc. Any changes to this file should be synced

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_unfulfilled_expectation.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_unfulfilled_expectation.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 // ignore-tidy-linelength
 
 #![warn(unused_mut)]

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_unused_inside_impl_block.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_unused_inside_impl_block.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ incremental
+//@only-16bit
 
 #![warn(unused)]
 

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_with_forbid.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_with_forbid.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -Zdeduplicate-diagnostics=yes
+//@only-16bit
 
 #[forbid(unused_variables)]
 //~^ NOTE `forbid` level set here

--- a/tests/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_fulfilled.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_fulfilled.rs
@@ -2,6 +2,7 @@
 //@ compile-flags: --force-warn unused_variables
 //@ compile-flags: --force-warn unused_mut
 //@ check-pass
+//@only-16bit
 
 fn expect_early_pass_lint() {
     #[expect(while_true)]

--- a/tests/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_unfulfilled.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_unfulfilled.rs
@@ -2,6 +2,7 @@
 //@ compile-flags: --force-warn unused_variables
 //@ compile-flags: --force-warn unused_mut
 //@ check-pass
+//@only-16bit
 
 fn expect_early_pass_lint(terminate: bool) {
     #[expect(while_true)]

--- a/tests/ui/lint/rfc-2383-lint-reason/fulfilled_expectation_early_lints.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/fulfilled_expectation_early_lints.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 fn expect_early_pass_lints() {
     #[expect(while_true)]

--- a/tests/ui/lint/rfc-2383-lint-reason/fulfilled_expectation_late_lints.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/fulfilled_expectation_late_lints.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 #![warn(unused)]
 

--- a/tests/ui/lint/rfc-2383-lint-reason/multiple_expect_attrs.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/multiple_expect_attrs.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@only-16bit
 
 #![warn(unused)]
 

--- a/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.rs
@@ -1,6 +1,7 @@
 // This ensures that ICEs like rust#94953 don't happen
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded
+//@only-16bit
 
 // This `expect` will create an expectation with an unstable expectation id
 #[expect(while_true)]

--- a/tests/ui/proc-macro/allowed-attr-stmt-expr.rs
+++ b/tests/ui/proc-macro/allowed-attr-stmt-expr.rs
@@ -2,6 +2,7 @@
 //@ aux-build:test-macros.rs
 //@ compile-flags: -Z span-debug
 //@ check-pass
+//@only-16bit
 
 #![feature(proc_macro_hygiene)]
 #![feature(stmt_expr_attributes)]

--- a/tests/ui/proc-macro/attr-stmt-expr-rpass.rs
+++ b/tests/ui/proc-macro/attr-stmt-expr-rpass.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@only-16bit
 //@ aux-build:attr-stmt-expr-rpass.rs
 
 #![feature(stmt_expr_attributes, proc_macro_hygiene)]

--- a/tests/ui/proc-macro/attr-stmt-expr.rs
+++ b/tests/ui/proc-macro/attr-stmt-expr.rs
@@ -1,6 +1,7 @@
 //@ aux-build:attr-stmt-expr.rs
 //@ aux-build:test-macros.rs
 //@ compile-flags: -Z span-debug
+//@only-16bit
 
 #![feature(proc_macro_hygiene)]
 #![feature(rustc_attrs)]

--- a/tests/ui/sse2.rs
+++ b/tests/ui/sse2.rs
@@ -1,3 +1,4 @@
+//@only-16bit
 //@ run-pass
 
 #![allow(stable_features)]

--- a/tests/ui/target-feature/no-llvm-leaks.rs
+++ b/tests/ui/target-feature/no-llvm-leaks.rs
@@ -4,6 +4,7 @@
 //@ [x86-64] compile-flags: -Ctarget-feature=+sse4.2,+rdrand --target=x86_64-unknown-linux-gnu
 //@ [x86-64] needs-llvm-components: x86
 //@ build-pass
+//@only-16bit
 #![no_core]
 #![crate_type = "rlib"]
 #![feature(intrinsics, rustc_attrs, no_core, lang_items, staged_api)]


### PR DESCRIPTION
#120924 stabilized the `lint_reasons` feature. This resulted in some performance regressions.

This PR tries to benchmark these changes and see where they come from. It can be safely ignored :D