### PR TITLE
Graciously handle `Drop` impls introducing more generic parameters than the ADT

### DIFF
--- a/tests/ui/dropck/const_drop_is_valid.rs
+++ b/tests/ui/dropck/const_drop_is_valid.rs
@@ -1,0 +1,11 @@
+#![feature(effects)]
+//~^ WARN: the feature `effects` is incomplete
+
+struct A();
+
+impl const Drop for A {}
+//~^ ERROR: const trait impls are experimental
+//~| const `impl` for trait `Drop` which is not marked with `#[const_trait]`
+//~| not all trait items implemented, missing: `drop`
+
+fn main() {}

--- a/tests/ui/dropck/const_drop_is_valid.stderr
+++ b/tests/ui/dropck/const_drop_is_valid.stderr
@@ -1,0 +1,45 @@
+error[E0658]: const trait impls are experimental
+  --> $DIR/const_drop_is_valid.rs:6:6
+   |
+LL | impl const Drop for A {}
+   |      ^^^^^
+   |
+   = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+warning: the feature `effects` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/const_drop_is_valid.rs:1:12
+   |
+LL | #![feature(effects)]
+   |            ^^^^^^^
+   |
+   = note: see issue #102090 <https://github.com/rust-lang/rust/issues/102090> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: using `#![feature(effects)]` without enabling next trait solver globally
+   |
+   = note: the next trait solver must be enabled globally for the effects feature to work correctly
+   = help: use `-Znext-solver` to enable
+
+error: const `impl` for trait `Drop` which is not marked with `#[const_trait]`
+  --> $DIR/const_drop_is_valid.rs:6:12
+   |
+LL | impl const Drop for A {}
+   |            ^^^^
+   |
+   = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
+   = note: adding a non-const method body in the future would be a breaking change
+
+error[E0046]: not all trait items implemented, missing: `drop`
+  --> $DIR/const_drop_is_valid.rs:6:1
+   |
+LL | impl const Drop for A {}
+   | ^^^^^^^^^^^^^^^^^^^^^ missing `drop` in implementation
+   |
+   = help: implement the missing item: `fn drop(&mut self) { todo!() }`
+
+error: aborting due to 4 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0046, E0658.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/dropck/constrained_by_assoc_type_equality.rs
+++ b/tests/ui/dropck/constrained_by_assoc_type_equality.rs
@@ -1,3 +1,5 @@
+//@ check-pass
+
 struct Foo<T: Trait>(T);
 
 trait Trait {
@@ -5,7 +7,6 @@ trait Trait {
 }
 
 impl<T: Trait<Assoc = U>, U: ?Sized> Drop for Foo<T> {
-    //~^ ERROR: `Drop` impl requires `<T as Trait>::Assoc == U`
     fn drop(&mut self) {}
 }
 

--- a/tests/ui/dropck/constrained_by_assoc_type_equality.rs
+++ b/tests/ui/dropck/constrained_by_assoc_type_equality.rs
@@ -1,0 +1,12 @@
+struct Foo<T: Trait>(T);
+
+trait Trait {
+    type Assoc;
+}
+
+impl<T: Trait<Assoc = U>, U: ?Sized> Drop for Foo<T> {
+    //~^ ERROR: `Drop` impl requires `<T as Trait>::Assoc == U`
+    fn drop(&mut self) {}
+}
+
+fn main() {}

--- a/tests/ui/dropck/constrained_by_assoc_type_equality.stderr
+++ b/tests/ui/dropck/constrained_by_assoc_type_equality.stderr
@@ -1,0 +1,15 @@
+error[E0367]: `Drop` impl requires `<T as Trait>::Assoc == U` but the struct it is implemented for does not
+  --> $DIR/constrained_by_assoc_type_equality.rs:7:15
+   |
+LL | impl<T: Trait<Assoc = U>, U: ?Sized> Drop for Foo<T> {
+   |               ^^^^^^^^^
+   |
+note: the implementor must specify the same requirement
+  --> $DIR/constrained_by_assoc_type_equality.rs:1:1
+   |
+LL | struct Foo<T: Trait>(T);
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0367`.

--- a/tests/ui/dropck/constrained_by_assoc_type_equality_and_self_ty.rs
+++ b/tests/ui/dropck/constrained_by_assoc_type_equality_and_self_ty.rs
@@ -1,0 +1,12 @@
+trait Trait {
+    type Assoc;
+}
+
+struct Foo<T: Trait, U: ?Sized>(T, U);
+
+impl<T: Trait<Assoc = U>, U: ?Sized> Drop for Foo<T, U> {
+    //~^ ERROR: `Drop` impl requires `<T as Trait>::Assoc == U`
+    fn drop(&mut self) {}
+}
+
+fn main() {}

--- a/tests/ui/dropck/constrained_by_assoc_type_equality_and_self_ty.stderr
+++ b/tests/ui/dropck/constrained_by_assoc_type_equality_and_self_ty.stderr
@@ -1,14 +1,14 @@
 error[E0367]: `Drop` impl requires `<T as Trait>::Assoc == U` but the struct it is implemented for does not
-  --> $DIR/constrained_by_assoc_type_equality.rs:7:15
+  --> $DIR/constrained_by_assoc_type_equality_and_self_ty.rs:7:15
    |
-LL | impl<T: Trait<Assoc = U>, U: ?Sized> Drop for Foo<T> {
+LL | impl<T: Trait<Assoc = U>, U: ?Sized> Drop for Foo<T, U> {
    |               ^^^^^^^^^
    |
 note: the implementor must specify the same requirement
-  --> $DIR/constrained_by_assoc_type_equality.rs:1:1
+  --> $DIR/constrained_by_assoc_type_equality_and_self_ty.rs:5:1
    |
-LL | struct Foo<T: Trait>(T);
-   | ^^^^^^^^^^^^^^^^^^^^
+LL | struct Foo<T: Trait, U: ?Sized>(T, U);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/dropck/reject-specialized-drops-8142.rs
+++ b/tests/ui/dropck/reject-specialized-drops-8142.rs
@@ -1,75 +1,145 @@
 // Issue 8142: Test that Drop impls cannot be specialized beyond the
 // predicates attached to the type definition itself.
-trait Bound { fn foo(&self) { } }
-struct K<'l1,'l2> { x: &'l1 i8, y: &'l2 u8 }
-struct L<'l1,'l2> { x: &'l1 i8, y: &'l2 u8 }
-struct M<'m> { x: &'m i8 }
-struct N<'n> { x: &'n i8 }
-struct O<To> { x: *const To }
-struct P<Tp> { x: *const Tp }
-struct Q<Tq> { x: *const Tq }
-struct R<Tr> { x: *const Tr }
-struct S<Ts:Bound> { x: *const Ts }
-struct T<'t,Ts:'t> { x: &'t Ts }
+trait Bound {
+    fn foo(&self) {}
+}
+struct K<'l1, 'l2> {
+    x: &'l1 i8,
+    y: &'l2 u8,
+}
+struct L<'l1, 'l2> {
+    x: &'l1 i8,
+    y: &'l2 u8,
+}
+struct M<'m> {
+    x: &'m i8,
+}
+struct N<'n> {
+    x: &'n i8,
+}
+struct O<To> {
+    x: *const To,
+}
+struct P<Tp> {
+    x: *const Tp,
+}
+struct Q<Tq> {
+    x: *const Tq,
+}
+struct R<Tr> {
+    x: *const Tr,
+}
+struct S<Ts: Bound> {
+    x: *const Ts,
+}
+struct T<'t, Ts: 't> {
+    x: &'t Ts,
+}
 struct U;
-struct V<Tva, Tvb> { x: *const Tva, y: *const Tvb }
-struct W<'l1, 'l2> { x: &'l1 i8, y: &'l2 u8 }
+struct V<Tva, Tvb> {
+    x: *const Tva,
+    y: *const Tvb,
+}
+struct W<'l1, 'l2> {
+    x: &'l1 i8,
+    y: &'l2 u8,
+}
 struct X<const Ca: usize>;
 struct Y<const Ca: usize, const Cb: usize>;
 
-enum Enum<T> { Variant(T) }
+enum Enum<T> {
+    Variant(T),
+}
 struct TupleStruct<T>(T);
-union Union<T: Copy> { f: T }
+union Union<T: Copy> {
+    f: T,
+}
 
-impl<'al,'adds_bnd:'al> Drop for K<'al,'adds_bnd> {                        // REJECT
+impl<'al, 'adds_bnd: 'al> Drop for K<'al, 'adds_bnd> {
     //~^ ERROR `Drop` impl requires `'adds_bnd: 'al`
-    fn drop(&mut self) { } }
+    fn drop(&mut self) {}
+}
 
-impl<'al,'adds_bnd>     Drop for L<'al,'adds_bnd> where 'adds_bnd:'al {    // REJECT
-    //~^ ERROR `Drop` impl requires `'adds_bnd: 'al`
-    fn drop(&mut self) { } }
+impl<'al, 'adds_bnd> Drop for L<'al, 'adds_bnd>
+//~^ ERROR `Drop` impl requires `'adds_bnd: 'al`
+where
+    'adds_bnd: 'al,
+{
+    fn drop(&mut self) {}
+}
 
-impl<'ml>               Drop for M<'ml>         { fn drop(&mut self) { } } // ACCEPT
+impl<'ml> Drop for M<'ml> {
+    fn drop(&mut self) {}
+}
 
-impl                    Drop for N<'static>     { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `Drop` impls cannot be specialized
+impl Drop for N<'static> {
+    //~^ ERROR `Drop` impls cannot be specialized
+    fn drop(&mut self) {}
+}
 
-impl<COkNoBound> Drop for O<COkNoBound> { fn drop(&mut self) { } } // ACCEPT
+impl<COkNoBound> Drop for O<COkNoBound> {
+    fn drop(&mut self) {}
+}
 
-impl              Drop for P<i8>          { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `Drop` impls cannot be specialized
+impl Drop for P<i8> {
+    //~^ ERROR `Drop` impls cannot be specialized
+    fn drop(&mut self) {}
+}
 
-impl<AddsBnd:Bound> Drop for Q<AddsBnd> { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `Drop` impl requires `AddsBnd: Bound`
+impl<AddsBnd: Bound> Drop for Q<AddsBnd> {
+    //~^ ERROR `Drop` impl requires `AddsBnd: Bound`
+    fn drop(&mut self) {}
+}
 
-impl<'rbnd,AddsRBnd:'rbnd> Drop for R<AddsRBnd> { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `Drop` impl requires `AddsRBnd: 'rbnd`
+impl<'rbnd, AddsRBnd: 'rbnd> Drop for R<AddsRBnd> {
+    fn drop(&mut self) {}
+}
 
-impl<Bs:Bound>    Drop for S<Bs>          { fn drop(&mut self) { } } // ACCEPT
+impl<Bs: Bound> Drop for S<Bs> {
+    fn drop(&mut self) {}
+}
 
-impl<'t,Bt:'t>    Drop for T<'t,Bt>       { fn drop(&mut self) { } } // ACCEPT
+impl<'t, Bt: 't> Drop for T<'t, Bt> {
+    fn drop(&mut self) {}
+}
 
-impl              Drop for U              { fn drop(&mut self) { } } // ACCEPT
+impl Drop for U {
+    fn drop(&mut self) {}
+}
 
-impl<One>         Drop for V<One,One>     { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `Drop` impls cannot be specialized
+impl<One> Drop for V<One, One> {
+    //~^ ERROR `Drop` impls cannot be specialized
+    fn drop(&mut self) {}
+}
 
-impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `Drop` impls cannot be specialized
+impl<'lw> Drop for W<'lw, 'lw> {
+    //~^ ERROR `Drop` impls cannot be specialized
+    fn drop(&mut self) {}
+}
 
-impl              Drop for X<3>           { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `Drop` impls cannot be specialized
+impl Drop for X<3> {
+    //~^ ERROR `Drop` impls cannot be specialized
+    fn drop(&mut self) {}
+}
 
-impl<const Ca: usize> Drop for Y<Ca, Ca>     { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `Drop` impls cannot be specialized
+impl<const Ca: usize> Drop for Y<Ca, Ca> {
+    //~^ ERROR `Drop` impls cannot be specialized
+    fn drop(&mut self) {}
+}
 
-impl<AddsBnd:Bound> Drop for Enum<AddsBnd> { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `Drop` impl requires `AddsBnd: Bound`
+impl<AddsBnd: Bound> Drop for Enum<AddsBnd> {
+    //~^ ERROR `Drop` impl requires `AddsBnd: Bound`
+    fn drop(&mut self) {}
+}
 
-impl<AddsBnd:Bound> Drop for TupleStruct<AddsBnd> { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `Drop` impl requires `AddsBnd: Bound`
+impl<AddsBnd: Bound> Drop for TupleStruct<AddsBnd> {
+    //~^ ERROR `Drop` impl requires `AddsBnd: Bound`
+    fn drop(&mut self) {}
+}
 
-impl<AddsBnd:Copy + Bound> Drop for Union<AddsBnd> { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `Drop` impl requires `AddsBnd: Bound`
+impl<AddsBnd: Copy + Bound> Drop for Union<AddsBnd> {
+    //~^ ERROR `Drop` impl requires `AddsBnd: Bound`
+    fn drop(&mut self) {}
+}
 
-pub fn main() { }
+pub fn main() {}

--- a/tests/ui/dropck/reject-specialized-drops-8142.stderr
+++ b/tests/ui/dropck/reject-specialized-drops-8142.stderr
@@ -1,166 +1,157 @@
 error[E0367]: `Drop` impl requires `'adds_bnd: 'al` but the struct it is implemented for does not
-  --> $DIR/reject-specialized-drops-8142.rs:24:20
+  --> $DIR/reject-specialized-drops-8142.rs:58:1
    |
-LL | impl<'al,'adds_bnd:'al> Drop for K<'al,'adds_bnd> {                        // REJECT
-   |                    ^^^
+LL | impl<'al, 'adds_bnd: 'al> Drop for K<'al, 'adds_bnd> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the implementor must specify the same requirement
-  --> $DIR/reject-specialized-drops-8142.rs:4:1
+  --> $DIR/reject-specialized-drops-8142.rs:6:1
    |
-LL | struct K<'l1,'l2> { x: &'l1 i8, y: &'l2 u8 }
-   | ^^^^^^^^^^^^^^^^^
+LL | struct K<'l1, 'l2> {
+   | ^^^^^^^^^^^^^^^^^^
 
 error[E0367]: `Drop` impl requires `'adds_bnd: 'al` but the struct it is implemented for does not
-  --> $DIR/reject-specialized-drops-8142.rs:28:67
+  --> $DIR/reject-specialized-drops-8142.rs:63:1
    |
-LL | impl<'al,'adds_bnd>     Drop for L<'al,'adds_bnd> where 'adds_bnd:'al {    // REJECT
-   |                                                                   ^^^
-   |
-note: the implementor must specify the same requirement
-  --> $DIR/reject-specialized-drops-8142.rs:5:1
-   |
-LL | struct L<'l1,'l2> { x: &'l1 i8, y: &'l2 u8 }
-   | ^^^^^^^^^^^^^^^^^
-
-error[E0366]: `Drop` impls cannot be specialized
-  --> $DIR/reject-specialized-drops-8142.rs:34:1
-   |
-LL | impl                    Drop for N<'static>     { fn drop(&mut self) { } } // REJECT
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `'static` is not a generic parameter
-note: use the same sequence of generic lifetime, type and const parameters as the struct definition
-  --> $DIR/reject-specialized-drops-8142.rs:7:1
-   |
-LL | struct N<'n> { x: &'n i8 }
-   | ^^^^^^^^^^^^
-
-error[E0366]: `Drop` impls cannot be specialized
-  --> $DIR/reject-specialized-drops-8142.rs:39:1
-   |
-LL | impl              Drop for P<i8>          { fn drop(&mut self) { } } // REJECT
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `i8` is not a generic parameter
-note: use the same sequence of generic lifetime, type and const parameters as the struct definition
-  --> $DIR/reject-specialized-drops-8142.rs:9:1
-   |
-LL | struct P<Tp> { x: *const Tp }
-   | ^^^^^^^^^^^^
-
-error[E0367]: `Drop` impl requires `AddsBnd: Bound` but the struct it is implemented for does not
-  --> $DIR/reject-specialized-drops-8142.rs:42:14
-   |
-LL | impl<AddsBnd:Bound> Drop for Q<AddsBnd> { fn drop(&mut self) { } } // REJECT
-   |              ^^^^^
+LL | / impl<'al, 'adds_bnd> Drop for L<'al, 'adds_bnd>
+LL | |
+LL | | where
+LL | |     'adds_bnd: 'al,
+   | |___________________^
    |
 note: the implementor must specify the same requirement
   --> $DIR/reject-specialized-drops-8142.rs:10:1
    |
-LL | struct Q<Tq> { x: *const Tq }
-   | ^^^^^^^^^^^^
+LL | struct L<'l1, 'l2> {
+   | ^^^^^^^^^^^^^^^^^^
 
-error[E0367]: `Drop` impl requires `AddsRBnd: 'rbnd` but the struct it is implemented for does not
-  --> $DIR/reject-specialized-drops-8142.rs:45:21
+error[E0366]: `Drop` impls cannot be specialized
+  --> $DIR/reject-specialized-drops-8142.rs:75:1
    |
-LL | impl<'rbnd,AddsRBnd:'rbnd> Drop for R<AddsRBnd> { fn drop(&mut self) { } } // REJECT
-   |                     ^^^^^
+LL | impl Drop for N<'static> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the implementor must specify the same requirement
-  --> $DIR/reject-specialized-drops-8142.rs:11:1
+   = note: `'static` is not a generic parameter
+note: use the same sequence of generic lifetime, type and const parameters as the struct definition
+  --> $DIR/reject-specialized-drops-8142.rs:17:1
    |
-LL | struct R<Tr> { x: *const Tr }
+LL | struct N<'n> {
    | ^^^^^^^^^^^^
 
 error[E0366]: `Drop` impls cannot be specialized
-  --> $DIR/reject-specialized-drops-8142.rs:54:1
+  --> $DIR/reject-specialized-drops-8142.rs:84:1
    |
-LL | impl<One>         Drop for V<One,One>     { fn drop(&mut self) { } } // REJECT
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | impl Drop for P<i8> {
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `i8` is not a generic parameter
+note: use the same sequence of generic lifetime, type and const parameters as the struct definition
+  --> $DIR/reject-specialized-drops-8142.rs:23:1
+   |
+LL | struct P<Tp> {
+   | ^^^^^^^^^^^^
+
+error[E0367]: `Drop` impl requires `AddsBnd: Bound` but the struct it is implemented for does not
+  --> $DIR/reject-specialized-drops-8142.rs:89:15
+   |
+LL | impl<AddsBnd: Bound> Drop for Q<AddsBnd> {
+   |               ^^^^^
+   |
+note: the implementor must specify the same requirement
+  --> $DIR/reject-specialized-drops-8142.rs:26:1
+   |
+LL | struct Q<Tq> {
+   | ^^^^^^^^^^^^
+
+error[E0366]: `Drop` impls cannot be specialized
+  --> $DIR/reject-specialized-drops-8142.rs:110:1
+   |
+LL | impl<One> Drop for V<One, One> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `One` is mentioned multiple times
 note: use the same sequence of generic lifetime, type and const parameters as the struct definition
-  --> $DIR/reject-specialized-drops-8142.rs:15:1
+  --> $DIR/reject-specialized-drops-8142.rs:39:1
    |
-LL | struct V<Tva, Tvb> { x: *const Tva, y: *const Tvb }
+LL | struct V<Tva, Tvb> {
    | ^^^^^^^^^^^^^^^^^^
 
 error[E0366]: `Drop` impls cannot be specialized
-  --> $DIR/reject-specialized-drops-8142.rs:57:1
+  --> $DIR/reject-specialized-drops-8142.rs:115:1
    |
-LL | impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | impl<'lw> Drop for W<'lw, 'lw> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `'lw` is mentioned multiple times
 note: use the same sequence of generic lifetime, type and const parameters as the struct definition
-  --> $DIR/reject-specialized-drops-8142.rs:16:1
+  --> $DIR/reject-specialized-drops-8142.rs:43:1
    |
-LL | struct W<'l1, 'l2> { x: &'l1 i8, y: &'l2 u8 }
+LL | struct W<'l1, 'l2> {
    | ^^^^^^^^^^^^^^^^^^
 
 error[E0366]: `Drop` impls cannot be specialized
-  --> $DIR/reject-specialized-drops-8142.rs:60:1
+  --> $DIR/reject-specialized-drops-8142.rs:120:1
    |
-LL | impl              Drop for X<3>           { fn drop(&mut self) { } } // REJECT
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | impl Drop for X<3> {
+   | ^^^^^^^^^^^^^^^^^^
    |
    = note: `3` is not a generic parameter
 note: use the same sequence of generic lifetime, type and const parameters as the struct definition
-  --> $DIR/reject-specialized-drops-8142.rs:17:1
+  --> $DIR/reject-specialized-drops-8142.rs:47:1
    |
 LL | struct X<const Ca: usize>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0366]: `Drop` impls cannot be specialized
-  --> $DIR/reject-specialized-drops-8142.rs:63:1
+  --> $DIR/reject-specialized-drops-8142.rs:125:1
    |
-LL | impl<const Ca: usize> Drop for Y<Ca, Ca>     { fn drop(&mut self) { } } // REJECT
+LL | impl<const Ca: usize> Drop for Y<Ca, Ca> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `Ca` is mentioned multiple times
 note: use the same sequence of generic lifetime, type and const parameters as the struct definition
-  --> $DIR/reject-specialized-drops-8142.rs:18:1
+  --> $DIR/reject-specialized-drops-8142.rs:48:1
    |
 LL | struct Y<const Ca: usize, const Cb: usize>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0367]: `Drop` impl requires `AddsBnd: Bound` but the enum it is implemented for does not
-  --> $DIR/reject-specialized-drops-8142.rs:66:14
+  --> $DIR/reject-specialized-drops-8142.rs:130:15
    |
-LL | impl<AddsBnd:Bound> Drop for Enum<AddsBnd> { fn drop(&mut self) { } } // REJECT
-   |              ^^^^^
+LL | impl<AddsBnd: Bound> Drop for Enum<AddsBnd> {
+   |               ^^^^^
    |
 note: the implementor must specify the same requirement
-  --> $DIR/reject-specialized-drops-8142.rs:20:1
+  --> $DIR/reject-specialized-drops-8142.rs:50:1
    |
-LL | enum Enum<T> { Variant(T) }
+LL | enum Enum<T> {
    | ^^^^^^^^^^^^
 
 error[E0367]: `Drop` impl requires `AddsBnd: Bound` but the struct it is implemented for does not
-  --> $DIR/reject-specialized-drops-8142.rs:69:14
+  --> $DIR/reject-specialized-drops-8142.rs:135:15
    |
-LL | impl<AddsBnd:Bound> Drop for TupleStruct<AddsBnd> { fn drop(&mut self) { } } // REJECT
-   |              ^^^^^
+LL | impl<AddsBnd: Bound> Drop for TupleStruct<AddsBnd> {
+   |               ^^^^^
    |
 note: the implementor must specify the same requirement
-  --> $DIR/reject-specialized-drops-8142.rs:21:1
+  --> $DIR/reject-specialized-drops-8142.rs:53:1
    |
 LL | struct TupleStruct<T>(T);
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0367]: `Drop` impl requires `AddsBnd: Bound` but the union it is implemented for does not
-  --> $DIR/reject-specialized-drops-8142.rs:72:21
+  --> $DIR/reject-specialized-drops-8142.rs:140:22
    |
-LL | impl<AddsBnd:Copy + Bound> Drop for Union<AddsBnd> { fn drop(&mut self) { } } // REJECT
-   |                     ^^^^^
+LL | impl<AddsBnd: Copy + Bound> Drop for Union<AddsBnd> {
+   |                      ^^^^^
    |
 note: the implementor must specify the same requirement
-  --> $DIR/reject-specialized-drops-8142.rs:22:1
+  --> $DIR/reject-specialized-drops-8142.rs:54:1
    |
-LL | union Union<T: Copy> { f: T }
+LL | union Union<T: Copy> {
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 13 previous errors
+error: aborting due to 12 previous errors
 
 Some errors have detailed explanations: E0366, E0367.
 For more information about an error, try `rustc --explain E0366`.

--- a/tests/ui/dropck/transitive-outlives.bad.stderr
+++ b/tests/ui/dropck/transitive-outlives.bad.stderr
@@ -1,8 +1,11 @@
 error[E0367]: `Drop` impl requires `'a: 'c` but the struct it is implemented for does not
-  --> $DIR/transitive-outlives.rs:20:9
+  --> $DIR/transitive-outlives.rs:18:1
    |
-LL |     'a: 'c,
-   |         ^^
+LL | / impl<'a, 'b, 'c> Drop for DropMe<'a, 'b, 'c>
+LL | |
+LL | | where
+LL | |     'a: 'c,
+   | |___________^
    |
 note: the implementor must specify the same requirement
   --> $DIR/transitive-outlives.rs:7:1

--- a/tests/ui/dropck/transitive-outlives.rs
+++ b/tests/ui/dropck/transitive-outlives.rs
@@ -16,9 +16,9 @@ where
 
 #[cfg(bad)]
 impl<'a, 'b, 'c> Drop for DropMe<'a, 'b, 'c>
+//[bad]~^ ERROR `Drop` impl requires `'a: 'c`
 where
     'a: 'c,
-    //[bad]~^ ERROR `Drop` impl requires `'a: 'c`
 {
     fn drop(&mut self) {}
 }

--- a/tests/ui/dropck/unconstrained_const_param_on_drop.rs
+++ b/tests/ui/dropck/unconstrained_const_param_on_drop.rs
@@ -1,8 +1,7 @@
-//@ known-bug: unknown
-//@ failure-status: 101
-
 struct Foo {}
 
 impl<const UNUSED: usize> Drop for Foo {}
+//~^ ERROR: `Drop` impl requires `the constant `_` has type `usize``
+//~| ERROR: the const parameter `UNUSED` is not constrained by the impl trait, self type, or predicates
 
 fn main() {}

--- a/tests/ui/dropck/unconstrained_const_param_on_drop.rs
+++ b/tests/ui/dropck/unconstrained_const_param_on_drop.rs
@@ -1,0 +1,8 @@
+//@ known-bug: unknown
+//@ failure-status: 101
+
+struct Foo {}
+
+impl<const UNUSED: usize> Drop for Foo {}
+
+fn main() {}

--- a/tests/ui/dropck/unconstrained_const_param_on_drop.stderr
+++ b/tests/ui/dropck/unconstrained_const_param_on_drop.stderr
@@ -1,212 +1,17 @@
-thread 'rustc' panicked at compiler/rustc_middle/src/ty/sty.rs:360:36:
-called `Option::unwrap()` on a `None` value
-stack backtrace:
-   0: begin_panic_handler
-             at ./library/std/src/panicking.rs:661:5
-   1: panic_fmt
-             at ./library/core/src/panicking.rs:74:14
-   2: panic
-             at ./library/core/src/panicking.rs:148:5
-   3: core::option::unwrap_failed
-             at ./library/core/src/option.rs:2013:5
-   4: unwrap<rustc_middle::ty::Ty>
-             at ./library/core/src/option.rs:963:21
-   5: find_ty_from_env
-             at ./compiler/rustc_middle/src/ty/sty.rs:360:36
-   6: process_obligation
-             at ./compiler/rustc_trait_selection/src/traits/fulfill.rs:472:29
-   7: process_obligations<rustc_trait_selection::traits::fulfill::PendingPredicateObligation, rustc_trait_selection::traits::fulfill::FulfillProcessor>
-             at ./compiler/rustc_data_structures/src/obligation_forest/mod.rs:462:23
-   8: select<rustc_trait_selection::traits::FulfillmentError>
-             at ./compiler/rustc_trait_selection/src/traits/fulfill.rs:107:13
-   9: select_where_possible<rustc_trait_selection::traits::FulfillmentError>
-             at ./compiler/rustc_trait_selection/src/traits/fulfill.rs:160:9
-  10: select_all_or_error<rustc_trait_selection::traits::fulfill::FulfillmentContext<rustc_trait_selection::traits::FulfillmentError>, rustc_trait_selection::traits::FulfillmentError>
-             at ./compiler/rustc_infer/src/traits/engine.rs:82:22
-  11: select_all_or_error<rustc_trait_selection::traits::FulfillmentError>
-             at ./compiler/rustc_trait_selection/src/traits/engine.rs:189:9
-  12: ensure_drop_predicates_are_implied_by_item_defn
-             at ./compiler/rustc_hir_analysis/src/check/dropck.rs:154:18
-  13: check_drop_impl
-             at ./compiler/rustc_hir_analysis/src/check/dropck.rs:60:13
-  14: call<fn(rustc_middle::ty::context::TyCtxt, rustc_span::def_id::DefId) -> core::result::Result<(), rustc_span::ErrorGuaranteed>, (rustc_middle::ty::context::TyCtxt, rustc_span::def_id::DefId)>
-             at ./library/core/src/ops/function.rs:79:5
-  15: {closure#0}<fn(rustc_middle::ty::context::TyCtxt, rustc_span::def_id::DefId) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./compiler/rustc_middle/src/ty/util.rs:360:16
-  16: for_each_relevant_impl<rustc_middle::ty::util::{impl#2}::calculate_dtor::{closure_env#0}<fn(rustc_middle::ty::context::TyCtxt, rustc_span::def_id::DefId) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>>
-             at ./compiler/rustc_middle/src/ty/trait_def.rs:166:21
-  17: calculate_dtor<fn(rustc_middle::ty::context::TyCtxt, rustc_span::def_id::DefId) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./compiler/rustc_middle/src/ty/util.rs:359:9
-  18: rustc_hir_analysis::check::adt_destructor
-             at ./compiler/rustc_hir_analysis/src/check/mod.rs:125:5
-  19: {closure#0}
-             at ./compiler/rustc_query_impl/src/plumbing.rs:285:13
-      [... omitted 22 frames ...]
-  20: query_get_at<rustc_query_system::query::caches::DefIdCache<rustc_middle::query::erase::Erased<[u8; 12]>>>
-             at ./compiler/rustc_middle/src/query/plumbing.rs:145:17
-  21: adt_destructor<rustc_span::def_id::DefId>
-             at ./compiler/rustc_middle/src/query/plumbing.rs:423:31
-  22: adt_destructor<rustc_span::def_id::DefId>
-             at ./compiler/rustc_middle/src/query/plumbing.rs:414:35
-  23: destructor
-             at ./compiler/rustc_middle/src/ty/adt.rs:610:13
-  24: check_struct
-             at ./compiler/rustc_hir_analysis/src/check/check.rs:71:5
-  25: check_item_type
-             at ./compiler/rustc_hir_analysis/src/check/check.rs:730:13
-  26: check_item
-             at ./compiler/rustc_hir_analysis/src/check/wfcheck.rs:335:5
-  27: check_well_formed
-             at ./compiler/rustc_hir_analysis/src/check/wfcheck.rs:192:39
-  28: {closure#0}
-             at ./compiler/rustc_query_impl/src/plumbing.rs:281:9
-      [... omitted 22 frames ...]
-  29: query_ensure_error_guaranteed<rustc_query_system::query::caches::VecCache<rustc_hir::hir_id::OwnerId, rustc_middle::query::erase::Erased<[u8; 1]>>, ()>
-             at ./compiler/rustc_middle/src/query/plumbing.rs:181:9
-  30: check_well_formed
-             at ./compiler/rustc_middle/src/query/plumbing.rs:199:9
-  31: {closure#1}
-             at ./compiler/rustc_hir_analysis/src/check/wfcheck.rs:1995:47
-  32: {closure#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#1}>
-             at ./compiler/rustc_middle/src/hir/mod.rs:89:57
-  33: {closure#0}<&[rustc_hir::hir::ImplItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_impl_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#1}>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:203:50
-  34: call_once<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&[rustc_hir::hir::ImplItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_impl_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#1}>>>
-             at ./library/core/src/panic/unwind_safe.rs:272:9
-  35: do_call<core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&[rustc_hir::hir::ImplItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_impl_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#1}>>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./library/std/src/panicking.rs:553:40
-  36: try<core::result::Result<(), rustc_span::ErrorGuaranteed>, core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&[rustc_hir::hir::ImplItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_impl_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#1}>>>>
-             at ./library/std/src/panicking.rs:517:19
-  37: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure#2}::{closure_env#0}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./library/std/src/panic.rs:350:14
-  38: run<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure#2}::{closure_env#0}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:28:9
-  39: {closure#2}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:206:46
-  40: {closure#0}<&rustc_hir::hir::ItemId, core::result::Result<(), rustc_span::ErrorGuaranteed>, core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure_env#2}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>, fn(core::result::Result<(), rustc_span::ErrorGuaranteed>, core::result::Result<(), rustc_span::ErrorGuaranteed>) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./library/core/src/iter/adapters/filter_map.rs:39:28
-  41: fold<rustc_hir::hir::ItemId, core::result::Result<(), rustc_span::ErrorGuaranteed>, core::iter::adapters::filter_map::filter_map_fold::{closure_env#0}<&rustc_hir::hir::ItemId, core::result::Result<(), rustc_span::ErrorGuaranteed>, core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure_env#2}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>, fn(core::result::Result<(), rustc_span::ErrorGuaranteed>, core::result::Result<(), rustc_span::ErrorGuaranteed>) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>>
-             at ./library/core/src/slice/iter/macros.rs:232:27
-  42: fold<core::result::Result<(), rustc_span::ErrorGuaranteed>, core::slice::iter::Iter<rustc_hir::hir::ItemId>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure_env#2}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>, core::result::Result<(), rustc_span::ErrorGuaranteed>, fn(core::result::Result<(), rustc_span::ErrorGuaranteed>, core::result::Result<(), rustc_span::ErrorGuaranteed>) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./library/core/src/iter/adapters/filter_map.rs:148:9
-  43: {closure#0}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:206:73
-  44: parallel_guard<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure_env#0}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:44:15
-  45: try_par_for_each_in<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:199:9
-  46: par_items<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>
-             at ./compiler/rustc_middle/src/hir/mod.rs:75:9
-  47: check_mod_type_wf
-             at ./compiler/rustc_hir_analysis/src/check/wfcheck.rs:1994:19
-  48: {closure#0}
-             at ./compiler/rustc_query_impl/src/plumbing.rs:281:9
-      [... omitted 22 frames ...]
-  49: query_ensure_error_guaranteed<rustc_query_system::query::caches::DefaultCache<rustc_span::def_id::LocalModDefId, rustc_middle::query::erase::Erased<[u8; 1]>>, ()>
-             at ./compiler/rustc_middle/src/query/plumbing.rs:181:9
-  50: check_mod_type_wf
-             at ./compiler/rustc_middle/src/query/plumbing.rs:199:9
-  51: {closure#0}
-             at ./compiler/rustc_hir_analysis/src/lib.rs:162:21
-  52: {closure#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>
-             at ./compiler/rustc_middle/src/hir/map/mod.rs:463:13
-  53: {closure#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:182:34
-  54: call_once<(), rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>
-             at ./library/core/src/panic/unwind_safe.rs:272:9
-  55: do_call<core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>, ()>
-             at ./library/std/src/panicking.rs:553:40
-  56: try<(), core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>>
-             at ./library/std/src/panicking.rs:517:19
-  57: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure#1}::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>, ()>
-             at ./library/std/src/panic.rs:350:14
-  58: run<(), rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure#1}::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:28:9
-  59: {closure#1}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:186:21
-  60: for_each<rustc_hir::hir_id::OwnerId, rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure_env#1}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>
-             at ./library/core/src/slice/iter/macros.rs:254:21
-  61: {closure#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:185:17
-  62: parallel_guard<(), rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:44:15
-  63: par_for_each_in<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>
-             at ./compiler/rustc_data_structures/src/sync/parallel.rs:178:9
-  64: par_for_each_module<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>
-             at ./compiler/rustc_middle/src/hir/map/mod.rs:462:9
-  65: {closure#0}
-             at ./compiler/rustc_hir_analysis/src/lib.rs:161:9
-  66: run<(), rustc_hir_analysis::check_crate::{closure_env#0}>
-             at ./compiler/rustc_data_structures/src/profiling.rs:754:9
-  67: time<(), rustc_hir_analysis::check_crate::{closure_env#0}>
-             at ./compiler/rustc_session/src/utils.rs:16:9
-  68: check_crate
-             at ./compiler/rustc_hir_analysis/src/lib.rs:160:5
-  69: run_required_analyses
-             at ./compiler/rustc_interface/src/passes.rs:784:5
-  70: analysis
-             at ./compiler/rustc_interface/src/passes.rs:823:5
-  71: {closure#0}
-             at ./compiler/rustc_query_impl/src/plumbing.rs:281:9
-      [... omitted 22 frames ...]
-  72: query_get_at<rustc_query_system::query::caches::SingleCache<rustc_middle::query::erase::Erased<[u8; 1]>>>
-             at ./compiler/rustc_middle/src/query/plumbing.rs:145:17
-  73: analysis
-             at ./compiler/rustc_middle/src/query/plumbing.rs:423:31
-  74: analysis
-             at ./compiler/rustc_middle/src/query/plumbing.rs:414:35
-  75: {closure#5}
-             at ./compiler/rustc_driver_impl/src/lib.rs:445:52
-  76: {closure#1}<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./compiler/rustc_middle/src/ty/context.rs:1296:37
-  77: {closure#0}<rustc_middle::ty::context::{impl#19}::enter::{closure_env#1}<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./compiler/rustc_middle/src/ty/context/tls.rs:82:9
-  78: try_with<core::cell::Cell<*const ()>, rustc_middle::ty::context::tls::enter_context::{closure_env#0}<rustc_middle::ty::context::{impl#19}::enter::{closure_env#1}<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./library/std/src/thread/local.rs:283:12
-  79: with<core::cell::Cell<*const ()>, rustc_middle::ty::context::tls::enter_context::{closure_env#0}<rustc_middle::ty::context::{impl#19}::enter::{closure_env#1}<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./library/std/src/thread/local.rs:260:9
-  80: enter_context<rustc_middle::ty::context::{impl#19}::enter::{closure_env#1}<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./compiler/rustc_middle/src/ty/context/tls.rs:79:9
-  81: enter<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./compiler/rustc_middle/src/ty/context.rs:1296:9
-  82: {closure#1}
-             at ./compiler/rustc_driver_impl/src/lib.rs:445:13
-  83: enter<rustc_driver_impl::run_compiler::{closure#0}::{closure_env#1}, core::result::Result<core::option::Option<rustc_interface::queries::Linker>, rustc_span::ErrorGuaranteed>>
-             at ./compiler/rustc_interface/src/queries.rs:202:19
-  84: {closure#0}
-             at ./compiler/rustc_driver_impl/src/lib.rs:389:22
-  85: {closure#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>
-             at ./compiler/rustc_interface/src/interface.rs:502:27
-  86: {closure#0}<rustc_interface::interface::run_compiler::{closure_env#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./compiler/rustc_interface/src/util.rs:154:13
-  87: {closure#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./compiler/rustc_interface/src/util.rs:106:21
-  88: set<rustc_span::SessionGlobals, rustc_interface::util::run_in_thread_with_globals::{closure#0}::{closure#0}::{closure_env#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at /home/boxy/.cargo/registry/src/index.crates.io-6f17d22bba15001f/scoped-tls-1.0.1/src/lib.rs:137:9
-  89: create_session_globals_then<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_interface::util::run_in_thread_with_globals::{closure#0}::{closure#0}::{closure_env#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>>
-             at ./compiler/rustc_span/src/lib.rs:134:5
-  90: {closure#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
-             at ./compiler/rustc_interface/src/util.rs:105:17
-note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
+error[E0367]: `Drop` impl requires `the constant `_` has type `usize`` but the struct it is implemented for does not
+  --> $DIR/unconstrained_const_param_on_drop.rs:3:6
+   |
+LL | impl<const UNUSED: usize> Drop for Foo {}
+   |      ^^^^^^^^^^^^^^^^^^^
+   |
+note: the implementor must specify the same requirement
+  --> $DIR/unconstrained_const_param_on_drop.rs:1:1
+   |
+LL | struct Foo {}
+   | ^^^^^^^^^^
 
-error: the compiler unexpectedly panicked. this is a bug.
-
-note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md
-
-note: please make sure that you have updated to the latest nightly
-
-note: rustc 1.81.0-dev running on x86_64-unknown-linux-gnu
-
-note: compiler flags: -Z threads=1 -Z simulate-remapped-rust-src-base=/rustc/FAKE_PREFIX -Z translate-remapped-path-to-local-path=no -Z ignore-directory-in-diagnostics-source-blocks=/home/boxy/.cargo -Z ignore-directory-in-diagnostics-source-blocks=/media/Nyoomies/Repos/rust/vendor -C codegen-units=1 -Z ui-testing -Z deduplicate-diagnostics=no -Z write-long-types-to-disk=no -C strip=debuginfo -C prefer-dynamic -C rpath -C debuginfo=0
-
-query stack during panic:
-#0 [adt_destructor] computing `Drop` impl for `Foo`
-#1 [check_well_formed] checking that `Foo` is well-formed
-#2 [check_mod_type_wf] checking that types are well-formed in top-level module
-#3 [analysis] running analysis passes on this crate
-end of query stack
 error[E0207]: the const parameter `UNUSED` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/unconstrained_const_param_on_drop.rs:6:6
+  --> $DIR/unconstrained_const_param_on_drop.rs:3:6
    |
 LL | impl<const UNUSED: usize> Drop for Foo {}
    |      ^^^^^^^^^^^^^^^^^^^ unconstrained const parameter
@@ -214,6 +19,7 @@ LL | impl<const UNUSED: usize> Drop for Foo {}
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0207`.
+Some errors have detailed explanations: E0207, E0367.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/dropck/unconstrained_const_param_on_drop.stderr
+++ b/tests/ui/dropck/unconstrained_const_param_on_drop.stderr
@@ -1,0 +1,219 @@
+thread 'rustc' panicked at compiler/rustc_middle/src/ty/sty.rs:360:36:
+called `Option::unwrap()` on a `None` value
+stack backtrace:
+   0: begin_panic_handler
+             at ./library/std/src/panicking.rs:661:5
+   1: panic_fmt
+             at ./library/core/src/panicking.rs:74:14
+   2: panic
+             at ./library/core/src/panicking.rs:148:5
+   3: core::option::unwrap_failed
+             at ./library/core/src/option.rs:2013:5
+   4: unwrap<rustc_middle::ty::Ty>
+             at ./library/core/src/option.rs:963:21
+   5: find_ty_from_env
+             at ./compiler/rustc_middle/src/ty/sty.rs:360:36
+   6: process_obligation
+             at ./compiler/rustc_trait_selection/src/traits/fulfill.rs:472:29
+   7: process_obligations<rustc_trait_selection::traits::fulfill::PendingPredicateObligation, rustc_trait_selection::traits::fulfill::FulfillProcessor>
+             at ./compiler/rustc_data_structures/src/obligation_forest/mod.rs:462:23
+   8: select<rustc_trait_selection::traits::FulfillmentError>
+             at ./compiler/rustc_trait_selection/src/traits/fulfill.rs:107:13
+   9: select_where_possible<rustc_trait_selection::traits::FulfillmentError>
+             at ./compiler/rustc_trait_selection/src/traits/fulfill.rs:160:9
+  10: select_all_or_error<rustc_trait_selection::traits::fulfill::FulfillmentContext<rustc_trait_selection::traits::FulfillmentError>, rustc_trait_selection::traits::FulfillmentError>
+             at ./compiler/rustc_infer/src/traits/engine.rs:82:22
+  11: select_all_or_error<rustc_trait_selection::traits::FulfillmentError>
+             at ./compiler/rustc_trait_selection/src/traits/engine.rs:189:9
+  12: ensure_drop_predicates_are_implied_by_item_defn
+             at ./compiler/rustc_hir_analysis/src/check/dropck.rs:154:18
+  13: check_drop_impl
+             at ./compiler/rustc_hir_analysis/src/check/dropck.rs:60:13
+  14: call<fn(rustc_middle::ty::context::TyCtxt, rustc_span::def_id::DefId) -> core::result::Result<(), rustc_span::ErrorGuaranteed>, (rustc_middle::ty::context::TyCtxt, rustc_span::def_id::DefId)>
+             at ./library/core/src/ops/function.rs:79:5
+  15: {closure#0}<fn(rustc_middle::ty::context::TyCtxt, rustc_span::def_id::DefId) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./compiler/rustc_middle/src/ty/util.rs:360:16
+  16: for_each_relevant_impl<rustc_middle::ty::util::{impl#2}::calculate_dtor::{closure_env#0}<fn(rustc_middle::ty::context::TyCtxt, rustc_span::def_id::DefId) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>>
+             at ./compiler/rustc_middle/src/ty/trait_def.rs:166:21
+  17: calculate_dtor<fn(rustc_middle::ty::context::TyCtxt, rustc_span::def_id::DefId) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./compiler/rustc_middle/src/ty/util.rs:359:9
+  18: rustc_hir_analysis::check::adt_destructor
+             at ./compiler/rustc_hir_analysis/src/check/mod.rs:125:5
+  19: {closure#0}
+             at ./compiler/rustc_query_impl/src/plumbing.rs:285:13
+      [... omitted 22 frames ...]
+  20: query_get_at<rustc_query_system::query::caches::DefIdCache<rustc_middle::query::erase::Erased<[u8; 12]>>>
+             at ./compiler/rustc_middle/src/query/plumbing.rs:145:17
+  21: adt_destructor<rustc_span::def_id::DefId>
+             at ./compiler/rustc_middle/src/query/plumbing.rs:423:31
+  22: adt_destructor<rustc_span::def_id::DefId>
+             at ./compiler/rustc_middle/src/query/plumbing.rs:414:35
+  23: destructor
+             at ./compiler/rustc_middle/src/ty/adt.rs:610:13
+  24: check_struct
+             at ./compiler/rustc_hir_analysis/src/check/check.rs:71:5
+  25: check_item_type
+             at ./compiler/rustc_hir_analysis/src/check/check.rs:730:13
+  26: check_item
+             at ./compiler/rustc_hir_analysis/src/check/wfcheck.rs:335:5
+  27: check_well_formed
+             at ./compiler/rustc_hir_analysis/src/check/wfcheck.rs:192:39
+  28: {closure#0}
+             at ./compiler/rustc_query_impl/src/plumbing.rs:281:9
+      [... omitted 22 frames ...]
+  29: query_ensure_error_guaranteed<rustc_query_system::query::caches::VecCache<rustc_hir::hir_id::OwnerId, rustc_middle::query::erase::Erased<[u8; 1]>>, ()>
+             at ./compiler/rustc_middle/src/query/plumbing.rs:181:9
+  30: check_well_formed
+             at ./compiler/rustc_middle/src/query/plumbing.rs:199:9
+  31: {closure#1}
+             at ./compiler/rustc_hir_analysis/src/check/wfcheck.rs:1995:47
+  32: {closure#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#1}>
+             at ./compiler/rustc_middle/src/hir/mod.rs:89:57
+  33: {closure#0}<&[rustc_hir::hir::ImplItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_impl_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#1}>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:203:50
+  34: call_once<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&[rustc_hir::hir::ImplItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_impl_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#1}>>>
+             at ./library/core/src/panic/unwind_safe.rs:272:9
+  35: do_call<core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&[rustc_hir::hir::ImplItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_impl_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#1}>>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./library/std/src/panicking.rs:553:40
+  36: try<core::result::Result<(), rustc_span::ErrorGuaranteed>, core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&[rustc_hir::hir::ImplItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_impl_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#1}>>>>
+             at ./library/std/src/panicking.rs:517:19
+  37: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure#2}::{closure_env#0}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./library/std/src/panic.rs:350:14
+  38: run<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure#2}::{closure_env#0}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:28:9
+  39: {closure#2}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:206:46
+  40: {closure#0}<&rustc_hir::hir::ItemId, core::result::Result<(), rustc_span::ErrorGuaranteed>, core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure_env#2}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>, fn(core::result::Result<(), rustc_span::ErrorGuaranteed>, core::result::Result<(), rustc_span::ErrorGuaranteed>) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./library/core/src/iter/adapters/filter_map.rs:39:28
+  41: fold<rustc_hir::hir::ItemId, core::result::Result<(), rustc_span::ErrorGuaranteed>, core::iter::adapters::filter_map::filter_map_fold::{closure_env#0}<&rustc_hir::hir::ItemId, core::result::Result<(), rustc_span::ErrorGuaranteed>, core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure_env#2}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>, fn(core::result::Result<(), rustc_span::ErrorGuaranteed>, core::result::Result<(), rustc_span::ErrorGuaranteed>) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>>
+             at ./library/core/src/slice/iter/macros.rs:232:27
+  42: fold<core::result::Result<(), rustc_span::ErrorGuaranteed>, core::slice::iter::Iter<rustc_hir::hir::ItemId>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure#0}::{closure_env#2}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>, core::result::Result<(), rustc_span::ErrorGuaranteed>, fn(core::result::Result<(), rustc_span::ErrorGuaranteed>, core::result::Result<(), rustc_span::ErrorGuaranteed>) -> core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./library/core/src/iter/adapters/filter_map.rs:148:9
+  43: {closure#0}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:206:73
+  44: parallel_guard<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_data_structures::sync::parallel::enabled::try_par_for_each_in::{closure_env#0}<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:44:15
+  45: try_par_for_each_in<&[rustc_hir::hir::ItemId], rustc_span::ErrorGuaranteed, rustc_middle::hir::{impl#0}::par_items::{closure_env#0}<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:199:9
+  46: par_items<rustc_hir_analysis::check::wfcheck::check_mod_type_wf::{closure_env#0}>
+             at ./compiler/rustc_middle/src/hir/mod.rs:75:9
+  47: check_mod_type_wf
+             at ./compiler/rustc_hir_analysis/src/check/wfcheck.rs:1994:19
+  48: {closure#0}
+             at ./compiler/rustc_query_impl/src/plumbing.rs:281:9
+      [... omitted 22 frames ...]
+  49: query_ensure_error_guaranteed<rustc_query_system::query::caches::DefaultCache<rustc_span::def_id::LocalModDefId, rustc_middle::query::erase::Erased<[u8; 1]>>, ()>
+             at ./compiler/rustc_middle/src/query/plumbing.rs:181:9
+  50: check_mod_type_wf
+             at ./compiler/rustc_middle/src/query/plumbing.rs:199:9
+  51: {closure#0}
+             at ./compiler/rustc_hir_analysis/src/lib.rs:162:21
+  52: {closure#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>
+             at ./compiler/rustc_middle/src/hir/map/mod.rs:463:13
+  53: {closure#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:182:34
+  54: call_once<(), rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>
+             at ./library/core/src/panic/unwind_safe.rs:272:9
+  55: do_call<core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>, ()>
+             at ./library/std/src/panicking.rs:553:40
+  56: try<(), core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure#0}::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>>
+             at ./library/std/src/panicking.rs:517:19
+  57: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure#1}::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>, ()>
+             at ./library/std/src/panic.rs:350:14
+  58: run<(), rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure#1}::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:28:9
+  59: {closure#1}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:186:21
+  60: for_each<rustc_hir::hir_id::OwnerId, rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure#0}::{closure_env#1}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>
+             at ./library/core/src/slice/iter/macros.rs:254:21
+  61: {closure#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:185:17
+  62: parallel_guard<(), rustc_data_structures::sync::parallel::enabled::par_for_each_in::{closure_env#0}<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:44:15
+  63: par_for_each_in<&rustc_hir::hir_id::OwnerId, &[rustc_hir::hir_id::OwnerId], rustc_middle::hir::map::{impl#3}::par_for_each_module::{closure_env#0}<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>>
+             at ./compiler/rustc_data_structures/src/sync/parallel.rs:178:9
+  64: par_for_each_module<rustc_hir_analysis::check_crate::{closure#0}::{closure_env#0}>
+             at ./compiler/rustc_middle/src/hir/map/mod.rs:462:9
+  65: {closure#0}
+             at ./compiler/rustc_hir_analysis/src/lib.rs:161:9
+  66: run<(), rustc_hir_analysis::check_crate::{closure_env#0}>
+             at ./compiler/rustc_data_structures/src/profiling.rs:754:9
+  67: time<(), rustc_hir_analysis::check_crate::{closure_env#0}>
+             at ./compiler/rustc_session/src/utils.rs:16:9
+  68: check_crate
+             at ./compiler/rustc_hir_analysis/src/lib.rs:160:5
+  69: run_required_analyses
+             at ./compiler/rustc_interface/src/passes.rs:784:5
+  70: analysis
+             at ./compiler/rustc_interface/src/passes.rs:823:5
+  71: {closure#0}
+             at ./compiler/rustc_query_impl/src/plumbing.rs:281:9
+      [... omitted 22 frames ...]
+  72: query_get_at<rustc_query_system::query::caches::SingleCache<rustc_middle::query::erase::Erased<[u8; 1]>>>
+             at ./compiler/rustc_middle/src/query/plumbing.rs:145:17
+  73: analysis
+             at ./compiler/rustc_middle/src/query/plumbing.rs:423:31
+  74: analysis
+             at ./compiler/rustc_middle/src/query/plumbing.rs:414:35
+  75: {closure#5}
+             at ./compiler/rustc_driver_impl/src/lib.rs:445:52
+  76: {closure#1}<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./compiler/rustc_middle/src/ty/context.rs:1296:37
+  77: {closure#0}<rustc_middle::ty::context::{impl#19}::enter::{closure_env#1}<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./compiler/rustc_middle/src/ty/context/tls.rs:82:9
+  78: try_with<core::cell::Cell<*const ()>, rustc_middle::ty::context::tls::enter_context::{closure_env#0}<rustc_middle::ty::context::{impl#19}::enter::{closure_env#1}<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./library/std/src/thread/local.rs:283:12
+  79: with<core::cell::Cell<*const ()>, rustc_middle::ty::context::tls::enter_context::{closure_env#0}<rustc_middle::ty::context::{impl#19}::enter::{closure_env#1}<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./library/std/src/thread/local.rs:260:9
+  80: enter_context<rustc_middle::ty::context::{impl#19}::enter::{closure_env#1}<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./compiler/rustc_middle/src/ty/context/tls.rs:79:9
+  81: enter<rustc_driver_impl::run_compiler::{closure#0}::{closure#1}::{closure_env#5}, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./compiler/rustc_middle/src/ty/context.rs:1296:9
+  82: {closure#1}
+             at ./compiler/rustc_driver_impl/src/lib.rs:445:13
+  83: enter<rustc_driver_impl::run_compiler::{closure#0}::{closure_env#1}, core::result::Result<core::option::Option<rustc_interface::queries::Linker>, rustc_span::ErrorGuaranteed>>
+             at ./compiler/rustc_interface/src/queries.rs:202:19
+  84: {closure#0}
+             at ./compiler/rustc_driver_impl/src/lib.rs:389:22
+  85: {closure#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>
+             at ./compiler/rustc_interface/src/interface.rs:502:27
+  86: {closure#0}<rustc_interface::interface::run_compiler::{closure_env#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./compiler/rustc_interface/src/util.rs:154:13
+  87: {closure#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./compiler/rustc_interface/src/util.rs:106:21
+  88: set<rustc_span::SessionGlobals, rustc_interface::util::run_in_thread_with_globals::{closure#0}::{closure#0}::{closure_env#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at /home/boxy/.cargo/registry/src/index.crates.io-6f17d22bba15001f/scoped-tls-1.0.1/src/lib.rs:137:9
+  89: create_session_globals_then<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_interface::util::run_in_thread_with_globals::{closure#0}::{closure#0}::{closure_env#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>>
+             at ./compiler/rustc_span/src/lib.rs:134:5
+  90: {closure#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#1}<core::result::Result<(), rustc_span::ErrorGuaranteed>, rustc_driver_impl::run_compiler::{closure_env#0}>, core::result::Result<(), rustc_span::ErrorGuaranteed>>, core::result::Result<(), rustc_span::ErrorGuaranteed>>
+             at ./compiler/rustc_interface/src/util.rs:105:17
+note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
+
+error: the compiler unexpectedly panicked. this is a bug.
+
+note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md
+
+note: please make sure that you have updated to the latest nightly
+
+note: rustc 1.81.0-dev running on x86_64-unknown-linux-gnu
+
+note: compiler flags: -Z threads=1 -Z simulate-remapped-rust-src-base=/rustc/FAKE_PREFIX -Z translate-remapped-path-to-local-path=no -Z ignore-directory-in-diagnostics-source-blocks=/home/boxy/.cargo -Z ignore-directory-in-diagnostics-source-blocks=/media/Nyoomies/Repos/rust/vendor -C codegen-units=1 -Z ui-testing -Z deduplicate-diagnostics=no -Z write-long-types-to-disk=no -C strip=debuginfo -C prefer-dynamic -C rpath -C debuginfo=0
+
+query stack during panic:
+#0 [adt_destructor] computing `Drop` impl for `Foo`
+#1 [check_well_formed] checking that `Foo` is well-formed
+#2 [check_mod_type_wf] checking that types are well-formed in top-level module
+#3 [analysis] running analysis passes on this crate
+end of query stack
+error[E0207]: the const parameter `UNUSED` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained_const_param_on_drop.rs:6:6
+   |
+LL | impl<const UNUSED: usize> Drop for Foo {}
+   |      ^^^^^^^^^^^^^^^^^^^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0207`.


### PR DESCRIPTION
Follow up to #110577
Fixes #126378
Fixes #126889

## Motivation

A current issue with the way we check drop impls do not specialize any of their generic parameters is that when the `Drop` impl introduces *more* generic parameters than are present on the ADT, we fail to prove any bounds involving those parameters. This can be demonstrated with the following [code on stable](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=139b65e4294634d7286a3282bc61e628) which fails due to the fact that `<T as Trait>::Assoc == U` is not present in `Foo`s `ParamEnv` even though arguably there is no reason it cannot compiler:
```rust
struct Foo<T: Trait>(T);

trait Trait {
    type Assoc;
}

impl<T: Trait<Assoc = U>, U: ?Sized> Drop for Foo<T> {
    //~^ ERROR: `Drop` impl requires `<T as Trait>::Assoc == U` but the struct ...
    fn drop(&mut self) {}
}

fn main() {}
```

I think the motivation for supporting this code is somewhat lacking, it might be useful in practice for deeply nested associated types where you might want to be able to write:
`where T: Trait<Assoc: Other<AnotherAssoc: MoreTrait<YetAnotherAssoc: InnerTrait<Final = U>>>>`
in order to be able to just use `U` in the function body instead of writing out the whole nested associated type. Regardless I don't think there is really any reason to *not* support this code and it is relatively easy to support it.

What I find slightly more compelling is the fact that when defining a const parameter `const N: u8` we desugar that to having a where clause requiring the constant `N` is typed as `u8` (`ClauseKind::ConstArgHasType`). As we *always* desugar const parameters to have these bounds, if we attempt to prove that some const parameter `N` is of type `u8` and there is no bound on `N` in the enviroment that generally indicates usage of an incorrect `ParamEnv` (this has caught a bug already).

Given that, if we write the following code:
```rust
#![feature(associated_const_equality)]
struct Foo<T: Trait>(T);

trait Trait {
    const ASSOC: usize;
}

impl<T: Trait<ASSOC = N>, const N: usize> Drop for Foo<T> {
    fn drop(&mut self) {}
}

fn main() {}
```

The `Drop` impl would have this desugared where clause about `N` being of type `usize`, and if we were to try to prove that where clause in `Foo`'s `ParamEnv` we would ICE as there would not be any `ConstArgHasType` in the environment (which generally indicates improper `ParamEnv` usage. As this is otherwise well formed code (the `T: Trait<ASSOC = N>` causes `N` to be constrained) we have to handle this *somehow* and I believe the only principled way to support this is the changes I have made to `dropck.rs` that would cause these code examples to compiler (Perhaps we could just throw out all `ConstArgHasType` where clauses from the predicates we prove but that makes me nervous even if it might actually be okay).

## The changes

Currently the way `dropck.rs` works is that take the `ParamEnv` of the ADT and instantiate it with the generic arguments used on the self ty of the `impl`. We then instantiate the predicates of the drop impl with the identity params to the impl,  e.g. in the original example `<T as Trait>::Assoc == U` stays as `<T as Trait>::Assoc == U`. We then attempt to prove all the where clauses in the instantiated env of the self type ADT.

This PR changes us to first instantiate the impl with infer vars, then we equate the self type (with infer vars as its generic arguments) with the self type as written by the user. This causes all generic parameters on the impl that are constrained via associated type/const equality bounds to be left as inference variables while all other parameters are still `Ty`/`Const`/`Region` 

Finally when instantiating the predicates on the impl, instead of using the identity arguments, we use the list of inference variables of which some have been inferred to the impl parameters. In practice this means that we wind up proving `<T as Trait>::Assoc == ?x` which can succeed just fine. In the const generics example we would wind up trying to prove `ConstArgHasType(?x: usize)` instead of `ConstArgHasType(N: usize)` which avoids the ICE as it is expected to encounter goals of the form `?x: usize`.

At a higher level the way I justify/think about this is that as we are proving goals in the environment of the ADT (`Foo` in the above examples), we do not expect to encounter generic parameters from a different environment so we must "deal with them" somehow. In this PR we handle them by replacing them with inference variables as they should either *actually* be unconstrained (and we will error later) or they are constrained to be equal to some associated type/const.

To go along with this it would be nice if we were not instantiating the adt's env with the generic arguments to the ADT in the `Drop` impl as it would make it clearer we are proving bounds in the adt's env instead of the `Drop` impl's. Instead we would map the predicates on the drop impl to be valid in the environment of the adt. In practice this causes diagnostic regressions as all of the generic parameters in errors refer to the ones defined on the adt; attempting to map these back to the ones on the impl, while possible, is involved as writing a `TypeFolder` over `FulfillmentError` is non trivial.

## Edge cases

There are some subtle interactions here:

One is that we should not allow `<T as Trait>::Assoc == U` to be present on the `Drop` if `U` is constrained by the self type of the impl and the bound is not present in the ADT's environment. demonstrated with the [following code](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=af839e2c3e43e03a624825c58af84dff):
```rust
trait Trait {
    type Assoc;
}

struct Foo<T: Trait, U: ?Sized>(T, U);

impl<T: Trait<Assoc = U>, U: ?Sized> Drop for Foo<T, U> {
    //~^ ERROR: `Drop` impl requires `<T as Trait>::Assoc == U`
    fn drop(&mut self) {}
}

fn main() {}
```
This is tested at `tests/ui/dropck/constrained_by_assoc_type_equality_and_self_ty.rs`.

Another weirdness is that we permit the following code to compile now:
```rust
struct Foo<T>(T);

impl<'a, T: 'a> Drop for Foo<T> {
    fn drop(&mut self) {}
}
```
This is caused by the fact that we permit unconstrained lifetime parameters in trait implementations as long as they are not used in associated types (so we do not wind up erroring on this code like we perhaps ought to), combined with the fact that as we are now proving `T: '?x` instead of `T: 'a` which allows proving the bound via `'?x= 'empty` wheras previously it would have failed.

This is tested as part of `tests/ui/dropck/reject-specialized-drops-8142.rs`.

---

r? @compiler-errors 