### PR TITLE
doc: update config file path in platform-support/wasm32-wasip1-threads.md

### DIFF
--- a/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
@@ -107,7 +107,7 @@ flag, for example:
 
 Users need to install or built wasi-sdk since release 20.0
 https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-20
-and specify path to *wasi-root* `.cargo/config.toml`
+and specify path to *wasi-root* `config.toml`
 
 ```toml
 [target.wasm32-wasip1-threads]


### PR DESCRIPTION
The config content described in the `Building the target` section should be the configuration used for building Rust itself:

https://github.com/rust-lang/rust/blob/7d97c59438e933e86f557ed999da3b8dfc6855a7/config.example.toml#L845-L848

I believe this is different from Cargo's configuration. There seems to be some misunderstanding in the discussion here: https://github.com/rust-lang/rust/pull/112922#discussion_r1272263810.