### PR TITLE
remove unnecessary ignore-endian-big from stack-overflow-trait-infer …

### DIFF
--- a/tests/ui/sized/stack-overflow-trait-infer-98842.32bit.stderr
+++ b/tests/ui/sized/stack-overflow-trait-infer-98842.32bit.stderr
@@ -3,14 +3,14 @@ error[E0391]: cycle detected when computing layout of `Foo`
    = note: ...which requires computing layout of `<&'static Foo as core::ops::deref::Deref>::Target`...
    = note: ...which again requires computing layout of `Foo`, completing the cycle
 note: cycle used when const-evaluating + checking `_`
-  --> $DIR/stack-overflow-trait-infer-98842.rs:15:1
+  --> $DIR/stack-overflow-trait-infer-98842.rs:14:1
    |
 LL | const _: *const Foo = 0 as _;
    | ^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/stack-overflow-trait-infer-98842.rs:15:1
+  --> $DIR/stack-overflow-trait-infer-98842.rs:14:1
    |
 LL | const _: *const Foo = 0 as _;
    | ^^^^^^^^^^^^^^^^^^^ a cycle occurred during layout computation

--- a/tests/ui/sized/stack-overflow-trait-infer-98842.64bit.stderr
+++ b/tests/ui/sized/stack-overflow-trait-infer-98842.64bit.stderr
@@ -3,14 +3,14 @@ error[E0391]: cycle detected when computing layout of `Foo`
    = note: ...which requires computing layout of `<&'static Foo as core::ops::deref::Deref>::Target`...
    = note: ...which again requires computing layout of `Foo`, completing the cycle
 note: cycle used when const-evaluating + checking `_`
-  --> $DIR/stack-overflow-trait-infer-98842.rs:15:1
+  --> $DIR/stack-overflow-trait-infer-98842.rs:14:1
    |
 LL | const _: *const Foo = 0 as _;
    | ^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/stack-overflow-trait-infer-98842.rs:15:1
+  --> $DIR/stack-overflow-trait-infer-98842.rs:14:1
    |
 LL | const _: *const Foo = 0 as _;
    | ^^^^^^^^^^^^^^^^^^^ a cycle occurred during layout computation

--- a/tests/ui/sized/stack-overflow-trait-infer-98842.rs
+++ b/tests/ui/sized/stack-overflow-trait-infer-98842.rs
@@ -3,8 +3,7 @@
 //@ check-fail
 //@ edition:2021
 //@ stderr-per-bitwidth
-//@ ignore-endian-big
-//~^^^^^^ ERROR cycle detected when computing layout of `Foo`
+//~^^^^^ ERROR cycle detected when computing layout of `Foo`
 
 // If the inner `Foo` is named through an associated type,
 // the "infinite size" error does not occur.


### PR DESCRIPTION
Follow-up to [this](https://github.com/rust-lang/rust/pull/122895#discussion_r1632206218) discussion