### PR TITLE
Mark span parent in def_collector.

### DIFF
--- a/compiler/rustc_ast/src/format.rs
+++ b/compiler/rustc_ast/src/format.rs
@@ -180,7 +180,6 @@ pub struct FormatPlaceholder {
     #[visitable(ignore)]
     pub format_trait: FormatTrait,
     /// `{}` or `{:.5}` or `{:-^20}`, etc.
-    #[visitable(ignore)]
     pub format_options: FormatOptions,
 }
 
@@ -229,23 +228,26 @@ pub enum FormatTrait {
     UpperHex,
 }
 
-#[derive(Clone, Encodable, Decodable, Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Encodable, Decodable, Default, Debug, PartialEq, Eq, Walkable)]
 pub struct FormatOptions {
     /// The width. E.g. `{:5}` or `{:width$}`.
     pub width: Option<FormatCount>,
     /// The precision. E.g. `{:.5}` or `{:.precision$}`.
     pub precision: Option<FormatCount>,
     /// The alignment. E.g. `{:>}` or `{:<}` or `{:^}`.
+    #[visitable(ignore)]
     pub alignment: Option<FormatAlignment>,
     /// The fill character. E.g. the `.` in `{:.>10}`.
     pub fill: Option<char>,
     /// The `+` or `-` flag.
+    #[visitable(ignore)]
     pub sign: Option<FormatSign>,
     /// The `#` flag.
     pub alternate: bool,
     /// The `0` flag. E.g. the `0` in `{:02x}`.
     pub zero_pad: bool,
     /// The `x` or `X` flag (for `Debug` only). E.g. the `x` in `{:x?}`.
+    #[visitable(ignore)]
     pub debug_hex: Option<FormatDebugHex>,
 }
 
@@ -275,7 +277,7 @@ pub enum FormatAlignment {
     Center,
 }
 
-#[derive(Clone, Encodable, Decodable, Debug, PartialEq, Eq)]
+#[derive(Clone, Encodable, Decodable, Debug, PartialEq, Eq, Walkable)]
 pub enum FormatCount {
     /// `{:5}` or `{:.5}`
     Literal(u16),

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -1070,6 +1070,7 @@ macro_rules! common_visitor_and_walkers {
             pub fn walk_contract(FnContract);
             pub fn walk_coroutine_kind(CoroutineKind);
             pub fn walk_crate(Crate);
+            pub fn walk_defaultness(Defaultness);
             pub fn walk_expr(Expr);
             pub fn walk_expr_field(ExprField);
             pub fn walk_field_def(FieldDef);

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -375,6 +375,7 @@ macro_rules! common_visitor_and_walkers {
             std::borrow::Cow<'_, str>,
             Symbol,
             u8,
+            u16,
             usize,
         );
         // `Span` is only a no-op for the non-mutable visitor.
@@ -436,6 +437,8 @@ macro_rules! common_visitor_and_walkers {
             FormatArgument,
             FormatArgumentKind,
             FormatArguments,
+            FormatCount,
+            FormatOptions,
             FormatPlaceholder,
             GenericParamKind,
             Impl,

--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -237,7 +237,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         hir::InlineAsmOperand::Label { block: self.lower_block(block, false) }
                     }
                 };
-                (op, self.lower_span(*op_sp))
+                (op, *op_sp)
             })
             .collect();
 
@@ -463,7 +463,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             late: true,
                             expr: None,
                         },
-                        self.lower_span(abi_span),
+                        abi_span,
                     ));
                     clobbered.insert(clobber);
                 }
@@ -497,12 +497,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         let operands = self.arena.alloc_from_iter(operands);
         let template = self.arena.alloc_from_iter(asm.template.iter().cloned());
         let template_strs = self.arena.alloc_from_iter(
-            asm.template_strs
-                .iter()
-                .map(|(sym, snippet, span)| (*sym, *snippet, self.lower_span(*span))),
+            asm.template_strs.iter().map(|(sym, snippet, span)| (*sym, *snippet, *span)),
         );
-        let line_spans =
-            self.arena.alloc_from_iter(asm.line_spans.iter().map(|span| self.lower_span(*span)));
+        let line_spans = self.arena.alloc_from_iter(asm.line_spans.iter().copied());
         let hir_asm = hir::InlineAsm {
             asm_macro: asm.asm_macro,
             template,

--- a/compiler/rustc_ast_lowering/src/block.rs
+++ b/compiler/rustc_ast_lowering/src/block.rs
@@ -23,7 +23,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     ) -> hir::Block<'hir> {
         let (stmts, expr) = self.lower_stmts(&b.stmts);
         let rules = self.lower_block_check_mode(&b.rules);
-        hir::Block { hir_id, stmts, expr, rules, span: self.lower_span(b.span), targeted_by_break }
+        hir::Block { hir_id, stmts, expr, rules, span: b.span, targeted_by_break }
     }
 
     fn lower_stmts(
@@ -39,7 +39,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     let local = self.lower_local(local);
                     self.alias_attrs(hir_id, local.hir_id);
                     let kind = hir::StmtKind::Let(local);
-                    let span = self.lower_span(s.span);
+                    let span = s.span;
                     stmts.push(hir::Stmt { hir_id, kind, span });
                 }
                 StmtKind::Item(it) => {
@@ -50,7 +50,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                 _ => self.next_id(),
                             };
                             let kind = hir::StmtKind::Item(item_id);
-                            let span = self.lower_span(s.span);
+                            let span = s.span;
                             hir::Stmt { hir_id, kind, span }
                         },
                     ));
@@ -63,7 +63,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         let hir_id = self.lower_node_id(s.id);
                         self.alias_attrs(hir_id, e.hir_id);
                         let kind = hir::StmtKind::Expr(e);
-                        let span = self.lower_span(s.span);
+                        let span = s.span;
                         stmts.push(hir::Stmt { hir_id, kind, span });
                     }
                 }
@@ -72,7 +72,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     let hir_id = self.lower_node_id(s.id);
                     self.alias_attrs(hir_id, e.hir_id);
                     let kind = hir::StmtKind::Semi(e);
-                    let span = self.lower_span(s.span);
+                    let span = s.span;
                     stmts.push(hir::Stmt { hir_id, kind, span });
                 }
                 StmtKind::Empty => {}
@@ -107,7 +107,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         } else {
             None
         };
-        let span = self.lower_span(l.span);
+        let span = l.span;
         let source = hir::LocalSource::Normal;
         self.lower_attrs(hir_id, &l.attrs, l.span);
         self.arena.alloc(hir::LetStmt { hir_id, super_, ty, pat, init, els, span, source })

--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -83,7 +83,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         item_id: NodeId,
         is_in_trait_impl: bool,
     ) -> DelegationResults<'hir> {
-        let span = self.lower_span(delegation.path.segments.last().unwrap().ident.span);
+        let span = delegation.path.segments.last().unwrap().ident.span;
         let sig_id = self.get_delegation_sig_id(item_id, delegation.id, span, is_in_trait_impl);
         match sig_id {
             Ok(sig_id) => {
@@ -92,9 +92,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let decl = self.lower_delegation_decl(sig_id, param_count, c_variadic, span);
                 let sig = self.lower_delegation_sig(sig_id, decl, span);
                 let body_id = self.lower_delegation_body(delegation, is_method, param_count, span);
-                let ident = self.lower_ident(delegation.ident);
                 let generics = self.lower_delegation_generics(span);
-                DelegationResults { body_id, sig, ident, generics }
+                DelegationResults { body_id, sig, ident: delegation.ident, generics }
             }
             Err(err) => self.generate_delegation_error(err, span),
         }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -13,7 +13,7 @@ use rustc_middle::span_bug;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::errors::report_lit_error;
 use rustc_span::source_map::{Spanned, respan};
-use rustc_span::{DUMMY_SP, DesugaringKind, Ident, Span, Symbol, sym};
+use rustc_span::{DesugaringKind, Ident, Span, Symbol, sym};
 use thin_vec::{ThinVec, thin_vec};
 use visit::{Visitor, walk_expr};
 
@@ -508,7 +508,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let last_segment = path.segments.last_mut().unwrap();
         assert!(last_segment.args.is_none());
         last_segment.args = Some(AstP(GenericArgs::AngleBracketed(AngleBracketedArgs {
-            span: DUMMY_SP,
+            span: last_segment.span().shrink_to_hi(),
             args: generic_args,
         })));
 

--- a/compiler/rustc_ast_lowering/src/index.rs
+++ b/compiler/rustc_ast_lowering/src/index.rs
@@ -79,31 +79,23 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
 
         // Make sure that the DepNode of some node coincides with the HirId
         // owner of that node.
-        if cfg!(debug_assertions) {
-            if hir_id.owner != self.owner {
-                span_bug!(
-                    span,
-                    "inconsistent HirId at `{:?}` for `{node:?}`: \
+        if cfg!(debug_assertions) && hir_id.owner != self.owner {
+            span_bug!(
+                span,
+                "inconsistent HirId at `{:?}` for `{node:?}`: \
                      current_dep_node_owner={} ({:?}), hir_id.owner={} ({:?})",
-                    self.tcx.sess.source_map().span_to_diagnostic_string(span),
-                    self.tcx
-                        .definitions_untracked()
-                        .def_path(self.owner.def_id)
-                        .to_string_no_crate_verbose(),
-                    self.owner,
-                    self.tcx
-                        .definitions_untracked()
-                        .def_path(hir_id.owner.def_id)
-                        .to_string_no_crate_verbose(),
-                    hir_id.owner,
-                )
-            }
-            if self.tcx.sess.opts.incremental.is_some()
-                && span.parent().is_none()
-                && !span.is_dummy()
-            {
-                span_bug!(span, "span without a parent: {:#?}, {node:?}", span.data())
-            }
+                self.tcx.sess.source_map().span_to_diagnostic_string(span),
+                self.tcx
+                    .definitions_untracked()
+                    .def_path(self.owner.def_id)
+                    .to_string_no_crate_verbose(),
+                self.owner,
+                self.tcx
+                    .definitions_untracked()
+                    .def_path(hir_id.owner.def_id)
+                    .to_string_no_crate_verbose(),
+                hir_id.owner,
+            )
         }
 
         self.nodes[hir_id.local_id] = ParentedNode { parent: self.parent_node, node };

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -138,11 +138,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     )
                 },
             )),
-            span: self.lower_span(
-                p.segments[..proj_start]
-                    .last()
-                    .map_or(path_span_lo, |segment| path_span_lo.to(segment.span())),
-            ),
+            span: p.segments[..proj_start]
+                .last()
+                .map_or(path_span_lo, |segment| path_span_lo.to(segment.span())),
         });
 
         if let Some(bound_modifier_allowed_features) = bound_modifier_allowed_features {
@@ -243,7 +241,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     None,
                 )
             })),
-            span: self.lower_span(p.span),
+            span: p.span,
         })
     }
 
@@ -401,7 +399,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         );
 
         hir::PathSegment {
-            ident: self.lower_ident(segment.ident),
+            ident: segment.ident,
             hir_id,
             res: self.lower_res(res),
             infer_args,
@@ -580,13 +578,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             parenthesized: hir::GenericArgsParentheses::No,
             span_ext: DUMMY_SP,
         });
-        hir::AssocItemConstraint {
-            hir_id: self.next_id(),
-            gen_args,
-            span: self.lower_span(span),
-            ident,
-            kind,
-        }
+        hir::AssocItemConstraint { hir_id: self.next_id(), gen_args, span, ident, kind }
     }
 
     /// When a bound is annotated with `async`, it signals to lowering that the trait

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -498,6 +498,17 @@ impl MultiSpan {
     pub fn clone_ignoring_labels(&self) -> Self {
         Self { primary_spans: self.primary_spans.clone(), ..MultiSpan::new() }
     }
+
+    pub fn clone_ignoring_parents(&self) -> Self {
+        Self {
+            primary_spans: self.primary_spans.iter().map(|s| s.with_parent(None)).collect(),
+            span_labels: self
+                .span_labels
+                .iter()
+                .map(|(s, l)| (s.with_parent(None), l.clone()))
+                .collect(),
+        }
+    }
 }
 
 impl From<Span> for MultiSpan {

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -433,19 +433,28 @@ impl DiagInner {
         &Level,
         &[(DiagMessage, Style)],
         &Option<ErrCode>,
-        &MultiSpan,
-        &[Subdiag],
-        &Suggestions,
+        MultiSpan,
+        Vec<Subdiag>,
+        Suggestions,
         Vec<(&DiagArgName, &DiagArgValue)>,
         &Option<IsLint>,
     ) {
+        let suggestions = match &self.suggestions {
+            Suggestions::Enabled(sugg) => Suggestions::Enabled(
+                sugg.iter().map(CodeSuggestion::clone_ignoring_parents).collect(),
+            ),
+            Suggestions::Sealed(sugg) => Suggestions::Sealed(
+                sugg.iter().map(CodeSuggestion::clone_ignoring_parents).collect(),
+            ),
+            Suggestions::Disabled => Suggestions::Disabled,
+        };
         (
             &self.level,
             &self.messages,
             &self.code,
-            &self.span,
-            &self.children,
-            &self.suggestions,
+            self.span.clone_ignoring_parents(),
+            self.children.iter().map(Subdiag::clone_ignoring_parents).collect(),
+            suggestions,
             self.args.iter().collect(),
             // omit self.sort_span
             &self.is_lint,
@@ -476,6 +485,13 @@ pub struct Subdiag {
     pub level: Level,
     pub messages: Vec<(DiagMessage, Style)>,
     pub span: MultiSpan,
+}
+
+impl Subdiag {
+    fn clone_ignoring_parents(&self) -> Subdiag {
+        let Subdiag { level, messages, span } = self;
+        Subdiag { level: *level, messages: messages.clone(), span: span.clone_ignoring_parents() }
+    }
 }
 
 /// Used for emitting structured error messages and other diagnostic information.

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1063,7 +1063,7 @@ pub trait ResolverExpand {
     fn visit_ast_fragment_with_placeholders(
         &mut self,
         expn_id: LocalExpnId,
-        fragment: &AstFragment,
+        fragment: &mut AstFragment,
     );
     fn register_builtin_macro(&mut self, name: Symbol, ext: SyntaxExtensionKind);
 

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -137,7 +137,7 @@ macro_rules! ast_fragments {
                 T::fragment_to_output(self)
             }
 
-            pub(crate) fn mut_visit_with(&mut self, vis: &mut impl MutVisitor) {
+            pub fn mut_visit_with(&mut self, vis: &mut impl MutVisitor) {
                 match self {
                     AstFragment::OptExpr(opt_expr) => {
                         if let Some(expr) = opt_expr.take() {
@@ -664,7 +664,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         if self.monotonic {
             self.cx
                 .resolver
-                .visit_ast_fragment_with_placeholders(self.cx.current_expansion.id, &fragment);
+                .visit_ast_fragment_with_placeholders(self.cx.current_expansion.id, &mut fragment);
 
             if self.cx.sess.opts.incremental.is_some() {
                 for (invoc, _) in invocations.iter_mut() {

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -770,9 +770,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 expected.only_has_type(self),
             );
         }
-        if let Some(span) =
-            tcx.resolutions(()).confused_type_with_std_module.get(&span.with_parent(None))
-        {
+        if let Some(span) = tcx.resolutions(()).confused_type_with_std_module.get(&span) {
             err.span_suggestion(
                 span.shrink_to_lo(),
                 "you are looking for the module in `std`, not the primitive type",

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -183,7 +183,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
     pub(crate) fn build_reduced_graph(
         &mut self,
-        fragment: &AstFragment,
+        fragment: &mut AstFragment,
         parent_scope: ParentScope<'ra>,
     ) -> MacroRulesScopeRef<'ra> {
         collect_definitions(self, fragment, parent_scope.expansion);

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -140,18 +140,12 @@ impl<'a, 'ra, 'tcx> mut_visit::MutVisitor for DefCollector<'a, 'ra, 'tcx> {
                     Vec::new(),
                     Early { emit_errors: ShouldEmit::Nothing },
                 );
-                let attrs = parser.parse_attribute_list(
-                    &i.attrs,
-                    i.span,
-                    i.id,
-                    OmitDoc::Skip,
-                    std::convert::identity,
-                    |_l| {
+                let attrs =
+                    parser.parse_attribute_list(&i.attrs, i.span, i.id, OmitDoc::Skip, |_l| {
                         // FIXME(jdonszelmann): emit lints here properly
                         // NOTE that before new attribute parsing, they didn't happen either
                         // but it would be nice if we could change that.
-                    },
-                );
+                    });
 
                 let macro_data =
                     self.resolver.compile_macro(def, *ident, &attrs, i.span, i.id, edition);

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -100,6 +100,12 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
 }
 
 impl<'a, 'ra, 'tcx> mut_visit::MutVisitor for DefCollector<'a, 'ra, 'tcx> {
+    fn visit_span(&mut self, span: &mut Span) {
+        if self.resolver.tcx.sess.opts.incremental.is_some() {
+            *span = span.with_parent(Some(self.invocation_parent.parent_def));
+        }
+    }
+
     fn visit_item(&mut self, i: &mut Item) {
         // Pick the def data. This need not be unique, but the more
         // information we encapsulate into, the better

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -1,6 +1,7 @@
 use std::mem;
 
-use rustc_ast::visit::FnKind;
+use rustc_ast::mut_visit::FnKind;
+use rustc_ast::visit::AssocCtxt;
 use rustc_ast::*;
 use rustc_attr_parsing::{AttributeParser, Early, OmitDoc, ShouldEmit};
 use rustc_expand::expand::AstFragment;
@@ -10,18 +11,20 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_middle::span_bug;
 use rustc_span::hygiene::LocalExpnId;
 use rustc_span::{Span, Symbol, sym};
+use smallvec::{SmallVec, smallvec};
 use tracing::debug;
 
 use crate::{ImplTraitContext, InvocationParent, Resolver};
 
+#[tracing::instrument(level = "trace", skip(resolver, fragment), ret)]
 pub(crate) fn collect_definitions(
     resolver: &mut Resolver<'_, '_>,
-    fragment: &AstFragment,
+    fragment: &mut AstFragment,
     expansion: LocalExpnId,
 ) {
     let invocation_parent = resolver.invocation_parents[&expansion];
     let mut visitor = DefCollector { resolver, expansion, invocation_parent };
-    fragment.visit_with(&mut visitor);
+    fragment.mut_visit_with(&mut visitor);
 }
 
 /// Creates `DefId`s for nodes in the AST.
@@ -56,24 +59,20 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
             .def_id()
     }
 
-    fn with_parent<F: FnOnce(&mut Self)>(&mut self, parent_def: LocalDefId, f: F) {
+    fn with_parent(&mut self, parent_def: LocalDefId, f: impl FnOnce(&mut Self)) {
         let orig_parent_def = mem::replace(&mut self.invocation_parent.parent_def, parent_def);
         f(self);
         self.invocation_parent.parent_def = orig_parent_def;
     }
 
-    fn with_impl_trait<F: FnOnce(&mut Self)>(
-        &mut self,
-        impl_trait_context: ImplTraitContext,
-        f: F,
-    ) {
+    fn with_impl_trait(&mut self, impl_trait_context: ImplTraitContext, f: impl FnOnce(&mut Self)) {
         let orig_itc =
             mem::replace(&mut self.invocation_parent.impl_trait_context, impl_trait_context);
         f(self);
         self.invocation_parent.impl_trait_context = orig_itc;
     }
 
-    fn collect_field(&mut self, field: &'a FieldDef, index: Option<usize>) {
+    fn collect_field(&mut self, field: &mut FieldDef, index: Option<usize>) {
         let index = |this: &Self| {
             index.unwrap_or_else(|| {
                 let node_id = NodeId::placeholder_from_expn_id(this.expansion);
@@ -88,10 +87,11 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         } else {
             let name = field.ident.map_or_else(|| sym::integer(index(self)), |ident| ident.name);
             let def = self.create_def(field.id, Some(name), DefKind::Field, field.span);
-            self.with_parent(def, |this| visit::walk_field_def(this, field));
+            self.with_parent(def, |this| mut_visit::walk_field_def(this, field))
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn visit_macro_invoc(&mut self, id: NodeId) {
         let id = id.placeholder_to_expn_id();
         let old_parent = self.resolver.invocation_parents.insert(id, self.invocation_parent);
@@ -99,8 +99,8 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
     }
 }
 
-impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
-    fn visit_item(&mut self, i: &'a Item) {
+impl<'a, 'ra, 'tcx> mut_visit::MutVisitor for DefCollector<'a, 'ra, 'tcx> {
+    fn visit_item(&mut self, i: &mut Item) {
         // Pick the def data. This need not be unique, but the more
         // information we encapsulate into, the better
         let mut opt_macro_data = None;
@@ -156,7 +156,9 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
             ItemKind::GlobalAsm(..) => DefKind::GlobalAsm,
             ItemKind::Use(use_tree) => {
                 self.create_def(i.id, None, DefKind::Use, use_tree.span);
-                return visit::walk_item(self, i);
+                // HIR lowers use trees as a flat stream of `ItemKind::Use`.
+                // This means all the def-ids must be parented to the module.
+                return mut_visit::walk_item(self, i);
             }
             ItemKind::MacCall(..) | ItemKind::DelegationMac(..) => {
                 return self.visit_macro_invoc(i.id);
@@ -186,68 +188,115 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                     }
                     _ => {}
                 }
-                visit::walk_item(this, i);
+                mut_visit::walk_item(this, i)
             })
-        });
+        })
     }
 
-    fn visit_fn(&mut self, fn_kind: FnKind<'a>, span: Span, _: NodeId) {
-        match fn_kind {
+    #[tracing::instrument(level = "trace", skip(self))]
+    fn visit_fn(&mut self, mut fn_kind: FnKind<'_>, fn_span: Span, _: NodeId) {
+        match &mut fn_kind {
             FnKind::Fn(
                 _ctxt,
                 _vis,
                 Fn {
-                    sig: FnSig { header, decl, span: _ }, ident, generics, contract, body, ..
+                    defaultness,
+                    ident,
+                    sig: FnSig { header, decl, span },
+                    generics,
+                    contract,
+                    body,
+                    define_opaque,
                 },
-            ) if let Some(coroutine_kind) = header.coroutine_kind => {
+            ) => {
+                mut_visit::walk_defaultness(self, defaultness);
                 self.visit_ident(ident);
                 self.visit_fn_header(header);
                 self.visit_generics(generics);
                 if let Some(contract) = contract {
                     self.visit_contract(contract);
                 }
+                self.visit_span(span);
+                if let Some(define_opaque) = define_opaque {
+                    for (node_id, path) in define_opaque {
+                        self.visit_id(node_id);
+                        self.visit_path(path);
+                    }
+                }
 
                 // For async functions, we need to create their inner defs inside of a
                 // closure to match their desugared representation. Besides that,
                 // we must mirror everything that `visit::walk_fn` below does.
-                let FnDecl { inputs, output } = &**decl;
+                let FnDecl { inputs, output } = &mut **decl;
                 for param in inputs {
                     self.visit_param(param);
                 }
 
-                let (return_id, return_span) = coroutine_kind.return_id();
-                let return_def = self.create_def(return_id, None, DefKind::OpaqueTy, return_span);
+                let return_def = if let Some(coroutine_kind) = header.coroutine_kind {
+                    // coroutine_kind has been visited by visit_header.
+                    let (return_id, return_span) = coroutine_kind.return_id();
+                    self.create_def(return_id, None, DefKind::OpaqueTy, return_span)
+                } else {
+                    self.invocation_parent.parent_def
+                };
                 self.with_parent(return_def, |this| this.visit_fn_ret_ty(output));
 
                 // If this async fn has no body (i.e. it's an async fn signature in a trait)
                 // then the closure_def will never be used, and we should avoid generating a
                 // def-id for it.
                 if let Some(body) = body {
-                    let closure_def =
-                        self.create_def(coroutine_kind.closure_id(), None, DefKind::Closure, span);
+                    let closure_def = if let Some(coroutine_kind) = header.coroutine_kind {
+                        self.create_def(
+                            coroutine_kind.closure_id(),
+                            None,
+                            DefKind::Closure,
+                            fn_span,
+                        )
+                    } else {
+                        self.invocation_parent.parent_def
+                    };
                     self.with_parent(closure_def, |this| this.visit_block(body));
                 }
             }
-            FnKind::Closure(binder, Some(coroutine_kind), decl, body) => {
+            FnKind::Closure(binder, coroutine_kind, decl, body) => {
                 self.visit_closure_binder(binder);
-                visit::walk_fn_decl(self, decl);
+                self.visit_fn_decl(decl);
 
                 // Async closures desugar to closures inside of closures, so
                 // we must create two defs.
-                let coroutine_def =
-                    self.create_def(coroutine_kind.closure_id(), None, DefKind::Closure, span);
-                self.with_parent(coroutine_def, |this| this.visit_expr(body));
+                let closure_def = if let Some(coroutine_kind) = coroutine_kind {
+                    self.visit_coroutine_kind(coroutine_kind);
+                    self.create_def(coroutine_kind.closure_id(), None, DefKind::Closure, fn_span)
+                } else {
+                    self.invocation_parent.parent_def
+                };
+                self.with_parent(closure_def, |this| this.visit_expr(body));
             }
-            _ => visit::walk_fn(self, fn_kind),
         }
     }
 
-    fn visit_nested_use_tree(&mut self, use_tree: &'a UseTree, id: NodeId) {
-        self.create_def(id, None, DefKind::Use, use_tree.span);
-        visit::walk_use_tree(self, use_tree);
+    fn visit_use_tree(&mut self, use_tree: &mut UseTree) {
+        let UseTree { prefix, kind, span } = use_tree;
+        self.visit_path(prefix);
+        match kind {
+            UseTreeKind::Simple(None) => {}
+            UseTreeKind::Simple(Some(rename)) => self.visit_ident(rename),
+            UseTreeKind::Nested { items, span } => {
+                for (tree, id) in items {
+                    self.visit_id(id);
+                    // HIR lowers use trees as a flat stream of `ItemKind::Use`.
+                    // This means all the def-ids must be parented to the module.
+                    self.create_def(*id, None, DefKind::Use, *span);
+                    self.visit_use_tree(tree);
+                }
+                self.visit_span(span);
+            }
+            UseTreeKind::Glob => {}
+        }
+        self.visit_span(span);
     }
 
-    fn visit_foreign_item(&mut self, fi: &'a ForeignItem) {
+    fn visit_foreign_item(&mut self, fi: &mut ForeignItem) {
         let (ident, def_kind) = match fi.kind {
             ForeignItemKind::Static(box StaticItem {
                 ident,
@@ -270,14 +319,14 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         };
 
         let def = self.create_def(fi.id, Some(ident.name), def_kind, fi.span);
-
-        self.with_parent(def, |this| visit::walk_item(this, fi));
+        self.with_parent(def, |this| mut_visit::walk_item(this, fi))
     }
 
-    fn visit_variant(&mut self, v: &'a Variant) {
+    fn visit_variant(&mut self, v: &mut Variant) {
         if v.is_placeholder {
             return self.visit_macro_invoc(v.id);
         }
+
         let def = self.create_def(v.id, Some(v.ident.name), DefKind::Variant, v.span);
         self.with_parent(def, |this| {
             if let Some((ctor_kind, ctor_node_id)) = CtorKind::from_ast(&v.data) {
@@ -288,31 +337,41 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                     v.span,
                 );
             }
-            visit::walk_variant(this, v)
-        });
+            mut_visit::walk_variant(this, v)
+        })
     }
 
-    fn visit_where_predicate(&mut self, pred: &'a WherePredicate) {
+    fn visit_where_predicate(&mut self, pred: &mut WherePredicate) {
         if pred.is_placeholder {
             self.visit_macro_invoc(pred.id)
         } else {
-            visit::walk_where_predicate(self, pred)
+            mut_visit::walk_where_predicate(self, pred)
         }
     }
 
-    fn visit_variant_data(&mut self, data: &'a VariantData) {
+    fn visit_variant_data(&mut self, data: &mut VariantData) {
         // The assumption here is that non-`cfg` macro expansion cannot change field indices.
         // It currently holds because only inert attributes are accepted on fields,
         // and every such attribute expands into a single field after it's resolved.
-        for (index, field) in data.fields().iter().enumerate() {
+        let fields = match data {
+            VariantData::Struct { fields, recovered: _ } => fields,
+            VariantData::Tuple(fields, id) => {
+                self.visit_id(id);
+                fields
+            }
+            VariantData::Unit(id) => {
+                self.visit_id(id);
+                return;
+            }
+        };
+        for (index, field) in fields.iter_mut().enumerate() {
             self.collect_field(field, Some(index));
         }
     }
 
-    fn visit_generic_param(&mut self, param: &'a GenericParam) {
+    fn visit_generic_param(&mut self, param: &mut GenericParam) {
         if param.is_placeholder {
-            self.visit_macro_invoc(param.id);
-            return;
+            return self.visit_macro_invoc(param.id);
         }
         let def_kind = match param.kind {
             GenericParamKind::Lifetime { .. } => DefKind::LifetimeParam,
@@ -328,11 +387,11 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         //
         // In that case, the impl-trait is lowered as an additional generic parameter.
         self.with_impl_trait(ImplTraitContext::Universal, |this| {
-            visit::walk_generic_param(this, param)
-        });
+            mut_visit::walk_generic_param(this, param)
+        })
     }
 
-    fn visit_assoc_item(&mut self, i: &'a AssocItem, ctxt: visit::AssocCtxt) {
+    fn visit_assoc_item(&mut self, i: &mut AssocItem, ctxt: AssocCtxt) {
         let (ident, def_kind) = match &i.kind {
             AssocItemKind::Fn(box Fn { ident, .. })
             | AssocItemKind::Delegation(box Delegation { ident, .. }) => (*ident, DefKind::AssocFn),
@@ -344,43 +403,45 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         };
 
         let def = self.create_def(i.id, Some(ident.name), def_kind, i.span);
-        self.with_parent(def, |this| visit::walk_assoc_item(this, i, ctxt));
+        self.with_parent(def, |this| mut_visit::walk_assoc_item(this, i, ctxt));
     }
 
-    fn visit_pat(&mut self, pat: &'a Pat) {
-        match pat.kind {
-            PatKind::MacCall(..) => self.visit_macro_invoc(pat.id),
-            _ => visit::walk_pat(self, pat),
+    fn visit_pat(&mut self, pat: &mut Pat) {
+        if let PatKind::MacCall(..) = pat.kind {
+            return self.visit_macro_invoc(pat.id);
         }
+        mut_visit::walk_pat(self, pat)
     }
 
-    fn visit_anon_const(&mut self, constant: &'a AnonConst) {
+    fn visit_anon_const(&mut self, constant: &mut AnonConst) {
         let parent = self.create_def(constant.id, None, DefKind::AnonConst, constant.value.span);
-        self.with_parent(parent, |this| visit::walk_anon_const(this, constant));
+        self.with_parent(parent, |this| mut_visit::walk_anon_const(this, constant));
     }
 
-    fn visit_expr(&mut self, expr: &'a Expr) {
+    fn visit_expr(&mut self, expr: &mut Expr) {
         let parent_def = match expr.kind {
             ExprKind::MacCall(..) => return self.visit_macro_invoc(expr.id),
             ExprKind::Closure(..) | ExprKind::Gen(..) => {
                 self.create_def(expr.id, None, DefKind::Closure, expr.span)
             }
-            ExprKind::ConstBlock(ref constant) => {
-                for attr in &expr.attrs {
-                    visit::walk_attribute(self, attr);
+            ExprKind::ConstBlock(ref mut constant) => {
+                let Expr { id: _, kind: _, span, attrs, tokens: _ } = expr;
+                for attr in attrs {
+                    self.visit_attribute(attr);
                 }
                 let def =
                     self.create_def(constant.id, None, DefKind::InlineConst, constant.value.span);
-                self.with_parent(def, |this| visit::walk_anon_const(this, constant));
+                self.with_parent(def, |this| mut_visit::walk_anon_const(this, constant));
+                self.visit_span(span);
                 return;
             }
             _ => self.invocation_parent.parent_def,
         };
 
-        self.with_parent(parent_def, |this| visit::walk_expr(this, expr))
+        self.with_parent(parent_def, |this| mut_visit::walk_expr(this, expr))
     }
 
-    fn visit_ty(&mut self, ty: &'a Ty) {
+    fn visit_ty(&mut self, ty: &mut Ty) {
         match ty.kind {
             TyKind::MacCall(..) => self.visit_macro_invoc(ty.id),
             TyKind::ImplTrait(opaque_id, _) => {
@@ -392,96 +453,114 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                 let kind = match self.invocation_parent.impl_trait_context {
                     ImplTraitContext::Universal => DefKind::TyParam,
                     ImplTraitContext::Existential => DefKind::OpaqueTy,
-                    ImplTraitContext::InBinding => return visit::walk_ty(self, ty),
+                    ImplTraitContext::InBinding => return mut_visit::walk_ty(self, ty),
                 };
                 let id = self.create_def(opaque_id, Some(name), kind, ty.span);
                 match self.invocation_parent.impl_trait_context {
                     // Do not nest APIT, as we desugar them as `impl_trait: bounds`,
                     // so the `impl_trait` node is not a parent to `bounds`.
-                    ImplTraitContext::Universal => visit::walk_ty(self, ty),
+                    ImplTraitContext::Universal => mut_visit::walk_ty(self, ty),
                     ImplTraitContext::Existential => {
-                        self.with_parent(id, |this| visit::walk_ty(this, ty))
+                        self.with_parent(id, |this| mut_visit::walk_ty(this, ty))
                     }
                     ImplTraitContext::InBinding => unreachable!(),
                 };
             }
-            _ => visit::walk_ty(self, ty),
+            _ => mut_visit::walk_ty(self, ty),
         }
     }
 
-    fn visit_stmt(&mut self, stmt: &'a Stmt) {
-        match stmt.kind {
-            StmtKind::MacCall(..) => self.visit_macro_invoc(stmt.id),
+    fn flat_map_stmt(&mut self, mut stmt: Stmt) -> SmallVec<[Stmt; 1]> {
+        let Stmt { id, kind, span } = &mut stmt;
+        match kind {
+            StmtKind::MacCall(..) => {
+                self.visit_macro_invoc(*id);
+                smallvec![stmt]
+            }
             // FIXME(impl_trait_in_bindings): We don't really have a good way of
             // introducing the right `ImplTraitContext` here for all the cases we
             // care about, in case we want to introduce ITIB to other positions
             // such as turbofishes (e.g. `foo::<impl Fn()>(|| {})`).
-            StmtKind::Let(ref local) => self.with_impl_trait(ImplTraitContext::InBinding, |this| {
-                visit::walk_local(this, local)
-            }),
-            _ => visit::walk_stmt(self, stmt),
+            StmtKind::Let(local) => {
+                self.with_impl_trait(ImplTraitContext::InBinding, |this| {
+                    mut_visit::walk_local(this, local);
+                    this.visit_span(span);
+                });
+                smallvec![stmt]
+            }
+            _ => mut_visit::walk_flat_map_stmt(self, stmt),
         }
     }
 
-    fn visit_arm(&mut self, arm: &'a Arm) {
-        if arm.is_placeholder { self.visit_macro_invoc(arm.id) } else { visit::walk_arm(self, arm) }
+    fn visit_arm(&mut self, arm: &mut Arm) {
+        if arm.is_placeholder {
+            return self.visit_macro_invoc(arm.id);
+        }
+        mut_visit::walk_arm(self, arm)
     }
 
-    fn visit_expr_field(&mut self, f: &'a ExprField) {
+    fn visit_expr_field(&mut self, f: &mut ExprField) {
         if f.is_placeholder {
-            self.visit_macro_invoc(f.id)
-        } else {
-            visit::walk_expr_field(self, f)
+            return self.visit_macro_invoc(f.id);
         }
+        mut_visit::walk_expr_field(self, f)
     }
 
-    fn visit_pat_field(&mut self, fp: &'a PatField) {
+    fn visit_pat_field(&mut self, fp: &mut PatField) {
         if fp.is_placeholder {
-            self.visit_macro_invoc(fp.id)
-        } else {
-            visit::walk_pat_field(self, fp)
+            return self.visit_macro_invoc(fp.id);
         }
+        mut_visit::walk_pat_field(self, fp)
     }
 
-    fn visit_param(&mut self, p: &'a Param) {
+    fn visit_param(&mut self, p: &mut Param) {
         if p.is_placeholder {
-            self.visit_macro_invoc(p.id)
-        } else {
-            self.with_impl_trait(ImplTraitContext::Universal, |this| visit::walk_param(this, p))
+            return self.visit_macro_invoc(p.id);
         }
+        self.with_impl_trait(ImplTraitContext::Universal, |this| mut_visit::walk_param(this, p))
     }
 
     // This method is called only when we are visiting an individual field
     // after expanding an attribute on it.
-    fn visit_field_def(&mut self, field: &'a FieldDef) {
-        self.collect_field(field, None);
+    fn visit_field_def(&mut self, field: &mut FieldDef) {
+        self.collect_field(field, None)
     }
 
-    fn visit_crate(&mut self, krate: &'a Crate) {
+    fn visit_crate(&mut self, krate: &mut Crate) {
         if krate.is_placeholder {
-            self.visit_macro_invoc(krate.id)
-        } else {
-            visit::walk_crate(self, krate)
+            return self.visit_macro_invoc(krate.id);
         }
+        mut_visit::walk_crate(self, krate)
     }
 
-    fn visit_attribute(&mut self, attr: &'a Attribute) -> Self::Result {
+    fn visit_attribute(&mut self, attr: &mut Attribute) {
         let orig_in_attr = mem::replace(&mut self.invocation_parent.in_attr, true);
-        visit::walk_attribute(self, attr);
+        mut_visit::walk_attribute(self, attr);
         self.invocation_parent.in_attr = orig_in_attr;
     }
 
-    fn visit_inline_asm(&mut self, asm: &'a InlineAsm) {
+    fn visit_inline_asm(&mut self, asm: &mut InlineAsm) {
         let InlineAsm {
             asm_macro: _,
-            template: _,
-            template_strs: _,
+            template,
+            template_strs,
             operands,
-            clobber_abis: _,
+            clobber_abis,
             options: _,
-            line_spans: _,
+            line_spans,
         } = asm;
-        for (op, _span) in operands {
+        for piece in template {
+            match piece {
+                InlineAsmTemplatePiece::String(_str) => {}
+                InlineAsmTemplatePiece::Placeholder { operand_idx: _, modifier: _, span } => {
+                    self.visit_span(span);
+                }
+            }
+        }
+        for (_s1, _s2, span) in template_strs {
+            self.visit_span(span);
+        }
+        for (op, span) in operands {
             match op {
                 InlineAsmOperand::In { expr, reg: _ }
                 | InlineAsmOperand::Out { expr: Some(expr), reg: _, late: _ }
@@ -502,11 +581,18 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                         DefKind::InlineConst,
                         anon_const.value.span,
                     );
-                    self.with_parent(def, |this| visit::walk_anon_const(this, anon_const));
+                    self.with_parent(def, |this| mut_visit::walk_anon_const(this, anon_const));
                 }
                 InlineAsmOperand::Sym { sym } => self.visit_inline_asm_sym(sym),
                 InlineAsmOperand::Label { block } => self.visit_block(block),
             }
+            self.visit_span(span);
+        }
+        for (_s1, span) in clobber_abis {
+            self.visit_span(span);
+        }
+        for span in line_spans {
+            self.visit_span(span);
         }
     }
 }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -261,19 +261,19 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             false => errors::NameDefinedMultipleTimeLabel::Redefined { span },
         };
 
-        let old_binding_label =
-            (!old_binding.span.is_dummy() && old_binding.span != span).then(|| {
-                let span = self.tcx.sess.source_map().guess_head_span(old_binding.span);
-                match old_binding.is_import_user_facing() {
-                    true => {
-                        errors::NameDefinedMultipleTimeOldBindingLabel::Import { span, old_kind }
-                    }
-                    false => errors::NameDefinedMultipleTimeOldBindingLabel::Definition {
-                        span,
-                        old_kind,
-                    },
+        let old_binding_label = if !old_binding.span.is_dummy()
+            && old_binding.span.with_parent(None) != span.with_parent(None)
+        {
+            let span = self.tcx.sess.source_map().guess_head_span(old_binding.span);
+            Some(match old_binding.is_import_user_facing() {
+                true => errors::NameDefinedMultipleTimeOldBindingLabel::Import { span, old_kind },
+                false => {
+                    errors::NameDefinedMultipleTimeOldBindingLabel::Definition { span, old_kind }
                 }
-            });
+            })
+        } else {
+            None
+        };
 
         let mut err = self
             .dcx()

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2908,7 +2908,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                         .psess
                         .raw_identifier_spans
                         .iter()
-                        .any(|span| span == param.span());
+                        .any(|span| span == param.span().with_parent(None));
 
                     self.r
                         .dcx()

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -184,7 +184,7 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
     fn visit_ast_fragment_with_placeholders(
         &mut self,
         expansion: LocalExpnId,
-        fragment: &AstFragment,
+        fragment: &mut AstFragment,
     ) {
         // Integrate the new AST fragment into all the definition and module structures.
         // We are inside the `expansion` now, but other parent scope components are still the same.

--- a/tests/incremental/hashes/function_interfaces.rs
+++ b/tests/incremental/hashes/function_interfaces.rs
@@ -320,7 +320,7 @@ pub fn change_return_impl_trait() -> impl Clone {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes")]
 #[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck")]
+#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes")]
 #[rustc_clean(cfg = "cfail6")]
 pub fn change_return_impl_trait() -> impl  Copy {
     0u32


### PR DESCRIPTION
The current device of marking spans with a parent def-id during lowering has been frustrating me for quite some time, as it's very easy to forget marking some spans.

This PR moves such marking to the def_collector, which is responsible for creating def-ids on partially expanded AST. This is much more robust as long as visitors are exhaustive.

r? ghost

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
