### PR TITLE
Skip const-eval if evaluatable predicate is trivial

### DIFF
--- a/tests/ui/const-generics/generic_const_exprs/ice-123959.rs
+++ b/tests/ui/const-generics/generic_const_exprs/ice-123959.rs
@@ -1,5 +1,7 @@
-//@ known-bug: #123959
+//@ check-pass
 #![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
 fn foo<T>(_: [(); std::mem::offset_of!((T,), 0)]) {}
 
 pub fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.rs
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.rs
@@ -14,8 +14,8 @@ mod v20 {
     //~^ ERROR cannot find value `v8` in this scope
     //~| ERROR cannot find function `v6` in this scope
     pub struct v17<const v10: usize, const v7: v11> {
-    //~^ WARN type `v17` should have an upper camel case name
-    //~| ERROR `[[usize; v4]; v4]` is forbidden as the type of a const generic parameter
+        //~^ WARN type `v17` should have an upper camel case name
+        //~| ERROR `[[usize; v4]; v4]` is forbidden as the type of a const generic parameter
         _p: (),
     }
 
@@ -25,10 +25,9 @@ mod v20 {
     }
 
     impl<const v10: usize> v17<v10, v2> {
-    //~^ ERROR maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#1}
-    //~| ERROR maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#1}
+        //~^ ERROR maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#1}
         pub const fn v21() -> v18 {
-        //~^ ERROR cannot find type `v18` in this scope
+            //~^ ERROR cannot find type `v18` in this scope
             v18 { _p: () }
             //~^ ERROR cannot find struct, variant or union type `v18` in this scope
         }

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
@@ -1,5 +1,5 @@
 error[E0432]: unresolved import `v20::v13`
-  --> $DIR/unevaluated-const-ice-119731.rs:37:15
+  --> $DIR/unevaluated-const-ice-119731.rs:36:15
    |
 LL | pub use v20::{v13, v17};
    |               ^^^
@@ -23,7 +23,7 @@ LL |         pub const fn v21() -> v18 {}
    |                               ^^^ help: a type alias with a similar name exists: `v11`
 
 error[E0412]: cannot find type `v18` in this scope
-  --> $DIR/unevaluated-const-ice-119731.rs:30:31
+  --> $DIR/unevaluated-const-ice-119731.rs:29:31
    |
 LL |     pub type v11 = [[usize; v4]; v4];
    |     --------------------------------- similarly named type alias `v11` defined here
@@ -32,7 +32,7 @@ LL |         pub const fn v21() -> v18 {
    |                               ^^^ help: a type alias with a similar name exists: `v11`
 
 error[E0422]: cannot find struct, variant or union type `v18` in this scope
-  --> $DIR/unevaluated-const-ice-119731.rs:32:13
+  --> $DIR/unevaluated-const-ice-119731.rs:31:13
    |
 LL |     pub type v11 = [[usize; v4]; v4];
    |     --------------------------------- similarly named type alias `v11` defined here
@@ -78,15 +78,7 @@ error: maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{consta
 LL |     impl<const v10: usize> v17<v10, v2> {
    |                                     ^^
 
-error: maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#1}
-  --> $DIR/unevaluated-const-ice-119731.rs:27:37
-   |
-LL |     impl<const v10: usize> v17<v10, v2> {
-   |                                     ^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 9 previous errors; 2 warnings emitted
+error: aborting due to 8 previous errors; 2 warnings emitted
 
 Some errors have detailed explanations: E0412, E0422, E0425, E0432.
 For more information about an error, try `rustc --explain E0412`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

It appears that `ConstEvaluatable` predicate is given already in `ParamEnv` during type-checking in well-formness checks. This is an attempt at simplifying the checks.

Fix #123959