### PR TITLE
Give remote-test-client a longer timeout

### DIFF
--- a/src/tools/remote-test-client/src/main.rs
+++ b/src/tools/remote-test-client/src/main.rs
@@ -71,7 +71,7 @@ fn spawn_emulator(target: &str, server: &Path, tmpdir: &Path, rootfs: Option<Pat
 
     // Wait for the emulator to come online
     loop {
-        let dur = Duration::from_millis(100);
+        let dur = Duration::from_millis(2000);
         if let Ok(mut client) = TcpStream::connect(&device_address) {
             t!(client.set_read_timeout(Some(dur)));
             t!(client.set_write_timeout(Some(dur)));


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->


In https://github.com/rust-lang/rust/pull/126959, @Mark-Simulacrum suggested we simply extend the timeout of the `remote-test-client` instead of making it configurable. This is acceptable for my use case.

I'm doing some work with a remote host running tests using `x.py`'s remote test runner system.

After building the `remote-test-server` with:

```bash
./x build src/tools/remote-test-server --target aarch64-unknown-linux-gnu
```

I can transfer the `remote-test-server` to the remote and set up a port forwarded SSH connection, then I run:

```bash
TEST_DEVICE_ADDR=127.0.0.1:12345 ./x.py test library/core --target aarch64-unknown-linux-gnu
```

This works great if the host is nearby, however if the average round trip time is over 100ms (the timeout), it creates problems as it silently trips the timeout.

This PR extends that timeout to a less strict 2s.

r? @Mark-Simulacrum 
