### PR TITLE
Add parse fail test using safe trait/impl trait

### DIFF
--- a/tests/ui/rust-2024/unsafe-extern-blocks/safe-impl-trait.gated.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/safe-impl-trait.gated.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found keyword `impl`
+  --> $DIR/safe-impl-trait.rs:5:6
+   |
+LL | safe impl Bar for () { }
+   |      ^^^^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rust-2024/unsafe-extern-blocks/safe-impl-trait.rs
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/safe-impl-trait.rs
@@ -1,0 +1,8 @@
+//@ revisions: gated ungated
+#![cfg_attr(gated, feature(unsafe_extern_blocks))]
+
+trait Bar {}
+safe impl Bar for () { }
+//~^ ERROR expected one of `!` or `::`, found keyword `impl`
+
+fn main() {}

--- a/tests/ui/rust-2024/unsafe-extern-blocks/safe-impl-trait.ungated.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/safe-impl-trait.ungated.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found keyword `impl`
+  --> $DIR/safe-impl-trait.rs:5:6
+   |
+LL | safe impl Bar for () { }
+   |      ^^^^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rust-2024/unsafe-extern-blocks/safe-trait.gated.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/safe-trait.gated.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found keyword `trait`
+  --> $DIR/safe-trait.rs:4:6
+   |
+LL | safe trait Foo {}
+   |      ^^^^^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rust-2024/unsafe-extern-blocks/safe-trait.rs
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/safe-trait.rs
@@ -1,0 +1,7 @@
+//@ revisions: gated ungated
+#![cfg_attr(gated, feature(unsafe_extern_blocks))]
+
+safe trait Foo {}
+//~^ ERROR expected one of `!` or `::`, found keyword `trait`
+
+fn main() {}

--- a/tests/ui/rust-2024/unsafe-extern-blocks/safe-trait.ungated.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/safe-trait.ungated.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found keyword `trait`
+  --> $DIR/safe-trait.rs:4:6
+   |
+LL | safe trait Foo {}
+   |      ^^^^^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Added 2 more tests to be sure that nothing weird happens using `safe` on items.
Needed to do this in separate tests as they give parsing errors.