### PR TITLE
rustc_codegen_llvm: less pubs

### DIFF
--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -13,12 +13,12 @@ use rustc_codegen_ssa::traits::*;
 use rustc_codegen_ssa::MemFlags;
 use rustc_middle::bug;
 use rustc_middle::ty::layout::LayoutOf;
-pub use rustc_middle::ty::layout::{FAT_PTR_ADDR, FAT_PTR_EXTRA};
+pub(crate) use rustc_middle::ty::layout::{FAT_PTR_ADDR, FAT_PTR_EXTRA};
 use rustc_middle::ty::Ty;
 use rustc_session::config;
-pub use rustc_target::abi::call::*;
+pub(crate) use rustc_target::abi::call::*;
 use rustc_target::abi::{self, HasDataLayout, Int, Size};
-pub use rustc_target::spec::abi::Abi;
+pub(crate) use rustc_target::spec::abi::Abi;
 use rustc_target::spec::SanitizerSet;
 
 use libc::c_uint;

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -15,7 +15,7 @@ use crate::errors::{MissingFeatures, SanitizerMemtagRequiresMte, TargetFeatureDi
 use crate::llvm::AttributePlace::Function;
 use crate::llvm::{self, AllocKindFlags, Attribute, AttributeKind, AttributePlace, MemoryEffects};
 use crate::llvm_util;
-pub use rustc_attr::{InlineAttr, InstructionSetAttr, OptimizeAttr};
+pub(crate) use rustc_attr::{InlineAttr, InstructionSetAttr, OptimizeAttr};
 
 use crate::context::CodegenCx;
 use crate::value::Value;

--- a/compiler/rustc_codegen_llvm/src/common.rs
+++ b/compiler/rustc_codegen_llvm/src/common.rs
@@ -1,7 +1,7 @@
 //! Code that is useful in various codegen modules.
 
 use crate::consts::const_alloc_to_llvm;
-pub use crate::context::CodegenCx;
+pub(crate) use crate::context::CodegenCx;
 use crate::llvm::{self, BasicBlock, Bool, ConstantInt, False, OperandBundleDef, True};
 use crate::type_::Type;
 use crate::value::Value;

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/ffi.rs
@@ -375,7 +375,7 @@ impl CounterMappingRegion {
 
     // This function might be used in the future; the LLVM API is still evolving, as is coverage
     // support.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn expansion_region(
         file_id: u32,
         expanded_file_id: u32,
@@ -400,7 +400,7 @@ impl CounterMappingRegion {
 
     // This function might be used in the future; the LLVM API is still evolving, as is coverage
     // support.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn skipped_region(
         file_id: u32,
         start_line: u32,
@@ -424,7 +424,7 @@ impl CounterMappingRegion {
 
     // This function might be used in the future; the LLVM API is still evolving, as is coverage
     // support.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn gap_region(
         counter: Counter,
         file_id: u32,

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -50,8 +50,8 @@ pub mod metadata;
 mod namespace;
 mod utils;
 
-pub use self::create_scope_map::compute_mir_scopes;
-pub use self::metadata::build_global_var_di_node;
+pub(crate) use self::create_scope_map::compute_mir_scopes;
+pub(crate) use self::metadata::build_global_var_di_node;
 
 #[allow(non_upper_case_globals)]
 const DW_TAG_auto_variable: c_uint = 0x100;

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
+#![feature(lint_reasons)]
 #![feature(rustdoc_internals)]
 // tidy-alphabetical-end
 
@@ -21,7 +22,7 @@ use back::owned_target_machine::OwnedTargetMachine;
 use back::write::{create_informational_target_machine, create_target_machine};
 
 use errors::ParseTargetMachineConfig;
-pub use llvm_util::target_features;
+pub(crate) use llvm_util::target_features;
 use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_codegen_ssa::back::lto::{LtoModuleCodegen, SerializedModule, ThinModule};
 use rustc_codegen_ssa::back::write::{

--- a/compiler/rustc_codegen_llvm/src/llvm/diagnostic.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/diagnostic.rs
@@ -1,7 +1,7 @@
 //! LLVM diagnostic reports.
 
-pub use self::Diagnostic::*;
-pub use self::OptimizationDiagnosticKind::*;
+pub(crate) use self::Diagnostic::*;
+pub(crate) use self::OptimizationDiagnosticKind::*;
 
 use crate::value::Value;
 use libc::c_uint;

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -161,6 +161,7 @@ pub enum DLLStorageClass {
 #[derive(Copy, Clone, Debug)]
 pub enum AttributeKind {
     AlwaysInline = 0,
+    #[expect(dead_code)]
     ByVal = 1,
     Cold = 2,
     InlineHint = 3,
@@ -176,7 +177,9 @@ pub enum AttributeKind {
     OptimizeForSize = 13,
     ReadOnly = 14,
     SExt = 15,
+    #[expect(dead_code)]
     StructRet = 16,
+    #[expect(dead_code)]
     UWTable = 17,
     ZExt = 18,
     InReg = 19,
@@ -184,7 +187,9 @@ pub enum AttributeKind {
     SanitizeAddress = 21,
     SanitizeMemory = 22,
     NonLazyBind = 23,
+    #[expect(dead_code)]
     OptimizeNone = 24,
+    #[expect(dead_code)]
     ReadNone = 26,
     SanitizeHWAddress = 28,
     WillReturn = 29,
@@ -195,6 +200,7 @@ pub enum AttributeKind {
     SanitizeMemTag = 34,
     NoCfCheck = 35,
     ShadowCallStack = 36,
+    #[expect(dead_code)]
     AllocSize = 37,
     AllocatedPointer = 38,
     AllocAlign = 39,
@@ -289,7 +295,8 @@ impl RealPredicate {
 /// LLVMTypeKind
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(C)]
-pub enum TypeKind {
+#[expect(dead_code)] // FP, see #85677
+pub(crate) enum TypeKind {
     Void = 0,
     Half = 1,
     Float = 2,
@@ -418,16 +425,24 @@ pub enum FileType {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub enum MetadataType {
+    #[expect(dead_code)]
     MD_dbg = 0,
+    #[expect(dead_code)]
     MD_tbaa = 1,
+    #[expect(dead_code)]
     MD_prof = 2,
+    #[expect(dead_code)]
     MD_fpmath = 3,
     MD_range = 4,
+    #[expect(dead_code)]
     MD_tbaa_struct = 5,
     MD_invariant_load = 6,
+    #[expect(dead_code)]
     MD_alias_scope = 7,
+    #[expect(dead_code)]
     MD_noalias = 8,
     MD_nontemporal = 9,
+    #[expect(dead_code)]
     MD_mem_parallel_loop_access = 10,
     MD_nonnull = 11,
     MD_align = 17,
@@ -598,6 +613,7 @@ pub enum ThreadLocalMode {
 /// LLVMRustTailCallKind
 #[derive(Copy, Clone)]
 #[repr(C)]
+#[expect(dead_code)]
 pub enum TailCallKind {
     None,
     Tail,
@@ -663,9 +679,6 @@ pub struct Builder<'a>(InvariantOpaque<'a>);
 #[repr(C)]
 pub struct PassManager<'a>(InvariantOpaque<'a>);
 extern "C" {
-    pub type Pass;
-}
-extern "C" {
     pub type TargetMachine;
 }
 extern "C" {
@@ -696,7 +709,6 @@ extern "C" {
 }
 
 pub type DiagnosticHandlerTy = unsafe extern "C" fn(&DiagnosticInfo, *mut c_void);
-pub type InlineAsmDiagHandlerTy = unsafe extern "C" fn(&SMDiagnostic, *const c_void, c_uint);
 
 pub mod debuginfo {
     use super::{InvariantOpaque, Metadata};
@@ -804,6 +816,7 @@ pub mod debuginfo {
     #[repr(C)]
     pub enum DebugNameTableKind {
         Default,
+        #[expect(dead_code)]
         Gnu,
         None,
     }
@@ -1563,6 +1576,8 @@ extern "C" {
         Name: *const c_char,
         NameLen: size_t,
     ) -> Option<&Value>;
+
+    #[expect(dead_code)]
     pub fn LLVMRustSetTailCallKind(CallInst: &Value, TKC: TailCallKind);
 
     // Operations on attributes

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -22,7 +22,6 @@ pub const False: Bool = 0 as Bool;
 
 #[derive(Copy, Clone, PartialEq)]
 #[repr(C)]
-#[allow(dead_code)] // Variants constructed by C++.
 pub enum LLVMRustResult {
     Success,
     Failure,
@@ -147,10 +146,10 @@ pub enum UnnamedAddr {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub enum DLLStorageClass {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     Default = 0,
     DllImport = 1, // Function to be imported from DLL.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     DllExport = 2, // Function to be accessible from DLL.
 }
 
@@ -385,7 +384,7 @@ impl AtomicRmwBinOp {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub enum AtomicOrdering {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     NotAtomic = 0,
     Unordered = 1,
     Monotonic = 2,
@@ -539,7 +538,7 @@ pub enum CodeModel {
 /// LLVMRustDiagnosticKind
 #[derive(Copy, Clone)]
 #[repr(C)]
-#[allow(dead_code)] // Variants constructed by C++.
+#[expect(dead_code)] // Variants constructed by C++.
 pub enum DiagnosticKind {
     Other,
     InlineAsm,
@@ -562,7 +561,6 @@ pub enum DiagnosticKind {
 /// LLVMRustDiagnosticLevel
 #[derive(Copy, Clone)]
 #[repr(C)]
-#[allow(dead_code)] // Variants constructed by C++.
 pub enum DiagnosticLevel {
     Error,
     Warning,

--- a/compiler/rustc_codegen_llvm/src/llvm/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/mod.rs
@@ -1,12 +1,8 @@
 #![allow(non_snake_case)]
 
-pub use self::AtomicRmwBinOp::*;
-pub use self::CallConv::*;
-pub use self::CodeGenOptSize::*;
-pub use self::IntPredicate::*;
-pub use self::Linkage::*;
-pub use self::MetadataType::*;
-pub use self::RealPredicate::*;
+pub(crate) use self::CallConv::*;
+pub(crate) use self::CodeGenOptSize::*;
+pub(crate) use self::MetadataType::*;
 
 use libc::c_uint;
 use rustc_data_structures::small_c_str::SmallCStr;
@@ -21,7 +17,7 @@ pub mod archive_ro;
 pub mod diagnostic;
 mod ffi;
 
-pub use self::ffi::*;
+pub(crate) use self::ffi::*;
 
 impl LLVMRustResult {
     pub fn into_result(self) -> Result<(), ()> {

--- a/compiler/rustc_codegen_llvm/src/type_.rs
+++ b/compiler/rustc_codegen_llvm/src/type_.rs
@@ -1,4 +1,4 @@
-pub use crate::llvm::Type;
+pub(crate) use crate::llvm::Type;
 
 use crate::abi::{FnAbiLlvmExt, LlvmType};
 use crate::common;

--- a/compiler/rustc_codegen_llvm/src/value.rs
+++ b/compiler/rustc_codegen_llvm/src/value.rs
@@ -1,4 +1,4 @@
-pub use crate::llvm::Value;
+pub(crate) use crate::llvm::Value;
 
 use crate::llvm;
 


### PR DESCRIPTION
This removes few pubs around and slaps `dead_code`s around.