### PR TITLE
use old ctx if has same expand environment during decode span

### DIFF
--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -1413,6 +1413,14 @@ pub fn decode_syntax_context<D: Decoder, F: FnOnce(&mut D, u32) -> SyntaxContext
 
     // Overwrite the dummy data with our decoded SyntaxContextData
     HygieneData::with(|hygiene_data| {
+        if let Some(old) = hygiene_data.syntax_context_data.get(raw_id as usize)
+            && old.outer_expn == ctxt_data.outer_expn
+            && old.outer_transparency == ctxt_data.outer_transparency
+            && old.parent == ctxt_data.parent
+        {
+            ctxt_data = old.clone();
+        }
+
         let dummy = std::mem::replace(
             &mut hygiene_data.syntax_context_data[ctxt.as_u32() as usize],
             ctxt_data,

--- a/tests/incremental/decl_macro.rs
+++ b/tests/incremental/decl_macro.rs
@@ -1,0 +1,34 @@
+//@ revisions: rpass1 rpass2
+
+// issue#112680
+
+#![feature(decl_macro)]
+
+pub trait T {
+    type Key;
+    fn index_from_key(key: Self::Key) -> usize;
+}
+
+pub macro m($key_ty:ident, $val_ty:ident) {
+    struct $key_ty {
+        inner: usize,
+    }
+
+    impl T for $val_ty {
+        type Key = $key_ty;
+
+        fn index_from_key(key: Self::Key) -> usize {
+            key.inner
+        }
+    }
+}
+
+m!(TestId, Test);
+
+#[cfg(rpass1)]
+struct Test(u32);
+
+#[cfg(rpass2)]
+struct Test;
+
+fn main() {}


### PR DESCRIPTION
Fixes #112680

The root reason why #112680 failed with incremental compilation on the second attempt is the difference in `opaque` between the span of the field [`ident`](https://github.com/rust-lang/rust/blob/master/compiler/rustc_hir_typeck/src/expr.rs#L2348) and the span in the incremental cache at `tcx.def_ident_span(field.did)`.

-  Let's call the span of `ident` as `span_a`, which is generated by [`apply_mark_internal`](https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/hygiene.rs#L553-L554). Its content is similar to:

```rs
span_a_ctx -> SyntaxContextData {
      opaque: span_a_ctx,
      opaque_and_semitransparent: span_a_ctx,
      // ....
}
```

- And call the span of `tcx.def_ident_span` as `span_b`, which is generated by [`decode_syntax_context`](https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/hygiene.rs#L1390). Its content is:

```rs
span_b_ctx -> SyntaxContextData {
      opaque: span_b_ctx,
      // note `span_b_ctx` is not same as `span_a_ctx`
      opaque_and_semitransparent: span_b_ctx,
      // ....
}
```

Although they have the same `parent` (both refer to the root) and `outer_expn`, I cannot find the specific connection between them. Therefore, I chose a solution that may not be the best: give up the incremental compile cache to ensure we can use `span_a` in this case.

r?  @petrochenkov Do you have any advice on this? Or perhaps this solution is acceptable?