### PR TITLE
Disable rmake test rustdoc-io-error on riscv64gc-gnu

### DIFF
--- a/tests/run-make/inaccessible-temp-dir/rmake.rs
+++ b/tests/run-make/inaccessible-temp-dir/rmake.rs
@@ -14,7 +14,7 @@
 // See https://github.com/rust-lang/rust/issues/66530
 
 //@ ignore-riscv64
-// FIXME: The riscv build container runs as root, and can always write
+// FIXME: The riscv64gc-gnu build container runs as root, and can always write
 // into `inaccessible/tmp`. Ideally, the riscv64-gnu docker container
 // would use a non-root user, but this leads to issues with
 // `mkfs.ext4 -d`, as well as mounting a loop device for the rootfs.

--- a/tests/run-make/rustdoc-io-error/rmake.rs
+++ b/tests/run-make/rustdoc-io-error/rmake.rs
@@ -6,8 +6,13 @@
 // permissions so that it is not writable. We have to take special care to set
 // the permissions back to normal so that it's able to be deleted later.
 
+//@ ignore-riscv64
+//@ ignore-arm
+// FIXME: The riscv64gc-gnu and armhf-gnu build containers run as root,
+// and can always write into `inaccessible/tmp`. Ideally, these docker
+// containers would use a non-root user, but this leads to issues with
+// `mkfs.ext4 -d`, as well as mounting a loop device for the rootfs.
 //@ ignore-windows - the `set_readonly` functions doesn't work on folders.
-//@ ignore-arm - weird file perms on armhf-gnu
 
 use run_make_support::{path, rustdoc};
 use std::fs;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

In https://github.com/rust-lang/rust/pull/126917 we disabled `inaccessible-temp-dir` on `riscv64gc-gnu` because the container runs the build as `root` (just like the `armhf-gnu` builds). Tests creating an inaccessible test directory are not possible, since `root` can always touch those directories.


https://github.com/rust-lang/rust/blob/553a69030e5a086eb3841d020db8c9c463948c72/src/ci/docker/host-x86_64/disabled/riscv64gc-gnu/Dockerfile#L99

This means the tests are run as `root`. As `root`, it's perfectly normal and reasonable to violate permission checks this way:

```bash
$ sudo mkdir scratch
$ sudo chmod o-w scratch
$ sudo mkdir scratch/backs
$
```

Because of this, this PR makes the test ignored on `riscv64gc` (just like on `armhf-gnu`) for now.

As an alternative, I believe the best long-term strategy would be to not run the tests as `root` for this job. Some preliminary exploration was done in https://github.com/rust-lang/rust/pull/126917#issuecomment-2189933970, however that appears a larger lift.


## Testing

> [!NOTE]  
> `riscv64gc-unknown-linux-gnu` is a [**Tier 2 with Host Tools** platform](https://doc.rust-lang.org/beta/rustc/platform-support.html), all tests may not necessarily pass! This change should only ignore `inaccessible-temp-dir` and not affect other tests.

You can test out the job locally:

```sh
DEPLOY=1 ./src/ci/docker/run.sh riscv64gc-gnu
```

r? @jieyouxu
