### PR TITLE
Reject SmartPointer constructions not serving the purpose

### DIFF
--- a/tests/ui/deriving/deriving-smart-pointer-neg.rs
+++ b/tests/ui/deriving/deriving-smart-pointer-neg.rs
@@ -1,0 +1,45 @@
+#![feature(derive_smart_pointer, arbitrary_self_types)]
+
+use std::marker::SmartPointer;
+
+#[derive(SmartPointer)]
+//~^ ERROR: `SmartPointer` can only be derived on `struct`s with `#[repr(transparent)]`
+enum NotStruct<'a, T: ?Sized> {
+    Variant(&'a T),
+}
+
+#[derive(SmartPointer)]
+//~^ ERROR: At least one generic type should be designated as `#[pointee]` in order to derive `SmartPointer` traits
+#[repr(transparent)]
+struct NoPointee<'a, T: ?Sized> {
+    ptr: &'a T,
+}
+
+#[derive(SmartPointer)]
+//~^ ERROR: `SmartPointer` can only be derived on `struct`s with at least one field
+#[repr(transparent)]
+struct NoField<'a, #[pointee] T: ?Sized> {}
+//~^ ERROR: lifetime parameter `'a` is never used
+//~| ERROR: type parameter `T` is never used
+
+#[derive(SmartPointer)]
+//~^ ERROR: `SmartPointer` can only be derived on `struct`s with at least one field
+#[repr(transparent)]
+struct NoFieldUnit<'a, #[pointee] T: ?Sized>();
+//~^ ERROR: lifetime parameter `'a` is never used
+//~| ERROR: type parameter `T` is never used
+
+#[derive(SmartPointer)]
+//~^ ERROR: `SmartPointer` can only be derived on `struct`s with `#[repr(transparent)]`
+struct NotTransparent<'a, #[pointee] T: ?Sized> {
+    ptr: &'a T,
+}
+
+// However, reordering attributes should work nevertheless.
+#[repr(transparent)]
+#[derive(SmartPointer)]
+struct ThisIsAPossibleSmartPointer<'a, #[pointee] T: ?Sized> {
+    ptr: &'a T,
+}
+
+fn main() {}

--- a/tests/ui/deriving/deriving-smart-pointer-neg.stderr
+++ b/tests/ui/deriving/deriving-smart-pointer-neg.stderr
@@ -1,0 +1,75 @@
+error: `SmartPointer` can only be derived on `struct`s with `#[repr(transparent)]`
+  --> $DIR/deriving-smart-pointer-neg.rs:5:10
+   |
+LL | #[derive(SmartPointer)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `SmartPointer` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: At least one generic type should be designated as `#[pointee]` in order to derive `SmartPointer` traits
+  --> $DIR/deriving-smart-pointer-neg.rs:11:10
+   |
+LL | #[derive(SmartPointer)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `SmartPointer` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `SmartPointer` can only be derived on `struct`s with at least one field
+  --> $DIR/deriving-smart-pointer-neg.rs:18:10
+   |
+LL | #[derive(SmartPointer)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `SmartPointer` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `SmartPointer` can only be derived on `struct`s with at least one field
+  --> $DIR/deriving-smart-pointer-neg.rs:25:10
+   |
+LL | #[derive(SmartPointer)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `SmartPointer` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `SmartPointer` can only be derived on `struct`s with `#[repr(transparent)]`
+  --> $DIR/deriving-smart-pointer-neg.rs:32:10
+   |
+LL | #[derive(SmartPointer)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `SmartPointer` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0392]: lifetime parameter `'a` is never used
+  --> $DIR/deriving-smart-pointer-neg.rs:21:16
+   |
+LL | struct NoField<'a, #[pointee] T: ?Sized> {}
+   |                ^^ unused lifetime parameter
+   |
+   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/deriving-smart-pointer-neg.rs:21:31
+   |
+LL | struct NoField<'a, #[pointee] T: ?Sized> {}
+   |                               ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+
+error[E0392]: lifetime parameter `'a` is never used
+  --> $DIR/deriving-smart-pointer-neg.rs:28:20
+   |
+LL | struct NoFieldUnit<'a, #[pointee] T: ?Sized>();
+   |                    ^^ unused lifetime parameter
+   |
+   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/deriving-smart-pointer-neg.rs:28:35
+   |
+LL | struct NoFieldUnit<'a, #[pointee] T: ?Sized>();
+   |                                   ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0392`.

--- a/tests/ui/deriving/deriving-smart-pointer.rs
+++ b/tests/ui/deriving/deriving-smart-pointer.rs
@@ -4,6 +4,7 @@
 use std::marker::SmartPointer;
 
 #[derive(SmartPointer)]
+#[repr(transparent)]
 struct MyPointer<'a, #[pointee] T: ?Sized> {
     ptr: &'a T,
 }

--- a/tests/ui/feature-gates/feature-gate-derive-smart-pointer.rs
+++ b/tests/ui/feature-gates/feature-gate-derive-smart-pointer.rs
@@ -1,6 +1,7 @@
 use std::marker::SmartPointer; //~ ERROR use of unstable library feature 'derive_smart_pointer'
 
 #[derive(SmartPointer)] //~ ERROR use of unstable library feature 'derive_smart_pointer'
+#[repr(transparent)]
 struct MyPointer<'a, #[pointee] T: ?Sized> {
     //~^ ERROR the `#[pointee]` attribute is an experimental feature
     ptr: &'a T,

--- a/tests/ui/feature-gates/feature-gate-derive-smart-pointer.stderr
+++ b/tests/ui/feature-gates/feature-gate-derive-smart-pointer.stderr
@@ -9,7 +9,7 @@ LL | #[derive(SmartPointer)]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[pointee]` attribute is an experimental feature
-  --> $DIR/feature-gate-derive-smart-pointer.rs:4:22
+  --> $DIR/feature-gate-derive-smart-pointer.rs:5:22
    |
 LL | struct MyPointer<'a, #[pointee] T: ?Sized> {
    |                      ^^^^^^^^^^


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
Tracking issue: #123430

With this PR we will reject a row of malformed `SmartPointer` implementor candidates.

cc @Darksonn @davidtwco for context.