### PR TITLE
jsondocck: Use correct index for error message.

### DIFF
--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -56,6 +56,8 @@ pub enum CommandKind {
 
 impl CommandKind {
     fn validate(&self, args: &[String], lineno: usize) -> bool {
+        // FIXME(adotinthevoid): We should "parse, don't validate" here, so we avoid ad-hoc
+        // indexing in check_command.
         let count = match self {
             CommandKind::Has => (1..=2).contains(&args.len()),
             CommandKind::IsMany => args.len() >= 2,
@@ -71,7 +73,7 @@ impl CommandKind {
         if let CommandKind::Count = self {
             if args[1].parse::<usize>().is_err() {
                 print_err(
-                    &format!("Second argument to @count must be a valid usize (got `{}`)", args[2]),
+                    &format!("Second argument to @count must be a valid usize (got `{}`)", args[1]),
                     lineno,
                 );
                 return false;


### PR DESCRIPTION
If you misused a count command like `@count $some.selector '"T'"`, you would panic with OOB:

```
thread 'main' panicked at src/tools/jsondocck/src/main.rs:76:92:
index out of bounds: the len is 2 but the index is 2
```

This is because 57c85bd97da3 removed the file param, but didn't update the error case. We now error with:

```
Invalid command: Second argument to @count must be a valid usize (got `"T"`) on line 20
```

As some point I want to rewrite this code to avoid indexing in general, but this is a nice small fix.

r? @GuillaumeGomez 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
