### PR TITLE
Gauge usage of `FnOnce::Output` in the wild

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -129,6 +129,7 @@ struct LoweringContext<'a, 'hir> {
     /// NodeIds that are lowered inside the current HIR owner.
     node_id_to_local_id: NodeMap<hir::ItemLocalId>,
 
+    allow_fn_once_output: Lrc<[Symbol]>,
     allow_try_trait: Lrc<[Symbol]>,
     allow_gen_future: Lrc<[Symbol]>,
     allow_async_iterator: Lrc<[Symbol]>,
@@ -177,6 +178,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             current_item: None,
             impl_trait_defs: Vec::new(),
             impl_trait_bounds: Vec::new(),
+            allow_fn_once_output: [sym::fn_traits].into(),
             allow_try_trait: [sym::try_trait_v2, sym::yeet_desugar_details].into(),
             allow_gen_future: if tcx.features().async_fn_track_caller {
                 [sym::gen_future, sym::closure_track_caller].into()

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -440,14 +440,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
         // If we have a bound like `async Fn() -> T`, make sure that we mark the
         // `Output = T` associated type bound with the right feature gates.
-        let mut output_span = output_ty.span;
-        if let Some(bound_modifier_allowed_features) = bound_modifier_allowed_features {
-            output_span = self.mark_span_with_reason(
-                DesugaringKind::BoundModifier,
-                output_span,
-                Some(bound_modifier_allowed_features),
-            );
-        }
+        let output_span  = self.mark_span_with_reason(
+            DesugaringKind::BoundModifier,
+            output_ty.span,
+            Some(bound_modifier_allowed_features.unwrap_or_else(|| self.allow_fn_once_output.clone())),
+        );
         let constraint = self.assoc_ty_binding(sym::Output, output_span, output_ty);
 
         (

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -440,10 +440,13 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
         // If we have a bound like `async Fn() -> T`, make sure that we mark the
         // `Output = T` associated type bound with the right feature gates.
-        let output_span  = self.mark_span_with_reason(
+        let output_span = self.mark_span_with_reason(
             DesugaringKind::BoundModifier,
             output_ty.span,
-            Some(bound_modifier_allowed_features.unwrap_or_else(|| self.allow_fn_once_output.clone())),
+            Some(
+                bound_modifier_allowed_features
+                    .unwrap_or_else(|| self.allow_fn_once_output.clone()),
+            ),
         );
         let constraint = self.assoc_ty_binding(sym::Output, output_span, output_ty);
 

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::unord::UnordMap;
 use rustc_errors::{Applicability, Diag, EmissionGuarantee};
 use rustc_feature::GateIssue;
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::{DefId, LocalDefId, LocalDefIdMap};
+use rustc_hir::def_id::{DefId, LocalDefId, LocalDefIdMap, LOCAL_CRATE};
 use rustc_hir::{self as hir, HirId};
 use rustc_macros::{Decodable, Encodable, HashStable, Subdiagnostic};
 use rustc_middle::ty::print::with_no_trimmed_paths;
@@ -604,16 +604,22 @@ impl<'tcx> TyCtxt<'tcx> {
         let is_allowed = matches!(eval_result, EvalResult::Allow);
         match eval_result {
             EvalResult::Allow => {}
-            EvalResult::Deny { feature, reason, issue, suggestion, is_soft } => report_unstable(
-                self.sess,
-                feature,
-                reason,
-                issue,
-                suggestion,
-                is_soft,
-                span,
-                soft_handler,
-            ),
+            EvalResult::Deny { feature, reason, issue, suggestion, is_soft } => {
+                if feature.as_str() == "fn_traits" && std::env::var("RUSTC_BOOTSTRAP").is_ok() {
+                    // uwu
+                } else {
+                    report_unstable(
+                        self.sess,
+                        feature,
+                        reason,
+                        issue,
+                        suggestion,
+                        is_soft,
+                        span,
+                        soft_handler,
+                    )
+                }
+            }
             EvalResult::Unmarked => unmarked(span, def_id),
         }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -898,6 +898,7 @@ symbols! {
         fn_once_output,
         fn_ptr_addr,
         fn_ptr_trait,
+        fn_traits,
         forbid,
         forget,
         format,

--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -242,7 +242,8 @@ pub trait FnMut<Args: Tuple>: FnOnce<Args> {
 pub trait FnOnce<Args: Tuple> {
     /// The returned type after the call operator is used.
     #[lang = "fn_once_output"]
-    #[stable(feature = "fn_once_output", since = "1.12.0")]
+    #[cfg_attr(bootstrap, stable(feature = "fn_once_output", since = "1.12.0"))]
+    #[cfg_attr(not(bootstrap), unstable(feature = "fn_traits", issue = "29625"))]
     type Output;
 
     /// Performs the call operation.


### PR DESCRIPTION
I'm curious what crates are using `FnOnce::Output` directly. Let's run crater to see.

I downloaded all crates with `get-all-crates --latest` then used `zgrep` to grep for `::Output`, which may or may not be any of the traits in `std::ops`, though it did majorly cut down on the crates we'll crater: https://gist.githubusercontent.com/compiler-errors/1ef63d6e086d9a5915fb510dafdfdd43/raw/86e3bac4235e667c4c2cdf2a21d52ca38567ab1a/gistfile1.txt

r? @ghost 