### PR TITLE
Tweak some structured suggestions to be more verbose and accurate

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -449,8 +449,8 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                     .is_ok_and(|snippet| snippet.starts_with("&mut ")) =>
             {
                 err.span_label(span, format!("cannot {act}"));
-                err.span_suggestion(
-                    span,
+                err.span_suggestion_verbose(
+                    span.with_hi(span.lo() + BytePos(5)),
                     "try removing `&mut` here",
                     "",
                     Applicability::MaybeIncorrect,

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -408,10 +408,10 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                                     fn_decl.implicit_self,
                                     hir::ImplicitSelfKind::RefImm | hir::ImplicitSelfKind::RefMut
                                 ) {
-                                    err.span_suggestion(
-                                        upvar_ident.span,
+                                    err.span_suggestion_verbose(
+                                        upvar_ident.span.shrink_to_lo(),
                                         "consider changing this to be mutable",
-                                        format!("mut {}", upvar_ident.name),
+                                        "mut ",
                                         Applicability::MachineApplicable,
                                     );
                                     break;
@@ -419,10 +419,10 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                             }
                         }
                     } else {
-                        err.span_suggestion(
-                            upvar_ident.span,
+                        err.span_suggestion_verbose(
+                            upvar_ident.span.shrink_to_lo(),
                             "consider changing this to be mutable",
-                            format!("mut {}", upvar_ident.name),
+                            "mut ",
                             Applicability::MachineApplicable,
                         );
                     }
@@ -755,13 +755,16 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                 pat: hir::Pat { kind: hir::PatKind::Ref(_, _), .. },
                 ..
             }) = node
-            && let Ok(name) =
-                self.infcx.tcx.sess.source_map().span_to_snippet(local_decl.source_info.span)
         {
-            err.span_suggestion(
-                pat_span,
+            err.multipart_suggestion(
                 "consider changing this to be mutable",
-                format!("&(mut {name})"),
+                vec![
+                    (pat_span.until(local_decl.source_info.span), "&(mut ".to_string()),
+                    (
+                        local_decl.source_info.span.shrink_to_hi().with_hi(pat_span.hi()),
+                        ")".to_string(),
+                    ),
+                ],
                 Applicability::MachineApplicable,
             );
             return;

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2273,9 +2273,26 @@ impl HumanEmitter {
                     &normalize_whitespace(last_line),
                     Style::NoStyle,
                 );
-                buffer.puts(*row_num, 0, &self.maybe_anonymized(line_num), Style::LineNumber);
-                buffer.puts(*row_num, max_line_num_len + 1, "+ ", Style::Addition);
-                buffer.append(*row_num, &normalize_whitespace(line_to_add), Style::NoStyle);
+                if !line_to_add.trim().is_empty() {
+                    // Check if after the removal, the line is left with only whitespace. If so, we
+                    // will not show an "addition" line, as removing the whole line is what the user
+                    // would really want.
+                    // For example, for the following:
+                    //   |
+                    // 2 -     .await
+                    // 2 +     (note the left over whitepsace)
+                    //   |
+                    // We really want
+                    //   |
+                    // 2 -     .await
+                    //   |
+                    // *row_num -= 1;
+                    buffer.puts(*row_num, 0, &self.maybe_anonymized(line_num), Style::LineNumber);
+                    buffer.puts(*row_num, max_line_num_len + 1, "+ ", Style::Addition);
+                    buffer.append(*row_num, &normalize_whitespace(line_to_add), Style::NoStyle);
+                } else {
+                    *row_num -= 1;
+                }
             } else {
                 *row_num -= 2;
             }

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -453,12 +453,11 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for MissingTypeParams {
             } else {
                 // The user wrote `Iterator`, so we don't have a type we can suggest, but at
                 // least we can clue them to the correct syntax `Iterator<Type>`.
-                err.span_suggestion(
-                    self.span,
+                err.span_suggestion_verbose(
+                    self.span.shrink_to_hi(),
                     fluent::hir_analysis_suggestion,
                     format!(
-                        "{}<{}>",
-                        snippet,
+                        "<{}>",
                         self.missing_type_params
                             .iter()
                             .map(|n| n.to_string())

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -2499,7 +2499,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .any(|(ty, _)| matches!(ty.kind(), ty::Slice(..) | ty::Array(..)))
             && let Some(span) = ti.span
             && let Some(_) = ti.origin_expr
-            && let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span)
         {
             let resolved_ty = self.resolve_vars_if_possible(ti.expected);
             let (is_slice_or_array_or_vector, resolved_ty) =
@@ -2510,10 +2509,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         || self.tcx.is_diagnostic_item(sym::Result, adt_def.did()) =>
                 {
                     // Slicing won't work here, but `.as_deref()` might (issue #91328).
-                    err.span_suggestion(
-                        span,
+                    err.span_suggestion_verbose(
+                        span.shrink_to_hi(),
                         "consider using `as_deref` here",
-                        format!("{snippet}.as_deref()"),
+                        ".as_deref()",
                         Applicability::MaybeIncorrect,
                     );
                 }
@@ -2522,10 +2521,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             let is_top_level = current_depth <= 1;
             if is_slice_or_array_or_vector && is_top_level {
-                err.span_suggestion(
-                    span,
+                err.span_suggestion_verbose(
+                    span.shrink_to_hi(),
                     "consider slicing here",
-                    format!("{snippet}[..]"),
+                    "[..]",
                     Applicability::MachineApplicable,
                 );
             }

--- a/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/note_and_explain.rs
@@ -52,10 +52,10 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         ) = tcx.sess.source_map().span_to_snippet(sp) =>
                     {
                         if snippet.chars().all(|c| c.is_digit(10) || c == '-' || c == '_') {
-                            diag.span_suggestion(
-                                sp,
+                            diag.span_suggestion_verbose(
+                                sp.shrink_to_hi(),
                                 "use a float literal",
-                                format!("{snippet}.0"),
+                                ".0",
                                 MachineApplicable,
                             );
                         }

--- a/src/librustdoc/passes/lint/bare_urls.rs
+++ b/src/librustdoc/passes/lint/bare_urls.rs
@@ -19,22 +19,22 @@ pub(super) fn visit_item(cx: &DocContext<'_>, item: &Item) {
     };
     let dox = item.doc_value();
     if !dox.is_empty() {
-        let report_diag =
-            |cx: &DocContext<'_>, msg: &'static str, url: &str, range: Range<usize>| {
-                let sp =
-                    source_span_for_markdown_range(cx.tcx, &dox, &range, &item.attrs.doc_strings)
-                        .unwrap_or_else(|| item.attr_span(cx.tcx));
-                cx.tcx.node_span_lint(crate::lint::BARE_URLS, hir_id, sp, |lint| {
-                    lint.primary_message(msg)
-                        .note("bare URLs are not automatically turned into clickable links")
-                        .span_suggestion(
-                            sp,
-                            "use an automatic link instead",
-                            format!("<{url}>"),
-                            Applicability::MachineApplicable,
-                        );
-                });
-            };
+        let report_diag = |cx: &DocContext<'_>, msg: &'static str, range: Range<usize>| {
+            let sp = source_span_for_markdown_range(cx.tcx, &dox, &range, &item.attrs.doc_strings)
+                .unwrap_or_else(|| item.attr_span(cx.tcx));
+            cx.tcx.node_span_lint(crate::lint::BARE_URLS, hir_id, sp, |lint| {
+                lint.primary_message(msg)
+                    .note("bare URLs are not automatically turned into clickable links")
+                    .multipart_suggestion(
+                        "use an automatic link instead",
+                        vec![
+                            (sp.shrink_to_lo(), "<".to_string()),
+                            (sp.shrink_to_hi(), ">".to_string()),
+                        ],
+                        Applicability::MachineApplicable,
+                    );
+            });
+        };
 
         let mut p = Parser::new_ext(&dox, main_body_opts()).into_offset_iter();
 
@@ -74,17 +74,15 @@ fn find_raw_urls(
     cx: &DocContext<'_>,
     text: &str,
     range: Range<usize>,
-    f: &impl Fn(&DocContext<'_>, &'static str, &str, Range<usize>),
+    f: &impl Fn(&DocContext<'_>, &'static str, Range<usize>),
 ) {
     trace!("looking for raw urls in {text}");
     // For now, we only check "full" URLs (meaning, starting with "http://" or "https://").
     for match_ in URL_REGEX.find_iter(text) {
-        let url = match_.as_str();
         let url_range = match_.range();
         f(
             cx,
             "this URL is not a hyperlink",
-            url,
             Range { start: range.start + url_range.start, end: range.start + url_range.end },
         );
     }

--- a/src/tools/clippy/tests/ui/dbg_macro/dbg_macro.stderr
+++ b/src/tools/clippy/tests/ui/dbg_macro/dbg_macro.stderr
@@ -86,7 +86,6 @@ LL |     dbg!();
 help: remove the invocation before committing it to a version control system
    |
 LL -     dbg!();
-LL +     
    |
 
 error: the `dbg!` macro is intended as a debugging tool
@@ -146,7 +145,6 @@ LL |     expand_to_dbg!();
 help: remove the invocation before committing it to a version control system
    |
 LL -             dbg!();
-LL +             
    |
 
 error: the `dbg!` macro is intended as a debugging tool

--- a/src/tools/clippy/tests/ui/dbg_macro/dbg_macro_unfixable.stderr
+++ b/src/tools/clippy/tests/ui/dbg_macro/dbg_macro_unfixable.stderr
@@ -9,7 +9,6 @@ LL |     dbg!();
 help: remove the invocation before committing it to a version control system
    |
 LL -     dbg!();
-LL +     
    |
 
 error: the `dbg!` macro is intended as a debugging tool

--- a/src/tools/clippy/tests/ui/manual_split_once.stderr
+++ b/src/tools/clippy/tests/ui/manual_split_once.stderr
@@ -96,12 +96,10 @@ LL |     let (l, r) = "a.b.c".split_once('.').unwrap();
 help: remove the `iter` usages
    |
 LL -     let l = iter.next().unwrap();
-LL +     
    |
 help: remove the `iter` usages
    |
 LL -     let r = iter.next().unwrap();
-LL +     
    |
 
 error: manual implementation of `split_once`
@@ -121,12 +119,10 @@ LL |     let (l, r) = "a.b.c".split_once('.')?;
 help: remove the `iter` usages
    |
 LL -     let l = iter.next()?;
-LL +     
    |
 help: remove the `iter` usages
    |
 LL -     let r = iter.next()?;
-LL +     
    |
 
 error: manual implementation of `rsplit_once`
@@ -146,12 +142,10 @@ LL |     let (l, r) = "a.b.c".rsplit_once('.').unwrap();
 help: remove the `iter` usages
    |
 LL -     let r = iter.next().unwrap();
-LL +     
    |
 help: remove the `iter` usages
    |
 LL -     let l = iter.next().unwrap();
-LL +     
    |
 
 error: manual implementation of `rsplit_once`
@@ -171,12 +165,10 @@ LL |     let (l, r) = "a.b.c".rsplit_once('.')?;
 help: remove the `iter` usages
    |
 LL -     let r = iter.next()?;
-LL +     
    |
 help: remove the `iter` usages
    |
 LL -     let l = iter.next()?;
-LL +     
    |
 
 error: manual implementation of `split_once`
@@ -202,12 +194,10 @@ LL |     let (a, b) = "a.b.c".split_once('.').unwrap();
 help: remove the `iter` usages
    |
 LL -     let a = iter.next().unwrap();
-LL +     
    |
 help: remove the `iter` usages
    |
 LL -     let b = iter.next().unwrap();
-LL +     
    |
 
 error: aborting due to 19 previous errors

--- a/src/tools/clippy/tests/ui/significant_drop_tightening.stderr
+++ b/src/tools/clippy/tests/ui/significant_drop_tightening.stderr
@@ -64,7 +64,6 @@ LL +         let rslt0 = mutex.lock().unwrap().abs();
 help: remove separated single usage
    |
 LL -         let rslt0 = lock.abs();
-LL +         
    |
 
 error: temporary with significant `Drop` can be early dropped
@@ -88,7 +87,6 @@ LL +         mutex.lock().unwrap().clear();
 help: remove separated single usage
    |
 LL -         lock.clear();
-LL +         
    |
 
 error: aborting due to 4 previous errors

--- a/tests/rustdoc-ui/diagnostic-width.stderr
+++ b/tests/rustdoc-ui/diagnostic-width.stderr
@@ -2,7 +2,7 @@ error: this URL is not a hyperlink
   --> $DIR/diagnostic-width.rs:4:41
    |
 LL | ... a http://link.com
-   |       ^^^^^^^^^^^^^^^ help: use an automatic link instead: `<http://link.com>`
+   |       ^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
 note: the lint level is defined here
@@ -10,6 +10,10 @@ note: the lint level is defined here
    |
 LL | ...ny(rustdoc::bare_url...
    |       ^^^^^^^^^^^^^^^^^^
+help: use an automatic link instead
+   |
+LL | /// This is a long line that contains a <http://link.com>
+   |                                         +               +
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/include-str-bare-urls.stderr
+++ b/tests/rustdoc-ui/include-str-bare-urls.stderr
@@ -2,7 +2,7 @@ error: this URL is not a hyperlink
   --> $DIR/auxiliary/include-str-bare-urls.md:1:11
    |
 LL | HEADS UP! https://example.com MUST SHOW UP IN THE STDERR FILE!
-   |           ^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://example.com>`
+   |           ^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
 note: the lint level is defined here
@@ -10,6 +10,10 @@ note: the lint level is defined here
    |
 LL | #![deny(rustdoc::bare_urls)]
    |         ^^^^^^^^^^^^^^^^^^
+help: use an automatic link instead
+   |
+LL | HEADS UP! <https://example.com> MUST SHOW UP IN THE STDERR FILE!
+   |           +                   +
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/lints/bare-urls.stderr
+++ b/tests/rustdoc-ui/lints/bare-urls.stderr
@@ -2,7 +2,7 @@ error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:5:5
    |
 LL | /// https://somewhere.com
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com>`
+   |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
 note: the lint level is defined here
@@ -10,134 +10,202 @@ note: the lint level is defined here
    |
 LL | #![deny(rustdoc::bare_urls)]
    |         ^^^^^^^^^^^^^^^^^^
+help: use an automatic link instead
+   |
+LL | /// <https://somewhere.com>
+   |     +                     +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:7:5
    |
 LL | /// https://somewhere.com/a
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com/a>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://somewhere.com/a>
+   |     +                       +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:9:5
    |
 LL | /// https://www.somewhere.com
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://www.somewhere.com>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://www.somewhere.com>
+   |     +                         +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:11:5
    |
 LL | /// https://www.somewhere.com/a
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://www.somewhere.com/a>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://www.somewhere.com/a>
+   |     +                           +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:13:5
    |
 LL | /// https://subdomain.example.com
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://subdomain.example.com>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://subdomain.example.com>
+   |     +                             +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:15:5
    |
 LL | /// https://somewhere.com?
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com?>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://somewhere.com?>
+   |     +                      +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:17:5
    |
 LL | /// https://somewhere.com/a?
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com/a?>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://somewhere.com/a?>
+   |     +                        +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:19:5
    |
 LL | /// https://somewhere.com?hello=12
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com?hello=12>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://somewhere.com?hello=12>
+   |     +                              +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:21:5
    |
 LL | /// https://somewhere.com/a?hello=12
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com/a?hello=12>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://somewhere.com/a?hello=12>
+   |     +                                +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:23:5
    |
 LL | /// https://example.com?hello=12#xyz
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://example.com?hello=12#xyz>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://example.com?hello=12#xyz>
+   |     +                                +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:25:5
    |
 LL | /// https://example.com/a?hello=12#xyz
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://example.com/a?hello=12#xyz>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://example.com/a?hello=12#xyz>
+   |     +                                  +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:27:5
    |
 LL | /// https://example.com#xyz
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://example.com#xyz>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://example.com#xyz>
+   |     +                       +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:29:5
    |
 LL | /// https://example.com/a#xyz
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://example.com/a#xyz>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://example.com/a#xyz>
+   |     +                         +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:31:5
    |
 LL | /// https://somewhere.com?hello=12&bye=11
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com?hello=12&bye=11>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://somewhere.com?hello=12&bye=11>
+   |     +                                     +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:33:5
    |
 LL | /// https://somewhere.com/a?hello=12&bye=11
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com/a?hello=12&bye=11>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://somewhere.com/a?hello=12&bye=11>
+   |     +                                       +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:35:5
    |
 LL | /// https://somewhere.com?hello=12&bye=11#xyz
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com?hello=12&bye=11#xyz>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// <https://somewhere.com?hello=12&bye=11#xyz>
+   |     +                                         +
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:37:10
    |
 LL | /// hey! https://somewhere.com/a?hello=12&bye=11#xyz
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com/a?hello=12&bye=11#xyz>`
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// hey! <https://somewhere.com/a?hello=12&bye=11#xyz>
+   |          +                                           +
 
 error: aborting due to 17 previous errors
 

--- a/tests/rustdoc-ui/lints/renamed-lint-still-applies.stderr
+++ b/tests/rustdoc-ui/lints/renamed-lint-still-applies.stderr
@@ -29,7 +29,7 @@ error: this URL is not a hyperlink
   --> $DIR/renamed-lint-still-applies.rs:9:5
    |
 LL | //! http://example.com
-   |     ^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<http://example.com>`
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
 note: the lint level is defined here
@@ -37,6 +37,10 @@ note: the lint level is defined here
    |
 LL | #![deny(rustdoc::non_autolinks)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+help: use an automatic link instead
+   |
+LL | //! <http://example.com>
+   |     +                  +
 
 error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/tests/ui/assign-imm-local-twice.rs
+++ b/tests/ui/assign-imm-local-twice.rs
@@ -1,7 +1,7 @@
 fn test() {
     let v: isize;
     //~^ HELP consider making this binding mutable
-    //~| SUGGESTION mut v
+    //~| SUGGESTION mut
     v = 1; //~ NOTE first assignment
     println!("v={}", v);
     v = 2; //~ ERROR cannot assign twice to immutable variable

--- a/tests/ui/assign-imm-local-twice.stderr
+++ b/tests/ui/assign-imm-local-twice.stderr
@@ -1,14 +1,16 @@
 error[E0384]: cannot assign twice to immutable variable `v`
   --> $DIR/assign-imm-local-twice.rs:7:5
    |
-LL |     let v: isize;
-   |         - help: consider making this binding mutable: `mut v`
-...
 LL |     v = 1;
    |     ----- first assignment to `v`
 LL |     println!("v={}", v);
 LL |     v = 2;
    |     ^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut v: isize;
+   |         +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/issue-22560.stderr
+++ b/tests/ui/associated-types/issue-22560.stderr
@@ -35,9 +35,13 @@ LL | trait Add<Rhs=Self> {
    | ------------------- type parameter `Rhs` must be specified for this
 ...
 LL | type Test = dyn Add + Sub;
-   |                 ^^^ help: set the type parameter to the desired type: `Add<Rhs>`
+   |                 ^^^
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
+help: set the type parameter to the desired type
+   |
+LL | type Test = dyn Add<Rhs> + Sub;
+   |                    +++++
 
 error[E0393]: the type parameter `Rhs` must be explicitly specified
   --> $DIR/issue-22560.rs:9:23
@@ -46,9 +50,13 @@ LL | trait Sub<Rhs=Self> {
    | ------------------- type parameter `Rhs` must be specified for this
 ...
 LL | type Test = dyn Add + Sub;
-   |                       ^^^ help: set the type parameter to the desired type: `Sub<Rhs>`
+   |                       ^^^
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
+help: set the type parameter to the desired type
+   |
+LL | type Test = dyn Add + Sub<Rhs>;
+   |                          +++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/async-await/issue-61452.stderr
+++ b/tests/ui/async-await/issue-61452.stderr
@@ -13,12 +13,14 @@ error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/issue-61452.rs:9:5
    |
 LL | pub async fn g(x: usize) {
-   |                -
-   |                |
-   |                first assignment to `x`
-   |                help: consider making this binding mutable: `mut x`
+   |                - first assignment to `x`
 LL |     x += 1;
    |     ^^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL | pub async fn g(mut x: usize) {
+   |                +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrow-raw-address-of-mutability.stderr
+++ b/tests/ui/borrowck/borrow-raw-address-of-mutability.stderr
@@ -12,11 +12,13 @@ LL |     let mut x = 0;
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrow-raw-address-of-mutability.rs:11:17
    |
-LL |     let x = 0;
-   |         - help: consider changing this to be mutable: `mut x`
-LL |     let mut f = || {
 LL |         let y = &raw mut x;
    |                 ^^^^^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 0;
+   |         +++
 
 error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
   --> $DIR/borrow-raw-address-of-mutability.rs:21:5

--- a/tests/ui/borrowck/borrowck-closures-unique.stderr
+++ b/tests/ui/borrowck/borrowck-closures-unique.stderr
@@ -43,10 +43,13 @@ LL |     c1;
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/borrowck-closures-unique.rs:43:38
    |
-LL | fn e(x: &'static mut isize) {
-   |      - help: consider changing this to be mutable: `mut x`
 LL |     let c1 = |y: &'static mut isize| x = y;
    |                                      ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn e(mut x: &'static mut isize) {
+   |      +++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/borrowck/borrowck-match-binding-is-assignment.stderr
+++ b/tests/ui/borrowck/borrowck-match-binding-is-assignment.stderr
@@ -9,11 +9,11 @@ LL |             x += 1;
 help: consider making this binding mutable
    |
 LL |         mut x => {
-   |         ~~~~~
+   |         +++
 help: to modify the original value, take a borrow instead
    |
 LL |         ref mut x => {
-   |         ~~~~~~~~~
+   |         +++++++
 
 error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/borrowck-match-binding-is-assignment.rs:20:13
@@ -26,11 +26,11 @@ LL |             x += 1;
 help: consider making this binding mutable
    |
 LL |         E::Foo(mut x) => {
-   |                ~~~~~
+   |                +++
 help: to modify the original value, take a borrow instead
    |
 LL |         E::Foo(ref mut x) => {
-   |                ~~~~~~~~~
+   |                +++++++
 
 error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/borrowck-match-binding-is-assignment.rs:26:13
@@ -43,11 +43,11 @@ LL |             x += 1;
 help: consider making this binding mutable
    |
 LL |         S { bar: mut x } => {
-   |                  ~~~~~
+   |                  +++
 help: to modify the original value, take a borrow instead
    |
 LL |         S { bar: ref mut x } => {
-   |                  ~~~~~~~~~
+   |                  +++++++
 
 error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/borrowck-match-binding-is-assignment.rs:32:13
@@ -60,11 +60,11 @@ LL |             x += 1;
 help: consider making this binding mutable
    |
 LL |         (mut x,) => {
-   |          ~~~~~
+   |          +++
 help: to modify the original value, take a borrow instead
    |
 LL |         (ref mut x,) => {
-   |          ~~~~~~~~~
+   |          +++++++
 
 error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/borrowck-match-binding-is-assignment.rs:38:13
@@ -77,11 +77,11 @@ LL |             x += 1;
 help: consider making this binding mutable
    |
 LL |         [mut x,_,_] => {
-   |          ~~~~~
+   |          +++
 help: to modify the original value, take a borrow instead
    |
 LL |         [ref mut x,_,_] => {
-   |          ~~~~~~~~~
+   |          +++++++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/borrowck/immutable-arg.stderr
+++ b/tests/ui/borrowck/immutable-arg.stderr
@@ -1,10 +1,13 @@
 error[E0384]: cannot assign to immutable argument `_x`
   --> $DIR/immutable-arg.rs:2:5
    |
-LL | fn foo(_x: u32) {
-   |        -- help: consider making this binding mutable: `mut _x`
 LL |     _x = 4;
    |     ^^^^^^ cannot assign to immutable argument
+   |
+help: consider making this binding mutable
+   |
+LL | fn foo(mut _x: u32) {
+   |        +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-111554.stderr
+++ b/tests/ui/borrowck/issue-111554.stderr
@@ -19,10 +19,13 @@ LL |         || bar(&mut self);
 error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-111554.rs:21:16
    |
-LL |     pub fn quux(self) {
-   |                 ---- help: consider changing this to be mutable: `mut self`
 LL |         || bar(&mut self);
    |                ^^^^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     pub fn quux(mut self) {
+   |                 +++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/borrowck/issue-33819.stderr
+++ b/tests/ui/borrowck/issue-33819.stderr
@@ -2,10 +2,13 @@ error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
   --> $DIR/issue-33819.rs:4:34
    |
 LL |         Some(ref v) => { let a = &mut v; },
-   |                                  ^^^^^^
-   |                                  |
-   |                                  cannot borrow as mutable
-   |                                  help: try removing `&mut` here
+   |                                  ^^^^^^ cannot borrow as mutable
+   |
+help: try removing `&mut` here
+   |
+LL -         Some(ref v) => { let a = &mut v; },
+LL +         Some(ref v) => { let a = v; },
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-45199.rs
+++ b/tests/ui/borrowck/issue-45199.rs
@@ -1,7 +1,7 @@
 fn test_drop_replace() {
     let b: Box<isize>;
     //~^ HELP consider making this binding mutable
-    //~| SUGGESTION mut b
+    //~| SUGGESTION mut
     b = Box::new(1);    //~ NOTE first assignment
     b = Box::new(2);    //~ ERROR cannot assign twice to immutable variable `b`
                         //~| NOTE cannot assign twice to immutable
@@ -10,13 +10,13 @@ fn test_drop_replace() {
 fn test_call() {
     let b = Box::new(1);    //~ NOTE first assignment
                             //~| HELP consider making this binding mutable
-                            //~| SUGGESTION mut b
+                            //~| SUGGESTION mut
     b = Box::new(2);        //~ ERROR cannot assign twice to immutable variable `b`
                             //~| NOTE cannot assign twice to immutable
 }
 
 fn test_args(b: Box<i32>) {  //~ HELP consider making this binding mutable
-                                //~| SUGGESTION mut b
+                                //~| SUGGESTION mut
     b = Box::new(2);            //~ ERROR cannot assign to immutable argument `b`
                                 //~| NOTE cannot assign to immutable argument
 }

--- a/tests/ui/borrowck/issue-45199.stderr
+++ b/tests/ui/borrowck/issue-45199.stderr
@@ -1,34 +1,40 @@
 error[E0384]: cannot assign twice to immutable variable `b`
   --> $DIR/issue-45199.rs:6:5
    |
-LL |     let b: Box<isize>;
-   |         - help: consider making this binding mutable: `mut b`
-...
 LL |     b = Box::new(1);
    |     - first assignment to `b`
 LL |     b = Box::new(2);
    |     ^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut b: Box<isize>;
+   |         +++
 
 error[E0384]: cannot assign twice to immutable variable `b`
   --> $DIR/issue-45199.rs:14:5
    |
 LL |     let b = Box::new(1);
-   |         -
-   |         |
-   |         first assignment to `b`
-   |         help: consider making this binding mutable: `mut b`
+   |         - first assignment to `b`
 ...
 LL |     b = Box::new(2);
    |     ^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut b = Box::new(1);
+   |         +++
 
 error[E0384]: cannot assign to immutable argument `b`
   --> $DIR/issue-45199.rs:20:5
    |
-LL | fn test_args(b: Box<i32>) {
-   |              - help: consider making this binding mutable: `mut b`
-LL |
 LL |     b = Box::new(2);
    |     ^ cannot assign to immutable argument
+   |
+help: consider making this binding mutable
+   |
+LL | fn test_args(mut b: Box<i32>) {
+   |              +++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.stderr
+++ b/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.stderr
@@ -44,56 +44,68 @@ LL |         borrowck_closures_unique::e(addr_of_mut!(X));
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:9:46
    |
-LL |     pub fn e(x: &'static mut isize) {
-   |              - help: consider changing this to be mutable: `mut x`
-LL |         static mut Y: isize = 3;
 LL |         let mut c1 = |y: &'static mut isize| x = y;
    |                                              ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     pub fn e(mut x: &'static mut isize) {
+   |              +++
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:22:50
    |
-LL |     pub fn ee(x: &'static mut isize) {
-   |               - help: consider changing this to be mutable: `mut x`
-...
 LL |             let mut c2 = |y: &'static mut isize| x = y;
    |                                                  ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     pub fn ee(mut x: &'static mut isize) {
+   |               +++
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:37:13
    |
-LL |     pub fn capture_assign_whole(x: (i32,)) {
-   |                                 - help: consider changing this to be mutable: `mut x`
-LL |         || {
 LL |             x = (1,);
    |             ^^^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     pub fn capture_assign_whole(mut x: (i32,)) {
+   |                                 +++
 
 error[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:43:13
    |
-LL |     pub fn capture_assign_part(x: (i32,)) {
-   |                                - help: consider changing this to be mutable: `mut x`
-LL |         || {
 LL |             x.0 = 1;
    |             ^^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     pub fn capture_assign_part(mut x: (i32,)) {
+   |                                +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:49:13
    |
-LL |     pub fn capture_reborrow_whole(x: (i32,)) {
-   |                                   - help: consider changing this to be mutable: `mut x`
-LL |         || {
 LL |             &mut x;
    |             ^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     pub fn capture_reborrow_whole(mut x: (i32,)) {
+   |                                   +++
 
 error[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:55:13
    |
-LL |     pub fn capture_reborrow_part(x: (i32,)) {
-   |                                  - help: consider changing this to be mutable: `mut x`
-LL |         || {
 LL |             &mut x.0;
    |             ^^^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     pub fn capture_reborrow_part(mut x: (i32,)) {
+   |                                  +++
 
 error: aborting due to 6 previous errors; 3 warnings emitted
 

--- a/tests/ui/borrowck/mutability-errors.stderr
+++ b/tests/ui/borrowck/mutability-errors.stderr
@@ -262,74 +262,90 @@ LL | fn imm_local(mut x: (i32,)) {
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:60:9
    |
-LL | fn imm_capture(x: (i32,)) {
-   |                - help: consider changing this to be mutable: `mut x`
-LL |     || {
 LL |         x = (1,);
    |         ^^^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn imm_capture(mut x: (i32,)) {
+   |                +++
 
 error[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
   --> $DIR/mutability-errors.rs:61:9
    |
-LL | fn imm_capture(x: (i32,)) {
-   |                - help: consider changing this to be mutable: `mut x`
-...
 LL |         x.0 = 1;
    |         ^^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn imm_capture(mut x: (i32,)) {
+   |                +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:62:9
    |
-LL | fn imm_capture(x: (i32,)) {
-   |                - help: consider changing this to be mutable: `mut x`
-...
 LL |         &mut x;
    |         ^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL | fn imm_capture(mut x: (i32,)) {
+   |                +++
 
 error[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
   --> $DIR/mutability-errors.rs:63:9
    |
-LL | fn imm_capture(x: (i32,)) {
-   |                - help: consider changing this to be mutable: `mut x`
-...
 LL |         &mut x.0;
    |         ^^^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL | fn imm_capture(mut x: (i32,)) {
+   |                +++
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:66:9
    |
-LL | fn imm_capture(x: (i32,)) {
-   |                - help: consider changing this to be mutable: `mut x`
-...
 LL |         x = (1,);
    |         ^^^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn imm_capture(mut x: (i32,)) {
+   |                +++
 
 error[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
   --> $DIR/mutability-errors.rs:67:9
    |
-LL | fn imm_capture(x: (i32,)) {
-   |                - help: consider changing this to be mutable: `mut x`
-...
 LL |         x.0 = 1;
    |         ^^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn imm_capture(mut x: (i32,)) {
+   |                +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:68:9
    |
-LL | fn imm_capture(x: (i32,)) {
-   |                - help: consider changing this to be mutable: `mut x`
-...
 LL |         &mut x;
    |         ^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL | fn imm_capture(mut x: (i32,)) {
+   |                +++
 
 error[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
   --> $DIR/mutability-errors.rs:69:9
    |
-LL | fn imm_capture(x: (i32,)) {
-   |                - help: consider changing this to be mutable: `mut x`
-...
 LL |         &mut x.0;
    |         ^^^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL | fn imm_capture(mut x: (i32,)) {
+   |                +++
 
 error[E0594]: cannot assign to immutable static item `X`
   --> $DIR/mutability-errors.rs:76:5

--- a/tests/ui/borrowck/suggest-ref-mut-issue-118596.stderr
+++ b/tests/ui/borrowck/suggest-ref-mut-issue-118596.stderr
@@ -9,11 +9,11 @@ LL |         x = 2;
 help: consider making this binding mutable
    |
 LL |     if let Some(mut x) = y {
-   |                 ~~~~~
+   |                 +++
 help: to modify the original value, take a borrow instead
    |
 LL |     if let Some(ref mut x) = y {
-   |                 ~~~~~~~~~
+   |                 +++++++
 
 error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/suggest-ref-mut-issue-118596.rs:9:5
@@ -26,11 +26,11 @@ LL |     x = 0;
 help: consider making this binding mutable
    |
 LL |     let [mut x, ref xs_hold @ ..] = arr;
-   |          ~~~~~
+   |          +++
 help: to modify the original value, take a borrow instead
    |
 LL |     let [ref mut x, ref xs_hold @ ..] = arr;
-   |          ~~~~~~~~~
+   |          +++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/tainted-promoteds.stderr
+++ b/tests/ui/borrowck/tainted-promoteds.stderr
@@ -2,12 +2,14 @@ error[E0384]: cannot assign twice to immutable variable `a`
   --> $DIR/tainted-promoteds.rs:7:5
    |
 LL |     let a = 0;
-   |         -
-   |         |
-   |         first assignment to `a`
-   |         help: consider making this binding mutable: `mut a`
+   |         - first assignment to `a`
 LL |     a = &0 * &1 * &2 * &3;
    |     ^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut a = 0;
+   |         +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cannot-mutate-captured-non-mut-var.stderr
+++ b/tests/ui/cannot-mutate-captured-non-mut-var.stderr
@@ -1,18 +1,24 @@
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/cannot-mutate-captured-non-mut-var.rs:9:25
    |
-LL |     let x = 1;
-   |         - help: consider changing this to be mutable: `mut x`
 LL |     to_fn_once(move|| { x = 2; });
    |                         ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 1;
+   |         +++
 
 error[E0596]: cannot borrow `s` as mutable, as it is not declared as mutable
   --> $DIR/cannot-mutate-captured-non-mut-var.rs:13:25
    |
-LL |     let s = std::io::stdin();
-   |         - help: consider changing this to be mutable: `mut s`
 LL |     to_fn_once(move|| { s.read_to_end(&mut Vec::new()); });
    |                         ^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut s = std::io::stdin();
+   |         +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/closures/2229_closure_analysis/array_subslice.stderr
+++ b/tests/ui/closures/2229_closure_analysis/array_subslice.stderr
@@ -1,11 +1,13 @@
 error[E0596]: cannot borrow `x[..]` as mutable, as `x` is not declared as mutable
   --> $DIR/array_subslice.rs:7:21
    |
-LL | pub fn subslice_array(x: [u8; 3]) {
-   |                       - help: consider changing this to be mutable: `mut x`
-...
 LL |         let [ref y, ref mut z @ ..] = x;
    |                     ^^^^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL | pub fn subslice_array(mut x: [u8; 3]) {
+   |                       +++
 
 error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
   --> $DIR/array_subslice.rs:10:5

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm.stderr
@@ -1,20 +1,24 @@
 error[E0594]: cannot assign to `z.0.0.0`, as it is not declared as mutable
   --> $DIR/cant-mutate-imm.rs:12:9
    |
-LL |     let z = (y, 10);
-   |         - help: consider changing this to be mutable: `mut z`
-...
 LL |         z.0.0.0 = 20;
    |         ^^^^^^^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut z = (y, 10);
+   |         +++
 
 error[E0594]: cannot assign to `*bx.0`, as it is not declared as mutable
   --> $DIR/cant-mutate-imm.rs:24:9
    |
-LL |     let bx = Box::new(x);
-   |         -- help: consider changing this to be mutable: `mut bx`
-...
 LL |         bx.0 = 20;
    |         ^^^^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut bx = Box::new(x);
+   |         +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/closures/closure-immutable-outer-variable.stderr
+++ b/tests/ui/closures/closure-immutable-outer-variable.stderr
@@ -1,10 +1,13 @@
 error[E0594]: cannot assign to `y`, as it is not declared as mutable
   --> $DIR/closure-immutable-outer-variable.rs:11:26
    |
-LL |     let y = true;
-   |         - help: consider changing this to be mutable: `mut y`
 LL |     foo(Box::new(move || y = !y) as Box<_>);
    |                          ^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut y = true;
+   |         +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/command-line-diagnostics.stderr
+++ b/tests/ui/command-line-diagnostics.stderr
@@ -2,12 +2,14 @@ error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/command-line-diagnostics.rs:6:5
    |
 LL |     let x = 42;
-   |         -
-   |         |
-   |         first assignment to `x`
-   |         help: consider making this binding mutable: `mut x`
+   |         - first assignment to `x`
 LL |     x = 43;
    |     ^^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut x = 42;
+   |         +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
@@ -20,24 +20,32 @@ error[E0393]: the type parameter `Rhs` must be explicitly specified
   --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:16:27
    |
 LL | ) -> impl Iterator<Item = SubAssign> {
-   |                           ^^^^^^^^^ help: set the type parameter to the desired type: `SubAssign<Rhs>`
+   |                           ^^^^^^^^^
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
    = note: type parameter `Rhs` must be specified for this
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
+help: set the type parameter to the desired type
+   |
+LL | ) -> impl Iterator<Item = SubAssign<Rhs>> {
+   |                                    +++++
 
 error[E0393]: the type parameter `Rhs` must be explicitly specified
   --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:16:27
    |
 LL | ) -> impl Iterator<Item = SubAssign> {
-   |                           ^^^^^^^^^ help: set the type parameter to the desired type: `SubAssign<Rhs>`
+   |                           ^^^^^^^^^
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
    = note: type parameter `Rhs` must be specified for this
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: set the type parameter to the desired type
+   |
+LL | ) -> impl Iterator<Item = SubAssign<Rhs>> {
+   |                                    +++++
 
 error[E0277]: `()` is not an iterator
   --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:16:6

--- a/tests/ui/consts/issue-39974.stderr
+++ b/tests/ui/consts/issue-39974.stderr
@@ -2,10 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/issue-39974.rs:1:21
    |
 LL | const LENGTH: f64 = 2;
-   |                     ^
-   |                     |
-   |                     expected `f64`, found integer
-   |                     help: use a float literal: `2.0`
+   |                     ^ expected `f64`, found integer
+   |
+help: use a float literal
+   |
+LL | const LENGTH: f64 = 2.0;
+   |                      ++
 
 error[E0308]: mismatched types
   --> $DIR/issue-39974.rs:5:19

--- a/tests/ui/did_you_mean/issue-34337.stderr
+++ b/tests/ui/did_you_mean/issue-34337.stderr
@@ -2,10 +2,13 @@ error[E0596]: cannot borrow `key` as mutable, as it is not declared as mutable
   --> $DIR/issue-34337.rs:6:9
    |
 LL |     get(&mut key);
-   |         ^^^^^^^^
-   |         |
-   |         cannot borrow as mutable
-   |         help: try removing `&mut` here
+   |         ^^^^^^^^ cannot borrow as mutable
+   |
+help: try removing `&mut` here
+   |
+LL -     get(&mut key);
+LL +     get(key);
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/issue-37139.stderr
+++ b/tests/ui/did_you_mean/issue-37139.stderr
@@ -2,10 +2,13 @@ error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/issue-37139.rs:12:18
    |
 LL |             test(&mut x);
-   |                  ^^^^^^
-   |                  |
-   |                  cannot borrow as mutable
-   |                  help: try removing `&mut` here
+   |                  ^^^^^^ cannot borrow as mutable
+   |
+help: try removing `&mut` here
+   |
+LL -             test(&mut x);
+LL +             test(x);
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/issue-53280-expected-float-found-integer-literal.stderr
+++ b/tests/ui/did_you_mean/issue-53280-expected-float-found-integer-literal.stderr
@@ -2,31 +2,40 @@ error[E0308]: mismatched types
   --> $DIR/issue-53280-expected-float-found-integer-literal.rs:2:24
    |
 LL |     let sixteen: f32 = 16;
-   |                  ---   ^^
-   |                  |     |
-   |                  |     expected `f32`, found integer
-   |                  |     help: use a float literal: `16.0`
+   |                  ---   ^^ expected `f32`, found integer
+   |                  |
    |                  expected due to this
+   |
+help: use a float literal
+   |
+LL |     let sixteen: f32 = 16.0;
+   |                          ++
 
 error[E0308]: mismatched types
   --> $DIR/issue-53280-expected-float-found-integer-literal.rs:5:38
    |
 LL |     let a_million_and_seventy: f64 = 1_000_070;
-   |                                ---   ^^^^^^^^^
-   |                                |     |
-   |                                |     expected `f64`, found integer
-   |                                |     help: use a float literal: `1_000_070.0`
+   |                                ---   ^^^^^^^^^ expected `f64`, found integer
+   |                                |
    |                                expected due to this
+   |
+help: use a float literal
+   |
+LL |     let a_million_and_seventy: f64 = 1_000_070.0;
+   |                                               ++
 
 error[E0308]: mismatched types
   --> $DIR/issue-53280-expected-float-found-integer-literal.rs:8:30
    |
 LL |     let negative_nine: f32 = -9;
-   |                        ---   ^^
-   |                        |     |
-   |                        |     expected `f32`, found integer
-   |                        |     help: use a float literal: `-9.0`
+   |                        ---   ^^ expected `f32`, found integer
+   |                        |
    |                        expected due to this
+   |
+help: use a float literal
+   |
+LL |     let negative_nine: f32 = -9.0;
+   |                                ++
 
 error[E0308]: mismatched types
   --> $DIR/issue-53280-expected-float-found-integer-literal.rs:15:30

--- a/tests/ui/error-codes/E0393.stderr
+++ b/tests/ui/error-codes/E0393.stderr
@@ -5,9 +5,13 @@ LL | trait A<T=Self> {}
    | --------------- type parameter `T` must be specified for this
 LL |
 LL | fn together_we_will_rule_the_galaxy(son: &dyn A) {}
-   |                                               ^ help: set the type parameter to the desired type: `A<T>`
+   |                                               ^
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
+help: set the type parameter to the desired type
+   |
+LL | fn together_we_will_rule_the_galaxy(son: &dyn A<T>) {}
+   |                                                +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/fn/suggest-return-closure.stderr
+++ b/tests/ui/fn/suggest-return-closure.stderr
@@ -34,11 +34,13 @@ LL | fn fun() -> _ {
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/suggest-return-closure.rs:23:9
    |
-LL |     let x = String::new();
-   |         - help: consider changing this to be mutable: `mut x`
-...
 LL |         x.push(c);
    |         ^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = String::new();
+   |         +++
 
 error[E0597]: `x` does not live long enough
   --> $DIR/suggest-return-closure.rs:23:9

--- a/tests/ui/issues/issue-11004.stderr
+++ b/tests/ui/issues/issue-11004.stderr
@@ -2,19 +2,23 @@ error[E0609]: no field `x` on type `*mut A`
   --> $DIR/issue-11004.rs:7:21
    |
 LL |     let x : i32 = n.x;
-   |                   --^
-   |                   | |
-   |                   | unknown field
-   |                   help: `n` is a raw pointer; try dereferencing it: `(*n).x`
+   |                     ^ unknown field
+   |
+help: `n` is a raw pointer; try dereferencing it
+   |
+LL |     let x : i32 = (*n).x;
+   |                   ++ +
 
 error[E0609]: no field `y` on type `*mut A`
   --> $DIR/issue-11004.rs:8:21
    |
 LL |     let y : f64 = n.y;
-   |                   --^
-   |                   | |
-   |                   | unknown field
-   |                   help: `n` is a raw pointer; try dereferencing it: `(*n).y`
+   |                     ^ unknown field
+   |
+help: `n` is a raw pointer; try dereferencing it
+   |
+LL |     let y : f64 = (*n).y;
+   |                   ++ +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-21950.stderr
+++ b/tests/ui/issues/issue-21950.stderr
@@ -14,9 +14,13 @@ LL | trait Add<Rhs=Self> {
    | ------------------- type parameter `Rhs` must be specified for this
 ...
 LL |     let x = &10 as &dyn Add;
-   |                         ^^^ help: set the type parameter to the desired type: `Add<Rhs>`
+   |                         ^^^
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
+help: set the type parameter to the desired type
+   |
+LL |     let x = &10 as &dyn Add<Rhs>;
+   |                            +++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-22370.stderr
+++ b/tests/ui/issues/issue-22370.stderr
@@ -5,9 +5,13 @@ LL | trait A<T=Self> {}
    | --------------- type parameter `T` must be specified for this
 LL |
 LL | fn f(a: &dyn A) {}
-   |              ^ help: set the type parameter to the desired type: `A<T>`
+   |              ^
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
+help: set the type parameter to the desired type
+   |
+LL | fn f(a: &dyn A<T>) {}
+   |               +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/let-else/let-else-slicing-error.stderr
+++ b/tests/ui/let-else/let-else-slicing-error.stderr
@@ -2,9 +2,12 @@ error[E0529]: expected an array or slice, found `Vec<{integer}>`
   --> $DIR/let-else-slicing-error.rs:6:9
    |
 LL |     let [x, y] = nums else {
-   |         ^^^^^^   ---- help: consider slicing here: `nums[..]`
-   |         |
-   |         pattern cannot match with input type `Vec<{integer}>`
+   |         ^^^^^^ pattern cannot match with input type `Vec<{integer}>`
+   |
+help: consider slicing here
+   |
+LL |     let [x, y] = nums[..] else {
+   |                      ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.stderr
@@ -16,10 +16,13 @@ LL | fn foo<'a>(mut x: Ref<'a, 'a>, y: &'a u32) {
 error[E0384]: cannot assign to immutable argument `y`
   --> $DIR/ex3-both-anon-regions-one-is-struct-2.rs:4:5
    |
-LL | fn foo(mut x: Ref, y: &u32) {
-   |                    - help: consider making this binding mutable: `mut y`
 LL |     y = x.b;
    |     ^^^^^^^ cannot assign to immutable argument
+   |
+help: consider making this binding mutable
+   |
+LL | fn foo(mut x: Ref, mut y: &u32) {
+   |                    +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/lifetime-errors/liveness-assign-imm-local-notes.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/liveness-assign-imm-local-notes.stderr
@@ -1,45 +1,53 @@
 error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/liveness-assign-imm-local-notes.rs:10:9
    |
-LL |     let x;
-   |         - help: consider making this binding mutable: `mut x`
-...
 LL |         x = 2;
    |         ----- first assignment to `x`
 LL |         x = 3;
    |         ^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut x;
+   |         +++
 
 error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/liveness-assign-imm-local-notes.rs:21:13
    |
-LL |         let x;
-   |             - help: consider making this binding mutable: `mut x`
-...
 LL |             x = 2;
    |             ----- first assignment to `x`
 LL |             x = 3;
    |             ^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |         let mut x;
+   |             +++
 
 error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/liveness-assign-imm-local-notes.rs:30:13
    |
-LL |     let x;
-   |         - help: consider making this binding mutable: `mut x`
-...
 LL |             x = 1;
    |             ^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut x;
+   |         +++
 
 error[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/liveness-assign-imm-local-notes.rs:32:13
    |
-LL |     let x;
-   |         - help: consider making this binding mutable: `mut x`
-...
 LL |             x = 1;
    |             ----- first assignment to `x`
 LL |         } else {
 LL |             x = 2;
    |             ^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut x;
+   |         +++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.rs
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.rs
@@ -1,7 +1,7 @@
 fn test() {
     let v: isize;
     //~^ HELP consider making this binding mutable
-    //~| SUGGESTION mut v
+    //~| SUGGESTION mut
     loop {
         v = 1; //~ ERROR cannot assign twice to immutable variable `v`
                //~| NOTE cannot assign twice to immutable variable

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.stderr
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.stderr
@@ -1,11 +1,13 @@
 error[E0384]: cannot assign twice to immutable variable `v`
   --> $DIR/liveness-assign-imm-local-in-loop.rs:6:9
    |
-LL |     let v: isize;
-   |         - help: consider making this binding mutable: `mut v`
-...
 LL |         v = 1;
    |         ^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut v: isize;
+   |         +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.rs
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.rs
@@ -1,7 +1,7 @@
 fn test() {
     let v: isize;
     //~^ HELP consider making this binding mutable
-    //~| SUGGESTION mut v
+    //~| SUGGESTION mut
     v = 2;  //~ NOTE first assignment
     v += 1; //~ ERROR cannot assign twice to immutable variable `v`
             //~| NOTE cannot assign twice to immutable

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.stderr
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.stderr
@@ -1,13 +1,15 @@
 error[E0384]: cannot assign twice to immutable variable `v`
   --> $DIR/liveness-assign-imm-local-in-op-eq.rs:6:5
    |
-LL |     let v: isize;
-   |         - help: consider making this binding mutable: `mut v`
-...
 LL |     v = 2;
    |     ----- first assignment to `v`
 LL |     v += 1;
    |     ^^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut v: isize;
+   |         +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.rs
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.rs
@@ -1,7 +1,7 @@
 fn test() {
     let b = Box::new(1); //~ NOTE first assignment
                          //~| HELP consider making this binding mutable
-                         //~| SUGGESTION mut b
+                         //~| SUGGESTION mut
     drop(b);
     b = Box::new(2); //~ ERROR cannot assign twice to immutable variable `b`
                      //~| NOTE cannot assign twice to immutable

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.stderr
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.stderr
@@ -2,13 +2,15 @@ error[E0384]: cannot assign twice to immutable variable `b`
   --> $DIR/liveness-assign-imm-local-with-drop.rs:6:5
    |
 LL |     let b = Box::new(1);
-   |         -
-   |         |
-   |         first assignment to `b`
-   |         help: consider making this binding mutable: `mut b`
+   |         - first assignment to `b`
 ...
 LL |     b = Box::new(2);
    |     ^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut b = Box::new(1);
+   |         +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.rs
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.rs
@@ -1,7 +1,7 @@
 fn test() {
     let v: isize = 1; //~ NOTE first assignment
                       //~| HELP consider making this binding mutable
-                      //~| SUGGESTION mut v
+                      //~| SUGGESTION mut
     v.clone();
     v = 2; //~ ERROR cannot assign twice to immutable variable `v`
            //~| NOTE cannot assign twice to immutable

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.stderr
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.stderr
@@ -2,13 +2,15 @@ error[E0384]: cannot assign twice to immutable variable `v`
   --> $DIR/liveness-assign-imm-local-with-init.rs:6:5
    |
 LL |     let v: isize = 1;
-   |         -
-   |         |
-   |         first assignment to `v`
-   |         help: consider making this binding mutable: `mut v`
+   |         - first assignment to `v`
 ...
 LL |     v = 2;
    |     ^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut v: isize = 1;
+   |         +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/mismatched_types/float-literal-inference-restrictions.stderr
+++ b/tests/ui/mismatched_types/float-literal-inference-restrictions.stderr
@@ -2,11 +2,14 @@ error[E0308]: mismatched types
   --> $DIR/float-literal-inference-restrictions.rs:2:18
    |
 LL |     let x: f32 = 1;
-   |            ---   ^
-   |            |     |
-   |            |     expected `f32`, found integer
-   |            |     help: use a float literal: `1.0`
+   |            ---   ^ expected `f32`, found integer
+   |            |
    |            expected due to this
+   |
+help: use a float literal
+   |
+LL |     let x: f32 = 1.0;
+   |                   ++
 
 error[E0308]: mismatched types
   --> $DIR/float-literal-inference-restrictions.rs:3:18

--- a/tests/ui/mut/mut-pattern-internal-mutability.stderr
+++ b/tests/ui/mut/mut-pattern-internal-mutability.stderr
@@ -9,11 +9,11 @@ LL |     x += 1;
 help: consider making this binding mutable
    |
 LL |     let &mut mut x = foo;
-   |              ~~~~~
+   |              +++
 help: to modify the original value, take a borrow instead
    |
 LL |     let &mut ref mut x = foo;
-   |              ~~~~~~~~~
+   |              +++++++
 
 error[E0506]: cannot assign to `*foo` because it is borrowed
   --> $DIR/mut-pattern-internal-mutability.rs:13:5

--- a/tests/ui/nll/closure-captures.stderr
+++ b/tests/ui/nll/closure-captures.stderr
@@ -1,38 +1,46 @@
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:7:5
    |
-LL | fn one_closure(x: i32) {
-   |                - help: consider changing this to be mutable: `mut x`
-LL |     ||
 LL |     x = 1;
    |     ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn one_closure(mut x: i32) {
+   |                +++
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:9:5
    |
-LL | fn one_closure(x: i32) {
-   |                - help: consider changing this to be mutable: `mut x`
-...
 LL |     x = 1;
    |     ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn one_closure(mut x: i32) {
+   |                +++
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:15:9
    |
-LL | fn two_closures(x: i32) {
-   |                 - help: consider changing this to be mutable: `mut x`
-...
 LL |         x = 1;
    |         ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn two_closures(mut x: i32) {
+   |                 +++
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:19:9
    |
-LL | fn two_closures(x: i32) {
-   |                 - help: consider changing this to be mutable: `mut x`
-...
 LL |         x = 1;
    |         ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn two_closures(mut x: i32) {
+   |                 +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
   --> $DIR/closure-captures.rs:27:9
@@ -67,11 +75,13 @@ LL |     x = 1;});
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:39:10
    |
-LL | fn two_closures_ref(x: i32) {
-   |                     - help: consider changing this to be mutable: `mut x`
-...
 LL |          x = 1;}
    |          ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn two_closures_ref(mut x: i32) {
+   |                     +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
   --> $DIR/closure-captures.rs:38:9
@@ -91,11 +101,13 @@ LL |          x = 1;}
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:43:5
    |
-LL | fn two_closures_ref(x: i32) {
-   |                     - help: consider changing this to be mutable: `mut x`
-...
 LL |     x = 1;});
    |     ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn two_closures_ref(mut x: i32) {
+   |                     +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
   --> $DIR/closure-captures.rs:42:9

--- a/tests/ui/nll/coroutine-upvar-mutability.stderr
+++ b/tests/ui/nll/coroutine-upvar-mutability.stderr
@@ -1,11 +1,13 @@
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/coroutine-upvar-mutability.rs:10:9
    |
-LL |     let x = 0;
-   |         - help: consider changing this to be mutable: `mut x`
-...
 LL |         x = 1;
    |         ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 0;
+   |         +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/issue-46023.stderr
+++ b/tests/ui/nll/issue-46023.stderr
@@ -1,11 +1,13 @@
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/issue-46023.rs:5:9
    |
-LL |     let x = 0;
-   |         - help: consider changing this to be mutable: `mut x`
-...
 LL |         x = 1;
    |         ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 0;
+   |         +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.stderr
+++ b/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.stderr
@@ -78,11 +78,11 @@ LL |         | Err(a @ b @ a)
 help: consider making this binding mutable
    |
 LL |         Ok(a @ b @ mut a)
-   |                    ~~~~~
+   |                    +++
 help: to modify the original value, take a borrow instead
    |
 LL |         Ok(a @ b @ ref mut a)
-   |                    ~~~~~~~~~
+   |                    +++++++
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -22,11 +22,11 @@ LL |     _x1 = U;
 help: consider making this binding mutable
    |
 LL |     let [ref _x0_hold, mut _x1, ref xs_hold @ ..] = arr;
-   |                        ~~~~~~~
+   |                        +++
 help: to modify the original value, take a borrow instead
    |
 LL |     let [ref _x0_hold, ref mut _x1, ref xs_hold @ ..] = arr;
-   |                        ~~~~~~~~~~~
+   |                        +++++++
 
 error[E0505]: cannot move out of `arr[..]` because it is borrowed
   --> $DIR/borrowck-move-ref-pattern.rs:11:10
@@ -86,11 +86,11 @@ LL |     _x1 = U;
 help: consider making this binding mutable
    |
 LL |     let (ref _x0, mut _x1, ref _x2, ..) = tup;
-   |                   ~~~~~~~
+   |                   +++
 help: to modify the original value, take a borrow instead
    |
 LL |     let (ref _x0, ref mut _x1, ref _x2, ..) = tup;
-   |                   ~~~~~~~~~~~
+   |                   +++++++
 
 error[E0502]: cannot borrow `tup.0` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-move-ref-pattern.rs:24:20

--- a/tests/ui/pattern/mut-ref-mut-2021.stderr
+++ b/tests/ui/pattern/mut-ref-mut-2021.stderr
@@ -9,11 +9,11 @@ LL |     a = 42;
 help: consider making this binding mutable
    |
 LL |     let Foo(mut a) = Foo(0);
-   |             ~~~~~
+   |             +++
 help: to modify the original value, take a borrow instead
    |
 LL |     let Foo(ref mut a) = Foo(0);
-   |             ~~~~~~~~~
+   |             +++++++
 
 error[E0384]: cannot assign twice to immutable variable `a`
   --> $DIR/mut-ref-mut-2021.rs:15:5

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
@@ -1,10 +1,13 @@
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
   --> $DIR/patkind-ref-binding-issue-114896.rs:7:9
    |
-LL |         let &b = a;
-   |             -- help: consider changing this to be mutable: `&(mut b)`
 LL |         b.make_ascii_uppercase();
    |         ^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |         let &(mut b) = a;
+   |             ~~~~~  +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
@@ -1,10 +1,13 @@
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/patkind-ref-binding-issue-122415.rs:7:12
    |
-LL | fn foo(&x: &i32) {
-   |        -- help: consider changing this to be mutable: `&(mut x)`
 LL |     mutate(&mut x);
    |            ^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL | fn foo(&(mut x): &i32) {
+   |        ~~~~~  +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/structs/structure-constructor-type-mismatch.stderr
+++ b/tests/ui/structs/structure-constructor-type-mismatch.stderr
@@ -2,55 +2,67 @@ error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:17:12
    |
 LL |         x: 1,
-   |            ^
-   |            |
-   |            expected `f32`, found integer
-   |            help: use a float literal: `1.0`
+   |            ^ expected `f32`, found integer
+   |
+help: use a float literal
+   |
+LL |         x: 1.0,
+   |             ++
 
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:20:12
    |
 LL |         y: 2,
-   |            ^
-   |            |
-   |            expected `f32`, found integer
-   |            help: use a float literal: `2.0`
+   |            ^ expected `f32`, found integer
+   |
+help: use a float literal
+   |
+LL |         y: 2.0,
+   |             ++
 
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:26:12
    |
 LL |         x: 3,
-   |            ^
-   |            |
-   |            expected `f32`, found integer
-   |            help: use a float literal: `3.0`
+   |            ^ expected `f32`, found integer
+   |
+help: use a float literal
+   |
+LL |         x: 3.0,
+   |             ++
 
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:29:12
    |
 LL |         y: 4,
-   |            ^
-   |            |
-   |            expected `f32`, found integer
-   |            help: use a float literal: `4.0`
+   |            ^ expected `f32`, found integer
+   |
+help: use a float literal
+   |
+LL |         y: 4.0,
+   |             ++
 
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:35:12
    |
 LL |         x: 5,
-   |            ^
-   |            |
-   |            expected `f32`, found integer
-   |            help: use a float literal: `5.0`
+   |            ^ expected `f32`, found integer
+   |
+help: use a float literal
+   |
+LL |         x: 5.0,
+   |             ++
 
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:42:12
    |
 LL |         x: 7,
-   |            ^
-   |            |
-   |            expected `f32`, found integer
-   |            help: use a float literal: `7.0`
+   |            ^ expected `f32`, found integer
+   |
+help: use a float literal
+   |
+LL |         x: 7.0,
+   |             ++
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/structure-constructor-type-mismatch.rs:48:15
@@ -70,19 +82,23 @@ error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:49:12
    |
 LL |         x: 9,
-   |            ^
-   |            |
-   |            expected `f32`, found integer
-   |            help: use a float literal: `9.0`
+   |            ^ expected `f32`, found integer
+   |
+help: use a float literal
+   |
+LL |         x: 9.0,
+   |             ++
 
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:50:12
    |
 LL |         y: 10,
-   |            ^^
-   |            |
-   |            expected `f32`, found integer
-   |            help: use a float literal: `10.0`
+   |            ^^ expected `f32`, found integer
+   |
+help: use a float literal
+   |
+LL |         y: 10.0,
+   |              ++
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/structure-constructor-type-mismatch.rs:54:9

--- a/tests/ui/suggestions/match-ergonomics.stderr
+++ b/tests/ui/suggestions/match-ergonomics.stderr
@@ -17,18 +17,24 @@ LL +         [v] => {},
 error[E0529]: expected an array or slice, found `Vec<i32>`
   --> $DIR/match-ergonomics.rs:8:9
    |
-LL |     match x {
-   |           - help: consider slicing here: `x[..]`
 LL |         [&v] => {},
    |         ^^^^ pattern cannot match with input type `Vec<i32>`
+   |
+help: consider slicing here
+   |
+LL |     match x[..] {
+   |            ++++
 
 error[E0529]: expected an array or slice, found `Vec<i32>`
   --> $DIR/match-ergonomics.rs:20:9
    |
-LL |     match x {
-   |           - help: consider slicing here: `x[..]`
 LL |         [v] => {},
    |         ^^^ pattern cannot match with input type `Vec<i32>`
+   |
+help: consider slicing here
+   |
+LL |     match x[..] {
+   |            ++++
 
 error[E0308]: mismatched types
   --> $DIR/match-ergonomics.rs:29:9

--- a/tests/ui/suggestions/parenthesized-deref-suggestion.stderr
+++ b/tests/ui/suggestions/parenthesized-deref-suggestion.stderr
@@ -4,19 +4,21 @@ error[E0609]: no field `opts` on type `*const Session`
 LL |     (sess as *const Session).opts;
    |                              ^^^^ unknown field
    |
-help: `(sess as *const Session)` is a raw pointer; try dereferencing it
+help: the value is a raw pointer; try dereferencing it
    |
 LL |     (*(sess as *const Session)).opts;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |     ++                        +
 
 error[E0609]: no field `0` on type `[u32; 1]`
   --> $DIR/parenthesized-deref-suggestion.rs:10:21
    |
 LL |     (x as [u32; 1]).0;
-   |     ----------------^
-   |     |               |
-   |     |               unknown field
-   |     help: instead of using tuple indexing, use array indexing: `(x as [u32; 1])[0]`
+   |                     ^ unknown field
+   |
+help: instead of using tuple indexing, use array indexing
+   |
+LL |     (x as [u32; 1])[0];
+   |                    ~ +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/pattern-slice-vec.stderr
+++ b/tests/ui/suggestions/pattern-slice-vec.stderr
@@ -2,42 +2,56 @@ error[E0529]: expected an array or slice, found `Vec<i32>`
   --> $DIR/pattern-slice-vec.rs:8:12
    |
 LL |     if let [_, _, _] = foo() {}
-   |            ^^^^^^^^^   ----- help: consider slicing here: `foo()[..]`
-   |            |
-   |            pattern cannot match with input type `Vec<i32>`
+   |            ^^^^^^^^^ pattern cannot match with input type `Vec<i32>`
+   |
+help: consider slicing here
+   |
+LL |     if let [_, _, _] = foo()[..] {}
+   |                             ++++
 
 error[E0529]: expected an array or slice, found `Vec<i32>`
   --> $DIR/pattern-slice-vec.rs:12:12
    |
 LL |     if let [] = &foo() {}
-   |            ^^   ------ help: consider slicing here: `&foo()[..]`
-   |            |
-   |            pattern cannot match with input type `Vec<i32>`
+   |            ^^ pattern cannot match with input type `Vec<i32>`
+   |
+help: consider slicing here
+   |
+LL |     if let [] = &foo()[..] {}
+   |                       ++++
 
 error[E0529]: expected an array or slice, found `Vec<i32>`
   --> $DIR/pattern-slice-vec.rs:16:12
    |
 LL |     if let [] = foo() {}
-   |            ^^   ----- help: consider slicing here: `foo()[..]`
-   |            |
-   |            pattern cannot match with input type `Vec<i32>`
+   |            ^^ pattern cannot match with input type `Vec<i32>`
+   |
+help: consider slicing here
+   |
+LL |     if let [] = foo()[..] {}
+   |                      ++++
 
 error[E0529]: expected an array or slice, found `Vec<_>`
   --> $DIR/pattern-slice-vec.rs:23:9
    |
-LL |     match &v {
-   |           -- help: consider slicing here: `&v[..]`
-LL |
 LL |         [5] => {}
    |         ^^^ pattern cannot match with input type `Vec<_>`
+   |
+help: consider slicing here
+   |
+LL |     match &v[..] {
+   |             ++++
 
 error[E0529]: expected an array or slice, found `Vec<{integer}>`
   --> $DIR/pattern-slice-vec.rs:28:9
    |
 LL |     let [..] = vec![1, 2, 3];
-   |         ^^^^   ------------- help: consider slicing here: `vec![1, 2, 3][..]`
-   |         |
-   |         pattern cannot match with input type `Vec<{integer}>`
+   |         ^^^^ pattern cannot match with input type `Vec<{integer}>`
+   |
+help: consider slicing here
+   |
+LL |     let [..] = vec![1, 2, 3][..];
+   |                             ++++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/suggestions/suppress-consider-slicing-issue-120605.stderr
+++ b/tests/ui/suggestions/suppress-consider-slicing-issue-120605.stderr
@@ -2,9 +2,12 @@ error[E0529]: expected an array or slice, found `Vec<Struct>`
   --> $DIR/suppress-consider-slicing-issue-120605.rs:7:16
    |
 LL |         if let [Struct { a: [] }] = &self.a {
-   |                ^^^^^^^^^^^^^^^^^^   ------- help: consider slicing here: `&self.a[..]`
-   |                |
-   |                pattern cannot match with input type `Vec<Struct>`
+   |                ^^^^^^^^^^^^^^^^^^ pattern cannot match with input type `Vec<Struct>`
+   |
+help: consider slicing here
+   |
+LL |         if let [Struct { a: [] }] = &self.a[..] {
+   |                                            ++++
 
 error[E0529]: expected an array or slice, found `Vec<Struct>`
   --> $DIR/suppress-consider-slicing-issue-120605.rs:7:29

--- a/tests/ui/try-block/try-block-type-error.stderr
+++ b/tests/ui/try-block/try-block-type-error.stderr
@@ -2,10 +2,12 @@ error[E0271]: type mismatch resolving `<Option<f32> as Try>::Output == {integer}
   --> $DIR/try-block-type-error.rs:10:9
    |
 LL |         42
-   |         ^^
-   |         |
-   |         expected `f32`, found integer
-   |         help: use a float literal: `42.0`
+   |         ^^ expected `f32`, found integer
+   |
+help: use a float literal
+   |
+LL |         42.0
+   |           ++
 
 error[E0271]: type mismatch resolving `<Option<i32> as Try>::Output == ()`
   --> $DIR/try-block-type-error.rs:16:5

--- a/tests/ui/type/type-parameter-defaults-referencing-Self.stderr
+++ b/tests/ui/type/type-parameter-defaults-referencing-Self.stderr
@@ -5,9 +5,13 @@ LL | trait Foo<T=Self> {
    | ----------------- type parameter `T` must be specified for this
 ...
 LL | fn foo(x: &dyn Foo) { }
-   |                ^^^ help: set the type parameter to the desired type: `Foo<T>`
+   |                ^^^
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
+help: set the type parameter to the desired type
+   |
+LL | fn foo(x: &dyn Foo<T>) { }
+   |                   +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-53712.rs
+++ b/tests/ui/typeck/issue-53712.rs
@@ -5,5 +5,5 @@ fn main() {
     arr.0;
     //~^ ERROR no field `0` on type `[{integer}; 5]` [E0609]
     //~| HELP instead of using tuple indexing, use array indexing
-    //~| SUGGESTION arr[0]
+    //~| SUGGESTION [
 }

--- a/tests/ui/typeck/issue-53712.stderr
+++ b/tests/ui/typeck/issue-53712.stderr
@@ -2,10 +2,12 @@ error[E0609]: no field `0` on type `[{integer}; 5]`
   --> $DIR/issue-53712.rs:5:9
    |
 LL |     arr.0;
-   |     ----^
-   |     |   |
-   |     |   unknown field
-   |     help: instead of using tuple indexing, use array indexing: `arr[0]`
+   |         ^ unknown field
+   |
+help: instead of using tuple indexing, use array indexing
+   |
+LL |     arr[0];
+   |        ~ +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-91328.stderr
+++ b/tests/ui/typeck/issue-91328.stderr
@@ -1,38 +1,46 @@
 error[E0529]: expected an array or slice, found `Vec<i32>`
   --> $DIR/issue-91328.rs:10:12
    |
-LL |     match r {
-   |           - help: consider using `as_deref` here: `r.as_deref()`
-LL |
 LL |         Ok([a, b]) => a + b,
    |            ^^^^^^ pattern cannot match with input type `Vec<i32>`
+   |
+help: consider using `as_deref` here
+   |
+LL |     match r.as_deref() {
+   |            +++++++++++
 
 error[E0529]: expected an array or slice, found `Vec<i32>`
   --> $DIR/issue-91328.rs:20:14
    |
-LL |     match o {
-   |           - help: consider using `as_deref` here: `o.as_deref()`
-LL |
 LL |         Some([a, b]) => a + b,
    |              ^^^^^^ pattern cannot match with input type `Vec<i32>`
+   |
+help: consider using `as_deref` here
+   |
+LL |     match o.as_deref() {
+   |            +++++++++++
 
 error[E0529]: expected an array or slice, found `Vec<i32>`
   --> $DIR/issue-91328.rs:30:9
    |
-LL |     match v {
-   |           - help: consider slicing here: `v[..]`
-LL |
 LL |         [a, b] => a + b,
    |         ^^^^^^ pattern cannot match with input type `Vec<i32>`
+   |
+help: consider slicing here
+   |
+LL |     match v[..] {
+   |            ++++
 
 error[E0529]: expected an array or slice, found `Box<[i32; 2]>`
   --> $DIR/issue-91328.rs:40:14
    |
-LL |     match a {
-   |           - help: consider using `as_deref` here: `a.as_deref()`
-LL |
 LL |         Some([a, b]) => a + b,
    |              ^^^^^^ pattern cannot match with input type `Box<[i32; 2]>`
+   |
+help: consider using `as_deref` here
+   |
+LL |     match a.as_deref() {
+   |            +++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/unboxed-closures/unboxed-closure-immutable-capture.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-immutable-capture.stderr
@@ -1,73 +1,90 @@
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:9:13
    |
-LL |     let x = 0;
-   |         - help: consider changing this to be mutable: `mut x`
 LL |     move || x = 1;
    |             ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 0;
+   |         +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:10:17
    |
-LL |     let x = 0;
-   |         - help: consider changing this to be mutable: `mut x`
-LL |     move || x = 1;
 LL |     move || set(&mut x);
    |                 ^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 0;
+   |         +++
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:11:13
    |
-LL |     let x = 0;
-   |         - help: consider changing this to be mutable: `mut x`
-...
 LL |     move || x = 1;
    |             ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 0;
+   |         +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:12:17
    |
-LL |     let x = 0;
-   |         - help: consider changing this to be mutable: `mut x`
-...
 LL |     move || set(&mut x);
    |                 ^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 0;
+   |         +++
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:13:8
    |
-LL |     let x = 0;
-   |         - help: consider changing this to be mutable: `mut x`
-...
 LL |     || x = 1;
    |        ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 0;
+   |         +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:14:12
    |
-LL |     let x = 0;
-   |         - help: consider changing this to be mutable: `mut x`
-...
 LL |     || set(&mut x);
    |            ^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 0;
+   |         +++
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:15:8
    |
-LL |     let x = 0;
-   |         - help: consider changing this to be mutable: `mut x`
-...
 LL |     || x = 1;
    |        ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 0;
+   |         +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/unboxed-closure-immutable-capture.rs:16:12
    |
-LL |     let x = 0;
-   |         - help: consider changing this to be mutable: `mut x`
-...
 LL |     || set(&mut x);
    |            ^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut x = 0;
+   |         +++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.stderr
@@ -1,13 +1,16 @@
 error[E0596]: cannot borrow `tick1` as mutable, as it is not declared as mutable
   --> $DIR/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs:16:9
    |
-LL |     let tick1 = || {
-   |         ----- help: consider changing this to be mutable: `mut tick1`
 LL |         counter += 1;
    |         ------- calling `tick1` requires mutable binding due to mutable borrow of `counter`
 ...
 LL |         tick1();
    |         ^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut tick1 = || {
+   |         +++
 
 error[E0596]: cannot borrow `tick2` as mutable, as it is not declared as mutable
   --> $DIR/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs:19:5

--- a/tests/ui/unboxed-closures/unboxed-closures-mutate-upvar.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-mutate-upvar.stderr
@@ -1,29 +1,35 @@
 error[E0594]: cannot assign to `n`, as it is not declared as mutable
   --> $DIR/unboxed-closures-mutate-upvar.rs:15:9
    |
-LL |     let n = 0;
-   |         - help: consider changing this to be mutable: `mut n`
-LL |     let mut f = to_fn_mut(|| {
 LL |         n += 1;
    |         ^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut n = 0;
+   |         +++
 
 error[E0594]: cannot assign to `n`, as it is not declared as mutable
   --> $DIR/unboxed-closures-mutate-upvar.rs:32:9
    |
-LL |     let n = 0;
-   |         - help: consider changing this to be mutable: `mut n`
-...
 LL |         n += 1;
    |         ^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut n = 0;
+   |         +++
 
 error[E0594]: cannot assign to `n`, as it is not declared as mutable
   --> $DIR/unboxed-closures-mutate-upvar.rs:46:9
    |
-LL |     let n = 0;
-   |         - help: consider changing this to be mutable: `mut n`
-LL |     let mut f = to_fn(move || {
 LL |         n += 1;
    |         ^^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut n = 0;
+   |         +++
 
 error[E0594]: cannot assign to `n`, as it is a captured variable in a `Fn` closure
   --> $DIR/unboxed-closures-mutate-upvar.rs:53:9

--- a/tests/ui/unsafe/unsafe-fn-autoderef.stderr
+++ b/tests/ui/unsafe/unsafe-fn-autoderef.stderr
@@ -2,10 +2,12 @@ error[E0609]: no field `f` on type `*const Rec`
   --> $DIR/unsafe-fn-autoderef.rs:19:14
    |
 LL |     return p.f;
-   |            --^
-   |            | |
-   |            | unknown field
-   |            help: `p` is a raw pointer; try dereferencing it: `(*p).f`
+   |              ^ unknown field
+   |
+help: `p` is a raw pointer; try dereferencing it
+   |
+LL |     return (*p).f;
+   |            ++ +
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Addressing some issues I found while working on #127282.
```
error: this URL is not a hyperlink
  --> $DIR/auxiliary/include-str-bare-urls.md:1:11
   |
LL | HEADS UP! https://example.com MUST SHOW UP IN THE STDERR FILE!
   |           ^^^^^^^^^^^^^^^^^^^
   |
   = note: bare URLs are not automatically turned into clickable links
note: the lint level is defined here
  --> $DIR/include-str-bare-urls.rs:14:9
   |
LL | #![deny(rustdoc::bare_urls)]
   |         ^^^^^^^^^^^^^^^^^^
help: use an automatic link instead
   |
LL | HEADS UP! <https://example.com> MUST SHOW UP IN THE STDERR FILE!
   |           +                   +
```
```
error[E0384]: cannot assign twice to immutable variable `v`
  --> $DIR/assign-imm-local-twice.rs:7:5
   |
LL |     v = 1;
   |     ----- first assignment to `v`
LL |     println!("v={}", v);
LL |     v = 2;
   |     ^^^^^ cannot assign twice to immutable variable
   |
help: consider making this binding mutable
   |
LL |     let mut v: isize;
   |         +++
```
```
error[E0393]: the type parameter `Rhs` must be explicitly specified
  --> $DIR/issue-22560.rs:9:23
   |
LL | trait Sub<Rhs=Self> {
   | ------------------- type parameter `Rhs` must be specified for this
...
LL | type Test = dyn Add + Sub;
   |                       ^^^
   |
   = note: because of the default `Self` reference, type parameters must be specified on object types
help: set the type parameter to the desired type
   |
LL | type Test = dyn Add + Sub<Rhs>;
   |                          +++++
```
```
error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
  --> $DIR/issue-33819.rs:4:34
   |
LL |         Some(ref v) => { let a = &mut v; },
   |                                  ^^^^^^ cannot borrow as mutable
   |
help: try removing `&mut` here
   |
LL -         Some(ref v) => { let a = &mut v; },
LL +         Some(ref v) => { let a = v; },
   |
```
```
help: remove the invocation before committing it to a version control system
   |
LL -     dbg!();
   |
```
```
error[E0308]: mismatched types
  --> $DIR/issue-39974.rs:1:21
   |
LL | const LENGTH: f64 = 2;
   |                     ^ expected `f64`, found integer
   |
help: use a float literal
   |
LL | const LENGTH: f64 = 2.0;
   |                      ++
```
```
error[E0529]: expected an array or slice, found `Vec<i32>`
  --> $DIR/match-ergonomics.rs:8:9
   |
LL |         [&v] => {},
   |         ^^^^ pattern cannot match with input type `Vec<i32>`
   |
help: consider slicing here
   |
LL |     match x[..] {
   |            ++++
```
```
error[E0609]: no field `0` on type `[u32; 1]`
  --> $DIR/parenthesized-deref-suggestion.rs:10:21
   |
LL |     (x as [u32; 1]).0;
   |                     ^ unknown field
   |
help: instead of using tuple indexing, use array indexing
   |
LL |     (x as [u32; 1])[0];
   |                    ~ +
```