### PR TITLE
jsondocck: add `$FILE` built-in variable

### DIFF
--- a/src/tools/jsondocck/src/cache.rs
+++ b/src/tools/jsondocck/src/cache.rs
@@ -23,7 +23,7 @@ impl Cache {
 
         Cache {
             value: serde_json::from_str::<Value>(&content).expect("failed to convert from JSON"),
-            variables: HashMap::new(),
+            variables: HashMap::from([("FILE".to_owned(), config.template.clone().into())]),
         }
     }
 


### PR DESCRIPTION
This built-in variable will allow accessing the full path to the currently tested file and allow to test things like source code spans generated by rustdoc-json, and that is exactly the reason why I've come up with the idea to add this

[futher discussion on zulip](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/rustdoc-json.20test.20help/near/449039819)