### PR TITLE
Make CI more agnostic of the owning GitHub organization

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -93,8 +93,7 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
     docker --version
 
     REGISTRY=ghcr.io
-    # PR CI runs on rust-lang, but we want to use the cache from rust-lang-ci
-    REGISTRY_USERNAME=rust-lang-ci
+    REGISTRY_USERNAME=${GITHUB_REPOSITORY_OWNER}
     # Tag used to push the final Docker image, so that it can be pulled by e.g. rustup
     IMAGE_TAG=${REGISTRY}/${REGISTRY_USERNAME}/rust-ci:${cksum}
     # Tag used to cache the Docker build

--- a/src/ci/github-actions/calculate-job-matrix.py
+++ b/src/ci/github-actions/calculate-job-matrix.py
@@ -91,21 +91,17 @@ def find_run_type(ctx: GitHubCtx) -> Optional[WorkflowRunType]:
     if ctx.event_name == "pull_request":
         return PRRunType()
     elif ctx.event_name == "push":
-        old_bors_try_build = (
-            ctx.ref in ("refs/heads/try", "refs/heads/try-perf") and
-            ctx.repository == "rust-lang-ci/rust"
+        try_build = ctx.ref in (
+            "refs/heads/try",
+            "refs/heads/try-perf",
+            "refs/heads/automation/bors/try"
         )
-        new_bors_try_build = (
-            ctx.ref == "refs/heads/automation/bors/try" and
-            ctx.repository == "rust-lang/rust"
-        )
-        try_build = old_bors_try_build or new_bors_try_build
 
         if try_build:
             jobs = get_custom_jobs(ctx)
             return TryRunType(custom_jobs=jobs)
 
-        if ctx.ref == "refs/heads/auto" and ctx.repository == "rust-lang-ci/rust":
+        if ctx.ref == "refs/heads/auto":
             return AutoRunType()
 
     return None


### PR DESCRIPTION
This should make it possible to switch running `auto` and `try` builds from `rust-lang-ci` to `rust-lang`.

r? @jdno