### PR TITLE
Rewrite lint_expectations in a single pass.

### DIFF
--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -12,7 +12,7 @@ use rustc_lint_defs::{Applicability, LintExpectationId};
 use rustc_macros::{Decodable, Encodable};
 use rustc_span::source_map::Spanned;
 use rustc_span::symbol::Symbol;
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{AttrId, Span, DUMMY_SP};
 use tracing::debug;
 
 use crate::snippet::Style;
@@ -356,24 +356,19 @@ impl DiagInner {
 
     pub(crate) fn update_unstable_expectation_id(
         &mut self,
-        unstable_to_stable: &FxIndexMap<LintExpectationId, LintExpectationId>,
+        unstable_to_stable: &FxIndexMap<AttrId, LintExpectationId>,
     ) {
         if let Level::Expect(expectation_id) | Level::ForceWarning(Some(expectation_id)) =
             &mut self.level
+            && let LintExpectationId::Unstable { attr_id, lint_index } = *expectation_id
         {
-            if expectation_id.is_stable() {
-                return;
-            }
-
             // The unstable to stable map only maps the unstable `AttrId` to a stable `HirId` with an attribute index.
             // The lint index inside the attribute is manually transferred here.
-            let lint_index = expectation_id.get_lint_index();
-            expectation_id.set_lint_index(None);
-            let mut stable_id = unstable_to_stable
-                .get(expectation_id)
-                .expect("each unstable `LintExpectationId` must have a matching stable id")
-                .normalize();
+            let Some(stable_id) = unstable_to_stable.get(&attr_id) else {
+                panic!("{expectation_id:?} must have a matching stable id")
+            };
 
+            let mut stable_id = stable_id.normalize();
             stable_id.set_lint_index(lint_index);
             *expectation_id = stable_id;
         }

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -368,7 +368,7 @@ impl DiagInner {
                 panic!("{expectation_id:?} must have a matching stable id")
             };
 
-            let mut stable_id = stable_id.normalize();
+            let mut stable_id = *stable_id;
             stable_id.set_lint_index(lint_index);
             *expectation_id = stable_id;
         }

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -69,7 +69,7 @@ use rustc_macros::{Decodable, Encodable};
 pub use rustc_span::fatal_error::{FatalError, FatalErrorMarker};
 use rustc_span::source_map::SourceMap;
 pub use rustc_span::ErrorGuaranteed;
-use rustc_span::{Loc, Span, DUMMY_SP};
+use rustc_span::{AttrId, Loc, Span, DUMMY_SP};
 pub use snippet::Style;
 // Used by external projects such as `rust-gpu`.
 // See https://github.com/rust-lang/rust/pull/115393.
@@ -1096,7 +1096,7 @@ impl<'a> DiagCtxtHandle<'a> {
 
     pub fn update_unstable_expectation_id(
         &self,
-        unstable_to_stable: &FxIndexMap<LintExpectationId, LintExpectationId>,
+        unstable_to_stable: FxIndexMap<AttrId, LintExpectationId>,
     ) {
         let mut inner = self.inner.borrow_mut();
         let diags = std::mem::take(&mut inner.unstable_expect_diagnostics);
@@ -1105,7 +1105,7 @@ impl<'a> DiagCtxtHandle<'a> {
         if !diags.is_empty() {
             inner.suppressed_expected_diag = true;
             for mut diag in diags.into_iter() {
-                diag.update_unstable_expectation_id(unstable_to_stable);
+                diag.update_unstable_expectation_id(&unstable_to_stable);
 
                 // Here the diagnostic is given back to `emit_diagnostic` where it was first
                 // intercepted. Now it should be processed as usual, since the unstable expectation
@@ -1117,11 +1117,11 @@ impl<'a> DiagCtxtHandle<'a> {
         inner
             .stashed_diagnostics
             .values_mut()
-            .for_each(|(diag, _guar)| diag.update_unstable_expectation_id(unstable_to_stable));
+            .for_each(|(diag, _guar)| diag.update_unstable_expectation_id(&unstable_to_stable));
         inner
             .future_breakage_diagnostics
             .iter_mut()
-            .for_each(|diag| diag.update_unstable_expectation_id(unstable_to_stable));
+            .for_each(|diag| diag.update_unstable_expectation_id(&unstable_to_stable));
     }
 
     /// This methods steals all [`LintExpectationId`]s that are stored inside

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1567,7 +1567,7 @@ impl DiagCtxtInner {
                 if let LintExpectationId::Unstable { .. } = expect_id {
                     unreachable!(); // this case was handled at the top of this function
                 }
-                self.fulfilled_expectations.insert(expect_id.normalize());
+                self.fulfilled_expectations.insert(expect_id);
                 if let Expect(_) = diagnostic.level {
                     // Nothing emitted here for expected lints.
                     TRACK_DIAGNOSTIC(diagnostic, &mut |_| None);

--- a/compiler/rustc_lint/src/expect.rs
+++ b/compiler/rustc_lint/src/expect.rs
@@ -20,8 +20,7 @@ fn lint_expectations(tcx: TyCtxt<'_>, (): ()) -> Vec<(LintExpectationId, LintExp
     let mut unstable_to_stable_ids = FxIndexMap::default();
 
     let mut record_stable = |attr_id, hir_id, attr_index| {
-        let expect_id =
-            LintExpectationId::Stable { hir_id, attr_index, lint_index: None, attr_id: None };
+        let expect_id = LintExpectationId::Stable { hir_id, attr_index, lint_index: None };
         unstable_to_stable_ids.entry(attr_id).or_insert(expect_id);
     };
     let mut push_expectations = |owner| {

--- a/compiler/rustc_lint/src/expect.rs
+++ b/compiler/rustc_lint/src/expect.rs
@@ -1,20 +1,66 @@
+use rustc_data_structures::fx::FxIndexMap;
+use rustc_hir::{HirId, CRATE_OWNER_ID};
+use rustc_middle::lint::LintExpectation;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::lint::builtin::UNFULFILLED_LINT_EXPECTATIONS;
-use rustc_session::lint::LintExpectationId;
+use rustc_session::lint::{Level, LintExpectationId};
 use rustc_span::Symbol;
 
 use crate::lints::{Expectation, ExpectationNote};
 
 pub(crate) fn provide(providers: &mut Providers) {
-    *providers = Providers { check_expectations, ..*providers };
+    *providers = Providers { lint_expectations, check_expectations, ..*providers };
+}
+
+fn lint_expectations(tcx: TyCtxt<'_>, (): ()) -> Vec<(LintExpectationId, LintExpectation)> {
+    let krate = tcx.hir_crate_items(());
+
+    let mut expectations = Vec::new();
+    let mut unstable_to_stable_ids = FxIndexMap::default();
+
+    let mut record_stable = |attr_id, hir_id, attr_index| {
+        let expect_id =
+            LintExpectationId::Stable { hir_id, attr_index, lint_index: None, attr_id: None };
+        unstable_to_stable_ids.entry(attr_id).or_insert(expect_id);
+    };
+    let mut push_expectations = |owner| {
+        let lints = tcx.shallow_lint_levels_on(owner);
+        if lints.expectations.is_empty() {
+            return;
+        }
+
+        expectations.extend_from_slice(&lints.expectations);
+
+        let attrs = tcx.hir_attrs(owner);
+        for &(local_id, attrs) in attrs.map.iter() {
+            // Some attributes appear multiple times in HIR, to ensure they are correctly taken
+            // into account where they matter. This means we cannot just associate the AttrId to
+            // the first HirId where we see it, but need to check it actually appears in a lint
+            // level.
+            // FIXME(cjgillot): Can this cause an attribute to appear in multiple expectation ids?
+            if !lints.specs.contains_key(&local_id) {
+                continue;
+            }
+            for (attr_index, attr) in attrs.iter().enumerate() {
+                let Some(Level::Expect(_)) = Level::from_attr(attr) else { continue };
+                record_stable(attr.id, HirId { owner, local_id }, attr_index.try_into().unwrap());
+            }
+        }
+    };
+
+    push_expectations(CRATE_OWNER_ID);
+    for owner in krate.owners() {
+        push_expectations(owner);
+    }
+
+    tcx.dcx().update_unstable_expectation_id(unstable_to_stable_ids);
+    expectations
 }
 
 fn check_expectations(tcx: TyCtxt<'_>, tool_filter: Option<Symbol>) {
     let lint_expectations = tcx.lint_expectations(());
     let fulfilled_expectations = tcx.dcx().steal_fulfilled_expectation_ids();
-
-    tracing::debug!(?lint_expectations, ?fulfilled_expectations);
 
     for (id, expectation) in lint_expectations {
         // This check will always be true, since `lint_expectations` only

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -98,7 +98,7 @@ pub enum LintExpectationId {
     /// stable and can be cached. The additional index ensures that nodes with
     /// several expectations can correctly match diagnostics to the individual
     /// expectation.
-    Stable { hir_id: HirId, attr_index: u16, lint_index: Option<u16>, attr_id: Option<AttrId> },
+    Stable { hir_id: HirId, attr_index: u16, lint_index: Option<u16> },
 }
 
 impl LintExpectationId {
@@ -122,31 +122,13 @@ impl LintExpectationId {
 
         *lint_index = new_lint_index
     }
-
-    /// Prepares the id for hashing. Removes references to the ast.
-    /// Should only be called when the id is stable.
-    pub fn normalize(self) -> Self {
-        match self {
-            Self::Stable { hir_id, attr_index, lint_index, .. } => {
-                Self::Stable { hir_id, attr_index, lint_index, attr_id: None }
-            }
-            Self::Unstable { .. } => {
-                unreachable!("`normalize` called when `ExpectationId` is unstable")
-            }
-        }
-    }
 }
 
 impl<HCX: rustc_hir::HashStableContext> HashStable<HCX> for LintExpectationId {
     #[inline]
     fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
         match self {
-            LintExpectationId::Stable {
-                hir_id,
-                attr_index,
-                lint_index: Some(lint_index),
-                attr_id: _,
-            } => {
+            LintExpectationId::Stable { hir_id, attr_index, lint_index: Some(lint_index) } => {
                 hir_id.hash_stable(hcx, hasher);
                 attr_index.hash_stable(hcx, hasher);
                 lint_index.hash_stable(hcx, hasher);
@@ -166,12 +148,9 @@ impl<HCX: rustc_hir::HashStableContext> ToStableHashKey<HCX> for LintExpectation
     #[inline]
     fn to_stable_hash_key(&self, _: &HCX) -> Self::KeyType {
         match self {
-            LintExpectationId::Stable {
-                hir_id,
-                attr_index,
-                lint_index: Some(lint_index),
-                attr_id: _,
-            } => (*hir_id, *attr_index, *lint_index),
+            LintExpectationId::Stable { hir_id, attr_index, lint_index: Some(lint_index) } => {
+                (*hir_id, *attr_index, *lint_index)
+            }
             _ => {
                 unreachable!("HashStable should only be called for a filled `LintExpectationId`")
             }

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -6,7 +6,7 @@ use rustc_errors::{Diag, MultiSpan};
 use rustc_hir::{HirId, ItemLocalId};
 use rustc_macros::HashStable;
 use rustc_session::lint::builtin::{self, FORBIDDEN_LINT_GROUPS};
-use rustc_session::lint::{FutureIncompatibilityReason, Level, Lint, LintId};
+use rustc_session::lint::{FutureIncompatibilityReason, Level, Lint, LintExpectationId, LintId};
 use rustc_session::Session;
 use rustc_span::hygiene::{ExpnKind, MacroKind};
 use rustc_span::{symbol, DesugaringKind, Span, Symbol, DUMMY_SP};
@@ -61,6 +61,7 @@ pub type LevelAndSource = (Level, LintLevelSource);
 /// by the attributes for *a single HirId*.
 #[derive(Default, Debug, HashStable)]
 pub struct ShallowLintLevelMap {
+    pub expectations: Vec<(LintExpectationId, LintExpectation)>,
     pub specs: SortedMap<ItemLocalId, FxIndexMap<LintId, LevelAndSource>>,
 }
 

--- a/tests/ui/error-codes/E0602.stderr
+++ b/tests/ui/error-codes/E0602.stderr
@@ -13,11 +13,6 @@ warning[E0602]: unknown lint: `bogus`
    = note: requested on the command line with `-D bogus`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-warning[E0602]: unknown lint: `bogus`
-   |
-   = note: requested on the command line with `-D bogus`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning: 4 warnings emitted
+warning: 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0602`.

--- a/tests/ui/lint/cli-unknown-force-warn.stderr
+++ b/tests/ui/lint/cli-unknown-force-warn.stderr
@@ -13,11 +13,6 @@ warning[E0602]: unknown lint: `foo_qux`
    = note: requested on the command line with `--force-warn foo_qux`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-warning[E0602]: unknown lint: `foo_qux`
-   |
-   = note: requested on the command line with `--force-warn foo_qux`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning: 4 warnings emitted
+warning: 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0602`.

--- a/tests/ui/lint/lint-removed-cmdline-deny.stderr
+++ b/tests/ui/lint/lint-removed-cmdline-deny.stderr
@@ -26,10 +26,5 @@ LL | #[deny(warnings)]
    |        ^^^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(warnings)]`
 
-error: lint `raw_pointer_derive` has been removed: using derive with raw pointers is ok
-   |
-   = note: requested on the command line with `-D raw_pointer_derive`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/lint/lint-removed-cmdline.stderr
+++ b/tests/ui/lint/lint-removed-cmdline.stderr
@@ -26,10 +26,5 @@ LL | #[deny(warnings)]
    |        ^^^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(warnings)]`
 
-warning: lint `raw_pointer_derive` has been removed: using derive with raw pointers is ok
-   |
-   = note: requested on the command line with `-D raw_pointer_derive`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 1 previous error; 4 warnings emitted
+error: aborting due to 1 previous error; 3 warnings emitted
 

--- a/tests/ui/lint/lint-renamed-cmdline-deny.stderr
+++ b/tests/ui/lint/lint-renamed-cmdline-deny.stderr
@@ -29,11 +29,5 @@ LL | #[deny(unused)]
    |        ^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(unused)]`
 
-error: lint `bare_trait_object` has been renamed to `bare_trait_objects`
-   |
-   = help: use the new name `bare_trait_objects`
-   = note: requested on the command line with `-D bare_trait_object`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/lint/lint-renamed-cmdline.stderr
+++ b/tests/ui/lint/lint-renamed-cmdline.stderr
@@ -29,11 +29,5 @@ LL | #[deny(unused)]
    |        ^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(unused)]`
 
-warning: lint `bare_trait_object` has been renamed to `bare_trait_objects`
-   |
-   = help: use the new name `bare_trait_objects`
-   = note: requested on the command line with `-D bare_trait_object`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 1 previous error; 4 warnings emitted
+error: aborting due to 1 previous error; 3 warnings emitted
 

--- a/tests/ui/lint/lint-unexported-no-mangle.stderr
+++ b/tests/ui/lint/lint-unexported-no-mangle.stderr
@@ -45,15 +45,5 @@ LL | pub const PUB_FOO: u64 = 1;
    | |
    | help: try a static value: `pub static`
 
-warning: lint `private_no_mangle_fns` has been removed: no longer a warning, `#[no_mangle]` functions always exported
-   |
-   = note: requested on the command line with `-F private_no_mangle_fns`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning: lint `private_no_mangle_statics` has been removed: no longer a warning, `#[no_mangle]` statics always exported
-   |
-   = note: requested on the command line with `-F private_no_mangle_statics`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors; 8 warnings emitted
+error: aborting due to 2 previous errors; 6 warnings emitted
 

--- a/tests/ui/lint/lint-unknown-lint-cmdline-deny.stderr
+++ b/tests/ui/lint/lint-unknown-lint-cmdline-deny.stderr
@@ -30,17 +30,6 @@ error[E0602]: unknown lint: `dead_cod`
    = note: requested on the command line with `-D dead_cod`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0602]: unknown lint: `bogus`
-   |
-   = note: requested on the command line with `-D bogus`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error[E0602]: unknown lint: `dead_cod`
-   |
-   = help: did you mean: `dead_code`
-   = note: requested on the command line with `-D dead_cod`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0602`.

--- a/tests/ui/lint/lint-unknown-lint-cmdline.stderr
+++ b/tests/ui/lint/lint-unknown-lint-cmdline.stderr
@@ -30,17 +30,6 @@ warning[E0602]: unknown lint: `dead_cod`
    = note: requested on the command line with `-D dead_cod`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-warning[E0602]: unknown lint: `bogus`
-   |
-   = note: requested on the command line with `-D bogus`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning[E0602]: unknown lint: `dead_cod`
-   |
-   = help: did you mean: `dead_code`
-   = note: requested on the command line with `-D dead_cod`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning: 8 warnings emitted
+warning: 6 warnings emitted
 
 For more information about this error, try `rustc --explain E0602`.


### PR DESCRIPTION
This PR aims at reducing the perf regression from https://github.com/rust-lang/rust/pull/120924#issuecomment-2202486203 with drive-by simplifications.

Basically, instead of using the lint level builder, which is slow, this PR splits `lint_expectations` logic in 2:
- listing the `LintExpectations` is done in `shallow_lint_levels_on`, on a per-owner basis;
- building the unstable->stable expectation id map is done by iterating on attributes.

r? ghost for perf

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
