### PR TITLE
Tweak `-1 as usize` suggestion

### DIFF
--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -838,8 +838,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     },
                                 ) = ex.kind
                                 {
-                                    err.span_suggestion(
-                                        ex.span,
+                                    let span = if let hir::Node::Expr(parent) =
+                                        self.tcx.parent_hir_node(ex.hir_id)
+                                        && let hir::ExprKind::Cast(..) = parent.kind
+                                    {
+                                        // `-1 as usize` -> `usize::MAX`
+                                        parent.span
+                                    } else {
+                                        ex.span
+                                    };
+                                    err.span_suggestion_verbose(
+                                        span,
                                         format!(
                                             "you may have meant the maximum value of `{actual}`",
                                         ),

--- a/tests/ui/feature-gates/feature-gate-negate-unsigned.stderr
+++ b/tests/ui/feature-gates/feature-gate-negate-unsigned.stderr
@@ -2,12 +2,13 @@ error[E0600]: cannot apply unary operator `-` to type `usize`
   --> $DIR/feature-gate-negate-unsigned.rs:10:23
    |
 LL |     let _max: usize = -1;
-   |                       ^^
-   |                       |
-   |                       cannot apply unary operator `-`
-   |                       help: you may have meant the maximum value of `usize`: `usize::MAX`
+   |                       ^^ cannot apply unary operator `-`
    |
    = note: unsigned values cannot be negated
+help: you may have meant the maximum value of `usize`
+   |
+LL |     let _max: usize = usize::MAX;
+   |                       ~~~~~~~~~~
 
 error[E0600]: cannot apply unary operator `-` to type `u8`
   --> $DIR/feature-gate-negate-unsigned.rs:14:14

--- a/tests/ui/unsigned-literal-negation.stderr
+++ b/tests/ui/unsigned-literal-negation.stderr
@@ -2,34 +2,37 @@ error[E0600]: cannot apply unary operator `-` to type `usize`
   --> $DIR/unsigned-literal-negation.rs:2:13
    |
 LL |     let x = -1 as usize;
-   |             ^^
-   |             |
-   |             cannot apply unary operator `-`
-   |             help: you may have meant the maximum value of `usize`: `usize::MAX`
+   |             ^^ cannot apply unary operator `-`
    |
    = note: unsigned values cannot be negated
+help: you may have meant the maximum value of `usize`
+   |
+LL |     let x = usize::MAX;
+   |             ~~~~~~~~~~
 
 error[E0600]: cannot apply unary operator `-` to type `usize`
   --> $DIR/unsigned-literal-negation.rs:3:13
    |
 LL |     let x = (-1) as usize;
-   |             ^^^^
-   |             |
-   |             cannot apply unary operator `-`
-   |             help: you may have meant the maximum value of `usize`: `usize::MAX`
+   |             ^^^^ cannot apply unary operator `-`
    |
    = note: unsigned values cannot be negated
+help: you may have meant the maximum value of `usize`
+   |
+LL |     let x = usize::MAX;
+   |             ~~~~~~~~~~
 
 error[E0600]: cannot apply unary operator `-` to type `u32`
   --> $DIR/unsigned-literal-negation.rs:4:18
    |
 LL |     let x: u32 = -1;
-   |                  ^^
-   |                  |
-   |                  cannot apply unary operator `-`
-   |                  help: you may have meant the maximum value of `u32`: `u32::MAX`
+   |                  ^^ cannot apply unary operator `-`
    |
    = note: unsigned values cannot be negated
+help: you may have meant the maximum value of `u32`
+   |
+LL |     let x: u32 = u32::MAX;
+   |                  ~~~~~~~~
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
When writing a negative unsigned integer literal, use a verbose suggestion and account for `as` casting.