### PR TITLE
Reduce or make explicit calls to the `hir_crate`.

### DIFF
--- a/compiler/rustc_driver_impl/src/pretty.rs
+++ b/compiler/rustc_driver_impl/src/pretty.rs
@@ -293,7 +293,7 @@ pub fn print<'tcx>(sess: &Session, ppm: PpMode, ex: PrintExtra<'tcx>) {
         }
         HirTree => {
             debug!("pretty printing HIR tree");
-            format!("{:#?}", ex.tcx().hir().krate())
+            format!("{:#?}", ex.tcx().hir_crate(()))
         }
         Mir => {
             let mut out = Vec::new();

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -118,7 +118,7 @@ macro_rules! arena_types {
             [] features: rustc_feature::Features,
             [decode] specialization_graph: rustc_middle::traits::specialization_graph::Graph,
             [] crate_inherent_impls: rustc_middle::ty::CrateInherentImpls,
-            [] hir_owner_nodes: rustc_hir::OwnerNodes<'tcx>,
+            [] hir_owner_info: rustc_hir::OwnerInfo<'tcx>,
         ]);
     )
 }

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -152,11 +152,6 @@ impl<'tcx> TyCtxt<'tcx> {
 
 impl<'hir> Map<'hir> {
     #[inline]
-    pub fn krate(self) -> &'hir Crate<'hir> {
-        self.tcx.hir_crate(())
-    }
-
-    #[inline]
     pub fn root_module(self) -> &'hir Mod<'hir> {
         match self.tcx.hir_owner_node(CRATE_OWNER_ID) {
             OwnerNode::Crate(item) => item,
@@ -394,7 +389,7 @@ impl<'hir> Map<'hir> {
     where
         V: Visitor<'hir>,
     {
-        let krate = self.krate();
+        let krate = self.tcx.hir_crate(());
         for info in krate.owners.iter() {
             if let MaybeOwner::Owner(info) = info {
                 for attrs in info.attrs.map.values() {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -199,6 +199,15 @@ rustc_queries! {
         feedable
     }
 
+    /// Gives access to the HIR owner.
+    ///
+    /// This can be conveniently accessed by methods on `tcx.hir()`.
+    /// Avoid calling this query directly.
+    query opt_hir_owner(key: LocalDefId) -> Option<&'tcx hir::OwnerInfo<'tcx>> {
+        desc { |tcx| "getting HIR owner info in `{}`", tcx.def_path_str(key) }
+        feedable
+    }
+
     /// Gives access to the HIR attributes inside the HIR owner `key`.
     ///
     /// This can be conveniently accessed by methods on `tcx.hir()`.

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -359,7 +359,7 @@ pub(crate) fn run_global_ctxt(
         ctxt.external_traits.borrow_mut().insert(sized_trait_did, sized_trait);
     }
 
-    debug!("crate: {:?}", tcx.hir().krate());
+    debug!("crate: {:?}", tcx.hir_crate(()));
 
     let mut krate = tcx.sess.time("clean_crate", || clean::krate(&mut ctxt));
 


### PR DESCRIPTION
We add a new query to have a per-item indirection instead of looking into the large table every time. This also makes feeding the HIR easier

r? @ghost