### PR TITLE
Make target-spec json file extensions case-insensitive

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -19,8 +19,8 @@ use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 use rustc_span::edition::{Edition, DEFAULT_EDITION, EDITION_NAME_LIST, LATEST_STABLE_EDITION};
 use rustc_span::source_map::FilePathMapping;
 use rustc_span::{FileName, FileNameDisplayPreference, RealFileName, SourceFileHashAlgorithm};
+use rustc_target::spec::{has_ext_ignore_case, SplitDebuginfo, Target, TargetTriple};
 use rustc_target::spec::{FramePointer, LinkSelfContainedComponents, LinkerFeatures};
-use rustc_target::spec::{SplitDebuginfo, Target, TargetTriple};
 use std::collections::btree_map::{
     Iter as BTreeMapIter, Keys as BTreeMapKeysIter, Values as BTreeMapValuesIter,
 };
@@ -1991,7 +1991,7 @@ fn collect_print_requests(
 
 pub fn parse_target_triple(early_dcx: &EarlyDiagCtxt, matches: &getopts::Matches) -> TargetTriple {
     match matches.opt_str("target") {
-        Some(target) if target.ends_with(".json") => {
+        Some(target) if has_ext_ignore_case(&target, "json") => {
             let path = Path::new(&target);
             TargetTriple::from_path(path).unwrap_or_else(|_| {
                 early_dcx.early_fatal(format!("target file {path:?} does not exist"))

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -46,6 +46,7 @@ use rustc_span::symbol::{kw, sym, Symbol};
 use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::ffi::OsStr;
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
@@ -3715,4 +3716,12 @@ impl fmt::Display for TargetTriple {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.debug_triple())
     }
+}
+
+/// Helper function to check if the given `s` ends with `ext` __case-insensitive__.
+/// The `ext` should not starts with a dot.
+///
+/// Does not check if the path exists.
+pub fn has_ext_ignore_case<S: AsRef<OsStr>, Ext: AsRef<OsStr>>(s: S, ext: Ext) -> bool {
+    Path::new(&s).extension().is_some_and(|s| s.eq_ignore_ascii_case(ext))
 }

--- a/tests/run-make/target-specs-filename/ALL-IN-CAPS.JSON
+++ b/tests/run-make/target-specs-filename/ALL-IN-CAPS.JSON
@@ -1,0 +1,6 @@
+{
+  "arch": "x86_64",
+  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+  "llvm-target": "x86_64-unknown-unknown-gnu",
+  "target-pointer-width": "64"
+}

--- a/tests/run-make/target-specs-filename/ext-in-caps.JSON
+++ b/tests/run-make/target-specs-filename/ext-in-caps.JSON
@@ -1,0 +1,6 @@
+{
+  "arch": "x86_64",
+  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+  "llvm-target": "x86_64-unknown-unknown-gnu",
+  "target-pointer-width": "64"
+}

--- a/tests/run-make/target-specs-filename/normal-target-triple.json
+++ b/tests/run-make/target-specs-filename/normal-target-triple.json
@@ -1,0 +1,6 @@
+{
+  "arch": "x86_64",
+  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+  "llvm-target": "x86_64-unknown-unknown-gnu",
+  "target-pointer-width": "64"
+}

--- a/tests/run-make/target-specs-filename/rmake.rs
+++ b/tests/run-make/target-specs-filename/rmake.rs
@@ -1,0 +1,22 @@
+// This test checks the rustc can accept target-spec-json with cases
+// including file extension - it could be in upper and lower case.
+// Used to test: print target-spec-json and cfg
+// Issue: https://github.com/rust-lang/rust/issues/127387
+
+use run_make_support::rustc;
+
+fn main() {
+    // This is a matrix [files x args], files for target, args for print.
+    for file in [
+        "normal-target-triple",
+        "normal-target-triple.json",
+        "ext-in-caps.JSON",
+        "ALL-IN-CAPS.JSON",
+    ] {
+        for args in [["cfg"].as_slice(), &["target-spec-json", "-Zunstable-options"]] {
+            let output = rustc().arg("--print").args(args).args(["--target", file]).run();
+            // check that the target triple is read correctly
+            output.assert_stdout_contains("x86_64");
+        }
+    }
+}


### PR DESCRIPTION
Currently user's target json file can have only `json` ext, but cannot have `JSON' or any other strange form.

This is a little fix with added support of case-insensitive file-ext for user specified target only.
That means that not supported in following cases:
- any directory traversal, such as in `$RUST_TARGET_PATH`
- same for `rustc_target::spec::Target::search`, so it doesn't work with `JSON` on case-sensitive FS, but __works fine on case-insensitive FS__.
- `$RUST_TARGET_PATH` dir traversal in the bootstrap is not touched too.

## Performance cost:

Almost without changes.
Comparison using `eq_ignore_ascii_case` for __only latest ext_len chars__ of the `OsStr` (as bytes).

## Testing

How to test:
1. `rustc --print target-spec-json -Zunstable-options > ./some-target.JSON`
1. remove `is-builtin` field from the `some-target.JSON` or set to `false`
1. `rustc --print target-spec-json -Zunstable-options --target=some-target.JSON` should work
1. `rustc --print target-spec-json -Zunstable-options --target=some-target` should work on case-insensitive FS
1. `rustc --print cfg --target=some-target` should work too, on case-insensitive FS

Tests added.

## Implementation note

I've separated the comparison into a method for potential future use instead of just `str.ends_with(".json")` and to maintain compatibility. 
The method is public for the same reasons.

Fixes #127387 issue.

try-job: test-various
try-job: armhf-gnu
try-job: x86_64-msvc
try-job: aarch64-apple