### PR TITLE
fix interleaved output in the default panic hook when multiple threads panic simultaneously

### DIFF
--- a/tests/ui/backtrace/synchronized-panic-handler.rs
+++ b/tests/ui/backtrace/synchronized-panic-handler.rs
@@ -1,6 +1,8 @@
 //@ run-pass
 //@ check-run-results
 //@ edition:2021
+//@ exec-env:RUST_BACKTRACE=0
+//@ needs-threads
 use std::thread;
 const PANIC_MESSAGE: &str = "oops oh no woe is me";
 

--- a/tests/ui/backtrace/synchronized-panic-handler.rs
+++ b/tests/ui/backtrace/synchronized-panic-handler.rs
@@ -1,0 +1,15 @@
+//@ run-pass
+//@ check-run-results
+//@ edition:2021
+use std::thread;
+const PANIC_MESSAGE: &str = "oops oh no woe is me";
+
+fn entry() {
+    panic!("{PANIC_MESSAGE}")
+}
+
+fn main() {
+    let (a, b) = (thread::spawn(entry), thread::spawn(entry));
+    assert_eq!(&**a.join().unwrap_err().downcast::<String>().unwrap(), PANIC_MESSAGE);
+    assert_eq!(&**b.join().unwrap_err().downcast::<String>().unwrap(), PANIC_MESSAGE);
+}

--- a/tests/ui/backtrace/synchronized-panic-handler.run.stderr
+++ b/tests/ui/backtrace/synchronized-panic-handler.run.stderr
@@ -1,5 +1,5 @@
-thread '<unnamed>' panicked at $DIR/synchronized-panic-handler.rs:thread '8<unnamed>:5' panicked at :
-oops oh no woe is me$DIR/synchronized-panic-handler.rs
-:note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-8:5:
+thread '<unnamed>' panicked at $DIR/synchronized-panic-handler.rs:10:5:
+oops oh no woe is me
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+thread '<unnamed>' panicked at $DIR/synchronized-panic-handler.rs:10:5:
 oops oh no woe is me

--- a/tests/ui/backtrace/synchronized-panic-handler.run.stderr
+++ b/tests/ui/backtrace/synchronized-panic-handler.run.stderr
@@ -1,0 +1,5 @@
+thread '<unnamed>' panicked at $DIR/synchronized-panic-handler.rs:thread '8<unnamed>:5' panicked at :
+oops oh no woe is me$DIR/synchronized-panic-handler.rs
+:note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+8:5:
+oops oh no woe is me


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

previously, we only held a lock for printing the backtrace itself. since all threads were printing to the same file descriptor, that meant random output in the default panic hook from one thread would be interleaved with the backtrace from another. now, we hold the lock for the full duration of the hook, and the output is ordered.

---

i noticed some odd things while working on this you may or may not already be aware of.

- libbacktrace is included as a submodule instead of a normal rustc crate, and as a result uses `cfg(backtrace_in_std)` instead of a more normal `cfg(feature = "rustc-dep-of-std")`. probably this is left over from before rust used a cargo-based build system?
- the default panic handler uses `trace_unsynchronized`, etc, in `sys::backtrace::print`. as a result, the lock only applies to concurrent *panic handlers*, not concurrent *threads*.  in other words, if another, non-panicking, thread tried to print a backtrace at the same time as the panic handler, we may have UB, especially on windows.
    - we have the option of changing backtrace to enable locking when `backtrace_in_std` is set so we can reuse their lock instead of trying to add our own.