### PR TITLE
Verify that allocations output by GVN are sufficiently aligned.

### DIFF
--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1391,11 +1391,15 @@ fn op_to_prop_const<'tcx>(
         let (prov, offset) = pointer.into_parts();
         let alloc_id = prov.alloc_id();
         intern_const_alloc_for_constprop(ecx, alloc_id).ok()?;
-        if matches!(ecx.tcx.global_alloc(alloc_id), GlobalAlloc::Memory(_)) {
-            // `alloc_id` may point to a static. Codegen will choke on an `Indirect` with anything
-            // by `GlobalAlloc::Memory`, so do fall through to copying if needed.
-            // FIXME: find a way to treat this more uniformly
-            // (probably by fixing codegen)
+
+        // `alloc_id` may point to a static. Codegen will choke on an `Indirect` with anything
+        // by `GlobalAlloc::Memory`, so do fall through to copying if needed.
+        // FIXME: find a way to treat this more uniformly (probably by fixing codegen)
+        if let GlobalAlloc::Memory(alloc) = ecx.tcx.global_alloc(alloc_id)
+            // Transmuting a constant is just an offset in the allocation. If the alignement of the
+            // allocation is noe enough, fallback to copying into a properly aligned value.
+            && alloc.inner().align >= op.layout.align.abi
+        {
             return Some(ConstValue::Indirect { alloc_id, offset });
         }
     }

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1396,8 +1396,8 @@ fn op_to_prop_const<'tcx>(
         // by `GlobalAlloc::Memory`, so do fall through to copying if needed.
         // FIXME: find a way to treat this more uniformly (probably by fixing codegen)
         if let GlobalAlloc::Memory(alloc) = ecx.tcx.global_alloc(alloc_id)
-            // Transmuting a constant is just an offset in the allocation. If the alignement of the
-            // allocation is noe enough, fallback to copying into a properly aligned value.
+            // Transmuting a constant is just an offset in the allocation. If the alignment of the
+            // allocation is not enough, fallback to copying into a properly aligned value.
             && alloc.inner().align >= op.layout.align.abi
         {
             return Some(ConstValue::Indirect { alloc_id, offset });

--- a/tests/ui/mir/alignment/misaligned-constant-gvn.rs
+++ b/tests/ui/mir/alignment/misaligned-constant-gvn.rs
@@ -1,0 +1,8 @@
+//@ build-pass
+//@ compile-flags: -Zmir-opt-level=0 -Zmir-enable-passes=+GVN
+
+fn main() {
+    let variant: Option<u32> = None;
+    let transmuted: u64 = unsafe { std::mem::transmute(variant) };
+    println!("{transmuted}");
+}


### PR DESCRIPTION
Fixes #127396

r? @oli-obk 
