### PR TITLE
Remove some `reuse_or_mk_predicate` from elaboration

### DIFF
--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -11,8 +11,7 @@ pub fn anonymize_predicate<'tcx>(
     tcx: TyCtxt<'tcx>,
     pred: ty::Predicate<'tcx>,
 ) -> ty::Predicate<'tcx> {
-    let new = tcx.anonymize_bound_vars(pred.kind());
-    tcx.reuse_or_mk_predicate(pred, new)
+    tcx.anonymize_bound_vars(pred.kind()).upcast(tcx)
 }
 
 pub struct PredicateSet<'tcx> {

--- a/compiler/rustc_middle/src/ty/predicate.rs
+++ b/compiler/rustc_middle/src/ty/predicate.rs
@@ -444,12 +444,7 @@ impl<'tcx> Clause<'tcx> {
         let bound_vars =
             tcx.mk_bound_variable_kinds_from_iter(trait_bound_vars.iter().chain(pred_bound_vars));
 
-        // FIXME: Is it really perf sensitive to use reuse_or_mk_predicate here?
-        tcx.reuse_or_mk_predicate(
-            self.as_predicate(),
-            ty::Binder::bind_with_vars(PredicateKind::Clause(new), bound_vars),
-        )
-        .expect_clause()
+        ty::Binder::bind_with_vars(new, bound_vars).upcast(tcx)
     }
 }
 


### PR DESCRIPTION
Curious to know if it's even needed.

r? @ghost