### PR TITLE
Make parse error suggestions verbose and fix spans

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -1,7 +1,7 @@
 parse_add_paren = try adding parentheses
 
 parse_ambiguous_range_pattern = the range pattern here has ambiguous interpretation
-    .suggestion = add parentheses to clarify the precedence
+parse_ambiguous_range_pattern_suggestion = add parentheses to clarify the precedence
 
 parse_array_brackets_instead_of_braces = this is a block expression, not an array
     .suggestion = to make an array, use square brackets instead of curly braces
@@ -644,7 +644,7 @@ parse_parentheses_with_struct_fields = invalid `struct` delimiters or `fn` call 
     .suggestion_no_fields_for_fn = if `{$type}` is a function, use the arguments directly
 
 parse_parenthesized_lifetime = parenthesized lifetime bounds are not supported
-    .suggestion = remove the parentheses
+parse_parenthesized_lifetime_suggestion = remove the parentheses
 
 parse_path_single_colon = path separator must be a double colon
     .suggestion = use a double colon instead

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -323,10 +323,10 @@ parse_incorrect_semicolon =
     .suggestion = remove this semicolon
     .help = {$name} declarations are not followed by a semicolon
 
-parse_incorrect_use_of_await =
-    incorrect use of `await`
+parse_incorrect_use_of_await = incorrect use of `await`
     .parentheses_suggestion = `await` is not a method call, remove the parentheses
-    .postfix_suggestion = `await` is a postfix operation
+
+parse_incorrect_use_of_await_postfix_suggestion = `await` is a postfix operation
 
 parse_incorrect_visibility_restriction = incorrect visibility restriction
     .help = some possible visibility restrictions are:

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1215,14 +1215,14 @@ pub(crate) enum ExpectedSemiSugg {
         parse_sugg_change_this_to_semi,
         code = ";",
         applicability = "machine-applicable",
-        style = "verbose"
+        style = "short"
     )]
     ChangeToSemi(#[primary_span] Span),
     #[suggestion(
         parse_sugg_add_semi,
-        style = "verbose",
         code = ";",
-        applicability = "machine-applicable"
+        applicability = "machine-applicable",
+        style = "short"
     )]
     AddSemi(#[primary_span] Span),
 }

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1562,8 +1562,10 @@ pub(crate) struct ExpectedFnPathFoundFnKeyword {
 #[diag(parse_path_single_colon)]
 pub(crate) struct PathSingleColon {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = "::", style = "verbose")]
     pub span: Span,
+
+    #[suggestion(applicability = "machine-applicable", code = ":", style = "verbose")]
+    pub suggestion: Span,
 
     #[note(parse_type_ascription_removed)]
     pub type_ascription: Option<()>,

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -18,10 +18,10 @@ use crate::parser::{ForbiddenLetReason, TokenDescription};
 #[derive(Diagnostic)]
 #[diag(parse_maybe_report_ambiguous_plus)]
 pub(crate) struct AmbiguousPlus {
-    pub sum_ty: String,
     #[primary_span]
-    #[suggestion(code = "({sum_ty})")]
     pub span: Span,
+    #[subdiagnostic]
+    pub suggestion: AddParen,
 }
 
 #[derive(Diagnostic)]
@@ -35,16 +35,19 @@ pub(crate) struct BadTypePlus {
 }
 
 #[derive(Subdiagnostic)]
+#[multipart_suggestion(parse_add_paren, applicability = "machine-applicable")]
+pub(crate) struct AddParen {
+    #[suggestion_part(code = "(")]
+    pub lo: Span,
+    #[suggestion_part(code = ")")]
+    pub hi: Span,
+}
+
+#[derive(Subdiagnostic)]
 pub(crate) enum BadTypePlusSub {
-    #[suggestion(
-        parse_add_paren,
-        code = "{sum_with_parens}",
-        applicability = "machine-applicable"
-    )]
     AddParen {
-        sum_with_parens: String,
-        #[primary_span]
-        span: Span,
+        #[subdiagnostic]
+        suggestion: AddParen,
     },
     #[label(parse_forgot_paren)]
     ForgotParen {
@@ -80,7 +83,7 @@ pub(crate) struct WrapType {
 #[diag(parse_incorrect_semicolon)]
 pub(crate) struct IncorrectSemicolon<'a> {
     #[primary_span]
-    #[suggestion(style = "short", code = "", applicability = "machine-applicable")]
+    #[suggestion(style = "verbose", code = "", applicability = "machine-applicable")]
     pub span: Span,
     #[help]
     pub show_help: bool,
@@ -91,7 +94,12 @@ pub(crate) struct IncorrectSemicolon<'a> {
 #[diag(parse_incorrect_use_of_await)]
 pub(crate) struct IncorrectUseOfAwait {
     #[primary_span]
-    #[suggestion(parse_parentheses_suggestion, code = "", applicability = "machine-applicable")]
+    #[suggestion(
+        parse_parentheses_suggestion,
+        style = "verbose",
+        code = "",
+        applicability = "machine-applicable"
+    )]
     pub span: Span,
 }
 
@@ -100,7 +108,11 @@ pub(crate) struct IncorrectUseOfAwait {
 pub(crate) struct IncorrectAwait {
     #[primary_span]
     pub span: Span,
-    #[suggestion(parse_postfix_suggestion, code = "{expr}.await{question_mark}")]
+    #[suggestion(
+        parse_postfix_suggestion,
+        style = "verbose",
+        code = "{expr}.await{question_mark}"
+    )]
     pub sugg_span: (Span, Applicability),
     pub expr: String,
     pub question_mark: &'static str,
@@ -111,7 +123,7 @@ pub(crate) struct IncorrectAwait {
 pub(crate) struct InInTypo {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", style = "verbose", applicability = "machine-applicable")]
     pub sugg_span: Span,
 }
 
@@ -126,17 +138,33 @@ pub(crate) struct InvalidVariableDeclaration {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum InvalidVariableDeclarationSub {
-    #[suggestion(parse_switch_mut_let_order, applicability = "maybe-incorrect", code = "let mut")]
+    #[suggestion(
+        parse_switch_mut_let_order,
+        style = "verbose",
+        applicability = "maybe-incorrect",
+        code = "let mut"
+    )]
     SwitchMutLetOrder(#[primary_span] Span),
     #[suggestion(
         parse_missing_let_before_mut,
         applicability = "machine-applicable",
+        style = "verbose",
         code = "let mut"
     )]
     MissingLet(#[primary_span] Span),
-    #[suggestion(parse_use_let_not_auto, applicability = "machine-applicable", code = "let")]
+    #[suggestion(
+        parse_use_let_not_auto,
+        style = "verbose",
+        applicability = "machine-applicable",
+        code = "let"
+    )]
     UseLetNotAuto(#[primary_span] Span),
-    #[suggestion(parse_use_let_not_var, applicability = "machine-applicable", code = "let")]
+    #[suggestion(
+        parse_use_let_not_var,
+        style = "verbose",
+        applicability = "machine-applicable",
+        code = "let"
+    )]
     UseLetNotVar(#[primary_span] Span),
 }
 
@@ -144,7 +172,7 @@ pub(crate) enum InvalidVariableDeclarationSub {
 #[diag(parse_switch_ref_box_order)]
 pub(crate) struct SwitchRefBoxOrder {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = "box ref")]
+    #[suggestion(applicability = "machine-applicable", style = "verbose", code = "box ref")]
     pub span: Span,
 }
 
@@ -162,7 +190,7 @@ pub(crate) struct InvalidComparisonOperator {
 pub(crate) enum InvalidComparisonOperatorSub {
     #[suggestion(
         parse_use_instead,
-        style = "short",
+        style = "verbose",
         applicability = "machine-applicable",
         code = "{correct}"
     )]
@@ -191,14 +219,14 @@ pub(crate) struct InvalidLogicalOperator {
 pub(crate) enum InvalidLogicalOperatorSub {
     #[suggestion(
         parse_use_amp_amp_for_conjunction,
-        style = "short",
+        style = "verbose",
         applicability = "machine-applicable",
         code = "&&"
     )]
     Conjunction(#[primary_span] Span),
     #[suggestion(
         parse_use_pipe_pipe_for_disjunction,
-        style = "short",
+        style = "verbose",
         applicability = "machine-applicable",
         code = "||"
     )]
@@ -209,7 +237,7 @@ pub(crate) enum InvalidLogicalOperatorSub {
 #[diag(parse_tilde_is_not_unary_operator)]
 pub(crate) struct TildeAsUnaryOperator(
     #[primary_span]
-    #[suggestion(style = "short", applicability = "machine-applicable", code = "!")]
+    #[suggestion(style = "verbose", applicability = "machine-applicable", code = "!")]
     pub Span,
 );
 
@@ -227,7 +255,7 @@ pub(crate) struct NotAsNegationOperator {
 pub enum NotAsNegationOperatorSub {
     #[suggestion(
         parse_unexpected_token_after_not_default,
-        style = "short",
+        style = "verbose",
         applicability = "machine-applicable",
         code = "!"
     )]
@@ -235,7 +263,7 @@ pub enum NotAsNegationOperatorSub {
 
     #[suggestion(
         parse_unexpected_token_after_not_bitwise,
-        style = "short",
+        style = "verbose",
         applicability = "machine-applicable",
         code = "!"
     )]
@@ -243,7 +271,7 @@ pub enum NotAsNegationOperatorSub {
 
     #[suggestion(
         parse_unexpected_token_after_not_logical,
-        style = "short",
+        style = "verbose",
         applicability = "machine-applicable",
         code = "!"
     )]
@@ -254,9 +282,9 @@ pub enum NotAsNegationOperatorSub {
 #[diag(parse_malformed_loop_label)]
 pub(crate) struct MalformedLoopLabel {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = "{correct_label}")]
     pub span: Span,
-    pub correct_label: Ident,
+    #[suggestion(applicability = "machine-applicable", code = "'", style = "verbose")]
+    pub suggestion: Span,
 }
 
 #[derive(Diagnostic)]
@@ -264,7 +292,7 @@ pub(crate) struct MalformedLoopLabel {
 pub(crate) struct LifetimeInBorrowExpression {
     #[primary_span]
     pub span: Span,
-    #[suggestion(applicability = "machine-applicable", code = "")]
+    #[suggestion(applicability = "machine-applicable", code = "", style = "verbose")]
     #[label]
     pub lifetime_span: Span,
 }
@@ -306,7 +334,7 @@ pub(crate) struct RequireColonAfterLabeledExpression {
     pub span: Span,
     #[label]
     pub label: Span,
-    #[suggestion(style = "short", applicability = "machine-applicable", code = ": ")]
+    #[suggestion(style = "verbose", applicability = "machine-applicable", code = ": ")]
     pub label_end: Span,
 }
 
@@ -315,7 +343,7 @@ pub(crate) struct RequireColonAfterLabeledExpression {
 #[note]
 pub(crate) struct DoCatchSyntaxRemoved {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = "try")]
+    #[suggestion(applicability = "machine-applicable", code = "try", style = "verbose")]
     pub span: Span,
 }
 
@@ -323,9 +351,9 @@ pub(crate) struct DoCatchSyntaxRemoved {
 #[diag(parse_float_literal_requires_integer_part)]
 pub(crate) struct FloatLiteralRequiresIntegerPart {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = "{correct}")]
     pub span: Span,
-    pub correct: String,
+    #[suggestion(applicability = "machine-applicable", code = "0", style = "verbose")]
+    pub suggestion: Span,
 }
 
 #[derive(Diagnostic)]
@@ -394,7 +422,12 @@ pub struct TernaryOperator {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parse_extra_if_in_let_else, applicability = "maybe-incorrect", code = "")]
+#[suggestion(
+    parse_extra_if_in_let_else,
+    applicability = "maybe-incorrect",
+    code = "",
+    style = "verbose"
+)]
 pub(crate) struct IfExpressionLetSomeSub {
     #[primary_span]
     pub if_span: Span,
@@ -463,7 +496,7 @@ pub(crate) struct ExpectedElseBlock {
     pub first_tok: String,
     #[label]
     pub else_span: Span,
-    #[suggestion(applicability = "maybe-incorrect", code = "if ")]
+    #[suggestion(applicability = "maybe-incorrect", code = "if ", style = "verbose")]
     pub condition_start: Span,
 }
 
@@ -491,7 +524,7 @@ pub(crate) struct OuterAttributeNotAllowedOnIfElse {
     pub ctx_span: Span,
     pub ctx: String,
 
-    #[suggestion(applicability = "machine-applicable", code = "")]
+    #[suggestion(applicability = "machine-applicable", code = "", style = "verbose")]
     pub attributes: Span,
 }
 
@@ -509,12 +542,17 @@ pub(crate) enum MissingInInForLoopSub {
     // Has been misleading, at least in the past (closed Issue #48492), thus maybe-incorrect
     #[suggestion(
         parse_use_in_not_of,
-        style = "short",
+        style = "verbose",
         applicability = "maybe-incorrect",
         code = "in"
     )]
     InNotOf(#[primary_span] Span),
-    #[suggestion(parse_add_in, style = "short", applicability = "maybe-incorrect", code = " in ")]
+    #[suggestion(
+        parse_add_in,
+        style = "verbose",
+        applicability = "maybe-incorrect",
+        code = " in "
+    )]
     AddIn(#[primary_span] Span),
 }
 
@@ -545,7 +583,7 @@ pub(crate) struct LoopElseNotSupported {
 #[diag(parse_missing_comma_after_match_arm)]
 pub(crate) struct MissingCommaAfterMatchArm {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = ",")]
+    #[suggestion(applicability = "machine-applicable", code = ",", style = "verbose")]
     pub span: Span,
 }
 
@@ -563,7 +601,7 @@ pub(crate) struct CatchAfterTry {
 pub(crate) struct CommaAfterBaseStruct {
     #[primary_span]
     pub span: Span,
-    #[suggestion(style = "short", applicability = "machine-applicable", code = "")]
+    #[suggestion(style = "verbose", applicability = "machine-applicable", code = "")]
     pub comma: Span,
 }
 
@@ -572,7 +610,7 @@ pub(crate) struct CommaAfterBaseStruct {
 pub(crate) struct EqFieldInit {
     #[primary_span]
     pub span: Span,
-    #[suggestion(applicability = "machine-applicable", code = ":")]
+    #[suggestion(applicability = "machine-applicable", code = ":", style = "verbose")]
     pub eq: Span,
 }
 
@@ -580,8 +618,18 @@ pub(crate) struct EqFieldInit {
 #[diag(parse_dotdotdot)]
 pub(crate) struct DotDotDot {
     #[primary_span]
-    #[suggestion(parse_suggest_exclusive_range, applicability = "maybe-incorrect", code = "..")]
-    #[suggestion(parse_suggest_inclusive_range, applicability = "maybe-incorrect", code = "..=")]
+    #[suggestion(
+        parse_suggest_exclusive_range,
+        applicability = "maybe-incorrect",
+        code = "..",
+        style = "verbose"
+    )]
+    #[suggestion(
+        parse_suggest_inclusive_range,
+        applicability = "maybe-incorrect",
+        code = "..=",
+        style = "verbose"
+    )]
     pub span: Span,
 }
 
@@ -589,7 +637,7 @@ pub(crate) struct DotDotDot {
 #[diag(parse_left_arrow_operator)]
 pub(crate) struct LeftArrowOperator {
     #[primary_span]
-    #[suggestion(applicability = "maybe-incorrect", code = "< -")]
+    #[suggestion(applicability = "maybe-incorrect", code = "< -", style = "verbose")]
     pub span: Span,
 }
 
@@ -597,7 +645,7 @@ pub(crate) struct LeftArrowOperator {
 #[diag(parse_remove_let)]
 pub(crate) struct RemoveLet {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = "")]
+    #[suggestion(applicability = "machine-applicable", code = "", style = "verbose")]
     pub span: Span,
 }
 
@@ -605,8 +653,9 @@ pub(crate) struct RemoveLet {
 #[diag(parse_use_eq_instead)]
 pub(crate) struct UseEqInstead {
     #[primary_span]
-    #[suggestion(style = "short", applicability = "machine-applicable", code = "=")]
     pub span: Span,
+    #[suggestion(style = "verbose", applicability = "machine-applicable", code = "")]
+    pub suggestion: Span,
 }
 
 #[derive(Diagnostic)]
@@ -780,7 +829,7 @@ pub(crate) struct InclusiveRangeExtraEquals {
     #[primary_span]
     #[suggestion(
         parse_suggestion_remove_eq,
-        style = "short",
+        style = "verbose",
         code = "..=",
         applicability = "maybe-incorrect"
     )]
@@ -803,13 +852,14 @@ pub(crate) struct InclusiveRangeMatchArrow {
 #[note]
 pub(crate) struct InclusiveRangeNoEnd {
     #[primary_span]
+    pub span: Span,
     #[suggestion(
         parse_suggestion_open_range,
-        code = "..",
+        code = "",
         applicability = "machine-applicable",
-        style = "short"
+        style = "verbose"
     )]
-    pub span: Span,
+    pub suggestion: Span,
 }
 
 #[derive(Subdiagnostic)]
@@ -824,7 +874,8 @@ pub(crate) enum MatchArmBodyWithoutBracesSugg {
     #[suggestion(
         parse_suggestion_use_comma_not_semicolon,
         code = ",",
-        applicability = "machine-applicable"
+        applicability = "machine-applicable",
+        style = "verbose"
     )]
     UseComma {
         #[primary_span]
@@ -867,7 +918,7 @@ pub(crate) struct InvalidLiteralSuffixOnTupleIndex {
 #[diag(parse_non_string_abi_literal)]
 pub(crate) struct NonStringAbiLiteral {
     #[primary_span]
-    #[suggestion(code = "\"C\"", applicability = "maybe-incorrect")]
+    #[suggestion(code = "\"C\"", applicability = "maybe-incorrect", style = "verbose")]
     pub span: Span,
 }
 
@@ -890,7 +941,7 @@ pub(crate) struct MismatchedClosingDelimiter {
 #[help]
 pub(crate) struct IncorrectVisibilityRestriction {
     #[primary_span]
-    #[suggestion(code = "in {inner_str}", applicability = "machine-applicable")]
+    #[suggestion(code = "in {inner_str}", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
     pub inner_str: String,
 }
@@ -915,7 +966,7 @@ pub(crate) struct ExpectedStatementAfterOuterAttr {
 pub(crate) struct DocCommentDoesNotDocumentAnything {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = ",", applicability = "machine-applicable")]
+    #[suggestion(code = ",", applicability = "machine-applicable", style = "verbose")]
     pub missing_comma: Option<Span>,
 }
 
@@ -923,7 +974,7 @@ pub(crate) struct DocCommentDoesNotDocumentAnything {
 #[diag(parse_const_let_mutually_exclusive)]
 pub(crate) struct ConstLetMutuallyExclusive {
     #[primary_span]
-    #[suggestion(code = "const", applicability = "maybe-incorrect")]
+    #[suggestion(code = "const", applicability = "maybe-incorrect", style = "verbose")]
     pub span: Span,
 }
 
@@ -951,8 +1002,9 @@ pub(crate) struct InvalidCurlyInLetElse {
 #[help]
 pub(crate) struct CompoundAssignmentExpressionInLet {
     #[primary_span]
-    #[suggestion(style = "short", code = "=", applicability = "maybe-incorrect")]
     pub span: Span,
+    #[suggestion(style = "verbose", code = "", applicability = "maybe-incorrect")]
+    pub suggestion: Span,
 }
 
 #[derive(Diagnostic)]
@@ -996,7 +1048,12 @@ pub(crate) struct SuggEscapeIdentifier {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(parse_sugg_remove_comma, applicability = "machine-applicable", code = "")]
+#[suggestion(
+    parse_sugg_remove_comma,
+    applicability = "machine-applicable",
+    code = "",
+    style = "verbose"
+)]
 pub(crate) struct SuggRemoveComma {
     #[primary_span]
     pub span: Span,
@@ -1147,11 +1204,16 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for ExpectedSemi {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum ExpectedSemiSugg {
-    #[suggestion(parse_sugg_change_this_to_semi, code = ";", applicability = "machine-applicable")]
+    #[suggestion(
+        parse_sugg_change_this_to_semi,
+        code = ";",
+        applicability = "machine-applicable",
+        style = "verbose"
+    )]
     ChangeToSemi(#[primary_span] Span),
     #[suggestion(
         parse_sugg_add_semi,
-        style = "short",
+        style = "verbose",
         code = ";",
         applicability = "machine-applicable"
     )]
@@ -1198,7 +1260,7 @@ pub(crate) struct StructLiteralNeedingParensSugg {
 #[diag(parse_unmatched_angle_brackets)]
 pub(crate) struct UnmatchedAngleBrackets {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
     pub num_extra_brackets: usize,
 }
@@ -1337,7 +1399,7 @@ pub(crate) struct AttributeOnParamType {
 #[diag(parse_pattern_method_param_without_body, code = E0642)]
 pub(crate) struct PatternMethodParamWithoutBody {
     #[primary_span]
-    #[suggestion(code = "_", applicability = "machine-applicable")]
+    #[suggestion(code = "_", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
 }
 
@@ -1421,7 +1483,7 @@ pub(crate) struct AsyncMoveOrderIncorrect {
 pub(crate) struct DoubleColonInBound {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = ": ", applicability = "machine-applicable")]
+    #[suggestion(code = ": ", applicability = "machine-applicable", style = "verbose")]
     pub between: Span,
 }
 
@@ -1500,7 +1562,7 @@ pub(crate) struct ExpectedFnPathFoundFnKeyword {
 #[diag(parse_path_single_colon)]
 pub(crate) struct PathSingleColon {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = "::")]
+    #[suggestion(applicability = "machine-applicable", code = "::", style = "verbose")]
     pub span: Span,
 
     #[note(parse_type_ascription_removed)]
@@ -1511,7 +1573,7 @@ pub(crate) struct PathSingleColon {
 #[diag(parse_colon_as_semi)]
 pub(crate) struct ColonAsSemi {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = ";")]
+    #[suggestion(applicability = "machine-applicable", code = ";", style = "verbose")]
     pub span: Span,
 
     #[note(parse_type_ascription_removed)]
@@ -1662,9 +1724,9 @@ pub(crate) enum MissingKeywordForItemDefinition {
 pub(crate) enum AmbiguousMissingKwForItemSub {
     #[suggestion(
         parse_suggestion,
-        style = "verbose",
         applicability = "maybe-incorrect",
-        code = "{snippet}!"
+        code = "{snippet}!",
+        style = "verbose"
     )]
     SuggestMacro {
         #[primary_span]
@@ -1679,7 +1741,7 @@ pub(crate) enum AmbiguousMissingKwForItemSub {
 #[diag(parse_missing_fn_params)]
 pub(crate) struct MissingFnParams {
     #[primary_span]
-    #[suggestion(code = "()", applicability = "machine-applicable", style = "short")]
+    #[suggestion(code = "()", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
 }
 
@@ -1687,9 +1749,19 @@ pub(crate) struct MissingFnParams {
 #[diag(parse_missing_trait_in_trait_impl)]
 pub(crate) struct MissingTraitInTraitImpl {
     #[primary_span]
-    #[suggestion(parse_suggestion_add_trait, code = " Trait ", applicability = "has-placeholders")]
+    #[suggestion(
+        parse_suggestion_add_trait,
+        code = " Trait ",
+        applicability = "has-placeholders",
+        style = "verbose"
+    )]
     pub span: Span,
-    #[suggestion(parse_suggestion_remove_for, code = "", applicability = "maybe-incorrect")]
+    #[suggestion(
+        parse_suggestion_remove_for,
+        code = "",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
     pub for_span: Span,
 }
 
@@ -1697,7 +1769,7 @@ pub(crate) struct MissingTraitInTraitImpl {
 #[diag(parse_missing_for_in_trait_impl)]
 pub(crate) struct MissingForInTraitImpl {
     #[primary_span]
-    #[suggestion(style = "short", code = " for ", applicability = "machine-applicable")]
+    #[suggestion(style = "verbose", code = " for ", applicability = "machine-applicable")]
     pub span: Span,
 }
 
@@ -1712,7 +1784,7 @@ pub(crate) struct ExpectedTraitInTraitImplFoundType {
 #[diag(parse_extra_impl_keyword_in_trait_impl)]
 pub(crate) struct ExtraImplKeywordInTraitImpl {
     #[primary_span]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     pub extra_impl_kw: Span,
     #[note]
     pub impl_trait_span: Span,
@@ -1771,7 +1843,7 @@ pub(crate) struct ExternCrateNameWithDashesSugg {
 pub(crate) struct ExternItemCannotBeConst {
     #[primary_span]
     pub ident_span: Span,
-    #[suggestion(code = "static ", applicability = "machine-applicable")]
+    #[suggestion(code = "static ", applicability = "machine-applicable", style = "verbose")]
     pub const_span: Option<Span>,
 }
 
@@ -1781,7 +1853,7 @@ pub(crate) struct ConstGlobalCannotBeMutable {
     #[primary_span]
     #[label]
     pub ident_span: Span,
-    #[suggestion(code = "static", applicability = "maybe-incorrect")]
+    #[suggestion(code = "static", style = "verbose", applicability = "maybe-incorrect")]
     pub const_span: Span,
 }
 
@@ -1789,7 +1861,7 @@ pub(crate) struct ConstGlobalCannotBeMutable {
 #[diag(parse_missing_const_type)]
 pub(crate) struct MissingConstType {
     #[primary_span]
-    #[suggestion(code = "{colon} <type>", applicability = "has-placeholders")]
+    #[suggestion(code = "{colon} <type>", style = "verbose", applicability = "has-placeholders")]
     pub span: Span,
 
     pub kind: &'static str,
@@ -1800,7 +1872,7 @@ pub(crate) struct MissingConstType {
 #[diag(parse_enum_struct_mutually_exclusive)]
 pub(crate) struct EnumStructMutuallyExclusive {
     #[primary_span]
-    #[suggestion(code = "enum", applicability = "machine-applicable")]
+    #[suggestion(code = "enum", style = "verbose", applicability = "machine-applicable")]
     pub span: Span,
 }
 
@@ -2037,7 +2109,12 @@ pub struct UnknownTokenStart {
 
 #[derive(Subdiagnostic)]
 pub enum TokenSubstitution {
-    #[suggestion(parse_sugg_quotes, code = "{suggestion}", applicability = "maybe-incorrect")]
+    #[suggestion(
+        parse_sugg_quotes,
+        code = "{suggestion}",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
     DirectedQuotes {
         #[primary_span]
         span: Span,
@@ -2045,7 +2122,12 @@ pub enum TokenSubstitution {
         ascii_str: &'static str,
         ascii_name: &'static str,
     },
-    #[suggestion(parse_sugg_other, code = "{suggestion}", applicability = "maybe-incorrect")]
+    #[suggestion(
+        parse_sugg_other,
+        code = "{suggestion}",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
     Other {
         #[primary_span]
         span: Span,
@@ -2081,7 +2163,12 @@ pub enum UnescapeError {
     EscapeOnlyChar {
         #[primary_span]
         span: Span,
-        #[suggestion(parse_escape, applicability = "machine-applicable", code = "{escaped_sugg}")]
+        #[suggestion(
+            parse_escape,
+            applicability = "machine-applicable",
+            code = "{escaped_sugg}",
+            style = "verbose"
+        )]
         char_span: Span,
         escaped_sugg: String,
         escaped_msg: String,
@@ -2090,7 +2177,12 @@ pub enum UnescapeError {
     #[diag(parse_bare_cr)]
     BareCr {
         #[primary_span]
-        #[suggestion(parse_escape, applicability = "machine-applicable", code = "\\r")]
+        #[suggestion(
+            parse_escape,
+            applicability = "machine-applicable",
+            code = "\\r",
+            style = "verbose"
+        )]
         span: Span,
         double_quotes: bool,
     },
@@ -2207,7 +2299,8 @@ pub enum MoreThanOneCharSugg {
     #[suggestion(
         parse_consider_normalized,
         code = "{normalized}",
-        applicability = "machine-applicable"
+        applicability = "machine-applicable",
+        style = "verbose"
     )]
     NormalizedForm {
         #[primary_span]
@@ -2215,13 +2308,23 @@ pub enum MoreThanOneCharSugg {
         ch: String,
         normalized: String,
     },
-    #[suggestion(parse_remove_non, code = "{ch}", applicability = "maybe-incorrect")]
+    #[suggestion(
+        parse_remove_non,
+        code = "{ch}",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
     RemoveNonPrinting {
         #[primary_span]
         span: Span,
         ch: String,
     },
-    #[suggestion(parse_use_double_quotes, code = "{sugg}", applicability = "machine-applicable")]
+    #[suggestion(
+        parse_use_double_quotes,
+        code = "{sugg}",
+        applicability = "machine-applicable",
+        style = "verbose"
+    )]
     QuotesFull {
         #[primary_span]
         span: Span,
@@ -2259,7 +2362,12 @@ pub enum MoreThanOneCharNote {
 
 #[derive(Subdiagnostic)]
 pub enum NoBraceUnicodeSub {
-    #[suggestion(parse_use_braces, code = "{suggestion}", applicability = "maybe-incorrect")]
+    #[suggestion(
+        parse_use_braces,
+        code = "{suggestion}",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
     Suggestion {
         #[primary_span]
         span: Span,
@@ -2270,26 +2378,31 @@ pub enum NoBraceUnicodeSub {
 }
 
 #[derive(Subdiagnostic)]
+#[multipart_suggestion(parse_sugg_wrap_pattern_in_parens, applicability = "machine-applicable")]
+pub(crate) struct WrapInParens {
+    #[suggestion_part(code = "(")]
+    pub(crate) lo: Span,
+    #[suggestion_part(code = ")")]
+    pub(crate) hi: Span,
+}
+
+#[derive(Subdiagnostic)]
 pub(crate) enum TopLevelOrPatternNotAllowedSugg {
     #[suggestion(
         parse_sugg_remove_leading_vert_in_pattern,
-        code = "{pat}",
-        applicability = "machine-applicable"
+        code = "",
+        applicability = "machine-applicable",
+        style = "verbose"
     )]
     RemoveLeadingVert {
         #[primary_span]
         span: Span,
-        pat: String,
     },
-    #[suggestion(
-        parse_sugg_wrap_pattern_in_parens,
-        code = "({pat})",
-        applicability = "machine-applicable"
-    )]
     WrapInParens {
         #[primary_span]
         span: Span,
-        pat: String,
+        #[subdiagnostic]
+        suggestion: WrapInParens,
     },
 }
 
@@ -2298,7 +2411,7 @@ pub(crate) enum TopLevelOrPatternNotAllowedSugg {
 #[note(parse_note_pattern_alternatives_use_single_vert)]
 pub(crate) struct UnexpectedVertVertBeforeFunctionParam {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
 }
 
@@ -2306,7 +2419,7 @@ pub(crate) struct UnexpectedVertVertBeforeFunctionParam {
 #[diag(parse_unexpected_vert_vert_in_pattern)]
 pub(crate) struct UnexpectedVertVertInPattern {
     #[primary_span]
-    #[suggestion(code = "|", applicability = "machine-applicable")]
+    #[suggestion(code = "|", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
     #[label(parse_label_while_parsing_or_pattern_here)]
     pub start: Option<Span>,
@@ -2316,7 +2429,7 @@ pub(crate) struct UnexpectedVertVertInPattern {
 #[diag(parse_trailing_vert_not_allowed)]
 pub(crate) struct TrailingVertNotAllowed {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
     #[label(parse_label_while_parsing_or_pattern_here)]
     pub start: Option<Span>,
@@ -2329,16 +2442,17 @@ pub(crate) struct TrailingVertNotAllowed {
 #[diag(parse_dotdotdot_rest_pattern)]
 pub(crate) struct DotDotDotRestPattern {
     #[primary_span]
-    #[suggestion(style = "short", code = "..", applicability = "machine-applicable")]
     #[label]
     pub span: Span,
+    #[suggestion(style = "verbose", code = "", applicability = "machine-applicable")]
+    pub suggestion: Span,
 }
 
 #[derive(Diagnostic)]
 #[diag(parse_pattern_on_wrong_side_of_at)]
 pub(crate) struct PatternOnWrongSideOfAt {
     #[primary_span]
-    #[suggestion(code = "{whole_pat}", applicability = "machine-applicable")]
+    #[suggestion(code = "{whole_pat}", applicability = "machine-applicable", style = "verbose")]
     pub whole_span: Span,
     pub whole_pat: String,
     #[label(parse_label_pattern)]
@@ -2359,22 +2473,35 @@ pub(crate) struct ExpectedBindingLeftOfAt {
     pub rhs: Span,
 }
 
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(
+    parse_ambiguous_range_pattern_suggestion,
+    applicability = "machine-applicable"
+)]
+pub(crate) struct ParenRangeSuggestion {
+    #[suggestion_part(code = "(")]
+    pub lo: Span,
+    #[suggestion_part(code = ")")]
+    pub hi: Span,
+}
+
 #[derive(Diagnostic)]
 #[diag(parse_ambiguous_range_pattern)]
 pub(crate) struct AmbiguousRangePattern {
     #[primary_span]
-    #[suggestion(code = "({pat})", applicability = "maybe-incorrect")]
     pub span: Span,
-    pub pat: String,
+    #[subdiagnostic]
+    pub suggestion: ParenRangeSuggestion,
 }
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_lifetime_in_pattern)]
 pub(crate) struct UnexpectedLifetimeInPattern {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
     pub span: Span,
     pub symbol: Symbol,
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
+    pub suggestion: Span,
 }
 
 #[derive(Diagnostic)]
@@ -2383,7 +2510,7 @@ pub(crate) enum InvalidMutInPattern {
     #[note(parse_note_mut_pattern_usage)]
     NestedIdent {
         #[primary_span]
-        #[suggestion(code = "{pat}", applicability = "machine-applicable")]
+        #[suggestion(code = "{pat}", applicability = "machine-applicable", style = "verbose")]
         span: Span,
         pat: String,
     },
@@ -2391,7 +2518,7 @@ pub(crate) enum InvalidMutInPattern {
     #[note(parse_note_mut_pattern_usage)]
     NonIdent {
         #[primary_span]
-        #[suggestion(code = "", applicability = "machine-applicable")]
+        #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
         span: Span,
     },
 }
@@ -2400,7 +2527,7 @@ pub(crate) enum InvalidMutInPattern {
 #[diag(parse_repeated_mut_in_pattern)]
 pub(crate) struct RepeatedMutInPattern {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
 }
 
@@ -2408,7 +2535,7 @@ pub(crate) struct RepeatedMutInPattern {
 #[diag(parse_dot_dot_dot_range_to_pattern_not_allowed)]
 pub(crate) struct DotDotDotRangeToPatternNotAllowed {
     #[primary_span]
-    #[suggestion(style = "short", code = "..=", applicability = "machine-applicable")]
+    #[suggestion(style = "verbose", code = "..=", applicability = "machine-applicable")]
     pub span: Span,
 }
 
@@ -2472,8 +2599,9 @@ pub(crate) struct UnexpectedParenInRangePatSugg {
 #[diag(parse_return_types_use_thin_arrow)]
 pub(crate) struct ReturnTypesUseThinArrow {
     #[primary_span]
-    #[suggestion(style = "short", code = "->", applicability = "machine-applicable")]
     pub span: Span,
+    #[suggestion(style = "verbose", code = " -> ", applicability = "machine-applicable")]
+    pub suggestion: Span,
 }
 
 #[derive(Diagnostic)]
@@ -2488,7 +2616,7 @@ pub(crate) struct NeedPlusAfterTraitObjectLifetime {
 pub(crate) struct ExpectedMutOrConstInRawPointerType {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code("mut ", "const "), applicability = "has-placeholders")]
+    #[suggestion(code("mut ", "const "), applicability = "has-placeholders", style = "verbose")]
     pub after_asterisk: Span,
 }
 
@@ -2497,7 +2625,7 @@ pub(crate) struct ExpectedMutOrConstInRawPointerType {
 pub(crate) struct LifetimeAfterMut {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = "&{snippet} mut", applicability = "maybe-incorrect")]
+    #[suggestion(code = "&{snippet} mut", applicability = "maybe-incorrect", style = "verbose")]
     pub suggest_lifetime: Option<Span>,
     pub snippet: String,
 }
@@ -2506,7 +2634,7 @@ pub(crate) struct LifetimeAfterMut {
 #[diag(parse_dyn_after_mut)]
 pub(crate) struct DynAfterMut {
     #[primary_span]
-    #[suggestion(code = "&mut dyn", applicability = "machine-applicable")]
+    #[suggestion(code = "&mut dyn", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
 }
 
@@ -2515,7 +2643,7 @@ pub(crate) struct DynAfterMut {
 pub(crate) struct FnPointerCannotBeConst {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     #[label]
     pub qualifier: Span,
 }
@@ -2525,7 +2653,7 @@ pub(crate) struct FnPointerCannotBeConst {
 pub(crate) struct FnPointerCannotBeAsync {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     #[label]
     pub qualifier: Span,
 }
@@ -2542,8 +2670,9 @@ pub(crate) struct NestedCVariadicType {
 #[help]
 pub(crate) struct InvalidDynKeyword {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
     pub span: Span,
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
+    pub suggestion: Span,
 }
 
 #[derive(Subdiagnostic)]
@@ -2584,7 +2713,7 @@ pub struct BoxSyntaxRemoved<'a> {
 #[diag(parse_bad_return_type_notation_output)]
 pub(crate) struct BadReturnTypeNotationOutput {
     #[primary_span]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     pub span: Span,
 }
 
@@ -2655,14 +2784,25 @@ pub(crate) struct ModifierLifetime {
     pub modifier: &'static str,
 }
 
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(
+    parse_parenthesized_lifetime_suggestion,
+    applicability = "machine-applicable"
+)]
+pub(crate) struct RemoveParens {
+    #[suggestion_part(code = "")]
+    pub lo: Span,
+    #[suggestion_part(code = "")]
+    pub hi: Span,
+}
+
 #[derive(Diagnostic)]
 #[diag(parse_parenthesized_lifetime)]
 pub(crate) struct ParenthesizedLifetime {
     #[primary_span]
     pub span: Span,
-    #[suggestion(style = "short", applicability = "machine-applicable", code = "{snippet}")]
-    pub sugg: Option<Span>,
-    pub snippet: String,
+    #[subdiagnostic]
+    pub sugg: RemoveParens,
 }
 
 #[derive(Diagnostic)]
@@ -2677,7 +2817,7 @@ pub(crate) struct UnderscoreLiteralSuffix {
 pub(crate) struct ExpectedLabelFoundIdent {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = "'", applicability = "machine-applicable", style = "short")]
+    #[suggestion(code = "'", applicability = "machine-applicable", style = "verbose")]
     pub start: Span,
 }
 
@@ -2696,7 +2836,7 @@ pub(crate) struct InappropriateDefault {
 #[diag(parse_recover_import_as_use)]
 pub(crate) struct RecoverImportAsUse {
     #[primary_span]
-    #[suggestion(code = "use", applicability = "machine-applicable", style = "short")]
+    #[suggestion(code = "use", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
     pub token_name: String,
 }
@@ -2706,7 +2846,7 @@ pub(crate) struct RecoverImportAsUse {
 #[note]
 pub(crate) struct SingleColonImportPath {
     #[primary_span]
-    #[suggestion(code = "::", applicability = "machine-applicable", style = "short")]
+    #[suggestion(code = "::", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
 }
 
@@ -2733,7 +2873,7 @@ pub(crate) struct SingleColonStructType {
 #[diag(parse_equals_struct_default)]
 pub(crate) struct EqualsStructDefault {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
 }
 
@@ -2750,7 +2890,7 @@ pub(crate) struct MacroRulesMissingBang {
 #[diag(parse_macro_name_remove_bang)]
 pub(crate) struct MacroNameRemoveBang {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
 }
 
@@ -2758,7 +2898,7 @@ pub(crate) struct MacroNameRemoveBang {
 #[diag(parse_macro_rules_visibility)]
 pub(crate) struct MacroRulesVisibility<'a> {
     #[primary_span]
-    #[suggestion(code = "#[macro_export]", applicability = "maybe-incorrect")]
+    #[suggestion(code = "#[macro_export]", applicability = "maybe-incorrect", style = "verbose")]
     pub span: Span,
     pub vis: &'a str,
 }
@@ -2768,7 +2908,7 @@ pub(crate) struct MacroRulesVisibility<'a> {
 #[help]
 pub(crate) struct MacroInvocationVisibility<'a> {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
     pub vis: &'a str,
 }
@@ -2778,7 +2918,7 @@ pub(crate) struct MacroInvocationVisibility<'a> {
 pub(crate) struct NestedAdt<'a> {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     pub item: Span,
     pub keyword: &'a str,
     pub kw_str: Cow<'a, str>,
@@ -2818,7 +2958,7 @@ pub(crate) struct BoxNotPat {
 #[diag(parse_unmatched_angle)]
 pub(crate) struct UnmatchedAngle {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
     pub plural: bool,
 }
@@ -2858,7 +2998,7 @@ pub(crate) struct IncorrectParensTraitBoundsSugg {
 #[diag(parse_kw_bad_case)]
 pub(crate) struct KwBadCase<'a> {
     #[primary_span]
-    #[suggestion(code = "{kw}", applicability = "machine-applicable")]
+    #[suggestion(code = "{kw}", style = "verbose", applicability = "machine-applicable")]
     pub span: Span,
     pub kw: &'a str,
 }
@@ -2895,7 +3035,7 @@ pub(crate) struct MetaBadDelimSugg {
 #[note]
 pub(crate) struct MalformedCfgAttr {
     #[primary_span]
-    #[suggestion(code = "{sugg}")]
+    #[suggestion(style = "verbose", code = "{sugg}")]
     pub span: Span,
     pub sugg: &'static str,
 }
@@ -3000,7 +3140,7 @@ pub(crate) struct AsyncImpl {
 #[help]
 pub(crate) struct ExprRArrowCall {
     #[primary_span]
-    #[suggestion(style = "short", applicability = "machine-applicable", code = ".")]
+    #[suggestion(style = "verbose", applicability = "machine-applicable", code = ".")]
     pub span: Span,
 }
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -103,19 +103,26 @@ pub(crate) struct IncorrectUseOfAwait {
     pub span: Span,
 }
 
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(
+    parse_incorrect_use_of_await_postfix_suggestion,
+    applicability = "machine-applicable"
+)]
+pub(crate) struct AwaitSuggestion {
+    #[suggestion_part(code = "")]
+    pub removal: Span,
+    #[suggestion_part(code = ".await{question_mark}")]
+    pub dot_await: Span,
+    pub question_mark: &'static str,
+}
+
 #[derive(Diagnostic)]
 #[diag(parse_incorrect_use_of_await)]
 pub(crate) struct IncorrectAwait {
     #[primary_span]
     pub span: Span,
-    #[suggestion(
-        parse_postfix_suggestion,
-        style = "verbose",
-        code = "{expr}.await{question_mark}"
-    )]
-    pub sugg_span: (Span, Applicability),
-    pub expr: String,
-    pub question_mark: &'static str,
+    #[subdiagnostic]
+    pub suggestion: AwaitSuggestion,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1784,7 +1784,7 @@ pub(crate) struct ExpectedTraitInTraitImplFoundType {
 #[diag(parse_extra_impl_keyword_in_trait_impl)]
 pub(crate) struct ExtraImplKeywordInTraitImpl {
     #[primary_span]
-    #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
+    #[suggestion(code = "", applicability = "maybe-incorrect", style = "short")]
     pub extra_impl_kw: Span,
     #[note]
     pub impl_trait_span: Span,
@@ -2890,7 +2890,7 @@ pub(crate) struct MacroRulesMissingBang {
 #[diag(parse_macro_name_remove_bang)]
 pub(crate) struct MacroNameRemoveBang {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "short")]
     pub span: Span,
 }
 

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -3,8 +3,8 @@ use super::{
     BlockMode, CommaRecoveryMode, Parser, PathStyle, Restrictions, SemiColonMode, SeqSep, TokenType,
 };
 use crate::errors::{
-    AmbiguousPlus, AsyncMoveBlockIn2015, AttributeOnParamType, BadQPathStage2, BadTypePlus,
-    BadTypePlusSub, ColonAsSemi, ComparisonOperatorsCannotBeChained,
+    AddParen, AmbiguousPlus, AsyncMoveBlockIn2015, AttributeOnParamType, BadQPathStage2,
+    BadTypePlus, BadTypePlusSub, ColonAsSemi, ComparisonOperatorsCannotBeChained,
     ComparisonOperatorsCannotBeChainedSugg, ConstGenericWithoutBraces,
     ConstGenericWithoutBracesSugg, DocCommentDoesNotDocumentAnything, DocCommentOnParamType,
     DoubleColonInBound, ExpectedIdentifier, ExpectedSemi, ExpectedSemiSugg,
@@ -566,7 +566,10 @@ impl<'a> Parser<'a> {
             && expected.iter().any(|tok| matches!(tok, TokenType::Token(TokenKind::Eq)))
         {
             // Likely typo: `=` → `==` in let expr or enum item
-            return Err(self.dcx().create_err(UseEqInstead { span: self.token.span }));
+            return Err(self.dcx().create_err(UseEqInstead {
+                span: self.token.span,
+                suggestion: self.token.span.with_lo(self.token.span.lo() + BytePos(1)),
+            }));
         }
 
         if self.token.is_keyword(kw::Move) && self.prev_token.is_keyword(kw::Async) {
@@ -1151,7 +1154,7 @@ impl<'a> Parser<'a> {
             // Eat from where we started until the end token so that parsing can continue
             // as if we didn't have those extra angle brackets.
             self.eat_to_tokens(end);
-            let span = lo.until(self.token.span);
+            let span = lo.to(self.prev_token.span);
 
             let num_extra_brackets = number_of_gt + number_of_shr * 2;
             return Some(self.dcx().emit_err(UnmatchedAngleBrackets { span, num_extra_brackets }));
@@ -1539,7 +1542,10 @@ impl<'a> Parser<'a> {
 
     pub(super) fn maybe_report_ambiguous_plus(&mut self, impl_dyn_multi: bool, ty: &Ty) {
         if impl_dyn_multi {
-            self.dcx().emit_err(AmbiguousPlus { sum_ty: pprust::ty_to_string(ty), span: ty.span });
+            self.dcx().emit_err(AmbiguousPlus {
+                span: ty.span,
+                suggestion: AddParen { lo: ty.span.shrink_to_lo(), hi: ty.span.shrink_to_hi() },
+            });
         }
     }
 
@@ -1608,21 +1614,10 @@ impl<'a> Parser<'a> {
         let sum_span = ty.span.to(self.prev_token.span);
 
         let sub = match &ty.kind {
-            TyKind::Ref(lifetime, mut_ty) => {
-                let sum_with_parens = pprust::to_string(|s| {
-                    s.s.word("&");
-                    s.print_opt_lifetime(lifetime);
-                    s.print_mutability(mut_ty.mutbl, false);
-                    s.popen();
-                    s.print_type(&mut_ty.ty);
-                    if !bounds.is_empty() {
-                        s.word(" + ");
-                        s.print_type_bounds(&bounds);
-                    }
-                    s.pclose()
-                });
-
-                BadTypePlusSub::AddParen { sum_with_parens, span: sum_span }
+            TyKind::Ref(_lifetime, mut_ty) => {
+                let lo = mut_ty.ty.span.shrink_to_lo();
+                let hi = self.prev_token.span.shrink_to_hi();
+                BadTypePlusSub::AddParen { suggestion: AddParen { lo, hi } }
             }
             TyKind::Ptr(..) | TyKind::BareFn(..) => BadTypePlusSub::ForgotParen { span: sum_span },
             _ => BadTypePlusSub::ExpectPath { span: sum_span },

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1610,7 +1610,7 @@ impl<'a> Parser<'a> {
         }
 
         self.bump(); // `+`
-        let bounds = self.parse_generic_bounds()?;
+        let _bounds = self.parse_generic_bounds()?;
         let sum_span = ty.span.to(self.prev_token.span);
 
         let sub = match &ty.kind {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2241,9 +2241,13 @@ impl<'a> Parser<'a> {
             let kw_token = self.token.clone();
             let kw_str = pprust::token_to_string(&kw_token);
             let item = self.parse_item(ForceCollect::No)?;
+            let mut item = item.unwrap().span;
+            if self.token == token::Comma {
+                item = item.to(self.token.span);
+            }
             self.dcx().emit_err(errors::NestedAdt {
                 span: kw_token.span,
-                item: item.unwrap().span,
+                item,
                 kw_str,
                 keyword: keyword.as_str(),
             });

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -4,11 +4,11 @@ use crate::errors::{
     DotDotDotRestPattern, EnumPatternInsteadOfIdentifier, ExpectedBindingLeftOfAt,
     ExpectedCommaAfterPatternField, GenericArgsInPatRequireTurbofishSyntax,
     InclusiveRangeExtraEquals, InclusiveRangeMatchArrow, InclusiveRangeNoEnd, InvalidMutInPattern,
-    PatternOnWrongSideOfAt, RemoveLet, RepeatedMutInPattern, SwitchRefBoxOrder,
-    TopLevelOrPatternNotAllowed, TopLevelOrPatternNotAllowedSugg, TrailingVertNotAllowed,
-    UnexpectedExpressionInPattern, UnexpectedLifetimeInPattern, UnexpectedParenInRangePat,
-    UnexpectedParenInRangePatSugg, UnexpectedVertVertBeforeFunctionParam,
-    UnexpectedVertVertInPattern,
+    ParenRangeSuggestion, PatternOnWrongSideOfAt, RemoveLet, RepeatedMutInPattern,
+    SwitchRefBoxOrder, TopLevelOrPatternNotAllowed, TopLevelOrPatternNotAllowedSugg,
+    TrailingVertNotAllowed, UnexpectedExpressionInPattern, UnexpectedLifetimeInPattern,
+    UnexpectedParenInRangePat, UnexpectedParenInRangePatSugg,
+    UnexpectedVertVertBeforeFunctionParam, UnexpectedVertVertInPattern, WrapInParens,
 };
 use crate::parser::expr::{could_be_unclosed_char_literal, LhsExpr};
 use crate::{maybe_recover_from_interpolated_ty_qpath, maybe_whole};
@@ -24,7 +24,7 @@ use rustc_errors::{Applicability, Diag, PResult};
 use rustc_session::errors::ExprParenthesesNeeded;
 use rustc_span::source_map::{respan, Spanned};
 use rustc_span::symbol::{kw, sym, Ident};
-use rustc_span::{ErrorGuaranteed, Span};
+use rustc_span::{BytePos, ErrorGuaranteed, Span};
 use thin_vec::{thin_vec, ThinVec};
 
 #[derive(PartialEq, Copy, Clone)]
@@ -236,11 +236,15 @@ impl<'a> Parser<'a> {
 
         if let PatKind::Or(pats) = &pat.kind {
             let span = pat.span;
-            let pat = pprust::pat_to_string(&pat);
             let sub = if pats.len() == 1 {
-                Some(TopLevelOrPatternNotAllowedSugg::RemoveLeadingVert { span, pat })
+                Some(TopLevelOrPatternNotAllowedSugg::RemoveLeadingVert {
+                    span: span.with_hi(span.lo() + BytePos(1)),
+                })
             } else {
-                Some(TopLevelOrPatternNotAllowedSugg::WrapInParens { span, pat })
+                Some(TopLevelOrPatternNotAllowedSugg::WrapInParens {
+                    span,
+                    suggestion: WrapInParens { lo: span.shrink_to_lo(), hi: span.shrink_to_hi() },
+                })
             };
 
             let err = self.dcx().create_err(match syntax_loc {
@@ -599,7 +603,10 @@ impl<'a> Parser<'a> {
         self.bump(); // `...`
 
         // The user probably mistook `...` for a rest pattern `..`.
-        self.dcx().emit_err(DotDotDotRestPattern { span: lo });
+        self.dcx().emit_err(DotDotDotRestPattern {
+            span: lo,
+            suggestion: lo.with_lo(lo.hi() - BytePos(1)),
+        });
         PatKind::Rest
     }
 
@@ -664,8 +671,13 @@ impl<'a> Parser<'a> {
             _ => return,
         }
 
-        self.dcx()
-            .emit_err(AmbiguousRangePattern { span: pat.span, pat: pprust::pat_to_string(pat) });
+        self.dcx().emit_err(AmbiguousRangePattern {
+            span: pat.span,
+            suggestion: ParenRangeSuggestion {
+                lo: pat.span.shrink_to_lo(),
+                hi: pat.span.shrink_to_hi(),
+            },
+        });
     }
 
     /// Parse `&pat` / `&mut pat`.
@@ -674,8 +686,11 @@ impl<'a> Parser<'a> {
         if let token::Lifetime(name) = self.token.kind {
             self.bump(); // `'a`
 
-            self.dcx()
-                .emit_err(UnexpectedLifetimeInPattern { span: self.prev_token.span, symbol: name });
+            self.dcx().emit_err(UnexpectedLifetimeInPattern {
+                span: self.prev_token.span,
+                symbol: name,
+                suggestion: self.prev_token.span.until(self.token.span),
+            });
         }
 
         let mutbl = self.parse_mutability();
@@ -913,10 +928,13 @@ impl<'a> Parser<'a> {
                 self.dcx().emit_err(InclusiveRangeExtraEquals { span: span_with_eq })
             }
             token::Gt if no_space => {
-                let after_pat = span.with_hi(span.hi() - rustc_span::BytePos(1)).shrink_to_hi();
+                let after_pat = span.with_hi(span.hi() - BytePos(1)).shrink_to_hi();
                 self.dcx().emit_err(InclusiveRangeMatchArrow { span, arrow: tok.span, after_pat })
             }
-            _ => self.dcx().emit_err(InclusiveRangeNoEnd { span }),
+            _ => self.dcx().emit_err(InclusiveRangeNoEnd {
+                span,
+                suggestion: span.with_lo(span.hi() - BytePos(1)),
+            }),
         }
     }
 

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -258,6 +258,7 @@ impl<'a> Parser<'a> {
                         self.bump(); // bump past the colon
                         self.dcx().emit_err(PathSingleColon {
                             span: self.prev_token.span,
+                            suggestion: self.prev_token.span.shrink_to_hi(),
                             type_ascription: self
                                 .psess
                                 .unstable_features
@@ -329,6 +330,7 @@ impl<'a> Parser<'a> {
                             err.cancel();
                             err = self.dcx().create_err(PathSingleColon {
                                 span: self.token.span,
+                                suggestion: self.prev_token.span.shrink_to_hi(),
                                 type_ascription: self
                                     .psess
                                     .unstable_features

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -430,8 +430,10 @@ impl<'a> Parser<'a> {
         let eq_consumed = match self.token.kind {
             token::BinOpEq(..) => {
                 // Recover `let x <op>= 1` as `let x = 1`
-                self.dcx()
-                    .emit_err(errors::CompoundAssignmentExpressionInLet { span: self.token.span });
+                self.dcx().emit_err(errors::CompoundAssignmentExpressionInLet {
+                    span: self.token.span,
+                    suggestion: self.token.span.with_hi(self.token.span.lo() + BytePos(1)),
+                });
                 self.bump();
                 true
             }
@@ -717,7 +719,7 @@ impl<'a> Parser<'a> {
                                                 e.cancel();
                                                 self.dcx().emit_err(MalformedLoopLabel {
                                                     span: label.ident.span,
-                                                    correct_label: label.ident,
+                                                    suggestion: label.ident.span.shrink_to_lo(),
                                                 });
                                                 *expr = labeled_expr;
                                                 break 'break_recover None;

--- a/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.stdout
@@ -9,9 +9,14 @@ error: expected item, found `;`
   --> $DIR/failed-doctest-extra-semicolon-on-item.rs:12:12
    |
 LL | struct S {}; // unexpected semicolon after struct def
-   |            ^ help: remove this semicolon
+   |            ^
    |
    = help: braced struct declarations are not followed by a semicolon
+help: remove this semicolon
+   |
+LL - struct S {}; // unexpected semicolon after struct def
+LL + struct S {} // unexpected semicolon after struct def
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
+++ b/tests/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
@@ -2,115 +2,214 @@ error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:8:13
    |
 LL |     let _ = await bar();
-   |             ^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
+   |             ^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = bar().await;
+   |             ~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:12:13
    |
 LL |     let _ = await? bar();
-   |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await?`
+   |             ^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = bar().await?;
+   |             ~~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:16:13
    |
 LL |     let _ = await bar()?;
-   |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `bar()?.await`
+   |             ^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = bar()?.await;
+   |             ~~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:20:13
    |
 LL |     let _ = await { bar() };
-   |             ^^^^^^^^^^^^^^^ help: `await` is a postfix operation: `{ bar() }.await`
+   |             ^^^^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = { bar() }.await;
+   |             ~~~~~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:24:13
    |
 LL |     let _ = await(bar());
-   |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `(bar()).await`
+   |             ^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = (bar()).await;
+   |             ~~~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:28:13
    |
 LL |     let _ = await { bar() }?;
-   |             ^^^^^^^^^^^^^^^ help: `await` is a postfix operation: `{ bar() }.await`
+   |             ^^^^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = { bar() }.await?;
+   |             ~~~~~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:32:14
    |
 LL |     let _ = (await bar())?;
-   |              ^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
+   |              ^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = (bar().await)?;
+   |              ~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:36:24
    |
 LL |     let _ = bar().await();
-   |                        ^^ help: `await` is not a method call, remove the parentheses
+   |                        ^^
+   |
+help: `await` is not a method call, remove the parentheses
+   |
+LL -     let _ = bar().await();
+LL +     let _ = bar().await;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:40:24
    |
 LL |     let _ = bar().await()?;
-   |                        ^^ help: `await` is not a method call, remove the parentheses
+   |                        ^^
+   |
+help: `await` is not a method call, remove the parentheses
+   |
+LL -     let _ = bar().await()?;
+LL +     let _ = bar().await?;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:52:13
    |
 LL |     let _ = await bar();
-   |             ^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
+   |             ^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = bar().await;
+   |             ~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:56:13
    |
 LL |     let _ = await? bar();
-   |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await?`
+   |             ^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = bar().await?;
+   |             ~~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:60:13
    |
 LL |     let _ = await bar()?;
-   |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `bar()?.await`
+   |             ^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = bar()?.await;
+   |             ~~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:64:14
    |
 LL |     let _ = (await bar())?;
-   |              ^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
+   |              ^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = (bar().await)?;
+   |              ~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:68:24
    |
 LL |     let _ = bar().await();
-   |                        ^^ help: `await` is not a method call, remove the parentheses
+   |                        ^^
+   |
+help: `await` is not a method call, remove the parentheses
+   |
+LL -     let _ = bar().await();
+LL +     let _ = bar().await;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:73:24
    |
 LL |     let _ = bar().await()?;
-   |                        ^^ help: `await` is not a method call, remove the parentheses
+   |                        ^^
+   |
+help: `await` is not a method call, remove the parentheses
+   |
+LL -     let _ = bar().await()?;
+LL +     let _ = bar().await?;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:101:13
    |
 LL |     let _ = await!(bar());
-   |             ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
+   |             ^^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = bar().await;
+   |             ~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:105:13
    |
 LL |     let _ = await!(bar())?;
-   |             ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
+   |             ^^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     let _ = bar().await?;
+   |             ~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:110:17
    |
 LL |         let _ = await!(bar())?;
-   |                 ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
+   |                 ^^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |         let _ = bar().await?;
+   |                 ~~~~~~~~~~~
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:117:17
    |
 LL |         let _ = await!(bar())?;
-   |                 ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
+   |                 ^^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |         let _ = bar().await?;
+   |                 ~~~~~~~~~~~
 
 error: expected expression, found `=>`
   --> $DIR/incorrect-syntax-suggestions.rs:124:25
@@ -124,7 +223,12 @@ error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:124:11
    |
 LL |     match await { await => () }
-   |           ^^^^^^^^^^^^^^^^^^^^^ help: `await` is a postfix operation: `{ await => () }.await`
+   |           ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     match { await => () }.await
+   |           ~~~~~~~~~~~~~~~~~~~~~
 
 error: expected one of `.`, `?`, `{`, or an operator, found `}`
   --> $DIR/incorrect-syntax-suggestions.rs:127:1

--- a/tests/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
+++ b/tests/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
@@ -6,8 +6,9 @@ LL |     let _ = await bar();
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = bar().await;
-   |             ~~~~~~~~~~~
+LL -     let _ = await bar();
+LL +     let _ = bar().await;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:12:13
@@ -17,8 +18,9 @@ LL |     let _ = await? bar();
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = bar().await?;
-   |             ~~~~~~~~~~~~
+LL -     let _ = await? bar();
+LL +     let _ = bar().await?;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:16:13
@@ -28,8 +30,9 @@ LL |     let _ = await bar()?;
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = bar()?.await;
-   |             ~~~~~~~~~~~~
+LL -     let _ = await bar()?;
+LL +     let _ = bar()?.await;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:20:13
@@ -39,8 +42,9 @@ LL |     let _ = await { bar() };
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = { bar() }.await;
-   |             ~~~~~~~~~~~~~~~
+LL -     let _ = await { bar() };
+LL +     let _ = { bar() }.await;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:24:13
@@ -50,8 +54,9 @@ LL |     let _ = await(bar());
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = (bar()).await;
-   |             ~~~~~~~~~~~~~
+LL -     let _ = await(bar());
+LL +     let _ = (bar()).await;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:28:13
@@ -61,8 +66,9 @@ LL |     let _ = await { bar() }?;
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = { bar() }.await?;
-   |             ~~~~~~~~~~~~~~~
+LL -     let _ = await { bar() }?;
+LL +     let _ = { bar() }.await?;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:32:14
@@ -72,8 +78,9 @@ LL |     let _ = (await bar())?;
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = (bar().await)?;
-   |              ~~~~~~~~~~~
+LL -     let _ = (await bar())?;
+LL +     let _ = (bar().await)?;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:36:24
@@ -107,8 +114,9 @@ LL |     let _ = await bar();
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = bar().await;
-   |             ~~~~~~~~~~~
+LL -     let _ = await bar();
+LL +     let _ = bar().await;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:56:13
@@ -118,8 +126,9 @@ LL |     let _ = await? bar();
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = bar().await?;
-   |             ~~~~~~~~~~~~
+LL -     let _ = await? bar();
+LL +     let _ = bar().await?;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:60:13
@@ -129,8 +138,9 @@ LL |     let _ = await bar()?;
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = bar()?.await;
-   |             ~~~~~~~~~~~~
+LL -     let _ = await bar()?;
+LL +     let _ = bar()?.await;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:64:14
@@ -140,8 +150,9 @@ LL |     let _ = (await bar())?;
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = (bar().await)?;
-   |              ~~~~~~~~~~~
+LL -     let _ = (await bar())?;
+LL +     let _ = (bar().await)?;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:68:24
@@ -175,8 +186,9 @@ LL |     let _ = await!(bar());
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = bar().await;
-   |             ~~~~~~~~~~~
+LL -     let _ = await!(bar());
+LL +     let _ = bar().await);
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:105:13
@@ -186,8 +198,9 @@ LL |     let _ = await!(bar())?;
    |
 help: `await` is a postfix operation
    |
-LL |     let _ = bar().await?;
-   |             ~~~~~~~~~~~
+LL -     let _ = await!(bar())?;
+LL +     let _ = bar().await)?;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:110:17
@@ -197,8 +210,9 @@ LL |         let _ = await!(bar())?;
    |
 help: `await` is a postfix operation
    |
-LL |         let _ = bar().await?;
-   |                 ~~~~~~~~~~~
+LL -         let _ = await!(bar())?;
+LL +         let _ = bar().await)?;
+   |
 
 error: incorrect use of `await`
   --> $DIR/incorrect-syntax-suggestions.rs:117:17
@@ -208,8 +222,9 @@ LL |         let _ = await!(bar())?;
    |
 help: `await` is a postfix operation
    |
-LL |         let _ = bar().await?;
-   |                 ~~~~~~~~~~~
+LL -         let _ = await!(bar())?;
+LL +         let _ = bar().await)?;
+   |
 
 error: expected expression, found `=>`
   --> $DIR/incorrect-syntax-suggestions.rs:124:25
@@ -227,8 +242,9 @@ LL |     match await { await => () }
    |
 help: `await` is a postfix operation
    |
-LL |     match { await => () }.await
-   |           ~~~~~~~~~~~~~~~~~~~~~
+LL -     match await { await => () }
+LL +     match { await => () }.await
+   |
 
 error: expected one of `.`, `?`, `{`, or an operator, found `}`
   --> $DIR/incorrect-syntax-suggestions.rs:127:1

--- a/tests/ui/attributes/issue-90873.stderr
+++ b/tests/ui/attributes/issue-90873.stderr
@@ -32,7 +32,12 @@ error: missing type for `static` item
   --> $DIR/issue-90873.rs:1:17
    |
 LL | #![u=||{static d=||1;}]
-   |                 ^ help: provide a type for the item: `: <type>`
+   |                 ^
+   |
+help: provide a type for the item
+   |
+LL | #![u=||{static d: <type>=||1;}]
+   |                 ++++++++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/conditional-compilation/cfg-attr-parse.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-parse.stderr
@@ -2,9 +2,13 @@ error: malformed `cfg_attr` attribute input
   --> $DIR/cfg-attr-parse.rs:4:1
    |
 LL | #[cfg_attr()]
-   | ^^^^^^^^^^^^^ help: missing condition and attribute: `#[cfg_attr(condition, attribute, other_attribute, ...)]`
+   | ^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: missing condition and attribute
+   |
+LL | #[cfg_attr(condition, attribute, other_attribute, ...)]
+   | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: expected `,`, found end of `cfg_attr` input
   --> $DIR/cfg-attr-parse.rs:8:17

--- a/tests/ui/consts/const-eval/issue-104390.stderr
+++ b/tests/ui/consts/const-eval/issue-104390.stderr
@@ -38,28 +38,43 @@ error: borrow expressions cannot be annotated with lifetimes
   --> $DIR/issue-104390.rs:3:25
    |
 LL | fn f3() -> impl Sized { &'a 2E }
-   |                         ^--^^^
+   |                         ^---^^
    |                          |
    |                          annotated with lifetime here
-   |                          help: remove the lifetime annotation
+   |
+help: remove the lifetime annotation
+   |
+LL - fn f3() -> impl Sized { &'a 2E }
+LL + fn f3() -> impl Sized { &2E }
+   |
 
 error: borrow expressions cannot be annotated with lifetimes
   --> $DIR/issue-104390.rs:5:25
    |
 LL | fn f4() -> impl Sized { &'static 2E }
-   |                         ^-------^^^
+   |                         ^--------^^
    |                          |
    |                          annotated with lifetime here
-   |                          help: remove the lifetime annotation
+   |
+help: remove the lifetime annotation
+   |
+LL - fn f4() -> impl Sized { &'static 2E }
+LL + fn f4() -> impl Sized { &2E }
+   |
 
 error: borrow expressions cannot be annotated with lifetimes
   --> $DIR/issue-104390.rs:8:25
    |
 LL | fn f6() -> impl Sized { &'_ 2E }
-   |                         ^--^^^
+   |                         ^---^^
    |                          |
    |                          annotated with lifetime here
-   |                          help: remove the lifetime annotation
+   |
+help: remove the lifetime annotation
+   |
+LL - fn f6() -> impl Sized { &'_ 2E }
+LL + fn f6() -> impl Sized { &2E }
+   |
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/coverage-attr/bad-syntax.stderr
+++ b/tests/ui/coverage-attr/bad-syntax.stderr
@@ -106,10 +106,13 @@ error: expected identifier, found `,`
   --> $DIR/bad-syntax.rs:42:12
    |
 LL | #[coverage(,off)]
-   |            ^
-   |            |
-   |            expected identifier
-   |            help: remove this comma
+   |            ^ expected identifier
+   |
+help: remove this comma
+   |
+LL - #[coverage(,off)]
+LL + #[coverage(off)]
+   |
 
 error: multiple `coverage` attributes
   --> $DIR/bad-syntax.rs:7:1

--- a/tests/ui/did_you_mean/E0178.stderr
+++ b/tests/ui/did_you_mean/E0178.stderr
@@ -2,19 +2,34 @@ error[E0178]: expected a path on the left-hand side of `+`, not `&'a Foo`
   --> $DIR/E0178.rs:6:8
    |
 LL |     w: &'a Foo + Copy,
-   |        ^^^^^^^^^^^^^^ help: try adding parentheses: `&'a (Foo + Copy)`
+   |        ^^^^^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL |     w: &'a (Foo + Copy),
+   |            +          +
 
 error[E0178]: expected a path on the left-hand side of `+`, not `&'a Foo`
   --> $DIR/E0178.rs:7:8
    |
 LL |     x: &'a Foo + 'a,
-   |        ^^^^^^^^^^^^ help: try adding parentheses: `&'a (Foo + 'a)`
+   |        ^^^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL |     x: &'a (Foo + 'a),
+   |            +        +
 
 error[E0178]: expected a path on the left-hand side of `+`, not `&'a mut Foo`
   --> $DIR/E0178.rs:8:8
    |
 LL |     y: &'a mut Foo + 'a,
-   |        ^^^^^^^^^^^^^^^^ help: try adding parentheses: `&'a mut (Foo + 'a)`
+   |        ^^^^^^^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL |     y: &'a mut (Foo + 'a),
+   |                +        +
 
 error[E0178]: expected a path on the left-hand side of `+`, not `fn() -> Foo`
   --> $DIR/E0178.rs:9:8

--- a/tests/ui/did_you_mean/issue-41679-tilde-bitwise-negation-attempt.stderr
+++ b/tests/ui/did_you_mean/issue-41679-tilde-bitwise-negation-attempt.stderr
@@ -2,39 +2,56 @@ error: `~` cannot be used as a unary operator
   --> $DIR/issue-41679-tilde-bitwise-negation-attempt.rs:4:14
    |
 LL |     let _x = ~1;
-   |              ^ help: use `!` to perform bitwise not
+   |              ^
+   |
+help: use `!` to perform bitwise not
+   |
+LL |     let _x = !1;
+   |              ~
 
 error: unexpected `1` after identifier
   --> $DIR/issue-41679-tilde-bitwise-negation-attempt.rs:5:18
    |
 LL |     let _y = not 1;
-   |              ----^
-   |              |
-   |              help: use `!` to perform bitwise not
+   |                  ^
+   |
+help: use `!` to perform bitwise not
+   |
+LL |     let _y = !1;
+   |              ~
 
 error: unexpected keyword `false` after identifier
   --> $DIR/issue-41679-tilde-bitwise-negation-attempt.rs:6:18
    |
 LL |     let _z = not false;
-   |              ----^^^^^
-   |              |
-   |              help: use `!` to perform logical negation
+   |                  ^^^^^
+   |
+help: use `!` to perform logical negation
+   |
+LL |     let _z = !false;
+   |              ~
 
 error: unexpected keyword `true` after identifier
   --> $DIR/issue-41679-tilde-bitwise-negation-attempt.rs:7:18
    |
 LL |     let _a = not true;
-   |              ----^^^^
-   |              |
-   |              help: use `!` to perform logical negation
+   |                  ^^^^
+   |
+help: use `!` to perform logical negation
+   |
+LL |     let _a = !true;
+   |              ~
 
 error: unexpected `v` after identifier
   --> $DIR/issue-41679-tilde-bitwise-negation-attempt.rs:9:18
    |
 LL |     let _v = not v;
-   |              ----^
-   |              |
-   |              help: use `!` to perform logical negation or bitwise not
+   |                  ^
+   |
+help: use `!` to perform logical negation or bitwise not
+   |
+LL |     let _v = !v;
+   |              ~
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/did_you_mean/issue-46836-identifier-not-instead-of-negation.stderr
+++ b/tests/ui/did_you_mean/issue-46836-identifier-not-instead-of-negation.stderr
@@ -2,25 +2,34 @@ error: unexpected `for_you` after identifier
   --> $DIR/issue-46836-identifier-not-instead-of-negation.rs:3:12
    |
 LL |     if not for_you {
-   |        ----^^^^^^^
-   |        |
-   |        help: use `!` to perform logical negation or bitwise not
+   |            ^^^^^^^
+   |
+help: use `!` to perform logical negation or bitwise not
+   |
+LL |     if !for_you {
+   |        ~
 
 error: unexpected `the_worst` after identifier
   --> $DIR/issue-46836-identifier-not-instead-of-negation.rs:11:15
    |
 LL |     while not the_worst {
-   |           ----^^^^^^^^^
-   |           |
-   |           help: use `!` to perform logical negation or bitwise not
+   |               ^^^^^^^^^
+   |
+help: use `!` to perform logical negation or bitwise not
+   |
+LL |     while !the_worst {
+   |           ~
 
 error: unexpected `println` after identifier
   --> $DIR/issue-46836-identifier-not-instead-of-negation.rs:20:9
    |
-LL |     if not  // lack of braces is [sic]
-   |        ----- help: use `!` to perform logical negation or bitwise not
 LL |         println!("Then when?");
    |         ^^^^^^^
+   |
+help: use `!` to perform logical negation or bitwise not
+   |
+LL |     if !// lack of braces is [sic]
+   |        ~
 
 error: expected `{`, found `;`
   --> $DIR/issue-46836-identifier-not-instead-of-negation.rs:20:31
@@ -40,17 +49,23 @@ error: unexpected `2` after identifier
   --> $DIR/issue-46836-identifier-not-instead-of-negation.rs:26:24
    |
 LL |     let resource = not 2;
-   |                    ----^
-   |                    |
-   |                    help: use `!` to perform bitwise not
+   |                        ^
+   |
+help: use `!` to perform bitwise not
+   |
+LL |     let resource = !2;
+   |                    ~
 
 error: unexpected `be_smothered_out_before` after identifier
   --> $DIR/issue-46836-identifier-not-instead-of-negation.rs:32:27
    |
 LL |     let young_souls = not be_smothered_out_before;
-   |                       ----^^^^^^^^^^^^^^^^^^^^^^^
-   |                       |
-   |                       help: use `!` to perform logical negation or bitwise not
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `!` to perform logical negation or bitwise not
+   |
+LL |     let young_souls = !be_smothered_out_before;
+   |                       ~
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/did_you_mean/issue-54109-and_instead_of_ampersands.stderr
+++ b/tests/ui/did_you_mean/issue-54109-and_instead_of_ampersands.stderr
@@ -2,65 +2,97 @@ error: `and` is not a logical operator
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:7:15
    |
 LL |     let _ = a and b;
-   |               ^^^ help: use `&&` to perform logical conjunction
+   |               ^^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `&&` to perform logical conjunction
+   |
+LL |     let _ = a && b;
+   |               ~~
 
 error: `and` is not a logical operator
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:9:10
    |
 LL |     if a and b {
-   |          ^^^ help: use `&&` to perform logical conjunction
+   |          ^^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `&&` to perform logical conjunction
+   |
+LL |     if a && b {
+   |          ~~
 
 error: `or` is not a logical operator
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:20:15
    |
 LL |     let _ = a or b;
-   |               ^^ help: use `||` to perform logical disjunction
+   |               ^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `||` to perform logical disjunction
+   |
+LL |     let _ = a || b;
+   |               ~~
 
 error: `or` is not a logical operator
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:22:10
    |
 LL |     if a or b {
-   |          ^^ help: use `||` to perform logical disjunction
+   |          ^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `||` to perform logical disjunction
+   |
+LL |     if a || b {
+   |          ~~
 
 error: `and` is not a logical operator
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:30:11
    |
 LL |     if (a and b) {
-   |           ^^^ help: use `&&` to perform logical conjunction
+   |           ^^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `&&` to perform logical conjunction
+   |
+LL |     if (a && b) {
+   |           ~~
 
 error: `or` is not a logical operator
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:38:11
    |
 LL |     if (a or b) {
-   |           ^^ help: use `||` to perform logical disjunction
+   |           ^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `||` to perform logical disjunction
+   |
+LL |     if (a || b) {
+   |           ~~
 
 error: `and` is not a logical operator
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:46:13
    |
 LL |     while a and b {
-   |             ^^^ help: use `&&` to perform logical conjunction
+   |             ^^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `&&` to perform logical conjunction
+   |
+LL |     while a && b {
+   |             ~~
 
 error: `or` is not a logical operator
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:54:13
    |
 LL |     while a or b {
-   |             ^^ help: use `||` to perform logical disjunction
+   |             ^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `||` to perform logical disjunction
+   |
+LL |     while a || b {
+   |             ~~
 
 error[E0308]: mismatched types
   --> $DIR/issue-54109-and_instead_of_ampersands.rs:13:33

--- a/tests/ui/did_you_mean/issue-54109-without-witness.stderr
+++ b/tests/ui/did_you_mean/issue-54109-without-witness.stderr
@@ -2,65 +2,97 @@ error: `and` is not a logical operator
   --> $DIR/issue-54109-without-witness.rs:13:15
    |
 LL |     let _ = a and b;
-   |               ^^^ help: use `&&` to perform logical conjunction
+   |               ^^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `&&` to perform logical conjunction
+   |
+LL |     let _ = a && b;
+   |               ~~
 
 error: `and` is not a logical operator
   --> $DIR/issue-54109-without-witness.rs:15:10
    |
 LL |     if a and b {
-   |          ^^^ help: use `&&` to perform logical conjunction
+   |          ^^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `&&` to perform logical conjunction
+   |
+LL |     if a && b {
+   |          ~~
 
 error: `or` is not a logical operator
   --> $DIR/issue-54109-without-witness.rs:24:15
    |
 LL |     let _ = a or b;
-   |               ^^ help: use `||` to perform logical disjunction
+   |               ^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `||` to perform logical disjunction
+   |
+LL |     let _ = a || b;
+   |               ~~
 
 error: `or` is not a logical operator
   --> $DIR/issue-54109-without-witness.rs:26:10
    |
 LL |     if a or b {
-   |          ^^ help: use `||` to perform logical disjunction
+   |          ^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `||` to perform logical disjunction
+   |
+LL |     if a || b {
+   |          ~~
 
 error: `and` is not a logical operator
   --> $DIR/issue-54109-without-witness.rs:34:11
    |
 LL |     if (a and b) {
-   |           ^^^ help: use `&&` to perform logical conjunction
+   |           ^^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `&&` to perform logical conjunction
+   |
+LL |     if (a && b) {
+   |           ~~
 
 error: `or` is not a logical operator
   --> $DIR/issue-54109-without-witness.rs:42:11
    |
 LL |     if (a or b) {
-   |           ^^ help: use `||` to perform logical disjunction
+   |           ^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `||` to perform logical disjunction
+   |
+LL |     if (a || b) {
+   |           ~~
 
 error: `and` is not a logical operator
   --> $DIR/issue-54109-without-witness.rs:50:13
    |
 LL |     while a and b {
-   |             ^^^ help: use `&&` to perform logical conjunction
+   |             ^^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `&&` to perform logical conjunction
+   |
+LL |     while a && b {
+   |             ~~
 
 error: `or` is not a logical operator
   --> $DIR/issue-54109-without-witness.rs:58:13
    |
 LL |     while a or b {
-   |             ^^ help: use `||` to perform logical disjunction
+   |             ^^
    |
    = note: unlike in e.g., Python and PHP, `&&` and `||` are used for logical operators
+help: use `||` to perform logical disjunction
+   |
+LL |     while a || b {
+   |             ~~
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/did_you_mean/pub-macro-rules.stderr
+++ b/tests/ui/did_you_mean/pub-macro-rules.stderr
@@ -2,7 +2,12 @@ error: can't qualify macro_rules invocation with `pub`
   --> $DIR/pub-macro-rules.rs:2:5
    |
 LL |     pub macro_rules! foo {
-   |     ^^^ help: try exporting the macro: `#[macro_export]`
+   |     ^^^
+   |
+help: try exporting the macro
+   |
+LL |     #[macro_export] macro_rules! foo {
+   |     ~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
+++ b/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
@@ -2,13 +2,23 @@ error[E0178]: expected a path on the left-hand side of `+`, not `&Copy`
   --> $DIR/trait-object-reference-without-parens-suggestion.rs:4:12
    |
 LL |     let _: &Copy + 'static;
-   |            ^^^^^^^^^^^^^^^ help: try adding parentheses: `&(Copy + 'static)`
+   |            ^^^^^^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL |     let _: &(Copy + 'static);
+   |             +              +
 
 error[E0178]: expected a path on the left-hand side of `+`, not `&'static Copy`
   --> $DIR/trait-object-reference-without-parens-suggestion.rs:6:12
    |
 LL |     let _: &'static Copy + 'static;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^ help: try adding parentheses: `&'static (Copy + 'static)`
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL |     let _: &'static (Copy + 'static);
+   |                     +              +
 
 error[E0038]: the trait `Copy` cannot be made into an object
   --> $DIR/trait-object-reference-without-parens-suggestion.rs:4:12

--- a/tests/ui/did_you_mean/use_instead_of_import.stderr
+++ b/tests/ui/did_you_mean/use_instead_of_import.stderr
@@ -2,25 +2,45 @@ error: expected item, found `import`
   --> $DIR/use_instead_of_import.rs:3:1
    |
 LL | import std::{
-   | ^^^^^^ help: items are imported using the `use` keyword
+   | ^^^^^^
+   |
+help: items are imported using the `use` keyword
+   |
+LL | use std::{
+   | ~~~
 
 error: expected item, found `require`
   --> $DIR/use_instead_of_import.rs:9:1
    |
 LL | require std::time::Duration;
-   | ^^^^^^^ help: items are imported using the `use` keyword
+   | ^^^^^^^
+   |
+help: items are imported using the `use` keyword
+   |
+LL | use std::time::Duration;
+   | ~~~
 
 error: expected item, found `include`
   --> $DIR/use_instead_of_import.rs:12:1
    |
 LL | include std::time::Instant;
-   | ^^^^^^^ help: items are imported using the `use` keyword
+   | ^^^^^^^
+   |
+help: items are imported using the `use` keyword
+   |
+LL | use std::time::Instant;
+   | ~~~
 
 error: expected item, found `using`
   --> $DIR/use_instead_of_import.rs:15:5
    |
 LL | pub using std::io;
-   |     ^^^^^ help: items are imported using the `use` keyword
+   |     ^^^^^
+   |
+help: items are imported using the `use` keyword
+   |
+LL | pub use std::io;
+   |     ~~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/enum/nested-enum.rs
+++ b/tests/ui/enum/nested-enum.rs
@@ -1,7 +1,10 @@
 enum Foo {
-    enum Bar { Baz }, //~ ERROR `enum` definition cannot be nested inside `enum`
-    struct Quux { field: u8 }, //~ ERROR `struct` definition cannot be nested inside `enum`
-    union Wibble { field: u8 }, //~ ERROR `union` definition cannot be nested inside `enum`
+    enum Bar { Baz },
+    //~^ ERROR `enum` definition cannot be nested inside `enum`
+    struct Quux { field: u8 },
+    //~^ ERROR `struct` definition cannot be nested inside `enum`
+    union Wibble { field: u8 },
+    //~^ ERROR `union` definition cannot be nested inside `enum`
     Bat,
 }
 

--- a/tests/ui/enum/nested-enum.stderr
+++ b/tests/ui/enum/nested-enum.stderr
@@ -7,11 +7,10 @@ LL |     enum Bar { Baz },
 help: consider creating a new `enum` definition instead of nesting
    |
 LL -     enum Bar { Baz },
-LL +
    |
 
 error: `struct` definition cannot be nested inside `enum`
-  --> $DIR/nested-enum.rs:3:5
+  --> $DIR/nested-enum.rs:4:5
    |
 LL |     struct Quux { field: u8 },
    |     ^^^^^^
@@ -19,11 +18,10 @@ LL |     struct Quux { field: u8 },
 help: consider creating a new `struct` definition instead of nesting
    |
 LL -     struct Quux { field: u8 },
-LL +
    |
 
 error: `union` definition cannot be nested inside `enum`
-  --> $DIR/nested-enum.rs:4:5
+  --> $DIR/nested-enum.rs:6:5
    |
 LL |     union Wibble { field: u8 },
    |     ^^^^^
@@ -31,7 +29,6 @@ LL |     union Wibble { field: u8 },
 help: consider creating a new `union` definition instead of nesting
    |
 LL -     union Wibble { field: u8 },
-LL +
    |
 
 error: aborting due to 3 previous errors

--- a/tests/ui/enum/nested-enum.stderr
+++ b/tests/ui/enum/nested-enum.stderr
@@ -2,25 +2,37 @@ error: `enum` definition cannot be nested inside `enum`
   --> $DIR/nested-enum.rs:2:5
    |
 LL |     enum Bar { Baz },
-   |     ^^^^------------
-   |     |
-   |     help: consider creating a new `enum` definition instead of nesting
+   |     ^^^^
+   |
+help: consider creating a new `enum` definition instead of nesting
+   |
+LL -     enum Bar { Baz },
+LL +
+   |
 
 error: `struct` definition cannot be nested inside `enum`
   --> $DIR/nested-enum.rs:3:5
    |
 LL |     struct Quux { field: u8 },
-   |     ^^^^^^-------------------
-   |     |
-   |     help: consider creating a new `struct` definition instead of nesting
+   |     ^^^^^^
+   |
+help: consider creating a new `struct` definition instead of nesting
+   |
+LL -     struct Quux { field: u8 },
+LL +
+   |
 
 error: `union` definition cannot be nested inside `enum`
   --> $DIR/nested-enum.rs:4:5
    |
 LL |     union Wibble { field: u8 },
-   |     ^^^^^---------------------
-   |     |
-   |     help: consider creating a new `union` definition instead of nesting
+   |     ^^^^^
+   |
+help: consider creating a new `union` definition instead of nesting
+   |
+LL -     union Wibble { field: u8 },
+LL +
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/error-codes/E0586.stderr
+++ b/tests/ui/error-codes/E0586.stderr
@@ -2,9 +2,14 @@ error[E0586]: inclusive range with no end
   --> $DIR/E0586.rs:3:19
    |
 LL |     let x = &tmp[1..=];
-   |                   ^^^ help: use `..` instead
+   |                   ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     let x = &tmp[1..=];
+LL +     let x = &tmp[1..];
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/expr/if/attrs/else-attrs.stderr
+++ b/tests/ui/expr/if/attrs/else-attrs.stderr
@@ -9,12 +9,17 @@ error: outer attributes are not allowed on `if` and `else` branches
    |
 LL |       } else #[attr] if false {
    |  _______----_^^^^^^^_-
-   | |       |    |
-   | |       |    help: remove the attributes
+   | |       |
    | |       the branch belongs to this `else`
 LL | |     } else {
 LL | |     }
    | |_____- the attributes are attached to this branch
+   |
+help: remove the attributes
+   |
+LL -     } else #[attr] if false {
+LL +     } else if false {
+   |
 
 error: expected expression, found keyword `else`
   --> $DIR/else-attrs.rs:20:15

--- a/tests/ui/extern/extern-const.stderr
+++ b/tests/ui/extern/extern-const.stderr
@@ -2,11 +2,13 @@ error: extern items cannot be `const`
   --> $DIR/extern-const.rs:14:11
    |
 LL |     const rust_dbg_static_mut: c_int;
-   |     ------^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     help: try using a static value: `static`
+   |           ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: try using a static value
+   |
+LL |     static rust_dbg_static_mut: c_int;
+   |     ~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/fmt/format-string-error-2.stderr
+++ b/tests/ui/fmt/format-string-error-2.stderr
@@ -2,7 +2,12 @@ error: incorrect unicode escape sequence
   --> $DIR/format-string-error-2.rs:77:20
    |
 LL |     println!("\x7B}\u8 {", 1);
-   |                    ^^^ help: format of unicode escape sequences uses braces: `\u{8}`
+   |                    ^^^
+   |
+help: format of unicode escape sequences uses braces
+   |
+LL |     println!("\x7B}\u{8} {", 1);
+   |                    ~~~~~
 
 error: invalid format string: expected `'}'`, found `'a'`
   --> $DIR/format-string-error-2.rs:5:5

--- a/tests/ui/fn/fn-recover-return-sign.fixed
+++ b/tests/ui/fn/fn-recover-return-sign.fixed
@@ -3,7 +3,7 @@
 fn a() -> usize { 0 }
 //~^ ERROR return types are denoted using `->`
 
-fn b()-> usize { 0 }
+fn b() -> usize { 0 }
 //~^ ERROR return types are denoted using `->`
 
 fn bar(_: u32) {}
@@ -22,7 +22,7 @@ fn main() {
     //~^ ERROR return types are denoted using `->`
     dbg!(foo(false));
 
-    let bar = |a: bool|-> bool { a };
+    let bar = |a: bool| -> bool { a };
     //~^ ERROR return types are denoted using `->`
     dbg!(bar(false));
 }

--- a/tests/ui/fn/fn-recover-return-sign.stderr
+++ b/tests/ui/fn/fn-recover-return-sign.stderr
@@ -2,25 +2,45 @@ error: return types are denoted using `->`
   --> $DIR/fn-recover-return-sign.rs:3:8
    |
 LL | fn a() => usize { 0 }
-   |        ^^ help: use `->` instead
+   |        ^^
+   |
+help: use `->` instead
+   |
+LL | fn a() -> usize { 0 }
+   |        ~~
 
 error: return types are denoted using `->`
   --> $DIR/fn-recover-return-sign.rs:6:7
    |
 LL | fn b(): usize { 0 }
-   |       ^ help: use `->` instead
+   |       ^
+   |
+help: use `->` instead
+   |
+LL | fn b() -> usize { 0 }
+   |        ~~
 
 error: return types are denoted using `->`
   --> $DIR/fn-recover-return-sign.rs:21:25
    |
 LL |     let foo = |a: bool| => bool { a };
-   |                         ^^ help: use `->` instead
+   |                         ^^
+   |
+help: use `->` instead
+   |
+LL |     let foo = |a: bool| -> bool { a };
+   |                         ~~
 
 error: return types are denoted using `->`
   --> $DIR/fn-recover-return-sign.rs:25:24
    |
 LL |     let bar = |a: bool|: bool { a };
-   |                        ^ help: use `->` instead
+   |                        ^
+   |
+help: use `->` instead
+   |
+LL |     let bar = |a: bool| -> bool { a };
+   |                         ~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/fn/fn-recover-return-sign2.stderr
+++ b/tests/ui/fn/fn-recover-return-sign2.stderr
@@ -2,7 +2,12 @@ error: return types are denoted using `->`
   --> $DIR/fn-recover-return-sign2.rs:4:10
    |
 LL | fn foo() => impl Fn() => bool {
-   |          ^^ help: use `->` instead
+   |          ^^
+   |
+help: use `->` instead
+   |
+LL | fn foo() -> impl Fn() => bool {
+   |          ~~
 
 error: expected one of `+`, `->`, `::`, `where`, or `{`, found `=>`
   --> $DIR/fn-recover-return-sign2.rs:4:23

--- a/tests/ui/generics/issue-95208-ignore-qself.stderr
+++ b/tests/ui/generics/issue-95208-ignore-qself.stderr
@@ -2,9 +2,12 @@ error: expected `:` followed by trait or lifetime
   --> $DIR/issue-95208-ignore-qself.rs:6:88
    |
 LL | impl<T: Iterator> Struct<T> where <T as std:: iter::Iterator>::Item:: std::fmt::Display {
-   |                                                                    ---                 ^
-   |                                                                    |
-   |                                                                    help: use single colon: `:`
+   |                                                                                        ^
+   |
+help: use single colon
+   |
+LL | impl<T: Iterator> Struct<T> where <T as std:: iter::Iterator>::Item: std::fmt::Display {
+   |                                                                    ~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/issue-95208.stderr
+++ b/tests/ui/generics/issue-95208.stderr
@@ -2,9 +2,12 @@ error: expected `:` followed by trait or lifetime
   --> $DIR/issue-95208.rs:6:46
    |
 LL | impl<T> Struct<T> where T:: std::fmt::Display {
-   |                          ---                 ^
-   |                          |
-   |                          help: use single colon: `:`
+   |                                              ^
+   |
+help: use single colon
+   |
+LL | impl<T> Struct<T> where T: std::fmt::Display {
+   |                          ~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/single-colon-path-not-const-generics.stderr
+++ b/tests/ui/generics/single-colon-path-not-const-generics.stderr
@@ -4,9 +4,13 @@ error: path separator must be a double colon
 LL | pub struct Foo {
    |            --- while parsing this struct
 LL |   a: Vec<foo::bar:A>,
-   |                  ^ help: use a double colon instead: `::`
+   |                  ^
    |
    = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: use a double colon instead
+   |
+LL |   a: Vec<foo::bar::A>,
+   |                  ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/single-colon-path-not-const-generics.stderr
+++ b/tests/ui/generics/single-colon-path-not-const-generics.stderr
@@ -10,7 +10,7 @@ LL |   a: Vec<foo::bar:A>,
 help: use a double colon instead
    |
 LL |   a: Vec<foo::bar::A>,
-   |                  ~~
+   |                  +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.stderr
@@ -2,36 +2,60 @@ error: range-to patterns with `...` are not allowed
   --> $DIR/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs:15:9
    |
 LL |         ...X => {}
-   |         ^^^ help: use `..=` instead
+   |         ^^^
+   |
+help: use `..=` instead
+   |
+LL |         ..=X => {}
+   |         ~~~
 
 error: range-to patterns with `...` are not allowed
   --> $DIR/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs:16:9
    |
 LL |         ...0 => {}
-   |         ^^^ help: use `..=` instead
+   |         ^^^
+   |
+help: use `..=` instead
+   |
+LL |         ..=0 => {}
+   |         ~~~
 
 error: range-to patterns with `...` are not allowed
   --> $DIR/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs:17:9
    |
 LL |         ...'a' => {}
-   |         ^^^ help: use `..=` instead
+   |         ^^^
+   |
+help: use `..=` instead
+   |
+LL |         ..='a' => {}
+   |         ~~~
 
 error: range-to patterns with `...` are not allowed
   --> $DIR/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs:18:9
    |
 LL |         ...0.0f32 => {}
-   |         ^^^ help: use `..=` instead
+   |         ^^^
+   |
+help: use `..=` instead
+   |
+LL |         ..=0.0f32 => {}
+   |         ~~~
 
 error: range-to patterns with `...` are not allowed
   --> $DIR/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs:25:17
    |
 LL |             let ...$e;
-   |                 ^^^ help: use `..=` instead
+   |                 ^^^
 ...
 LL |     mac!(0);
    |     ------- in this macro invocation
    |
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `..=` instead
+   |
+LL |             let ..=$e;
+   |                 ~~~
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs:25:17

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.stderr
@@ -2,57 +2,87 @@ error[E0586]: inclusive range with no end
   --> $DIR/half-open-range-pats-inclusive-no-end.rs:8:13
    |
 LL |     if let 0... = 1 {}
-   |             ^^^ help: use `..` instead
+   |             ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let 0... = 1 {}
+LL +     if let 0.. = 1 {}
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/half-open-range-pats-inclusive-no-end.rs:9:13
    |
 LL |     if let 0..= = 1 {}
-   |             ^^^ help: use `..` instead
+   |             ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let 0..= = 1 {}
+LL +     if let 0.. = 1 {}
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/half-open-range-pats-inclusive-no-end.rs:11:13
    |
 LL |     if let X... = 1 {}
-   |             ^^^ help: use `..` instead
+   |             ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let X... = 1 {}
+LL +     if let X.. = 1 {}
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/half-open-range-pats-inclusive-no-end.rs:12:13
    |
 LL |     if let X..= = 1 {}
-   |             ^^^ help: use `..` instead
+   |             ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let X..= = 1 {}
+LL +     if let X.. = 1 {}
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/half-open-range-pats-inclusive-no-end.rs:18:19
    |
 LL |             let $e...;
-   |                   ^^^ help: use `..` instead
+   |                   ^^^
 ...
 LL |     mac!(0);
    |     ------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `..` instead
+   |
+LL -             let $e...;
+LL +             let $e..;
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/half-open-range-pats-inclusive-no-end.rs:20:19
    |
 LL |             let $e..=;
-   |                   ^^^ help: use `..` instead
+   |                   ^^^
 ...
 LL |     mac!(0);
    |     ------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `..` instead
+   |
+LL -             let $e..=;
+LL +             let $e..;
+   |
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/half-open-range-pats-inclusive-no-end.rs:18:17

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-ref-ambiguous-interp.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-ref-ambiguous-interp.stderr
@@ -2,53 +2,93 @@ error: the range pattern here has ambiguous interpretation
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:6:10
    |
 LL |         &0.. | _ => {}
-   |          ^^^ help: add parentheses to clarify the precedence: `(0..)`
+   |          ^^^
+   |
+help: add parentheses to clarify the precedence
+   |
+LL |         &(0..) | _ => {}
+   |          +   +
 
 error[E0586]: inclusive range with no end
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:8:11
    |
 LL |         &0..= | _ => {}
-   |           ^^^ help: use `..` instead
+   |           ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -         &0..= | _ => {}
+LL +         &0.. | _ => {}
+   |
 
 error: the range pattern here has ambiguous interpretation
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:8:10
    |
 LL |         &0..= | _ => {}
-   |          ^^^^ help: add parentheses to clarify the precedence: `(0..=)`
+   |          ^^^^
+   |
+help: add parentheses to clarify the precedence
+   |
+LL |         &(0..=) | _ => {}
+   |          +    +
 
 error[E0586]: inclusive range with no end
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:11:11
    |
 LL |         &0... | _ => {}
-   |           ^^^ help: use `..` instead
+   |           ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -         &0... | _ => {}
+LL +         &0.. | _ => {}
+   |
 
 error: the range pattern here has ambiguous interpretation
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:16:10
    |
 LL |         &..0 | _ => {}
-   |          ^^^ help: add parentheses to clarify the precedence: `(..0)`
+   |          ^^^
+   |
+help: add parentheses to clarify the precedence
+   |
+LL |         &(..0) | _ => {}
+   |          +   +
 
 error: the range pattern here has ambiguous interpretation
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:18:10
    |
 LL |         &..=0 | _ => {}
-   |          ^^^^ help: add parentheses to clarify the precedence: `(..=0)`
+   |          ^^^^
+   |
+help: add parentheses to clarify the precedence
+   |
+LL |         &(..=0) | _ => {}
+   |          +    +
 
 error: range-to patterns with `...` are not allowed
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:20:10
    |
 LL |         &...0 | _ => {}
-   |          ^^^ help: use `..=` instead
+   |          ^^^
+   |
+help: use `..=` instead
+   |
+LL |         &..=0 | _ => {}
+   |          ~~~
 
 error: the range pattern here has ambiguous interpretation
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:20:10
    |
 LL |         &...0 | _ => {}
-   |          ^^^^ help: add parentheses to clarify the precedence: `(..=0)`
+   |          ^^^^
+   |
+help: add parentheses to clarify the precedence
+   |
+LL |         &(...0) | _ => {}
+   |          +    +
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/impl-trait/extra-impl-in-trait-impl.stderr
+++ b/tests/ui/impl-trait/extra-impl-in-trait-impl.stderr
@@ -2,25 +2,35 @@ error: unexpected `impl` keyword
   --> $DIR/extra-impl-in-trait-impl.rs:8:18
    |
 LL | impl<T: Default> impl Default for S<T> {
-   |                  ^^^^^ help: remove the extra `impl`
+   |                  ^^^^^
    |
 note: this is parsed as an `impl Trait` type, but a trait is expected at this position
   --> $DIR/extra-impl-in-trait-impl.rs:8:18
    |
 LL | impl<T: Default> impl Default for S<T> {
    |                  ^^^^^^^^^^^^
+help: remove the extra `impl`
+   |
+LL - impl<T: Default> impl Default for S<T> {
+LL + impl<T: Default> Default for S<T> {
+   |
 
 error: unexpected `impl` keyword
   --> $DIR/extra-impl-in-trait-impl.rs:14:6
    |
 LL | impl impl Default for S2 {
-   |      ^^^^^ help: remove the extra `impl`
+   |      ^^^^^
    |
 note: this is parsed as an `impl Trait` type, but a trait is expected at this position
   --> $DIR/extra-impl-in-trait-impl.rs:14:6
    |
 LL | impl impl Default for S2 {
    |      ^^^^^^^^^^^^
+help: remove the extra `impl`
+   |
+LL - impl impl Default for S2 {
+LL + impl Default for S2 {
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/extra-impl-in-trait-impl.stderr
+++ b/tests/ui/impl-trait/extra-impl-in-trait-impl.stderr
@@ -2,35 +2,25 @@ error: unexpected `impl` keyword
   --> $DIR/extra-impl-in-trait-impl.rs:8:18
    |
 LL | impl<T: Default> impl Default for S<T> {
-   |                  ^^^^^
+   |                  ^^^^^ help: remove the extra `impl`
    |
 note: this is parsed as an `impl Trait` type, but a trait is expected at this position
   --> $DIR/extra-impl-in-trait-impl.rs:8:18
    |
 LL | impl<T: Default> impl Default for S<T> {
    |                  ^^^^^^^^^^^^
-help: remove the extra `impl`
-   |
-LL - impl<T: Default> impl Default for S<T> {
-LL + impl<T: Default> Default for S<T> {
-   |
 
 error: unexpected `impl` keyword
   --> $DIR/extra-impl-in-trait-impl.rs:14:6
    |
 LL | impl impl Default for S2 {
-   |      ^^^^^
+   |      ^^^^^ help: remove the extra `impl`
    |
 note: this is parsed as an `impl Trait` type, but a trait is expected at this position
   --> $DIR/extra-impl-in-trait-impl.rs:14:6
    |
 LL | impl impl Default for S2 {
    |      ^^^^^^^^^^^^
-help: remove the extra `impl`
-   |
-LL - impl impl Default for S2 {
-LL + impl Default for S2 {
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
+++ b/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
@@ -2,13 +2,23 @@ error: ambiguous `+` in a type
   --> $DIR/impl-fn-parsing-ambiguities.rs:4:27
    |
 LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
-   |                           ^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + '_)`
+   |                           ^^^^^^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
+   |                           +               +
 
 error: ambiguous `+` in a type
   --> $DIR/impl-fn-parsing-ambiguities.rs:10:24
    |
 LL | fn b() -> impl Fn() -> impl Debug + Send {
-   |                        ^^^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + Send)`
+   |                        ^^^^^^^^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | fn b() -> impl Fn() -> (impl Debug + Send) {
+   |                        +                 +
 
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
   --> $DIR/impl-fn-parsing-ambiguities.rs:4:40

--- a/tests/ui/impl-trait/impl-trait-plus-priority.stderr
+++ b/tests/ui/impl-trait/impl-trait-plus-priority.stderr
@@ -2,19 +2,34 @@ error: ambiguous `+` in a type
   --> $DIR/impl-trait-plus-priority.rs:23:18
    |
 LL | type A = fn() -> impl A +;
-   |                  ^^^^^^^^ help: use parentheses to disambiguate: `(impl A)`
+   |                  ^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | type A = fn() -> (impl A +);
+   |                  +        +
 
 error: ambiguous `+` in a type
   --> $DIR/impl-trait-plus-priority.rs:25:18
    |
 LL | type A = fn() -> impl A + B;
-   |                  ^^^^^^^^^^ help: use parentheses to disambiguate: `(impl A + B)`
+   |                  ^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | type A = fn() -> (impl A + B);
+   |                  +          +
 
 error: ambiguous `+` in a type
   --> $DIR/impl-trait-plus-priority.rs:27:18
    |
 LL | type A = fn() -> dyn A + B;
-   |                  ^^^^^^^^^ help: use parentheses to disambiguate: `(dyn A + B)`
+   |                  ^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | type A = fn() -> (dyn A + B);
+   |                  +         +
 
 error[E0178]: expected a path on the left-hand side of `+`, not `fn() -> A`
   --> $DIR/impl-trait-plus-priority.rs:29:10
@@ -26,43 +41,78 @@ error: ambiguous `+` in a type
   --> $DIR/impl-trait-plus-priority.rs:32:18
    |
 LL | type A = Fn() -> impl A +;
-   |                  ^^^^^^^^ help: use parentheses to disambiguate: `(impl A)`
+   |                  ^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | type A = Fn() -> (impl A +);
+   |                  +        +
 
 error: ambiguous `+` in a type
   --> $DIR/impl-trait-plus-priority.rs:34:18
    |
 LL | type A = Fn() -> impl A + B;
-   |                  ^^^^^^^^^^ help: use parentheses to disambiguate: `(impl A + B)`
+   |                  ^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | type A = Fn() -> (impl A + B);
+   |                  +          +
 
 error: ambiguous `+` in a type
   --> $DIR/impl-trait-plus-priority.rs:36:18
    |
 LL | type A = Fn() -> dyn A + B;
-   |                  ^^^^^^^^^ help: use parentheses to disambiguate: `(dyn A + B)`
+   |                  ^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | type A = Fn() -> (dyn A + B);
+   |                  +         +
 
 error: ambiguous `+` in a type
   --> $DIR/impl-trait-plus-priority.rs:40:11
    |
 LL | type A = &impl A +;
-   |           ^^^^^^^^ help: use parentheses to disambiguate: `(impl A)`
+   |           ^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | type A = &(impl A +);
+   |           +        +
 
 error: ambiguous `+` in a type
   --> $DIR/impl-trait-plus-priority.rs:42:11
    |
 LL | type A = &impl A + B;
-   |           ^^^^^^^^^^ help: use parentheses to disambiguate: `(impl A + B)`
+   |           ^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | type A = &(impl A + B);
+   |           +          +
 
 error: ambiguous `+` in a type
   --> $DIR/impl-trait-plus-priority.rs:44:11
    |
 LL | type A = &dyn A + B;
-   |           ^^^^^^^^^ help: use parentheses to disambiguate: `(dyn A + B)`
+   |           ^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | type A = &(dyn A + B);
+   |           +         +
 
 error[E0178]: expected a path on the left-hand side of `+`, not `&A`
   --> $DIR/impl-trait-plus-priority.rs:46:10
    |
 LL | type A = &A + B;
-   |          ^^^^^^ help: try adding parentheses: `&(A + B)`
+   |          ^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | type A = &(A + B);
+   |           +     +
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/issues/issue-40782.stderr
+++ b/tests/ui/issues/issue-40782.stderr
@@ -2,13 +2,23 @@ error: missing `in` in `for` loop
   --> $DIR/issue-40782.rs:4:11
    |
 LL |     for _i 0..2 {
-   |           ^ help: try adding `in` here
+   |           ^
+   |
+help: try adding `in` here
+   |
+LL |     for _i in 0..2 {
+   |            ++
 
 error: missing `in` in `for` loop
   --> $DIR/issue-40782.rs:6:12
    |
 LL |     for _i of 0..2 {
-   |            ^^ help: try using `in` here instead
+   |            ^^
+   |
+help: try using `in` here instead
+   |
+LL |     for _i in 0..2 {
+   |            ~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/label/label_misspelled_2.stderr
+++ b/tests/ui/label/label_misspelled_2.stderr
@@ -2,13 +2,23 @@ error: malformed loop label
   --> $DIR/label_misspelled_2.rs:10:5
    |
 LL |     c: for _ in 0..1 {
-   |     ^ help: use the correct loop label format: `'c`
+   |     ^
+   |
+help: use the correct loop label format
+   |
+LL |     'c: for _ in 0..1 {
+   |     +
 
 error: malformed loop label
   --> $DIR/label_misspelled_2.rs:13:5
    |
 LL |     d: for _ in 0..1 {
-   |     ^ help: use the correct loop label format: `'d`
+   |     ^
+   |
+help: use the correct loop label format
+   |
+LL |     'd: for _ in 0..1 {
+   |     +
 
 error[E0425]: cannot find value `b` in this scope
   --> $DIR/label_misspelled_2.rs:8:15

--- a/tests/ui/let-else/let-else-missing-semicolon.stderr
+++ b/tests/ui/let-else/let-else-missing-semicolon.stderr
@@ -2,27 +2,17 @@ error: expected `;`, found keyword `let`
   --> $DIR/let-else-missing-semicolon.rs:4:6
    |
 LL |     }
-   |      ^
+   |      ^ help: add `;` here
 LL |     let _ = "";
    |     --- unexpected token
-   |
-help: add `;` here
-   |
-LL |     };
-   |      +
 
 error: expected `;`, found `}`
   --> $DIR/let-else-missing-semicolon.rs:8:6
    |
 LL |     }
-   |      ^
+   |      ^ help: add `;` here
 LL | }
    | - unexpected token
-   |
-help: add `;` here
-   |
-LL |     };
-   |      +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/let-else/let-else-missing-semicolon.stderr
+++ b/tests/ui/let-else/let-else-missing-semicolon.stderr
@@ -2,17 +2,27 @@ error: expected `;`, found keyword `let`
   --> $DIR/let-else-missing-semicolon.rs:4:6
    |
 LL |     }
-   |      ^ help: add `;` here
+   |      ^
 LL |     let _ = "";
    |     --- unexpected token
+   |
+help: add `;` here
+   |
+LL |     };
+   |      +
 
 error: expected `;`, found `}`
   --> $DIR/let-else-missing-semicolon.rs:8:6
    |
 LL |     }
-   |      ^ help: add `;` here
+   |      ^
 LL | }
    | - unexpected token
+   |
+help: add `;` here
+   |
+LL |     };
+   |      +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lexer/lex-bare-cr-string-literal-doc-comment.stderr
+++ b/tests/ui/lexer/lex-bare-cr-string-literal-doc-comment.stderr
@@ -26,7 +26,12 @@ error: bare CR not allowed in string, use `\r` instead
   --> $DIR/lex-bare-cr-string-literal-doc-comment.rs:19:18
    |
 LL |     let _s = "foobar";
-   |                  ^ help: escape the character: `\r`
+   |                  ^
+   |
+help: escape the character
+   |
+LL |     let _s = "foo\rbar";
+   |                  ++
 
 error: bare CR not allowed in raw string
   --> $DIR/lex-bare-cr-string-literal-doc-comment.rs:22:19

--- a/tests/ui/macros/bang-after-name.stderr
+++ b/tests/ui/macros/bang-after-name.stderr
@@ -2,7 +2,13 @@ error: macro names aren't followed by a `!`
   --> $DIR/bang-after-name.rs:4:17
    |
 LL | macro_rules! foo! {
-   |                 ^ help: remove the `!`
+   |                 ^
+   |
+help: remove the `!`
+   |
+LL - macro_rules! foo! {
+LL + macro_rules! foo {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/bang-after-name.stderr
+++ b/tests/ui/macros/bang-after-name.stderr
@@ -2,13 +2,7 @@ error: macro names aren't followed by a `!`
   --> $DIR/bang-after-name.rs:4:17
    |
 LL | macro_rules! foo! {
-   |                 ^
-   |
-help: remove the `!`
-   |
-LL - macro_rules! foo! {
-LL + macro_rules! foo {
-   |
+   |                 ^ help: remove the `!`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/missing-bang-in-decl.stderr
+++ b/tests/ui/macros/missing-bang-in-decl.stderr
@@ -24,7 +24,13 @@ error: macro names aren't followed by a `!`
   --> $DIR/missing-bang-in-decl.rs:10:16
    |
 LL | macro_rules bar! {
-   |                ^ help: remove the `!`
+   |                ^
+   |
+help: remove the `!`
+   |
+LL - macro_rules bar! {
+LL + macro_rules bar {
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/macros/missing-bang-in-decl.stderr
+++ b/tests/ui/macros/missing-bang-in-decl.stderr
@@ -24,13 +24,7 @@ error: macro names aren't followed by a `!`
   --> $DIR/missing-bang-in-decl.rs:10:16
    |
 LL | macro_rules bar! {
-   |                ^
-   |
-help: remove the `!`
-   |
-LL - macro_rules bar! {
-LL + macro_rules bar {
-   |
+   |                ^ help: remove the `!`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/macros/recovery-allowed.stderr
+++ b/tests/ui/macros/recovery-allowed.stderr
@@ -2,9 +2,12 @@ error: unexpected `1` after identifier
   --> $DIR/recovery-allowed.rs:5:23
    |
 LL | please_recover! { not 1 }
-   |                   ----^
-   |                   |
-   |                   help: use `!` to perform bitwise not
+   |                       ^
+   |
+help: use `!` to perform bitwise not
+   |
+LL | please_recover! { !1 }
+   |                   ~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/malformed/malformed-special-attrs.stderr
+++ b/tests/ui/malformed/malformed-special-attrs.stderr
@@ -2,17 +2,25 @@ error: malformed `cfg_attr` attribute input
   --> $DIR/malformed-special-attrs.rs:1:1
    |
 LL | #[cfg_attr]
-   | ^^^^^^^^^^^ help: missing condition and attribute: `#[cfg_attr(condition, attribute, other_attribute, ...)]`
+   | ^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: missing condition and attribute
+   |
+LL | #[cfg_attr(condition, attribute, other_attribute, ...)]
+   | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: malformed `cfg_attr` attribute input
   --> $DIR/malformed-special-attrs.rs:4:1
    |
 LL | #[cfg_attr = ""]
-   | ^^^^^^^^^^^^^^^^ help: missing condition and attribute: `#[cfg_attr(condition, attribute, other_attribute, ...)]`
+   | ^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: missing condition and attribute
+   |
+LL | #[cfg_attr(condition, attribute, other_attribute, ...)]
+   | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: malformed `derive` attribute input
   --> $DIR/malformed-special-attrs.rs:7:1

--- a/tests/ui/object-safety/avoid-ice-on-warning.new.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning.new.stderr
@@ -2,7 +2,12 @@ error: return types are denoted using `->`
   --> $DIR/avoid-ice-on-warning.rs:4:23
    |
 LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
-   |                       ^ help: use `->` instead
+   |                       ^
+   |
+help: use `->` instead
+   |
+LL | fn call_this<F>(f: F) -> Fn(&str) + call_that {}
+   |                       ~~
 
 error[E0405]: cannot find trait `call_that` in this scope
   --> $DIR/avoid-ice-on-warning.rs:4:36

--- a/tests/ui/object-safety/avoid-ice-on-warning.old.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning.old.stderr
@@ -2,7 +2,12 @@ error: return types are denoted using `->`
   --> $DIR/avoid-ice-on-warning.rs:4:23
    |
 LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
-   |                       ^ help: use `->` instead
+   |                       ^
+   |
+help: use `->` instead
+   |
+LL | fn call_this<F>(f: F) -> Fn(&str) + call_that {}
+   |                       ~~
 
 error[E0405]: cannot find trait `call_that` in this scope
   --> $DIR/avoid-ice-on-warning.rs:4:36

--- a/tests/ui/operator-recovery/less-than-greater-than.stderr
+++ b/tests/ui/operator-recovery/less-than-greater-than.stderr
@@ -2,7 +2,12 @@ error: invalid comparison operator `<>`
   --> $DIR/less-than-greater-than.rs:2:22
    |
 LL |     println!("{}", 1 <> 2);
-   |                      ^^ help: `<>` is not a valid comparison operator, use `!=`
+   |                      ^^
+   |
+help: `<>` is not a valid comparison operator, use `!=`
+   |
+LL |     println!("{}", 1 != 2);
+   |                      ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/or-patterns/fn-param-wrap-parens.stderr
+++ b/tests/ui/or-patterns/fn-param-wrap-parens.stderr
@@ -2,7 +2,12 @@ error: top-level or-patterns are not allowed in function parameters
   --> $DIR/fn-param-wrap-parens.rs:13:9
    |
 LL | fn fun1(A | B: E) {}
-   |         ^^^^^ help: wrap the pattern in parentheses: `(A | B)`
+   |         ^^^^^
+   |
+help: wrap the pattern in parentheses
+   |
+LL | fn fun1((A | B): E) {}
+   |         +     +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/or-patterns/issue-64879-trailing-before-guard.stderr
+++ b/tests/ui/or-patterns/issue-64879-trailing-before-guard.stderr
@@ -4,7 +4,13 @@ error: a trailing `|` is not allowed in an or-pattern
 LL |         E::A |
    |         ---- while parsing this or-pattern starting here
 LL |         E::B |
-   |              ^ help: remove the `|`
+   |              ^
+   |
+help: remove the `|`
+   |
+LL -         E::B |
+LL +         E::B
+   |
 
 error[E0308]: mismatched types
   --> $DIR/issue-64879-trailing-before-guard.rs:12:42

--- a/tests/ui/or-patterns/multiple-pattern-typo.stderr
+++ b/tests/ui/or-patterns/multiple-pattern-typo.stderr
@@ -2,55 +2,90 @@ error: unexpected token `||` in pattern
   --> $DIR/multiple-pattern-typo.rs:7:15
    |
 LL |         1 | 2 || 3 => (),
-   |         -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |         -     ^^
    |         |
    |         while parsing this or-pattern starting here
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |         1 | 2 | 3 => (),
+   |               ~
 
 error: unexpected token `||` in pattern
   --> $DIR/multiple-pattern-typo.rs:12:16
    |
 LL |         (1 | 2 || 3) => (),
-   |          -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |          -     ^^
    |          |
    |          while parsing this or-pattern starting here
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |         (1 | 2 | 3) => (),
+   |                ~
 
 error: unexpected token `||` in pattern
   --> $DIR/multiple-pattern-typo.rs:17:16
    |
 LL |         (1 | 2 || 3,) => (),
-   |          -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |          -     ^^
    |          |
    |          while parsing this or-pattern starting here
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |         (1 | 2 | 3,) => (),
+   |                ~
 
 error: unexpected token `||` in pattern
   --> $DIR/multiple-pattern-typo.rs:24:18
    |
 LL |         TS(1 | 2 || 3) => (),
-   |            -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |            -     ^^
    |            |
    |            while parsing this or-pattern starting here
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |         TS(1 | 2 | 3) => (),
+   |                  ~
 
 error: unexpected token `||` in pattern
   --> $DIR/multiple-pattern-typo.rs:31:23
    |
 LL |         NS { f: 1 | 2 || 3 } => (),
-   |                 -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |                 -     ^^
    |                 |
    |                 while parsing this or-pattern starting here
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |         NS { f: 1 | 2 | 3 } => (),
+   |                       ~
 
 error: unexpected token `||` in pattern
   --> $DIR/multiple-pattern-typo.rs:36:16
    |
 LL |         [1 | 2 || 3] => (),
-   |          -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |          -     ^^
    |          |
    |          while parsing this or-pattern starting here
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |         [1 | 2 | 3] => (),
+   |                ~
 
 error: unexpected token `||` in pattern
   --> $DIR/multiple-pattern-typo.rs:41:9
    |
 LL |         || 1 | 2 | 3 => (),
-   |         ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |         ^^
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |         | 1 | 2 | 3 => (),
+   |         ~
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/or-patterns/nested-undelimited-precedence.stderr
+++ b/tests/ui/or-patterns/nested-undelimited-precedence.stderr
@@ -2,31 +2,56 @@ error: top-level or-patterns are not allowed in `let` bindings
   --> $DIR/nested-undelimited-precedence.rs:19:9
    |
 LL |     let b @ A | B: E = A;
-   |         ^^^^^^^^^ help: wrap the pattern in parentheses: `(b @ A | B)`
+   |         ^^^^^^^^^
+   |
+help: wrap the pattern in parentheses
+   |
+LL |     let (b @ A | B): E = A;
+   |         +         +
 
 error: top-level or-patterns are not allowed in `let` bindings
   --> $DIR/nested-undelimited-precedence.rs:34:9
    |
 LL |     let &A(_) | B(_): F = A(3);
-   |         ^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&A(_) | B(_))`
+   |         ^^^^^^^^^^^^
+   |
+help: wrap the pattern in parentheses
+   |
+LL |     let (&A(_) | B(_)): F = A(3);
+   |         +            +
 
 error: top-level or-patterns are not allowed in `let` bindings
   --> $DIR/nested-undelimited-precedence.rs:36:9
    |
 LL |     let &&A(_) | B(_): F = A(3);
-   |         ^^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&&A(_) | B(_))`
+   |         ^^^^^^^^^^^^^
+   |
+help: wrap the pattern in parentheses
+   |
+LL |     let (&&A(_) | B(_)): F = A(3);
+   |         +             +
 
 error: top-level or-patterns are not allowed in `let` bindings
   --> $DIR/nested-undelimited-precedence.rs:38:9
    |
 LL |     let &mut A(_) | B(_): F = A(3);
-   |         ^^^^^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&mut A(_) | B(_))`
+   |         ^^^^^^^^^^^^^^^^
+   |
+help: wrap the pattern in parentheses
+   |
+LL |     let (&mut A(_) | B(_)): F = A(3);
+   |         +                +
 
 error: top-level or-patterns are not allowed in `let` bindings
   --> $DIR/nested-undelimited-precedence.rs:40:9
    |
 LL |     let &&mut A(_) | B(_): F = A(3);
-   |         ^^^^^^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&&mut A(_) | B(_))`
+   |         ^^^^^^^^^^^^^^^^^
+   |
+help: wrap the pattern in parentheses
+   |
+LL |     let (&&mut A(_) | B(_)): F = A(3);
+   |         +                 +
 
 error[E0408]: variable `b` is not bound in all patterns
   --> $DIR/nested-undelimited-precedence.rs:19:17

--- a/tests/ui/or-patterns/or-patterns-syntactic-fail.stderr
+++ b/tests/ui/or-patterns/or-patterns-syntactic-fail.stderr
@@ -16,25 +16,45 @@ error: top-level or-patterns are not allowed in function parameters
   --> $DIR/or-patterns-syntactic-fail.rs:18:13
    |
 LL |     fn fun1(A | B: E) {}
-   |             ^^^^^ help: wrap the pattern in parentheses: `(A | B)`
+   |             ^^^^^
+   |
+help: wrap the pattern in parentheses
+   |
+LL |     fn fun1((A | B): E) {}
+   |             +     +
 
 error: top-level or-patterns are not allowed in function parameters
   --> $DIR/or-patterns-syntactic-fail.rs:21:13
    |
 LL |     fn fun2(| A | B: E) {}
-   |             ^^^^^^^ help: wrap the pattern in parentheses: `(A | B)`
+   |             ^^^^^^^
+   |
+help: wrap the pattern in parentheses
+   |
+LL |     fn fun2((| A | B): E) {}
+   |             +       +
 
 error: top-level or-patterns are not allowed in `let` bindings
   --> $DIR/or-patterns-syntactic-fail.rs:26:9
    |
 LL |     let A | B: E = A;
-   |         ^^^^^ help: wrap the pattern in parentheses: `(A | B)`
+   |         ^^^^^
+   |
+help: wrap the pattern in parentheses
+   |
+LL |     let (A | B): E = A;
+   |         +     +
 
 error: top-level or-patterns are not allowed in `let` bindings
   --> $DIR/or-patterns-syntactic-fail.rs:29:9
    |
 LL |     let | A | B: E = A;
-   |         ^^^^^^^ help: wrap the pattern in parentheses: `(A | B)`
+   |         ^^^^^^^
+   |
+help: wrap the pattern in parentheses
+   |
+LL |     let (| A | B): E = A;
+   |         +       +
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/or-patterns/remove-leading-vert.fixed
+++ b/tests/ui/or-patterns/remove-leading-vert.fixed
@@ -8,7 +8,7 @@ fn main() {}
 
 #[cfg(FALSE)]
 fn leading() {
-    fn fun1( A: E) {} //~ ERROR top-level or-patterns are not allowed
+    fn fun1(  A: E) {} //~ ERROR top-level or-patterns are not allowed
     fn fun2(  A: E) {} //~ ERROR unexpected `||` before function parameter
     let ( | A): E;
     let ( | A): (E); //~ ERROR unexpected token `||` in pattern

--- a/tests/ui/or-patterns/remove-leading-vert.stderr
+++ b/tests/ui/or-patterns/remove-leading-vert.stderr
@@ -2,161 +2,279 @@ error: top-level or-patterns are not allowed in function parameters
   --> $DIR/remove-leading-vert.rs:11:14
    |
 LL |     fn fun1( | A: E) {}
-   |              ^^^ help: remove the `|`: `A`
+   |              ^^^
+   |
+help: remove the `|`
+   |
+LL -     fn fun1( | A: E) {}
+LL +     fn fun1(  A: E) {}
+   |
 
 error: unexpected `||` before function parameter
   --> $DIR/remove-leading-vert.rs:12:14
    |
 LL |     fn fun2( || A: E) {}
-   |              ^^ help: remove the `||`
+   |              ^^
    |
    = note: alternatives in or-patterns are separated with `|`, not `||`
+help: remove the `||`
+   |
+LL -     fn fun2( || A: E) {}
+LL +     fn fun2(  A: E) {}
+   |
 
 error: unexpected token `||` in pattern
   --> $DIR/remove-leading-vert.rs:14:11
    |
 LL |     let ( || A): (E);
-   |           ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |           ^^
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |     let ( | A): (E);
+   |           ~
 
 error: unexpected token `||` in pattern
   --> $DIR/remove-leading-vert.rs:17:11
    |
 LL |     let [ || A ]: [E; 1];
-   |           ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |           ^^
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |     let [ | A ]: [E; 1];
+   |           ~
 
 error: unexpected token `||` in pattern
   --> $DIR/remove-leading-vert.rs:19:13
    |
 LL |     let TS( || A ): TS;
-   |             ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |             ^^
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |     let TS( | A ): TS;
+   |             ~
 
 error: unexpected token `||` in pattern
   --> $DIR/remove-leading-vert.rs:21:17
    |
 LL |     let NS { f: || A }: NS;
-   |                 ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |                 ^^
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |     let NS { f: | A }: NS;
+   |                 ~
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:26:13
    |
 LL |     let ( A | ): E;
-   |           - ^ help: remove the `|`
+   |           - ^
    |           |
    |           while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -     let ( A | ): E;
+LL +     let ( A  ): E;
+   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:27:12
    |
 LL |     let (a |,): (E,);
-   |          - ^ help: remove the `|`
+   |          - ^
    |          |
    |          while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -     let (a |,): (E,);
+LL +     let (a ,): (E,);
+   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:28:17
    |
 LL |     let ( A | B | ): E;
-   |           -     ^ help: remove the `|`
+   |           -     ^
    |           |
    |           while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -     let ( A | B | ): E;
+LL +     let ( A | B  ): E;
+   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:29:17
    |
 LL |     let [ A | B | ]: [E; 1];
-   |           -     ^ help: remove the `|`
+   |           -     ^
    |           |
    |           while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -     let [ A | B | ]: [E; 1];
+LL +     let [ A | B  ]: [E; 1];
+   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:30:18
    |
 LL |     let S { f: B | };
-   |                - ^ help: remove the `|`
+   |                - ^
    |                |
    |                while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -     let S { f: B | };
+LL +     let S { f: B  };
+   |
 
 error: unexpected token `||` in pattern
   --> $DIR/remove-leading-vert.rs:31:13
    |
 LL |     let ( A || B | ): E;
-   |           - ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |           - ^^
    |           |
    |           while parsing this or-pattern starting here
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |     let ( A | B | ): E;
+   |             ~
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:31:18
    |
 LL |     let ( A || B | ): E;
-   |           -      ^ help: remove the `|`
+   |           -      ^
    |           |
    |           while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -     let ( A || B | ): E;
+LL +     let ( A || B  ): E;
+   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:34:11
    |
 LL |         A | => {}
-   |         - ^ help: remove the `|`
+   |         - ^
    |         |
    |         while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -         A | => {}
+LL +         A  => {}
+   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:35:11
    |
 LL |         A || => {}
-   |         - ^^ help: remove the `||`
+   |         - ^^
    |         |
    |         while parsing this or-pattern starting here
    |
    = note: alternatives in or-patterns are separated with `|`, not `||`
+help: remove the `||`
+   |
+LL -         A || => {}
+LL +         A  => {}
+   |
 
 error: unexpected token `||` in pattern
   --> $DIR/remove-leading-vert.rs:36:11
    |
 LL |         A || B | => {}
-   |         - ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |         - ^^
    |         |
    |         while parsing this or-pattern starting here
+   |
+help: use a single `|` to separate multiple alternative patterns
+   |
+LL |         A | B | => {}
+   |           ~
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:36:16
    |
 LL |         A || B | => {}
-   |         -      ^ help: remove the `|`
+   |         -      ^
    |         |
    |         while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -         A || B | => {}
+LL +         A || B  => {}
+   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:38:17
    |
 LL |         | A | B | => {}
-   |         -       ^ help: remove the `|`
+   |         -       ^
    |         |
    |         while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -         | A | B | => {}
+LL +         | A | B  => {}
+   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:45:11
    |
 LL |     let a | : u8 = 0;
-   |         - ^ help: remove the `|`
+   |         - ^
    |         |
    |         while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -     let a | : u8 = 0;
+LL +     let a  : u8 = 0;
+   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:46:11
    |
 LL |     let a | = 0;
-   |         - ^ help: remove the `|`
+   |         - ^
    |         |
    |         while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -     let a | = 0;
+LL +     let a  = 0;
+   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:47:11
    |
 LL |     let a | ;
-   |         - ^ help: remove the `|`
+   |         - ^
    |         |
    |         while parsing this or-pattern starting here
+   |
+help: remove the `|`
+   |
+LL -     let a | ;
+LL +     let a  ;
+   |
 
 error: aborting due to 21 previous errors
 

--- a/tests/ui/parser/attribute/attr-stmt-expr-attr-bad.stderr
+++ b/tests/ui/parser/attribute/attr-stmt-expr-attr-bad.stderr
@@ -154,9 +154,14 @@ error: outer attributes are not allowed on `if` and `else` branches
    |
 LL | #[cfg(FALSE)] fn e() { let _ = if 0 #[attr] {}; }
    |                                --   ^^^^^^^ -- the attributes are attached to this branch
-   |                                |    |
-   |                                |    help: remove the attributes
+   |                                |
    |                                the branch belongs to this `if`
+   |
+help: remove the attributes
+   |
+LL - #[cfg(FALSE)] fn e() { let _ = if 0 #[attr] {}; }
+LL + #[cfg(FALSE)] fn e() { let _ = if 0 {}; }
+   |
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:40:38
@@ -178,9 +183,14 @@ error: outer attributes are not allowed on `if` and `else` branches
    |
 LL | #[cfg(FALSE)] fn e() { let _ = if 0 {} else #[attr] {}; }
    |                                        ---- ^^^^^^^ -- the attributes are attached to this branch
-   |                                        |    |
-   |                                        |    help: remove the attributes
+   |                                        |
    |                                        the branch belongs to this `else`
+   |
+help: remove the attributes
+   |
+LL - #[cfg(FALSE)] fn e() { let _ = if 0 {} else #[attr] {}; }
+LL + #[cfg(FALSE)] fn e() { let _ = if 0 {} else {}; }
+   |
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:46:46
@@ -196,18 +206,28 @@ error: outer attributes are not allowed on `if` and `else` branches
    |
 LL | #[cfg(FALSE)] fn e() { let _ = if 0 {} else #[attr] if 0 {}; }
    |                                        ---- ^^^^^^^ ------- the attributes are attached to this branch
-   |                                        |    |
-   |                                        |    help: remove the attributes
+   |                                        |
    |                                        the branch belongs to this `else`
+   |
+help: remove the attributes
+   |
+LL - #[cfg(FALSE)] fn e() { let _ = if 0 {} else #[attr] if 0 {}; }
+LL + #[cfg(FALSE)] fn e() { let _ = if 0 {} else if 0 {}; }
+   |
 
 error: outer attributes are not allowed on `if` and `else` branches
   --> $DIR/attr-stmt-expr-attr-bad.rs:50:50
    |
 LL | #[cfg(FALSE)] fn e() { let _ = if 0 {} else if 0 #[attr] {}; }
    |                                             --   ^^^^^^^ -- the attributes are attached to this branch
-   |                                             |    |
-   |                                             |    help: remove the attributes
+   |                                             |
    |                                             the branch belongs to this `if`
+   |
+help: remove the attributes
+   |
+LL - #[cfg(FALSE)] fn e() { let _ = if 0 {} else if 0 #[attr] {}; }
+LL + #[cfg(FALSE)] fn e() { let _ = if 0 {} else if 0 {}; }
+   |
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:52:51
@@ -223,9 +243,14 @@ error: outer attributes are not allowed on `if` and `else` branches
    |
 LL | #[cfg(FALSE)] fn e() { let _ = if let _ = 0 #[attr] {}; }
    |                                --           ^^^^^^^ -- the attributes are attached to this branch
-   |                                |            |
-   |                                |            help: remove the attributes
+   |                                |
    |                                the branch belongs to this `if`
+   |
+help: remove the attributes
+   |
+LL - #[cfg(FALSE)] fn e() { let _ = if let _ = 0 #[attr] {}; }
+LL + #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {}; }
+   |
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:56:46
@@ -247,9 +272,14 @@ error: outer attributes are not allowed on `if` and `else` branches
    |
 LL | #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {} else #[attr] {}; }
    |                                                ---- ^^^^^^^ -- the attributes are attached to this branch
-   |                                                |    |
-   |                                                |    help: remove the attributes
+   |                                                |
    |                                                the branch belongs to this `else`
+   |
+help: remove the attributes
+   |
+LL - #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {} else #[attr] {}; }
+LL + #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {} else {}; }
+   |
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:62:54
@@ -265,18 +295,28 @@ error: outer attributes are not allowed on `if` and `else` branches
    |
 LL | #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {} else #[attr] if let _ = 0 {}; }
    |                                                ---- ^^^^^^^ --------------- the attributes are attached to this branch
-   |                                                |    |
-   |                                                |    help: remove the attributes
+   |                                                |
    |                                                the branch belongs to this `else`
+   |
+help: remove the attributes
+   |
+LL - #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {} else #[attr] if let _ = 0 {}; }
+LL + #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {} else if let _ = 0 {}; }
+   |
 
 error: outer attributes are not allowed on `if` and `else` branches
   --> $DIR/attr-stmt-expr-attr-bad.rs:66:66
    |
 LL | #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {} else if let _ = 0 #[attr] {}; }
    |                                                     --           ^^^^^^^ -- the attributes are attached to this branch
-   |                                                     |            |
-   |                                                     |            help: remove the attributes
+   |                                                     |
    |                                                     the branch belongs to this `if`
+   |
+help: remove the attributes
+   |
+LL - #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {} else if let _ = 0 #[attr] {}; }
+LL + #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {} else if let _ = 0 {}; }
+   |
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:68:67
@@ -361,9 +401,14 @@ error[E0586]: inclusive range with no end
   --> $DIR/attr-stmt-expr-attr-bad.rs:85:35
    |
 LL | #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] 10 => () } }
-   |                                   ^^^ help: use `..` instead
+   |                                   ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL - #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] 10 => () } }
+LL + #[cfg(FALSE)] fn e() { match 0 { 0..#[attr] 10 => () } }
+   |
 
 error: expected one of `=>`, `if`, or `|`, found `#`
   --> $DIR/attr-stmt-expr-attr-bad.rs:85:38
@@ -375,9 +420,14 @@ error[E0586]: inclusive range with no end
   --> $DIR/attr-stmt-expr-attr-bad.rs:88:35
    |
 LL | #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] -10 => () } }
-   |                                   ^^^ help: use `..` instead
+   |                                   ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL - #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] -10 => () } }
+LL + #[cfg(FALSE)] fn e() { match 0 { 0..#[attr] -10 => () } }
+   |
 
 error: expected one of `=>`, `if`, or `|`, found `#`
   --> $DIR/attr-stmt-expr-attr-bad.rs:88:38
@@ -395,9 +445,14 @@ error[E0586]: inclusive range with no end
   --> $DIR/attr-stmt-expr-attr-bad.rs:93:35
    |
 LL | #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] FOO => () } }
-   |                                   ^^^ help: use `..` instead
+   |                                   ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL - #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] FOO => () } }
+LL + #[cfg(FALSE)] fn e() { match 0 { 0..#[attr] FOO => () } }
+   |
 
 error: expected one of `=>`, `if`, or `|`, found `#`
   --> $DIR/attr-stmt-expr-attr-bad.rs:93:38

--- a/tests/ui/parser/bad-char-literals.stderr
+++ b/tests/ui/parser/bad-char-literals.stderr
@@ -2,7 +2,12 @@ error: character constant must be escaped: `'`
   --> $DIR/bad-char-literals.rs:6:6
    |
 LL |     ''';
-   |      ^ help: escape the character: `\'`
+   |      ^
+   |
+help: escape the character
+   |
+LL |     '\'';
+   |      ~~
 
 error: character constant must be escaped: `\n`
   --> $DIR/bad-char-literals.rs:10:6
@@ -10,19 +15,34 @@ error: character constant must be escaped: `\n`
 LL |       '
    |  ______^
 LL | | ';
-   | |_ help: escape the character: `\n`
+   | |_
+   |
+help: escape the character
+   |
+LL |     '\n';
+   |      ++
 
 error: character constant must be escaped: `\r`
   --> $DIR/bad-char-literals.rs:15:6
    |
 LL |     '';
-   |      ^ help: escape the character: `\r`
+   |      ^
+   |
+help: escape the character
+   |
+LL |     '\r';
+   |      ++
 
 error: character constant must be escaped: `\t`
   --> $DIR/bad-char-literals.rs:18:6
    |
 LL |     '    ';
-   |      ^^^^ help: escape the character: `\t`
+   |      ^^^^
+   |
+help: escape the character
+   |
+LL |     '\t';
+   |      ++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/parser/bad-fn-ptr-qualifier.stderr
+++ b/tests/ui/parser/bad-fn-ptr-qualifier.stderr
@@ -5,7 +5,12 @@ LL | pub type T0 = const fn();
    |               -----^^^^^
    |               |
    |               `const` because of this
-   |               help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - pub type T0 = const fn();
+LL + pub type T0 =  fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:6:15
@@ -14,7 +19,12 @@ LL | pub type T1 = const extern "C" fn();
    |               -----^^^^^^^^^^^^^^^^
    |               |
    |               `const` because of this
-   |               help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - pub type T1 = const extern "C" fn();
+LL + pub type T1 =  extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:7:15
@@ -23,7 +33,12 @@ LL | pub type T2 = const unsafe extern fn();
    |               -----^^^^^^^^^^^^^^^^^^^
    |               |
    |               `const` because of this
-   |               help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - pub type T2 = const unsafe extern fn();
+LL + pub type T2 =  unsafe extern fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/bad-fn-ptr-qualifier.rs:8:15
@@ -32,7 +47,12 @@ LL | pub type T3 = async fn();
    |               -----^^^^^
    |               |
    |               `async` because of this
-   |               help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - pub type T3 = async fn();
+LL + pub type T3 =  fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/bad-fn-ptr-qualifier.rs:9:15
@@ -41,7 +61,12 @@ LL | pub type T4 = async extern fn();
    |               -----^^^^^^^^^^^^
    |               |
    |               `async` because of this
-   |               help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - pub type T4 = async extern fn();
+LL + pub type T4 =  extern fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/bad-fn-ptr-qualifier.rs:10:15
@@ -50,7 +75,12 @@ LL | pub type T5 = async unsafe extern "C" fn();
    |               -----^^^^^^^^^^^^^^^^^^^^^^^
    |               |
    |               `async` because of this
-   |               help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - pub type T5 = async unsafe extern "C" fn();
+LL + pub type T5 =  unsafe extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:11:15
@@ -59,7 +89,12 @@ LL | pub type T6 = const async unsafe extern "C" fn();
    |               -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |               |
    |               `const` because of this
-   |               help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - pub type T6 = const async unsafe extern "C" fn();
+LL + pub type T6 =  async unsafe extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/bad-fn-ptr-qualifier.rs:11:15
@@ -68,7 +103,12 @@ LL | pub type T6 = const async unsafe extern "C" fn();
    |               ^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
    |                     |
    |                     `async` because of this
-   |                     help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - pub type T6 = const async unsafe extern "C" fn();
+LL + pub type T6 = const  unsafe extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:15:17
@@ -77,7 +117,12 @@ LL | pub type FTT0 = for<'a> const fn();
    |                 ^^^^^^^^-----^^^^^
    |                         |
    |                         `const` because of this
-   |                         help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - pub type FTT0 = for<'a> const fn();
+LL + pub type FTT0 = for<'a>  fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:16:17
@@ -86,7 +131,12 @@ LL | pub type FTT1 = for<'a> const extern "C" fn();
    |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^
    |                         |
    |                         `const` because of this
-   |                         help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - pub type FTT1 = for<'a> const extern "C" fn();
+LL + pub type FTT1 = for<'a>  extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:17:17
@@ -95,7 +145,12 @@ LL | pub type FTT2 = for<'a> const unsafe extern fn();
    |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^
    |                         |
    |                         `const` because of this
-   |                         help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - pub type FTT2 = for<'a> const unsafe extern fn();
+LL + pub type FTT2 = for<'a>  unsafe extern fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/bad-fn-ptr-qualifier.rs:18:17
@@ -104,7 +159,12 @@ LL | pub type FTT3 = for<'a> async fn();
    |                 ^^^^^^^^-----^^^^^
    |                         |
    |                         `async` because of this
-   |                         help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - pub type FTT3 = for<'a> async fn();
+LL + pub type FTT3 = for<'a>  fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/bad-fn-ptr-qualifier.rs:19:17
@@ -113,7 +173,12 @@ LL | pub type FTT4 = for<'a> async extern fn();
    |                 ^^^^^^^^-----^^^^^^^^^^^^
    |                         |
    |                         `async` because of this
-   |                         help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - pub type FTT4 = for<'a> async extern fn();
+LL + pub type FTT4 = for<'a>  extern fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/bad-fn-ptr-qualifier.rs:20:17
@@ -122,7 +187,12 @@ LL | pub type FTT5 = for<'a> async unsafe extern "C" fn();
    |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
    |                         |
    |                         `async` because of this
-   |                         help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - pub type FTT5 = for<'a> async unsafe extern "C" fn();
+LL + pub type FTT5 = for<'a>  unsafe extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:22:17
@@ -131,7 +201,12 @@ LL | pub type FTT6 = for<'a> const async unsafe extern "C" fn();
    |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                         |
    |                         `const` because of this
-   |                         help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - pub type FTT6 = for<'a> const async unsafe extern "C" fn();
+LL + pub type FTT6 = for<'a>  async unsafe extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/bad-fn-ptr-qualifier.rs:22:17
@@ -140,7 +215,12 @@ LL | pub type FTT6 = for<'a> const async unsafe extern "C" fn();
    |                 ^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
    |                               |
    |                               `async` because of this
-   |                               help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - pub type FTT6 = for<'a> const async unsafe extern "C" fn();
+LL + pub type FTT6 = for<'a> const  unsafe extern "C" fn();
+   |
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/parser/byte-literals.stderr
+++ b/tests/ui/parser/byte-literals.stderr
@@ -24,13 +24,23 @@ error: byte constant must be escaped: `\t`
   --> $DIR/byte-literals.rs:8:7
    |
 LL |     b'    ';
-   |       ^^^^ help: escape the character: `\t`
+   |       ^^^^
+   |
+help: escape the character
+   |
+LL |     b'\t';
+   |       ++
 
 error: byte constant must be escaped: `'`
   --> $DIR/byte-literals.rs:9:7
    |
 LL |     b''';
-   |       ^ help: escape the character: `\'`
+   |       ^
+   |
+help: escape the character
+   |
+LL |     b'\'';
+   |       ~~
 
 error: non-ASCII character in byte literal
   --> $DIR/byte-literals.rs:10:7

--- a/tests/ui/parser/char/whitespace-character-literal.stderr
+++ b/tests/ui/parser/char/whitespace-character-literal.stderr
@@ -2,15 +2,17 @@ error: character literal may only contain one codepoint
   --> $DIR/whitespace-character-literal.rs:5:30
    |
 LL |     let _hair_space_around = ' x​';
-   |                              ^--^
-   |                               |
-   |                               help: consider removing the non-printing characters: `x`
+   |                              ^^^^
    |
 note: there are non-printing characters, the full sequence is `\u{200a}x\u{200b}`
   --> $DIR/whitespace-character-literal.rs:5:31
    |
 LL |     let _hair_space_around = ' x​';
    |                               ^^
+help: consider removing the non-printing characters
+   |
+LL |     let _hair_space_around = 'x​';
+   |                               ~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/default-on-wrong-item-kind.stderr
+++ b/tests/ui/parser/default-on-wrong-item-kind.stderr
@@ -154,11 +154,13 @@ error: extern items cannot be `const`
   --> $DIR/default-on-wrong-item-kind.rs:38:19
    |
 LL |     default const foo: u8;
-   |     --------------^^^
-   |     |
-   |     help: try using a static value: `static`
+   |                   ^^^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: try using a static value
+   |
+LL |     static foo: u8;
+   |     ~~~~~~
 
 error: a module cannot be `default`
   --> $DIR/default-on-wrong-item-kind.rs:41:5

--- a/tests/ui/parser/do-catch-suggests-try.stderr
+++ b/tests/ui/parser/do-catch-suggests-try.stderr
@@ -2,9 +2,13 @@ error: found removed `do catch` syntax
   --> $DIR/do-catch-suggests-try.rs:4:25
    |
 LL |     let _: Option<()> = do catch {};
-   |                         ^^^^^^^^ help: replace with the new syntax: `try`
+   |                         ^^^^^^^^
    |
    = note: following RFC #2388, the new non-placeholder syntax is `try`
+help: replace with the new syntax
+   |
+LL |     let _: Option<()> = try {};
+   |                         ~~~
 
 error[E0308]: mismatched types
   --> $DIR/do-catch-suggests-try.rs:9:33

--- a/tests/ui/parser/doc-comment-in-if-statement.stderr
+++ b/tests/ui/parser/doc-comment-in-if-statement.stderr
@@ -16,9 +16,14 @@ error: outer attributes are not allowed on `if` and `else` branches
    |
 LL |     if true /*!*/ {}
    |     --      ^^^^^ -- the attributes are attached to this branch
-   |     |       |
-   |     |       help: remove the attributes
+   |     |
    |     the branch belongs to this `if`
+   |
+help: remove the attributes
+   |
+LL -     if true /*!*/ {}
+LL +     if true {}
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/expr-rarrow-call.stderr
+++ b/tests/ui/parser/expr-rarrow-call.stderr
@@ -2,41 +2,61 @@ error: `->` used for field access or method call
   --> $DIR/expr-rarrow-call.rs:14:10
    |
 LL |     named->foo;
-   |          ^^ help: try using `.` instead
+   |          ^^
    |
    = help: the `.` operator will dereference the value if needed
+help: try using `.` instead
+   |
+LL |     named.foo;
+   |          ~
 
 error: `->` used for field access or method call
   --> $DIR/expr-rarrow-call.rs:18:12
    |
 LL |     unnamed->0;
-   |            ^^ help: try using `.` instead
+   |            ^^
    |
    = help: the `.` operator will dereference the value if needed
+help: try using `.` instead
+   |
+LL |     unnamed.0;
+   |            ~
 
 error: `->` used for field access or method call
   --> $DIR/expr-rarrow-call.rs:22:6
    |
 LL |     t->0;
-   |      ^^ help: try using `.` instead
+   |      ^^
    |
    = help: the `.` operator will dereference the value if needed
+help: try using `.` instead
+   |
+LL |     t.0;
+   |      ~
 
 error: `->` used for field access or method call
   --> $DIR/expr-rarrow-call.rs:23:6
    |
 LL |     t->1;
-   |      ^^ help: try using `.` instead
+   |      ^^
    |
    = help: the `.` operator will dereference the value if needed
+help: try using `.` instead
+   |
+LL |     t.1;
+   |      ~
 
 error: `->` used for field access or method call
   --> $DIR/expr-rarrow-call.rs:30:8
    |
 LL |     foo->clone();
-   |        ^^ help: try using `.` instead
+   |        ^^
    |
    = help: the `.` operator will dereference the value if needed
+help: try using `.` instead
+   |
+LL |     foo.clone();
+   |        ~
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/parser/fn-colon-return-type.stderr
+++ b/tests/ui/parser/fn-colon-return-type.stderr
@@ -2,7 +2,12 @@ error: return types are denoted using `->`
   --> $DIR/fn-colon-return-type.rs:1:15
    |
 LL | fn foo(x: i32): i32 {
-   |               ^ help: use `->` instead
+   |               ^
+   |
+help: use `->` instead
+   |
+LL | fn foo(x: i32) -> i32 {
+   |                ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/foreign-const-semantic-fail.stderr
+++ b/tests/ui/parser/foreign-const-semantic-fail.stderr
@@ -2,21 +2,25 @@ error: extern items cannot be `const`
   --> $DIR/foreign-const-semantic-fail.rs:4:11
    |
 LL |     const A: isize;
-   |     ------^
-   |     |
-   |     help: try using a static value: `static`
+   |           ^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: try using a static value
+   |
+LL |     static A: isize;
+   |     ~~~~~~
 
 error: extern items cannot be `const`
   --> $DIR/foreign-const-semantic-fail.rs:6:11
    |
 LL |     const B: isize = 42;
-   |     ------^
-   |     |
-   |     help: try using a static value: `static`
+   |           ^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: try using a static value
+   |
+LL |     static B: isize = 42;
+   |     ~~~~~~
 
 error: incorrect `static` inside `extern` block
   --> $DIR/foreign-const-semantic-fail.rs:6:11

--- a/tests/ui/parser/foreign-const-syntactic-fail.stderr
+++ b/tests/ui/parser/foreign-const-syntactic-fail.stderr
@@ -2,21 +2,25 @@ error: extern items cannot be `const`
   --> $DIR/foreign-const-syntactic-fail.rs:7:11
    |
 LL |     const A: isize;
-   |     ------^
-   |     |
-   |     help: try using a static value: `static`
+   |           ^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: try using a static value
+   |
+LL |     static A: isize;
+   |     ~~~~~~
 
 error: extern items cannot be `const`
   --> $DIR/foreign-const-syntactic-fail.rs:8:11
    |
 LL |     const B: isize = 42;
-   |     ------^
-   |     |
-   |     help: try using a static value: `static`
+   |           ^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: try using a static value
+   |
+LL |     static B: isize = 42;
+   |     ~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/ident-recovery.stderr
+++ b/tests/ui/parser/ident-recovery.stderr
@@ -2,19 +2,25 @@ error: expected identifier, found `,`
   --> $DIR/ident-recovery.rs:1:4
    |
 LL | fn ,comma() {
-   |    ^
-   |    |
-   |    expected identifier
-   |    help: remove this comma
+   |    ^ expected identifier
+   |
+help: remove this comma
+   |
+LL - fn ,comma() {
+LL + fn comma() {
+   |
 
 error: expected identifier, found `,`
   --> $DIR/ident-recovery.rs:4:16
    |
 LL |         x: i32,,
-   |                ^
-   |                |
-   |                expected identifier
-   |                help: remove this comma
+   |                ^ expected identifier
+   |
+help: remove this comma
+   |
+LL -         x: i32,,
+LL +         x: i32,
+   |
 
 error: expected identifier, found keyword `break`
   --> $DIR/ident-recovery.rs:10:4

--- a/tests/ui/parser/if-in-in.stderr
+++ b/tests/ui/parser/if-in-in.stderr
@@ -2,9 +2,13 @@ error: expected iterable, found keyword `in`
   --> $DIR/if-in-in.rs:4:14
    |
 LL |     for i in in 1..2 {
-   |           ---^^
-   |           |
-   |           help: remove the duplicated `in`
+   |              ^^
+   |
+help: remove the duplicated `in`
+   |
+LL -     for i in in 1..2 {
+LL +     for i in 1..2 {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/impl-parsing.stderr
+++ b/tests/ui/parser/impl-parsing.stderr
@@ -2,13 +2,23 @@ error: missing `for` in a trait impl
   --> $DIR/impl-parsing.rs:4:11
    |
 LL | impl Trait Type {}
-   |           ^ help: add `for` here
+   |           ^
+   |
+help: add `for` here
+   |
+LL | impl Trait for Type {}
+   |            +++
 
 error: missing `for` in a trait impl
   --> $DIR/impl-parsing.rs:5:11
    |
 LL | impl Trait .. {}
-   |           ^ help: add `for` here
+   |           ^
+   |
+help: add `for` here
+   |
+LL | impl Trait for .. {}
+   |            +++
 
 error: expected a trait, found type
   --> $DIR/impl-parsing.rs:6:6

--- a/tests/ui/parser/intersection-patterns-1.stderr
+++ b/tests/ui/parser/intersection-patterns-1.stderr
@@ -6,7 +6,11 @@ LL |         Some(x) @ y => {}
    |         |         |
    |         |         binding on the right, should be on the left
    |         pattern on the left, should be on the right
-   |         help: switch the order: `y @ Some(x)`
+   |
+help: switch the order
+   |
+LL |         y @ Some(x) => {}
+   |         ~~~~~~~~~~~
 
 error: pattern on wrong side of `@`
   --> $DIR/intersection-patterns-1.rs:27:9
@@ -16,7 +20,11 @@ LL |         1 ..= 5 @ e => {}
    |         |         |
    |         |         binding on the right, should be on the left
    |         pattern on the left, should be on the right
-   |         help: switch the order: `e @ 1..=5`
+   |
+help: switch the order
+   |
+LL |         e @ 1..=5 => {}
+   |         ~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/issues/fn-no-semicolon-issue-124935-semi-after-item.rs
+++ b/tests/ui/parser/issues/fn-no-semicolon-issue-124935-semi-after-item.rs
@@ -2,5 +2,6 @@
 // Tests that we do not erroneously emit an error about
 // missing main function when the mod starts with a `;`
 
-; //~ ERROR expected item, found `;`
+;
+//~^ ERROR expected item, found `;`
 fn main() { }

--- a/tests/ui/parser/issues/fn-no-semicolon-issue-124935-semi-after-item.stderr
+++ b/tests/ui/parser/issues/fn-no-semicolon-issue-124935-semi-after-item.stderr
@@ -7,7 +7,6 @@ LL | ;
 help: remove this semicolon
    |
 LL - ;
-LL +
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/parser/issues/fn-no-semicolon-issue-124935-semi-after-item.stderr
+++ b/tests/ui/parser/issues/fn-no-semicolon-issue-124935-semi-after-item.stderr
@@ -2,7 +2,13 @@ error: expected item, found `;`
   --> $DIR/fn-no-semicolon-issue-124935-semi-after-item.rs:5:1
    |
 LL | ;
-   | ^ help: remove this semicolon
+   | ^
+   |
+help: remove this semicolon
+   |
+LL - ;
+LL +
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-100197-mut-let.stderr
+++ b/tests/ui/parser/issues/issue-100197-mut-let.stderr
@@ -2,7 +2,12 @@ error: invalid variable declaration
   --> $DIR/issue-100197-mut-let.rs:4:5
    |
 LL |     mut let _x = 123;
-   |     ^^^^^^^ help: switch the order of `mut` and `let`: `let mut`
+   |     ^^^^^^^
+   |
+help: switch the order of `mut` and `let`
+   |
+LL |     let mut _x = 123;
+   |     ~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-101477-enum.stderr
+++ b/tests/ui/parser/issues/issue-101477-enum.stderr
@@ -2,9 +2,14 @@ error: unexpected `==`
   --> $DIR/issue-101477-enum.rs:6:7
    |
 LL |     B == 2
-   |       ^^ help: try using `=` instead
+   |       ^^
    |
    = help: enum variants can be `Variant`, `Variant = <integer>`, `Variant(Type, ..., TypeN)` or `Variant { fields: Types }`
+help: try using `=` instead
+   |
+LL -     B == 2
+LL +     B = 2
+   |
 
 error: expected item, found `==`
   --> $DIR/issue-101477-enum.rs:6:7

--- a/tests/ui/parser/issues/issue-101477-let.stderr
+++ b/tests/ui/parser/issues/issue-101477-let.stderr
@@ -2,7 +2,13 @@ error: unexpected `==`
   --> $DIR/issue-101477-let.rs:4:11
    |
 LL |     let x == 2;
-   |           ^^ help: try using `=` instead
+   |           ^^
+   |
+help: try using `=` instead
+   |
+LL -     let x == 2;
+LL +     let x = 2;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-103425.stderr
+++ b/tests/ui/parser/issues/issue-103425.stderr
@@ -2,43 +2,28 @@ error: expected `;`, found `5.0`
   --> $DIR/issue-103425.rs:2:6
    |
 LL |     3
-   |      ^
+   |      ^ help: add `;` here
 LL |
 LL |     5.0
    |     --- unexpected token
-   |
-help: add `;` here
-   |
-LL |     3;
-   |      +
 
 error: expected `;`, found `3_i8`
   --> $DIR/issue-103425.rs:8:10
    |
 LL |     2_u32
-   |          ^
+   |          ^ help: add `;` here
 LL |
 LL |     3_i8
    |     ---- unexpected token
-   |
-help: add `;` here
-   |
-LL |     2_u32;
-   |          +
 
 error: expected `;`, found `5.0`
   --> $DIR/issue-103425.rs:10:9
    |
 LL |     3_i8
-   |         ^
+   |         ^ help: add `;` here
 LL |
 LL |     5.0
    |     --- unexpected token
-   |
-help: add `;` here
-   |
-LL |     3_i8;
-   |         +
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/issues/issue-103425.stderr
+++ b/tests/ui/parser/issues/issue-103425.stderr
@@ -2,28 +2,43 @@ error: expected `;`, found `5.0`
   --> $DIR/issue-103425.rs:2:6
    |
 LL |     3
-   |      ^ help: add `;` here
+   |      ^
 LL |
 LL |     5.0
    |     --- unexpected token
+   |
+help: add `;` here
+   |
+LL |     3;
+   |      +
 
 error: expected `;`, found `3_i8`
   --> $DIR/issue-103425.rs:8:10
    |
 LL |     2_u32
-   |          ^ help: add `;` here
+   |          ^
 LL |
 LL |     3_i8
    |     ---- unexpected token
+   |
+help: add `;` here
+   |
+LL |     2_u32;
+   |          +
 
 error: expected `;`, found `5.0`
   --> $DIR/issue-103425.rs:10:9
    |
 LL |     3_i8
-   |         ^ help: add `;` here
+   |         ^
 LL |
 LL |     5.0
    |     --- unexpected token
+   |
+help: add `;` here
+   |
+LL |     3_i8;
+   |         +
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/issues/issue-108109-fn-missing-params.stderr
+++ b/tests/ui/parser/issues/issue-108109-fn-missing-params.stderr
@@ -2,13 +2,23 @@ error: missing parameters for function definition
   --> $DIR/issue-108109-fn-missing-params.rs:3:15
    |
 LL | pub fn missing -> () {}
-   |               ^ help: add a parameter list
+   |               ^
+   |
+help: add a parameter list
+   |
+LL | pub fn missing() -> () {}
+   |               ++
 
 error: missing parameters for function definition
   --> $DIR/issue-108109-fn-missing-params.rs:6:16
    |
 LL | pub fn missing2 {}
-   |                ^ help: add a parameter list
+   |                ^
+   |
+help: add a parameter list
+   |
+LL | pub fn missing2() {}
+   |                ++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/issues/issue-113203.stderr
+++ b/tests/ui/parser/issues/issue-113203.stderr
@@ -2,7 +2,12 @@ error: incorrect use of `await`
   --> $DIR/issue-113203.rs:5:5
    |
 LL |     await {}()
-   |     ^^^^^^^^ help: `await` is a postfix operation: `{}.await`
+   |     ^^^^^^^^
+   |
+help: `await` is a postfix operation
+   |
+LL |     {}.await()
+   |     ~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-113203.stderr
+++ b/tests/ui/parser/issues/issue-113203.stderr
@@ -6,8 +6,9 @@ LL |     await {}()
    |
 help: `await` is a postfix operation
    |
-LL |     {}.await()
-   |     ~~~~~~~~
+LL -     await {}()
+LL +     {}.await()
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-118530-ice.stderr
+++ b/tests/ui/parser/issues/issue-118530-ice.stderr
@@ -30,11 +30,8 @@ LL |     #[feature]
    |     ---------- only `;` terminated statements or tail expressions are allowed after this attribute
 LL |     attr::fn bar() -> String {
    |             ^--- unexpected token
-   |
-help: add `;` here
-   |
-LL |     attr::fn; bar() -> String {
-   |             +
+   |             |
+   |             help: add `;` here
 
 error: `->` used for field access or method call
   --> $DIR/issue-118530-ice.rs:5:20

--- a/tests/ui/parser/issues/issue-118530-ice.stderr
+++ b/tests/ui/parser/issues/issue-118530-ice.stderr
@@ -30,16 +30,23 @@ LL |     #[feature]
    |     ---------- only `;` terminated statements or tail expressions are allowed after this attribute
 LL |     attr::fn bar() -> String {
    |             ^--- unexpected token
-   |             |
-   |             help: add `;` here
+   |
+help: add `;` here
+   |
+LL |     attr::fn; bar() -> String {
+   |             +
 
 error: `->` used for field access or method call
   --> $DIR/issue-118530-ice.rs:5:20
    |
 LL |     attr::fn bar() -> String {
-   |                    ^^ help: try using `.` instead
+   |                    ^^
    |
    = help: the `.` operator will dereference the value if needed
+help: try using `.` instead
+   |
+LL |     attr::fn bar() . String {
+   |                    ~
 
 error: expected one of `(`, `.`, `::`, `;`, `?`, `}`, or an operator, found `{`
   --> $DIR/issue-118530-ice.rs:5:30

--- a/tests/ui/parser/issues/issue-17718-const-mut.stderr
+++ b/tests/ui/parser/issues/issue-17718-const-mut.stderr
@@ -1,10 +1,13 @@
 error: const globals cannot be mutable
   --> $DIR/issue-17718-const-mut.rs:2:1
    |
-LL | const
-   | ----- help: you might want to declare a static instead: `static`
 LL | mut
    | ^^^ cannot be mutable
+   |
+help: you might want to declare a static instead
+   |
+LL | static
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-23620-invalid-escapes.stderr
+++ b/tests/ui/parser/issues/issue-23620-invalid-escapes.stderr
@@ -86,9 +86,12 @@ error: incorrect unicode escape sequence
   --> $DIR/issue-23620-invalid-escapes.rs:32:14
    |
 LL |     let _ = "\u8f";
-   |              ^^^-
-   |              |
-   |              help: format of unicode escape sequences uses braces: `\u{8f}`
+   |              ^^^
+   |
+help: format of unicode escape sequences uses braces
+   |
+LL |     let _ = "\u{8f}";
+   |              ~~~~~~
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/parser/issues/issue-27255.stderr
+++ b/tests/ui/parser/issues/issue-27255.stderr
@@ -2,13 +2,23 @@ error: missing `for` in a trait impl
   --> $DIR/issue-27255.rs:3:7
    |
 LL | impl A .. {}
-   |       ^ help: add `for` here
+   |       ^
+   |
+help: add `for` here
+   |
+LL | impl A for .. {}
+   |        +++
 
 error: missing `for` in a trait impl
   --> $DIR/issue-27255.rs:7:7
    |
 LL | impl A      usize {}
-   |       ^^^^^^ help: add `for` here
+   |       ^^^^^^
+   |
+help: add `for` here
+   |
+LL | impl A for usize {}
+   |        +++
 
 error: `impl Trait for .. {}` is an obsolete syntax
   --> $DIR/issue-27255.rs:3:1

--- a/tests/ui/parser/issues/issue-3036.stderr
+++ b/tests/ui/parser/issues/issue-3036.stderr
@@ -2,9 +2,14 @@ error: expected `;`, found `}`
   --> $DIR/issue-3036.rs:6:15
    |
 LL |     let _x = 3
-   |               ^ help: add `;` here
+   |               ^
 LL | }
    | - unexpected token
+   |
+help: add `;` here
+   |
+LL |     let _x = 3;
+   |               +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-3036.stderr
+++ b/tests/ui/parser/issues/issue-3036.stderr
@@ -2,14 +2,9 @@ error: expected `;`, found `}`
   --> $DIR/issue-3036.rs:6:15
    |
 LL |     let _x = 3
-   |               ^
+   |               ^ help: add `;` here
 LL | }
    | - unexpected token
-   |
-help: add `;` here
-   |
-LL |     let _x = 3;
-   |               +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-32501.stderr
+++ b/tests/ui/parser/issues/issue-32501.stderr
@@ -2,9 +2,14 @@ error: `mut` must be followed by a named binding
   --> $DIR/issue-32501.rs:7:9
    |
 LL |     let mut _ = 0;
-   |         ^^^^ help: remove the `mut` prefix
+   |         ^^^^
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
+help: remove the `mut` prefix
+   |
+LL -     let mut _ = 0;
+LL +     let _ = 0;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-46186.stderr
+++ b/tests/ui/parser/issues/issue-46186.stderr
@@ -2,9 +2,14 @@ error: expected item, found `;`
   --> $DIR/issue-46186.rs:5:2
    |
 LL | };
-   |  ^ help: remove this semicolon
+   |  ^
    |
    = help: braced struct declarations are not followed by a semicolon
+help: remove this semicolon
+   |
+LL - };
+LL + }
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-48636.stderr
+++ b/tests/ui/parser/issues/issue-48636.stderr
@@ -4,11 +4,14 @@ error[E0585]: found a documentation comment that doesn't document anything
 LL | struct S {
    |        - while parsing this struct
 LL |     x: u8
-   |          - help: missing comma here: `,`
 LL |     /// The ID of the parent core
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: doc comments must come before what they document, if a comment was intended use `//`
+help: missing comma here
+   |
+LL |     x: u8,
+   |          +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-49040.stderr
+++ b/tests/ui/parser/issues/issue-49040.stderr
@@ -2,7 +2,13 @@ error: expected item, found `;`
   --> $DIR/issue-49040.rs:1:28
    |
 LL | #![allow(unused_variables)];
-   |                            ^ help: remove this semicolon
+   |                            ^
+   |
+help: remove this semicolon
+   |
+LL - #![allow(unused_variables)];
+LL + #![allow(unused_variables)]
+   |
 
 error[E0601]: `main` function not found in crate `issue_49040`
   --> $DIR/issue-49040.rs:2:12

--- a/tests/ui/parser/issues/issue-52496.stderr
+++ b/tests/ui/parser/issues/issue-52496.stderr
@@ -2,7 +2,12 @@ error: float literals must have an integer part
   --> $DIR/issue-52496.rs:4:24
    |
 LL |     let _ = Foo { bar: .5, baz: 42 };
-   |                        ^^ help: must have an integer part: `0.5`
+   |                        ^^
+   |
+help: must have an integer part
+   |
+LL |     let _ = Foo { bar: 0.5, baz: 42 };
+   |                        +
 
 error: expected one of `,`, `:`, or `}`, found `.`
   --> $DIR/issue-52496.rs:8:22

--- a/tests/ui/parser/issues/issue-54521-2.stderr
+++ b/tests/ui/parser/issues/issue-54521-2.stderr
@@ -2,25 +2,49 @@ error: unmatched angle brackets
   --> $DIR/issue-54521-2.rs:11:25
    |
 LL |     let _ = Vec::<usize>>>>>::new();
-   |                         ^^^^ help: remove extra angle brackets
+   |                         ^^^^
+   |
+help: remove extra angle brackets
+   |
+LL -     let _ = Vec::<usize>>>>>::new();
+LL +     let _ = Vec::<usize>::new();
+   |
 
 error: unmatched angle brackets
   --> $DIR/issue-54521-2.rs:14:25
    |
 LL |     let _ = Vec::<usize>>>>::new();
-   |                         ^^^ help: remove extra angle brackets
+   |                         ^^^
+   |
+help: remove extra angle brackets
+   |
+LL -     let _ = Vec::<usize>>>>::new();
+LL +     let _ = Vec::<usize>::new();
+   |
 
 error: unmatched angle brackets
   --> $DIR/issue-54521-2.rs:17:25
    |
 LL |     let _ = Vec::<usize>>>::new();
-   |                         ^^ help: remove extra angle brackets
+   |                         ^^
+   |
+help: remove extra angle brackets
+   |
+LL -     let _ = Vec::<usize>>>::new();
+LL +     let _ = Vec::<usize>::new();
+   |
 
 error: unmatched angle bracket
   --> $DIR/issue-54521-2.rs:20:25
    |
 LL |     let _ = Vec::<usize>>::new();
-   |                         ^ help: remove extra angle bracket
+   |                         ^
+   |
+help: remove extra angle bracket
+   |
+LL -     let _ = Vec::<usize>>::new();
+LL +     let _ = Vec::<usize>::new();
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/parser/issues/issue-54521-3.stderr
+++ b/tests/ui/parser/issues/issue-54521-3.stderr
@@ -2,25 +2,49 @@ error: unmatched angle brackets
   --> $DIR/issue-54521-3.rs:11:60
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>>();
-   |                                                            ^^^^ help: remove extra angle brackets
+   |                                                            ^^^^
+   |
+help: remove extra angle brackets
+   |
+LL -     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>>();
+LL +     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+   |
 
 error: unmatched angle brackets
   --> $DIR/issue-54521-3.rs:14:60
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>();
-   |                                                            ^^^ help: remove extra angle brackets
+   |                                                            ^^^
+   |
+help: remove extra angle brackets
+   |
+LL -     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>>();
+LL +     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+   |
 
 error: unmatched angle brackets
   --> $DIR/issue-54521-3.rs:17:60
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
-   |                                                            ^^ help: remove extra angle brackets
+   |                                                            ^^
+   |
+help: remove extra angle brackets
+   |
+LL -     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>>();
+LL +     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+   |
 
 error: unmatched angle bracket
   --> $DIR/issue-54521-3.rs:20:60
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>();
-   |                                                            ^ help: remove extra angle bracket
+   |                                                            ^
+   |
+help: remove extra angle bracket
+   |
+LL -     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>>();
+LL +     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/parser/issues/issue-57684.stderr
+++ b/tests/ui/parser/issues/issue-57684.stderr
@@ -2,17 +2,23 @@ error: expected `:`, found `=`
   --> $DIR/issue-57684.rs:27:20
    |
 LL |     let _ = X { f1 = 5 };
-   |                   -^
-   |                   |
-   |                   help: replace equals symbol with a colon: `:`
+   |                    ^
+   |
+help: replace equals symbol with a colon
+   |
+LL |     let _ = X { f1: 5 };
+   |                   ~
 
 error: expected `:`, found `=`
   --> $DIR/issue-57684.rs:32:12
    |
 LL |         f1 = 5,
-   |           -^
-   |           |
-   |           help: replace equals symbol with a colon: `:`
+   |            ^
+   |
+help: replace equals symbol with a colon
+   |
+LL |         f1: 5,
+   |           ~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/issues/issue-57819.stderr
+++ b/tests/ui/parser/issues/issue-57819.stderr
@@ -2,43 +2,85 @@ error: unmatched angle brackets
   --> $DIR/issue-57819.rs:19:10
    |
 LL |     bar::<<<<<T as Foo>::Output>();
-   |          ^^^ help: remove extra angle brackets
+   |          ^^^
+   |
+help: remove extra angle brackets
+   |
+LL -     bar::<<<<<T as Foo>::Output>();
+LL +     bar::<<T as Foo>::Output>();
+   |
 
 error: unmatched angle brackets
   --> $DIR/issue-57819.rs:22:10
    |
 LL |     bar::<<<<T as Foo>::Output>();
-   |          ^^ help: remove extra angle brackets
+   |          ^^
+   |
+help: remove extra angle brackets
+   |
+LL -     bar::<<<<T as Foo>::Output>();
+LL +     bar::<<T as Foo>::Output>();
+   |
 
 error: unmatched angle bracket
   --> $DIR/issue-57819.rs:25:10
    |
 LL |     bar::<<<T as Foo>::Output>();
-   |          ^ help: remove extra angle bracket
+   |          ^
+   |
+help: remove extra angle bracket
+   |
+LL -     bar::<<<T as Foo>::Output>();
+LL +     bar::<<T as Foo>::Output>();
+   |
 
 error: unmatched angle brackets
   --> $DIR/issue-57819.rs:34:48
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<<<<<Vec<usize>>();
-   |                                                ^^^^ help: remove extra angle brackets
+   |                                                ^^^^
+   |
+help: remove extra angle brackets
+   |
+LL -     let _ = vec![1, 2, 3].into_iter().collect::<<<<<Vec<usize>>();
+LL +     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+   |
 
 error: unmatched angle brackets
   --> $DIR/issue-57819.rs:37:48
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<<<<Vec<usize>>();
-   |                                                ^^^ help: remove extra angle brackets
+   |                                                ^^^
+   |
+help: remove extra angle brackets
+   |
+LL -     let _ = vec![1, 2, 3].into_iter().collect::<<<<Vec<usize>>();
+LL +     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+   |
 
 error: unmatched angle brackets
   --> $DIR/issue-57819.rs:40:48
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<<<Vec<usize>>();
-   |                                                ^^ help: remove extra angle brackets
+   |                                                ^^
+   |
+help: remove extra angle brackets
+   |
+LL -     let _ = vec![1, 2, 3].into_iter().collect::<<<Vec<usize>>();
+LL +     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+   |
 
 error: unmatched angle bracket
   --> $DIR/issue-57819.rs:43:48
    |
 LL |     let _ = vec![1, 2, 3].into_iter().collect::<<Vec<usize>>();
-   |                                                ^ help: remove extra angle bracket
+   |                                                ^
+   |
+help: remove extra angle bracket
+   |
+LL -     let _ = vec![1, 2, 3].into_iter().collect::<<Vec<usize>>();
+LL +     let _ = vec![1, 2, 3].into_iter().collect::<Vec<usize>>();
+   |
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/parser/issues/issue-65122-mac-invoc-in-mut-patterns.stderr
+++ b/tests/ui/parser/issues/issue-65122-mac-invoc-in-mut-patterns.stderr
@@ -2,13 +2,18 @@ error: `mut` must be followed by a named binding
   --> $DIR/issue-65122-mac-invoc-in-mut-patterns.rs:6:13
    |
 LL |         let mut $eval = ();
-   |             ^^^^ help: remove the `mut` prefix
+   |             ^^^^
 ...
 LL |     mac1! { does_not_exist!() }
    |     --------------------------- in this macro invocation
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
    = note: this error originates in the macro `mac1` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove the `mut` prefix
+   |
+LL -         let mut $eval = ();
+LL +         let $eval = ();
+   |
 
 error: expected identifier, found `does_not_exist!()`
   --> $DIR/issue-65122-mac-invoc-in-mut-patterns.rs:13:17
@@ -25,13 +30,18 @@ error: `mut` must be followed by a named binding
   --> $DIR/issue-65122-mac-invoc-in-mut-patterns.rs:13:13
    |
 LL |         let mut $eval = ();
-   |             ^^^ help: remove the `mut` prefix
+   |             ^^^
 ...
 LL |     mac2! { does_not_exist!() }
    |     --------------------------- in this macro invocation
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
    = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove the `mut` prefix
+   |
+LL -         let mut $eval = ();
+LL +         let  $eval = ();
+   |
 
 error: cannot find macro `does_not_exist` in this scope
   --> $DIR/issue-65122-mac-invoc-in-mut-patterns.rs:22:13

--- a/tests/ui/parser/issues/issue-65257-invalid-var-decl-recovery.stderr
+++ b/tests/ui/parser/issues/issue-65257-invalid-var-decl-recovery.stderr
@@ -46,13 +46,23 @@ error: invalid variable declaration
   --> $DIR/issue-65257-invalid-var-decl-recovery.rs:14:5
    |
 LL |     mut n = 0;
-   |     ^^^ help: missing keyword: `let mut`
+   |     ^^^
+   |
+help: missing keyword
+   |
+LL |     let mut n = 0;
+   |     ~~~~~~~
 
 error: invalid variable declaration
   --> $DIR/issue-65257-invalid-var-decl-recovery.rs:16:5
    |
 LL |     mut var;
-   |     ^^^ help: missing keyword: `let mut`
+   |     ^^^
+   |
+help: missing keyword
+   |
+LL |     let mut var;
+   |     ~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/issue-65257-invalid-var-decl-recovery.rs:20:33

--- a/tests/ui/parser/issues/issue-70388-recover-dotdotdot-rest-pat.stderr
+++ b/tests/ui/parser/issues/issue-70388-recover-dotdotdot-rest-pat.stderr
@@ -2,19 +2,25 @@ error: unexpected `...`
   --> $DIR/issue-70388-recover-dotdotdot-rest-pat.rs:4:13
    |
 LL |     let Foo(...) = Foo(0);
-   |             ^^^
-   |             |
-   |             not a valid pattern
-   |             help: for a rest pattern, use `..` instead of `...`
+   |             ^^^ not a valid pattern
+   |
+help: for a rest pattern, use `..` instead of `...`
+   |
+LL -     let Foo(...) = Foo(0);
+LL +     let Foo(..) = Foo(0);
+   |
 
 error: unexpected `...`
   --> $DIR/issue-70388-recover-dotdotdot-rest-pat.rs:5:13
    |
 LL |     let [_, ..., _] = [0, 1];
-   |             ^^^
-   |             |
-   |             not a valid pattern
-   |             help: for a rest pattern, use `..` instead of `...`
+   |             ^^^ not a valid pattern
+   |
+help: for a rest pattern, use `..` instead of `...`
+   |
+LL -     let [_, ..., _] = [0, 1];
+LL +     let [_, .., _] = [0, 1];
+   |
 
 error[E0308]: mismatched types
   --> $DIR/issue-70388-recover-dotdotdot-rest-pat.rs:6:33

--- a/tests/ui/parser/issues/issue-70388-without-witness.stderr
+++ b/tests/ui/parser/issues/issue-70388-without-witness.stderr
@@ -2,19 +2,25 @@ error: unexpected `...`
   --> $DIR/issue-70388-without-witness.rs:7:13
    |
 LL |     let Foo(...) = Foo(0);
-   |             ^^^
-   |             |
-   |             not a valid pattern
-   |             help: for a rest pattern, use `..` instead of `...`
+   |             ^^^ not a valid pattern
+   |
+help: for a rest pattern, use `..` instead of `...`
+   |
+LL -     let Foo(...) = Foo(0);
+LL +     let Foo(..) = Foo(0);
+   |
 
 error: unexpected `...`
   --> $DIR/issue-70388-without-witness.rs:8:13
    |
 LL |     let [_, ..., _] = [0, 1];
-   |             ^^^
-   |             |
-   |             not a valid pattern
-   |             help: for a rest pattern, use `..` instead of `...`
+   |             ^^^ not a valid pattern
+   |
+help: for a rest pattern, use `..` instead of `...`
+   |
+LL -     let [_, ..., _] = [0, 1];
+LL +     let [_, .., _] = [0, 1];
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/issues/issue-70549-resolve-after-recovered-self-ctor.stderr
+++ b/tests/ui/parser/issues/issue-70549-resolve-after-recovered-self-ctor.stderr
@@ -17,7 +17,13 @@ error: unexpected lifetime `'static` in pattern
   --> $DIR/issue-70549-resolve-after-recovered-self-ctor.rs:8:13
    |
 LL |     fn bar(&'static mur Self) {}
-   |             ^^^^^^^ help: remove the lifetime
+   |             ^^^^^^^
+   |
+help: remove the lifetime
+   |
+LL -     fn bar(&'static mur Self) {}
+LL +     fn bar(&mur Self) {}
+   |
 
 error: expected identifier, found keyword `Self`
   --> $DIR/issue-70549-resolve-after-recovered-self-ctor.rs:8:25

--- a/tests/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
+++ b/tests/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
@@ -2,24 +2,38 @@ error: lifetime must precede `mut`
   --> $DIR/issue-73568-lifetime-after-mut.rs:2:13
    |
 LL | fn x<'a>(x: &mut 'a i32){}
-   |             ^^^^^^^ help: place the lifetime before `mut`: `&'a mut`
+   |             ^^^^^^^
+   |
+help: place the lifetime before `mut`
+   |
+LL | fn x<'a>(x: &'a mut i32){}
+   |             ~~~~~~~
 
 error[E0178]: expected a path on the left-hand side of `+`, not `&mut 'a`
   --> $DIR/issue-73568-lifetime-after-mut.rs:14:13
    |
 LL | fn y<'a>(y: &mut 'a + Send) {
-   |             ^^^^^^^^^^^^^^ help: try adding parentheses: `&mut ('a + Send)`
+   |             ^^^^^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | fn y<'a>(y: &mut ('a + Send)) {
+   |                  +         +
 
 error: lifetime must precede `mut`
   --> $DIR/issue-73568-lifetime-after-mut.rs:6:22
    |
 LL |         fn w<$lt>(w: &mut $lt i32) {}
-   |                      ^^^^^^^^ help: place the lifetime before `mut`: `&$lt mut`
+   |                      ^^^^^^^^
 ...
 LL | mac!('a);
    | -------- in this macro invocation
    |
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: place the lifetime before `mut`
+   |
+LL |         fn w<$lt>(w: &$lt mut i32) {}
+   |                      ~~~~~~~~
 
 error[E0423]: expected value, found trait `Send`
   --> $DIR/issue-73568-lifetime-after-mut.rs:17:28

--- a/tests/ui/parser/issues/issue-87197-missing-semicolon.stderr
+++ b/tests/ui/parser/issues/issue-87197-missing-semicolon.stderr
@@ -2,25 +2,40 @@ error: expected `;`, found `println`
   --> $DIR/issue-87197-missing-semicolon.rs:6:16
    |
 LL |     let x = 100
-   |                ^ help: add `;` here
+   |                ^
 LL |     println!("{}", x)
    |     ------- unexpected token
+   |
+help: add `;` here
+   |
+LL |     let x = 100;
+   |                +
 
 error: expected `;`, found keyword `let`
   --> $DIR/issue-87197-missing-semicolon.rs:7:22
    |
 LL |     println!("{}", x)
-   |                      ^ help: add `;` here
+   |                      ^
 LL |     let y = 200
    |     --- unexpected token
+   |
+help: add `;` here
+   |
+LL |     println!("{}", x);
+   |                      +
 
 error: expected `;`, found `println`
   --> $DIR/issue-87197-missing-semicolon.rs:8:16
    |
 LL |     let y = 200
-   |                ^ help: add `;` here
+   |                ^
 LL |     println!("{}", y);
    |     ------- unexpected token
+   |
+help: add `;` here
+   |
+LL |     let y = 200;
+   |                +
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/issues/issue-87197-missing-semicolon.stderr
+++ b/tests/ui/parser/issues/issue-87197-missing-semicolon.stderr
@@ -2,40 +2,25 @@ error: expected `;`, found `println`
   --> $DIR/issue-87197-missing-semicolon.rs:6:16
    |
 LL |     let x = 100
-   |                ^
+   |                ^ help: add `;` here
 LL |     println!("{}", x)
    |     ------- unexpected token
-   |
-help: add `;` here
-   |
-LL |     let x = 100;
-   |                +
 
 error: expected `;`, found keyword `let`
   --> $DIR/issue-87197-missing-semicolon.rs:7:22
    |
 LL |     println!("{}", x)
-   |                      ^
+   |                      ^ help: add `;` here
 LL |     let y = 200
    |     --- unexpected token
-   |
-help: add `;` here
-   |
-LL |     println!("{}", x);
-   |                      +
 
 error: expected `;`, found `println`
   --> $DIR/issue-87197-missing-semicolon.rs:8:16
    |
 LL |     let y = 200
-   |                ^
+   |                ^ help: add `;` here
 LL |     println!("{}", y);
    |     ------- unexpected token
-   |
-help: add `;` here
-   |
-LL |     let y = 200;
-   |                +
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/issues/issue-89574.stderr
+++ b/tests/ui/parser/issues/issue-89574.stderr
@@ -8,7 +8,12 @@ error: missing type for `const` item
   --> $DIR/issue-89574.rs:2:22
    |
 LL |     const EMPTY_ARRAY = [];
-   |                      ^ help: provide a type for the item: `: <type>`
+   |                      ^
+   |
+help: provide a type for the item
+   |
+LL |     const EMPTY_ARRAY: <type> = [];
+   |                      ++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/issue-89574.rs:2:25

--- a/tests/ui/parser/issues/issue-90993.stderr
+++ b/tests/ui/parser/issues/issue-90993.stderr
@@ -17,9 +17,13 @@ error: unexpected `=` after inclusive range
   --> $DIR/issue-90993.rs:2:5
    |
 LL |     ...=.
-   |     ^^^^ help: use `..=` instead
+   |     ^^^^
    |
    = note: inclusive ranges end with a single equals sign (`..=`)
+help: use `..=` instead
+   |
+LL |     ..=.
+   |     ~~~
 
 error: expected one of `-`, `;`, `}`, or path, found `.`
   --> $DIR/issue-90993.rs:2:9

--- a/tests/ui/parser/issues/issue-99625-enum-struct-mutually-exclusive.stderr
+++ b/tests/ui/parser/issues/issue-99625-enum-struct-mutually-exclusive.stderr
@@ -2,7 +2,12 @@ error: `enum` and `struct` are mutually exclusive
   --> $DIR/issue-99625-enum-struct-mutually-exclusive.rs:3:5
    |
 LL | pub enum struct Range {
-   |     ^^^^^^^^^^^ help: replace `enum struct` with: `enum`
+   |     ^^^^^^^^^^^
+   |
+help: replace `enum struct` with
+   |
+LL | pub enum Range {
+   |     ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-99910-const-let-mutually-exclusive.stderr
+++ b/tests/ui/parser/issues/issue-99910-const-let-mutually-exclusive.stderr
@@ -2,13 +2,23 @@ error: `const` and `let` are mutually exclusive
   --> $DIR/issue-99910-const-let-mutually-exclusive.rs:4:5
    |
 LL |     const let _FOO: i32 = 123;
-   |     ^^^^^^^^^ help: remove `let`: `const`
+   |     ^^^^^^^^^
+   |
+help: remove `let`
+   |
+LL |     const _FOO: i32 = 123;
+   |     ~~~~~
 
 error: `const` and `let` are mutually exclusive
   --> $DIR/issue-99910-const-let-mutually-exclusive.rs:6:5
    |
 LL |     let const _BAR: i32 = 123;
-   |     ^^^^^^^^^ help: remove `let`: `const`
+   |     ^^^^^^^^^
+   |
+help: remove `let`
+   |
+LL |     const _BAR: i32 = 123;
+   |     ~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/issues/missing-main-issue-124935-semi-after-item.rs
+++ b/tests/ui/parser/issues/missing-main-issue-124935-semi-after-item.rs
@@ -2,4 +2,5 @@
 // Tests that we still emit an error after an item.
 
 fn main() { }
-; //~ ERROR expected item, found `;`
+;
+//~^ ERROR expected item, found `;`

--- a/tests/ui/parser/issues/missing-main-issue-124935-semi-after-item.stderr
+++ b/tests/ui/parser/issues/missing-main-issue-124935-semi-after-item.stderr
@@ -2,9 +2,14 @@ error: expected item, found `;`
   --> $DIR/missing-main-issue-124935-semi-after-item.rs:5:1
    |
 LL | ;
-   | ^ help: remove this semicolon
+   | ^
    |
    = help: function declarations are not followed by a semicolon
+help: remove this semicolon
+   |
+LL - ;
+LL +
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/missing-main-issue-124935-semi-after-item.stderr
+++ b/tests/ui/parser/issues/missing-main-issue-124935-semi-after-item.stderr
@@ -8,7 +8,6 @@ LL | ;
 help: remove this semicolon
    |
 LL - ;
-LL +
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/parser/item-free-const-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/item-free-const-no-body-semantic-fail.stderr
@@ -18,7 +18,12 @@ error: missing type for `const` item
   --> $DIR/item-free-const-no-body-semantic-fail.rs:6:8
    |
 LL | const B;
-   |        ^ help: provide a type for the item: `: <type>`
+   |        ^
+   |
+help: provide a type for the item
+   |
+LL | const B: <type>;
+   |        ++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/item-free-static-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/item-free-static-no-body-semantic-fail.stderr
@@ -34,13 +34,23 @@ error: missing type for `static` item
   --> $DIR/item-free-static-no-body-semantic-fail.rs:6:9
    |
 LL | static B;
-   |         ^ help: provide a type for the item: `: <type>`
+   |         ^
+   |
+help: provide a type for the item
+   |
+LL | static B: <type>;
+   |         ++++++++
 
 error: missing type for `static mut` item
   --> $DIR/item-free-static-no-body-semantic-fail.rs:10:13
    |
 LL | static mut D;
-   |             ^ help: provide a type for the item: `: <type>`
+   |             ^
+   |
+help: provide a type for the item
+   |
+LL | static mut D: <type>;
+   |             ++++++++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/parser/item-kw-case-mismatch.stderr
+++ b/tests/ui/parser/item-kw-case-mismatch.stderr
@@ -2,85 +2,155 @@ error: keyword `use` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:7:1
    |
 LL | Use std::ptr::read;
-   | ^^^ help: write it in the correct case (notice the capitalization): `use`
+   | ^^^
+   |
+help: write it in the correct case (notice the capitalization difference)
+   |
+LL | use std::ptr::read;
+   | ~~~
 
 error: keyword `use` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:8:1
    |
 LL | USE std::ptr::write;
-   | ^^^ help: write it in the correct case: `use`
+   | ^^^
+   |
+help: write it in the correct case
+   |
+LL | use std::ptr::write;
+   | ~~~
 
 error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:10:7
    |
 LL | async Fn _a() {}
-   |       ^^ help: write it in the correct case (notice the capitalization): `fn`
+   |       ^^
+   |
+help: write it in the correct case (notice the capitalization difference)
+   |
+LL | async fn _a() {}
+   |       ~~
 
 error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:13:1
    |
 LL | Fn _b() {}
-   | ^^ help: write it in the correct case (notice the capitalization): `fn`
+   | ^^
+   |
+help: write it in the correct case (notice the capitalization difference)
+   |
+LL | fn _b() {}
+   | ~~
 
 error: keyword `async` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:16:1
    |
 LL | aSYNC fN _c() {}
-   | ^^^^^ help: write it in the correct case: `async`
+   | ^^^^^
+   |
+help: write it in the correct case
+   |
+LL | async fN _c() {}
+   | ~~~~~
 
 error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:16:7
    |
 LL | aSYNC fN _c() {}
-   |       ^^ help: write it in the correct case: `fn`
+   |       ^^
+   |
+help: write it in the correct case
+   |
+LL | aSYNC fn _c() {}
+   |       ~~
 
 error: keyword `async` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:20:1
    |
 LL | Async fn _d() {}
-   | ^^^^^ help: write it in the correct case: `async`
+   | ^^^^^
+   |
+help: write it in the correct case
+   |
+LL | async fn _d() {}
+   | ~~~~~
 
 error: keyword `const` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:23:1
    |
 LL | CONST UNSAFE FN _e() {}
-   | ^^^^^ help: write it in the correct case: `const`
+   | ^^^^^
+   |
+help: write it in the correct case
+   |
+LL | const UNSAFE FN _e() {}
+   | ~~~~~
 
 error: keyword `unsafe` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:23:7
    |
 LL | CONST UNSAFE FN _e() {}
-   |       ^^^^^^ help: write it in the correct case: `unsafe`
+   |       ^^^^^^
+   |
+help: write it in the correct case
+   |
+LL | CONST unsafe FN _e() {}
+   |       ~~~~~~
 
 error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:23:14
    |
 LL | CONST UNSAFE FN _e() {}
-   |              ^^ help: write it in the correct case: `fn`
+   |              ^^
+   |
+help: write it in the correct case
+   |
+LL | CONST UNSAFE fn _e() {}
+   |              ~~
 
 error: keyword `unsafe` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:28:1
    |
 LL | unSAFE EXTern fn _f() {}
-   | ^^^^^^ help: write it in the correct case: `unsafe`
+   | ^^^^^^
+   |
+help: write it in the correct case
+   |
+LL | unsafe EXTern fn _f() {}
+   | ~~~~~~
 
 error: keyword `extern` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:28:8
    |
 LL | unSAFE EXTern fn _f() {}
-   |        ^^^^^^ help: write it in the correct case: `extern`
+   |        ^^^^^^
+   |
+help: write it in the correct case
+   |
+LL | unSAFE extern fn _f() {}
+   |        ~~~~~~
 
 error: keyword `extern` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:32:1
    |
 LL | EXTERN "C" FN _g() {}
-   | ^^^^^^ help: write it in the correct case: `extern`
+   | ^^^^^^
+   |
+help: write it in the correct case
+   |
+LL | extern "C" FN _g() {}
+   | ~~~~~~
 
 error: keyword `fn` is written in the wrong case
   --> $DIR/item-kw-case-mismatch.rs:32:12
    |
 LL | EXTERN "C" FN _g() {}
-   |            ^^ help: write it in the correct case: `fn`
+   |            ^^
+   |
+help: write it in the correct case
+   |
+LL | EXTERN "C" fn _g() {}
+   |            ~~
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/parser/label-after-block-like.stderr
+++ b/tests/ui/parser/label-after-block-like.stderr
@@ -2,12 +2,15 @@ error: labeled expression must be followed by `:`
   --> $DIR/label-after-block-like.rs:2:20
    |
 LL |     if let () = () 'a {}
-   |                    ---^^
-   |                    | |
-   |                    | help: add `:` after the label
+   |                    --^^^
+   |                    |
    |                    the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     if let () = () 'a: {}
+   |                      +
 
 error: expected `{`, found `'a`
   --> $DIR/label-after-block-like.rs:2:20
@@ -29,12 +32,15 @@ error: labeled expression must be followed by `:`
   --> $DIR/label-after-block-like.rs:8:13
    |
 LL |     if true 'a {}
-   |             ---^^
-   |             | |
-   |             | help: add `:` after the label
+   |             --^^^
+   |             |
    |             the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     if true 'a: {}
+   |               +
 
 error: expected `{`, found `'a`
   --> $DIR/label-after-block-like.rs:8:13
@@ -56,12 +62,15 @@ error: labeled expression must be followed by `:`
   --> $DIR/label-after-block-like.rs:14:10
    |
 LL |     loop 'a {}
-   |          ---^^
-   |          | |
-   |          | help: add `:` after the label
+   |          --^^^
+   |          |
    |          the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     loop 'a: {}
+   |            +
 
 error: expected `{`, found `'a`
   --> $DIR/label-after-block-like.rs:14:10
@@ -80,12 +89,15 @@ error: labeled expression must be followed by `:`
   --> $DIR/label-after-block-like.rs:20:16
    |
 LL |     while true 'a {}
-   |                ---^^
-   |                | |
-   |                | help: add `:` after the label
+   |                --^^^
+   |                |
    |                the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     while true 'a: {}
+   |                  +
 
 error: expected `{`, found `'a`
   --> $DIR/label-after-block-like.rs:20:16
@@ -105,12 +117,15 @@ error: labeled expression must be followed by `:`
   --> $DIR/label-after-block-like.rs:26:23
    |
 LL |     while let () = () 'a {}
-   |                       ---^^
-   |                       | |
-   |                       | help: add `:` after the label
+   |                       --^^^
+   |                       |
    |                       the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     while let () = () 'a: {}
+   |                         +
 
 error: expected `{`, found `'a`
   --> $DIR/label-after-block-like.rs:26:23
@@ -130,12 +145,15 @@ error: labeled expression must be followed by `:`
   --> $DIR/label-after-block-like.rs:32:19
    |
 LL |     for _ in 0..0 'a {}
-   |                   ---^^
-   |                   | |
-   |                   | help: add `:` after the label
+   |                   --^^^
+   |                   |
    |                   the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     for _ in 0..0 'a: {}
+   |                     +
 
 error: expected `{`, found `'a`
   --> $DIR/label-after-block-like.rs:32:19
@@ -152,12 +170,15 @@ error: labeled expression must be followed by `:`
   --> $DIR/label-after-block-like.rs:38:12
    |
 LL |     unsafe 'a {}
-   |            ---^^
-   |            | |
-   |            | help: add `:` after the label
+   |            --^^^
+   |            |
    |            the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     unsafe 'a: {}
+   |              +
 
 error: expected `{`, found `'a`
   --> $DIR/label-after-block-like.rs:38:12

--- a/tests/ui/parser/labeled-no-colon-expr.stderr
+++ b/tests/ui/parser/labeled-no-colon-expr.stderr
@@ -2,45 +2,57 @@ error: labeled expression must be followed by `:`
   --> $DIR/labeled-no-colon-expr.rs:2:5
    |
 LL |     'l0 while false {}
-   |     ----^^^^^^^^^^^^^^
-   |     |  |
-   |     |  help: add `:` after the label
+   |     ---^^^^^^^^^^^^^^^
+   |     |
    |     the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     'l0: while false {}
+   |        +
 
 error: labeled expression must be followed by `:`
   --> $DIR/labeled-no-colon-expr.rs:3:5
    |
 LL |     'l1 for _ in 0..1 {}
-   |     ----^^^^^^^^^^^^^^^^
-   |     |  |
-   |     |  help: add `:` after the label
+   |     ---^^^^^^^^^^^^^^^^^
+   |     |
    |     the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     'l1: for _ in 0..1 {}
+   |        +
 
 error: labeled expression must be followed by `:`
   --> $DIR/labeled-no-colon-expr.rs:4:5
    |
 LL |     'l2 loop {}
-   |     ----^^^^^^^
-   |     |  |
-   |     |  help: add `:` after the label
+   |     ---^^^^^^^^
+   |     |
    |     the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     'l2: loop {}
+   |        +
 
 error: labeled expression must be followed by `:`
   --> $DIR/labeled-no-colon-expr.rs:5:5
    |
 LL |     'l3 {}
-   |     ----^^
-   |     |  |
-   |     |  help: add `:` after the label
+   |     ---^^^
+   |     |
    |     the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     'l3: {}
+   |        +
 
 error: expected `while`, `for`, `loop` or `{` after a label
   --> $DIR/labeled-no-colon-expr.rs:6:9
@@ -58,12 +70,15 @@ error: labeled expression must be followed by `:`
   --> $DIR/labeled-no-colon-expr.rs:6:9
    |
 LL |     'l4 0;
-   |     ----^
-   |     |  |
-   |     |  help: add `:` after the label
+   |     --- ^
+   |     |
    |     the label
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |     'l4: 0;
+   |        +
 
 error: cannot use a `block` macro fragment here
   --> $DIR/labeled-no-colon-expr.rs:11:17
@@ -86,14 +101,16 @@ error: labeled expression must be followed by `:`
   --> $DIR/labeled-no-colon-expr.rs:14:8
    |
 LL |             'l5 $b;
-   |             ---- help: add `:` after the label
-   |             |
-   |             the label
+   |             --- the label
 ...
 LL |     m!({});
    |        ^^
    |
    = note: labels are used before loops and blocks, allowing e.g., `break 'label` to them
+help: add `:` after the label
+   |
+LL |             'l5: $b;
+   |                +
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/parser/let-binop.stderr
+++ b/tests/ui/parser/let-binop.stderr
@@ -2,25 +2,40 @@ error: can't reassign to an uninitialized variable
   --> $DIR/let-binop.rs:4:15
    |
 LL |     let a: i8 *= 1;
-   |               ^^ help: initialize the variable
+   |               ^^
    |
    = help: if you meant to overwrite, remove the `let` binding
+help: initialize the variable
+   |
+LL -     let a: i8 *= 1;
+LL +     let a: i8 = 1;
+   |
 
 error: can't reassign to an uninitialized variable
   --> $DIR/let-binop.rs:6:11
    |
 LL |     let b += 1;
-   |           ^^ help: initialize the variable
+   |           ^^
    |
    = help: if you meant to overwrite, remove the `let` binding
+help: initialize the variable
+   |
+LL -     let b += 1;
+LL +     let b = 1;
+   |
 
 error: can't reassign to an uninitialized variable
   --> $DIR/let-binop.rs:8:11
    |
 LL |     let c *= 1;
-   |           ^^ help: initialize the variable
+   |           ^^
    |
    = help: if you meant to overwrite, remove the `let` binding
+help: initialize the variable
+   |
+LL -     let c *= 1;
+LL +     let c = 1;
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/lifetime-in-pattern-recover.stderr
+++ b/tests/ui/parser/lifetime-in-pattern-recover.stderr
@@ -2,13 +2,25 @@ error: unexpected lifetime `'a` in pattern
   --> $DIR/lifetime-in-pattern-recover.rs:2:10
    |
 LL |     let &'a x = &0;
-   |          ^^ help: remove the lifetime
+   |          ^^
+   |
+help: remove the lifetime
+   |
+LL -     let &'a x = &0;
+LL +     let &x = &0;
+   |
 
 error: unexpected lifetime `'a` in pattern
   --> $DIR/lifetime-in-pattern-recover.rs:3:10
    |
 LL |     let &'a mut y = &mut 0;
-   |          ^^ help: remove the lifetime
+   |          ^^
+   |
+help: remove the lifetime
+   |
+LL -     let &'a mut y = &mut 0;
+LL +     let &mut y = &mut 0;
+   |
 
 error[E0308]: mismatched types
   --> $DIR/lifetime-in-pattern-recover.rs:5:33

--- a/tests/ui/parser/lifetime-in-pattern.stderr
+++ b/tests/ui/parser/lifetime-in-pattern.stderr
@@ -2,7 +2,13 @@ error: unexpected lifetime `'a` in pattern
   --> $DIR/lifetime-in-pattern.rs:1:10
    |
 LL | fn test(&'a str) {
-   |          ^^ help: remove the lifetime
+   |          ^^
+   |
+help: remove the lifetime
+   |
+LL - fn test(&'a str) {
+LL + fn test(&str) {
+   |
 
 error: expected one of `:`, `@`, or `|`, found `)`
   --> $DIR/lifetime-in-pattern.rs:1:16

--- a/tests/ui/parser/macro/pub-item-macro.stderr
+++ b/tests/ui/parser/macro/pub-item-macro.stderr
@@ -2,13 +2,18 @@ error: can't qualify macro invocation with `pub`
   --> $DIR/pub-item-macro.rs:10:5
    |
 LL |     pub priv_x!();
-   |     ^^^ help: remove the visibility
+   |     ^^^
 ...
 LL |     pub_x!();
    |     -------- in this macro invocation
    |
    = help: try adjusting the macro to put `pub` inside the invocation
    = note: this error originates in the macro `pub_x` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove the visibility
+   |
+LL -     pub priv_x!();
+LL +      priv_x!();
+   |
 
 error[E0603]: static `x` is private
   --> $DIR/pub-item-macro.rs:20:23

--- a/tests/ui/parser/macros-no-semicolon.stderr
+++ b/tests/ui/parser/macros-no-semicolon.stderr
@@ -2,27 +2,17 @@ error: expected `;`, found `assert_eq`
   --> $DIR/macros-no-semicolon.rs:2:21
    |
 LL |     assert_eq!(1, 2)
-   |                     ^
+   |                     ^ help: add `;` here
 LL |     assert_eq!(3, 4)
    |     --------- unexpected token
-   |
-help: add `;` here
-   |
-LL |     assert_eq!(1, 2);
-   |                     +
 
 error: expected `;`, found `println`
   --> $DIR/macros-no-semicolon.rs:3:21
    |
 LL |     assert_eq!(3, 4)
-   |                     ^
+   |                     ^ help: add `;` here
 LL |     println!("hello");
    |     ------- unexpected token
-   |
-help: add `;` here
-   |
-LL |     assert_eq!(3, 4);
-   |                     +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/macros-no-semicolon.stderr
+++ b/tests/ui/parser/macros-no-semicolon.stderr
@@ -2,17 +2,27 @@ error: expected `;`, found `assert_eq`
   --> $DIR/macros-no-semicolon.rs:2:21
    |
 LL |     assert_eq!(1, 2)
-   |                     ^ help: add `;` here
+   |                     ^
 LL |     assert_eq!(3, 4)
    |     --------- unexpected token
+   |
+help: add `;` here
+   |
+LL |     assert_eq!(1, 2);
+   |                     +
 
 error: expected `;`, found `println`
   --> $DIR/macros-no-semicolon.rs:3:21
    |
 LL |     assert_eq!(3, 4)
-   |                     ^ help: add `;` here
+   |                     ^
 LL |     println!("hello");
    |     ------- unexpected token
+   |
+help: add `;` here
+   |
+LL |     assert_eq!(3, 4);
+   |                     +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/match-arm-without-body.stderr
+++ b/tests/ui/parser/match-arm-without-body.stderr
@@ -56,7 +56,12 @@ error: expected `,` following `match` arm
   --> $DIR/match-arm-without-body.rs:66:15
    |
 LL |         pat!()
-   |               ^ help: missing a comma here to end this `match` arm: `,`
+   |               ^
+   |
+help: missing a comma here to end this `match` arm
+   |
+LL |         pat!(),
+   |               +
 
 error: `match` arm with no body
   --> $DIR/match-arm-without-body.rs:7:9

--- a/tests/ui/parser/match-arm-without-braces.stderr
+++ b/tests/ui/parser/match-arm-without-braces.stderr
@@ -60,7 +60,12 @@ error: expected `,` following `match` arm
   --> $DIR/match-arm-without-braces.rs:48:29
    |
 LL |         Some(Val::Foo) => 17
-   |                             ^ help: missing a comma here to end this `match` arm: `,`
+   |                             ^
+   |
+help: missing a comma here to end this `match` arm
+   |
+LL |         Some(Val::Foo) => 17,
+   |                             +
 
 error: `match` arm body without braces
   --> $DIR/match-arm-without-braces.rs:53:11

--- a/tests/ui/parser/mut-patterns.stderr
+++ b/tests/ui/parser/mut-patterns.stderr
@@ -2,53 +2,87 @@ error: `mut` must be followed by a named binding
   --> $DIR/mut-patterns.rs:9:9
    |
 LL |     let mut _ = 0;
-   |         ^^^^ help: remove the `mut` prefix
+   |         ^^^^
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
+help: remove the `mut` prefix
+   |
+LL -     let mut _ = 0;
+LL +     let _ = 0;
+   |
 
 error: `mut` must be followed by a named binding
   --> $DIR/mut-patterns.rs:10:9
    |
 LL |     let mut (_, _) = (0, 0);
-   |         ^^^^ help: remove the `mut` prefix
+   |         ^^^^
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
+help: remove the `mut` prefix
+   |
+LL -     let mut (_, _) = (0, 0);
+LL +     let (_, _) = (0, 0);
+   |
 
 error: `mut` must be attached to each individual binding
   --> $DIR/mut-patterns.rs:12:9
    |
 LL |     let mut (x @ y) = 0;
-   |         ^^^^^^^^^^^ help: add `mut` to each binding: `(mut x @ mut y)`
+   |         ^^^^^^^^^^^
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
+help: add `mut` to each binding
+   |
+LL |     let (mut x @ mut y) = 0;
+   |         ~~~~~~~~~~~~~~~
 
 error: `mut` on a binding may not be repeated
   --> $DIR/mut-patterns.rs:14:13
    |
 LL |     let mut mut x = 0;
-   |             ^^^ help: remove the additional `mut`s
+   |             ^^^
+   |
+help: remove the additional `mut`s
+   |
+LL -     let mut mut x = 0;
+LL +     let mut  x = 0;
+   |
 
 error: `mut` must be attached to each individual binding
   --> $DIR/mut-patterns.rs:19:9
    |
 LL |     let mut Foo { x: x } = Foo { x: 3 };
-   |         ^^^^^^^^^^^^^^^^ help: add `mut` to each binding: `Foo { x: mut x }`
+   |         ^^^^^^^^^^^^^^^^
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
+help: add `mut` to each binding
+   |
+LL |     let Foo { x: mut x } = Foo { x: 3 };
+   |         ~~~~~~~~~~~~~~~~
 
 error: `mut` must be attached to each individual binding
   --> $DIR/mut-patterns.rs:23:9
    |
 LL |     let mut Foo { x } = Foo { x: 3 };
-   |         ^^^^^^^^^^^^^ help: add `mut` to each binding: `Foo { mut x }`
+   |         ^^^^^^^^^^^^^
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
+help: add `mut` to each binding
+   |
+LL |     let Foo { mut x } = Foo { x: 3 };
+   |         ~~~~~~~~~~~~~
 
 error: `mut` on a binding may not be repeated
   --> $DIR/mut-patterns.rs:28:13
    |
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
-   |             ^^^ help: remove the additional `mut`s
+   |             ^^^
+   |
+help: remove the additional `mut`s
+   |
+LL -     let mut mut yield(become, await) = r#yield(0, 0);
+LL +     let mut  yield(become, await) = r#yield(0, 0);
+   |
 
 error: expected identifier, found reserved keyword `yield`
   --> $DIR/mut-patterns.rs:28:17
@@ -87,17 +121,26 @@ error: `mut` must be followed by a named binding
   --> $DIR/mut-patterns.rs:28:9
    |
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
-   |         ^^^^^^^^ help: remove the `mut` prefix
+   |         ^^^^^^^^
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
+help: remove the `mut` prefix
+   |
+LL -     let mut mut yield(become, await) = r#yield(0, 0);
+LL +     let yield(become, await) = r#yield(0, 0);
+   |
 
 error: `mut` must be attached to each individual binding
   --> $DIR/mut-patterns.rs:37:9
    |
 LL |     let mut W(mut a, W(b, W(ref c, W(d, B { box f }))))
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add `mut` to each binding: `W(mut a, W(mut b, W(ref c, W(mut d, B { box mut f }))))`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
+help: add `mut` to each binding
+   |
+LL |     let W(mut a, W(mut b, W(ref c, W(mut d, B { box mut f }))))
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: expected identifier, found `x`
   --> $DIR/mut-patterns.rs:44:21

--- a/tests/ui/parser/not-a-pred.stderr
+++ b/tests/ui/parser/not-a-pred.stderr
@@ -2,7 +2,12 @@ error: return types are denoted using `->`
   --> $DIR/not-a-pred.rs:1:26
    |
 LL | fn f(a: isize, b: isize) : lt(a, b) { }
-   |                          ^ help: use `->` instead
+   |                          ^
+   |
+help: use `->` instead
+   |
+LL | fn f(a: isize, b: isize) -> lt(a, b) { }
+   |                          ~~
 
 error[E0573]: expected type, found function `lt`
   --> $DIR/not-a-pred.rs:1:28

--- a/tests/ui/parser/pat-recover-wildcards.stderr
+++ b/tests/ui/parser/pat-recover-wildcards.stderr
@@ -32,9 +32,14 @@ error[E0586]: inclusive range with no end
   --> $DIR/pat-recover-wildcards.rs:35:10
    |
 LL |         0..._ => ()
-   |          ^^^ help: use `..` instead
+   |          ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -         0..._ => ()
+LL +         0.._ => ()
+   |
 
 error: expected one of `=>`, `if`, or `|`, found reserved identifier `_`
   --> $DIR/pat-recover-wildcards.rs:35:13

--- a/tests/ui/parser/pub-method-macro.stderr
+++ b/tests/ui/parser/pub-method-macro.stderr
@@ -2,9 +2,14 @@ error: can't qualify macro invocation with `pub`
   --> $DIR/pub-method-macro.rs:17:9
    |
 LL |         pub defn!(f);
-   |         ^^^ help: remove the visibility
+   |         ^^^
    |
    = help: try adjusting the macro to put `pub` inside the invocation
+help: remove the visibility
+   |
+LL -         pub defn!(f);
+LL +          defn!(f);
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/range-inclusive-extra-equals.stderr
+++ b/tests/ui/parser/range-inclusive-extra-equals.stderr
@@ -2,9 +2,13 @@ error: unexpected `=` after inclusive range
   --> $DIR/range-inclusive-extra-equals.rs:7:13
    |
 LL |     if let 1..==3 = 1 {}
-   |             ^^^^ help: use `..=` instead
+   |             ^^^^
    |
    = note: inclusive ranges end with a single equals sign (`..=`)
+help: use `..=` instead
+   |
+LL |     if let 1..=3 = 1 {}
+   |             ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/range_inclusive.stderr
+++ b/tests/ui/parser/range_inclusive.stderr
@@ -2,9 +2,14 @@ error[E0586]: inclusive range with no end
   --> $DIR/range_inclusive.rs:5:15
    |
 LL |     for _ in 1..= {}
-   |               ^^^ help: use `..` instead
+   |               ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     for _ in 1..= {}
+LL +     for _ in 1.. {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/raw/raw-str-unbalanced.stderr
+++ b/tests/ui/parser/raw/raw-str-unbalanced.stderr
@@ -19,10 +19,15 @@ error: expected `;`, found `#`
   --> $DIR/raw-str-unbalanced.rs:10:28
    |
 LL | const A: &'static str = r""
-   |                            ^ help: add `;` here
+   |                            ^
 ...
 LL | #[test]
    | - unexpected token
+   |
+help: add `;` here
+   |
+LL | const A: &'static str = r"";
+   |                            +
 
 error: too many `#` when terminating raw string
   --> $DIR/raw-str-unbalanced.rs:16:28

--- a/tests/ui/parser/raw/raw-str-unbalanced.stderr
+++ b/tests/ui/parser/raw/raw-str-unbalanced.stderr
@@ -19,15 +19,10 @@ error: expected `;`, found `#`
   --> $DIR/raw-str-unbalanced.rs:10:28
    |
 LL | const A: &'static str = r""
-   |                            ^
+   |                            ^ help: add `;` here
 ...
 LL | #[test]
    | - unexpected token
-   |
-help: add `;` here
-   |
-LL | const A: &'static str = r"";
-   |                            +
 
 error: too many `#` when terminating raw string
   --> $DIR/raw-str-unbalanced.rs:16:28

--- a/tests/ui/parser/recover/recover-const-async-fn-ptr.stderr
+++ b/tests/ui/parser/recover/recover-const-async-fn-ptr.stderr
@@ -5,7 +5,12 @@ LL | type T0 = const fn();
    |           -----^^^^^
    |           |
    |           `const` because of this
-   |           help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - type T0 = const fn();
+LL + type T0 =  fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:4:11
@@ -14,7 +19,12 @@ LL | type T1 = const extern "C" fn();
    |           -----^^^^^^^^^^^^^^^^
    |           |
    |           `const` because of this
-   |           help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - type T1 = const extern "C" fn();
+LL + type T1 =  extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:5:11
@@ -23,7 +33,12 @@ LL | type T2 = const unsafe extern fn();
    |           -----^^^^^^^^^^^^^^^^^^^
    |           |
    |           `const` because of this
-   |           help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - type T2 = const unsafe extern fn();
+LL + type T2 =  unsafe extern fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/recover-const-async-fn-ptr.rs:6:11
@@ -32,7 +47,12 @@ LL | type T3 = async fn();
    |           -----^^^^^
    |           |
    |           `async` because of this
-   |           help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - type T3 = async fn();
+LL + type T3 =  fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/recover-const-async-fn-ptr.rs:7:11
@@ -41,7 +61,12 @@ LL | type T4 = async extern fn();
    |           -----^^^^^^^^^^^^
    |           |
    |           `async` because of this
-   |           help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - type T4 = async extern fn();
+LL + type T4 =  extern fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/recover-const-async-fn-ptr.rs:8:11
@@ -50,7 +75,12 @@ LL | type T5 = async unsafe extern "C" fn();
    |           -----^^^^^^^^^^^^^^^^^^^^^^^
    |           |
    |           `async` because of this
-   |           help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - type T5 = async unsafe extern "C" fn();
+LL + type T5 =  unsafe extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:9:11
@@ -59,7 +89,12 @@ LL | type T6 = const async unsafe extern "C" fn();
    |           -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |           |
    |           `const` because of this
-   |           help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - type T6 = const async unsafe extern "C" fn();
+LL + type T6 =  async unsafe extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/recover-const-async-fn-ptr.rs:9:11
@@ -68,7 +103,12 @@ LL | type T6 = const async unsafe extern "C" fn();
    |           ^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
    |                 |
    |                 `async` because of this
-   |                 help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - type T6 = const async unsafe extern "C" fn();
+LL + type T6 = const  unsafe extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:13:12
@@ -77,7 +117,12 @@ LL | type FT0 = for<'a> const fn();
    |            ^^^^^^^^-----^^^^^
    |                    |
    |                    `const` because of this
-   |                    help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - type FT0 = for<'a> const fn();
+LL + type FT0 = for<'a>  fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:14:12
@@ -86,7 +131,12 @@ LL | type FT1 = for<'a> const extern "C" fn();
    |            ^^^^^^^^-----^^^^^^^^^^^^^^^^
    |                    |
    |                    `const` because of this
-   |                    help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - type FT1 = for<'a> const extern "C" fn();
+LL + type FT1 = for<'a>  extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:15:12
@@ -95,7 +145,12 @@ LL | type FT2 = for<'a> const unsafe extern fn();
    |            ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^
    |                    |
    |                    `const` because of this
-   |                    help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - type FT2 = for<'a> const unsafe extern fn();
+LL + type FT2 = for<'a>  unsafe extern fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/recover-const-async-fn-ptr.rs:16:12
@@ -104,7 +159,12 @@ LL | type FT3 = for<'a> async fn();
    |            ^^^^^^^^-----^^^^^
    |                    |
    |                    `async` because of this
-   |                    help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - type FT3 = for<'a> async fn();
+LL + type FT3 = for<'a>  fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/recover-const-async-fn-ptr.rs:17:12
@@ -113,7 +173,12 @@ LL | type FT4 = for<'a> async extern fn();
    |            ^^^^^^^^-----^^^^^^^^^^^^
    |                    |
    |                    `async` because of this
-   |                    help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - type FT4 = for<'a> async extern fn();
+LL + type FT4 = for<'a>  extern fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/recover-const-async-fn-ptr.rs:18:12
@@ -122,7 +187,12 @@ LL | type FT5 = for<'a> async unsafe extern "C" fn();
    |            ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
    |                    |
    |                    `async` because of this
-   |                    help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - type FT5 = for<'a> async unsafe extern "C" fn();
+LL + type FT5 = for<'a>  unsafe extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:19:12
@@ -131,7 +201,12 @@ LL | type FT6 = for<'a> const async unsafe extern "C" fn();
    |            ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                    |
    |                    `const` because of this
-   |                    help: remove the `const` qualifier
+   |
+help: remove the `const` qualifier
+   |
+LL - type FT6 = for<'a> const async unsafe extern "C" fn();
+LL + type FT6 = for<'a>  async unsafe extern "C" fn();
+   |
 
 error: an `fn` pointer type cannot be `async`
   --> $DIR/recover-const-async-fn-ptr.rs:19:12
@@ -140,7 +215,12 @@ LL | type FT6 = for<'a> const async unsafe extern "C" fn();
    |            ^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
    |                          |
    |                          `async` because of this
-   |                          help: remove the `async` qualifier
+   |
+help: remove the `async` qualifier
+   |
+LL - type FT6 = for<'a> const async unsafe extern "C" fn();
+LL + type FT6 = for<'a> const  unsafe extern "C" fn();
+   |
 
 error[E0308]: mismatched types
   --> $DIR/recover-const-async-fn-ptr.rs:24:33

--- a/tests/ui/parser/recover/recover-field-extra-angle-brackets-in-struct-with-a-field.stderr
+++ b/tests/ui/parser/recover/recover-field-extra-angle-brackets-in-struct-with-a-field.stderr
@@ -1,11 +1,14 @@
 error: unmatched angle bracket
   --> $DIR/recover-field-extra-angle-brackets-in-struct-with-a-field.rs:2:25
    |
-LL |       next: Option<String>>
-   |  _________________________^
-LL | |
-LL | | }
-   | |_ help: remove extra angle bracket
+LL |     next: Option<String>>
+   |                         ^
+   |
+help: remove extra angle bracket
+   |
+LL -     next: Option<String>>
+LL +     next: Option<String>
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/recover/recover-field-extra-angle-brackets.stderr
+++ b/tests/ui/parser/recover/recover-field-extra-angle-brackets.stderr
@@ -2,7 +2,13 @@ error: unmatched angle bracket
   --> $DIR/recover-field-extra-angle-brackets.rs:5:19
    |
 LL |     first: Vec<u8>>,
-   |                   ^ help: remove extra angle bracket
+   |                   ^
+   |
+help: remove extra angle bracket
+   |
+LL -     first: Vec<u8>>,
+LL +     first: Vec<u8>,
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/recover/recover-missing-semi-before-item.stderr
+++ b/tests/ui/parser/recover/recover-missing-semi-before-item.stderr
@@ -2,82 +2,132 @@ error: expected `;`, found keyword `struct`
   --> $DIR/recover-missing-semi-before-item.rs:6:16
    |
 LL |     let foo = 3
-   |                ^ help: add `;` here
+   |                ^
 LL |     struct Foo;
    |     ------ unexpected token
+   |
+help: add `;` here
+   |
+LL |     let foo = 3;
+   |                +
 
 error: expected `;`, found `union`
   --> $DIR/recover-missing-semi-before-item.rs:11:16
    |
 LL |     let foo = 3
-   |                ^ help: add `;` here
+   |                ^
 LL |     union Foo {
    |     ----- unexpected token
+   |
+help: add `;` here
+   |
+LL |     let foo = 3;
+   |                +
 
 error: expected `;`, found keyword `enum`
   --> $DIR/recover-missing-semi-before-item.rs:18:16
    |
 LL |     let foo = 3
-   |                ^ help: add `;` here
+   |                ^
 LL |     enum Foo {
    |     ---- unexpected token
+   |
+help: add `;` here
+   |
+LL |     let foo = 3;
+   |                +
 
 error: expected `;`, found keyword `fn`
   --> $DIR/recover-missing-semi-before-item.rs:25:16
    |
 LL |     let foo = 3
-   |                ^ help: add `;` here
+   |                ^
 LL |     fn foo() {}
    |     -- unexpected token
+   |
+help: add `;` here
+   |
+LL |     let foo = 3;
+   |                +
 
 error: expected `;`, found keyword `extern`
   --> $DIR/recover-missing-semi-before-item.rs:30:16
    |
 LL |     let foo = 3
-   |                ^ help: add `;` here
+   |                ^
 LL |     extern fn foo() {}
    |     ------ unexpected token
+   |
+help: add `;` here
+   |
+LL |     let foo = 3;
+   |                +
 
 error: expected `;`, found keyword `impl`
   --> $DIR/recover-missing-semi-before-item.rs:36:16
    |
 LL |     let foo = 3
-   |                ^ help: add `;` here
+   |                ^
 LL |     impl Foo {}
    |     ---- unexpected token
+   |
+help: add `;` here
+   |
+LL |     let foo = 3;
+   |                +
 
 error: expected `;`, found keyword `pub`
   --> $DIR/recover-missing-semi-before-item.rs:41:16
    |
 LL |     let foo = 3
-   |                ^ help: add `;` here
+   |                ^
 LL |     pub use bar::Bar;
    |     --- unexpected token
+   |
+help: add `;` here
+   |
+LL |     let foo = 3;
+   |                +
 
 error: expected `;`, found keyword `mod`
   --> $DIR/recover-missing-semi-before-item.rs:46:16
    |
 LL |     let foo = 3
-   |                ^ help: add `;` here
+   |                ^
 LL |     mod foo {}
    |     --- unexpected token
+   |
+help: add `;` here
+   |
+LL |     let foo = 3;
+   |                +
 
 error: expected `;`, found keyword `type`
   --> $DIR/recover-missing-semi-before-item.rs:51:16
    |
 LL |     let foo = 3
-   |                ^ help: add `;` here
+   |                ^
 LL |     type Foo = usize;
    |     ---- unexpected token
+   |
+help: add `;` here
+   |
+LL |     let foo = 3;
+   |                +
 
 error: expected `;`, found keyword `fn`
   --> $DIR/recover-missing-semi-before-item.rs:59:19
    |
 LL | const X: i32 = 123
-   |                   ^ help: add `;` here
+   |                   ^
 LL |
 LL | fn main() {}
    | -- unexpected token
+   |
+help: add `;` here
+   |
+LL | const X: i32 = 123;
+   |                   +
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/parser/recover/recover-missing-semi-before-item.stderr
+++ b/tests/ui/parser/recover/recover-missing-semi-before-item.stderr
@@ -2,132 +2,82 @@ error: expected `;`, found keyword `struct`
   --> $DIR/recover-missing-semi-before-item.rs:6:16
    |
 LL |     let foo = 3
-   |                ^
+   |                ^ help: add `;` here
 LL |     struct Foo;
    |     ------ unexpected token
-   |
-help: add `;` here
-   |
-LL |     let foo = 3;
-   |                +
 
 error: expected `;`, found `union`
   --> $DIR/recover-missing-semi-before-item.rs:11:16
    |
 LL |     let foo = 3
-   |                ^
+   |                ^ help: add `;` here
 LL |     union Foo {
    |     ----- unexpected token
-   |
-help: add `;` here
-   |
-LL |     let foo = 3;
-   |                +
 
 error: expected `;`, found keyword `enum`
   --> $DIR/recover-missing-semi-before-item.rs:18:16
    |
 LL |     let foo = 3
-   |                ^
+   |                ^ help: add `;` here
 LL |     enum Foo {
    |     ---- unexpected token
-   |
-help: add `;` here
-   |
-LL |     let foo = 3;
-   |                +
 
 error: expected `;`, found keyword `fn`
   --> $DIR/recover-missing-semi-before-item.rs:25:16
    |
 LL |     let foo = 3
-   |                ^
+   |                ^ help: add `;` here
 LL |     fn foo() {}
    |     -- unexpected token
-   |
-help: add `;` here
-   |
-LL |     let foo = 3;
-   |                +
 
 error: expected `;`, found keyword `extern`
   --> $DIR/recover-missing-semi-before-item.rs:30:16
    |
 LL |     let foo = 3
-   |                ^
+   |                ^ help: add `;` here
 LL |     extern fn foo() {}
    |     ------ unexpected token
-   |
-help: add `;` here
-   |
-LL |     let foo = 3;
-   |                +
 
 error: expected `;`, found keyword `impl`
   --> $DIR/recover-missing-semi-before-item.rs:36:16
    |
 LL |     let foo = 3
-   |                ^
+   |                ^ help: add `;` here
 LL |     impl Foo {}
    |     ---- unexpected token
-   |
-help: add `;` here
-   |
-LL |     let foo = 3;
-   |                +
 
 error: expected `;`, found keyword `pub`
   --> $DIR/recover-missing-semi-before-item.rs:41:16
    |
 LL |     let foo = 3
-   |                ^
+   |                ^ help: add `;` here
 LL |     pub use bar::Bar;
    |     --- unexpected token
-   |
-help: add `;` here
-   |
-LL |     let foo = 3;
-   |                +
 
 error: expected `;`, found keyword `mod`
   --> $DIR/recover-missing-semi-before-item.rs:46:16
    |
 LL |     let foo = 3
-   |                ^
+   |                ^ help: add `;` here
 LL |     mod foo {}
    |     --- unexpected token
-   |
-help: add `;` here
-   |
-LL |     let foo = 3;
-   |                +
 
 error: expected `;`, found keyword `type`
   --> $DIR/recover-missing-semi-before-item.rs:51:16
    |
 LL |     let foo = 3
-   |                ^
+   |                ^ help: add `;` here
 LL |     type Foo = usize;
    |     ---- unexpected token
-   |
-help: add `;` here
-   |
-LL |     let foo = 3;
-   |                +
 
 error: expected `;`, found keyword `fn`
   --> $DIR/recover-missing-semi-before-item.rs:59:19
    |
 LL | const X: i32 = 123
-   |                   ^
+   |                   ^ help: add `;` here
 LL |
 LL | fn main() {}
    | -- unexpected token
-   |
-help: add `;` here
-   |
-LL | const X: i32 = 123;
-   |                   +
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/parser/recover/recover-missing-semi.stderr
+++ b/tests/ui/parser/recover/recover-missing-semi.stderr
@@ -2,19 +2,29 @@ error: expected `;`, found keyword `let`
   --> $DIR/recover-missing-semi.rs:2:22
    |
 LL |     let _: usize = ()
-   |                      ^ help: add `;` here
+   |                      ^
 ...
 LL |     let _ = 3;
    |     --- unexpected token
+   |
+help: add `;` here
+   |
+LL |     let _: usize = ();
+   |                      +
 
 error: expected `;`, found keyword `return`
   --> $DIR/recover-missing-semi.rs:9:22
    |
 LL |     let _: usize = ()
-   |                      ^ help: add `;` here
+   |                      ^
 ...
 LL |     return 3;
    |     ------ unexpected token
+   |
+help: add `;` here
+   |
+LL |     let _: usize = ();
+   |                      +
 
 error[E0308]: mismatched types
   --> $DIR/recover-missing-semi.rs:2:20

--- a/tests/ui/parser/recover/recover-missing-semi.stderr
+++ b/tests/ui/parser/recover/recover-missing-semi.stderr
@@ -2,29 +2,19 @@ error: expected `;`, found keyword `let`
   --> $DIR/recover-missing-semi.rs:2:22
    |
 LL |     let _: usize = ()
-   |                      ^
+   |                      ^ help: add `;` here
 ...
 LL |     let _ = 3;
    |     --- unexpected token
-   |
-help: add `;` here
-   |
-LL |     let _: usize = ();
-   |                      +
 
 error: expected `;`, found keyword `return`
   --> $DIR/recover-missing-semi.rs:9:22
    |
 LL |     let _: usize = ()
-   |                      ^
+   |                      ^ help: add `;` here
 ...
 LL |     return 3;
    |     ------ unexpected token
-   |
-help: add `;` here
-   |
-LL |     let _: usize = ();
-   |                      +
 
 error[E0308]: mismatched types
   --> $DIR/recover-missing-semi.rs:2:20

--- a/tests/ui/parser/recover/recover-range-pats.stderr
+++ b/tests/ui/parser/recover/recover-range-pats.stderr
@@ -2,196 +2,330 @@ error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:20:12
    |
 LL |     if let .0..Y = 0 {}
-   |            ^^ help: must have an integer part: `0.0`
+   |            ^^
+   |
+help: must have an integer part
+   |
+LL |     if let 0.0..Y = 0 {}
+   |            +
 
 error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:22:16
    |
 LL |     if let X.. .0 = 0 {}
-   |                ^^ help: must have an integer part: `0.0`
+   |                ^^
+   |
+help: must have an integer part
+   |
+LL |     if let X.. 0.0 = 0 {}
+   |                +
 
 error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:33:12
    |
 LL |     if let .0..=Y = 0 {}
-   |            ^^ help: must have an integer part: `0.0`
+   |            ^^
+   |
+help: must have an integer part
+   |
+LL |     if let 0.0..=Y = 0 {}
+   |            +
 
 error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:35:16
    |
 LL |     if let X..=.0 = 0 {}
-   |                ^^ help: must have an integer part: `0.0`
+   |                ^^
+   |
+help: must have an integer part
+   |
+LL |     if let X..=0.0 = 0 {}
+   |                +
 
 error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:58:12
    |
 LL |     if let .0...Y = 0 {}
-   |            ^^ help: must have an integer part: `0.0`
+   |            ^^
+   |
+help: must have an integer part
+   |
+LL |     if let 0.0...Y = 0 {}
+   |            +
 
 error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:62:17
    |
 LL |     if let X... .0 = 0 {}
-   |                 ^^ help: must have an integer part: `0.0`
+   |                 ^^
+   |
+help: must have an integer part
+   |
+LL |     if let X... 0.0 = 0 {}
+   |                 +
 
 error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:73:12
    |
 LL |     if let .0.. = 0 {}
-   |            ^^ help: must have an integer part: `0.0`
+   |            ^^
+   |
+help: must have an integer part
+   |
+LL |     if let 0.0.. = 0 {}
+   |            +
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:79:13
    |
 LL |     if let 0..= = 0 {}
-   |             ^^^ help: use `..` instead
+   |             ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let 0..= = 0 {}
+LL +     if let 0.. = 0 {}
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:80:13
    |
 LL |     if let X..= = 0 {}
-   |             ^^^ help: use `..` instead
+   |             ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let X..= = 0 {}
+LL +     if let X.. = 0 {}
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:81:16
    |
 LL |     if let true..= = 0 {}
-   |                ^^^ help: use `..` instead
+   |                ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let true..= = 0 {}
+LL +     if let true.. = 0 {}
+   |
 
 error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:83:12
    |
 LL |     if let .0..= = 0 {}
-   |            ^^ help: must have an integer part: `0.0`
+   |            ^^
+   |
+help: must have an integer part
+   |
+LL |     if let 0.0..= = 0 {}
+   |            +
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:83:14
    |
 LL |     if let .0..= = 0 {}
-   |              ^^^ help: use `..` instead
+   |              ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let .0..= = 0 {}
+LL +     if let .0.. = 0 {}
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:89:13
    |
 LL |     if let 0... = 0 {}
-   |             ^^^ help: use `..` instead
+   |             ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let 0... = 0 {}
+LL +     if let 0.. = 0 {}
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:90:13
    |
 LL |     if let X... = 0 {}
-   |             ^^^ help: use `..` instead
+   |             ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let X... = 0 {}
+LL +     if let X.. = 0 {}
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:91:16
    |
 LL |     if let true... = 0 {}
-   |                ^^^ help: use `..` instead
+   |                ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let true... = 0 {}
+LL +     if let true.. = 0 {}
+   |
 
 error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:93:12
    |
 LL |     if let .0... = 0 {}
-   |            ^^ help: must have an integer part: `0.0`
+   |            ^^
+   |
+help: must have an integer part
+   |
+LL |     if let 0.0... = 0 {}
+   |            +
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:93:14
    |
 LL |     if let .0... = 0 {}
-   |              ^^^ help: use `..` instead
+   |              ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     if let .0... = 0 {}
+LL +     if let .0.. = 0 {}
+   |
 
 error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:103:15
    |
 LL |     if let .. .0 = 0 {}
-   |               ^^ help: must have an integer part: `0.0`
+   |               ^^
+   |
+help: must have an integer part
+   |
+LL |     if let .. 0.0 = 0 {}
+   |               +
 
 error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:113:15
    |
 LL |     if let ..=.0 = 0 {}
-   |               ^^ help: must have an integer part: `0.0`
+   |               ^^
+   |
+help: must have an integer part
+   |
+LL |     if let ..=0.0 = 0 {}
+   |               +
 
 error: range-to patterns with `...` are not allowed
   --> $DIR/recover-range-pats.rs:119:12
    |
 LL |     if let ...3 = 0 {}
-   |            ^^^ help: use `..=` instead
+   |            ^^^
+   |
+help: use `..=` instead
+   |
+LL |     if let ..=3 = 0 {}
+   |            ~~~
 
 error: range-to patterns with `...` are not allowed
   --> $DIR/recover-range-pats.rs:121:12
    |
 LL |     if let ...Y = 0 {}
-   |            ^^^ help: use `..=` instead
+   |            ^^^
+   |
+help: use `..=` instead
+   |
+LL |     if let ..=Y = 0 {}
+   |            ~~~
 
 error: range-to patterns with `...` are not allowed
   --> $DIR/recover-range-pats.rs:123:12
    |
 LL |     if let ...true = 0 {}
-   |            ^^^ help: use `..=` instead
+   |            ^^^
+   |
+help: use `..=` instead
+   |
+LL |     if let ..=true = 0 {}
+   |            ~~~
 
 error: float literals must have an integer part
   --> $DIR/recover-range-pats.rs:126:15
    |
 LL |     if let ....3 = 0 {}
-   |               ^^ help: must have an integer part: `0.3`
+   |               ^^
+   |
+help: must have an integer part
+   |
+LL |     if let ...0.3 = 0 {}
+   |               +
 
 error: range-to patterns with `...` are not allowed
   --> $DIR/recover-range-pats.rs:126:12
    |
 LL |     if let ....3 = 0 {}
-   |            ^^^ help: use `..=` instead
+   |            ^^^
+   |
+help: use `..=` instead
+   |
+LL |     if let ..=.3 = 0 {}
+   |            ~~~
 
 error: range-to patterns with `...` are not allowed
   --> $DIR/recover-range-pats.rs:152:17
    |
 LL |             let ...$e;
-   |                 ^^^ help: use `..=` instead
+   |                 ^^^
 ...
 LL |     mac!(0);
    |     ------- in this macro invocation
    |
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `..=` instead
+   |
+LL |             let ..=$e;
+   |                 ~~~
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:159:19
    |
 LL |             let $e...;
-   |                   ^^^ help: use `..` instead
+   |                   ^^^
 ...
 LL |     mac!(0);
    |     ------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `..` instead
+   |
+LL -             let $e...;
+LL +             let $e..;
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:161:19
    |
 LL |             let $e..=;
-   |                   ^^^ help: use `..` instead
+   |                   ^^^
 ...
 LL |     mac!(0);
    |     ------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `..` instead
+   |
+LL -             let $e..=;
+LL +             let $e..;
+   |
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:40:13

--- a/tests/ui/parser/recover/recover-ref-dyn-mut.stderr
+++ b/tests/ui/parser/recover/recover-ref-dyn-mut.stderr
@@ -2,7 +2,12 @@ error: `mut` must precede `dyn`
   --> $DIR/recover-ref-dyn-mut.rs:5:12
    |
 LL |     let r: &dyn mut Trait;
-   |            ^^^^^^^^ help: place `mut` before `dyn`: `&mut dyn`
+   |            ^^^^^^^^
+   |
+help: place `mut` before `dyn`
+   |
+LL |     let r: &mut dyn Trait;
+   |            ~~~~~~~~
 
 error[E0405]: cannot find trait `Trait` in this scope
   --> $DIR/recover-ref-dyn-mut.rs:5:21

--- a/tests/ui/parser/recover/recover-unticked-labels.stderr
+++ b/tests/ui/parser/recover/recover-unticked-labels.stderr
@@ -2,17 +2,23 @@ error: expected a label, found an identifier
   --> $DIR/recover-unticked-labels.rs:5:26
    |
 LL |     'label: loop { break label 0 };
-   |                          -^^^^
-   |                          |
-   |                          help: labels start with a tick
+   |                          ^^^^^
+   |
+help: labels start with a tick
+   |
+LL |     'label: loop { break 'label 0 };
+   |                          +
 
 error: expected a label, found an identifier
   --> $DIR/recover-unticked-labels.rs:6:29
    |
 LL |     'label: loop { continue label };
-   |                             -^^^^
-   |                             |
-   |                             help: labels start with a tick
+   |                             ^^^^^
+   |
+help: labels start with a tick
+   |
+LL |     'label: loop { continue 'label };
+   |                             +
 
 error[E0425]: cannot find value `label` in this scope
   --> $DIR/recover-unticked-labels.rs:4:26

--- a/tests/ui/parser/regions-out-of-scope-slice.stderr
+++ b/tests/ui/parser/regions-out-of-scope-slice.stderr
@@ -2,10 +2,15 @@ error: borrow expressions cannot be annotated with lifetimes
   --> $DIR/regions-out-of-scope-slice.rs:7:13
    |
 LL |         x = &'blk [1,2,3];
-   |             ^----^^^^^^^^
+   |             ^-----^^^^^^^
    |              |
    |              annotated with lifetime here
-   |              help: remove the lifetime annotation
+   |
+help: remove the lifetime annotation
+   |
+LL -         x = &'blk [1,2,3];
+LL +         x = &[1,2,3];
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/removed-syntax/removed-syntax-fn-sigil.stderr
+++ b/tests/ui/parser/removed-syntax/removed-syntax-fn-sigil.stderr
@@ -2,7 +2,12 @@ error: missing parameters for function definition
   --> $DIR/removed-syntax-fn-sigil.rs:2:14
    |
 LL |     let x: fn~() = || ();
-   |              ^ help: add a parameter list
+   |              ^
+   |
+help: add a parameter list
+   |
+LL |     let x: fn()~() = || ();
+   |              ++
 
 error: expected one of `->`, `;`, or `=`, found `~`
   --> $DIR/removed-syntax-fn-sigil.rs:2:14

--- a/tests/ui/parser/removed-syntax/removed-syntax-static-fn.stderr
+++ b/tests/ui/parser/removed-syntax/removed-syntax-static-fn.stderr
@@ -19,7 +19,12 @@ error: missing type for `static` item
   --> $DIR/removed-syntax-static-fn.rs:4:14
    |
 LL |     static fn f() {}
-   |              ^ help: provide a type for the item: `: <type>`
+   |              ^
+   |
+help: provide a type for the item
+   |
+LL |     static fn: <type> f() {}
+   |              ++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/struct-default-values-and-missing-field-separator.stderr
+++ b/tests/ui/parser/struct-default-values-and-missing-field-separator.stderr
@@ -2,37 +2,73 @@ error: default values on `struct` fields aren't supported
   --> $DIR/struct-default-values-and-missing-field-separator.rs:9:16
    |
 LL |     field1: i32 = 42,
-   |                ^^^^^ help: remove this unsupported default value
+   |                ^^^^^
+   |
+help: remove this unsupported default value
+   |
+LL -     field1: i32 = 42,
+LL +     field1: i32,
+   |
 
 error: default values on `struct` fields aren't supported
   --> $DIR/struct-default-values-and-missing-field-separator.rs:10:14
    |
 LL |     field2: E = E::A,
-   |              ^^^^^^^ help: remove this unsupported default value
+   |              ^^^^^^^
+   |
+help: remove this unsupported default value
+   |
+LL -     field2: E = E::A,
+LL +     field2: E,
+   |
 
 error: default values on `struct` fields aren't supported
   --> $DIR/struct-default-values-and-missing-field-separator.rs:11:16
    |
 LL |     field3: i32 = 1 + 2,
-   |                ^^^^^^^^ help: remove this unsupported default value
+   |                ^^^^^^^^
+   |
+help: remove this unsupported default value
+   |
+LL -     field3: i32 = 1 + 2,
+LL +     field3: i32,
+   |
 
 error: default values on `struct` fields aren't supported
   --> $DIR/struct-default-values-and-missing-field-separator.rs:12:16
    |
 LL |     field4: i32 = { 1 + 2 },
-   |                ^^^^^^^^^^^^ help: remove this unsupported default value
+   |                ^^^^^^^^^^^^
+   |
+help: remove this unsupported default value
+   |
+LL -     field4: i32 = { 1 + 2 },
+LL +     field4: i32,
+   |
 
 error: default values on `struct` fields aren't supported
   --> $DIR/struct-default-values-and-missing-field-separator.rs:13:14
    |
 LL |     field5: E = foo(42),
-   |              ^^^^^^^^^^ help: remove this unsupported default value
+   |              ^^^^^^^^^^
+   |
+help: remove this unsupported default value
+   |
+LL -     field5: E = foo(42),
+LL +     field5: E,
+   |
 
 error: default values on `struct` fields aren't supported
   --> $DIR/struct-default-values-and-missing-field-separator.rs:14:14
    |
 LL |     field6: E = { foo(42) },
-   |              ^^^^^^^^^^^^^^ help: remove this unsupported default value
+   |              ^^^^^^^^^^^^^^
+   |
+help: remove this unsupported default value
+   |
+LL -     field6: E = { foo(42) },
+LL +     field6: E,
+   |
 
 error: expected `,`, or `}`, found `field2`
   --> $DIR/struct-default-values-and-missing-field-separator.rs:18:16
@@ -50,25 +86,49 @@ error: default values on `struct` fields aren't supported
   --> $DIR/struct-default-values-and-missing-field-separator.rs:20:16
    |
 LL |     field3: i32 = 1 + 2,
-   |                ^^^^^^^^ help: remove this unsupported default value
+   |                ^^^^^^^^
+   |
+help: remove this unsupported default value
+   |
+LL -     field3: i32 = 1 + 2,
+LL +     field3: i32,
+   |
 
 error: default values on `struct` fields aren't supported
   --> $DIR/struct-default-values-and-missing-field-separator.rs:21:16
    |
 LL |     field4: i32 = { 1 + 2 },
-   |                ^^^^^^^^^^^^ help: remove this unsupported default value
+   |                ^^^^^^^^^^^^
+   |
+help: remove this unsupported default value
+   |
+LL -     field4: i32 = { 1 + 2 },
+LL +     field4: i32,
+   |
 
 error: default values on `struct` fields aren't supported
   --> $DIR/struct-default-values-and-missing-field-separator.rs:22:14
    |
 LL |     field5: E = foo(42),
-   |              ^^^^^^^^^^ help: remove this unsupported default value
+   |              ^^^^^^^^^^
+   |
+help: remove this unsupported default value
+   |
+LL -     field5: E = foo(42),
+LL +     field5: E,
+   |
 
 error: default values on `struct` fields aren't supported
   --> $DIR/struct-default-values-and-missing-field-separator.rs:23:14
    |
 LL |     field6: E = { foo(42) },
-   |              ^^^^^^^^^^^^^^ help: remove this unsupported default value
+   |              ^^^^^^^^^^^^^^
+   |
+help: remove this unsupported default value
+   |
+LL -     field6: E = { foo(42) },
+LL +     field6: E,
+   |
 
 error: expected `:`, found `=`
   --> $DIR/struct-default-values-and-missing-field-separator.rs:27:12

--- a/tests/ui/parser/trait-object-delimiters.stderr
+++ b/tests/ui/parser/trait-object-delimiters.stderr
@@ -2,7 +2,12 @@ error: ambiguous `+` in a type
   --> $DIR/trait-object-delimiters.rs:3:13
    |
 LL | fn foo1(_: &dyn Drop + AsRef<str>) {}
-   |             ^^^^^^^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(dyn Drop + AsRef<str>)`
+   |             ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL | fn foo1(_: &(dyn Drop + AsRef<str>)) {}
+   |             +                     +
 
 error: incorrect parentheses around trait bounds
   --> $DIR/trait-object-delimiters.rs:6:17
@@ -52,9 +57,14 @@ error: invalid `dyn` keyword
   --> $DIR/trait-object-delimiters.rs:16:25
    |
 LL | fn foo5(_: &(dyn Drop + dyn AsRef<str>)) {}
-   |                         ^^^ help: remove this keyword
+   |                         ^^^
    |
    = help: `dyn` is only needed at the start of a trait `+`-separated list
+help: remove this keyword
+   |
+LL - fn foo5(_: &(dyn Drop + dyn AsRef<str>)) {}
+LL + fn foo5(_: &(dyn Drop + AsRef<str>)) {}
+   |
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-delimiters.rs:3:24

--- a/tests/ui/parser/trait-object-lifetime-parens.stderr
+++ b/tests/ui/parser/trait-object-lifetime-parens.stderr
@@ -2,13 +2,25 @@ error: parenthesized lifetime bounds are not supported
   --> $DIR/trait-object-lifetime-parens.rs:5:21
    |
 LL | fn f<'a, T: Trait + ('a)>() {}
-   |                     ^^^^ help: remove the parentheses
+   |                     ^^^^
+   |
+help: remove the parentheses
+   |
+LL - fn f<'a, T: Trait + ('a)>() {}
+LL + fn f<'a, T: Trait + 'a>() {}
+   |
 
 error: parenthesized lifetime bounds are not supported
   --> $DIR/trait-object-lifetime-parens.rs:8:24
    |
 LL |     let _: Box<Trait + ('a)>;
-   |                        ^^^^ help: remove the parentheses
+   |                        ^^^^
+   |
+help: remove the parentheses
+   |
+LL -     let _: Box<Trait + ('a)>;
+LL +     let _: Box<Trait + 'a>;
+   |
 
 error: lifetime in trait object type must be followed by `+`
   --> $DIR/trait-object-lifetime-parens.rs:10:17

--- a/tests/ui/parser/trait-object-polytrait-priority.rs
+++ b/tests/ui/parser/trait-object-polytrait-priority.rs
@@ -6,5 +6,4 @@ fn main() {
     let _: &for<'a> Trait<'a> + 'static;
     //~^ ERROR expected a path on the left-hand side of `+`, not `&for<'a> Trait<'a>`
     //~| HELP try adding parentheses
-    //~| SUGGESTION &(for<'a> Trait<'a> + 'static)
 }

--- a/tests/ui/parser/trait-object-polytrait-priority.stderr
+++ b/tests/ui/parser/trait-object-polytrait-priority.stderr
@@ -2,7 +2,12 @@ error[E0178]: expected a path on the left-hand side of `+`, not `&for<'a> Trait<
   --> $DIR/trait-object-polytrait-priority.rs:6:12
    |
 LL |     let _: &for<'a> Trait<'a> + 'static;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try adding parentheses: `&(for<'a> Trait<'a> + 'static)`
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try adding parentheses
+   |
+LL |     let _: &(for<'a> Trait<'a> + 'static);
+   |             +                           +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/unicode-character-literal.stderr
+++ b/tests/ui/parser/unicode-character-literal.stderr
@@ -34,15 +34,17 @@ error: character literal may only contain one codepoint
   --> $DIR/unicode-character-literal.rs:17:14
    |
 LL |     let _a = 'Å';
-   |              ^-^
-   |               |
-   |               help: consider using the normalized form `\u{c5}` of this character: `Å`
+   |              ^^^
    |
 note: this `A` is followed by the combining mark `\u{30a}`
   --> $DIR/unicode-character-literal.rs:17:15
    |
 LL |     let _a = 'Å';
    |               ^
+help: consider using the normalized form `\u{c5}` of this character
+   |
+LL |     let _a = 'Å';
+   |               ~
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/unmatched-langle-1.stderr
+++ b/tests/ui/parser/unmatched-langle-1.stderr
@@ -2,7 +2,13 @@ error: unmatched angle brackets
   --> $DIR/unmatched-langle-1.rs:5:10
    |
 LL |     foo::<<<<Ty<i32>>();
-   |          ^^^ help: remove extra angle brackets
+   |          ^^^
+   |
+help: remove extra angle brackets
+   |
+LL -     foo::<<<<Ty<i32>>();
+LL +     foo::<Ty<i32>>();
+   |
 
 error[E0412]: cannot find type `Ty` in this scope
   --> $DIR/unmatched-langle-1.rs:5:14

--- a/tests/ui/parser/unnecessary-let.stderr
+++ b/tests/ui/parser/unnecessary-let.stderr
@@ -2,19 +2,36 @@ error: expected pattern, found `let`
   --> $DIR/unnecessary-let.rs:2:9
    |
 LL |     for let x of [1, 2, 3] {}
-   |         ^^^ help: remove the unnecessary `let` keyword
+   |         ^^^
+   |
+help: remove the unnecessary `let` keyword
+   |
+LL -     for let x of [1, 2, 3] {}
+LL +     for  x of [1, 2, 3] {}
+   |
 
 error: missing `in` in `for` loop
   --> $DIR/unnecessary-let.rs:2:15
    |
 LL |     for let x of [1, 2, 3] {}
-   |               ^^ help: try using `in` here instead
+   |               ^^
+   |
+help: try using `in` here instead
+   |
+LL |     for let x in [1, 2, 3] {}
+   |               ~~
 
 error: expected pattern, found `let`
   --> $DIR/unnecessary-let.rs:7:9
    |
 LL |         let 1 => {}
-   |         ^^^ help: remove the unnecessary `let` keyword
+   |         ^^^
+   |
+help: remove the unnecessary `let` keyword
+   |
+LL -         let 1 => {}
+LL +          1 => {}
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/use-colon-as-mod-sep.stderr
+++ b/tests/ui/parser/use-colon-as-mod-sep.stderr
@@ -2,33 +2,49 @@ error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:3:17
    |
 LL | use std::process:Command;
-   |                 ^ help: use double colon
+   |                 ^
    |
    = note: import paths are delimited using `::`
+help: use double colon
+   |
+LL | use std::process::Command;
+   |                 ~~
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:5:8
    |
 LL | use std:fs::File;
-   |        ^ help: use double colon
+   |        ^
    |
    = note: import paths are delimited using `::`
+help: use double colon
+   |
+LL | use std::fs::File;
+   |        ~~
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:7:8
    |
 LL | use std:collections:HashMap;
-   |        ^ help: use double colon
+   |        ^
    |
    = note: import paths are delimited using `::`
+help: use double colon
+   |
+LL | use std::collections:HashMap;
+   |        ~~
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:7:20
    |
 LL | use std:collections:HashMap;
-   |                    ^ help: use double colon
+   |                    ^
    |
    = note: import paths are delimited using `::`
+help: use double colon
+   |
+LL | use std:collections::HashMap;
+   |                    ~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pattern/bindings-after-at/wild-before-at-syntactically-rejected.stderr
+++ b/tests/ui/pattern/bindings-after-at/wild-before-at-syntactically-rejected.stderr
@@ -6,7 +6,11 @@ LL |     let _ @ a = 0;
    |         |   |
    |         |   binding on the right, should be on the left
    |         pattern on the left, should be on the right
-   |         help: switch the order: `a @ _`
+   |
+help: switch the order
+   |
+LL |     let a @ _ = 0;
+   |         ~~~~~
 
 error: pattern on wrong side of `@`
   --> $DIR/wild-before-at-syntactically-rejected.rs:10:9
@@ -16,7 +20,11 @@ LL |     let _ @ ref a = 0;
    |         |   |
    |         |   binding on the right, should be on the left
    |         pattern on the left, should be on the right
-   |         help: switch the order: `ref a @ _`
+   |
+help: switch the order
+   |
+LL |     let ref a @ _ = 0;
+   |         ~~~~~~~~~
 
 error: pattern on wrong side of `@`
   --> $DIR/wild-before-at-syntactically-rejected.rs:12:9
@@ -26,7 +34,11 @@ LL |     let _ @ ref mut a = 0;
    |         |   |
    |         |   binding on the right, should be on the left
    |         pattern on the left, should be on the right
-   |         help: switch the order: `ref mut a @ _`
+   |
+help: switch the order
+   |
+LL |     let ref mut a @ _ = 0;
+   |         ~~~~~~~~~~~~~
 
 error: left-hand side of `@` must be a binding
   --> $DIR/wild-before-at-syntactically-rejected.rs:14:9

--- a/tests/ui/pattern/issue-80186-mut-binding-help-suggestion.stderr
+++ b/tests/ui/pattern/issue-80186-mut-binding-help-suggestion.stderr
@@ -2,9 +2,13 @@ error: `mut` must be attached to each individual binding
   --> $DIR/issue-80186-mut-binding-help-suggestion.rs:5:9
    |
 LL |     let mut &x = &0;
-   |         ^^^^^^ help: add `mut` to each binding: `&(mut x)`
+   |         ^^^^^^
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
+help: add `mut` to each binding
+   |
+LL |     let &(mut x) = &0;
+   |         ~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/pattern-bad-ref-box-order.stderr
+++ b/tests/ui/pattern/pattern-bad-ref-box-order.stderr
@@ -2,7 +2,12 @@ error: switch the order of `ref` and `box`
   --> $DIR/pattern-bad-ref-box-order.rs:8:14
    |
 LL |         Some(ref box _i) => {},
-   |              ^^^^^^^ help: swap them: `box ref`
+   |              ^^^^^^^
+   |
+help: swap them
+   |
+LL |         Some(box ref _i) => {},
+   |              ~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/range-pattern-meant-to-be-slice-rest-pattern.stderr
+++ b/tests/ui/pattern/range-pattern-meant-to-be-slice-rest-pattern.stderr
@@ -2,7 +2,12 @@ error: range-to patterns with `...` are not allowed
   --> $DIR/range-pattern-meant-to-be-slice-rest-pattern.rs:17:13
    |
 LL |         [_, ...tail] => println!("{tail}"),
-   |             ^^^ help: use `..=` instead
+   |             ^^^
+   |
+help: use `..=` instead
+   |
+LL |         [_, ..=tail] => println!("{tail}"),
+   |             ~~~
 
 error[E0425]: cannot find value `rest` in this scope
   --> $DIR/range-pattern-meant-to-be-slice-rest-pattern.rs:3:13

--- a/tests/ui/pub/pub-restricted.stderr
+++ b/tests/ui/pub/pub-restricted.stderr
@@ -2,56 +2,76 @@ error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:3:6
    |
 LL | pub (a) fn afn() {}
-   |      ^ help: make this visible only to module `a` with `in`: `in a`
+   |      ^
    |
    = help: some possible visibility restrictions are:
            `pub(crate)`: visible only on the current crate
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
+help: make this visible only to module `a` with `in`
+   |
+LL | pub (in a) fn afn() {}
+   |      ~~~~
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:4:6
    |
 LL | pub (b) fn bfn() {}
-   |      ^ help: make this visible only to module `b` with `in`: `in b`
+   |      ^
    |
    = help: some possible visibility restrictions are:
            `pub(crate)`: visible only on the current crate
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
+help: make this visible only to module `b` with `in`
+   |
+LL | pub (in b) fn bfn() {}
+   |      ~~~~
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:5:6
    |
 LL | pub (crate::a) fn cfn() {}
-   |      ^^^^^^^^ help: make this visible only to module `crate::a` with `in`: `in crate::a`
+   |      ^^^^^^^^
    |
    = help: some possible visibility restrictions are:
            `pub(crate)`: visible only on the current crate
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
+help: make this visible only to module `crate::a` with `in`
+   |
+LL | pub (in crate::a) fn cfn() {}
+   |      ~~~~~~~~~~~
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:22:14
    |
 LL |         pub (a) invalid: usize,
-   |              ^ help: make this visible only to module `a` with `in`: `in a`
+   |              ^
    |
    = help: some possible visibility restrictions are:
            `pub(crate)`: visible only on the current crate
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
+help: make this visible only to module `a` with `in`
+   |
+LL |         pub (in a) invalid: usize,
+   |              ~~~~
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:31:6
    |
 LL | pub (xyz) fn xyz() {}
-   |      ^^^ help: make this visible only to module `xyz` with `in`: `in xyz`
+   |      ^^^
    |
    = help: some possible visibility restrictions are:
            `pub(crate)`: visible only on the current crate
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
+help: make this visible only to module `xyz` with `in`
+   |
+LL | pub (in xyz) fn xyz() {}
+   |      ~~~~~~
 
 error[E0742]: visibilities can only be restricted to ancestor modules
   --> $DIR/pub-restricted.rs:23:17

--- a/tests/ui/range/impossible_range.stderr
+++ b/tests/ui/range/impossible_range.stderr
@@ -2,17 +2,27 @@ error[E0586]: inclusive range with no end
   --> $DIR/impossible_range.rs:11:5
    |
 LL |     ..=;
-   |     ^^^ help: use `..` instead
+   |     ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     ..=;
+LL +     ..;
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/impossible_range.rs:18:6
    |
 LL |     0..=;
-   |      ^^^ help: use `..` instead
+   |      ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL -     0..=;
+LL +     0..;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/range/range-inclusive-pattern-precedence.stderr
+++ b/tests/ui/range/range-inclusive-pattern-precedence.stderr
@@ -2,7 +2,12 @@ error: the range pattern here has ambiguous interpretation
   --> $DIR/range-inclusive-pattern-precedence.rs:15:10
    |
 LL |         &10..=15 => {}
-   |          ^^^^^^^ help: add parentheses to clarify the precedence: `(10..=15)`
+   |          ^^^^^^^
+   |
+help: add parentheses to clarify the precedence
+   |
+LL |         &(10..=15) => {}
+   |          +       +
 
 warning: `...` range patterns are deprecated
   --> $DIR/range-inclusive-pattern-precedence.rs:11:9

--- a/tests/ui/range/range-inclusive-pattern-precedence2.stderr
+++ b/tests/ui/range/range-inclusive-pattern-precedence2.stderr
@@ -2,7 +2,12 @@ error: the range pattern here has ambiguous interpretation
   --> $DIR/range-inclusive-pattern-precedence2.rs:14:13
    |
 LL |         box 10..=15 => {}
-   |             ^^^^^^^ help: add parentheses to clarify the precedence: `(10..=15)`
+   |             ^^^^^^^
+   |
+help: add parentheses to clarify the precedence
+   |
+LL |         box (10..=15) => {}
+   |             +       +
 
 warning: `...` range patterns are deprecated
   --> $DIR/range-inclusive-pattern-precedence2.rs:10:14

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
@@ -2,13 +2,23 @@ error: expected `,` following `match` arm
   --> $DIR/parse.rs:26:16
    |
 LL |         Some(!)
-   |                ^ help: missing a comma here to end this `match` arm: `,`
+   |                ^
+   |
+help: missing a comma here to end this `match` arm
+   |
+LL |         Some(!),
+   |                +
 
 error: expected `,` following `match` arm
   --> $DIR/parse.rs:31:24
    |
 LL |         Some(!) if true
-   |                        ^ help: missing a comma here to end this `match` arm: `,`
+   |                        ^
+   |
+help: missing a comma here to end this `match` arm
+   |
+LL |         Some(!) if true,
+   |                        +
 
 error: expected one of `,`, `=>`, `if`, `|`, or `}`, found `<=`
   --> $DIR/parse.rs:42:17
@@ -20,7 +30,12 @@ error: top-level or-patterns are not allowed in `let` bindings
   --> $DIR/parse.rs:67:9
    |
 LL |     let Ok(_) | Err(!) = &res; // Disallowed; see #82048.
-   |         ^^^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(Ok(_) | Err(!))`
+   |         ^^^^^^^^^^^^^^
+   |
+help: wrap the pattern in parentheses
+   |
+LL |     let (Ok(_) | Err(!)) = &res; // Disallowed; see #82048.
+   |         +              +
 
 error: never patterns cannot contain variable bindings
   --> $DIR/parse.rs:73:9

--- a/tests/ui/self/self-vs-path-ambiguity.stderr
+++ b/tests/ui/self/self-vs-path-ambiguity.stderr
@@ -2,7 +2,13 @@ error: unexpected lifetime `'a` in pattern
   --> $DIR/self-vs-path-ambiguity.rs:9:11
    |
 LL |     fn i(&'a self::S: &S) {}
-   |           ^^ help: remove the lifetime
+   |           ^^
+   |
+help: remove the lifetime
+   |
+LL -     fn i(&'a self::S: &S) {}
+LL +     fn i(&self::S: &S) {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/self/self_type_keyword.stderr
+++ b/tests/ui/self/self_type_keyword.stderr
@@ -14,9 +14,14 @@ error: `mut` must be followed by a named binding
   --> $DIR/self_type_keyword.rs:16:9
    |
 LL |         mut Self => (),
-   |         ^^^^ help: remove the `mut` prefix
+   |         ^^^^
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
+help: remove the `mut` prefix
+   |
+LL -         mut Self => (),
+LL +         Self => (),
+   |
 
 error: expected identifier, found keyword `Self`
   --> $DIR/self_type_keyword.rs:19:17

--- a/tests/ui/structs/struct-duplicate-comma.stderr
+++ b/tests/ui/structs/struct-duplicate-comma.stderr
@@ -4,10 +4,13 @@ error: expected identifier, found `,`
 LL |     let _ = Foo {
    |             --- while parsing this struct
 LL |         a: 0,,
-   |              ^
-   |              |
-   |              expected identifier
-   |              help: remove this comma
+   |              ^ expected identifier
+   |
+help: remove this comma
+   |
+LL -         a: 0,,
+LL +         a: 0,
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/structs/struct-field-init-syntax.stderr
+++ b/tests/ui/structs/struct-field-init-syntax.stderr
@@ -2,17 +2,27 @@ error: cannot use a comma after the base struct
   --> $DIR/struct-field-init-syntax.rs:11:9
    |
 LL |         ..Foo::default(),
-   |         ^^^^^^^^^^^^^^^^- help: remove this comma
+   |         ^^^^^^^^^^^^^^^^
    |
    = note: the base struct must always be the last field
+help: remove this comma
+   |
+LL -         ..Foo::default(),
+LL +         ..Foo::default()
+   |
 
 error: cannot use a comma after the base struct
   --> $DIR/struct-field-init-syntax.rs:16:9
    |
 LL |         ..Foo::default(),
-   |         ^^^^^^^^^^^^^^^^- help: remove this comma
+   |         ^^^^^^^^^^^^^^^^
    |
    = note: the base struct must always be the last field
+help: remove this comma
+   |
+LL -         ..Foo::default(),
+LL +         ..Foo::default()
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/const-no-type.stderr
+++ b/tests/ui/suggestions/const-no-type.stderr
@@ -26,19 +26,34 @@ error: missing type for `const` item
   --> $DIR/const-no-type.rs:14:9
    |
 LL | const C2 = 42;
-   |         ^ help: provide a type for the item: `: <type>`
+   |         ^
+   |
+help: provide a type for the item
+   |
+LL | const C2: <type> = 42;
+   |         ++++++++
 
 error: missing type for `static` item
   --> $DIR/const-no-type.rs:20:10
    |
 LL | static S2 = "abc";
-   |          ^ help: provide a type for the item: `: <type>`
+   |          ^
+   |
+help: provide a type for the item
+   |
+LL | static S2: <type> = "abc";
+   |          ++++++++
 
 error: missing type for `static mut` item
   --> $DIR/const-no-type.rs:26:15
    |
 LL | static mut SM2 = "abc";
-   |               ^ help: provide a type for the item: `: <type>`
+   |               ^
+   |
+help: provide a type for the item
+   |
+LL | static mut SM2: <type> = "abc";
+   |               ++++++++
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/suggestions/js-style-comparison-op.stderr
+++ b/tests/ui/suggestions/js-style-comparison-op.stderr
@@ -2,13 +2,23 @@ error: invalid comparison operator `===`
   --> $DIR/js-style-comparison-op.rs:3:10
    |
 LL |     if 1 === 1 {
-   |          ^^^ help: `===` is not a valid comparison operator, use `==`
+   |          ^^^
+   |
+help: `===` is not a valid comparison operator, use `==`
+   |
+LL |     if 1 == 1 {
+   |          ~~
 
 error: invalid comparison operator `!==`
   --> $DIR/js-style-comparison-op.rs:5:17
    |
 LL |     } else if 1 !== 1 {
-   |                 ^^^ help: `!==` is not a valid comparison operator, use `!=`
+   |                 ^^^
+   |
+help: `!==` is not a valid comparison operator, use `!=`
+   |
+LL |     } else if 1 != 1 {
+   |                 ~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/missing-semicolon.stderr
+++ b/tests/ui/suggestions/missing-semicolon.stderr
@@ -2,17 +2,27 @@ error: expected `;`, found `}`
   --> $DIR/missing-semicolon.rs:6:7
    |
 LL |     ()
-   |       ^ help: add `;` here
+   |       ^
 LL | }
    | - unexpected token
+   |
+help: add `;` here
+   |
+LL |     ();
+   |       +
 
 error: expected `;`, found `}`
   --> $DIR/missing-semicolon.rs:32:7
    |
 LL |     ()
-   |       ^ help: add `;` here
+   |       ^
 LL | }
    | - unexpected token
+   |
+help: add `;` here
+   |
+LL |     ();
+   |       +
 
 error[E0618]: expected function, found `{integer}`
   --> $DIR/missing-semicolon.rs:5:13

--- a/tests/ui/suggestions/missing-semicolon.stderr
+++ b/tests/ui/suggestions/missing-semicolon.stderr
@@ -2,27 +2,17 @@ error: expected `;`, found `}`
   --> $DIR/missing-semicolon.rs:6:7
    |
 LL |     ()
-   |       ^
+   |       ^ help: add `;` here
 LL | }
    | - unexpected token
-   |
-help: add `;` here
-   |
-LL |     ();
-   |       +
 
 error: expected `;`, found `}`
   --> $DIR/missing-semicolon.rs:32:7
    |
 LL |     ()
-   |       ^
+   |       ^ help: add `;` here
 LL | }
    | - unexpected token
-   |
-help: add `;` here
-   |
-LL |     ();
-   |       +
 
 error[E0618]: expected function, found `{integer}`
   --> $DIR/missing-semicolon.rs:5:13

--- a/tests/ui/suggestions/recover-from-semicolon-trailing-item.stderr
+++ b/tests/ui/suggestions/recover-from-semicolon-trailing-item.stderr
@@ -2,25 +2,40 @@ error: expected item, found `;`
   --> $DIR/recover-from-semicolon-trailing-item.rs:2:9
    |
 LL | mod M {};
-   |         ^ help: remove this semicolon
+   |         ^
    |
    = help: module declarations are not followed by a semicolon
+help: remove this semicolon
+   |
+LL - mod M {};
+LL + mod M {}
+   |
 
 error: expected item, found `;`
   --> $DIR/recover-from-semicolon-trailing-item.rs:4:12
    |
 LL | struct S {};
-   |            ^ help: remove this semicolon
+   |            ^
    |
    = help: braced struct declarations are not followed by a semicolon
+help: remove this semicolon
+   |
+LL - struct S {};
+LL + struct S {}
+   |
 
 error: expected item, found `;`
   --> $DIR/recover-from-semicolon-trailing-item.rs:6:20
    |
 LL | fn foo(a: usize) {};
-   |                    ^ help: remove this semicolon
+   |                    ^
    |
    = help: function declarations are not followed by a semicolon
+help: remove this semicolon
+   |
+LL - fn foo(a: usize) {};
+LL + fn foo(a: usize) {}
+   |
 
 error[E0308]: mismatched types
   --> $DIR/recover-from-semicolon-trailing-item.rs:10:20

--- a/tests/ui/suggestions/recover-invalid-float.stderr
+++ b/tests/ui/suggestions/recover-invalid-float.stderr
@@ -2,19 +2,34 @@ error: float literals must have an integer part
   --> $DIR/recover-invalid-float.rs:4:18
    |
 LL |     let _: f32 = .3;
-   |                  ^^ help: must have an integer part: `0.3`
+   |                  ^^
+   |
+help: must have an integer part
+   |
+LL |     let _: f32 = 0.3;
+   |                  +
 
 error: float literals must have an integer part
   --> $DIR/recover-invalid-float.rs:6:18
    |
 LL |     let _: f32 = .42f32;
-   |                  ^^^^^^ help: must have an integer part: `0.42f32`
+   |                  ^^^^^^
+   |
+help: must have an integer part
+   |
+LL |     let _: f32 = 0.42f32;
+   |                  +
 
 error: float literals must have an integer part
   --> $DIR/recover-invalid-float.rs:8:18
    |
 LL |     let _: f64 = .5f64;
-   |                  ^^^^^ help: must have an integer part: `0.5f64`
+   |                  ^^^^^
+   |
+help: must have an integer part
+   |
+LL |     let _: f64 = 0.5f64;
+   |                  +
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.stderr
+++ b/tests/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.stderr
@@ -2,9 +2,14 @@ error: expected `;`, found `}`
   --> $DIR/suggest-semicolon-for-fn-in-extern-block.rs:6:11
    |
 LL |   fn foo()
-   |           ^ help: add `;` here
+   |           ^
 LL | }
    | - unexpected token
+   |
+help: add `;` here
+   |
+LL |   fn foo();
+   |           +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.stderr
+++ b/tests/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.stderr
@@ -2,14 +2,9 @@ error: expected `;`, found `}`
   --> $DIR/suggest-semicolon-for-fn-in-extern-block.rs:6:11
    |
 LL |   fn foo()
-   |           ^
+   |           ^ help: add `;` here
 LL | }
    | - unexpected token
-   |
-help: add `;` here
-   |
-LL |   fn foo();
-   |           +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/type-ascription-instead-of-method.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-method.stderr
@@ -8,7 +8,7 @@ LL |     let _ = Box:new("foo".to_string());
 help: use a double colon instead
    |
 LL |     let _ = Box::new("foo".to_string());
-   |                ~~
+   |                 +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/type-ascription-instead-of-method.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-method.stderr
@@ -2,9 +2,13 @@ error: path separator must be a double colon
   --> $DIR/type-ascription-instead-of-method.rs:3:16
    |
 LL |     let _ = Box:new("foo".to_string());
-   |                ^ help: use a double colon instead: `::`
+   |                ^
    |
    = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: use a double colon instead
+   |
+LL |     let _ = Box::new("foo".to_string());
+   |                ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/type-ascription-instead-of-path.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path.stderr
@@ -8,7 +8,7 @@ LL |     std:io::stdin();
 help: use a double colon instead
    |
 LL |     std::io::stdin();
-   |        ~~
+   |         +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/type-ascription-instead-of-path.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path.stderr
@@ -2,9 +2,13 @@ error: path separator must be a double colon
   --> $DIR/type-ascription-instead-of-path.rs:2:8
    |
 LL |     std:io::stdin();
-   |        ^ help: use a double colon instead: `::`
+   |        ^
    |
    = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: use a double colon instead
+   |
+LL |     std::io::stdin();
+   |        ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/type-ascription-instead-of-variant.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-variant.stderr
@@ -2,9 +2,13 @@ error: path separator must be a double colon
   --> $DIR/type-ascription-instead-of-variant.rs:3:19
    |
 LL |     let _ = Option:Some("");
-   |                   ^ help: use a double colon instead: `::`
+   |                   ^
    |
    = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: use a double colon instead
+   |
+LL |     let _ = Option::Some("");
+   |                   ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/type-ascription-instead-of-variant.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-variant.stderr
@@ -8,7 +8,7 @@ LL |     let _ = Option:Some("");
 help: use a double colon instead
    |
 LL |     let _ = Option::Some("");
-   |                   ~~
+   |                    +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/ascription/issue-47666.stderr
+++ b/tests/ui/type/ascription/issue-47666.stderr
@@ -2,9 +2,13 @@ error: path separator must be a double colon
   --> $DIR/issue-47666.rs:3:19
    |
 LL |     let _ = Option:Some(vec![0, 1]);
-   |                   ^ help: use a double colon instead: `::`
+   |                   ^
    |
    = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: use a double colon instead
+   |
+LL |     let _ = Option::Some(vec![0, 1]);
+   |                   ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/ascription/issue-47666.stderr
+++ b/tests/ui/type/ascription/issue-47666.stderr
@@ -8,7 +8,7 @@ LL |     let _ = Option:Some(vec![0, 1]);
 help: use a double colon instead
    |
 LL |     let _ = Option::Some(vec![0, 1]);
-   |                   ~~
+   |                    +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/ascription/issue-54516.stderr
+++ b/tests/ui/type/ascription/issue-54516.stderr
@@ -2,9 +2,13 @@ error: path separator must be a double colon
   --> $DIR/issue-54516.rs:5:28
    |
 LL |     println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());
-   |                            ^ help: use a double colon instead: `::`
+   |                            ^
    |
    = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: use a double colon instead
+   |
+LL |     println!("{}", std::mem::size_of::<BTreeMap<u32, u32>>());
+   |                            ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/ascription/issue-54516.stderr
+++ b/tests/ui/type/ascription/issue-54516.stderr
@@ -8,7 +8,7 @@ LL |     println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());
 help: use a double colon instead
    |
 LL |     println!("{}", std::mem::size_of::<BTreeMap<u32, u32>>());
-   |                            ~~
+   |                             +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/ascription/issue-60933.stderr
+++ b/tests/ui/type/ascription/issue-60933.stderr
@@ -8,7 +8,7 @@ LL |     let _: usize = std::mem:size_of::<u32>();
 help: use a double colon instead
    |
 LL |     let _: usize = std::mem::size_of::<u32>();
-   |                            ~~
+   |                             +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/ascription/issue-60933.stderr
+++ b/tests/ui/type/ascription/issue-60933.stderr
@@ -2,9 +2,13 @@ error: path separator must be a double colon
   --> $DIR/issue-60933.rs:3:28
    |
 LL |     let _: usize = std::mem:size_of::<u32>();
-   |                            ^ help: use a double colon instead: `::`
+   |                            ^
    |
    = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: use a double colon instead
+   |
+LL |     let _: usize = std::mem::size_of::<u32>();
+   |                            ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/pattern_types/bad_pat.stderr
+++ b/tests/ui/type/pattern_types/bad_pat.stderr
@@ -2,17 +2,27 @@ error[E0586]: inclusive range with no end
   --> $DIR/bad_pat.rs:7:43
    |
 LL | type NonNullU32_2 = pattern_type!(u32 is 1..=);
-   |                                           ^^^ help: use `..` instead
+   |                                           ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL - type NonNullU32_2 = pattern_type!(u32 is 1..=);
+LL + type NonNullU32_2 = pattern_type!(u32 is 1..);
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/bad_pat.rs:9:40
    |
 LL | type Positive2 = pattern_type!(i32 is 0..=);
-   |                                        ^^^ help: use `..` instead
+   |                                        ^^^
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL - type Positive2 = pattern_type!(i32 is 0..=);
+LL + type Positive2 = pattern_type!(i32 is 0..);
+   |
 
 error: wildcard patterns are not permitted for pattern types
   --> $DIR/bad_pat.rs:11:33

--- a/tests/ui/type/type-ascription-instead-of-statement-end.stderr
+++ b/tests/ui/type/type-ascription-instead-of-statement-end.stderr
@@ -2,9 +2,13 @@ error: statements are terminated with a semicolon
   --> $DIR/type-ascription-instead-of-statement-end.rs:2:21
    |
 LL |     println!("test"):
-   |                     ^ help: use a semicolon instead: `;`
+   |                     ^
    |
    = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: use a semicolon instead
+   |
+LL |     println!("test");
+   |                     ~
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `:`
   --> $DIR/type-ascription-instead-of-statement-end.rs:7:21

--- a/tests/ui/type/type-ascription-with-fn-call.stderr
+++ b/tests/ui/type/type-ascription-with-fn-call.stderr
@@ -2,9 +2,13 @@ error: statements are terminated with a semicolon
   --> $DIR/type-ascription-with-fn-call.rs:3:10
    |
 LL |     f()  :
-   |          ^ help: use a semicolon instead: `;`
+   |          ^
    |
    = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: use a semicolon instead
+   |
+LL |     f()  ;
+   |          ~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/do-not-suggest-placeholder-to-const-static-without-type.stderr
+++ b/tests/ui/typeck/do-not-suggest-placeholder-to-const-static-without-type.stderr
@@ -8,13 +8,23 @@ error: missing type for `const` item
   --> $DIR/do-not-suggest-placeholder-to-const-static-without-type.rs:2:12
    |
 LL |     const A;
-   |            ^ help: provide a type for the item: `: <type>`
+   |            ^
+   |
+help: provide a type for the item
+   |
+LL |     const A: <type>;
+   |            ++++++++
 
 error: missing type for `static` item
   --> $DIR/do-not-suggest-placeholder-to-const-static-without-type.rs:3:13
    |
 LL |     static B;
-   |             ^ help: provide a type for the item: `: <type>`
+   |             ^
+   |
+help: provide a type for the item
+   |
+LL |     static B: <type>;
+   |             ++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/issue-79040.stderr
+++ b/tests/ui/typeck/issue-79040.stderr
@@ -10,7 +10,12 @@ error: missing type for `const` item
   --> $DIR/issue-79040.rs:2:14
    |
 LL |     const FOO = "hello" + 1;
-   |              ^ help: provide a type for the item: `: <type>`
+   |              ^
+   |
+help: provide a type for the item
+   |
+LL |     const FOO: <type> = "hello" + 1;
+   |              ++++++++
 
 error[E0369]: cannot add `{integer}` to `&str`
   --> $DIR/issue-79040.rs:2:25


### PR DESCRIPTION
Go over all structured parser suggestions and make them verbose style.

When suggesting to add or remove delimiters, turn them into multiple suggestion parts.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
