### PR TITLE
Stop using the `unpack!` macro in MIR building

### DIFF
--- a/compiler/rustc_mir_build/src/build/block.rs
+++ b/compiler/rustc_mir_build/src/build/block.rs
@@ -282,7 +282,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         )
                     } else {
                         let scope = (*init_scope, source_info);
-                        unpack!(this.in_scope(scope, *lint_level, |this| {
+                        let _: BlockAnd<()> = this.in_scope(scope, *lint_level, |this| {
                             this.declare_bindings(
                                 visibility_scope,
                                 remainder_span,
@@ -291,7 +291,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 None,
                             );
                             block.unit()
-                        }));
+                        });
 
                         debug!("ast_block_stmts: pattern={:?}", pattern);
                         this.visit_primary_bindings(

--- a/compiler/rustc_mir_build/src/build/block.rs
+++ b/compiler/rustc_mir_build/src/build/block.rs
@@ -71,11 +71,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 StmtKind::Expr { scope, expr } => {
                     this.block_context.push(BlockFrame::Statement { ignores_expr_result: true });
                     let si = (*scope, source_info);
-                    unpack!(
-                        block = this.in_scope(si, LintLevel::Inherited, |this| {
+                    block = this
+                        .in_scope(si, LintLevel::Inherited, |this| {
                             this.stmt_expr(block, *expr, Some(*scope))
                         })
-                    );
+                        .unpack_block_and_unit();
                 }
                 StmtKind::Let {
                     remainder_scope,
@@ -166,14 +166,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     let dummy_place = this.temp(this.tcx.types.never, else_block_span);
                     let failure_entry = this.cfg.start_new_block();
                     let failure_block;
-                    unpack!(
-                        failure_block = this.ast_block(
+                    failure_block = this
+                        .ast_block(
                             dummy_place,
                             failure_entry,
                             *else_block,
                             this.source_info(else_block_span),
                         )
-                    );
+                        .unpack_block_and_unit();
                     this.cfg.terminate(
                         failure_block,
                         this.source_info(else_block_span),
@@ -267,8 +267,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         let initializer_span = this.thir[init].span;
                         let scope = (*init_scope, source_info);
 
-                        unpack!(
-                            block = this.in_scope(scope, *lint_level, |this| {
+                        block = this
+                            .in_scope(scope, *lint_level, |this| {
                                 this.declare_bindings(
                                     visibility_scope,
                                     remainder_span,
@@ -279,7 +279,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 this.expr_into_pattern(block, &pattern, init)
                                 // irrefutable pattern
                             })
-                        )
+                            .unpack_block_and_unit();
                     } else {
                         let scope = (*init_scope, source_info);
                         let _: BlockAnd<()> = this.in_scope(scope, *lint_level, |this| {
@@ -333,7 +333,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             this.block_context
                 .push(BlockFrame::TailExpr { tail_result_is_ignored, span: expr.span });
 
-            unpack!(block = this.expr_into_dest(destination, block, expr_id));
+            block = this.expr_into_dest(destination, block, expr_id).unpack_block_and_unit();
             let popped = this.block_context.pop();
 
             assert!(popped.is_some_and(|bf| bf.is_tail_expr()));
@@ -355,7 +355,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // Finally, we pop all the let scopes before exiting out from the scope of block
         // itself.
         for scope in let_scope_stack.into_iter().rev() {
-            unpack!(block = this.pop_scope((*scope, source_info), block));
+            block = this.pop_scope((*scope, source_info), block).unpack_block_and_unit();
         }
         // Restore the original source scope.
         this.source_scope = outer_source_scope;

--- a/compiler/rustc_mir_build/src/build/block.rs
+++ b/compiler/rustc_mir_build/src/build/block.rs
@@ -226,7 +226,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             });
                         matching.and(failure)
                     });
-                    let failure = unpack!(block = failure_and_block);
+                    let failure = failure_and_block.unpack(&mut block);
                     this.cfg.goto(failure, source_info, failure_entry);
 
                     if let Some(source_scope) = visibility_scope {

--- a/compiler/rustc_mir_build/src/build/expr/as_operand.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_operand.rs
@@ -128,7 +128,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block.and(Operand::Constant(Box::new(constant)))
             }
             Category::Constant | Category::Place | Category::Rvalue(..) => {
-                let operand = unpack!(block = this.as_temp(block, scope, expr_id, Mutability::Mut));
+                let operand =
+                    this.as_temp(block, scope, expr_id, Mutability::Mut).unpack(&mut block);
                 // Overwrite temp local info if we have something more interesting to record.
                 if !matches!(local_info, LocalInfo::Boring) {
                     let decl_info =
@@ -174,7 +175,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // type, and that value is coming from the deref of a box.
                 if let ExprKind::Deref { arg } = expr.kind {
                     // Generate let tmp0 = arg0
-                    let operand = unpack!(block = this.as_temp(block, scope, arg, Mutability::Mut));
+                    let operand =
+                        this.as_temp(block, scope, arg, Mutability::Mut).unpack(&mut block);
 
                     // Return the operand *tmp0 to be used as the call argument
                     let place = Place {

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -486,7 +486,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block.and(Rvalue::Aggregate(result, operands))
             }
             ExprKind::Assign { .. } | ExprKind::AssignOp { .. } => {
-                block = unpack!(this.stmt_expr(block, expr_id, None));
+                block = this.stmt_expr(block, expr_id, None).unpack_block_and_unit();
                 block.and(Rvalue::Use(Operand::Constant(Box::new(ConstOperand {
                     span: expr_span,
                     user_ty: None,

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -185,13 +185,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 this.cfg.push_assign(block, source_info, Place::from(result), box_);
 
                 // initialize the box contents:
-                unpack!(
-                    block = this.expr_into_dest(
-                        this.tcx.mk_place_deref(Place::from(result)),
-                        block,
-                        value,
-                    )
-                );
+                block = this
+                    .expr_into_dest(this.tcx.mk_place_deref(Place::from(result)), block, value)
+                    .unpack_block_and_unit();
                 block.and(Rvalue::Use(Operand::Move(Place::from(result))))
             }
             ExprKind::Cast { source } => {

--- a/compiler/rustc_mir_build/src/build/expr/as_temp.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_temp.rs
@@ -112,7 +112,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
         }
 
-        unpack!(block = this.expr_into_dest(temp_place, block, expr_id));
+        block = this.expr_into_dest(temp_place, block, expr_id).unpack_block_and_unit();
 
         if let Some(temp_lifetime) = temp_lifetime {
             this.schedule_drop(expr_span, temp_lifetime, temp, DropKind::Value);

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -107,7 +107,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                 // If there is an `else` arm, lower it into `else_blk`.
                 if let Some(else_expr) = else_opt {
-                    unpack!(else_blk = this.expr_into_dest(destination, else_blk, else_expr));
+                    else_blk = this
+                        .expr_into_dest(destination, else_blk, else_expr)
+                        .unpack_block_and_unit();
                 } else {
                     // There is no `else` arm, so we know both arms have type `()`.
                     // Generate the implicit `else {}` by assigning unit.
@@ -508,7 +510,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             // These cases don't actually need a destination
             ExprKind::Assign { .. } | ExprKind::AssignOp { .. } => {
-                unpack!(block = this.stmt_expr(block, expr_id, None));
+                block = this.stmt_expr(block, expr_id, None).unpack_block_and_unit();
                 this.cfg.push_assign_unit(block, source_info, destination, this.tcx);
                 block.unit()
             }
@@ -517,7 +519,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::Break { .. }
             | ExprKind::Return { .. }
             | ExprKind::Become { .. } => {
-                unpack!(block = this.stmt_expr(block, expr_id, None));
+                block = this.stmt_expr(block, expr_id, None).unpack_block_and_unit();
                 // No assign, as these have type `!`.
                 block.unit()
             }

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -82,13 +82,15 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         // Lower the condition, and have it branch into `then` and `else` blocks.
                         let (then_block, else_block) =
                             this.in_if_then_scope(condition_scope, then_span, |this| {
-                                let then_blk = unpack!(this.then_else_break(
-                                    block,
-                                    cond,
-                                    Some(condition_scope), // Temp scope
-                                    source_info,
-                                    DeclareLetBindings::Yes, // Declare `let` bindings normally
-                                ));
+                                let then_blk = this
+                                    .then_else_break(
+                                        block,
+                                        cond,
+                                        Some(condition_scope), // Temp scope
+                                        source_info,
+                                        DeclareLetBindings::Yes, // Declare `let` bindings normally
+                                    )
+                                    .unpack_block_and_unit();
 
                                 // Lower the `then` arm into its block.
                                 this.expr_into_dest(destination, then_blk, then)
@@ -187,7 +189,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         const_: Const::from_bool(this.tcx, constant),
                     },
                 );
-                let mut rhs_block = unpack!(this.expr_into_dest(destination, continuation, rhs));
+                let mut rhs_block =
+                    this.expr_into_dest(destination, continuation, rhs).unpack_block_and_unit();
                 // Instrument the lowered RHS's value for condition coverage.
                 // (Does nothing if condition coverage is not enabled.)
                 this.visit_coverage_standalone_condition(rhs, destination, &mut rhs_block);
@@ -230,7 +233,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     // introduce a unit temporary as the destination for the loop body.
                     let tmp = this.get_unit_temp();
                     // Execute the body, branching back to the test.
-                    let body_block_end = unpack!(this.expr_into_dest(tmp, body_block, body));
+                    let body_block_end =
+                        this.expr_into_dest(tmp, body_block, body).unpack_block_and_unit();
                     this.cfg.goto(body_block_end, source_info, loop_block);
 
                     // Loops are only exited by `break` expressions.
@@ -462,7 +466,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             targets.push(target);
 
                             let tmp = this.get_unit_temp();
-                            let target = unpack!(this.ast_block(tmp, target, block, source_info));
+                            let target = this
+                                .ast_block(tmp, target, block, source_info)
+                                .unpack_block_and_unit();
                             this.cfg.terminate(
                                 target,
                                 source_info,

--- a/compiler/rustc_mir_build/src/build/expr/stmt.rs
+++ b/compiler/rustc_mir_build/src/build/expr/stmt.rs
@@ -42,7 +42,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 if lhs_expr.ty.needs_drop(this.tcx, this.param_env) {
                     let rhs = unpack!(block = this.as_local_rvalue(block, rhs));
                     let lhs = unpack!(block = this.as_place(block, lhs));
-                    unpack!(block = this.build_drop_and_replace(block, lhs_expr.span, lhs, rhs));
+                    block = this
+                        .build_drop_and_replace(block, lhs_expr.span, lhs, rhs)
+                        .unpack_block_and_unit();
                 } else {
                     let rhs = unpack!(block = this.as_local_rvalue(block, rhs));
                     let lhs = unpack!(block = this.as_place(block, lhs));

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -626,7 +626,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     OutsideGuard,
                     ScheduleDrops::Yes,
                 );
-                unpack!(block = self.expr_into_dest(place, block, initializer_id));
+                block = self.expr_into_dest(place, block, initializer_id).unpack_block_and_unit();
 
                 // Inject a fake read, see comments on `FakeReadCause::ForLet`.
                 let source_info = self.source_info(irrefutable_pat.span);
@@ -665,7 +665,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     OutsideGuard,
                     ScheduleDrops::Yes,
                 );
-                unpack!(block = self.expr_into_dest(place, block, initializer_id));
+                block = self.expr_into_dest(place, block, initializer_id).unpack_block_and_unit();
 
                 // Inject a fake read, see comments on `FakeReadCause::ForLet`.
                 let pattern_source_info = self.source_info(irrefutable_pat.span);

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -403,6 +403,15 @@ enum NeedsTemporary {
 #[must_use = "if you don't use one of these results, you're leaving a dangling edge"]
 struct BlockAnd<T>(BasicBlock, T);
 
+impl BlockAnd<()> {
+    /// Unpacks `BlockAnd<()>` into a [`BasicBlock`].
+    #[must_use]
+    fn unpack_block_and_unit(self) -> BasicBlock {
+        let Self(block, ()) = self;
+        block
+    }
+}
+
 trait BlockAndExtension {
     fn and<T>(self, v: T) -> BlockAnd<T>;
     fn unit(self) -> BlockAnd<()>;
@@ -425,11 +434,6 @@ macro_rules! unpack {
         let BlockAnd(b, v) = $c;
         $x = b;
         v
-    }};
-
-    ($c:expr) => {{
-        let BlockAnd(b, ()) = $c;
-        b
     }};
 }
 
@@ -516,21 +520,22 @@ fn construct_fn<'tcx>(
         region::Scope { id: body.id().hir_id.local_id, data: region::ScopeData::Arguments };
     let source_info = builder.source_info(span);
     let call_site_s = (call_site_scope, source_info);
-    unpack!(builder.in_scope(call_site_s, LintLevel::Inherited, |builder| {
+    let _: BlockAnd<()> = builder.in_scope(call_site_s, LintLevel::Inherited, |builder| {
         let arg_scope_s = (arg_scope, source_info);
         // Attribute epilogue to function's closing brace
         let fn_end = span_with_body.shrink_to_hi();
-        let return_block =
-            unpack!(builder.in_breakable_scope(None, Place::return_place(), fn_end, |builder| {
+        let return_block = builder
+            .in_breakable_scope(None, Place::return_place(), fn_end, |builder| {
                 Some(builder.in_scope(arg_scope_s, LintLevel::Inherited, |builder| {
                     builder.args_and_body(START_BLOCK, arguments, arg_scope, expr)
                 }))
-            }));
+            })
+            .unpack_block_and_unit();
         let source_info = builder.source_info(fn_end);
         builder.cfg.terminate(return_block, source_info, TerminatorKind::Return);
         builder.build_drop_trees();
         return_block.unit()
-    }));
+    });
 
     let mut body = builder.finish();
 

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -584,7 +584,7 @@ fn construct_const<'a, 'tcx>(
         Builder::new(thir, infcx, def, hir_id, span, 0, const_ty, const_ty_span, None);
 
     let mut block = START_BLOCK;
-    unpack!(block = builder.expr_into_dest(Place::return_place(), block, expr));
+    block = builder.expr_into_dest(Place::return_place(), block, expr).unpack_block_and_unit();
 
     let source_info = builder.source_info(span);
     builder.cfg.terminate(block, source_info, TerminatorKind::Return);
@@ -966,7 +966,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         Some((Some(&place), span)),
                     );
                     let place_builder = PlaceBuilder::from(local);
-                    unpack!(block = self.place_into_pattern(block, pat, place_builder, false));
+                    block = self
+                        .place_into_pattern(block, pat, place_builder, false)
+                        .unpack_block_and_unit();
                 }
             }
             self.source_scope = original_source_scope;

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -585,8 +585,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.maybe_new_source_scope(region_scope.1.span, current_hir_id, parent_id);
         }
         self.push_scope(region_scope);
-        let mut block;
-        let rv = unpack!(block = f(self));
+
+        let (mut block, rv) = f(self).unpack_to_pair();
         block = self.pop_scope(region_scope, block).unpack_block_and_unit();
         self.source_scope = source_scope;
         debug!(?block);

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -587,7 +587,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.push_scope(region_scope);
         let mut block;
         let rv = unpack!(block = f(self));
-        unpack!(block = self.pop_scope(region_scope, block));
+        block = self.pop_scope(region_scope, block).unpack_block_and_unit();
         self.source_scope = source_scope;
         debug!(?block);
         block.and(rv)
@@ -659,7 +659,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             (Some(destination), Some(value)) => {
                 debug!("stmt_expr Break val block_context.push(SubExpr)");
                 self.block_context.push(BlockFrame::SubExpr);
-                unpack!(block = self.expr_into_dest(destination, block, value));
+                block = self.expr_into_dest(destination, block, value).unpack_block_and_unit();
                 self.block_context.pop();
             }
             (Some(destination), None) => {

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -510,12 +510,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let target = self.cfg.start_new_block();
                 let source_info = self.source_info(span);
                 self.cfg.terminate(
-                    unpack!(normal_block),
+                    normal_block.unpack_block_and_unit(),
                     source_info,
                     TerminatorKind::Goto { target },
                 );
                 self.cfg.terminate(
-                    unpack!(exit_block),
+                    exit_block.unpack_block_and_unit(),
                     source_info,
                     TerminatorKind::Goto { target },
                 );
@@ -552,14 +552,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let scope = IfThenScope { region_scope, else_drops: DropTree::new() };
         let previous_scope = mem::replace(&mut self.scopes.if_then_scope, Some(scope));
 
-        let then_block = unpack!(f(self));
+        let then_block = f(self).unpack_block_and_unit();
 
         let if_then_scope = mem::replace(&mut self.scopes.if_then_scope, previous_scope).unwrap();
         assert!(if_then_scope.region_scope == region_scope);
 
-        let else_block = self
-            .build_exit_tree(if_then_scope.else_drops, region_scope, span, None)
-            .map_or_else(|| self.cfg.start_new_block(), |else_block_and| unpack!(else_block_and));
+        let else_block =
+            self.build_exit_tree(if_then_scope.else_drops, region_scope, span, None).map_or_else(
+                || self.cfg.start_new_block(),
+                |else_block_and| else_block_and.unpack_block_and_unit(),
+            );
 
         (then_block, else_block)
     }
@@ -753,7 +755,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let unwind_to = if needs_cleanup { self.diverge_cleanup() } else { DropIdx::MAX };
 
         let scope = self.scopes.scopes.last().expect("leave_top_scope called with no scopes");
-        unpack!(build_scope_drops(
+        build_scope_drops(
             &mut self.cfg,
             &mut self.scopes.unwind_drops,
             scope,
@@ -761,7 +763,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             unwind_to,
             is_coroutine && needs_cleanup,
             self.arg_count,
-        ))
+        )
+        .unpack_block_and_unit()
     }
 
     /// Possibly creates a new source scope if `current_root` and `parent_root`


### PR DESCRIPTION
MIR building currently has an `unpack!` macro [(documented in the dev guide)](https://rustc-dev-guide.rust-lang.org/mir/construction.html#unpack-all-the-things) that is used to unpack values of `BlockAnd<T>`, by assigning the block to a variable and then returning the value. It is used in around 100 places in the `rustc_mir_build` crate.

The downside is that understanding this code requires understanding a custom macro, which to me seems like a poor tradeoff relative to the modest benefits of using the macro.

To explore this, I've prepared a PR that removes the `unpack!` macro completely, replacing it with a small number of ordinary methods on the `BlockAnd` type.

In the majority of cases, we replace this code:

```rust
// Note that the actual type of `self.foo(...)` does not match `value` or `block`.
let value = unpack!(block = self.foo(...));
```

With this code:

```rust
// This is just normal Rust code.
let value = self.foo(...).unpack(&mut block);
```

---

[Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/MIR.20building.3A.20removing.20the.20.60unpack!.60.20macro.3F)