### PR TITLE
Show fnsig's unit output  explicitly when there is output diff in diagnostics

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1168,14 +1168,21 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let output1 = sig1.output();
         let output2 = sig2.output();
         let (x1, x2) = self.cmp(output1, output2);
-        if !output1.is_unit() {
+        let only_output_diff = !lifetime_diff
+            && sig1.c_variadic == sig2.c_variadic
+            && sig1.safety == sig2.safety
+            && sig1.abi == sig2.abi
+            && sig1.inputs() == sig2.inputs()
+            && x1 != x2;
+        if !output1.is_unit() || only_output_diff {
             values.0.push_normal(" -> ");
             (values.0).0.extend(x1.0);
         }
-        if !output2.is_unit() {
+        if !output2.is_unit() || only_output_diff {
             values.1.push_normal(" -> ");
             (values.1).0.extend(x2.0);
         }
+
         values
     }
 

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1168,17 +1168,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let output1 = sig1.output();
         let output2 = sig2.output();
         let (x1, x2) = self.cmp(output1, output2);
-        let only_output_diff = !lifetime_diff
-            && sig1.c_variadic == sig2.c_variadic
-            && sig1.safety == sig2.safety
-            && sig1.abi == sig2.abi
-            && sig1.inputs() == sig2.inputs()
-            && x1 != x2;
-        if !output1.is_unit() || only_output_diff {
+        let output_diff = x1 != x2;
+        if !output1.is_unit() || output_diff {
             values.0.push_normal(" -> ");
             (values.0).0.extend(x1.0);
         }
-        if !output2.is_unit() || only_output_diff {
+        if !output2.is_unit() || output_diff {
             values.1.push_normal(" -> ");
             (values.1).0.extend(x2.0);
         }

--- a/tests/ui/compare-method/bad-self-type.stderr
+++ b/tests/ui/compare-method/bad-self-type.stderr
@@ -41,7 +41,7 @@ note: type in trait
 LL |     fn bar(self) -> Option<()>;
    |                     ^^^^^^^^^^
    = note: expected signature `fn(MyFuture) -> Option<()>`
-              found signature `fn(MyFuture)`
+              found signature `fn(MyFuture) -> ()`
 help: change the output type to match the trait
    |
 LL |     fn bar(self) -> Option<()> {}

--- a/tests/ui/error-codes/E0308.stderr
+++ b/tests/ui/error-codes/E0308.stderr
@@ -5,7 +5,7 @@ LL |     fn size_of<T>();
    |                    ^ expected `usize`, found `()`
    |
    = note: expected signature `extern "rust-intrinsic" fn() -> usize`
-              found signature `extern "rust-intrinsic" fn()`
+              found signature `extern "rust-intrinsic" fn() -> ()`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -92,7 +92,7 @@ LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    |                                ^^^^ expected `&Foo`, found `Foo`
    |
    = note: expected signature `extern "rust-call" fn(&Foo, ()) -> _`
-              found signature `extern "rust-call" fn(Foo, ())`
+              found signature `extern "rust-call" fn(Foo, ()) -> ()`
 help: change the self-receiver type to match the trait
    |
 LL |     extern "rust-call" fn call(&self, args: ()) -> () {}
@@ -162,7 +162,7 @@ LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    |                                    ^^^^^ types differ in mutability
    |
    = note: expected signature `extern "rust-call" fn(&mut Bar, ()) -> _`
-              found signature `extern "rust-call" fn(&Bar, ())`
+              found signature `extern "rust-call" fn(&Bar, ()) -> ()`
 help: change the self-receiver type to match the trait
    |
 LL |     extern "rust-call" fn call_mut(&mut self, args: ()) -> () {}

--- a/tests/ui/fn/fn_def_opaque_coercion_to_fn_ptr.stderr
+++ b/tests/ui/fn/fn_def_opaque_coercion_to_fn_ptr.stderr
@@ -10,7 +10,7 @@ LL |     x = foo::<()>;
    |         ^^^^^^^^^ expected fn item, found a different fn item
    |
    = note: expected fn item `fn(F) -> F {bar::<F>}`
-              found fn item `fn(()) {foo::<()>}`
+              found fn item `fn(()) -> () {foo::<()>}`
 
 error[E0308]: mismatched types
   --> $DIR/fn_def_opaque_coercion_to_fn_ptr.rs:27:9
@@ -26,7 +26,7 @@ LL |     let mut x = bar::<()>;
 LL |     x = foo::<I>;
    |         ^^^^^^^^ expected fn item, found a different fn item
    |
-   = note: expected fn item `fn(()) {bar::<()>}`
+   = note: expected fn item `fn(()) -> () {bar::<()>}`
               found fn item `fn(I) -> I {foo::<I>}`
 help: use parentheses to call this function
    |

--- a/tests/ui/impl-trait/in-assoc-type-unconstrained.stderr
+++ b/tests/ui/impl-trait/in-assoc-type-unconstrained.stderr
@@ -35,7 +35,7 @@ note: type in trait
 LL |         fn method() -> Self::Ty;
    |                        ^^^^^^^^
    = note: expected signature `fn() -> <() as compare_method::Trait>::Ty`
-              found signature `fn()`
+              found signature `fn() -> ()`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
   --> $DIR/in-assoc-type-unconstrained.rs:22:12
    |

--- a/tests/ui/impl-trait/trait_type.stderr
+++ b/tests/ui/impl-trait/trait_type.stderr
@@ -5,7 +5,7 @@ LL |    fn fmt(&self, x: &str) -> () { }
    |                     ^^^^ types differ in mutability
    |
    = note: expected signature `fn(&MyType, &mut Formatter<'_>) -> Result<(), std::fmt::Error>`
-              found signature `fn(&MyType, &str)`
+              found signature `fn(&MyType, &str) -> ()`
 help: change the parameter type to match the trait
    |
 LL |    fn fmt(&self, x: &mut Formatter<'_>) -> () { }

--- a/tests/ui/lang-items/start_lang_item_args.missing_ret.stderr
+++ b/tests/ui/lang-items/start_lang_item_args.missing_ret.stderr
@@ -5,7 +5,7 @@ LL | fn start<T>(_main: fn() -> T, _argc: isize, _argv: *const *const u8, _sigpi
    |                                                                                   ^ expected `isize`, found `()`
    |
    = note: expected signature `fn(fn() -> _, _, _, _) -> isize`
-              found signature `fn(fn() -> _, _, _, _)`
+              found signature `fn(fn() -> _, _, _, _) -> ()`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/method-output-diff-issue-127263.rs
+++ b/tests/ui/method-output-diff-issue-127263.rs
@@ -1,0 +1,8 @@
+fn bar() {}
+fn foo(x: i32) -> u32 {
+    0
+}
+fn main() {
+    let b: fn() -> u32 = bar; //~ ERROR mismatched types [E0308]
+    let f: fn(i32) = foo; //~ ERROR mismatched types [E0308]
+}

--- a/tests/ui/method-output-diff-issue-127263.stderr
+++ b/tests/ui/method-output-diff-issue-127263.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/method-output-diff-issue-127263.rs:6:26
+   |
+LL |     let b: fn() -> u32 = bar;
+   |            -----------   ^^^ expected fn pointer, found fn item
+   |            |
+   |            expected due to this
+   |
+   = note: expected fn pointer `fn() -> u32`
+                 found fn item `fn() -> () {bar}`
+
+error[E0308]: mismatched types
+  --> $DIR/method-output-diff-issue-127263.rs:7:22
+   |
+LL |     let f: fn(i32) = foo;
+   |            -------   ^^^ expected fn pointer, found fn item
+   |            |
+   |            expected due to this
+   |
+   = note: expected fn pointer `fn(_) -> ()`
+                 found fn item `fn(_) -> u32 {foo}`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/panic-handler/panic-handler-bad-signature-1.stderr
+++ b/tests/ui/panic-handler/panic-handler-bad-signature-1.stderr
@@ -5,7 +5,7 @@ LL | fn panic(info: PanicInfo) -> () {}
    |                ^^^^^^^^^ expected `&PanicInfo<'_>`, found `PanicInfo<'_>`
    |
    = note: expected signature `for<'a, 'b> fn(&'a PanicInfo<'b>) -> !`
-              found signature `for<'a> fn(PanicInfo<'a>)`
+              found signature `for<'a> fn(PanicInfo<'a>) -> ()`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/impl-method-mismatch.stderr
+++ b/tests/ui/traits/impl-method-mismatch.stderr
@@ -10,7 +10,7 @@ note: type in trait
 LL |     fn jumbo(&self, x: &usize) -> usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected signature `fn(&_, &_) -> usize`
-              found signature `unsafe fn(&_, &_)`
+              found signature `unsafe fn(&_, &_) -> ()`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Fixes #127263 
