### PR TITLE
Try to recover more from struct field parse error

### DIFF
--- a/tests/ui/pattern/struct-parser-recovery-issue-126344.rs
+++ b/tests/ui/pattern/struct-parser-recovery-issue-126344.rs
@@ -1,0 +1,42 @@
+struct Wrong {
+    x: i32; //~ ERROR struct fields are separated by `,`
+    y: i32,
+    z: i32,
+    h: i32,
+}
+
+fn oops(w: &Wrong) {
+    w.x; //~ ERROR no field `x` on type `&Wrong`
+}
+
+fn foo(w: &Wrong) {
+    w.y;
+}
+
+fn haha(w: &Wrong) {
+    w.z;
+}
+
+struct WrongWithType {
+    x: 1, //~ ERROR expected type, found `1`
+    y: i32,
+    z: i32,
+    h: i32,
+}
+
+fn oops_type(w: &WrongWithType) {
+    w.x; //~ ERROR no field `x` on type `&WrongWithType`
+}
+
+fn foo_type(w: &WrongWithType) {
+    w.y;
+}
+
+fn haha_type(w: &WrongWithType) {
+    w.z;
+}
+
+fn main() {
+    let v = Wrong { x: 1, y: 2, z: 3, h: 4 };
+    let x = WrongWithType { x: 1, y: 2, z: 3, h: 4 };
+}

--- a/tests/ui/pattern/struct-parser-recovery-issue-126344.stderr
+++ b/tests/ui/pattern/struct-parser-recovery-issue-126344.stderr
@@ -1,0 +1,41 @@
+error: struct fields are separated by `,`
+  --> $DIR/struct-parser-recovery-issue-126344.rs:2:11
+   |
+LL | struct Wrong {
+   |        ----- while parsing this struct
+LL |     x: i32;
+   |           ^ help: replace `;` with `,`
+
+error: expected type, found `1`
+  --> $DIR/struct-parser-recovery-issue-126344.rs:21:8
+   |
+LL | struct WrongWithType {
+   |        ------------- while parsing this struct
+LL |     x: 1,
+   |        ^ expected type
+
+error[E0609]: no field `x` on type `&Wrong`
+  --> $DIR/struct-parser-recovery-issue-126344.rs:9:7
+   |
+LL |     w.x;
+   |       ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL |     w.y;
+   |       ~
+
+error[E0609]: no field `x` on type `&WrongWithType`
+  --> $DIR/struct-parser-recovery-issue-126344.rs:28:7
+   |
+LL |     w.x;
+   |       ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL |     w.y;
+   |       ~
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0609`.


### PR DESCRIPTION
Partially fixes #126344 

I tried to recover more from parsing struct field error, instead of skipping the whole struct, we may continue to parse the other fields, this can help to reduce some noises when there is only one struct field is not parsed correctly, we will not report `unknown field` for all the other fields.

But this PR can not remove all later diagnostics from the `struct`, I'm not sure whether is worth to solve it, I think the main noise comes from too many fields are ignored, while the left one is trivial.


r? @estebank 





