### PR TITLE
Use field ident spans directly instead of the full field span in diagnostics on local fields

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -321,8 +321,14 @@ impl<'a, 'b, 'tcx> BuildReducedGraphVisitor<'a, 'b, 'tcx> {
             // The fields are not expanded yet.
             return;
         }
-        let def_ids = fields.iter().map(|field| self.r.local_def_id(field.id).to_def_id());
-        self.r.field_def_ids.insert(def_id, self.r.tcx.arena.alloc_from_iter(def_ids));
+        let fields = fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| {
+                field.ident.unwrap_or_else(|| Ident::from_str_and_span(&format!("{i}"), field.span))
+            })
+            .collect();
+        self.r.field_names.insert(def_id, fields);
     }
 
     fn insert_field_visibilities_local(&mut self, def_id: DefId, fields: &[ast::FieldDef]) {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1726,11 +1726,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         )) = binding.kind
         {
             let def_id = self.tcx.parent(ctor_def_id);
-            return self
-                .field_def_ids(def_id)?
-                .iter()
-                .map(|&field_id| self.def_span(field_id))
-                .reduce(Span::to); // None for `struct Foo()`
+            return self.field_idents(def_id)?.iter().map(|&f| f.span).reduce(Span::to); // None for `struct Foo()`
         }
         None
     }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -991,7 +991,7 @@ pub struct Resolver<'a, 'tcx> {
     extern_prelude: FxHashMap<Ident, ExternPreludeEntry<'a>>,
 
     /// N.B., this is used only for better diagnostics, not name resolution itself.
-    field_def_ids: LocalDefIdMap<&'tcx [DefId]>,
+    field_names: LocalDefIdMap<Vec<Ident>>,
 
     /// Span of the privacy modifier in fields of an item `DefId` accessible with dot syntax.
     /// Used for hints during error reporting.
@@ -1406,7 +1406,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             prelude: None,
             extern_prelude,
 
-            field_def_ids: Default::default(),
+            field_names: Default::default(),
             field_visibility_spans: FxHashMap::default(),
 
             determined_imports: Vec::new(),
@@ -2127,10 +2127,18 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         }
     }
 
-    fn field_def_ids(&self, def_id: DefId) -> Option<&'tcx [DefId]> {
+    fn field_idents(&self, def_id: DefId) -> Option<Vec<Ident>> {
         match def_id.as_local() {
-            Some(def_id) => self.field_def_ids.get(&def_id).copied(),
-            None => Some(self.tcx.associated_item_def_ids(def_id)),
+            Some(def_id) => self.field_names.get(&def_id).cloned(),
+            None => Some(
+                self.tcx
+                    .associated_item_def_ids(def_id)
+                    .iter()
+                    .map(|&def_id| {
+                        Ident::new(self.tcx.item_name(def_id), self.tcx.def_span(def_id))
+                    })
+                    .collect(),
+            ),
         }
     }
 

--- a/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.stderr
+++ b/tests/ui/resolve/field-and-method-in-self-not-available-in-assoc-fn.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `field` in this scope
   --> $DIR/field-and-method-in-self-not-available-in-assoc-fn.rs:11:9
    |
 LL |     field: u32,
-   |     ---------- a field by that name exists in `Self`
+   |     ----- a field by that name exists in `Self`
 ...
 LL |     fn field(&self) -> u32 {
    |        ----- a method by that name is available on `Self` here
@@ -14,7 +14,7 @@ error[E0425]: cannot find value `field` in this scope
   --> $DIR/field-and-method-in-self-not-available-in-assoc-fn.rs:12:15
    |
 LL |     field: u32,
-   |     ---------- a field by that name exists in `Self`
+   |     ----- a field by that name exists in `Self`
 ...
 LL |     fn field(&self) -> u32 {
    |        ----- a method by that name is available on `Self` here

--- a/tests/ui/resolve/issue-2356.stderr
+++ b/tests/ui/resolve/issue-2356.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:39:5
    |
 LL |   whiskers: isize,
-   |   --------------- a field by that name exists in `Self`
+   |   -------- a field by that name exists in `Self`
 ...
 LL |     whiskers -= other;
    |     ^^^^^^^^
@@ -35,7 +35,7 @@ error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:84:5
    |
 LL |   whiskers: isize,
-   |   --------------- a field by that name exists in `Self`
+   |   -------- a field by that name exists in `Self`
 ...
 LL |     whiskers = 4;
    |     ^^^^^^^^

--- a/tests/ui/resolve/issue-60057.stderr
+++ b/tests/ui/resolve/issue-60057.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `banana` in this scope
   --> $DIR/issue-60057.rs:8:21
    |
 LL |     banana: u8,
-   |     ---------- a field by that name exists in `Self`
+   |     ------ a field by that name exists in `Self`
 ...
 LL |             banana: banana
    |                     ^^^^^^

--- a/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `config` in this scope
   --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:7:16
    |
 LL |     config: String,
-   |     -------------- a field by that name exists in `Self`
+   |     ------ a field by that name exists in `Self`
 ...
 LL |         Self { config }
    |                ^^^^^^ help: a local variable with a similar name exists: `cofig`
@@ -11,7 +11,7 @@ error[E0425]: cannot find value `config` in this scope
   --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:11:20
    |
 LL |     config: String,
-   |     -------------- a field by that name exists in `Self`
+   |     ------ a field by that name exists in `Self`
 ...
 LL |         println!("{config}");
    |                    ^^^^^^ help: a local variable with a similar name exists: `cofig`

--- a/tests/ui/resolve/unresolved_static_type_field.stderr
+++ b/tests/ui/resolve/unresolved_static_type_field.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `cx` in this scope
   --> $DIR/unresolved_static_type_field.rs:9:11
    |
 LL |     cx: bool,
-   |     -------- a field by that name exists in `Self`
+   |     -- a field by that name exists in `Self`
 ...
 LL |         f(cx);
    |           ^^


### PR DESCRIPTION
This improves diagnostics and avoids having to store the `DefId`s of fields