### PR TITLE
Use same `FxHashMap` in `rustdoc-json-types` and `librustdoc`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2074,7 +2074,6 @@ dependencies = [
  "anyhow",
  "clap",
  "fs-err",
- "rustc-hash",
  "rustdoc-json-types",
  "serde",
  "serde_json",
@@ -4929,7 +4928,6 @@ name = "rustdoc-json-types"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "rustc-hash",
  "serde",
  "serde_json",
 ]

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -15,7 +15,7 @@ indexmap = "2"
 minifier = "0.3.0"
 pulldown-cmark-old = { version = "0.9.6", package = "pulldown-cmark", default-features = false }
 regex = "1"
-rustdoc-json-types = { path = "../rustdoc-json-types" }
+rustdoc-json-types = { path = "../rustdoc-json-types", features = ["rustc-hash"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 smallvec = "1.8.1"

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -228,14 +228,11 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
         let index = (*self.index).clone().into_inner();
 
         debug!("Constructing Output");
-        // This needs to be the default HashMap for compatibility with the public interface for
-        // rustdoc-json-types
-        #[allow(rustc::default_hash_types)]
         let output = types::Crate {
             root: types::Id(format!("0:0:{}", e.name(self.tcx).as_u32())),
             crate_version: self.cache.crate_version.clone(),
             includes_private: self.cache.document_private,
-            index: index.into_iter().collect(),
+            index,
             paths: self
                 .cache
                 .paths

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -8,8 +8,12 @@ path = "lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rustc-hash = "1.1.0"
+# rustc-hash = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
 bincode = "1"
+
+[features]
+rustc-hash = []
+

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -3,7 +3,14 @@
 //! These types are the public API exposed through the `--output-format json` flag. The [`Crate`]
 //! struct is the root of the JSON blob and all other items are contained within.
 
-use rustc_hash::FxHashMap;
+#![cfg_attr(feature = "rustc-hash", feature(rustc_private))]
+#[cfg(feature = "rustc-hash")]
+extern crate rustc_hash;
+#[cfg(feature = "rustc-hash")]
+use rustc_hash::FxHashMap as HashMap;
+#[cfg(not(feature = "rustc-hash"))]
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -23,11 +30,11 @@ pub struct Crate {
     pub includes_private: bool,
     /// A collection of all items in the local crate as well as some external traits and their
     /// items that are referenced locally.
-    pub index: FxHashMap<Id, Item>,
+    pub index: HashMap<Id, Item>,
     /// Maps IDs to fully qualified paths and other info helpful for generating links.
-    pub paths: FxHashMap<Id, ItemSummary>,
+    pub paths: HashMap<Id, ItemSummary>,
     /// Maps `crate_id` of items to a crate name and html_root_url if it exists.
-    pub external_crates: FxHashMap<u32, ExternalCrate>,
+    pub external_crates: HashMap<u32, ExternalCrate>,
     /// A single version number to be used in the future when making backwards incompatible changes
     /// to the JSON output.
     pub format_version: u32,
@@ -79,7 +86,7 @@ pub struct Item {
     /// Some("") if there is some documentation but it is empty (EG `#[doc = ""]`).
     pub docs: Option<String>,
     /// This mapping resolves [intra-doc links](https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md) from the docstring to their IDs
-    pub links: FxHashMap<String, Id>,
+    pub links: HashMap<String, Id>,
     /// Stringified versions of the attributes on this item (e.g. `"#[inline]"`)
     pub attrs: Vec<String>,
     pub deprecation: Option<Deprecation>,

--- a/src/tools/jsondoclint/Cargo.toml
+++ b/src/tools/jsondoclint/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 anyhow = "1.0.62"
 clap = { version = "4.0.15", features = ["derive"] }
 fs-err = "2.8.1"
-rustc-hash = "1.1.0"
 rustdoc-json-types = { version = "0.1.0", path = "../../rustdoc-json-types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"

--- a/src/tools/jsondoclint/src/validator/tests.rs
+++ b/src/tools/jsondoclint/src/validator/tests.rs
@@ -1,4 +1,5 @@
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
+
 use rustdoc_json_types::{Item, ItemKind, Visibility, FORMAT_VERSION};
 
 use crate::json_find::SelectorPart;
@@ -26,7 +27,7 @@ fn errors_on_missing_links() {
         root: id("0"),
         crate_version: None,
         includes_private: false,
-        index: FxHashMap::from_iter([(
+        index: HashMap::from_iter([(
             id("0"),
             Item {
                 name: Some("root".to_owned()),
@@ -35,7 +36,7 @@ fn errors_on_missing_links() {
                 span: None,
                 visibility: Visibility::Public,
                 docs: None,
-                links: FxHashMap::from_iter([("Not Found".to_owned(), id("1"))]),
+                links: HashMap::from_iter([("Not Found".to_owned(), id("1"))]),
                 attrs: vec![],
                 deprecation: None,
                 inner: ItemEnum::Module(Module {
@@ -45,8 +46,8 @@ fn errors_on_missing_links() {
                 }),
             },
         )]),
-        paths: FxHashMap::default(),
-        external_crates: FxHashMap::default(),
+        paths: HashMap::default(),
+        external_crates: HashMap::default(),
         format_version: rustdoc_json_types::FORMAT_VERSION,
     };
 
@@ -72,7 +73,7 @@ fn errors_on_local_in_paths_and_not_index() {
         root: id("0:0:1572"),
         crate_version: None,
         includes_private: false,
-        index: FxHashMap::from_iter([
+        index: HashMap::from_iter([
             (
                 id("0:0:1572"),
                 Item {
@@ -82,7 +83,7 @@ fn errors_on_local_in_paths_and_not_index() {
                     span: None,
                     visibility: Visibility::Public,
                     docs: None,
-                    links: FxHashMap::from_iter([(("prim@i32".to_owned(), id("0:1:1571")))]),
+                    links: HashMap::from_iter([(("prim@i32".to_owned(), id("0:1:1571")))]),
                     attrs: Vec::new(),
                     deprecation: None,
                     inner: ItemEnum::Module(Module {
@@ -101,14 +102,14 @@ fn errors_on_local_in_paths_and_not_index() {
                     span: None,
                     visibility: Visibility::Public,
                     docs: None,
-                    links: FxHashMap::default(),
+                    links: HashMap::default(),
                     attrs: Vec::new(),
                     deprecation: None,
                     inner: ItemEnum::Primitive(Primitive { name: "i32".to_owned(), impls: vec![] }),
                 },
             ),
         ]),
-        paths: FxHashMap::from_iter([(
+        paths: HashMap::from_iter([(
             id("0:1:1571"),
             ItemSummary {
                 crate_id: 0,
@@ -116,7 +117,7 @@ fn errors_on_local_in_paths_and_not_index() {
                 kind: ItemKind::Primitive,
             },
         )]),
-        external_crates: FxHashMap::default(),
+        external_crates: HashMap::default(),
         format_version: rustdoc_json_types::FORMAT_VERSION,
     };
 
@@ -136,7 +137,7 @@ fn checks_local_crate_id_is_correct() {
         root: id("root"),
         crate_version: None,
         includes_private: false,
-        index: FxHashMap::from_iter([(
+        index: HashMap::from_iter([(
             id("root"),
             Item {
                 id: id("root"),
@@ -145,7 +146,7 @@ fn checks_local_crate_id_is_correct() {
                 span: None,
                 visibility: Visibility::Public,
                 docs: None,
-                links: FxHashMap::default(),
+                links: HashMap::default(),
                 attrs: Vec::new(),
                 deprecation: None,
                 inner: ItemEnum::Module(Module {
@@ -155,8 +156,8 @@ fn checks_local_crate_id_is_correct() {
                 }),
             },
         )]),
-        paths: FxHashMap::default(),
-        external_crates: FxHashMap::default(),
+        paths: HashMap::default(),
+        external_crates: HashMap::default(),
         format_version: FORMAT_VERSION,
     };
     check(&krate, &[]);


### PR DESCRIPTION
Reopening of #110051, because bors has seemingly abandoned us there :'(

try-job: dist-arm-linux

try-job: dist-armhf-linux

try-job: armhf-gnu

try-job: test-various

r? @ghost