### PR TITLE
Make tidy fast without compromising case alternation

### DIFF
--- a/src/tools/tidy/src/style/tests.rs
+++ b/src/tools/tidy/src/style/tests.rs
@@ -1,17 +1,10 @@
 use super::*;
 
 #[test]
-fn test_generate_problematic_strings() {
-    let problematic_regex = RegexSet::new(
-        generate_problematic_strings(
-            ROOT_PROBLEMATIC_CONSTS,
-            &[('A', '4'), ('B', '8'), ('E', '3'), ('0', 'F')].iter().cloned().collect(), // use "futile" F intentionally
-        )
-        .as_slice(),
-    )
-    .unwrap();
-    assert!(problematic_regex.is_match("786357")); // check with no "decimal" hex digits - converted to integer
-    assert!(problematic_regex.is_match("589701")); // check with "decimal" replacements - converted to integer
-    assert!(problematic_regex.is_match("8FF85")); // check for hex display
-    assert!(!problematic_regex.is_match("1193046")); // check for non-matching value
+fn test_contains_problematic_const() {
+    assert!(contains_problematic_const("721077")); // check with no "decimal" hex digits - converted to integer
+    assert!(contains_problematic_const("524421")); // check with "decimal" replacements - converted to integer
+    assert!(contains_problematic_const(&(285 * 281).to_string())); // check for hex display
+    assert!(contains_problematic_const(&format!("{:x}B5", 2816))); // check for case-alternating hex display
+    assert!(!contains_problematic_const("1193046")); // check for non-matching value
 }


### PR DESCRIPTION
Fixes tidy speed issue but still catches case-alternation, enabled for other `style.rs` files, and also detects test files better.
r? @albertlarsan68 
@Nilstrieb 