### PR TITLE
Remove blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,4 +1,0 @@
----
-name: Blank Issue
-about: Create a blank issue.
----


### PR DESCRIPTION
This PR removes the blank issue template since you can already make a blank issue by going to the Issues tab, then New issue and scrolling to the bottom and selecting "Don’t see your issue here? Open a blank issue."