### PR TITLE
Allow disabling ASan instrumentation for globals

### DIFF
--- a/compiler/rustc_codegen_llvm/src/base.rs
+++ b/compiler/rustc_codegen_llvm/src/base.rs
@@ -172,3 +172,12 @@ pub(crate) fn visibility_to_llvm(linkage: Visibility) -> llvm::Visibility {
         Visibility::Protected => llvm::Visibility::Protected,
     }
 }
+
+pub(crate) fn set_variable_sanitizer_attrs(llval: &Value, attrs: &CodegenFnAttrs) {
+    if attrs.no_sanitize.contains(SanitizerSet::ADDRESS) {
+        unsafe { llvm::LLVMRustSetNoSanitizeAddress(llval) };
+    }
+    if attrs.no_sanitize.contains(SanitizerSet::HWADDRESS) {
+        unsafe { llvm::LLVMRustSetNoSanitizeHWAddress(llval) };
+    }
+}

--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -476,6 +476,8 @@ impl<'ll> CodegenCx<'ll, '_> {
                 base::set_link_section(g, attrs);
             }
 
+            base::set_variable_sanitizer_attrs(g, attrs);
+
             if attrs.flags.contains(CodegenFnAttrFlags::USED) {
                 // `USED` and `USED_LINKER` can't be used together.
                 assert!(!attrs.flags.contains(CodegenFnAttrFlags::USED_LINKER));

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2474,4 +2474,7 @@ unsafe extern "C" {
     pub fn LLVMRustIs64BitSymbolicFile(buf_ptr: *const u8, buf_len: usize) -> bool;
 
     pub fn LLVMRustIsECObject(buf_ptr: *const u8, buf_len: usize) -> bool;
+
+    pub fn LLVMRustSetNoSanitizeAddress(Global: &Value);
+    pub fn LLVMRustSetNoSanitizeHWAddress(Global: &Value);
 }

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1999,6 +1999,25 @@ extern "C" bool LLVMRustLLVMHasZstdCompressionForDebugSymbols() {
   return llvm::compression::zstd::isAvailable();
 }
 
+extern "C" void LLVMRustSetNoSanitizeAddress(LLVMValueRef Global) {
+  GlobalValue &GV = *unwrap<GlobalValue>(Global);
+  GlobalValue::SanitizerMetadata MD;
+  if (GV.hasSanitizerMetadata())
+    MD = GV.getSanitizerMetadata();
+  MD.NoAddress = true;
+  MD.IsDynInit = false;
+  GV.setSanitizerMetadata(MD);
+}
+
+extern "C" void LLVMRustSetNoSanitizeHWAddress(LLVMValueRef Global) {
+  GlobalValue &GV = *unwrap<GlobalValue>(Global);
+  GlobalValue::SanitizerMetadata MD;
+  if (GV.hasSanitizerMetadata())
+    MD = GV.getSanitizerMetadata();
+  MD.NoHWAddress = true;
+  GV.setSanitizerMetadata(MD);
+}
+
 // Operations on composite constants.
 // These are clones of LLVM api functions that will become available in future
 // releases. They can be removed once Rust's minimum supported LLVM version

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -555,6 +555,10 @@ passes_no_mangle_foreign =
 passes_no_patterns =
     patterns not allowed in naked function parameters
 
+passes_no_sanitize =
+    `#[no_sanitize({$attr_str})]` should be applied to {$accepted_kind}
+    .label = not {$accepted_kind}
+
 passes_non_exported_macro_invalid_attrs =
     attribute should be applied to function or closure
     .label = not a function or closure

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1848,3 +1848,14 @@ pub(crate) struct AttrCrateLevelOnlySugg {
     #[primary_span]
     pub attr: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(passes_no_sanitize)]
+pub(crate) struct NoSanitize<'a> {
+    #[primary_span]
+    pub attr_span: Span,
+    #[label]
+    pub defn_span: Span,
+    pub accepted_kind: &'a str,
+    pub attr_str: &'a str,
+}

--- a/tests/codegen/sanitizer/no-sanitize.rs
+++ b/tests/codegen/sanitizer/no-sanitize.rs
@@ -7,6 +7,16 @@
 #![crate_type = "lib"]
 #![feature(no_sanitize)]
 
+// CHECK:     @UNSANITIZED = constant{{.*}} no_sanitize_address
+// CHECK-NOT: @__asan_global_UNSANITIZED
+#[no_mangle]
+#[no_sanitize(address)]
+pub static UNSANITIZED: u32 = 0;
+
+// CHECK: @__asan_global_SANITIZED
+#[no_mangle]
+pub static SANITIZED: u32 = 0;
+
 // CHECK-LABEL: ; no_sanitize::unsanitized
 // CHECK-NEXT:  ; Function Attrs:
 // CHECK-NOT:   sanitize_address

--- a/tests/ui/attributes/no-sanitize.rs
+++ b/tests/ui/attributes/no-sanitize.rs
@@ -4,31 +4,37 @@
 #![allow(dead_code)]
 
 fn invalid() {
-    #[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+    #[no_sanitize(memory)] //~ ERROR `#[no_sanitize(memory)]` should be applied to a function
     {
         1
     };
 }
 
-#[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+#[no_sanitize(memory)] //~ ERROR `#[no_sanitize(memory)]` should be applied to a function
 type InvalidTy = ();
 
-#[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+#[no_sanitize(memory)] //~ ERROR `#[no_sanitize(memory)]` should be applied to a function
 mod invalid_module {}
 
 fn main() {
-    let _ = #[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+    let _ = #[no_sanitize(memory)] //~ ERROR `#[no_sanitize(memory)]` should be applied to a function
     (|| 1);
 }
 
-#[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+#[no_sanitize(memory)] //~ ERROR `#[no_sanitize(memory)]` should be applied to a function
 struct F;
 
-#[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+#[no_sanitize(memory)] //~ ERROR `#[no_sanitize(memory)]` should be applied to a function
 impl F {
     #[no_sanitize(memory)]
     fn valid(&self) {}
 }
 
+#[no_sanitize(address, memory)] //~ ERROR `#[no_sanitize(memory)]` should be applied to a function
+static INVALID : i32 = 0;
+
 #[no_sanitize(memory)]
 fn valid() {}
+
+#[no_sanitize(address)]
+static VALID : i32 = 0;

--- a/tests/ui/attributes/no-sanitize.stderr
+++ b/tests/ui/attributes/no-sanitize.stderr
@@ -1,55 +1,63 @@
-error: attribute should be applied to a function definition
-  --> $DIR/no-sanitize.rs:7:5
+error: `#[no_sanitize(memory)]` should be applied to a function
+  --> $DIR/no-sanitize.rs:7:19
    |
 LL |       #[no_sanitize(memory)]
-   |       ^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^
 LL | /     {
 LL | |         1
 LL | |     };
-   | |_____- not a function definition
+   | |_____- not a function
 
-error: attribute should be applied to a function definition
-  --> $DIR/no-sanitize.rs:13:1
+error: `#[no_sanitize(memory)]` should be applied to a function
+  --> $DIR/no-sanitize.rs:13:15
    |
 LL | #[no_sanitize(memory)]
-   | ^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^
 LL | type InvalidTy = ();
-   | -------------------- not a function definition
+   | -------------------- not a function
 
-error: attribute should be applied to a function definition
-  --> $DIR/no-sanitize.rs:16:1
+error: `#[no_sanitize(memory)]` should be applied to a function
+  --> $DIR/no-sanitize.rs:16:15
    |
 LL | #[no_sanitize(memory)]
-   | ^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^
 LL | mod invalid_module {}
-   | --------------------- not a function definition
+   | --------------------- not a function
 
-error: attribute should be applied to a function definition
-  --> $DIR/no-sanitize.rs:20:13
+error: `#[no_sanitize(memory)]` should be applied to a function
+  --> $DIR/no-sanitize.rs:20:27
    |
 LL |     let _ = #[no_sanitize(memory)]
-   |             ^^^^^^^^^^^^^^^^^^^^^^
+   |                           ^^^^^^
 LL |     (|| 1);
-   |     ------ not a function definition
+   |     ------ not a function
 
-error: attribute should be applied to a function definition
-  --> $DIR/no-sanitize.rs:24:1
+error: `#[no_sanitize(memory)]` should be applied to a function
+  --> $DIR/no-sanitize.rs:24:15
    |
 LL | #[no_sanitize(memory)]
-   | ^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^
 LL | struct F;
-   | --------- not a function definition
+   | --------- not a function
 
-error: attribute should be applied to a function definition
-  --> $DIR/no-sanitize.rs:27:1
+error: `#[no_sanitize(memory)]` should be applied to a function
+  --> $DIR/no-sanitize.rs:27:15
    |
 LL |   #[no_sanitize(memory)]
-   |   ^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^
 LL | / impl F {
 LL | |     #[no_sanitize(memory)]
 LL | |     fn valid(&self) {}
 LL | | }
-   | |_- not a function definition
+   | |_- not a function
 
-error: aborting due to 6 previous errors
+error: `#[no_sanitize(memory)]` should be applied to a function
+  --> $DIR/no-sanitize.rs:33:24
+   |
+LL | #[no_sanitize(address, memory)]
+   |                        ^^^^^^
+LL | static INVALID : i32 = 0;
+   | ------------------------- not a function
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
AddressSanitizer adds instrumentation to global variables unless the [`no_sanitize_address`](https://llvm.org/docs/LangRef.html#global-attributes) attribute is set on them.

This commit extends the existing `#[no_sanitize(address)]` attribute to set this; previously it only had the desired effect on functions.

(cc https://github.com/rust-lang/rust/issues/39699)
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
