### PR TITLE
`#[doc(alias)]`'s doc: say that ASCII spaces are allowed

### DIFF
--- a/src/doc/rustdoc/src/advanced-features.md
+++ b/src/doc/rustdoc/src/advanced-features.md
@@ -80,7 +80,8 @@ pub struct BigX;
 Then, when looking for it through the `rustdoc` search, if you enter "x" or
 "big", search will show the `BigX` struct first.
 
-There are some limitations on the doc alias names though: you can't use `"` or whitespace.
+There are some limitations on the doc alias names though: they cannot contain quotes (`'`, `"`)
+or most whitespace. ASCII space is allowed if it does not start or end the alias.
 
 You can add multiple aliases at the same time by using a list:
 


### PR DESCRIPTION
PR #77570 allowed ASCII spaces in doc aliases, but the documentation wasn't updated to say so.

The code checking the aliases:
https://github.com/rust-lang/rust/blob/7fdefb804ec300fb605039522a7c0dfc9e7dc366/compiler/rustc_passes/src/check_attr.rs#L693-L704

@rustbot label +A-docs