### PR TITLE
Suggest removing `.unwrap()` or `.expect()` if followed by a failed `?` operator

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -374,6 +374,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
                         self.suggest_floating_point_literal(&obligation, &mut err, leaf_trait_ref);
                         self.suggest_dereferencing_index(&obligation, &mut err, leaf_trait_predicate);
+                        suggested |= self.suggest_remove_unwrap(&obligation, &mut err, leaf_trait_predicate);
                         suggested |= self.suggest_dereferences(&obligation, &mut err, leaf_trait_predicate);
                         suggested |= self.suggest_fn_call(&obligation, &mut err, leaf_trait_predicate);
                         let impl_candidates = self.find_similar_impl_candidates(leaf_trait_predicate);

--- a/tests/ui/try-trait/try-after-unwrap-issue-127345.rs
+++ b/tests/ui/try-trait/try-after-unwrap-issue-127345.rs
@@ -1,0 +1,62 @@
+fn foo() -> Option<usize> {
+    let x = Some(42).expect("moop")?;
+    //~^ ERROR the `?` operator can only be applied to values that implement `Try`
+    //~| HELP the trait `Try` is not implemented for `{integer}`
+    //~| HELP remove the `.expect()`
+    let x = Some(42).unwrap()?;
+    //~^ ERROR the `?` operator can only be applied to values that implement `Try`
+    //~| HELP the trait `Try` is not implemented for `{integer}`
+    //~| HELP remove the `.unwrap()`
+    x
+}
+
+fn bar() -> Option<usize> {
+    foo().or(Some(43)).unwrap()?
+    //~^ ERROR the `?` operator can only be applied to values that implement `Try`
+    //~| HELP the trait `Try` is not implemented for `usize`
+    //~| HELP remove the `.unwrap()`
+}
+
+fn baz() -> Result<usize, ()> {
+    Ok(44).unwrap()?
+    //~^ ERROR the `?` operator can only be applied to values that implement `Try`
+    //~| HELP the trait `Try` is not implemented for `{integer}`
+    //~| HELP remove the `.unwrap()`
+}
+
+fn baz2() -> Result<String, ()> {
+    Ok(44).unwrap()?
+    //~^ ERROR the `?` operator can only be applied to values that implement `Try`
+    //~| HELP the trait `Try` is not implemented for `{integer}`
+    //~| HELP remove the `.unwrap()`
+}
+
+fn baz3() -> Option<usize> {
+    Ok(44).unwrap()?
+    //~^ ERROR the `?` operator can only be applied to values that implement `Try`
+    //~| HELP the trait `Try` is not implemented for `{integer}`
+    //~| HELP remove the `.unwrap()`
+}
+
+fn baz4() {
+    Ok(44).unwrap()?
+    //~^ ERROR the `?` operator can only be applied to values that implement `Try`
+    //~| HELP the trait `Try` is not implemented for `{integer}`
+    //~| HELP remove the `.unwrap()`
+    //~| ERROR the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
+    //~| HELP the trait `FromResidual<_>` is not implemented for `()`
+}
+
+struct FakeUnwrappable;
+
+impl FakeUnwrappable {
+    fn unwrap(self) -> () {}
+}
+
+fn qux() -> Option<usize> {
+    FakeUnwrappable.unwrap()?
+    //~^ ERROR the `?` operator can only be applied to values that implement `Try`
+    //~| HELP the trait `Try` is not implemented for `()`
+}
+
+fn main() {}

--- a/tests/ui/try-trait/try-after-unwrap-issue-127345.stderr
+++ b/tests/ui/try-trait/try-after-unwrap-issue-127345.stderr
@@ -1,0 +1,112 @@
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+  --> $DIR/try-after-unwrap-issue-127345.rs:2:13
+   |
+LL |     let x = Some(42).expect("moop")?;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `{integer}`
+   |
+   = help: the trait `Try` is not implemented for `{integer}`
+help: remove the `.expect()`
+   |
+LL -     let x = Some(42).expect("moop")?;
+LL +     let x = Some(42)?;
+   |
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+  --> $DIR/try-after-unwrap-issue-127345.rs:6:13
+   |
+LL |     let x = Some(42).unwrap()?;
+   |             ^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `{integer}`
+   |
+   = help: the trait `Try` is not implemented for `{integer}`
+help: remove the `.unwrap()`
+   |
+LL -     let x = Some(42).unwrap()?;
+LL +     let x = Some(42)?;
+   |
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+  --> $DIR/try-after-unwrap-issue-127345.rs:14:5
+   |
+LL |     foo().or(Some(43)).unwrap()?
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `usize`
+   |
+   = help: the trait `Try` is not implemented for `usize`
+help: remove the `.unwrap()`
+   |
+LL -     foo().or(Some(43)).unwrap()?
+LL +     foo().or(Some(43))?
+   |
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+  --> $DIR/try-after-unwrap-issue-127345.rs:21:5
+   |
+LL |     Ok(44).unwrap()?
+   |     ^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `{integer}`
+   |
+   = help: the trait `Try` is not implemented for `{integer}`
+help: remove the `.unwrap()`
+   |
+LL -     Ok(44).unwrap()?
+LL +     Ok(44)?
+   |
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+  --> $DIR/try-after-unwrap-issue-127345.rs:28:5
+   |
+LL |     Ok(44).unwrap()?
+   |     ^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `{integer}`
+   |
+   = help: the trait `Try` is not implemented for `{integer}`
+help: remove the `.unwrap()`
+   |
+LL -     Ok(44).unwrap()?
+LL +     Ok(44)?
+   |
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+  --> $DIR/try-after-unwrap-issue-127345.rs:35:5
+   |
+LL |     Ok(44).unwrap()?
+   |     ^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `{integer}`
+   |
+   = help: the trait `Try` is not implemented for `{integer}`
+help: remove the `.unwrap()`
+   |
+LL -     Ok(44).unwrap()?
+LL +     Ok(44)?
+   |
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+  --> $DIR/try-after-unwrap-issue-127345.rs:42:5
+   |
+LL |     Ok(44).unwrap()?
+   |     ^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `{integer}`
+   |
+   = help: the trait `Try` is not implemented for `{integer}`
+help: remove the `.unwrap()`
+   |
+LL -     Ok(44).unwrap()?
+LL +     Ok(44)?
+   |
+
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> $DIR/try-after-unwrap-issue-127345.rs:42:20
+   |
+LL | fn baz4() {
+   | --------- this function should return `Result` or `Option` to accept `?`
+LL |     Ok(44).unwrap()?
+   |                    ^ cannot use the `?` operator in a function that returns `()`
+   |
+   = help: the trait `FromResidual<_>` is not implemented for `()`
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+  --> $DIR/try-after-unwrap-issue-127345.rs:57:5
+   |
+LL |     FakeUnwrappable.unwrap()?
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+   |
+   = help: the trait `Try` is not implemented for `()`
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Closes #127345