### PR TITLE
Update `f16`/`f128` FIXMEs that needed `(NEG_)INFINITY`

### DIFF
--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -563,7 +563,8 @@ fn lint_literal<'tcx>(
         ty::Float(t) => {
             let is_infinite = match lit.node {
                 ast::LitKind::Float(v, _) => match t {
-                    // FIXME(f16_f128): add this check once we have library support
+                    // FIXME(f16_f128): add this check once `is_infinite` is reliable (ABI
+                    // issues resolved).
                     ty::FloatTy::F16 => Ok(false),
                     ty::FloatTy::F32 => v.as_str().parse().map(f32::is_infinite),
                     ty::FloatTy::F64 => v.as_str().parse().map(f64::is_infinite),

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-semantics.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-semantics.rs
@@ -45,9 +45,8 @@ fn range_to_inclusive() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f16::NEG_INFINITY, ..=f16::NEG_INFINITY));
-        // assert!(yes!(f16::NEG_INFINITY, ..=1.0f16));
+        assert!(yes!(f16::NEG_INFINITY, ..=f16::NEG_INFINITY));
+        assert!(yes!(f16::NEG_INFINITY, ..=1.0f16));
         assert!(yes!(1.5f16, ..=1.5f16));
         assert!(!yes!(1.6f16, ..=-1.5f16));
     }
@@ -68,9 +67,8 @@ fn range_to_inclusive() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f128::NEG_INFINITY, ..=f128::NEG_INFINITY));
-        // assert!(yes!(f128::NEG_INFINITY, ..=1.0f128));
+        assert!(yes!(f128::NEG_INFINITY, ..=f128::NEG_INFINITY));
+        assert!(yes!(f128::NEG_INFINITY, ..=1.0f128));
         assert!(yes!(1.5f128, ..=1.5f128));
         assert!(!yes!(1.6f128, ..=-1.5f128));
     }
@@ -111,8 +109,7 @@ fn range_to() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f16::NEG_INFINITY, ..1.0f16));
+        assert!(yes!(f16::NEG_INFINITY, ..1.0f16));
         assert!(!yes!(1.5f16, ..1.5f16));
         const E16: f16 = 1.5f16 + f16::EPSILON;
         assert!(yes!(1.5f16, ..E16));
@@ -137,8 +134,7 @@ fn range_to() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f128::NEG_INFINITY, ..1.0f128));
+        assert!(yes!(f128::NEG_INFINITY, ..1.0f128));
         assert!(!yes!(1.5f128, ..1.5f128));
         const E128: f128 = 1.5f128 + f128::EPSILON;
         assert!(yes!(1.5f128, ..E128));
@@ -181,15 +177,14 @@ fn range_from() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f16::NEG_INFINITY, f16::NEG_INFINITY..));
-        // assert!(yes!(f16::INFINITY, f16::NEG_INFINITY..));
-        // assert!(!yes!(f16::NEG_INFINITY, 1.0f16..));
-        // assert!(yes!(f16::INFINITY, 1.0f16..));
+        assert!(yes!(f16::NEG_INFINITY, f16::NEG_INFINITY..));
+        assert!(yes!(f16::INFINITY, f16::NEG_INFINITY..));
+        assert!(!yes!(f16::NEG_INFINITY, 1.0f16..));
+        assert!(yes!(f16::INFINITY, 1.0f16..));
         assert!(!yes!(1.0f16 - f16::EPSILON, 1.0f16..));
         assert!(yes!(1.0f16, 1.0f16..));
-        // assert!(yes!(f16::INFINITY, 1.0f16..));
-        // assert!(yes!(f16::INFINITY, f16::INFINITY..));
+        assert!(yes!(f16::INFINITY, 1.0f16..));
+        assert!(yes!(f16::INFINITY, f16::INFINITY..));
     }
 
     // f32; `X..`
@@ -216,15 +211,14 @@ fn range_from() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f128::NEG_INFINITY, f128::NEG_INFINITY..));
-        // assert!(yes!(f128::INFINITY, f128::NEG_INFINITY..));
-        // assert!(!yes!(f128::NEG_INFINITY, 1.0f128..));
-        // assert!(yes!(f128::INFINITY, 1.0f128..));
+        assert!(yes!(f128::NEG_INFINITY, f128::NEG_INFINITY..));
+        assert!(yes!(f128::INFINITY, f128::NEG_INFINITY..));
+        assert!(!yes!(f128::NEG_INFINITY, 1.0f128..));
+        assert!(yes!(f128::INFINITY, 1.0f128..));
         assert!(!yes!(1.0f128 - f128::EPSILON, 1.0f128..));
         assert!(yes!(1.0f128, 1.0f128..));
-        // assert!(yes!(f128::INFINITY, 1.0f128..));
-        // assert!(yes!(f128::INFINITY, f128::INFINITY..));
+        assert!(yes!(f128::INFINITY, 1.0f128..));
+        assert!(yes!(f128::INFINITY, f128::INFINITY..));
     }
 }
 

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.rs
@@ -1,3 +1,6 @@
+#![feature(f128)]
+#![feature(f16)]
+
 macro_rules! m {
     ($s:expr, $($t:tt)+) => {
         match $s { $($t)+ => {} }
@@ -27,10 +30,13 @@ fn main() {
     m!(0, ..i128::MIN);
     //~^ ERROR lower range bound must be less than upper
 
-    // FIXME(f16_f128): add tests when NEG_INFINITY is available
+    m!(0f16, ..f16::NEG_INFINITY);
+    //~^ ERROR lower range bound must be less than upper
     m!(0f32, ..f32::NEG_INFINITY);
     //~^ ERROR lower range bound must be less than upper
     m!(0f64, ..f64::NEG_INFINITY);
+    //~^ ERROR lower range bound must be less than upper
+    m!(0f128, ..f128::NEG_INFINITY);
     //~^ ERROR lower range bound must be less than upper
 
     m!('a', ..'\u{0}');

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.stderr
@@ -1,81 +1,93 @@
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:8:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:11:11
    |
 LL |     m!(0, ..u8::MIN);
    |           ^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:10:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:13:11
    |
 LL |     m!(0, ..u16::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:12:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:15:11
    |
 LL |     m!(0, ..u32::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:14:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:17:11
    |
 LL |     m!(0, ..u64::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:16:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:19:11
    |
 LL |     m!(0, ..u128::MIN);
    |           ^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:19:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:22:11
    |
 LL |     m!(0, ..i8::MIN);
    |           ^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:21:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:24:11
    |
 LL |     m!(0, ..i16::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:23:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:26:11
    |
 LL |     m!(0, ..i32::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:25:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:28:11
    |
 LL |     m!(0, ..i64::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:27:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:30:11
    |
 LL |     m!(0, ..i128::MIN);
    |           ^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:31:14
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:33:14
+   |
+LL |     m!(0f16, ..f16::NEG_INFINITY);
+   |              ^^^^^^^^^^^^^^^^^^^
+
+error[E0579]: lower range bound must be less than upper
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:35:14
    |
 LL |     m!(0f32, ..f32::NEG_INFINITY);
    |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:33:14
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:37:14
    |
 LL |     m!(0f64, ..f64::NEG_INFINITY);
    |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:36:13
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:39:15
+   |
+LL |     m!(0f128, ..f128::NEG_INFINITY);
+   |               ^^^^^^^^^^^^^^^^^^^^
+
+error[E0579]: lower range bound must be less than upper
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:42:13
    |
 LL |     m!('a', ..'\u{0}');
    |             ^^^^^^^^^
 
-error: aborting due to 13 previous errors
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0579`.


### PR DESCRIPTION
Just a small fix to the pattern matching tests now that we can. Also contains a small unrelated comment tweak.

<!-- homu-ignore:start -->
@rustbot label +F-f16_and_f128
r? @Nadrieril 
<!-- homu-ignore:end -->
