### PR TITLE
Mark some macros with must_use hint

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1010,8 +1010,12 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! format_args {
-        ($fmt:expr) => {{ /* compiler built-in */ }};
-        ($fmt:expr, $($args:tt)*) => {{ /* compiler built-in */ }};
+        ($fmt:expr) => {
+            $crate::hint::must_use({ /* compiler built-in */ })
+        };
+        ($fmt:expr, $($args:tt)*) => {
+            $crate::hint::must_use({ /* compiler built-in */ })
+        };
     }
 
     /// Same as [`format_args`], but can be used in some const contexts.
@@ -1081,8 +1085,12 @@ pub(crate) mod builtin {
     #[macro_export]
     #[rustc_diagnostic_item = "env_macro"] // useful for external lints
     macro_rules! env {
-        ($name:expr $(,)?) => {{ /* compiler built-in */ }};
-        ($name:expr, $error_msg:expr $(,)?) => {{ /* compiler built-in */ }};
+        ($name:expr $(,)?) => {
+            $crate::hint::must_use({ /* compiler built-in */ })
+        };
+        ($name:expr, $error_msg:expr $(,)?) => {
+            $crate::hint::must_use({ /* compiler built-in */ })
+        };
     }
 
     /// Optionally inspects an environment variable at compile time.
@@ -1112,7 +1120,9 @@ pub(crate) mod builtin {
     #[macro_export]
     #[rustc_diagnostic_item = "option_env_macro"] // useful for external lints
     macro_rules! option_env {
-        ($name:expr $(,)?) => {{ /* compiler built-in */ }};
+        ($name:expr $(,)?) => {
+            $crate::hint::must_use({ /* compiler built-in */ })
+        };
     }
 
     /// Concatenates identifiers into one identifier.
@@ -1174,7 +1184,9 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! concat_bytes {
-        ($($e:literal),+ $(,)?) => {{ /* compiler built-in */ }};
+        ($($e:literal),+ $(,)?) => {
+            $crate::hint::must_use({ /* compiler built-in */ })
+        };
     }
 
     /// Concatenates literals into a static string slice.
@@ -1196,7 +1208,9 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! concat {
-        ($($e:expr),* $(,)?) => {{ /* compiler built-in */ }};
+        ($($e:expr),* $(,)?) => {
+            $crate::hint::must_use({ /* compiler built-in */ })
+        };
     }
 
     /// Expands to the line number on which it was invoked.
@@ -1222,7 +1236,7 @@ pub(crate) mod builtin {
     #[macro_export]
     macro_rules! line {
         () => {
-            /* compiler built-in */
+            $crate::hint::must_use({ /* compiler built-in */ })
         };
     }
 
@@ -1261,7 +1275,7 @@ pub(crate) mod builtin {
     #[macro_export]
     macro_rules! column {
         () => {
-            /* compiler built-in */
+            $crate::hint::must_use(/* compiler built-in */)
         };
     }
 
@@ -1286,7 +1300,7 @@ pub(crate) mod builtin {
     #[macro_export]
     macro_rules! file {
         () => {
-            /* compiler built-in */
+            $crate::hint::must_use(/* compiler built-in */)
         };
     }
 
@@ -1310,7 +1324,7 @@ pub(crate) mod builtin {
     #[macro_export]
     macro_rules! stringify {
         ($($t:tt)*) => {
-            /* compiler built-in */
+            $crate::hint::must_use(/* compiler built-in */)
         };
     }
 
@@ -1351,7 +1365,9 @@ pub(crate) mod builtin {
     #[macro_export]
     #[cfg_attr(not(test), rustc_diagnostic_item = "include_str_macro")]
     macro_rules! include_str {
-        ($file:expr $(,)?) => {{ /* compiler built-in */ }};
+        ($file:expr $(,)?) => {
+            $crate::hint::must_use({ /* compiler built-in */ })
+        };
     }
 
     /// Includes a file as a reference to a byte array.
@@ -1391,7 +1407,9 @@ pub(crate) mod builtin {
     #[macro_export]
     #[cfg_attr(not(test), rustc_diagnostic_item = "include_bytes_macro")]
     macro_rules! include_bytes {
-        ($file:expr $(,)?) => {{ /* compiler built-in */ }};
+        ($file:expr $(,)?) => {
+            $crate::hint::must_use({ /* compiler built-in */ })
+        };
     }
 
     /// Expands to a string that represents the current module path.
@@ -1449,7 +1467,7 @@ pub(crate) mod builtin {
     #[macro_export]
     macro_rules! cfg {
         ($($cfg:tt)*) => {
-            /* compiler built-in */
+            $crate::hint::must_use(/* compiler built-in */)
         };
     }
 

--- a/library/core/tests/macros.rs
+++ b/library/core/tests/macros.rs
@@ -39,7 +39,7 @@ fn assert_ne_trailing_comma() {
 #[rustfmt::skip]
 #[test]
 fn matches_leading_pipe() {
-    matches!(1, | 1 | 2 | 3);
+    let _ = matches!(1, | 1 | 2 | 3);
 }
 
 #[test]

--- a/tests/ui/box/unit/unique-create.rs
+++ b/tests/ui/box/unit/unique-create.rs
@@ -7,5 +7,5 @@ pub fn main() {
 }
 
 fn vec() {
-    vec![0];
+    let _ = vec![0];
 }

--- a/tests/ui/rfcs/rfc-1857-stabilize-drop-order/drop-order.rs
+++ b/tests/ui/rfcs/rfc-1857-stabilize-drop-order/drop-order.rs
@@ -195,7 +195,7 @@ fn test_drop_list() {
     let dropped_fields = Rc::new(RefCell::new(Vec::new()));
     let cloned = AssertUnwindSafe(dropped_fields.clone());
     panic::catch_unwind(|| {
-        vec![
+        let _ = vec![
             PushOnDrop::new(2, cloned.clone()),
             PushOnDrop::new(1, cloned.clone()),
             panic!("this panic is caught :D")

--- a/tests/ui/rust-2018/remove-extern-crate.fixed
+++ b/tests/ui/rust-2018/remove-extern-crate.fixed
@@ -28,7 +28,7 @@ fn main() {
     with_visibility::foo();
     remove_extern_crate::foo!();
     bar!();
-    alloc::vec![5];
+    let _ = alloc::vec![5];
 }
 
 mod another {

--- a/tests/ui/rust-2018/remove-extern-crate.rs
+++ b/tests/ui/rust-2018/remove-extern-crate.rs
@@ -28,7 +28,7 @@ fn main() {
     with_visibility::foo();
     remove_extern_crate::foo!();
     bar!();
-    alloc::vec![5];
+    let _ = alloc::vec![5];
 }
 
 mod another {


### PR DESCRIPTION
Uses unstable feature https://github.com/rust-lang/rust/issues/94745

Part of #126475

Marking `pin::pin!()` currently results in errors like
```
error[E0716]: temporary value dropped while borrowed
  --> /home/tux/Downloads/rust/tests/ui/coroutine/async-gen-yield-ty-is-unit.rs:13:26
   |
LL |     let async_iterator = pin!(gen_fn());
   |                          ^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
   |                          |
   |                          creates a temporary value which is freed while still in use
LL |     let ctx = &mut Context::from_waker(Waker::noop());
LL |     async_iterator.poll_next(ctx);
   |     -------------- borrow later used here
   |
   = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider using a `let` binding to create a longer lived value
   |
LL ~     let binding = pin!(gen_fn());
LL ~     let async_iterator = binding;
   |

error: aborting due to 1 previous error
```
I think this is #124493?

r​? @oli-obk
