### PR TITLE
Terminate `--print link-args` output with newline

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -750,7 +750,7 @@ fn link_natively(
 
     for print in &sess.opts.prints {
         if print.kind == PrintKind::LinkArgs {
-            let content = format!("{cmd:?}");
+            let content = format!("{cmd:?}\n");
             print.out.overwrite(&content, sess);
         }
     }

--- a/tests/run-make/link-arg/rmake.rs
+++ b/tests/run-make/link-arg/rmake.rs
@@ -17,4 +17,5 @@ fn main() {
         .run_unchecked();
     out.assert_stdout_contains("lfoo");
     out.assert_stdout_contains("lbar");
+    assert!(out.stdout_utf8().ends_with('\n'));
 }


### PR DESCRIPTION
Fixes #127507