### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -163,7 +163,7 @@ pub struct CollectItemTypesVisitor<'tcx> {
 /// and suggest adding type parameters in the appropriate place, taking into consideration any and
 /// all already existing generic type parameters to avoid suggesting a name that is already in use.
 pub(crate) fn placeholder_type_error<'tcx>(
-    tcx: TyCtxt<'tcx>,
+    cx: &dyn HirTyLowerer<'tcx>,
     generics: Option<&hir::Generics<'_>>,
     placeholder_types: Vec<Span>,
     suggest: bool,
@@ -174,21 +174,21 @@ pub(crate) fn placeholder_type_error<'tcx>(
         return;
     }
 
-    placeholder_type_error_diag(tcx, generics, placeholder_types, vec![], suggest, hir_ty, kind)
+    placeholder_type_error_diag(cx, generics, placeholder_types, vec![], suggest, hir_ty, kind)
         .emit();
 }
 
-pub(crate) fn placeholder_type_error_diag<'tcx>(
-    tcx: TyCtxt<'tcx>,
+pub(crate) fn placeholder_type_error_diag<'cx, 'tcx>(
+    cx: &'cx dyn HirTyLowerer<'tcx>,
     generics: Option<&hir::Generics<'_>>,
     placeholder_types: Vec<Span>,
     additional_spans: Vec<Span>,
     suggest: bool,
     hir_ty: Option<&hir::Ty<'_>>,
     kind: &'static str,
-) -> Diag<'tcx> {
+) -> Diag<'cx> {
     if placeholder_types.is_empty() {
-        return bad_placeholder(tcx, additional_spans, kind);
+        return bad_placeholder(cx, additional_spans, kind);
     }
 
     let params = generics.map(|g| g.params).unwrap_or_default();
@@ -212,7 +212,7 @@ pub(crate) fn placeholder_type_error_diag<'tcx>(
     }
 
     let mut err =
-        bad_placeholder(tcx, placeholder_types.into_iter().chain(additional_spans).collect(), kind);
+        bad_placeholder(cx, placeholder_types.into_iter().chain(additional_spans).collect(), kind);
 
     // Suggest, but only if it is not a function in const or static
     if suggest {
@@ -226,7 +226,7 @@ pub(crate) fn placeholder_type_error_diag<'tcx>(
 
             // Check if parent is const or static
             is_const_or_static = matches!(
-                tcx.parent_hir_node(hir_ty.hir_id),
+                cx.tcx().parent_hir_node(hir_ty.hir_id),
                 Node::Item(&hir::Item {
                     kind: hir::ItemKind::Const(..) | hir::ItemKind::Static(..),
                     ..
@@ -269,7 +269,16 @@ fn reject_placeholder_type_signatures_in_item<'tcx>(
     let mut visitor = HirPlaceholderCollector::default();
     visitor.visit_item(item);
 
-    placeholder_type_error(tcx, Some(generics), visitor.0, suggest, None, item.kind.descr());
+    let icx = ItemCtxt::new(tcx, item.owner_id.def_id);
+
+    placeholder_type_error(
+        icx.lowerer(),
+        Some(generics),
+        visitor.0,
+        suggest,
+        None,
+        item.kind.descr(),
+    );
 }
 
 impl<'tcx> Visitor<'tcx> for CollectItemTypesVisitor<'tcx> {
@@ -331,15 +340,15 @@ impl<'tcx> Visitor<'tcx> for CollectItemTypesVisitor<'tcx> {
 ///////////////////////////////////////////////////////////////////////////
 // Utility types and common code for the above passes.
 
-fn bad_placeholder<'tcx>(
-    tcx: TyCtxt<'tcx>,
+fn bad_placeholder<'cx, 'tcx>(
+    cx: &'cx dyn HirTyLowerer<'tcx>,
     mut spans: Vec<Span>,
     kind: &'static str,
-) -> Diag<'tcx> {
+) -> Diag<'cx> {
     let kind = if kind.ends_with('s') { format!("{kind}es") } else { format!("{kind}s") };
 
     spans.sort();
-    tcx.dcx().create_err(errors::PlaceholderNotAllowedItemSignatures { spans, kind })
+    cx.dcx().create_err(errors::PlaceholderNotAllowedItemSignatures { spans, kind })
 }
 
 impl<'tcx> ItemCtxt<'tcx> {
@@ -383,14 +392,13 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
     fn re_infer(&self, span: Span, reason: RegionInferReason<'_>) -> ty::Region<'tcx> {
         if let RegionInferReason::BorrowedObjectLifetimeDefault = reason {
             let e = struct_span_code_err!(
-                self.tcx().dcx(),
+                self.dcx(),
                 span,
                 E0228,
                 "the lifetime bound for this object type cannot be deduced \
                 from context; please supply an explicit bound"
             )
             .emit();
-            self.set_tainted_by_errors(e);
             ty::Region::new_error(self.tcx(), e)
         } else {
             // This indicates an illegal lifetime in a non-assoc-trait position
@@ -515,10 +523,6 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
         None
     }
 
-    fn set_tainted_by_errors(&self, err: ErrorGuaranteed) {
-        self.tainted_by_errors.set(Some(err));
-    }
-
     fn lower_fn_sig(
         &self,
         decl: &hir::FnDecl<'tcx>,
@@ -576,7 +580,7 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
             // `ident_span` to not emit an error twice when we have `fn foo(_: fn() -> _)`.
 
             let mut diag = crate::collect::placeholder_type_error_diag(
-                tcx,
+                self,
                 generics,
                 visitor.0,
                 infer_replacements.iter().map(|(s, _)| *s).collect(),
@@ -596,7 +600,7 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
                 );
             }
 
-            self.set_tainted_by_errors(diag.emit());
+            diag.emit();
         }
 
         (input_tys, output_ty)
@@ -645,6 +649,7 @@ fn lower_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
     let it = tcx.hir().item(item_id);
     debug!(item = %it.ident, id = %it.hir_id());
     let def_id = item_id.owner_id.def_id;
+    let icx = ItemCtxt::new(tcx, def_id);
 
     match &it.kind {
         // These don't define types.
@@ -669,7 +674,7 @@ fn lower_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
                         let mut visitor = HirPlaceholderCollector::default();
                         visitor.visit_foreign_item(item);
                         placeholder_type_error(
-                            tcx,
+                            icx.lowerer(),
                             None,
                             visitor.0,
                             false,
@@ -748,7 +753,14 @@ fn lower_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
             if !ty.is_suggestable_infer_ty() {
                 let mut visitor = HirPlaceholderCollector::default();
                 visitor.visit_item(it);
-                placeholder_type_error(tcx, None, visitor.0, false, None, it.kind.descr());
+                placeholder_type_error(
+                    icx.lowerer(),
+                    None,
+                    visitor.0,
+                    false,
+                    None,
+                    it.kind.descr(),
+                );
             }
         }
 
@@ -766,6 +778,7 @@ fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId) {
     let trait_item = tcx.hir().trait_item(trait_item_id);
     let def_id = trait_item_id.owner_id;
     tcx.ensure().generics_of(def_id);
+    let icx = ItemCtxt::new(tcx, def_id.def_id);
 
     match trait_item.kind {
         hir::TraitItemKind::Fn(..) => {
@@ -782,7 +795,14 @@ fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId) {
                 // Account for `const C: _;`.
                 let mut visitor = HirPlaceholderCollector::default();
                 visitor.visit_trait_item(trait_item);
-                placeholder_type_error(tcx, None, visitor.0, false, None, "associated constant");
+                placeholder_type_error(
+                    icx.lowerer(),
+                    None,
+                    visitor.0,
+                    false,
+                    None,
+                    "associated constant",
+                );
             }
         }
 
@@ -793,7 +813,7 @@ fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId) {
             // Account for `type T = _;`.
             let mut visitor = HirPlaceholderCollector::default();
             visitor.visit_trait_item(trait_item);
-            placeholder_type_error(tcx, None, visitor.0, false, None, "associated type");
+            placeholder_type_error(icx.lowerer(), None, visitor.0, false, None, "associated type");
         }
 
         hir::TraitItemKind::Type(_, None) => {
@@ -804,7 +824,7 @@ fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId) {
             let mut visitor = HirPlaceholderCollector::default();
             visitor.visit_trait_item(trait_item);
 
-            placeholder_type_error(tcx, None, visitor.0, false, None, "associated type");
+            placeholder_type_error(icx.lowerer(), None, visitor.0, false, None, "associated type");
         }
     };
 
@@ -817,6 +837,7 @@ fn lower_impl_item(tcx: TyCtxt<'_>, impl_item_id: hir::ImplItemId) {
     tcx.ensure().type_of(def_id);
     tcx.ensure().predicates_of(def_id);
     let impl_item = tcx.hir().impl_item(impl_item_id);
+    let icx = ItemCtxt::new(tcx, def_id.def_id);
     match impl_item.kind {
         hir::ImplItemKind::Fn(..) => {
             tcx.ensure().codegen_fn_attrs(def_id);
@@ -827,14 +848,21 @@ fn lower_impl_item(tcx: TyCtxt<'_>, impl_item_id: hir::ImplItemId) {
             let mut visitor = HirPlaceholderCollector::default();
             visitor.visit_impl_item(impl_item);
 
-            placeholder_type_error(tcx, None, visitor.0, false, None, "associated type");
+            placeholder_type_error(icx.lowerer(), None, visitor.0, false, None, "associated type");
         }
         hir::ImplItemKind::Const(ty, _) => {
             // Account for `const T: _ = ..;`
             if !ty.is_suggestable_infer_ty() {
                 let mut visitor = HirPlaceholderCollector::default();
                 visitor.visit_impl_item(impl_item);
-                placeholder_type_error(tcx, None, visitor.0, false, None, "associated constant");
+                placeholder_type_error(
+                    icx.lowerer(),
+                    None,
+                    visitor.0,
+                    false,
+                    None,
+                    "associated constant",
+                );
             }
         }
     }
@@ -1385,7 +1413,7 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_, ty::PolyFn
             ..
         })
         | Item(hir::Item { kind: ItemKind::Fn(sig, generics, _), .. }) => {
-            infer_return_ty_for_fn_sig(tcx, sig, generics, def_id, &icx)
+            infer_return_ty_for_fn_sig(sig, generics, def_id, &icx)
         }
 
         ImplItem(hir::ImplItem { kind: ImplItemKind::Fn(sig, _), generics, .. }) => {
@@ -1402,7 +1430,7 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_, ty::PolyFn
                     None,
                 )
             } else {
-                infer_return_ty_for_fn_sig(tcx, sig, generics, def_id, &icx)
+                infer_return_ty_for_fn_sig(sig, generics, def_id, &icx)
             }
         }
 
@@ -1455,12 +1483,12 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_, ty::PolyFn
 }
 
 fn infer_return_ty_for_fn_sig<'tcx>(
-    tcx: TyCtxt<'tcx>,
     sig: &hir::FnSig<'tcx>,
     generics: &hir::Generics<'_>,
     def_id: LocalDefId,
     icx: &ItemCtxt<'tcx>,
 ) -> ty::PolyFnSig<'tcx> {
+    let tcx = icx.tcx;
     let hir_id = tcx.local_def_id_to_hir_id(def_id);
 
     match sig.decl.output.get_infer_ret_ty() {
@@ -1492,7 +1520,7 @@ fn infer_return_ty_for_fn_sig<'tcx>(
             let mut visitor = HirPlaceholderCollector::default();
             visitor.visit_ty(ty);
 
-            let mut diag = bad_placeholder(tcx, visitor.0, "return type");
+            let mut diag = bad_placeholder(icx.lowerer(), visitor.0, "return type");
             let ret_ty = fn_sig.output();
             // Don't leak types into signatures unless they're nameable!
             // For example, if a function returns itself, we don't want that

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -18,7 +18,9 @@ use rustc_ast::Recovered;
 use rustc_data_structures::captures::Captures;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_data_structures::unord::UnordMap;
-use rustc_errors::{struct_span_code_err, Applicability, Diag, ErrorGuaranteed, StashKey, E0228};
+use rustc_errors::{
+    struct_span_code_err, Applicability, Diag, DiagCtxtHandle, ErrorGuaranteed, StashKey, E0228,
+};
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::{self, walk_generics, Visitor};
@@ -368,6 +370,10 @@ impl<'tcx> ItemCtxt<'tcx> {
 impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
+    }
+
+    fn dcx(&self) -> DiagCtxtHandle<'_> {
+        self.tcx.dcx().taintable_handle(&self.tainted_by_errors)
     }
 
     fn item_def_id(&self) -> LocalDefId {

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -12,6 +12,7 @@ use rustc_span::symbol::Ident;
 use rustc_span::{Span, DUMMY_SP};
 
 use crate::errors::TypeofReservedKeywordUsed;
+use crate::hir_ty_lowering::HirTyLowerer;
 
 use super::bad_placeholder;
 use super::ItemCtxt;
@@ -357,7 +358,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
                 .and_then(|body_id| {
                     ty.is_suggestable_infer_ty().then(|| {
                         infer_placeholder_type(
-                            tcx,
+                            icx.lowerer(),
                             def_id,
                             body_id,
                             ty.span,
@@ -381,7 +382,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
             ImplItemKind::Const(ty, body_id) => {
                 if ty.is_suggestable_infer_ty() {
                     infer_placeholder_type(
-                        tcx,
+                        icx.lowerer(),
                         def_id,
                         body_id,
                         ty.span,
@@ -405,7 +406,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
             ItemKind::Static(ty, .., body_id) => {
                 if ty.is_suggestable_infer_ty() {
                     infer_placeholder_type(
-                        tcx,
+                        icx.lowerer(),
                         def_id,
                         body_id,
                         ty.span,
@@ -418,7 +419,14 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
             }
             ItemKind::Const(ty, _, body_id) => {
                 if ty.is_suggestable_infer_ty() {
-                    infer_placeholder_type(tcx, def_id, body_id, ty.span, item.ident, "constant")
+                    infer_placeholder_type(
+                        icx.lowerer(),
+                        def_id,
+                        body_id,
+                        ty.span,
+                        item.ident,
+                        "constant",
+                    )
                 } else {
                     icx.lower_ty(ty)
                 }
@@ -559,21 +567,22 @@ pub(super) fn type_of_opaque(
     }
 }
 
-fn infer_placeholder_type<'a>(
-    tcx: TyCtxt<'a>,
+fn infer_placeholder_type<'tcx>(
+    cx: &dyn HirTyLowerer<'tcx>,
     def_id: LocalDefId,
     body_id: hir::BodyId,
     span: Span,
     item_ident: Ident,
     kind: &'static str,
-) -> Ty<'a> {
+) -> Ty<'tcx> {
+    let tcx = cx.tcx();
     let ty = tcx.diagnostic_only_typeck(def_id).node_type(body_id.hir_id);
 
     // If this came from a free `const` or `static mut?` item,
     // then the user may have written e.g. `const A = 42;`.
     // In this case, the parser has stashed a diagnostic for
     // us to improve in typeck so we do that now.
-    let guar = tcx
+    let guar = cx
         .dcx()
         .try_steal_modify_and_emit_err(span, StashKey::ItemNoType, |err| {
             if !ty.references_error() {
@@ -602,7 +611,7 @@ fn infer_placeholder_type<'a>(
             }
         })
         .unwrap_or_else(|| {
-            let mut diag = bad_placeholder(tcx, vec![span], kind);
+            let mut diag = bad_placeholder(cx, vec![span], kind);
 
             if !ty.references_error() {
                 if let Some(ty) = ty.make_suggestable(tcx, false, None) {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -46,7 +46,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             return;
         }
 
-        self.tcx().dcx().emit_err(MissingTypeParams {
+        self.dcx().emit_err(MissingTypeParams {
             span,
             def_span: self.tcx().def_span(def_id),
             span_snippet: self.tcx().sess.source_map().span_to_snippet(span).ok(),
@@ -109,7 +109,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
         if is_impl {
             let trait_name = self.tcx().def_path_str(trait_def_id);
-            self.tcx().dcx().emit_err(ManualImplementation { span, trait_name });
+            self.dcx().emit_err(ManualImplementation { span, trait_name });
         }
     }
 
@@ -156,7 +156,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
         if is_dummy {
             err.label = Some(errors::AssocItemNotFoundLabel::NotFound { span });
-            return tcx.dcx().emit_err(err);
+            return self.dcx().emit_err(err);
         }
 
         let all_candidate_names: Vec<_> = all_candidates()
@@ -174,7 +174,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 assoc_kind: assoc_kind_str,
                 suggested_name,
             });
-            return tcx.dcx().emit_err(err);
+            return self.dcx().emit_err(err);
         }
 
         // If we didn't find a good item in the supertraits (or couldn't get
@@ -239,10 +239,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                             assoc_kind: assoc_kind_str,
                             suggested_name,
                         });
-                        return tcx.dcx().emit_err(err);
+                        return self.dcx().emit_err(err);
                     }
 
-                    let mut err = tcx.dcx().create_err(err);
+                    let mut err = self.dcx().create_err(err);
                     if suggest_constraining_type_param(
                         tcx,
                         generics,
@@ -264,7 +264,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     }
                     return err.emit();
                 }
-                return tcx.dcx().emit_err(err);
+                return self.dcx().emit_err(err);
             }
         }
 
@@ -291,7 +291,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             err.label = Some(errors::AssocItemNotFoundLabel::NotFound { span: assoc_name.span });
         }
 
-        tcx.dcx().emit_err(err)
+        self.dcx().emit_err(err)
     }
 
     fn complain_about_assoc_kind_mismatch(
@@ -347,7 +347,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             (ident.span, None, assoc_kind, assoc_item.kind)
         };
 
-        tcx.dcx().emit_err(errors::AssocKindMismatch {
+        self.dcx().emit_err(errors::AssocKindMismatch {
             span,
             expected: super::assoc_kind_str(expected),
             got: super::assoc_kind_str(got),
@@ -366,8 +366,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         traits: &[String],
         name: Symbol,
     ) -> ErrorGuaranteed {
-        let mut err =
-            struct_span_code_err!(self.tcx().dcx(), span, E0223, "ambiguous associated type");
+        let mut err = struct_span_code_err!(self.dcx(), span, E0223, "ambiguous associated type");
         if self
             .tcx()
             .resolutions(())
@@ -475,7 +474,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         span: Span,
     ) -> ErrorGuaranteed {
         let mut err = struct_span_code_err!(
-            self.tcx().dcx(),
+            self.dcx(),
             name.span,
             E0034,
             "multiple applicable items in scope"
@@ -576,7 +575,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             };
 
             let mut err = struct_span_code_err!(
-                tcx.dcx(),
+                self.dcx(),
                 name.span,
                 E0220,
                 "associated type `{name}` not found for `{self_ty}` in the current scope"
@@ -662,7 +661,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         bounds.sort();
         bounds.dedup();
 
-        let mut err = tcx.dcx().struct_span_err(
+        let mut err = self.dcx().struct_span_err(
             name.span,
             format!("the associated type `{name}` exists for `{self_ty}`, but its trait bounds were not satisfied")
         );
@@ -829,7 +828,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
         trait_bound_spans.sort();
         let mut err = struct_span_code_err!(
-            tcx.dcx(),
+            self.dcx(),
             trait_bound_spans,
             E0191,
             "the value of the associated type{} {} must be specified",
@@ -1012,7 +1011,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 .next()
         {
             let reported =
-                struct_span_code_err!(tcx.dcx(), span, E0223, "ambiguous associated type")
+                struct_span_code_err!(self.dcx(), span, E0223, "ambiguous associated type")
                     .with_span_suggestion_verbose(
                         ident2.span.to(ident3.span),
                         format!("there is an associated function with a similar name: `{name}`"),
@@ -1120,7 +1119,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let last_span = *arg_spans.last().unwrap();
         let span: MultiSpan = arg_spans.into();
         let mut err = struct_span_code_err!(
-            self.tcx().dcx(),
+            self.dcx(),
             span,
             E0109,
             "{kind} arguments are not allowed on {this_type}",
@@ -1139,11 +1138,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         regular_traits: &Vec<TraitAliasExpansionInfo<'_>>,
     ) -> ErrorGuaranteed {
-        let tcx = self.tcx();
         let first_trait = &regular_traits[0];
         let additional_trait = &regular_traits[1];
         let mut err = struct_span_code_err!(
-            tcx.dcx(),
+            self.dcx(),
             additional_trait.bottom().1,
             E0225,
             "only auto traits can be used as additional traits in a trait object"
@@ -1186,7 +1184,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             .find(|&trait_ref| tcx.is_trait_alias(trait_ref))
             .map(|trait_ref| tcx.def_span(trait_ref));
         let reported =
-            tcx.dcx().emit_err(TraitObjectDeclaredWithNoTraits { span, trait_alias_span });
+            self.dcx().emit_err(TraitObjectDeclaredWithNoTraits { span, trait_alias_span });
         self.set_tainted_by_errors(reported);
         reported
     }
@@ -1194,11 +1192,12 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
 /// Emit an error for the given associated item constraint.
 pub fn prohibit_assoc_item_constraint(
-    tcx: TyCtxt<'_>,
+    cx: &dyn HirTyLowerer<'_>,
     constraint: &hir::AssocItemConstraint<'_>,
     segment: Option<(DefId, &hir::PathSegment<'_>, Span)>,
 ) -> ErrorGuaranteed {
-    let mut err = tcx.dcx().create_err(AssocItemConstraintsNotAllowedHere {
+    let tcx = cx.tcx();
+    let mut err = cx.dcx().create_err(AssocItemConstraintsNotAllowedHere {
         span: constraint.span,
         fn_trait_expansion: if let Some((_, segment, span)) = segment
             && segment.args().parenthesized == hir::GenericArgsParentheses::ParenSugar

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -462,9 +462,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 }
             }
         }
-        let reported = err.emit();
-        self.set_tainted_by_errors(reported);
-        reported
+        err.emit()
     }
 
     pub(crate) fn complain_about_ambiguous_inherent_assoc_ty(
@@ -481,9 +479,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         );
         err.span_label(name.span, format!("multiple `{name}` found"));
         self.note_ambiguous_inherent_assoc_ty(&mut err, candidates, span);
-        let reported = err.emit();
-        self.set_tainted_by_errors(reported);
-        reported
+        err.emit()
     }
 
     // FIXME(fmease): Heavily adapted from `rustc_hir_typeck::method::suggest`. Deduplicate.
@@ -973,7 +969,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             }
         }
 
-        self.set_tainted_by_errors(err.emit());
+        err.emit();
     }
 
     /// On ambiguous associated type, look for an associated function whose name matches the
@@ -1010,17 +1006,14 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 .filter_by_name_unhygienic(Symbol::intern(&name))
                 .next()
         {
-            let reported =
-                struct_span_code_err!(self.dcx(), span, E0223, "ambiguous associated type")
-                    .with_span_suggestion_verbose(
-                        ident2.span.to(ident3.span),
-                        format!("there is an associated function with a similar name: `{name}`"),
-                        name,
-                        Applicability::MaybeIncorrect,
-                    )
-                    .emit();
-            self.set_tainted_by_errors(reported);
-            Err(reported)
+            Err(struct_span_code_err!(self.dcx(), span, E0223, "ambiguous associated type")
+                .with_span_suggestion_verbose(
+                    ident2.span.to(ident3.span),
+                    format!("there is an associated function with a similar name: `{name}`"),
+                    name,
+                    Applicability::MaybeIncorrect,
+                )
+                .emit())
         } else {
             Ok(())
         }
@@ -1129,9 +1122,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             err.span_label(span, format!("not allowed on {what}"));
         }
         generics_args_err_extend(self.tcx(), segments, &mut err, err_extend);
-        let reported = err.emit();
-        self.set_tainted_by_errors(reported);
-        reported
+        err.emit()
     }
 
     pub fn report_trait_object_addition_traits_error(
@@ -1167,9 +1158,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
              for more information on them, visit \
              <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>",
         );
-        let reported = err.emit();
-        self.set_tainted_by_errors(reported);
-        reported
+        err.emit()
     }
 
     pub fn report_trait_object_with_no_traits_error(
@@ -1183,10 +1172,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             .map(|&(trait_ref, _)| trait_ref.def_id())
             .find(|&trait_ref| tcx.is_trait_alias(trait_ref))
             .map(|trait_ref| tcx.def_span(trait_ref));
-        let reported =
-            self.dcx().emit_err(TraitObjectDeclaredWithNoTraits { span, trait_alias_span });
-        self.set_tainted_by_errors(reported);
-        reported
+
+        self.dcx().emit_err(TraitObjectDeclaredWithNoTraits { span, trait_alias_span })
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
@@ -60,7 +60,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             let msg = "trait objects must include the `dyn` keyword";
             let label = "add `dyn` keyword before this trait";
             let mut diag =
-                rustc_errors::struct_span_code_err!(tcx.dcx(), self_ty.span, E0782, "{}", msg);
+                rustc_errors::struct_span_code_err!(self.dcx(), self_ty.span, E0782, "{}", msg);
             if self_ty.span.can_be_used_for_suggestions()
                 && !self.maybe_suggest_impl_trait(self_ty, &mut diag)
             {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/object_safety.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/object_safety.rs
@@ -236,7 +236,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                             Ty::new_misc_error(tcx).into()
                         } else if arg.walk().any(|arg| arg == dummy_self.into()) {
                             references_self = true;
-                            let guar = tcx.dcx().span_delayed_bug(
+                            let guar = self.dcx().span_delayed_bug(
                                 span,
                                 "trait object trait bounds reference `Self`",
                             );
@@ -263,7 +263,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 if references_self {
                     let def_id = i.bottom().0.def_id();
                     let reported = struct_span_code_err!(
-                        tcx.dcx(),
+                        self.dcx(),
                         i.bottom().1,
                         E0038,
                         "the {} `{}` cannot be made into an object",

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/object_safety.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/object_safety.rs
@@ -262,7 +262,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
                 if references_self {
                     let def_id = i.bottom().0.def_id();
-                    let reported = struct_span_code_err!(
+                    struct_span_code_err!(
                         self.dcx(),
                         i.bottom().1,
                         E0038,
@@ -275,7 +275,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                             .error_msg(),
                     )
                     .emit();
-                    self.set_tainted_by_errors(reported);
                 }
 
                 ty::ExistentialTraitRef { def_id: trait_ref.def_id, args }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1139,7 +1139,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // parameter's value explicitly, so we have to do some error-
             // checking here.
             let arg_count =
-                check_generic_arg_count_for_call(tcx, def_id, generics, seg, IsMethodCall::No);
+                check_generic_arg_count_for_call(self, def_id, generics, seg, IsMethodCall::No);
 
             if let ExplicitLateBound::Yes = arg_count.explicit_late_bound {
                 explicit_late_bound = ExplicitLateBound::Yes;
@@ -1375,7 +1375,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let args_raw = self_ctor_args.unwrap_or_else(|| {
             lower_generic_args(
-                tcx,
+                self,
                 def_id,
                 &[],
                 has_self,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -217,6 +217,10 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
         self.tcx
     }
 
+    fn dcx(&self) -> DiagCtxtHandle<'_> {
+        self.root_ctxt.dcx()
+    }
+
     fn item_def_id(&self) -> LocalDefId {
         self.body_id
     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -5,7 +5,7 @@ mod checks;
 mod inspect_obligations;
 mod suggestions;
 
-use rustc_errors::{DiagCtxtHandle, ErrorGuaranteed};
+use rustc_errors::DiagCtxtHandle;
 
 use crate::coercion::DynamicCoerceMany;
 use crate::fallback::DivergingFallbackBehavior;
@@ -340,10 +340,6 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
 
     fn infcx(&self) -> Option<&infer::InferCtxt<'tcx>> {
         Some(&self.infcx)
-    }
-
-    fn set_tainted_by_errors(&self, e: ErrorGuaranteed) {
-        self.infcx.set_tainted_by_errors(e)
     }
 
     fn lower_fn_sig(

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -354,7 +354,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         let generics = self.tcx.generics_of(pick.item.def_id);
 
         let arg_count_correct = check_generic_arg_count_for_call(
-            self.tcx,
+            self.fcx,
             pick.item.def_id,
             generics,
             seg,
@@ -425,7 +425,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         }
 
         let args = lower_generic_args(
-            self.tcx,
+            self.fcx,
             pick.item.def_id,
             parent_args,
             false,

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -563,7 +563,8 @@ fn lint_literal<'tcx>(
         ty::Float(t) => {
             let is_infinite = match lit.node {
                 ast::LitKind::Float(v, _) => match t {
-                    // FIXME(f16_f128): add this check once we have library support
+                    // FIXME(f16_f128): add this check once `is_infinite` is reliable (ABI
+                    // issues resolved).
                     ty::FloatTy::F16 => Ok(false),
                     ty::FloatTy::F32 => v.as_str().parse().map(f32::is_infinite),
                     ty::FloatTy::F64 => v.as_str().parse().map(f64::is_infinite),

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1411,6 +1411,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     break;
                 }
             }
+            if expand_until != 0 {
+                expand_until = i + 1;
+            }
         }
         let (candidates_to_expand, remaining_candidates) = candidates.split_at_mut(expand_until);
 

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -48,12 +48,20 @@ enum GoalEvaluationKind {
     Nested,
 }
 
+// FIXME(trait-system-refactor-initiative#117): we don't detect whether a response
+// ended up pulling down any universes.
 fn has_no_inference_or_external_constraints<I: Interner>(
     response: ty::Canonical<I, Response<I>>,
 ) -> bool {
-    response.value.external_constraints.region_constraints.is_empty()
-        && response.value.var_values.is_identity()
-        && response.value.external_constraints.opaque_types.is_empty()
+    let ExternalConstraintsData {
+        ref region_constraints,
+        ref opaque_types,
+        ref normalization_nested_goals,
+    } = *response.value.external_constraints;
+    response.value.var_values.is_identity()
+        && region_constraints.is_empty()
+        && opaque_types.is_empty()
+        && normalization_nested_goals.is_empty()
 }
 
 impl<'a, D, I> EvalCtxt<'a, D>

--- a/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
@@ -71,7 +71,7 @@ struct StackEntry<I: Interner> {
     /// C :- D
     /// D :- C
     /// ```
-    cycle_participants: HashSet<CanonicalInput<I>>,
+    nested_goals: HashSet<CanonicalInput<I>>,
     /// Starts out as `None` and gets set when rerunning this
     /// goal in case we encounter a cycle.
     provisional_result: Option<QueryResult<I>>,
@@ -215,8 +215,8 @@ impl<I: Interner> SearchGraph<I> {
         let current_cycle_root = &mut stack[current_root.as_usize()];
         for entry in cycle_participants {
             entry.non_root_cycle_participant = entry.non_root_cycle_participant.max(Some(head));
-            current_cycle_root.cycle_participants.insert(entry.input);
-            current_cycle_root.cycle_participants.extend(mem::take(&mut entry.cycle_participants));
+            current_cycle_root.nested_goals.insert(entry.input);
+            current_cycle_root.nested_goals.extend(mem::take(&mut entry.nested_goals));
         }
     }
 
@@ -335,7 +335,7 @@ impl<I: Interner> SearchGraph<I> {
                 non_root_cycle_participant: None,
                 encountered_overflow: false,
                 has_been_used: HasBeenUsed::empty(),
-                cycle_participants: Default::default(),
+                nested_goals: Default::default(),
                 provisional_result: None,
             };
             assert_eq!(self.stack.push(entry), depth);
@@ -389,7 +389,7 @@ impl<I: Interner> SearchGraph<I> {
             //
             // We must not use the global cache entry of a root goal if a cycle
             // participant is on the stack. This is necessary to prevent unstable
-            // results. See the comment of `StackEntry::cycle_participants` for
+            // results. See the comment of `StackEntry::nested_goals` for
             // more details.
             self.global_cache(cx).insert(
                 cx,
@@ -397,7 +397,7 @@ impl<I: Interner> SearchGraph<I> {
                 proof_tree,
                 reached_depth,
                 final_entry.encountered_overflow,
-                final_entry.cycle_participants,
+                final_entry.nested_goals,
                 dep_node,
                 result,
             )
@@ -544,27 +544,27 @@ impl<I: Interner> SearchGraph<I> {
                 non_root_cycle_participant,
                 encountered_overflow: _,
                 has_been_used,
-                ref cycle_participants,
+                ref nested_goals,
                 provisional_result,
             } = *entry;
             let cache_entry = provisional_cache.get(&entry.input).unwrap();
             assert_eq!(cache_entry.stack_depth, Some(depth));
             if let Some(head) = non_root_cycle_participant {
                 assert!(head < depth);
-                assert!(cycle_participants.is_empty());
+                assert!(nested_goals.is_empty());
                 assert_ne!(stack[head].has_been_used, HasBeenUsed::empty());
 
                 let mut current_root = head;
                 while let Some(parent) = stack[current_root].non_root_cycle_participant {
                     current_root = parent;
                 }
-                assert!(stack[current_root].cycle_participants.contains(&input));
+                assert!(stack[current_root].nested_goals.contains(&input));
             }
 
-            if !cycle_participants.is_empty() {
+            if !nested_goals.is_empty() {
                 assert!(provisional_result.is_some() || !has_been_used.is_empty());
                 for entry in stack.iter().take(depth.as_usize()) {
-                    assert_eq!(cycle_participants.get(&entry.input), None);
+                    assert_eq!(nested_goals.get(&entry.input), None);
                 }
             }
         }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -796,7 +796,7 @@ impl<'a> Parser<'a> {
                         self.dcx().struct_span_err(non_item_span, "non-item in item list");
                     self.consume_block(Delimiter::Brace, ConsumeClosingDelim::Yes);
                     if is_let {
-                        err.span_suggestion(
+                        err.span_suggestion_verbose(
                             non_item_span,
                             "consider using `const` instead of `let` for associated const",
                             "const",

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -836,11 +836,12 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
                 let ((with, with_label), without) = match sp {
                     Some(sp) if !self.tcx.sess.source_map().is_multiline(sp) => {
-                        let sp = sp.with_lo(BytePos(sp.lo().0 - (current.len() as u32)));
+                        let sp = sp
+                            .with_lo(BytePos(sp.lo().0 - (current.len() as u32)))
+                            .until(ident.span);
                         (
                         (Some(errs::AttemptToUseNonConstantValueInConstantWithSuggestion {
                                 span: sp,
-                                ident,
                                 suggestion,
                                 current,
                             }), Some(errs::AttemptToUseNonConstantValueInConstantLabelWithSuggestion {span})),

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -819,7 +819,12 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             ResolutionError::CannotCaptureDynamicEnvironmentInFnItem => {
                 self.dcx().create_err(errs::CannotCaptureDynamicEnvironmentInFnItem { span })
             }
-            ResolutionError::AttemptToUseNonConstantValueInConstant(ident, suggestion, current) => {
+            ResolutionError::AttemptToUseNonConstantValueInConstant {
+                ident,
+                suggestion,
+                current,
+                type_span,
+            } => {
                 // let foo =...
                 //     ^^^ given this Span
                 // ------- get this Span to have an applicable suggestion
@@ -844,6 +849,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                 span: sp,
                                 suggestion,
                                 current,
+                                type_span,
                             }), Some(errs::AttemptToUseNonConstantValueInConstantLabelWithSuggestion {span})),
                             None,
                         )

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -242,13 +242,13 @@ pub(crate) struct AttemptToUseNonConstantValueInConstant<'a> {
 #[derive(Subdiagnostic)]
 #[suggestion(
     resolve_attempt_to_use_non_constant_value_in_constant_with_suggestion,
-    code = "{suggestion} {ident}",
+    code = "{suggestion} ",
+    style = "verbose",
     applicability = "maybe-incorrect"
 )]
 pub(crate) struct AttemptToUseNonConstantValueInConstantWithSuggestion<'a> {
     #[primary_span]
     pub(crate) span: Span,
-    pub(crate) ident: Ident,
     pub(crate) suggestion: &'a str,
     pub(crate) current: &'a str,
 }

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -240,16 +240,18 @@ pub(crate) struct AttemptToUseNonConstantValueInConstant<'a> {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(
+#[multipart_suggestion(
     resolve_attempt_to_use_non_constant_value_in_constant_with_suggestion,
-    code = "{suggestion} ",
     style = "verbose",
-    applicability = "maybe-incorrect"
+    applicability = "has-placeholders"
 )]
 pub(crate) struct AttemptToUseNonConstantValueInConstantWithSuggestion<'a> {
-    #[primary_span]
+    // #[primary_span]
+    #[suggestion_part(code = "{suggestion} ")]
     pub(crate) span: Span,
     pub(crate) suggestion: &'a str,
+    #[suggestion_part(code = ": /* Type */")]
+    pub(crate) type_span: Option<Span>,
     pub(crate) current: &'a str,
 }
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -236,11 +236,12 @@ enum ResolutionError<'a> {
     /// Error E0434: can't capture dynamic environment in a fn item.
     CannotCaptureDynamicEnvironmentInFnItem,
     /// Error E0435: attempt to use a non-constant value in a constant.
-    AttemptToUseNonConstantValueInConstant(
-        Ident,
-        /* suggestion */ &'static str,
-        /* current */ &'static str,
-    ),
+    AttemptToUseNonConstantValueInConstant {
+        ident: Ident,
+        suggestion: &'static str,
+        current: &'static str,
+        type_span: Option<Span>,
+    },
     /// Error E0530: `X` bindings cannot shadow `Y`s.
     BindingShadowsSomethingUnacceptable {
         shadowing_binding: PatternSource,

--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -1008,7 +1008,14 @@ impl<'a> Iterator for Source<'a> {
         self.current = self.current.and_then(Error::source);
         current
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.current.is_some() { (1, None) } else { (0, Some(0)) }
+    }
 }
+
+#[unstable(feature = "error_iter", issue = "58520")]
+impl<'a> crate::iter::FusedIterator for Source<'a> {}
 
 #[stable(feature = "error_by_ref", since = "1.51.0")]
 impl<'a, T: Error + ?Sized> Error for &'a T {

--- a/src/doc/rustdoc/src/advanced-features.md
+++ b/src/doc/rustdoc/src/advanced-features.md
@@ -80,7 +80,8 @@ pub struct BigX;
 Then, when looking for it through the `rustdoc` search, if you enter "x" or
 "big", search will show the `BigX` struct first.
 
-There are some limitations on the doc alias names though: you can't use `"` or whitespace.
+There are some limitations on the doc alias names though: they cannot contain quotes (`'`, `"`)
+or most whitespace. ASCII space is allowed if it does not start or end the alias.
 
 You can add multiple aliases at the same time by using a list:
 

--- a/tests/mir-opt/building/match/simple_match.match_enum.built.after.mir
+++ b/tests/mir-opt/building/match/simple_match.match_enum.built.after.mir
@@ -4,12 +4,11 @@ fn match_enum(_1: E1) -> bool {
     debug x => _1;
     let mut _0: bool;
     let mut _2: isize;
-    let mut _3: isize;
 
     bb0: {
         PlaceMention(_1);
         _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb3, 1: bb5, otherwise: bb2];
+        switchInt(move _2) -> [0: bb3, 1: bb5, 2: bb7, otherwise: bb2];
     }
 
     bb1: {
@@ -18,12 +17,11 @@ fn match_enum(_1: E1) -> bool {
     }
 
     bb2: {
-        _3 = discriminant(_1);
-        switchInt(move _3) -> [2: bb8, otherwise: bb1];
+        goto -> bb1;
     }
 
     bb3: {
-        goto -> bb7;
+        goto -> bb9;
     }
 
     bb4: {
@@ -31,7 +29,7 @@ fn match_enum(_1: E1) -> bool {
     }
 
     bb5: {
-        goto -> bb7;
+        goto -> bb9;
     }
 
     bb6: {
@@ -39,16 +37,16 @@ fn match_enum(_1: E1) -> bool {
     }
 
     bb7: {
-        falseEdge -> [real: bb10, imaginary: bb2];
-    }
-
-    bb8: {
         _0 = const false;
         goto -> bb11;
     }
 
+    bb8: {
+        goto -> bb2;
+    }
+
     bb9: {
-        goto -> bb1;
+        falseEdge -> [real: bb10, imaginary: bb7];
     }
 
     bb10: {

--- a/tests/mir-opt/building/match/simple_match.match_enum.built.after.mir
+++ b/tests/mir-opt/building/match/simple_match.match_enum.built.after.mir
@@ -1,0 +1,62 @@
+// MIR for `match_enum` after built
+
+fn match_enum(_1: E1) -> bool {
+    debug x => _1;
+    let mut _0: bool;
+    let mut _2: isize;
+    let mut _3: isize;
+
+    bb0: {
+        PlaceMention(_1);
+        _2 = discriminant(_1);
+        switchInt(move _2) -> [0: bb3, 1: bb5, otherwise: bb2];
+    }
+
+    bb1: {
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
+    }
+
+    bb2: {
+        _3 = discriminant(_1);
+        switchInt(move _3) -> [2: bb8, otherwise: bb1];
+    }
+
+    bb3: {
+        goto -> bb7;
+    }
+
+    bb4: {
+        goto -> bb2;
+    }
+
+    bb5: {
+        goto -> bb7;
+    }
+
+    bb6: {
+        goto -> bb2;
+    }
+
+    bb7: {
+        falseEdge -> [real: bb10, imaginary: bb2];
+    }
+
+    bb8: {
+        _0 = const false;
+        goto -> bb11;
+    }
+
+    bb9: {
+        goto -> bb1;
+    }
+
+    bb10: {
+        _0 = const true;
+        goto -> bb11;
+    }
+
+    bb11: {
+        return;
+    }
+}

--- a/tests/mir-opt/building/match/simple_match.rs
+++ b/tests/mir-opt/building/match/simple_match.rs
@@ -9,4 +9,18 @@ fn match_bool(x: bool) -> usize {
     }
 }
 
+pub enum E1 {
+    V1,
+    V2,
+    V3,
+}
+
+// EMIT_MIR simple_match.match_enum.built.after.mir
+pub fn match_enum(x: E1) -> bool {
+    match x {
+        E1::V1 | E1::V2 => true,
+        E1::V3 => false,
+    }
+}
+
 fn main() {}

--- a/tests/ui/asm/parse-error.stderr
+++ b/tests/ui/asm/parse-error.stderr
@@ -376,8 +376,8 @@ LL |         asm!("{}", options(), const foo);
    |
 help: consider using `const` instead of `let`
    |
-LL |     const foo = 0;
-   |     ~~~~~
+LL |     const foo: /* Type */ = 0;
+   |     ~~~~~    ++++++++++++
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/parse-error.rs:71:44
@@ -387,8 +387,8 @@ LL |         asm!("{}", clobber_abi("C"), const foo);
    |
 help: consider using `const` instead of `let`
    |
-LL |     const foo = 0;
-   |     ~~~~~
+LL |     const foo: /* Type */ = 0;
+   |     ~~~~~    ++++++++++++
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/parse-error.rs:74:55
@@ -398,8 +398,8 @@ LL |         asm!("{}", options(), clobber_abi("C"), const foo);
    |
 help: consider using `const` instead of `let`
    |
-LL |     const foo = 0;
-   |     ~~~~~
+LL |     const foo: /* Type */ = 0;
+   |     ~~~~~    ++++++++++++
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/parse-error.rs:76:31
@@ -409,8 +409,8 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    |
 help: consider using `const` instead of `let`
    |
-LL |     const foo = 0;
-   |     ~~~~~
+LL |     const foo: /* Type */ = 0;
+   |     ~~~~~    ++++++++++++
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/parse-error.rs:76:46
@@ -420,8 +420,8 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    |
 help: consider using `const` instead of `let`
    |
-LL |     const bar = 0;
-   |     ~~~~~
+LL |     const bar: /* Type */ = 0;
+   |     ~~~~~    ++++++++++++
 
 error: aborting due to 64 previous errors
 

--- a/tests/ui/asm/parse-error.stderr
+++ b/tests/ui/asm/parse-error.stderr
@@ -371,47 +371,57 @@ LL | global_asm!("{}", label {});
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/parse-error.rs:39:37
    |
-LL |     let mut foo = 0;
-   |     ----------- help: consider using `const` instead of `let`: `const foo`
-...
 LL |         asm!("{}", options(), const foo);
    |                                     ^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const foo = 0;
+   |     ~~~~~
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/parse-error.rs:71:44
    |
-LL |     let mut foo = 0;
-   |     ----------- help: consider using `const` instead of `let`: `const foo`
-...
 LL |         asm!("{}", clobber_abi("C"), const foo);
    |                                            ^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const foo = 0;
+   |     ~~~~~
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/parse-error.rs:74:55
    |
-LL |     let mut foo = 0;
-   |     ----------- help: consider using `const` instead of `let`: `const foo`
-...
 LL |         asm!("{}", options(), clobber_abi("C"), const foo);
    |                                                       ^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const foo = 0;
+   |     ~~~~~
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/parse-error.rs:76:31
    |
-LL |     let mut foo = 0;
-   |     ----------- help: consider using `const` instead of `let`: `const foo`
-...
 LL |         asm!("{a}", a = const foo, a = const bar);
    |                               ^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const foo = 0;
+   |     ~~~~~
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/parse-error.rs:76:46
    |
-LL |     let mut bar = 0;
-   |     ----------- help: consider using `const` instead of `let`: `const bar`
-...
 LL |         asm!("{a}", a = const foo, a = const bar);
    |                                              ^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const bar = 0;
+   |     ~~~~~
 
 error: aborting due to 64 previous errors
 

--- a/tests/ui/asm/type-check-1.stderr
+++ b/tests/ui/asm/type-check-1.stderr
@@ -1,29 +1,35 @@
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/type-check-1.rs:41:26
    |
-LL |         let x = 0;
-   |         ----- help: consider using `const` instead of `let`: `const x`
-...
 LL |         asm!("{}", const x);
    |                          ^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |         const x = 0;
+   |         ~~~~~
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/type-check-1.rs:44:36
    |
-LL |         let x = 0;
-   |         ----- help: consider using `const` instead of `let`: `const x`
-...
 LL |         asm!("{}", const const_foo(x));
    |                                    ^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |         const x = 0;
+   |         ~~~~~
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/type-check-1.rs:47:36
    |
-LL |         let x = 0;
-   |         ----- help: consider using `const` instead of `let`: `const x`
-...
 LL |         asm!("{}", const const_bar(x));
    |                                    ^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |         const x = 0;
+   |         ~~~~~
 
 error: invalid `sym` operand
   --> $DIR/type-check-1.rs:49:24

--- a/tests/ui/asm/type-check-1.stderr
+++ b/tests/ui/asm/type-check-1.stderr
@@ -6,8 +6,8 @@ LL |         asm!("{}", const x);
    |
 help: consider using `const` instead of `let`
    |
-LL |         const x = 0;
-   |         ~~~~~
+LL |         const x: /* Type */ = 0;
+   |         ~~~~~  ++++++++++++
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/type-check-1.rs:44:36
@@ -17,8 +17,8 @@ LL |         asm!("{}", const const_foo(x));
    |
 help: consider using `const` instead of `let`
    |
-LL |         const x = 0;
-   |         ~~~~~
+LL |         const x: /* Type */ = 0;
+   |         ~~~~~  ++++++++++++
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/type-check-1.rs:47:36
@@ -28,8 +28,8 @@ LL |         asm!("{}", const const_bar(x));
    |
 help: consider using `const` instead of `let`
    |
-LL |         const x = 0;
-   |         ~~~~~
+LL |         const x: /* Type */ = 0;
+   |         ~~~~~  ++++++++++++
 
 error: invalid `sym` operand
   --> $DIR/type-check-1.rs:49:24

--- a/tests/ui/asm/x86_64/x86_64_parse_error.stderr
+++ b/tests/ui/asm/x86_64/x86_64_parse_error.stderr
@@ -15,29 +15,35 @@ LL |         asm!("{1}", in("eax") foo, const bar);
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/x86_64_parse_error.rs:13:46
    |
-LL |     let mut bar = 0;
-   |     ----------- help: consider using `const` instead of `let`: `const bar`
-...
 LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                                              ^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const bar = 0;
+   |     ~~~~~
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/x86_64_parse_error.rs:15:46
    |
-LL |     let mut bar = 0;
-   |     ----------- help: consider using `const` instead of `let`: `const bar`
-...
 LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                                              ^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const bar = 0;
+   |     ~~~~~
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/x86_64_parse_error.rs:17:42
    |
-LL |     let mut bar = 0;
-   |     ----------- help: consider using `const` instead of `let`: `const bar`
-...
 LL |         asm!("{1}", in("eax") foo, const bar);
    |                                          ^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const bar = 0;
+   |     ~~~~~
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/asm/x86_64/x86_64_parse_error.stderr
+++ b/tests/ui/asm/x86_64/x86_64_parse_error.stderr
@@ -20,8 +20,8 @@ LL |         asm!("{a}", in("eax") foo, a = const bar);
    |
 help: consider using `const` instead of `let`
    |
-LL |     const bar = 0;
-   |     ~~~~~
+LL |     const bar: /* Type */ = 0;
+   |     ~~~~~    ++++++++++++
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/x86_64_parse_error.rs:15:46
@@ -31,8 +31,8 @@ LL |         asm!("{a}", in("eax") foo, a = const bar);
    |
 help: consider using `const` instead of `let`
    |
-LL |     const bar = 0;
-   |     ~~~~~
+LL |     const bar: /* Type */ = 0;
+   |     ~~~~~    ++++++++++++
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/x86_64_parse_error.rs:17:42
@@ -42,8 +42,8 @@ LL |         asm!("{1}", in("eax") foo, const bar);
    |
 help: consider using `const` instead of `let`
    |
-LL |     const bar = 0;
-   |     ~~~~~
+LL |     const bar: /* Type */ = 0;
+   |     ~~~~~    ++++++++++++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/associated-types/associated-types-eq-expr-path.rs
+++ b/tests/ui/associated-types/associated-types-eq-expr-path.rs
@@ -7,11 +7,12 @@ trait Foo {
 
 impl Foo for isize {
     type A = usize;
-    fn bar() -> isize { 42 }
+    fn bar() -> isize {
+        42
+    }
 }
 
 pub fn main() {
     let x: isize = Foo::<A = usize>::bar();
     //~^ ERROR associated item constraints are not allowed here
-    //~| ERROR cannot call
 }

--- a/tests/ui/associated-types/associated-types-eq-expr-path.stderr
+++ b/tests/ui/associated-types/associated-types-eq-expr-path.stderr
@@ -1,25 +1,9 @@
 error[E0229]: associated item constraints are not allowed here
-  --> $DIR/associated-types-eq-expr-path.rs:14:26
+  --> $DIR/associated-types-eq-expr-path.rs:16:26
    |
 LL |     let x: isize = Foo::<A = usize>::bar();
    |                          ^^^^^^^^^ associated item constraint not allowed here
 
-error[E0790]: cannot call associated function on trait without specifying the corresponding `impl` type
-  --> $DIR/associated-types-eq-expr-path.rs:14:20
-   |
-LL |     fn bar() -> isize;
-   |     ------------------ `Foo::bar` defined here
-...
-LL |     let x: isize = Foo::<A = usize>::bar();
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
-   |
-help: use the fully-qualified path to the only available implementation
-   |
-LL -     let x: isize = Foo::<A = usize>::bar();
-LL +     let x: isize = <isize as Foo<A = usize>>::bar();
-   |
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0229, E0790.
-For more information about an error, try `rustc --explain E0229`.
+For more information about this error, try `rustc --explain E0229`.

--- a/tests/ui/backtrace/synchronized-panic-handler.rs
+++ b/tests/ui/backtrace/synchronized-panic-handler.rs
@@ -1,0 +1,15 @@
+//@ run-pass
+//@ check-run-results
+//@ edition:2021
+use std::thread;
+const PANIC_MESSAGE: &str = "oops oh no woe is me";
+
+fn entry() {
+    panic!("{PANIC_MESSAGE}")
+}
+
+fn main() {
+    let (a, b) = (thread::spawn(entry), thread::spawn(entry));
+    assert_eq!(&**a.join().unwrap_err().downcast::<String>().unwrap(), PANIC_MESSAGE);
+    assert_eq!(&**b.join().unwrap_err().downcast::<String>().unwrap(), PANIC_MESSAGE);
+}

--- a/tests/ui/backtrace/synchronized-panic-handler.run.stderr
+++ b/tests/ui/backtrace/synchronized-panic-handler.run.stderr
@@ -1,5 +1,5 @@
-thread '<unnamed>' panicked at $DIR/synchronized-panic-handler.rs:thread '8<unnamed>:5' panicked at :
-oops oh no woe is me$DIR/synchronized-panic-handler.rs
-:note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-8:5:
+thread '<unnamed>' panicked at $DIR/synchronized-panic-handler.rs:8:5:
+oops oh no woe is me
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+thread '<unnamed>' panicked at $DIR/synchronized-panic-handler.rs:8:5:
 oops oh no woe is me

--- a/tests/ui/backtrace/synchronized-panic-handler.run.stderr
+++ b/tests/ui/backtrace/synchronized-panic-handler.run.stderr
@@ -1,0 +1,5 @@
+thread '<unnamed>' panicked at $DIR/synchronized-panic-handler.rs:thread '8<unnamed>:5' panicked at :
+oops oh no woe is me$DIR/synchronized-panic-handler.rs
+:note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+8:5:
+oops oh no woe is me

--- a/tests/ui/const-generics/assoc_const_as_type_argument.rs
+++ b/tests/ui/const-generics/assoc_const_as_type_argument.rs
@@ -8,7 +8,6 @@ fn foo<T: Trait>() {
     bar::<<T as Trait>::ASSOC>();
     //~^ ERROR: expected associated type, found associated constant `Trait::ASSOC`
     //~| ERROR: unresolved item provided when a constant was expected
-    //~| ERROR type annotations needed
 }
 
 fn main() {}

--- a/tests/ui/const-generics/assoc_const_as_type_argument.stderr
+++ b/tests/ui/const-generics/assoc_const_as_type_argument.stderr
@@ -15,19 +15,7 @@ help: if this generic argument was intended as a const parameter, surround it wi
 LL |     bar::<{ <T as Trait>::ASSOC }>();
    |           +                     +
 
-error[E0284]: type annotations needed
-  --> $DIR/assoc_const_as_type_argument.rs:8:5
-   |
-LL |     bar::<<T as Trait>::ASSOC>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
-   |
-note: required by a const generic parameter in `bar`
-  --> $DIR/assoc_const_as_type_argument.rs:5:8
-   |
-LL | fn bar<const N: usize>() {}
-   |        ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0284, E0575, E0747.
-For more information about an error, try `rustc --explain E0284`.
+Some errors have detailed explanations: E0575, E0747.
+For more information about an error, try `rustc --explain E0575`.

--- a/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
+++ b/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
@@ -17,7 +17,7 @@ LL |     let _: [u8; bar::<N>()];
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:19:23
+  --> $DIR/const-arg-in-const-arg.rs:18:23
    |
 LL |     let _: [u8; faz::<'a>(&())];
    |                       ^^ cannot perform const operation using `'a`
@@ -26,7 +26,7 @@ LL |     let _: [u8; faz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:21:23
+  --> $DIR/const-arg-in-const-arg.rs:20:23
    |
 LL |     let _: [u8; baz::<'a>(&())];
    |                       ^^ cannot perform const operation using `'a`
@@ -35,7 +35,7 @@ LL |     let _: [u8; baz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:22:23
+  --> $DIR/const-arg-in-const-arg.rs:21:23
    |
 LL |     let _: [u8; faz::<'b>(&())];
    |                       ^^ cannot perform const operation using `'b`
@@ -44,7 +44,7 @@ LL |     let _: [u8; faz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:24:23
+  --> $DIR/const-arg-in-const-arg.rs:23:23
    |
 LL |     let _: [u8; baz::<'b>(&())];
    |                       ^^ cannot perform const operation using `'b`
@@ -53,7 +53,7 @@ LL |     let _: [u8; baz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:27:23
+  --> $DIR/const-arg-in-const-arg.rs:26:23
    |
 LL |     let _ = [0; bar::<N>()];
    |                       ^ cannot perform const operation using `N`
@@ -62,7 +62,7 @@ LL |     let _ = [0; bar::<N>()];
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:30:23
+  --> $DIR/const-arg-in-const-arg.rs:28:23
    |
 LL |     let _ = [0; faz::<'a>(&())];
    |                       ^^ cannot perform const operation using `'a`
@@ -71,7 +71,7 @@ LL |     let _ = [0; faz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:32:23
+  --> $DIR/const-arg-in-const-arg.rs:30:23
    |
 LL |     let _ = [0; baz::<'a>(&())];
    |                       ^^ cannot perform const operation using `'a`
@@ -80,7 +80,7 @@ LL |     let _ = [0; baz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:33:23
+  --> $DIR/const-arg-in-const-arg.rs:31:23
    |
 LL |     let _ = [0; faz::<'b>(&())];
    |                       ^^ cannot perform const operation using `'b`
@@ -89,7 +89,7 @@ LL |     let _ = [0; faz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:35:23
+  --> $DIR/const-arg-in-const-arg.rs:33:23
    |
 LL |     let _ = [0; baz::<'b>(&())];
    |                       ^^ cannot perform const operation using `'b`
@@ -98,7 +98,7 @@ LL |     let _ = [0; baz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:36:24
+  --> $DIR/const-arg-in-const-arg.rs:34:24
    |
 LL |     let _: Foo<{ foo::<T>() }>;
    |                        ^ cannot perform const operation using `T`
@@ -107,7 +107,7 @@ LL |     let _: Foo<{ foo::<T>() }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:37:24
+  --> $DIR/const-arg-in-const-arg.rs:35:24
    |
 LL |     let _: Foo<{ bar::<N>() }>;
    |                        ^ cannot perform const operation using `N`
@@ -116,7 +116,7 @@ LL |     let _: Foo<{ bar::<N>() }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:40:24
+  --> $DIR/const-arg-in-const-arg.rs:37:24
    |
 LL |     let _: Foo<{ faz::<'a>(&()) }>;
    |                        ^^ cannot perform const operation using `'a`
@@ -125,7 +125,7 @@ LL |     let _: Foo<{ faz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:42:24
+  --> $DIR/const-arg-in-const-arg.rs:39:24
    |
 LL |     let _: Foo<{ baz::<'a>(&()) }>;
    |                        ^^ cannot perform const operation using `'a`
@@ -134,7 +134,7 @@ LL |     let _: Foo<{ baz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:43:24
+  --> $DIR/const-arg-in-const-arg.rs:40:24
    |
 LL |     let _: Foo<{ faz::<'b>(&()) }>;
    |                        ^^ cannot perform const operation using `'b`
@@ -143,7 +143,7 @@ LL |     let _: Foo<{ faz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:45:24
+  --> $DIR/const-arg-in-const-arg.rs:42:24
    |
 LL |     let _: Foo<{ baz::<'b>(&()) }>;
    |                        ^^ cannot perform const operation using `'b`
@@ -152,7 +152,7 @@ LL |     let _: Foo<{ baz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:46:27
+  --> $DIR/const-arg-in-const-arg.rs:43:27
    |
 LL |     let _ = Foo::<{ foo::<T>() }>;
    |                           ^ cannot perform const operation using `T`
@@ -161,7 +161,7 @@ LL |     let _ = Foo::<{ foo::<T>() }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:47:27
+  --> $DIR/const-arg-in-const-arg.rs:44:27
    |
 LL |     let _ = Foo::<{ bar::<N>() }>;
    |                           ^ cannot perform const operation using `N`
@@ -170,7 +170,7 @@ LL |     let _ = Foo::<{ bar::<N>() }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:50:27
+  --> $DIR/const-arg-in-const-arg.rs:46:27
    |
 LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    |                           ^^ cannot perform const operation using `'a`
@@ -179,7 +179,7 @@ LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:52:27
+  --> $DIR/const-arg-in-const-arg.rs:48:27
    |
 LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    |                           ^^ cannot perform const operation using `'a`
@@ -188,7 +188,7 @@ LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:53:27
+  --> $DIR/const-arg-in-const-arg.rs:49:27
    |
 LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    |                           ^^ cannot perform const operation using `'b`
@@ -197,7 +197,7 @@ LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:55:27
+  --> $DIR/const-arg-in-const-arg.rs:51:27
    |
 LL |     let _ = Foo::<{ baz::<'b>(&()) }>;
    |                           ^^ cannot perform const operation using `'b`
@@ -216,20 +216,8 @@ help: if this generic argument was intended as a const parameter, surround it wi
 LL |     let _: [u8; bar::<{ N }>()];
    |                       +   +
 
-error[E0284]: type annotations needed
-  --> $DIR/const-arg-in-const-arg.rs:16:17
-   |
-LL |     let _: [u8; bar::<N>()];
-   |                 ^^^^^^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
-   |
-note: required by a const generic parameter in `bar`
-  --> $DIR/const-arg-in-const-arg.rs:9:14
-   |
-LL | const fn bar<const N: usize>() -> usize { N }
-   |              ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
-
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:19:23
+  --> $DIR/const-arg-in-const-arg.rs:18:23
    |
 LL |     let _: [u8; faz::<'a>(&())];
    |                       ^^
@@ -241,7 +229,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:22:23
+  --> $DIR/const-arg-in-const-arg.rs:21:23
    |
 LL |     let _: [u8; faz::<'b>(&())];
    |                       ^^
@@ -253,7 +241,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:37:24
+  --> $DIR/const-arg-in-const-arg.rs:35:24
    |
 LL |     let _: Foo<{ bar::<N>() }>;
    |                        ^
@@ -263,20 +251,8 @@ help: if this generic argument was intended as a const parameter, surround it wi
 LL |     let _: Foo<{ bar::<{ N }>() }>;
    |                        +   +
 
-error[E0284]: type annotations needed
-  --> $DIR/const-arg-in-const-arg.rs:37:18
-   |
-LL |     let _: Foo<{ bar::<N>() }>;
-   |                  ^^^^^^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
-   |
-note: required by a const generic parameter in `bar`
-  --> $DIR/const-arg-in-const-arg.rs:9:14
-   |
-LL | const fn bar<const N: usize>() -> usize { N }
-   |              ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
-
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:40:24
+  --> $DIR/const-arg-in-const-arg.rs:37:24
    |
 LL |     let _: Foo<{ faz::<'a>(&()) }>;
    |                        ^^
@@ -288,7 +264,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:43:24
+  --> $DIR/const-arg-in-const-arg.rs:40:24
    |
 LL |     let _: Foo<{ faz::<'b>(&()) }>;
    |                        ^^
@@ -300,7 +276,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: constant expression depends on a generic parameter
-  --> $DIR/const-arg-in-const-arg.rs:26:17
+  --> $DIR/const-arg-in-const-arg.rs:25:17
    |
 LL |     let _ = [0; foo::<T>()];
    |                 ^^^^^^^^^^
@@ -308,7 +284,7 @@ LL |     let _ = [0; foo::<T>()];
    = note: this may fail depending on what value the parameter takes
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:27:23
+  --> $DIR/const-arg-in-const-arg.rs:26:23
    |
 LL |     let _ = [0; bar::<N>()];
    |                       ^
@@ -318,20 +294,8 @@ help: if this generic argument was intended as a const parameter, surround it wi
 LL |     let _ = [0; bar::<{ N }>()];
    |                       +   +
 
-error[E0284]: type annotations needed
-  --> $DIR/const-arg-in-const-arg.rs:27:17
-   |
-LL |     let _ = [0; bar::<N>()];
-   |                 ^^^^^^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
-   |
-note: required by a const generic parameter in `bar`
-  --> $DIR/const-arg-in-const-arg.rs:9:14
-   |
-LL | const fn bar<const N: usize>() -> usize { N }
-   |              ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
-
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:30:23
+  --> $DIR/const-arg-in-const-arg.rs:28:23
    |
 LL |     let _ = [0; faz::<'a>(&())];
    |                       ^^
@@ -343,7 +307,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:33:23
+  --> $DIR/const-arg-in-const-arg.rs:31:23
    |
 LL |     let _ = [0; faz::<'b>(&())];
    |                       ^^
@@ -355,7 +319,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:47:27
+  --> $DIR/const-arg-in-const-arg.rs:44:27
    |
 LL |     let _ = Foo::<{ bar::<N>() }>;
    |                           ^
@@ -365,20 +329,8 @@ help: if this generic argument was intended as a const parameter, surround it wi
 LL |     let _ = Foo::<{ bar::<{ N }>() }>;
    |                           +   +
 
-error[E0284]: type annotations needed
-  --> $DIR/const-arg-in-const-arg.rs:47:21
-   |
-LL |     let _ = Foo::<{ bar::<N>() }>;
-   |                     ^^^^^^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
-   |
-note: required by a const generic parameter in `bar`
-  --> $DIR/const-arg-in-const-arg.rs:9:14
-   |
-LL | const fn bar<const N: usize>() -> usize { N }
-   |              ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
-
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:50:27
+  --> $DIR/const-arg-in-const-arg.rs:46:27
    |
 LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    |                           ^^
@@ -390,7 +342,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:53:27
+  --> $DIR/const-arg-in-const-arg.rs:49:27
    |
 LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    |                           ^^
@@ -401,7 +353,7 @@ note: the late bound lifetime parameter is introduced here
 LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
-error: aborting due to 40 previous errors
+error: aborting due to 36 previous errors
 
-Some errors have detailed explanations: E0284, E0747, E0794.
-For more information about an error, try `rustc --explain E0284`.
+Some errors have detailed explanations: E0747, E0794.
+For more information about an error, try `rustc --explain E0747`.

--- a/tests/ui/const-generics/const-arg-in-const-arg.rs
+++ b/tests/ui/const-generics/const-arg-in-const-arg.rs
@@ -15,7 +15,6 @@ fn test<'a, 'b, T, const N: usize>() where &'b (): Sized {
     let _: [u8; foo::<T>()]; //[min]~ ERROR generic parameters may not
     let _: [u8; bar::<N>()]; //[min]~ ERROR generic parameters may not
                              //[min]~^ ERROR unresolved item provided when a constant was expected
-                             //[min]~| ERROR type annotations needed
     let _: [u8; faz::<'a>(&())]; //[min]~ ERROR generic parameters may not
                                  //[min]~^ ERROR cannot specify lifetime arguments
     let _: [u8; baz::<'a>(&())]; //[min]~ ERROR generic parameters may not
@@ -26,7 +25,6 @@ fn test<'a, 'b, T, const N: usize>() where &'b (): Sized {
     let _ = [0; foo::<T>()]; //[min]~ ERROR constant expression depends on a generic parameter
     let _ = [0; bar::<N>()]; //[min]~ ERROR generic parameters may not
                              //[min]~^ ERROR unresolved item provided when a constant was expected
-                             //[min]~| ERROR type annotations needed
     let _ = [0; faz::<'a>(&())]; //[min]~ ERROR generic parameters may not
                                  //[min]~^ ERROR cannot specify lifetime arguments
     let _ = [0; baz::<'a>(&())]; //[min]~ ERROR generic parameters may not
@@ -36,7 +34,6 @@ fn test<'a, 'b, T, const N: usize>() where &'b (): Sized {
     let _: Foo<{ foo::<T>() }>; //[min]~ ERROR generic parameters may not
     let _: Foo<{ bar::<N>() }>; //[min]~ ERROR generic parameters may not
                                 //[min]~^ ERROR unresolved item provided when a constant was expected
-                                //[min]~| ERROR type annotations needed
     let _: Foo<{ faz::<'a>(&()) }>; //[min]~ ERROR generic parameters may not
                                     //[min]~^ ERROR cannot specify lifetime arguments
     let _: Foo<{ baz::<'a>(&()) }>; //[min]~ ERROR generic parameters may not
@@ -46,7 +43,6 @@ fn test<'a, 'b, T, const N: usize>() where &'b (): Sized {
     let _ = Foo::<{ foo::<T>() }>; //[min]~ ERROR generic parameters may not
     let _ = Foo::<{ bar::<N>() }>; //[min]~ ERROR generic parameters may not
                                    //[min]~^ ERROR unresolved item provided when a constant was expected
-                                   //[min]~| ERROR type annotations needed
     let _ = Foo::<{ faz::<'a>(&()) }>; //[min]~ ERROR generic parameters may not
                                        //[min]~^ ERROR cannot specify lifetime arguments
     let _ = Foo::<{ baz::<'a>(&()) }>; //[min]~ ERROR generic parameters may not

--- a/tests/ui/const-generics/issues/issue-62878.min.stderr
+++ b/tests/ui/const-generics/issues/issue-62878.min.stderr
@@ -30,31 +30,7 @@ help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
 LL + #![feature(generic_arg_infer)]
    |
 
-error[E0284]: type annotations needed
-  --> $DIR/issue-62878.rs:10:5
-   |
-LL |     foo::<_, { [1] }>();
-   |     ^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
-   |
-note: required by a const generic parameter in `foo`
-  --> $DIR/issue-62878.rs:5:8
-   |
-LL | fn foo<const N: usize, const A: [u8; N]>() {}
-   |        ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+error: aborting due to 3 previous errors
 
-error[E0284]: type annotations needed
-  --> $DIR/issue-62878.rs:10:5
-   |
-LL |     foo::<_, { [1] }>();
-   |     ^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `A` declared on the function `foo`
-   |
-note: required by a const generic parameter in `foo`
-  --> $DIR/issue-62878.rs:5:24
-   |
-LL | fn foo<const N: usize, const A: [u8; N]>() {}
-   |                        ^^^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
-
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0284, E0747, E0770.
-For more information about an error, try `rustc --explain E0284`.
+Some errors have detailed explanations: E0747, E0770.
+For more information about an error, try `rustc --explain E0747`.

--- a/tests/ui/const-generics/issues/issue-62878.rs
+++ b/tests/ui/const-generics/issues/issue-62878.rs
@@ -9,6 +9,4 @@ fn foo<const N: usize, const A: [u8; N]>() {}
 fn main() {
     foo::<_, { [1] }>();
     //[min]~^ ERROR: type provided when a constant was expected
-    //[min]~| ERROR type annotations needed
-    //[min]~| ERROR type annotations needed
 }

--- a/tests/ui/const-generics/legacy-const-generics-bad.stderr
+++ b/tests/ui/const-generics/legacy-const-generics-bad.stderr
@@ -6,8 +6,8 @@ LL |     legacy_const_generics::foo(0, a, 2);
    |
 help: consider using `const` instead of `let`
    |
-LL |     const a = 1;
-   |     ~~~~~
+LL |     const a: /* Type */ = 1;
+   |     ~~~~~  ++++++++++++
 
 error: generic parameters may not be used in const operations
   --> $DIR/legacy-const-generics-bad.rs:12:35

--- a/tests/ui/const-generics/legacy-const-generics-bad.stderr
+++ b/tests/ui/const-generics/legacy-const-generics-bad.stderr
@@ -1,10 +1,13 @@
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/legacy-const-generics-bad.rs:7:35
    |
-LL |     let a = 1;
-   |     ----- help: consider using `const` instead of `let`: `const a`
 LL |     legacy_const_generics::foo(0, a, 2);
    |                                   ^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const a = 1;
+   |     ~~~~~
 
 error: generic parameters may not be used in const operations
   --> $DIR/legacy-const-generics-bad.rs:12:35

--- a/tests/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.rs
+++ b/tests/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.rs
@@ -12,7 +12,6 @@ fn b() {
     //~^ ERROR expected trait, found constant `BAR`
     //~| ERROR expected trait, found constant `BAR`
     //~| ERROR type provided when a constant was expected
-    //~| ERROR type annotations needed
 }
 fn c() {
     foo::<3 + 3>(); //~ ERROR expressions must be enclosed in braces

--- a/tests/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
+++ b/tests/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
@@ -10,7 +10,7 @@ LL |     foo::<{ BAR + 3 }>();
    |           +         +
 
 error: expressions must be enclosed in braces to be used as const generic arguments
-  --> $DIR/const-expression-suggest-missing-braces.rs:18:11
+  --> $DIR/const-expression-suggest-missing-braces.rs:17:11
    |
 LL |     foo::<3 + 3>();
    |           ^^^^^
@@ -21,7 +21,7 @@ LL |     foo::<{ 3 + 3 }>();
    |           +       +
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:21:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:20:15
    |
 LL |     foo::<BAR - 3>();
    |               ^ expected one of `,` or `>`
@@ -32,7 +32,7 @@ LL |     foo::<{ BAR - 3 }>();
    |           +         +
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:24:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:23:15
    |
 LL |     foo::<BAR - BAR>();
    |               ^ expected one of `,` or `>`
@@ -43,7 +43,7 @@ LL |     foo::<{ BAR - BAR }>();
    |           +           +
 
 error: expressions must be enclosed in braces to be used as const generic arguments
-  --> $DIR/const-expression-suggest-missing-braces.rs:27:11
+  --> $DIR/const-expression-suggest-missing-braces.rs:26:11
    |
 LL |     foo::<100 - BAR>();
    |           ^^^^^^^^^
@@ -54,7 +54,7 @@ LL |     foo::<{ 100 - BAR }>();
    |           +           +
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:30:19
+  --> $DIR/const-expression-suggest-missing-braces.rs:29:19
    |
 LL |     foo::<bar<i32>()>();
    |                   ^ expected one of `,` or `>`
@@ -65,7 +65,7 @@ LL |     foo::<{ bar<i32>() }>();
    |           +            +
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:33:21
+  --> $DIR/const-expression-suggest-missing-braces.rs:32:21
    |
 LL |     foo::<bar::<i32>()>();
    |                     ^ expected one of `,` or `>`
@@ -76,7 +76,7 @@ LL |     foo::<{ bar::<i32>() }>();
    |           +              +
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:36:21
+  --> $DIR/const-expression-suggest-missing-braces.rs:35:21
    |
 LL |     foo::<bar::<i32>() + BAR>();
    |                     ^ expected one of `,` or `>`
@@ -87,7 +87,7 @@ LL |     foo::<{ bar::<i32>() + BAR }>();
    |           +                    +
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:39:21
+  --> $DIR/const-expression-suggest-missing-braces.rs:38:21
    |
 LL |     foo::<bar::<i32>() - BAR>();
    |                     ^ expected one of `,` or `>`
@@ -98,7 +98,7 @@ LL |     foo::<{ bar::<i32>() - BAR }>();
    |           +                    +
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:42:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:41:15
    |
 LL |     foo::<BAR - bar::<i32>()>();
    |               ^ expected one of `,` or `>`
@@ -109,7 +109,7 @@ LL |     foo::<{ BAR - bar::<i32>() }>();
    |           +                    +
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:45:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:44:15
    |
 LL |     foo::<BAR - bar::<i32>()>();
    |               ^ expected one of `,` or `>`
@@ -137,19 +137,7 @@ error[E0747]: type provided when a constant was expected
 LL |     foo::<BAR + BAR>();
    |           ^^^^^^^^^
 
-error[E0284]: type annotations needed
-  --> $DIR/const-expression-suggest-missing-braces.rs:11:5
-   |
-LL |     foo::<BAR + BAR>();
-   |     ^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `C` declared on the function `foo`
-   |
-note: required by a const generic parameter in `foo`
-  --> $DIR/const-expression-suggest-missing-braces.rs:1:8
-   |
-LL | fn foo<const C: usize>() {}
-   |        ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+error: aborting due to 14 previous errors
 
-error: aborting due to 15 previous errors
-
-Some errors have detailed explanations: E0284, E0404, E0747.
-For more information about an error, try `rustc --explain E0284`.
+Some errors have detailed explanations: E0404, E0747.
+For more information about an error, try `rustc --explain E0404`.

--- a/tests/ui/const-generics/min_const_generics/macro-fail.rs
+++ b/tests/ui/const-generics/min_const_generics/macro-fail.rs
@@ -16,7 +16,6 @@ fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
   //~| ERROR: type provided when a constant was expected
   Example::<gimme_a_const!(marker)>
   //~^ ERROR: type provided when a constant was expected
-  //~| ERROR type annotations needed
 }
 
 fn from_marker(_: impl Marker<{
@@ -37,10 +36,8 @@ fn main() {
 
   let _fail = Example::<external_macro!()>;
   //~^ ERROR: type provided when a constant
-  //~| ERROR type annotations needed
 
   let _fail = Example::<gimme_a_const!()>;
   //~^ ERROR unexpected end of macro invocation
   //~| ERROR: type provided when a constant was expected
-  //~| ERROR type annotations needed
 }

--- a/tests/ui/const-generics/min_const_generics/macro-fail.stderr
+++ b/tests/ui/const-generics/min_const_generics/macro-fail.stderr
@@ -1,5 +1,5 @@
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:31:27
+  --> $DIR/macro-fail.rs:30:27
    |
 LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
    |                                 ----------------------
@@ -13,7 +13,7 @@ LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    = note: this error originates in the macro `gimme_a_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:31:27
+  --> $DIR/macro-fail.rs:30:27
    |
 LL |   Example::<gimme_a_const!(marker)>
    |             ----------------------
@@ -41,7 +41,7 @@ LL |   let _fail = Example::<external_macro!()>;
    = note: this error originates in the macro `external_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of macro invocation
-  --> $DIR/macro-fail.rs:42:25
+  --> $DIR/macro-fail.rs:40:25
    |
 LL |     macro_rules! gimme_a_const {
    |     -------------------------- when calling this macro
@@ -50,7 +50,7 @@ LL |   let _fail = Example::<gimme_a_const!()>;
    |                         ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
    |
 note: while trying to match meta-variable `$rusty:ident`
-  --> $DIR/macro-fail.rs:31:8
+  --> $DIR/macro-fail.rs:30:8
    |
 LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    |        ^^^^^^^^^^^^^
@@ -75,63 +75,18 @@ error[E0747]: type provided when a constant was expected
 LL |   Example::<gimme_a_const!(marker)>
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0284]: type annotations needed
-  --> $DIR/macro-fail.rs:17:3
-   |
-LL |   Example::<gimme_a_const!(marker)>
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the struct `Example`
-   |
-note: required by a const generic parameter in `Example`
-  --> $DIR/macro-fail.rs:1:16
-   |
-LL | struct Example<const N: usize>;
-   |                ^^^^^^^^^^^^^^ required by this const generic parameter in `Example`
-
 error[E0747]: type provided when a constant was expected
-  --> $DIR/macro-fail.rs:38:25
+  --> $DIR/macro-fail.rs:37:25
    |
 LL |   let _fail = Example::<external_macro!()>;
    |                         ^^^^^^^^^^^^^^^^^
 
 error[E0747]: type provided when a constant was expected
-  --> $DIR/macro-fail.rs:42:25
+  --> $DIR/macro-fail.rs:40:25
    |
 LL |   let _fail = Example::<gimme_a_const!()>;
    |                         ^^^^^^^^^^^^^^^^
 
-error[E0284]: type annotations needed for `Example<_>`
-  --> $DIR/macro-fail.rs:38:7
-   |
-LL |   let _fail = Example::<external_macro!()>;
-   |       ^^^^^   ---------------------------- type must be known at this point
-   |
-note: required by a const generic parameter in `Example`
-  --> $DIR/macro-fail.rs:1:16
-   |
-LL | struct Example<const N: usize>;
-   |                ^^^^^^^^^^^^^^ required by this const generic parameter in `Example`
-help: consider giving `_fail` an explicit type, where the value of const parameter `N` is specified
-   |
-LL |   let _fail: Example<N> = Example::<external_macro!()>;
-   |            ++++++++++++
+error: aborting due to 9 previous errors
 
-error[E0284]: type annotations needed for `Example<_>`
-  --> $DIR/macro-fail.rs:42:7
-   |
-LL |   let _fail = Example::<gimme_a_const!()>;
-   |       ^^^^^   --------------------------- type must be known at this point
-   |
-note: required by a const generic parameter in `Example`
-  --> $DIR/macro-fail.rs:1:16
-   |
-LL | struct Example<const N: usize>;
-   |                ^^^^^^^^^^^^^^ required by this const generic parameter in `Example`
-help: consider giving `_fail` an explicit type, where the value of const parameter `N` is specified
-   |
-LL |   let _fail: Example<N> = Example::<gimme_a_const!()>;
-   |            ++++++++++++
-
-error: aborting due to 12 previous errors
-
-Some errors have detailed explanations: E0284, E0747.
-For more information about an error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0747`.

--- a/tests/ui/const-generics/suggest_const_for_array.rs
+++ b/tests/ui/const-generics/suggest_const_for_array.rs
@@ -5,8 +5,6 @@ fn example<const N: usize>() {}
 fn other() {
     example::<[usize; 3]>();
     //~^ ERROR type provided when a const
-    //~| ERROR type annotations needed
     example::<[usize; 4 + 5]>();
     //~^ ERROR type provided when a const
-    //~| ERROR type annotations needed
 }

--- a/tests/ui/const-generics/suggest_const_for_array.stderr
+++ b/tests/ui/const-generics/suggest_const_for_array.stderr
@@ -5,36 +5,11 @@ LL |     example::<[usize; 3]>();
    |               ^^^^^^^^^^ help: array type provided where a `usize` was expected, try: `{ 3 }`
 
 error[E0747]: type provided when a constant was expected
-  --> $DIR/suggest_const_for_array.rs:9:15
+  --> $DIR/suggest_const_for_array.rs:8:15
    |
 LL |     example::<[usize; 4 + 5]>();
    |               ^^^^^^^^^^^^^^ help: array type provided where a `usize` was expected, try: `{ 4 + 5 }`
 
-error[E0284]: type annotations needed
-  --> $DIR/suggest_const_for_array.rs:6:5
-   |
-LL |     example::<[usize; 3]>();
-   |     ^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the function `example`
-   |
-note: required by a const generic parameter in `example`
-  --> $DIR/suggest_const_for_array.rs:3:12
-   |
-LL | fn example<const N: usize>() {}
-   |            ^^^^^^^^^^^^^^ required by this const generic parameter in `example`
+error: aborting due to 2 previous errors
 
-error[E0284]: type annotations needed
-  --> $DIR/suggest_const_for_array.rs:9:5
-   |
-LL |     example::<[usize; 4 + 5]>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the function `example`
-   |
-note: required by a const generic parameter in `example`
-  --> $DIR/suggest_const_for_array.rs:3:12
-   |
-LL | fn example<const N: usize>() {}
-   |            ^^^^^^^^^^^^^^ required by this const generic parameter in `example`
-
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0284, E0747.
-For more information about an error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0747`.

--- a/tests/ui/consts/issue-3521.stderr
+++ b/tests/ui/consts/issue-3521.stderr
@@ -1,11 +1,13 @@
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/issue-3521.rs:8:15
    |
-LL |     let foo: isize = 100;
-   |     ------- help: consider using `const` instead of `let`: `const foo`
-...
 LL |         Bar = foo
    |               ^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const foo: isize = 100;
+   |     ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-91560.stderr
+++ b/tests/ui/consts/issue-91560.stderr
@@ -1,20 +1,24 @@
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/issue-91560.rs:10:19
    |
-LL |     let mut length: usize = 2;
-   |     -------------- help: consider using `const` instead of `let`: `const length`
-LL |
 LL |     let arr = [0; length];
    |                   ^^^^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const length: usize = 2;
+   |     ~~~~~
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/issue-91560.rs:17:19
    |
-LL |     let   length: usize = 2;
-   |     ------------ help: consider using `const` instead of `let`: `const length`
-LL |
 LL |     let arr = [0; length];
    |                   ^^^^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const length: usize = 2;
+   |     ~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/non-const-value-in-const.stderr
+++ b/tests/ui/consts/non-const-value-in-const.stderr
@@ -17,8 +17,8 @@ LL |     let _ = [0; x];
    |
 help: consider using `const` instead of `let`
    |
-LL |     const x = 5;
-   |     ~~~~~
+LL |     const x: /* Type */ = 5;
+   |     ~~~~~  ++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/non-const-value-in-const.stderr
+++ b/tests/ui/consts/non-const-value-in-const.stderr
@@ -2,18 +2,23 @@ error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/non-const-value-in-const.rs:3:20
    |
 LL |     const Y: i32 = x;
-   |     -------        ^ non-constant value
-   |     |
-   |     help: consider using `let` instead of `const`: `let Y`
+   |                    ^ non-constant value
+   |
+help: consider using `let` instead of `const`
+   |
+LL |     let Y: i32 = x;
+   |     ~~~
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/non-const-value-in-const.rs:6:17
    |
-LL |     let x = 5;
-   |     ----- help: consider using `const` instead of `let`: `const x`
-...
 LL |     let _ = [0; x];
    |                 ^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const x = 5;
+   |     ~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0435.stderr
+++ b/tests/ui/error-codes/E0435.stderr
@@ -1,10 +1,13 @@
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/E0435.rs:5:17
    |
-LL |     let foo: usize = 42;
-   |     ------- help: consider using `const` instead of `let`: `const foo`
 LL |     let _: [u8; foo];
    |                 ^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const foo: usize = 42;
+   |     ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/generic-function-item-where-type.rs
+++ b/tests/ui/generics/generic-function-item-where-type.rs
@@ -3,5 +3,4 @@ fn foo<U>() {}
 fn main() {
     foo::<main>()
     //~^ ERROR constant provided when a type was expected
-    //~| ERROR type annotations needed
 }

--- a/tests/ui/generics/generic-function-item-where-type.stderr
+++ b/tests/ui/generics/generic-function-item-where-type.stderr
@@ -7,13 +7,6 @@ LL |     foo::<main>()
    = help: `main` is a function item, not a type
    = help: function item types cannot be named directly
 
-error[E0282]: type annotations needed
-  --> $DIR/generic-function-item-where-type.rs:4:5
-   |
-LL |     foo::<main>()
-   |     ^^^^^^^^^^^ cannot infer type of the type parameter `U` declared on the function `foo`
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0282, E0747.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0747`.

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-semantics.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-semantics.rs
@@ -45,9 +45,8 @@ fn range_to_inclusive() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f16::NEG_INFINITY, ..=f16::NEG_INFINITY));
-        // assert!(yes!(f16::NEG_INFINITY, ..=1.0f16));
+        assert!(yes!(f16::NEG_INFINITY, ..=f16::NEG_INFINITY));
+        assert!(yes!(f16::NEG_INFINITY, ..=1.0f16));
         assert!(yes!(1.5f16, ..=1.5f16));
         assert!(!yes!(1.6f16, ..=-1.5f16));
     }
@@ -68,9 +67,8 @@ fn range_to_inclusive() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f128::NEG_INFINITY, ..=f128::NEG_INFINITY));
-        // assert!(yes!(f128::NEG_INFINITY, ..=1.0f128));
+        assert!(yes!(f128::NEG_INFINITY, ..=f128::NEG_INFINITY));
+        assert!(yes!(f128::NEG_INFINITY, ..=1.0f128));
         assert!(yes!(1.5f128, ..=1.5f128));
         assert!(!yes!(1.6f128, ..=-1.5f128));
     }
@@ -111,8 +109,7 @@ fn range_to() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f16::NEG_INFINITY, ..1.0f16));
+        assert!(yes!(f16::NEG_INFINITY, ..1.0f16));
         assert!(!yes!(1.5f16, ..1.5f16));
         const E16: f16 = 1.5f16 + f16::EPSILON;
         assert!(yes!(1.5f16, ..E16));
@@ -137,8 +134,7 @@ fn range_to() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f128::NEG_INFINITY, ..1.0f128));
+        assert!(yes!(f128::NEG_INFINITY, ..1.0f128));
         assert!(!yes!(1.5f128, ..1.5f128));
         const E128: f128 = 1.5f128 + f128::EPSILON;
         assert!(yes!(1.5f128, ..E128));
@@ -181,15 +177,14 @@ fn range_from() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f16::NEG_INFINITY, f16::NEG_INFINITY..));
-        // assert!(yes!(f16::INFINITY, f16::NEG_INFINITY..));
-        // assert!(!yes!(f16::NEG_INFINITY, 1.0f16..));
-        // assert!(yes!(f16::INFINITY, 1.0f16..));
+        assert!(yes!(f16::NEG_INFINITY, f16::NEG_INFINITY..));
+        assert!(yes!(f16::INFINITY, f16::NEG_INFINITY..));
+        assert!(!yes!(f16::NEG_INFINITY, 1.0f16..));
+        assert!(yes!(f16::INFINITY, 1.0f16..));
         assert!(!yes!(1.0f16 - f16::EPSILON, 1.0f16..));
         assert!(yes!(1.0f16, 1.0f16..));
-        // assert!(yes!(f16::INFINITY, 1.0f16..));
-        // assert!(yes!(f16::INFINITY, f16::INFINITY..));
+        assert!(yes!(f16::INFINITY, 1.0f16..));
+        assert!(yes!(f16::INFINITY, f16::INFINITY..));
     }
 
     // f32; `X..`
@@ -216,15 +211,14 @@ fn range_from() {
     // FIXME(f16_f128): remove gate when ABI issues are resolved
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        // FIXME(f16_f128): enable infinity tests when constants are available
-        // assert!(yes!(f128::NEG_INFINITY, f128::NEG_INFINITY..));
-        // assert!(yes!(f128::INFINITY, f128::NEG_INFINITY..));
-        // assert!(!yes!(f128::NEG_INFINITY, 1.0f128..));
-        // assert!(yes!(f128::INFINITY, 1.0f128..));
+        assert!(yes!(f128::NEG_INFINITY, f128::NEG_INFINITY..));
+        assert!(yes!(f128::INFINITY, f128::NEG_INFINITY..));
+        assert!(!yes!(f128::NEG_INFINITY, 1.0f128..));
+        assert!(yes!(f128::INFINITY, 1.0f128..));
         assert!(!yes!(1.0f128 - f128::EPSILON, 1.0f128..));
         assert!(yes!(1.0f128, 1.0f128..));
-        // assert!(yes!(f128::INFINITY, 1.0f128..));
-        // assert!(yes!(f128::INFINITY, f128::INFINITY..));
+        assert!(yes!(f128::INFINITY, 1.0f128..));
+        assert!(yes!(f128::INFINITY, f128::INFINITY..));
     }
 }
 

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.rs
@@ -1,3 +1,6 @@
+#![feature(f128)]
+#![feature(f16)]
+
 macro_rules! m {
     ($s:expr, $($t:tt)+) => {
         match $s { $($t)+ => {} }
@@ -27,10 +30,13 @@ fn main() {
     m!(0, ..i128::MIN);
     //~^ ERROR lower range bound must be less than upper
 
-    // FIXME(f16_f128): add tests when NEG_INFINITY is available
+    m!(0f16, ..f16::NEG_INFINITY);
+    //~^ ERROR lower range bound must be less than upper
     m!(0f32, ..f32::NEG_INFINITY);
     //~^ ERROR lower range bound must be less than upper
     m!(0f64, ..f64::NEG_INFINITY);
+    //~^ ERROR lower range bound must be less than upper
+    m!(0f128, ..f128::NEG_INFINITY);
     //~^ ERROR lower range bound must be less than upper
 
     m!('a', ..'\u{0}');

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.stderr
@@ -1,81 +1,93 @@
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:8:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:11:11
    |
 LL |     m!(0, ..u8::MIN);
    |           ^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:10:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:13:11
    |
 LL |     m!(0, ..u16::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:12:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:15:11
    |
 LL |     m!(0, ..u32::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:14:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:17:11
    |
 LL |     m!(0, ..u64::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:16:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:19:11
    |
 LL |     m!(0, ..u128::MIN);
    |           ^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:19:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:22:11
    |
 LL |     m!(0, ..i8::MIN);
    |           ^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:21:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:24:11
    |
 LL |     m!(0, ..i16::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:23:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:26:11
    |
 LL |     m!(0, ..i32::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:25:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:28:11
    |
 LL |     m!(0, ..i64::MIN);
    |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:27:11
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:30:11
    |
 LL |     m!(0, ..i128::MIN);
    |           ^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:31:14
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:33:14
+   |
+LL |     m!(0f16, ..f16::NEG_INFINITY);
+   |              ^^^^^^^^^^^^^^^^^^^
+
+error[E0579]: lower range bound must be less than upper
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:35:14
    |
 LL |     m!(0f32, ..f32::NEG_INFINITY);
    |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:33:14
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:37:14
    |
 LL |     m!(0f64, ..f64::NEG_INFINITY);
    |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
-  --> $DIR/half-open-range-pats-thir-lower-empty.rs:36:13
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:39:15
+   |
+LL |     m!(0f128, ..f128::NEG_INFINITY);
+   |               ^^^^^^^^^^^^^^^^^^^^
+
+error[E0579]: lower range bound must be less than upper
+  --> $DIR/half-open-range-pats-thir-lower-empty.rs:42:13
    |
 LL |     m!('a', ..'\u{0}');
    |             ^^^^^^^^^
 
-error: aborting due to 13 previous errors
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0579`.

--- a/tests/ui/issues/issue-27433.fixed
+++ b/tests/ui/issues/issue-27433.fixed
@@ -3,5 +3,5 @@ fn main() {
     let foo = 42u32;
     #[allow(unused_variables, non_snake_case)]
     let FOO : u32 = foo;
-                   //~^ ERROR attempt to use a non-constant value in a constant
+    //~^ ERROR attempt to use a non-constant value in a constant
 }

--- a/tests/ui/issues/issue-27433.rs
+++ b/tests/ui/issues/issue-27433.rs
@@ -3,5 +3,5 @@ fn main() {
     let foo = 42u32;
     #[allow(unused_variables, non_snake_case)]
     const FOO : u32 = foo;
-                   //~^ ERROR attempt to use a non-constant value in a constant
+    //~^ ERROR attempt to use a non-constant value in a constant
 }

--- a/tests/ui/issues/issue-27433.stderr
+++ b/tests/ui/issues/issue-27433.stderr
@@ -2,9 +2,12 @@ error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/issue-27433.rs:5:23
    |
 LL |     const FOO : u32 = foo;
-   |     ---------         ^^^ non-constant value
-   |     |
-   |     help: consider using `let` instead of `const`: `let FOO`
+   |                       ^^^ non-constant value
+   |
+help: consider using `let` instead of `const`
+   |
+LL |     let FOO : u32 = foo;
+   |     ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-3521-2.stderr
+++ b/tests/ui/issues/issue-3521-2.stderr
@@ -2,9 +2,12 @@ error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/issue-3521-2.rs:5:23
    |
 LL |     static y: isize = foo + 1;
-   |     --------          ^^^ non-constant value
-   |     |
-   |     help: consider using `let` instead of `static`: `let y`
+   |                       ^^^ non-constant value
+   |
+help: consider using `let` instead of `static`
+   |
+LL |     let y: isize = foo + 1;
+   |     ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-3668-non-constant-value-in-constant/issue-3668-2.stderr
+++ b/tests/ui/issues/issue-3668-non-constant-value-in-constant/issue-3668-2.stderr
@@ -2,9 +2,12 @@ error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/issue-3668-2.rs:4:27
    |
 LL |     static child: isize = x + 1;
-   |     ------------          ^ non-constant value
-   |     |
-   |     help: consider using `let` instead of `static`: `let child`
+   |                           ^ non-constant value
+   |
+help: consider using `let` instead of `static`
+   |
+LL |     let child: isize = x + 1;
+   |     ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-3668-non-constant-value-in-constant/issue-3668.stderr
+++ b/tests/ui/issues/issue-3668-non-constant-value-in-constant/issue-3668.stderr
@@ -2,9 +2,12 @@ error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/issue-3668.rs:8:34
    |
 LL |        static childVal: Box<P> = self.child.get();
-   |        ---------------           ^^^^ non-constant value
-   |        |
-   |        help: consider using `let` instead of `static`: `let childVal`
+   |                                  ^^^^ non-constant value
+   |
+help: consider using `let` instead of `static`
+   |
+LL |        let childVal: Box<P> = self.child.get();
+   |        ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-44239.stderr
+++ b/tests/ui/issues/issue-44239.stderr
@@ -1,11 +1,13 @@
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/issue-44239.rs:8:26
    |
-LL |     let n: usize = 0;
-   |     ----- help: consider using `const` instead of `let`: `const n`
-...
 LL |         const N: usize = n;
    |                          ^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const n: usize = 0;
+   |     ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/suggest-assoc-const.stderr
+++ b/tests/ui/parser/suggest-assoc-const.stderr
@@ -2,7 +2,12 @@ error: non-item in item list
   --> $DIR/suggest-assoc-const.rs:5:5
    |
 LL |     let _X: i32;
-   |     ^^^ help: consider using `const` instead of `let` for associated const: `const`
+   |     ^^^
+   |
+help: consider using `const` instead of `let` for associated const
+   |
+LL |     const _X: i32;
+   |     ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/repeat-expr/repeat_count.stderr
+++ b/tests/ui/repeat-expr/repeat_count.stderr
@@ -6,8 +6,8 @@ LL |     let a = [0; n];
    |
 help: consider using `const` instead of `let`
    |
-LL |     const n = 1;
-   |     ~~~~~
+LL |     const n: /* Type */ = 1;
+   |     ~~~~~  ++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/repeat_count.rs:7:17

--- a/tests/ui/repeat-expr/repeat_count.stderr
+++ b/tests/ui/repeat-expr/repeat_count.stderr
@@ -1,10 +1,13 @@
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/repeat_count.rs:5:17
    |
-LL |     let n = 1;
-   |     ----- help: consider using `const` instead of `let`: `const n`
 LL |     let a = [0; n];
    |                 ^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const n = 1;
+   |     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/repeat_count.rs:7:17

--- a/tests/ui/type/type-dependent-def-issue-49241.stderr
+++ b/tests/ui/type/type-dependent-def-issue-49241.stderr
@@ -2,9 +2,12 @@ error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/type-dependent-def-issue-49241.rs:3:22
    |
 LL |     const l: usize = v.count();
-   |     -------          ^ non-constant value
-   |     |
-   |     help: consider using `let` instead of `const`: `let l`
+   |                      ^ non-constant value
+   |
+help: consider using `let` instead of `const`
+   |
+LL |     let l: usize = v.count();
+   |     ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeof/issue-42060.stderr
+++ b/tests/ui/typeof/issue-42060.stderr
@@ -6,8 +6,8 @@ LL |     let other: typeof(thing) = thing;
    |
 help: consider using `const` instead of `let`
    |
-LL |     const thing = ();
-   |     ~~~~~
+LL |     const thing: /* Type */ = ();
+   |     ~~~~~      ++++++++++++
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/issue-42060.rs:9:13
@@ -17,8 +17,8 @@ LL |     <typeof(q)>::N
    |
 help: consider using `const` instead of `let`
    |
-LL |     const q = 1;
-   |     ~~~~~
+LL |     const q: /* Type */ = 1;
+   |     ~~~~~  ++++++++++++
 
 error[E0516]: `typeof` is a reserved keyword but unimplemented
   --> $DIR/issue-42060.rs:3:16

--- a/tests/ui/typeof/issue-42060.stderr
+++ b/tests/ui/typeof/issue-42060.stderr
@@ -1,18 +1,24 @@
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/issue-42060.rs:3:23
    |
-LL |     let thing = ();
-   |     --------- help: consider using `const` instead of `let`: `const thing`
 LL |     let other: typeof(thing) = thing;
    |                       ^^^^^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const thing = ();
+   |     ~~~~~
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/issue-42060.rs:9:13
    |
-LL |     let q = 1;
-   |     ----- help: consider using `const` instead of `let`: `const q`
 LL |     <typeof(q)>::N
    |             ^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |     const q = 1;
+   |     ~~~~~
 
 error[E0516]: `typeof` is a reserved keyword but unimplemented
   --> $DIR/issue-42060.rs:3:16


### PR DESCRIPTION
Successful merges:

 - #127028 (Fix regression in the MIR lowering of or-patterns)
 - #127091 (impl FusedIterator and a size hint for the error sources iter)
 - #127358 (Automatically taint when reporting errors from ItemCtxt)
 - #127382 (Use verbose style when suggesting changing `const` with `let`)
 - #127397 (fix interleaved output in the default panic hook when multiple threads panic simultaneously)
 - #127484 (`#[doc(alias)]`'s doc: say that ASCII spaces are allowed)
 - #127496 (Update `f16`/`f128` FIXMEs that needed `(NEG_)INFINITY`)
 - #127508 (small search graph refactor)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=127028,127091,127358,127382,127397,127484,127496,127508)
<!-- homu-ignore:end -->