### PR TITLE
Implement a first version of RFC 3525: struct target features

### DIFF
--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -1,5 +1,6 @@
 use rustc_ast::{ast, attr, MetaItemKind, NestedMetaItem};
 use rustc_attr::{list_contains_name, InlineAttr, InstructionSetAttr, OptimizeAttr};
+use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::codes::*;
 use rustc_errors::{struct_span_code_err, DiagMessage, SubdiagMessage};
 use rustc_hir as hir;
@@ -8,7 +9,7 @@ use rustc_hir::def_id::{DefId, LocalDefId, LOCAL_CRATE};
 use rustc_hir::weak_lang_items::WEAK_LANG_ITEMS;
 use rustc_hir::{lang_items, LangItem};
 use rustc_middle::middle::codegen_fn_attrs::{
-    CodegenFnAttrFlags, CodegenFnAttrs, PatchableFunctionEntry,
+    CodegenFnAttrFlags, CodegenFnAttrs, PatchableFunctionEntry, TargetFeature,
 };
 use rustc_middle::mir::mono::Linkage;
 use rustc_middle::query::Providers;
@@ -17,6 +18,7 @@ use rustc_session::lint;
 use rustc_session::parse::feature_err;
 use rustc_span::symbol::Ident;
 use rustc_span::{sym, Span};
+use rustc_target::abi::VariantIdx;
 use rustc_target::spec::{abi, SanitizerSet};
 
 use crate::errors;
@@ -78,6 +80,13 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
     let mut link_ordinal_span = None;
     let mut no_sanitize_span = None;
 
+    let fn_sig_outer = || {
+        use DefKind::*;
+
+        let def_kind = tcx.def_kind(did);
+        if let Fn | AssocFn | Variant | Ctor(..) = def_kind { Some(tcx.fn_sig(did)) } else { None }
+    };
+
     for attr in attrs.iter() {
         // In some cases, attribute are only valid on functions, but it's the `check_attr`
         // pass that check that they aren't used anywhere else, rather this module.
@@ -85,16 +94,12 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
         // functions (such as calling `fn_sig`, which ICEs if given a non-function). We also
         // report a delayed bug, just in case `check_attr` isn't doing its job.
         let fn_sig = || {
-            use DefKind::*;
-
-            let def_kind = tcx.def_kind(did);
-            if let Fn | AssocFn | Variant | Ctor(..) = def_kind {
-                Some(tcx.fn_sig(did))
-            } else {
+            let sig = fn_sig_outer();
+            if sig.is_none() {
                 tcx.dcx()
                     .span_delayed_bug(attr.span, "this attribute can only be applied to functions");
-                None
             }
+            sig
         };
 
         let Some(Ident { name, .. }) = attr.ident() else {
@@ -613,7 +618,93 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
         }
     }
 
-    // If a function uses #[target_feature] it can't be inlined into general
+    if let Some(sig) = fn_sig_outer() {
+        // Collect target features from types reachable from arguments.
+        // We define a type as "reachable" if:
+        //  - it is a function argument
+        //  - it is a field of a reachable struct
+        //  - there is a reachable reference to it
+        // FIXME(struct_target_features): we may want to cache the result of this computation.
+        let mut visited_types = FxHashSet::default();
+        let mut reachable_types: Vec<_> = sig.skip_binder().inputs().skip_binder().to_owned();
+        let mut additional_tf = vec![];
+
+        while let Some(ty) = reachable_types.pop() {
+            if visited_types.contains(&ty) {
+                continue;
+            }
+            visited_types.insert(ty);
+            match ty.kind() {
+                ty::Alias(..) => {
+                    if let Ok(t) =
+                        tcx.try_normalize_erasing_regions(tcx.param_env(did.to_def_id()), ty)
+                    {
+                        reachable_types.push(t)
+                    }
+                }
+
+                ty::Ref(_, inner, _) => reachable_types.push(*inner),
+                ty::Tuple(tys) => reachable_types.extend(tys.iter()),
+                ty::Adt(adt_def, args) => {
+                    additional_tf.extend_from_slice(tcx.struct_target_features(adt_def.did()));
+                    // This only recurses into structs as i.e. an Option<TargetFeature> is an ADT
+                    // that doesn't actually always contain a TargetFeature.
+                    if adt_def.is_struct() {
+                        reachable_types.extend(
+                            adt_def
+                                .variant(VariantIdx::from_usize(0))
+                                .fields
+                                .iter()
+                                .map(|field| field.ty(tcx, args)),
+                        );
+                    }
+                }
+                ty::Bool
+                | ty::Char
+                | ty::Int(..)
+                | ty::Uint(..)
+                | ty::Float(..)
+                | ty::Foreign(..)
+                | ty::Str
+                | ty::Array(..)
+                | ty::Pat(..)
+                | ty::Slice(..)
+                | ty::RawPtr(..)
+                | ty::FnDef(..)
+                | ty::FnPtr(..)
+                | ty::Dynamic(..)
+                | ty::Closure(..)
+                | ty::CoroutineClosure(..)
+                | ty::Coroutine(..)
+                | ty::CoroutineWitness(..)
+                | ty::Never
+                | ty::Param(..)
+                | ty::Bound(..)
+                | ty::Placeholder(..)
+                | ty::Infer(..)
+                | ty::Error(..) => (),
+            }
+        }
+
+        // FIXME(struct_target_features): is this really necessary?
+        if !additional_tf.is_empty() && sig.skip_binder().abi() != abi::Abi::Rust {
+            tcx.dcx().span_err(
+                tcx.hir().span(tcx.local_def_id_to_hir_id(did)),
+                "cannot use a struct with target features in a function with non-Rust ABI",
+            );
+        }
+        if !additional_tf.is_empty() && codegen_fn_attrs.inline == InlineAttr::Always {
+            tcx.dcx().span_err(
+                tcx.hir().span(tcx.local_def_id_to_hir_id(did)),
+                "cannot use a struct with target features in a #[inline(always)] function",
+            );
+        }
+        codegen_fn_attrs
+            .target_features
+            .extend(additional_tf.iter().map(|tf| TargetFeature { implied: true, ..*tf }));
+    }
+
+    // If a function uses non-default target_features it can't be inlined into general
     // purpose functions as they wouldn't have the right target features
     // enabled. For that reason we also forbid #[inline(always)] as it can't be
     // respected.
@@ -758,6 +849,20 @@ fn check_link_name_xor_ordinal(
     }
 }
 
+fn struct_target_features(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &[TargetFeature] {
+    let mut features = vec![];
+    let supported_features = tcx.supported_target_features(LOCAL_CRATE);
+    for attr in tcx.get_attrs(def_id, sym::target_feature) {
+        from_target_feature(tcx, attr, supported_features, &mut features);
+    }
+    tcx.arena.alloc_slice(&features)
+}
+
 pub fn provide(providers: &mut Providers) {
-    *providers = Providers { codegen_fn_attrs, should_inherit_track_caller, ..*providers };
+    *providers = Providers {
+        codegen_fn_attrs,
+        should_inherit_track_caller,
+        struct_target_features,
+        ..*providers
+    };
 }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -594,6 +594,8 @@ declare_features! (
     (unstable, strict_provenance, "1.61.0", Some(95228)),
     /// Allows string patterns to dereference values to match them.
     (unstable, string_deref_patterns, "1.67.0", Some(87121)),
+    /// Allows structs to carry target_feature information.
+    (incomplete, struct_target_features, "CURRENT_RUSTC_VERSION", Some(129107)),
     /// Allows the use of `#[target_feature]` on safe functions.
     (unstable, target_feature_11, "1.45.0", Some(69098)),
     /// Allows using `#[thread_local]` on `static` items.

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -326,6 +326,41 @@ impl DefKind {
             | DefKind::ExternCrate => false,
         }
     }
+
+    /// Whether `query struct_target_features` should be used with this definition.
+    pub fn has_struct_target_features(self) -> bool {
+        match self {
+            DefKind::Struct | DefKind::Union | DefKind::Enum => true,
+            DefKind::Fn
+            | DefKind::AssocFn
+            | DefKind::Ctor(..)
+            | DefKind::Closure
+            | DefKind::Static { .. }
+            | DefKind::Mod
+            | DefKind::Variant
+            | DefKind::Trait
+            | DefKind::TyAlias
+            | DefKind::ForeignTy
+            | DefKind::TraitAlias
+            | DefKind::AssocTy
+            | DefKind::Const
+            | DefKind::AssocConst
+            | DefKind::Macro(..)
+            | DefKind::Use
+            | DefKind::ForeignMod
+            | DefKind::OpaqueTy
+            | DefKind::Impl { .. }
+            | DefKind::Field
+            | DefKind::TyParam
+            | DefKind::ConstParam
+            | DefKind::LifetimeParam
+            | DefKind::AnonConst
+            | DefKind::InlineConst
+            | DefKind::SyntheticCoroutineBody
+            | DefKind::GlobalAsm
+            | DefKind::ExternCrate => false,
+        }
+    }
 }
 
 /// The resolution of a path or export.

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -850,6 +850,8 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                     }
 
                     // Safe `#[target_feature]` functions are not assignable to safe fn pointers (RFC 2396).
+                    // FIXME(struct_target_features): should this be true also for functions that inherit
+                    // target features from structs?
 
                     if b_hdr.safety == hir::Safety::Safe
                         && !self.tcx.codegen_fn_attrs(def_id).target_features.is_empty()

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -224,6 +224,7 @@ provide! { tcx, def_id, other, cdata,
     variances_of => { table }
     fn_sig => { table }
     codegen_fn_attrs => { table }
+    struct_target_features => { table }
     impl_trait_header => { table }
     const_param_default => { table }
     object_lifetime_default => { table }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1392,6 +1392,9 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             if def_kind.has_codegen_attrs() {
                 record!(self.tables.codegen_fn_attrs[def_id] <- self.tcx.codegen_fn_attrs(def_id));
             }
+            if def_kind.has_struct_target_features() {
+                record_array!(self.tables.struct_target_features[def_id] <- self.tcx.struct_target_features(def_id));
+            }
             if should_encode_visibility(def_kind) {
                 let vis =
                     self.tcx.local_visibility(local_id).map_id(|def_id| def_id.local_def_index);

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -19,7 +19,7 @@ use rustc_macros::{
     Decodable, Encodable, MetadataDecodable, MetadataEncodable, TyDecodable, TyEncodable,
 };
 use rustc_middle::metadata::ModChild;
-use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs;
+use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrs, TargetFeature};
 use rustc_middle::middle::debugger_visualizer::DebuggerVisualizerFile;
 use rustc_middle::middle::exported_symbols::{ExportedSymbol, SymbolExportInfo};
 use rustc_middle::middle::lib_features::FeatureStability;
@@ -427,6 +427,7 @@ define_tables! {
     variances_of: Table<DefIndex, LazyArray<ty::Variance>>,
     fn_sig: Table<DefIndex, LazyValue<ty::EarlyBinder<'static, ty::PolyFnSig<'static>>>>,
     codegen_fn_attrs: Table<DefIndex, LazyValue<CodegenFnAttrs>>,
+    struct_target_features: Table<DefIndex, LazyArray<TargetFeature>>,
     impl_trait_header: Table<DefIndex, LazyValue<ty::ImplTraitHeader<'static>>>,
     const_param_default: Table<DefIndex, LazyValue<ty::EarlyBinder<'static, rustc_middle::ty::Const<'static>>>>,
     object_lifetime_default: Table<DefIndex, LazyValue<ObjectLifetimeDefault>>,

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -26,8 +26,8 @@ pub struct CodegenFnAttrs {
     /// be set when `link_name` is set. This is for foreign items with the
     /// "raw-dylib" kind.
     pub link_ordinal: Option<u16>,
-    /// The `#[target_feature(enable = "...")]` attribute and the enabled
-    /// features (only enabled features are supported right now).
+    /// All the target features that are enabled for this function. Some features might be enabled
+    /// implicitly.
     pub target_features: Vec<TargetFeature>,
     /// The `#[linkage = "..."]` attribute on Rust-defined items and the value we found.
     pub linkage: Option<Linkage>,
@@ -55,8 +55,8 @@ pub struct CodegenFnAttrs {
 pub struct TargetFeature {
     /// The name of the target feature (e.g. "avx")
     pub name: Symbol,
-    /// The feature is implied by another feature, rather than explicitly added by the
-    /// `#[target_feature]` attribute
+    /// The feature is implied by another feature or by an argument, rather than explicitly
+    /// added by the `#[target_feature]` attribute
     pub implied: bool,
 }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -47,7 +47,7 @@ use {rustc_ast as ast, rustc_attr as attr, rustc_hir as hir};
 use crate::infer::canonical::{self, Canonical};
 use crate::lint::LintExpectation;
 use crate::metadata::ModChild;
-use crate::middle::codegen_fn_attrs::CodegenFnAttrs;
+use crate::middle::codegen_fn_attrs::{CodegenFnAttrs, TargetFeature};
 use crate::middle::debugger_visualizer::DebuggerVisualizerFile;
 use crate::middle::exported_symbols::{ExportedSymbol, SymbolExportInfo};
 use crate::middle::lib_features::LibFeatures;
@@ -1243,6 +1243,11 @@ rustc_queries! {
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
         feedable
+    }
+
+    query struct_target_features(def_id: DefId) -> &'tcx [TargetFeature] {
+        separate_provide_extern
+        desc { |tcx| "computing target features for struct `{}`", tcx.def_path_str(def_id) }
     }
 
     query asm_target_features(def_id: DefId) -> &'tcx FxIndexSet<Symbol> {

--- a/compiler/rustc_middle/src/ty/parameterized.rs
+++ b/compiler/rustc_middle/src/ty/parameterized.rs
@@ -59,6 +59,7 @@ trivially_parameterized_over_tcx! {
     std::string::String,
     crate::metadata::ModChild,
     crate::middle::codegen_fn_attrs::CodegenFnAttrs,
+    crate::middle::codegen_fn_attrs::TargetFeature,
     crate::middle::debugger_visualizer::DebuggerVisualizerFile,
     crate::middle::exported_symbols::SymbolExportInfo,
     crate::middle::lib_features::FeatureStability,

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -125,6 +125,17 @@ mir_build_initializing_type_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed 
     .note = initializing a layout restricted type's field with a value outside the valid range is undefined behavior
     .label = initializing type with `rustc_layout_scalar_valid_range` attr
 
+mir_build_initializing_type_with_target_feature_requires_unsafe =
+    initializing type with `target_feature` attr is unsafe and requires unsafe block
+    .note = this struct can only be constructed if the corresponding `target_feature`s are available
+    .label = initializing type with `target_feature` attr
+
+mir_build_initializing_type_with_target_feature_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+    initializing type with `target_feature` attr is unsafe and requires unsafe function or block
+    .note = this struct can only be constructed if the corresponding `target_feature`s are available
+    .label = initializing type with `target_feature` attr
+
+
 mir_build_inline_assembly_requires_unsafe =
     use of inline assembly is unsafe and requires unsafe block
     .note = inline assembly is entirely unchecked and can cause undefined behavior
@@ -386,6 +397,11 @@ mir_build_unsafe_op_in_unsafe_fn_initializing_type_with_requires_unsafe =
     initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe block
     .note = initializing a layout restricted type's field with a value outside the valid range is undefined behavior
     .label = initializing type with `rustc_layout_scalar_valid_range` attr
+
+mir_build_unsafe_op_in_unsafe_fn_initializing_type_with_target_feature_requires_unsafe =
+    initializing type with `target_feature` attr is unsafe and requires unsafe block
+    .note = this struct can only be constructed if the corresponding `target_feature`s are available
+    .label = initializing type with `target_feature` attr
 
 mir_build_unsafe_op_in_unsafe_fn_inline_assembly_requires_unsafe =
     use of inline assembly is unsafe and requires unsafe block

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -87,6 +87,16 @@ pub(crate) struct UnsafeOpInUnsafeFnInitializingTypeWithRequiresUnsafe {
 }
 
 #[derive(LintDiagnostic)]
+#[diag(mir_build_unsafe_op_in_unsafe_fn_initializing_type_with_target_feature_requires_unsafe, code = E0133)]
+#[note]
+pub(crate) struct UnsafeOpInUnsafeFnInitializingTypeWithTargetFeatureRequiresUnsafe {
+    #[label]
+    pub(crate) span: Span,
+    #[subdiagnostic]
+    pub(crate) unsafe_not_inherited_note: Option<UnsafeNotInheritedLintNote>,
+}
+
+#[derive(LintDiagnostic)]
 #[diag(mir_build_unsafe_op_in_unsafe_fn_mutable_static_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnUseOfMutableStaticRequiresUnsafe {
@@ -251,12 +261,37 @@ pub(crate) struct InitializingTypeWithRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
+#[diag(mir_build_initializing_type_with_target_feature_requires_unsafe, code = E0133)]
+#[note]
+pub(crate) struct InitializingTypeWithTargetFeatureRequiresUnsafe {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+    #[subdiagnostic]
+    pub(crate) unsafe_not_inherited_note: Option<UnsafeNotInheritedNote>,
+}
+
+#[derive(Diagnostic)]
 #[diag(
     mir_build_initializing_type_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
     code = E0133
 )]
 #[note]
 pub(crate) struct InitializingTypeWithRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+    #[subdiagnostic]
+    pub(crate) unsafe_not_inherited_note: Option<UnsafeNotInheritedNote>,
+}
+
+#[derive(Diagnostic)]
+#[diag(
+    mir_build_initializing_type_with_target_feature_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
+    code = E0133
+)]
+#[note]
+pub(crate) struct InitializingTypeWithTargetFeatureRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
     #[label]
     pub(crate) span: Span,

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -672,6 +672,10 @@ passes_should_be_applied_to_fn =
         *[false] not a function definition
     }
 
+passes_should_be_applied_to_fn_or_unit_struct =
+    attribute should be applied to a function definition or unit struct
+    .label = not a function definition or a unit struct
+
 passes_should_be_applied_to_static =
     attribute should be applied to a static
     .label = not a static

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -746,12 +746,35 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             Target::Field | Target::Arm | Target::MacroDef => {
                 self.inline_attr_str_error_with_macro_def(hir_id, attr, "target_feature");
             }
+            Target::Struct if self.tcx.features().struct_target_features => {
+                let ty = self.tcx.hir_node(hir_id).expect_item();
+                match ty.kind {
+                    ItemKind::Struct(data, _) => {
+                        if data.fields().len() != 0 {
+                            self.dcx().emit_err(errors::AttrShouldBeAppliedToFnOrUnitStruct {
+                                attr_span: attr.span,
+                                defn_span: span,
+                            });
+                        }
+                    }
+                    _ => {
+                        panic!("Target::Struct for a non-struct");
+                    }
+                }
+            }
             _ => {
-                self.dcx().emit_err(errors::AttrShouldBeAppliedToFn {
-                    attr_span: attr.span,
-                    defn_span: span,
-                    on_crate: hir_id == CRATE_HIR_ID,
-                });
+                if self.tcx.features().struct_target_features {
+                    self.dcx().emit_err(errors::AttrShouldBeAppliedToFnOrUnitStruct {
+                        attr_span: attr.span,
+                        defn_span: span,
+                    });
+                } else {
+                    self.dcx().emit_err(errors::AttrShouldBeAppliedToFn {
+                        attr_span: attr.span,
+                        defn_span: span,
+                        on_crate: hir_id == CRATE_HIR_ID,
+                    });
+                }
             }
         }
     }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -83,6 +83,15 @@ pub struct AttrShouldBeAppliedToFn {
 }
 
 #[derive(Diagnostic)]
+#[diag(passes_should_be_applied_to_fn_or_unit_struct)]
+pub struct AttrShouldBeAppliedToFnOrUnitStruct {
+    #[primary_span]
+    pub attr_span: Span,
+    #[label]
+    pub defn_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(passes_should_be_applied_to_fn, code = E0739)]
 pub struct TrackedCallerWrongLocation {
     #[primary_span]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1852,6 +1852,7 @@ symbols! {
         stringify,
         struct_field_attributes,
         struct_inherit,
+        struct_target_features,
         struct_variant,
         structural_match,
         structural_peq,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -438,6 +438,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         let is_target_feature_fn = if let ty::FnDef(def_id, _) =
                             *leaf_trait_ref.skip_binder().self_ty().kind()
                         {
+                            // FIXME(struct_target_features): should a function that inherits
+                            // target_features through arguments implement Fn traits?
                             !self.tcx.codegen_fn_attrs(def_id).target_features.is_empty()
                         } else {
                             false

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -545,6 +545,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // Provide an impl for suitable functions, rejecting `#[target_feature]` functions (RFC 2396).
             ty::FnDef(def_id, args) => {
                 let tcx = self.tcx();
+                // FIXME(struct_target_features): should a function that inherits target_features
+                // through an argument implement Fn traits?
                 if tcx.fn_sig(def_id).skip_binder().is_fn_trait_compatible()
                     && tcx.codegen_fn_attrs(def_id).target_features.is_empty()
                 {

--- a/src/doc/unstable-book/src/language-features/struct-target-features.md
+++ b/src/doc/unstable-book/src/language-features/struct-target-features.md
@@ -1,0 +1,7 @@
+# `struct_target_features`
+
+The tracking issue for this feature is: [#129107]
+
+[#129107]: https://github.com/rust-lang/rust/issues/129107
+
+------------------------

--- a/tests/assembly/struct-target-features.rs
+++ b/tests/assembly/struct-target-features.rs
@@ -1,0 +1,37 @@
+//@ compile-flags: -O
+//@ assembly-output: emit-asm
+//@ only-x86_64
+
+#![crate_type = "lib"]
+#![feature(struct_target_features)]
+
+// Check that a struct_target_features type causes the compiler to effectively inline intrinsics.
+
+use std::arch::x86_64::*;
+
+#[target_feature(enable = "avx")]
+struct Avx {}
+
+#[target_feature(enable = "fma")]
+struct Fma {}
+
+pub fn add_simple(_: Avx, v: __m256) -> __m256 {
+    // CHECK-NOT: call
+    // CHECK: vaddps
+    unsafe { _mm256_add_ps(v, v) }
+}
+
+pub fn add_complex_type(_: (&Avx, ()), v: __m256) -> __m256 {
+    // CHECK-NOT: call
+    // CHECK: vaddps
+    unsafe { _mm256_add_ps(v, v) }
+}
+
+pub fn add_fma_combined(_: (&Avx, &Fma), v: __m256) -> (__m256, __m256) {
+    // CHECK-NOT: call
+    // CHECK-DAG: vaddps
+    let r1 = unsafe { _mm256_add_ps(v, v) };
+    // CHECK-DAG: vfmadd213ps
+    let r2 = unsafe { _mm256_fmadd_ps(v, v, v) };
+    (r1, r2)
+}

--- a/tests/ui/feature-gates/feature-gate-struct-target-features.rs
+++ b/tests/ui/feature-gates/feature-gate-struct-target-features.rs
@@ -1,0 +1,4 @@
+#[target_feature(enable = "avx")] //~ ERROR attribute should be applied to a function definition
+struct Avx {}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-struct-target-features.stderr
+++ b/tests/ui/feature-gates/feature-gate-struct-target-features.stderr
@@ -1,0 +1,10 @@
+error: attribute should be applied to a function definition
+  --> $DIR/feature-gate-struct-target-features.rs:1:1
+   |
+LL | #[target_feature(enable = "avx")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | struct Avx {}
+   | ------------- not a function definition
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/target-feature/struct-target-features.rs
+++ b/tests/ui/target-feature/struct-target-features.rs
@@ -1,0 +1,98 @@
+//@ only-x86_64
+#![feature(struct_target_features)]
+//~^ WARNING the feature `struct_target_features` is incomplete and may not be safe to use and/or cause compiler crashes
+#![feature(target_feature_11)]
+
+use std::arch::x86_64::*;
+
+#[target_feature(enable = "avx")]
+//~^ ERROR attribute should be applied to a function definition or unit struct
+struct Invalid(u32);
+
+#[target_feature(enable = "avx")]
+struct Avx {}
+
+#[target_feature(enable = "sse")]
+struct Sse();
+
+#[target_feature(enable = "avx")]
+fn avx() {}
+
+trait TFAssociatedType {
+    type Assoc;
+}
+
+impl TFAssociatedType for () {
+    type Assoc = Avx;
+}
+
+fn avx_self(_: <() as TFAssociatedType>::Assoc) {
+    avx();
+}
+
+fn avx_avx(_: Avx) {
+    avx();
+}
+
+extern "C" fn bad_fun(_: Avx) {}
+//~^ ERROR cannot use a struct with target features in a function with non-Rust ABI
+
+#[inline(always)]
+//~^ ERROR cannot use `#[inline(always)]` with `#[target_feature]`
+fn inline_fun(_: Avx) {}
+//~^ ERROR cannot use a struct with target features in a #[inline(always)] function
+
+trait Simd {
+    fn do_something(&self);
+}
+
+impl Simd for Avx {
+    fn do_something(&self) {
+        unsafe {
+            println!("{:?}", _mm256_setzero_ps());
+        }
+    }
+}
+
+impl Simd for Sse {
+    fn do_something(&self) {
+        unsafe {
+            println!("{:?}", _mm_setzero_ps());
+        }
+    }
+}
+
+struct WithAvx {
+    #[allow(dead_code)]
+    avx: Avx,
+}
+
+impl Simd for WithAvx {
+    fn do_something(&self) {
+        unsafe {
+            println!("{:?}", _mm256_setzero_ps());
+        }
+    }
+}
+
+#[inline(never)]
+fn dosomething<S: Simd>(simd: &S) {
+    simd.do_something();
+}
+
+fn avxfn(_: &Avx) {}
+
+fn main() {
+    Avx {};
+    //~^ ERROR initializing type with `target_feature` attr is unsafe and requires unsafe function or block [E0133]
+
+    if is_x86_feature_detected!("avx") {
+        let avx = unsafe { Avx {} };
+        avxfn(&avx);
+        dosomething(&avx);
+        dosomething(&WithAvx { avx });
+    }
+    if is_x86_feature_detected!("sse") {
+        dosomething(&unsafe { Sse {} })
+    }
+}

--- a/tests/ui/target-feature/struct-target-features.stderr
+++ b/tests/ui/target-feature/struct-target-features.stderr
@@ -1,0 +1,47 @@
+warning: the feature `struct_target_features` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/struct-target-features.rs:2:12
+   |
+LL | #![feature(struct_target_features)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #129107 <https://github.com/rust-lang/rust/issues/129107> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: attribute should be applied to a function definition or unit struct
+  --> $DIR/struct-target-features.rs:8:1
+   |
+LL | #[target_feature(enable = "avx")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | struct Invalid(u32);
+   | -------------------- not a function definition or a unit struct
+
+error: cannot use a struct with target features in a function with non-Rust ABI
+  --> $DIR/struct-target-features.rs:37:1
+   |
+LL | extern "C" fn bad_fun(_: Avx) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot use a struct with target features in a #[inline(always)] function
+  --> $DIR/struct-target-features.rs:42:1
+   |
+LL | fn inline_fun(_: Avx) {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot use `#[inline(always)]` with `#[target_feature]`
+  --> $DIR/struct-target-features.rs:40:1
+   |
+LL | #[inline(always)]
+   | ^^^^^^^^^^^^^^^^^
+
+error[E0133]: initializing type with `target_feature` attr is unsafe and requires unsafe function or block
+  --> $DIR/struct-target-features.rs:86:5
+   |
+LL |     Avx {};
+   |     ^^^^^^ initializing type with `target_feature` attr
+   |
+   = note: this struct can only be constructed if the corresponding `target_feature`s are available
+
+error: aborting due to 5 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR is an attempt at implementing https://github.com/rust-lang/rfcs/pull/3525, behind a feature gate `struct_target_features`.

There's obviously a few tasks that ought to be done before this is merged; in no particular order:
- add proper error messages
- add tests
- create a tracking issue for the RFC
- properly serialize/deserialize the new target_features field in `rmeta` (assuming I even understood that correctly :-))

That said, as I am definitely not a `rustc` expert, I'd like to get some early feedback on the overall approach before fixing those things (and perhaps some pointers for `rmeta`...), hence this early PR :-)

Here's an example piece of code that I have been using for testing - with the new code, the calls to intrinsics get correctly inlined:
```rust
#![feature(struct_target_features)]

use std::arch::x86_64::*;

/*
// fails to compile
#[target_feature(enable = "avx")]
struct Invalid(u32);
*/

#[target_feature(enable = "avx")]
struct Avx {}

#[target_feature(enable = "sse")]
struct Sse();

/*
// fails to compile
extern "C" fn bad_fun(_: Avx) {}
*/

/*
// fails to compile
#[inline(always)]
fn inline_fun(_: Avx) {}
*/

trait Simd {
    fn do_something(&self);
}

impl Simd for Avx {
    fn do_something(&self) {
        unsafe {
            println!("{:?}", _mm256_setzero_ps());
        }
    }
}

impl Simd for Sse {
    fn do_something(&self) {
        unsafe {
            println!("{:?}", _mm_setzero_ps());
        }
    }
}

struct WithAvx {
    #[allow(dead_code)]
    avx: Avx,
}

impl Simd for WithAvx {
    fn do_something(&self) {
        unsafe {
            println!("{:?}", _mm256_setzero_ps());
        }
    }
}

#[inline(never)]
fn dosomething<S: Simd>(simd: &S) {
    simd.do_something();
}

fn main() {
    /*
    // fails to compile
    Avx {};
    */

    if is_x86_feature_detected!("avx") {
        let avx = unsafe { Avx {} };
        dosomething(&avx);
        dosomething(&WithAvx { avx });
    }
    if is_x86_feature_detected!("sse") {
        dosomething(&unsafe { Sse {} })
    }
}
```

Tracking:

- https://github.com/rust-lang/rust/issues/129107