### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ If building LLVM from source, you'll need additional tools:
   [LLVM's documentation](https://llvm.org/docs/GettingStarted.html#host-c-toolchain-both-compiler-and-standard-library)
 * `ninja`, or GNU `make` 3.81 or later (Ninja is recommended, especially on
   Windows)
-* `cmake` 3.13.4 or later
+* `cmake` version listed on [LLVM's documentation](https://llvm.org/docs/GettingStarted.html#software)
 * `libstdc++-static` may be required on some Linux distributions such as Fedora
   and Ubuntu
 

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -439,6 +439,9 @@ lint_lintpass_by_hand = implementing `LintPass` by hand
 lint_macro_expanded_macro_exports_accessed_by_absolute_paths = macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
     .note = the macro is defined here
 
+lint_macro_expr_fragment_specifier_2024_migration =
+    the `expr` fragment specifier will accept more expressions in the 2024 edition
+    .suggestion = to keep the existing behavior, use the `expr_2021` fragment specifier
 lint_macro_is_private = macro `{$ident}` is private
 
 lint_macro_rule_never_used = rule #{$n} of macro `{$name}` is never used

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -60,6 +60,7 @@ mod late;
 mod let_underscore;
 mod levels;
 mod lints;
+mod macro_expr_fragment_specifier_2024_migration;
 mod map_unit_fn;
 mod methods;
 mod multiple_supertrait_upcastable;
@@ -97,6 +98,7 @@ use impl_trait_overcaptures::ImplTraitOvercaptures;
 use internal::*;
 use invalid_from_utf8::*;
 use let_underscore::*;
+use macro_expr_fragment_specifier_2024_migration::*;
 use map_unit_fn::*;
 use methods::*;
 use multiple_supertrait_upcastable::*;
@@ -170,6 +172,7 @@ early_lint_methods!(
             IncompleteInternalFeatures: IncompleteInternalFeatures,
             RedundantSemicolons: RedundantSemicolons,
             UnusedDocComment: UnusedDocComment,
+            Expr2024: Expr2024,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -317,6 +317,13 @@ pub struct BuiltinTypeAliasGenericBounds<'a, 'b> {
     pub sub: Option<SuggestChangingAssocTypes<'a, 'b>>,
 }
 
+#[derive(LintDiagnostic)]
+#[diag(lint_macro_expr_fragment_specifier_2024_migration)]
+pub struct MacroExprFragment2024 {
+    #[suggestion(code = "expr_2021", applicability = "machine-applicable")]
+    pub suggestion: Span,
+}
+
 pub struct BuiltinTypeAliasGenericBoundsSuggestion {
     pub suggestions: Vec<(Span, String)>,
 }

--- a/compiler/rustc_lint/src/macro_expr_fragment_specifier_2024_migration.rs
+++ b/compiler/rustc_lint/src/macro_expr_fragment_specifier_2024_migration.rs
@@ -1,0 +1,155 @@
+//! Migration code for the `expr_fragment_specifier_2024`
+//! rule.
+use tracing::debug;
+
+use rustc_ast::token::Token;
+use rustc_ast::token::TokenKind;
+use rustc_ast::tokenstream::TokenStream;
+use rustc_ast::tokenstream::TokenTree;
+use rustc_session::declare_lint;
+use rustc_session::declare_lint_pass;
+use rustc_session::lint::FutureIncompatibilityReason;
+use rustc_span::edition::Edition;
+use rustc_span::sym;
+
+use crate::lints::MacroExprFragment2024;
+use crate::EarlyLintPass;
+
+declare_lint! {
+    /// The `edition_2024_expr_fragment_specifier` lint detects the use of
+    /// `expr` fragments in macros during migration to the 2024 edition.
+    ///
+    /// The `expr` fragment specifier will accept more expressions in the 2024
+    /// edition. To maintain the behavior from the 2021 edition and earlier, use
+    /// the `expr_2021` fragment specifier.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,edition2021,compile_fail
+    /// #![deny(edition_2024_expr_fragment_specifier)]
+    /// macro_rules! m {
+    ///   ($e:expr) => {
+    ///       $e
+    ///   }
+    /// }
+    ///
+    /// fn main() {
+    ///    m!(1);
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Rust [editions] allow the language to evolve without breaking backwards
+    /// compatibility. This lint catches code that uses [macro matcher fragment
+    /// specifiers] that have changed meaning in the 2024 edition. If you switch
+    /// to the new edition without updating the code, your macros may behave
+    /// differently.
+    ///
+    /// In the 2024 edition, the `expr` fragment specifier `expr` will also
+    /// match `const { ... }` blocks. This means if a macro had a pattern that
+    /// matched `$e:expr` and another that matches `const { $e: expr }`, for
+    /// example, that under the 2024 edition the first pattern would match while
+    /// in the 2021 and earlier editions the second pattern would match. To keep
+    /// the old behavior, use the `expr_2021` fragment specifier.
+    ///
+    /// This lint detects macros whose behavior might change due to the changing
+    /// meaning of the `expr` fragment specifier. It is "allow" by default
+    /// because the code is perfectly valid in older editions. The [`cargo fix`]
+    /// tool with the `--edition` flag will switch this lint to "warn" and
+    /// automatically apply the suggested fix from the compiler. This provides a
+    /// completely automated way to update old code for a new edition.
+    ///
+    /// Using `cargo fix --edition` with this lint will ensure that your code
+    /// retains the same behavior. This may not be the desired, as macro authors
+    /// often will want their macros to use the latest grammar for matching
+    /// expressions. Be sure to carefully review changes introduced by this lint
+    /// to ensure the macros implement the desired behavior.
+    ///
+    /// [editions]: https://doc.rust-lang.org/edition-guide/
+    /// [macro matcher fragment specifiers]: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html
+    /// [`cargo fix`]: https://doc.rust-lang.org/cargo/commands/cargo-fix.html
+    pub EDITION_2024_EXPR_FRAGMENT_SPECIFIER,
+    Allow,
+    "The `expr` fragment specifier will accept more expressions in the 2024 edition. \
+    To keep the existing behavior, use the `expr_2021` fragment specifier.",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
+        reference: "Migration Guide <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html>",
+    };
+}
+
+declare_lint_pass!(Expr2024 => [EDITION_2024_EXPR_FRAGMENT_SPECIFIER,]);
+
+impl Expr2024 {
+    fn check_tokens(&mut self, cx: &crate::EarlyContext<'_>, tokens: &TokenStream) {
+        let mut prev_colon = false;
+        let mut prev_identifier = false;
+        let mut prev_dollar = false;
+        for tt in tokens.trees() {
+            debug!(
+                "check_tokens: {:?} - colon {prev_dollar} - ident {prev_identifier} - colon {prev_colon}",
+                tt
+            );
+            match tt {
+                TokenTree::Token(token, _) => match token.kind {
+                    TokenKind::Dollar => {
+                        prev_dollar = true;
+                        continue;
+                    }
+                    TokenKind::Ident(..) | TokenKind::NtIdent(..) => {
+                        if prev_colon && prev_identifier && prev_dollar {
+                            self.check_ident_token(cx, token);
+                        } else if prev_dollar {
+                            prev_identifier = true;
+                            continue;
+                        }
+                    }
+                    TokenKind::Colon => {
+                        if prev_dollar && prev_identifier {
+                            prev_colon = true;
+                            continue;
+                        }
+                    }
+                    _ => {}
+                },
+                TokenTree::Delimited(.., tts) => self.check_tokens(cx, tts),
+            }
+            prev_colon = false;
+            prev_identifier = false;
+            prev_dollar = false;
+        }
+    }
+
+    fn check_ident_token(&mut self, cx: &crate::EarlyContext<'_>, token: &Token) {
+        debug!("check_ident_token: {:?}", token);
+        let (sym, edition) = match token.kind {
+            TokenKind::Ident(sym, _) => (sym, Edition::Edition2024),
+            _ => return,
+        };
+
+        debug!("token.span.edition(): {:?}", token.span.edition());
+        if token.span.edition() >= edition {
+            return;
+        }
+
+        if sym != sym::expr {
+            return;
+        }
+
+        debug!("emitting lint");
+        cx.builder.emit_span_lint(
+            &EDITION_2024_EXPR_FRAGMENT_SPECIFIER,
+            token.span.into(),
+            MacroExprFragment2024 { suggestion: token.span },
+        );
+    }
+}
+
+impl EarlyLintPass for Expr2024 {
+    fn check_mac_def(&mut self, cx: &crate::EarlyContext<'_>, mc: &rustc_ast::MacroDef) {
+        self.check_tokens(cx, &mc.body.tokens);
+    }
+}

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -48,12 +48,20 @@ enum GoalEvaluationKind {
     Nested,
 }
 
+// FIXME(trait-system-refactor-initiative#117): we don't detect whether a response
+// ended up pulling down any universes.
 fn has_no_inference_or_external_constraints<I: Interner>(
     response: ty::Canonical<I, Response<I>>,
 ) -> bool {
-    response.value.external_constraints.region_constraints.is_empty()
-        && response.value.var_values.is_identity()
-        && response.value.external_constraints.opaque_types.is_empty()
+    let ExternalConstraintsData {
+        ref region_constraints,
+        ref opaque_types,
+        ref normalization_nested_goals,
+    } = *response.value.external_constraints;
+    response.value.var_values.is_identity()
+        && region_constraints.is_empty()
+        && opaque_types.is_empty()
+        && normalization_nested_goals.is_empty()
 }
 
 impl<'a, D, I> EvalCtxt<'a, D>

--- a/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
@@ -71,7 +71,7 @@ struct StackEntry<I: Interner> {
     /// C :- D
     /// D :- C
     /// ```
-    cycle_participants: HashSet<CanonicalInput<I>>,
+    nested_goals: HashSet<CanonicalInput<I>>,
     /// Starts out as `None` and gets set when rerunning this
     /// goal in case we encounter a cycle.
     provisional_result: Option<QueryResult<I>>,
@@ -215,8 +215,8 @@ impl<I: Interner> SearchGraph<I> {
         let current_cycle_root = &mut stack[current_root.as_usize()];
         for entry in cycle_participants {
             entry.non_root_cycle_participant = entry.non_root_cycle_participant.max(Some(head));
-            current_cycle_root.cycle_participants.insert(entry.input);
-            current_cycle_root.cycle_participants.extend(mem::take(&mut entry.cycle_participants));
+            current_cycle_root.nested_goals.insert(entry.input);
+            current_cycle_root.nested_goals.extend(mem::take(&mut entry.nested_goals));
         }
     }
 
@@ -335,7 +335,7 @@ impl<I: Interner> SearchGraph<I> {
                 non_root_cycle_participant: None,
                 encountered_overflow: false,
                 has_been_used: HasBeenUsed::empty(),
-                cycle_participants: Default::default(),
+                nested_goals: Default::default(),
                 provisional_result: None,
             };
             assert_eq!(self.stack.push(entry), depth);
@@ -389,7 +389,7 @@ impl<I: Interner> SearchGraph<I> {
             //
             // We must not use the global cache entry of a root goal if a cycle
             // participant is on the stack. This is necessary to prevent unstable
-            // results. See the comment of `StackEntry::cycle_participants` for
+            // results. See the comment of `StackEntry::nested_goals` for
             // more details.
             self.global_cache(cx).insert(
                 cx,
@@ -397,7 +397,7 @@ impl<I: Interner> SearchGraph<I> {
                 proof_tree,
                 reached_depth,
                 final_entry.encountered_overflow,
-                final_entry.cycle_participants,
+                final_entry.nested_goals,
                 dep_node,
                 result,
             )
@@ -544,27 +544,27 @@ impl<I: Interner> SearchGraph<I> {
                 non_root_cycle_participant,
                 encountered_overflow: _,
                 has_been_used,
-                ref cycle_participants,
+                ref nested_goals,
                 provisional_result,
             } = *entry;
             let cache_entry = provisional_cache.get(&entry.input).unwrap();
             assert_eq!(cache_entry.stack_depth, Some(depth));
             if let Some(head) = non_root_cycle_participant {
                 assert!(head < depth);
-                assert!(cycle_participants.is_empty());
+                assert!(nested_goals.is_empty());
                 assert_ne!(stack[head].has_been_used, HasBeenUsed::empty());
 
                 let mut current_root = head;
                 while let Some(parent) = stack[current_root].non_root_cycle_participant {
                     current_root = parent;
                 }
-                assert!(stack[current_root].cycle_participants.contains(&input));
+                assert!(stack[current_root].nested_goals.contains(&input));
             }
 
-            if !cycle_participants.is_empty() {
+            if !nested_goals.is_empty() {
                 assert!(provisional_result.is_some() || !has_been_used.is_empty());
                 for entry in stack.iter().take(depth.as_usize()) {
-                    assert_eq!(cycle_participants.get(&entry.input), None);
+                    assert_eq!(nested_goals.get(&entry.input), None);
                 }
             }
         }

--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -1008,7 +1008,14 @@ impl<'a> Iterator for Source<'a> {
         self.current = self.current.and_then(Error::source);
         current
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.current.is_some() { (1, None) } else { (0, Some(0)) }
+    }
 }
+
+#[unstable(feature = "error_iter", issue = "58520")]
+impl<'a> crate::iter::FusedIterator for Source<'a> {}
 
 #[stable(feature = "error_by_ref", since = "1.51.0")]
 impl<'a, T: Error + ?Sized> Error for &'a T {

--- a/src/doc/rustdoc/src/advanced-features.md
+++ b/src/doc/rustdoc/src/advanced-features.md
@@ -80,7 +80,8 @@ pub struct BigX;
 Then, when looking for it through the `rustdoc` search, if you enter "x" or
 "big", search will show the `BigX` struct first.
 
-There are some limitations on the doc alias names though: you can't use `"` or whitespace.
+There are some limitations on the doc alias names though: they cannot contain quotes (`'`, `"`)
+or most whitespace. ASCII space is allowed if it does not start or end the alias.
 
 You can add multiple aliases at the same time by using a list:
 

--- a/tests/ui/macros/expr_2021_cargo_fix_edition.fixed
+++ b/tests/ui/macros/expr_2021_cargo_fix_edition.fixed
@@ -1,0 +1,24 @@
+//@ run-rustfix
+//@ check-pass
+//@ compile-flags: --edition=2021
+#![allow(incomplete_features)]
+#![feature(expr_fragment_specifier_2024)]
+#![warn(edition_2024_expr_fragment_specifier)]
+
+macro_rules! m {
+    ($e:expr_2021) => { //~ WARN: the `expr` fragment specifier will accept more expressions in the 2024 edition
+       //~^ WARN: this changes meaning in Rust 2024
+        $e
+    };
+    ($($i:expr_2021)*) => { }; //~ WARN: the `expr` fragment specifier will accept more expressions in the 2024 edition
+       //~^ WARN: this changes meaning in Rust 2024
+}
+
+macro_rules! test {
+    (expr) => {}
+}
+
+fn main() {
+    m!(());
+    test!(expr);
+}

--- a/tests/ui/macros/expr_2021_cargo_fix_edition.rs
+++ b/tests/ui/macros/expr_2021_cargo_fix_edition.rs
@@ -1,0 +1,24 @@
+//@ run-rustfix
+//@ check-pass
+//@ compile-flags: --edition=2021
+#![allow(incomplete_features)]
+#![feature(expr_fragment_specifier_2024)]
+#![warn(edition_2024_expr_fragment_specifier)]
+
+macro_rules! m {
+    ($e:expr) => { //~ WARN: the `expr` fragment specifier will accept more expressions in the 2024 edition
+       //~^ WARN: this changes meaning in Rust 2024
+        $e
+    };
+    ($($i:expr)*) => { }; //~ WARN: the `expr` fragment specifier will accept more expressions in the 2024 edition
+       //~^ WARN: this changes meaning in Rust 2024
+}
+
+macro_rules! test {
+    (expr) => {}
+}
+
+fn main() {
+    m!(());
+    test!(expr);
+}

--- a/tests/ui/macros/expr_2021_cargo_fix_edition.stderr
+++ b/tests/ui/macros/expr_2021_cargo_fix_edition.stderr
@@ -1,0 +1,33 @@
+warning: the `expr` fragment specifier will accept more expressions in the 2024 edition
+  --> $DIR/expr_2021_cargo_fix_edition.rs:9:9
+   |
+LL |     ($e:expr) => {
+   |         ^^^^
+   |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see Migration Guide <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html>
+note: the lint level is defined here
+  --> $DIR/expr_2021_cargo_fix_edition.rs:6:9
+   |
+LL | #![warn(edition_2024_expr_fragment_specifier)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to keep the existing behavior, use the `expr_2021` fragment specifier
+   |
+LL |     ($e:expr_2021) => {
+   |         ~~~~~~~~~
+
+warning: the `expr` fragment specifier will accept more expressions in the 2024 edition
+  --> $DIR/expr_2021_cargo_fix_edition.rs:13:11
+   |
+LL |     ($($i:expr)*) => { };
+   |           ^^^^
+   |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see Migration Guide <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html>
+help: to keep the existing behavior, use the `expr_2021` fragment specifier
+   |
+LL |     ($($i:expr_2021)*) => { };
+   |           ~~~~~~~~~
+
+warning: 2 warnings emitted
+

--- a/tests/ui/macros/expr_2021_inline_const.edi2021.stderr
+++ b/tests/ui/macros/expr_2021_inline_const.edi2021.stderr
@@ -1,5 +1,5 @@
 error: no rules expected the token `const`
-  --> $DIR/expr_2021_inline_const.rs:21:12
+  --> $DIR/expr_2021_inline_const.rs:26:12
    |
 LL | macro_rules! m2021 {
    | ------------------ when calling this macro
@@ -14,7 +14,7 @@ LL |     ($e:expr_2021) => {
    |      ^^^^^^^^^^^^
 
 error: no rules expected the token `const`
-  --> $DIR/expr_2021_inline_const.rs:22:12
+  --> $DIR/expr_2021_inline_const.rs:27:12
    |
 LL | macro_rules! m2024 {
    | ------------------ when calling this macro

--- a/tests/ui/macros/expr_2021_inline_const.edi2024.stderr
+++ b/tests/ui/macros/expr_2021_inline_const.edi2024.stderr
@@ -1,5 +1,5 @@
 error: no rules expected the token `const`
-  --> $DIR/expr_2021_inline_const.rs:21:12
+  --> $DIR/expr_2021_inline_const.rs:26:12
    |
 LL | macro_rules! m2021 {
    | ------------------ when calling this macro

--- a/tests/ui/macros/expr_2021_inline_const.rs
+++ b/tests/ui/macros/expr_2021_inline_const.rs
@@ -17,7 +17,14 @@ macro_rules! m2024 {
         $e
     };
 }
+
+macro_rules! test {
+    (expr) => {}
+}
+
 fn main() {
     m2021!(const { 1 }); //~ ERROR: no rules expected the token `const`
     m2024!(const { 1 }); //[edi2021]~ ERROR: no rules expected the token `const`
+
+    test!(expr);
 }

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1051,7 +1051,6 @@ project-const-traits = [
 project-stable-mir = [
     "@celinval",
     "@oli-obk",
-    "@spastorino",
     "@ouz-a",
 ]
 


### PR DESCRIPTION
Successful merges:

 - #125627 (migration lint for `expr2024` for the edition 2024)
 - #127091 (impl FusedIterator and a size hint for the error sources iter)
 - #127484 (`#[doc(alias)]`'s doc: say that ASCII spaces are allowed)
 - #127508 (small search graph refactor)
 - #127521 (Remove spastorino from SMIR)
 - #127532 (documentation: update cmake version)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=125627,127091,127484,127508,127521,127532)
<!-- homu-ignore:end -->