### PR TITLE
 do not run test where it cannot run

### DIFF
--- a/library/alloc/src/slice/tests.rs
+++ b/library/alloc/src/slice/tests.rs
@@ -240,6 +240,7 @@ fn panic_safe() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
+#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_sort() {
     let mut rng = test_rng();
 


### PR DESCRIPTION
This was seen on Ferrocene, where we have a custom test target that does not have unwind support