### PR TITLE
Add a label to point to the lacking macro name definition

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1439,7 +1439,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         );
 
         if macro_kind == MacroKind::Bang && ident.name == sym::macro_rules {
-            err.subdiagnostic(MaybeMissingMacroRulesName { span: ident.span });
+            let label_span = ident.span.shrink_to_hi();
+            let mut spans = MultiSpan::from_span(label_span);
+            spans.push_span_label(label_span, "put a macro name here");
+            err.subdiagnostic(MaybeMissingMacroRulesName { spans: spans });
             return;
         }
 

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -667,7 +667,7 @@ pub(crate) struct MacroSuggMovePosition {
 #[note(resolve_missing_macro_rules_name)]
 pub(crate) struct MaybeMissingMacroRulesName {
     #[primary_span]
-    pub(crate) span: Span,
+    pub(crate) spans: MultiSpan,
 }
 
 #[derive(Subdiagnostic)]

--- a/tests/ui/macros/issue-118786.rs
+++ b/tests/ui/macros/issue-118786.rs
@@ -7,6 +7,7 @@ macro_rules! make_macro {
         macro_rules! $macro_name {
         //~^ ERROR macro expansion ignores token `{` and any following
         //~| ERROR cannot find macro `macro_rules` in this scope
+        //~| put a macro name here
             () => {}
         }
     }

--- a/tests/ui/macros/issue-118786.stderr
+++ b/tests/ui/macros/issue-118786.stderr
@@ -1,5 +1,5 @@
 error: macros that expand to items must be delimited with braces or followed by a semicolon
-  --> $DIR/issue-118786.rs:15:13
+  --> $DIR/issue-118786.rs:16:13
    |
 LL | make_macro!((meow));
    |             ^^^^^^
@@ -34,10 +34,10 @@ LL | make_macro!((meow));
    | ------------------- in this macro invocation
    |
 note: maybe you have forgotten to define a name for this `macro_rules!`
-  --> $DIR/issue-118786.rs:7:9
+  --> $DIR/issue-118786.rs:7:20
    |
 LL |         macro_rules! $macro_name {
-   |         ^^^^^^^^^^^
+   |                    ^ put a macro name here
 ...
 LL | make_macro!((meow));
    | ------------------- in this macro invocation

--- a/tests/ui/resolve/issue-118295.rs
+++ b/tests/ui/resolve/issue-118295.rs
@@ -1,5 +1,11 @@
 macro_rules! {}
 //~^ ERROR cannot find macro `macro_rules` in this scope
 //~| NOTE maybe you have forgotten to define a name for this `macro_rules!`
+//~| put a macro name here
+
+macro_rules!{}
+//~^ ERROR cannot find macro `macro_rules` in this scope
+//~| NOTE maybe you have forgotten to define a name for this `macro_rules!`
+//~| put a macro name here
 
 fn main() {}

--- a/tests/ui/resolve/issue-118295.stderr
+++ b/tests/ui/resolve/issue-118295.stderr
@@ -1,14 +1,26 @@
 error: cannot find macro `macro_rules` in this scope
+  --> $DIR/issue-118295.rs:6:1
+   |
+LL | macro_rules!{}
+   | ^^^^^^^^^^^
+   |
+note: maybe you have forgotten to define a name for this `macro_rules!`
+  --> $DIR/issue-118295.rs:6:12
+   |
+LL | macro_rules!{}
+   |            ^ put a macro name here
+
+error: cannot find macro `macro_rules` in this scope
   --> $DIR/issue-118295.rs:1:1
    |
 LL | macro_rules! {}
    | ^^^^^^^^^^^
    |
 note: maybe you have forgotten to define a name for this `macro_rules!`
-  --> $DIR/issue-118295.rs:1:1
+  --> $DIR/issue-118295.rs:1:12
    |
 LL | macro_rules! {}
-   | ^^^^^^^^^^^
+   |            ^ put a macro name here
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/126694, but adopts the suggestion from https://github.com/rust-lang/rust/issues/118295

```
 --> src/main.rs:1:14
  |
1 | macro_rules! {
  |            ^ put a macro name here
```