### PR TITLE
Fix local download of Docker caches from CI

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -93,7 +93,7 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
     docker --version
 
     REGISTRY=ghcr.io
-    REGISTRY_USERNAME=${GITHUB_REPOSITORY_OWNER}
+    REGISTRY_USERNAME=${GITHUB_REPOSITORY_OWNER:-rust-lang-ci}
     # Tag used to push the final Docker image, so that it can be pulled by e.g. rustup
     IMAGE_TAG=${REGISTRY}/${REGISTRY_USERNAME}/rust-ci:${cksum}
     # Tag used to cache the Docker build


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/127312 broke local downloads of Docker caches from CI, when you wanted to build a Docker image locally. This PR fixes that.

r? @nikic

(Can you please check if the cache works for you with this PR?)