### PR TITLE
core: Limit remaining f16 doctests to x86_64 linux

### DIFF
--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -353,12 +353,15 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
+    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
+    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
     ///
     /// let f = 7.0_f16;
     /// let g = -7.0_f16;
     ///
     /// assert!(f.is_sign_positive());
     /// assert!(!g.is_sign_positive());
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -376,12 +379,15 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
+    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
+    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
     ///
     /// let f = 7.0_f16;
     /// let g = -7.0_f16;
     ///
     /// assert!(!f.is_sign_negative());
     /// assert!(g.is_sign_negative());
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -694,9 +700,12 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
+    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
+    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
     ///
     /// let bytes = 12.5f16.to_be_bytes();
     /// assert_eq!(bytes, [0x4a, 0x40]);
+    /// # }
     /// ```
     #[inline]
     #[unstable(feature = "f16", issue = "116909")]
@@ -715,9 +724,12 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
+    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
+    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
     ///
     /// let bytes = 12.5f16.to_le_bytes();
     /// assert_eq!(bytes, [0x40, 0x4a]);
+    /// # }
     /// ```
     #[inline]
     #[unstable(feature = "f16", issue = "116909")]
@@ -742,6 +754,8 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
+    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
+    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
     ///
     /// let bytes = 12.5f16.to_ne_bytes();
     /// assert_eq!(
@@ -752,6 +766,7 @@ impl f16 {
     ///         [0x40, 0x4a]
     ///     }
     /// );
+    /// # }
     /// ```
     #[inline]
     #[unstable(feature = "f16", issue = "116909")]


### PR DESCRIPTION
On s390x, every use of the f16 data type will currently ICE due to https://github.com/llvm/llvm-project/issues/50374, causing doctest failures on the platform.

Most doctests were already restricted to certain platforms, so fix this by likewise restricting the remaining five.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
