### PR TITLE
Fix panic=abort tests on fuchsia

### DIFF
--- a/library/std/src/os/fuchsia/mod.rs
+++ b/library/std/src/os/fuchsia/mod.rs
@@ -3,4 +3,6 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod fs;
+#[unstable(feature = "fuchsia_exit_status", issue = "none")]
+pub mod process;
 pub mod raw;

--- a/library/std/src/os/fuchsia/process.rs
+++ b/library/std/src/os/fuchsia/process.rs
@@ -1,0 +1,52 @@
+//! Fuchsia-specific extensions to primitives in the [`std::process`] module.
+//!
+//! [`std::process`]: crate::process
+
+use crate::process;
+use crate::sealed::Sealed;
+
+#[unstable(feature = "fuchsia_exit_status", issue = "none")]
+pub type zx_status_t = i32;
+#[unstable(feature = "fuchsia_exit_status", issue = "none")]
+pub const ZX_TASK_RETCODE_SYSCALL_KILL: zx_status_t = -1024;
+#[unstable(feature = "fuchsia_exit_status", issue = "none")]
+pub const ZX_TASK_RETCODE_OOM_KILL: zx_status_t = -1025;
+#[unstable(feature = "fuchsia_exit_status", issue = "none")]
+pub const ZX_TASK_RETCODE_POLICY_KILL: zx_status_t = -1026;
+#[unstable(feature = "fuchsia_exit_status", issue = "none")]
+pub const ZX_TASK_RETCODE_VDSO_KILL: zx_status_t = -1027;
+/// On Zircon (the Fuchsia kernel), an abort from userspace calls the
+/// LLVM implementation of __builtin_trap(), e.g., ud2 on x86, which
+/// raises a kernel exception. If a userspace process does not
+/// otherwise arrange exception handling, the kernel kills the process
+/// with this return code.
+#[unstable(feature = "fuchsia_exit_status", issue = "none")]
+pub const ZX_TASK_RETCODE_EXCEPTION_KILL: zx_status_t = -1028;
+#[unstable(feature = "fuchsia_exit_status", issue = "none")]
+pub const ZX_TASK_RETCODE_CRITICAL_PROCESS_KILL: zx_status_t = -1029;
+
+#[unstable(feature = "fuchsia_exit_status", issue = "none")]
+pub trait ExitStatusExt: Sealed {
+    /// If the task was killed, returns the `ZX_TASK_RETCODE_*`.
+    #[must_use]
+    fn task_retcode(&self) -> Option<i32>;
+}
+
+#[unstable(feature = "fuchsia_exit_status", issue = "none")]
+impl ExitStatusExt for process::ExitStatus {
+    fn task_retcode(&self) -> Option<i32> {
+        self.code().and_then(|code| {
+            if code == ZX_TASK_RETCODE_SYSCALL_KILL
+                || code == ZX_TASK_RETCODE_OOM_KILL
+                || code == ZX_TASK_RETCODE_POLICY_KILL
+                || code == ZX_TASK_RETCODE_VDSO_KILL
+                || code == ZX_TASK_RETCODE_EXCEPTION_KILL
+                || code == ZX_TASK_RETCODE_CRITICAL_PROCESS_KILL
+            {
+                Some(code)
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -23,6 +23,7 @@
 #![feature(process_exitcode_internals)]
 #![feature(panic_can_unwind)]
 #![feature(test)]
+#![cfg_attr(target_os = "fuchsia", feature(fuchsia_exit_status))]
 #![allow(internal_features)]
 
 // Public reexports

--- a/tests/ui/process/signal-exit-status.rs
+++ b/tests/ui/process/signal-exit-status.rs
@@ -2,12 +2,15 @@
 //@ ignore-wasm32 no processes
 //@ ignore-sgx no processes
 //@ ignore-windows
-//@ ignore-fuchsia code returned as ZX_TASK_RETCODE_EXCEPTION_KILL, FIXME (#58590)
 
 #![feature(core_intrinsics)]
+#![cfg_attr(target_os = "fuchsia", feature(fuchsia_exit_status))]
 
 use std::env;
 use std::process::Command;
+
+#[cfg(target_os = "fuchsia")]
+use std::os::fuchsia::process::{ExitStatusExt, ZX_TASK_RETCODE_EXCEPTION_KILL};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();
@@ -15,7 +18,18 @@ pub fn main() {
         // Raise an aborting signal without UB
         core::intrinsics::abort();
     } else {
+        // Spawn a child process that will raise an aborting signal
         let status = Command::new(&args[0]).arg("signal").status().unwrap();
+
+        #[cfg(not(target_os = "fuchsia"))]
         assert!(status.code().is_none());
+
+        // Upon abort(), a Fuchsia process will trigger a kernel exception
+        // that, if uncaught, will cause the kernel to kill the process with
+        // ZX_TASK_RETCODE_EXCEPTION_KILL. The same code could be
+        // returned for a different unhandled exception, but the simplicity of
+        // the program under test makes such an exception unlikely.
+        #[cfg(target_os = "fuchsia")]
+        assert_eq!(Some(ZX_TASK_RETCODE_EXCEPTION_KILL), status.task_retcode());
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/127595)*
<!-- homu-ignore:end -->

This PR goes one step further than rust-lang/rust#127594 by adding an unstable feature to make determining whether a Fuchsia process aborted more robust. There is certainly more work that needs to go in to landing the unstable feature, but I'm drafting this PR as a means to convey intent for the feature to survey others' thoughts.

r​? @tmandry 
