### PR TITLE
Build sysroot when testing GCC backend

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3461,7 +3461,9 @@ impl Step for CodegenGCC {
             .arg("--out-dir")
             .arg(builder.stage_out(compiler, Mode::ToolRustc).join("cg_gcc"))
             .arg("--release")
+            .arg("--build-sysroot")
             .arg("--mini-tests")
+            .arg("--test-libcore")
             .arg("--std-tests");
         cargo.args(builder.config.test_args());
 


### PR DESCRIPTION
The goal is to catch a lot of bugs before we need to sync the GCC backend with the rust compiler.

r? ghost