### PR TITLE
Lower timeout of CI jobs to 4 hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     defaults:
       run:
         shell: ${{ contains(matrix.os, 'windows') && 'msys2 {0}' || 'bash' }}
-    timeout-minutes: 600
+    timeout-minutes: 240
     env:
       CI_JOB_NAME: ${{ matrix.image }}
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse


### PR DESCRIPTION
The previous value, 10 hours, is unnecessarily long, since most of our jobs finish within 2.5 hours currently. This could help us detect abnormally long CI runs.

r? @pietroalbini