### PR TITLE
Rename the internal `const_strlen` to just `strlen`

### DIFF
--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -282,7 +282,7 @@ impl CStr {
     pub const unsafe fn from_ptr<'a>(ptr: *const c_char) -> &'a CStr {
         // SAFETY: The caller has provided a pointer that points to a valid C
         // string with a NUL terminator less than `isize::MAX` from `ptr`.
-        let len = unsafe { const_strlen(ptr) };
+        let len = unsafe { strlen(ptr) };
 
         // SAFETY: The caller has provided a valid pointer with length less than
         // `isize::MAX`, so `from_raw_parts` is safe. The content remains valid
@@ -743,7 +743,7 @@ impl AsRef<CStr> for CStr {
 #[unstable(feature = "cstr_internals", issue = "none")]
 #[rustc_const_stable(feature = "const_cstr_from_ptr", since = "CURRENT_RUSTC_VERSION")]
 #[rustc_allow_const_fn_unstable(const_eval_select)]
-const unsafe fn const_strlen(ptr: *const c_char) -> usize {
+const unsafe fn strlen(ptr: *const c_char) -> usize {
     const fn strlen_ct(s: *const c_char) -> usize {
         let mut len = 0;
 


### PR DESCRIPTION
Since the libs and lang teams completed an FCP to allow for const `strlen` ([1]), currently implemented with `const_eval_select`, there is no longer any reason to avoid this specific function or use it only in const.

Rename it to reflect this status change.

[1]: https://github.com/rust-lang/rust/issues/113219#issuecomment-2016939401

<!-- homu-ignore:start -->
Discussed at https://github.com/rust-lang/rust/pull/127433#discussion_r1674807047 / https://github.com/rust-lang/rust/pull/127444#discussion_r1676264205

r? @dtolnay 
<!-- homu-ignore:end -->
