### PR TITLE
Fix precise capturing suggestion for hidden regions when we have APITs

### DIFF
--- a/compiler/rustc_infer/messages.ftl
+++ b/compiler/rustc_infer/messages.ftl
@@ -225,6 +225,8 @@ infer_outlives_content = lifetime of reference outlives lifetime of borrowed con
 infer_precise_capturing_existing = add `{$new_lifetime}` to the `use<...>` bound to explicitly capture it
 infer_precise_capturing_new = add a `use<...>` bound to explicitly capture `{$new_lifetime}`
 
+infer_precise_capturing_new_but_apit = add a `use<...>` bound to explicitly capture `{$new_lifetime}` after turning all argument-position `impl Trait` into type parameters, noting that this possibly affects the API of this crate
+
 infer_prlf_defined_with_sub = the lifetime `{$sub_symbol}` defined here...
 infer_prlf_defined_without_sub = the lifetime defined here...
 infer_prlf_known_limitation = this is a known limitation that will be removed in the future (see issue #100013 <https://github.com/rust-lang/rust/issues/100013> for more information)
@@ -387,6 +389,9 @@ infer_type_annotations_needed = {$source_kind ->
     .label = type must be known at this point
 
 infer_types_declared_different = these two types are declared with different lifetimes...
+
+infer_warn_removing_apit_params = you could use a `use<...>` bound to explicitly capture `{$new_lifetime}`, but argument-position `impl Trait`s are not nameable
+
 infer_where_copy_predicates = copy the `where` clause predicates from the trait
 
 infer_where_remove = remove the `where` clause

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -1609,3 +1609,25 @@ pub enum AddPreciseCapturing {
         post: &'static str,
     },
 }
+
+pub struct AddPreciseCapturingAndParams {
+    pub suggs: Vec<(Span, String)>,
+    pub new_lifetime: Symbol,
+    pub apit_spans: Vec<Span>,
+}
+
+impl Subdiagnostic for AddPreciseCapturingAndParams {
+    fn add_to_diag_with<G: EmissionGuarantee, F: SubdiagMessageOp<G>>(
+        self,
+        diag: &mut Diag<'_, G>,
+        _f: &F,
+    ) {
+        diag.arg("new_lifetime", self.new_lifetime);
+        diag.multipart_suggestion_verbose(
+            fluent::infer_precise_capturing_new_but_apit,
+            self.suggs,
+            Applicability::MaybeIncorrect,
+        );
+        diag.span_note(self.apit_spans, fluent::infer_warn_removing_apit_params);
+    }
+}

--- a/tests/ui/impl-trait/precise-capturing/hidden-type-suggestion.rs
+++ b/tests/ui/impl-trait/precise-capturing/hidden-type-suggestion.rs
@@ -27,4 +27,16 @@ fn missing<'a, 'captured, 'not_captured, Captured>(x: &'a ()) -> impl Captures<'
 //~^ ERROR hidden type for
 }
 
+fn no_params_yet(_: impl Sized, y: &()) -> impl Sized {
+//~^ HELP add a `use<...>` bound
+    y
+//~^ ERROR hidden type for
+}
+
+fn yes_params_yet<'a, T>(_: impl Sized, y: &'a ()) -> impl Sized {
+//~^ HELP add a `use<...>` bound
+    y
+//~^ ERROR hidden type for
+}
+
 fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/hidden-type-suggestion.stderr
+++ b/tests/ui/impl-trait/precise-capturing/hidden-type-suggestion.stderr
@@ -62,6 +62,48 @@ help: add a `use<...>` bound to explicitly capture `'a`
 LL | fn missing<'a, 'captured, 'not_captured, Captured>(x: &'a ()) -> impl Captures<'captured> + use<'captured, 'a, Captured> {
    |                                                                                           ++++++++++++++++++++++++++++++
 
-error: aborting due to 4 previous errors
+error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
+  --> $DIR/hidden-type-suggestion.rs:32:5
+   |
+LL | fn no_params_yet(_: impl Sized, y: &()) -> impl Sized {
+   |                                    ---     ---------- opaque type defined here
+   |                                    |
+   |                                    hidden type `&()` captures the anonymous lifetime defined here
+LL |
+LL |     y
+   |     ^
+   |
+note: you could use a `use<...>` bound to explicitly capture `'_`, but argument-position `impl Trait`s are not nameable
+  --> $DIR/hidden-type-suggestion.rs:30:21
+   |
+LL | fn no_params_yet(_: impl Sized, y: &()) -> impl Sized {
+   |                     ^^^^^^^^^^
+help: add a `use<...>` bound to explicitly capture `'_` after turning all argument-position `impl Trait` into type parameters, noting that this possibly affects the API of this crate
+   |
+LL | fn no_params_yet<T: Sized>(_: T, y: &()) -> impl Sized + use<'_, T> {
+   |                 ++++++++++    ~                        ++++++++++++
+
+error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
+  --> $DIR/hidden-type-suggestion.rs:38:5
+   |
+LL | fn yes_params_yet<'a, T>(_: impl Sized, y: &'a ()) -> impl Sized {
+   |                   --                                  ---------- opaque type defined here
+   |                   |
+   |                   hidden type `&'a ()` captures the lifetime `'a` as defined here
+LL |
+LL |     y
+   |     ^
+   |
+note: you could use a `use<...>` bound to explicitly capture `'a`, but argument-position `impl Trait`s are not nameable
+  --> $DIR/hidden-type-suggestion.rs:36:29
+   |
+LL | fn yes_params_yet<'a, T>(_: impl Sized, y: &'a ()) -> impl Sized {
+   |                             ^^^^^^^^^^
+help: add a `use<...>` bound to explicitly capture `'a` after turning all argument-position `impl Trait` into type parameters, noting that this possibly affects the API of this crate
+   |
+LL | fn yes_params_yet<'a, T, U: Sized>(_: U, y: &'a ()) -> impl Sized + use<'a, T, U> {
+   |                        ++++++++++     ~                           +++++++++++++++
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0700`.


### PR DESCRIPTION
Suggests to turn APITs into type parameters so they can be named in precise capturing syntax for hidden type lifetime errors. We also note that it may change the API.

This is currently done via a note *and* a suggestion, which feels a bit redundant, but I wasn't totally sure of a better alternative for the presentation.

Code is kind of a mess but there's a lot of cases to consider. Happy to iterate on this if you think the approach is too messy.

Based on #127619, only the last commit is relevant.
r? oli-obk

Tracking:

- https://github.com/rust-lang/rust/issues/123432