### PR TITLE
bootstrap: fully rely on RUSTC_WRAPPER

### DIFF
--- a/compiler/rustc_codegen_cranelift/Cargo.lock
+++ b/compiler/rustc_codegen_cranelift/Cargo.lock
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"

--- a/compiler/rustc_codegen_gcc/Cargo.lock
+++ b/compiler/rustc_codegen_gcc/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "memchr"

--- a/src/bootstrap/src/bin/rustc.rs
+++ b/src/bootstrap/src/bin/rustc.rs
@@ -75,7 +75,8 @@ fn main() {
             args.drain(..2);
             rustc_real
         } else {
-            // The first param is the clippy-driver we should call.
+            // The first param is the clippy-driver we should call. The 2nd param is the dummy rustc.
+            args.remove(1);
             args.remove(0)
         }
     } else {

--- a/src/bootstrap/src/bin/rustc.rs
+++ b/src/bootstrap/src/bin/rustc.rs
@@ -16,7 +16,7 @@
 //! never get replaced.
 
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::time::Instant;
 
@@ -75,17 +75,12 @@ fn main() {
             args.drain(..2);
             rustc_real
         } else {
+            // The first param is the clippy-driver we should call.
             args.remove(0)
         }
     } else {
-        // Cargo doesn't respect RUSTC_WRAPPER for version information >:(
-        // don't remove the first arg if we're being run as RUSTC instead of RUSTC_WRAPPER.
-        // Cargo also sometimes doesn't pass the `.exe` suffix on Windows - add it manually.
-        let current_exe = env::current_exe().expect("couldn't get path to rustc shim");
-        let arg0 = exe(args[0].to_str().expect("only utf8 paths are supported"), &host);
-        if Path::new(&arg0) == current_exe {
-            args.remove(0);
-        }
+        // We are RUSTC_WRAPPER; remove the dummy rustc invocation we wrap.
+        args.remove(0);
         rustc_real
     };
 

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1845,8 +1845,8 @@ impl<'a> Builder<'a> {
         // NOTE: we intentionally use RUSTC_WRAPPER so that we can support clippy - RUSTC is not
         // respected by clippy-driver; RUSTC_WRAPPER happens earlier, before clippy runs.
         cargo.env("RUSTC_WRAPPER", self.bootstrap_out.join("rustc"));
-        // NOTE: we also need to set RUSTC so cargo can run `rustc -vV`; apparently that ignores RUSTC_WRAPPER >:(
-        cargo.env("RUSTC", self.bootstrap_out.join("rustc"));
+        // Set RUSTC to a non-existent path: it should never be called, since we always invoke the wrapper!
+        cargo.env("RUSTC", "/path/to/nowhere/all-rustc-calls-should-go-through-the-wrapper");
 
         // Someone might have set some previous rustc wrapper (e.g.
         // sccache) before bootstrap overrode it. Respect that variable.

--- a/src/tools/rust-analyzer/Cargo.lock
+++ b/src/tools/rust-analyzer/Cargo.lock
@@ -898,9 +898,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/build.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/build.rs
@@ -7,7 +7,14 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(rust_analyzer)");
 
     let rustc = env::var("RUSTC").expect("proc-macro-srv's build script expects RUSTC to be set");
-    let output = Command::new(rustc).arg("--version").output().expect("rustc --version must run");
+    let mut cmd = if let Some(wrapper) = env::var_os("RUSTC_WRAPPER").filter(|w| !w.is_empty()) {
+        let mut cmd = Command::new(wrapper);
+        cmd.arg(rustc);
+        cmd
+    } else {
+        Command::new(rustc)
+    };
+    let output = cmd.arg("--version").output().expect("rustc --version must run");
     let version_string = std::str::from_utf8(&output.stdout[..])
         .expect("rustc --version output must be UTF-8")
         .trim();


### PR DESCRIPTION
With https://github.com/rust-lang/cargo/pull/13659, cargo now respects RUSTC_WRAPPER for all rustc invocations. That means we can finally remove the hack where we set our wrapper as both RUSTC and RUSTC_WRAPPER.

There could still be build scripts that fail to respect RUSTC_WRAPPER, but then we should fix those before they become a rustc dependency.

Fixes https://github.com/rust-lang/rust/issues/128383