### PR TITLE
Fix minor typos in std::process doc on Win argv

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -96,9 +96,9 @@
 //! child processes must agree on how the commandline string is encoded.
 //!
 //! Most programs use the standard C run-time `argv`, which in practice results
-//! in consistent argument handling. However some programs have their own way of
+//! in consistent argument handling. However, some programs have their own way of
 //! parsing the commandline string. In these cases using [`arg`] or [`args`] may
-//! result in the child process seeing a different array of arguments then the
+//! result in the child process seeing a different array of arguments than the
 //! parent process intended.
 //!
 //! Two ways of mitigating this are:


### PR DESCRIPTION
<!-- homu-ignore:start -->

Closes rust-lang/rust#127688

<!-- homu-ignore:end -->