### PR TITLE
clarify the meaning of the version number for accepted/removed features

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -42,6 +42,10 @@ declare_features! (
     // feature-group-start: accepted features
     // -------------------------------------------------------------------------
 
+    // Note that the version indicates when it got *stabilized*.
+    // When moving an unstable feature here, set the version number to
+    // `CURRENT RUSTC VERSION` with ` ` replaced by `_`.
+
     /// Allows `#[target_feature(...)]` on aarch64 platforms
     (accepted, aarch64_target_feature, "1.61.0", Some(44839)),
     /// Allows using the `efiapi` ABI.

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -31,6 +31,10 @@ use std::num::NonZero;
 #[derive(Debug, Clone)]
 pub struct Feature {
     pub name: Symbol,
+    /// For unstable features: the version the feature was added in.
+    /// For accepted features: the version the feature got stabilized in.
+    /// For removed features we are inconsistent; sometimes this is the
+    /// version it got added, sometimes the version it got removed.
     pub since: &'static str,
     issue: Option<NonZero<u32>>,
 }

--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -32,6 +32,12 @@ declare_features! (
     // feature-group-start: removed features
     // -------------------------------------------------------------------------
 
+    // Note that the version indicates when it got *removed*.
+    // When moving an unstable feature here, set the version number to
+    // `CURRENT RUSTC VERSION` with ` ` replaced by `_`.
+    // (But not all features below do this properly; many indicate the
+    // version they got originally added in.)
+
     /// Allows using the `amdgpu-kernel` ABI.
     (removed, abi_amdgpu_kernel, "1.77.0", Some(51575), None),
     (removed, advanced_slice_patterns, "1.0.0", Some(62254),


### PR DESCRIPTION
For accepted features this is pretty clear, we even use the version number in the warning that says "feature has been stabilized, please remove feature gate".

For removed features we are inconsistent. [This PR](https://github.com/rust-lang/rust/commit/8cece636b22620717d6e242ec20fa8d5cf979072#diff-a82bdbaaa3c79096a30755dce8896aaf2885128a7f3f3a290072b767f05b6095) set the version to when it got removed, but [here](https://github.com/rust-lang/rust/pull/116958/files#diff-1ff08f89ad7e972538827e989fa63732c5918b4d0216ccd921de08698d6e18ca) they just got copied over so the version says when the feature was originally added. As far as I can tell, this version number is not actually used anywhere in user-visible diagnostics.