### PR TITLE
Windows: Remove some unnecessary type aliases

### DIFF
--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -385,29 +385,25 @@ fn test_interior_nul_in_env_value_is_error() {
 #[cfg(windows)]
 fn test_creation_flags() {
     use crate::os::windows::process::CommandExt;
-    use crate::sys::c::{BOOL, DWORD, INFINITE};
+    use crate::sys::c::{BOOL, INFINITE};
     #[repr(C)]
     struct DEBUG_EVENT {
-        pub event_code: DWORD,
-        pub process_id: DWORD,
-        pub thread_id: DWORD,
+        pub event_code: u32,
+        pub process_id: u32,
+        pub thread_id: u32,
         // This is a union in the real struct, but we don't
         // need this data for the purposes of this test.
         pub _junk: [u8; 164],
     }
 
     extern "system" {
-        fn WaitForDebugEvent(lpDebugEvent: *mut DEBUG_EVENT, dwMilliseconds: DWORD) -> BOOL;
-        fn ContinueDebugEvent(
-            dwProcessId: DWORD,
-            dwThreadId: DWORD,
-            dwContinueStatus: DWORD,
-        ) -> BOOL;
+        fn WaitForDebugEvent(lpDebugEvent: *mut DEBUG_EVENT, dwMilliseconds: u32) -> BOOL;
+        fn ContinueDebugEvent(dwProcessId: u32, dwThreadId: u32, dwContinueStatus: u32) -> BOOL;
     }
 
-    const DEBUG_PROCESS: DWORD = 1;
-    const EXIT_PROCESS_DEBUG_EVENT: DWORD = 5;
-    const DBG_EXCEPTION_NOT_HANDLED: DWORD = 0x80010001;
+    const DEBUG_PROCESS: u32 = 1;
+    const EXIT_PROCESS_DEBUG_EVENT: u32 = 5;
+    const DBG_EXCEPTION_NOT_HANDLED: u32 = 0x80010001;
 
     let mut child =
         Command::new("cmd").creation_flags(DEBUG_PROCESS).stdin(Stdio::piped()).spawn().unwrap();

--- a/library/std/src/sys/pal/windows/alloc.rs
+++ b/library/std/src/sys/pal/windows/alloc.rs
@@ -15,7 +15,7 @@ mod tests;
 // See https://docs.microsoft.com/windows/win32/api/heapapi/
 
 // Flag to indicate that the memory returned by `HeapAlloc` should be zeroed.
-const HEAP_ZERO_MEMORY: c::DWORD = 0x00000008;
+const HEAP_ZERO_MEMORY: u32 = 0x00000008;
 
 // Get a handle to the default heap of the current process, or null if the operation fails.
 //
@@ -113,7 +113,7 @@ fn init_or_get_process_heap() -> c::HANDLE {
 #[cold]
 extern "C" fn process_heap_init_and_alloc(
     _heap: MaybeUninit<c::HANDLE>, // We pass this argument to match the ABI of `HeapAlloc`
-    flags: c::DWORD,
+    flags: u32,
     dwBytes: usize,
 ) -> *mut c_void {
     let heap = init_or_get_process_heap();
@@ -127,7 +127,7 @@ extern "C" fn process_heap_init_and_alloc(
 #[inline(never)]
 fn process_heap_alloc(
     _heap: MaybeUninit<c::HANDLE>, // We pass this argument to match the ABI of `HeapAlloc`,
-    flags: c::DWORD,
+    flags: u32,
     dwBytes: usize,
 ) -> *mut c_void {
     let heap = HEAP.load(Ordering::Relaxed);

--- a/library/std/src/sys/pal/windows/alloc.rs
+++ b/library/std/src/sys/pal/windows/alloc.rs
@@ -114,7 +114,7 @@ fn init_or_get_process_heap() -> c::HANDLE {
 extern "C" fn process_heap_init_and_alloc(
     _heap: MaybeUninit<c::HANDLE>, // We pass this argument to match the ABI of `HeapAlloc`
     flags: c::DWORD,
-    dwBytes: c::SIZE_T,
+    dwBytes: usize,
 ) -> c::LPVOID {
     let heap = init_or_get_process_heap();
     if core::intrinsics::unlikely(heap.is_null()) {
@@ -128,7 +128,7 @@ extern "C" fn process_heap_init_and_alloc(
 fn process_heap_alloc(
     _heap: MaybeUninit<c::HANDLE>, // We pass this argument to match the ABI of `HeapAlloc`,
     flags: c::DWORD,
-    dwBytes: c::SIZE_T,
+    dwBytes: usize,
 ) -> c::LPVOID {
     let heap = HEAP.load(Ordering::Relaxed);
     if core::intrinsics::likely(!heap.is_null()) {

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -19,7 +19,6 @@ pub use windows_sys::*;
 
 pub type DWORD = c_ulong;
 pub type WCHAR = u16;
-pub type SIZE_T = usize;
 pub type ULONG = c_ulong;
 
 pub type LPCVOID = *const c_void;

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -21,8 +21,6 @@ pub type DWORD = c_ulong;
 pub type WCHAR = u16;
 pub type ULONG = c_ulong;
 
-pub type LPVOID = *mut c_void;
-
 #[cfg(target_vendor = "win7")]
 pub type PSRWLOCK = *mut SRWLOCK;
 
@@ -390,7 +388,7 @@ compat_fn_with_fallback! {
     pub fn NtCreateKeyedEvent(
         KeyedEventHandle: *mut HANDLE,
         DesiredAccess: DWORD,
-        ObjectAttributes: LPVOID,
+        ObjectAttributes: *mut c_void,
         Flags: ULONG
     ) -> NTSTATUS {
         panic!("keyed events not available")
@@ -398,7 +396,7 @@ compat_fn_with_fallback! {
     #[cfg(target_vendor = "win7")]
     pub fn NtReleaseKeyedEvent(
         EventHandle: HANDLE,
-        Key: LPVOID,
+        Key: *mut c_void,
         Alertable: BOOLEAN,
         Timeout: *mut c_longlong
     ) -> NTSTATUS {
@@ -407,7 +405,7 @@ compat_fn_with_fallback! {
     #[cfg(target_vendor = "win7")]
     pub fn NtWaitForKeyedEvent(
         EventHandle: HANDLE,
-        Key: LPVOID,
+        Key: *mut c_void,
         Alertable: BOOLEAN,
         Timeout: *mut c_longlong
     ) -> NTSTATUS {

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -20,7 +20,6 @@ pub use windows_sys::*;
 pub type DWORD = c_ulong;
 pub type WCHAR = u16;
 pub type SIZE_T = usize;
-pub type CHAR = c_char;
 pub type ULONG = c_ulong;
 
 pub type LPCVOID = *const c_void;
@@ -142,9 +141,9 @@ pub struct MOUNT_POINT_REPARSE_BUFFER {
 #[repr(C)]
 pub struct SOCKADDR_STORAGE_LH {
     pub ss_family: ADDRESS_FAMILY,
-    pub __ss_pad1: [CHAR; 6],
+    pub __ss_pad1: [c_char; 6],
     pub __ss_align: i64,
-    pub __ss_pad2: [CHAR; 112],
+    pub __ss_pad2: [c_char; 112],
 }
 
 #[repr(C)]
@@ -153,7 +152,7 @@ pub struct sockaddr_in {
     pub sin_family: ADDRESS_FAMILY,
     pub sin_port: c_ushort,
     pub sin_addr: in_addr,
-    pub sin_zero: [CHAR; 8],
+    pub sin_zero: [c_char; 8],
 }
 
 #[repr(C)]

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -7,8 +7,7 @@
 
 use crate::ffi::CStr;
 use crate::mem;
-pub use crate::os::raw::c_int;
-use crate::os::raw::{c_char, c_uint, c_ulong, c_ushort, c_void};
+use crate::os::raw::{c_char, c_int, c_uint, c_ulong, c_ushort, c_void};
 use crate::os::windows::io::{AsRawHandle, BorrowedHandle};
 use crate::ptr;
 

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -8,7 +8,7 @@
 use crate::ffi::CStr;
 use crate::mem;
 pub use crate::os::raw::c_int;
-use crate::os::raw::{c_char, c_long, c_longlong, c_uint, c_ulong, c_ushort, c_void};
+use crate::os::raw::{c_char, c_long, c_uint, c_ulong, c_ushort, c_void};
 use crate::os::windows::io::{AsRawHandle, BorrowedHandle};
 use crate::ptr;
 
@@ -18,7 +18,6 @@ mod windows_sys;
 pub use windows_sys::*;
 
 pub type DWORD = c_ulong;
-pub type LARGE_INTEGER = c_longlong;
 #[cfg_attr(target_vendor = "uwp", allow(unused))]
 pub type LONG = c_long;
 pub type UINT = c_uint;
@@ -270,7 +269,7 @@ pub unsafe fn NtReadFile(
     iostatusblock: &mut IO_STATUS_BLOCK,
     buffer: *mut crate::mem::MaybeUninit<u8>,
     length: ULONG,
-    byteoffset: Option<&LARGE_INTEGER>,
+    byteoffset: Option<&i64>,
     key: Option<&ULONG>,
 ) -> NTSTATUS {
     windows_sys::NtReadFile(
@@ -293,7 +292,7 @@ pub unsafe fn NtWriteFile(
     iostatusblock: &mut IO_STATUS_BLOCK,
     buffer: *const u8,
     length: ULONG,
-    byteoffset: Option<&LARGE_INTEGER>,
+    byteoffset: Option<&i64>,
     key: Option<&ULONG>,
 ) -> NTSTATUS {
     windows_sys::NtWriteFile(
@@ -452,7 +451,7 @@ compat_fn_with_fallback! {
         iostatusblock: &mut IO_STATUS_BLOCK,
         buffer: *mut crate::mem::MaybeUninit<u8>,
         length: ULONG,
-        byteoffset: Option<&LARGE_INTEGER>,
+        byteoffset: Option<&i64>,
         key: Option<&ULONG>
     ) -> NTSTATUS {
         STATUS_NOT_IMPLEMENTED
@@ -466,7 +465,7 @@ compat_fn_with_fallback! {
         iostatusblock: &mut IO_STATUS_BLOCK,
         buffer: *const u8,
         length: ULONG,
-        byteoffset: Option<&LARGE_INTEGER>,
+        byteoffset: Option<&i64>,
         key: Option<&ULONG>
     ) -> NTSTATUS {
         STATUS_NOT_IMPLEMENTED

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -21,7 +21,6 @@ pub type DWORD = c_ulong;
 pub type WCHAR = u16;
 pub type ULONG = c_ulong;
 
-pub type LPOVERLAPPED = *mut OVERLAPPED;
 pub type LPSECURITY_ATTRIBUTES = *mut SECURITY_ATTRIBUTES;
 pub type LPVOID = *mut c_void;
 

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -17,7 +17,6 @@ pub(super) mod windows_targets;
 mod windows_sys;
 pub use windows_sys::*;
 
-pub type DWORD = c_ulong;
 pub type WCHAR = u16;
 
 pub type socklen_t = c_int;
@@ -316,13 +315,13 @@ compat_fn_with_fallback! {
     // >= Win10 1607
     // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription
     pub fn SetThreadDescription(hthread: HANDLE, lpthreaddescription: PCWSTR) -> HRESULT {
-        SetLastError(ERROR_CALL_NOT_IMPLEMENTED as DWORD); E_NOTIMPL
+        SetLastError(ERROR_CALL_NOT_IMPLEMENTED as u32); E_NOTIMPL
     }
 
     // >= Win10 1607
     // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreaddescription
     pub fn GetThreadDescription(hthread: HANDLE, lpthreaddescription: *mut PWSTR) -> HRESULT {
-        SetLastError(ERROR_CALL_NOT_IMPLEMENTED as DWORD); E_NOTIMPL
+        SetLastError(ERROR_CALL_NOT_IMPLEMENTED as u32); E_NOTIMPL
     }
 
     // >= Win8 / Server 2012
@@ -383,9 +382,9 @@ compat_fn_with_fallback! {
     #[cfg(target_vendor = "win7")]
     pub fn NtCreateKeyedEvent(
         KeyedEventHandle: *mut HANDLE,
-        DesiredAccess: DWORD,
+        DesiredAccess: u32,
         ObjectAttributes: *mut c_void,
-        Flags: ULONG
+        Flags: u32
     ) -> NTSTATUS {
         panic!("keyed events not available")
     }
@@ -433,9 +432,9 @@ compat_fn_with_fallback! {
         apccontext: *mut c_void,
         iostatusblock: &mut IO_STATUS_BLOCK,
         buffer: *mut crate::mem::MaybeUninit<u8>,
-        length: ULONG,
+        length: u32,
         byteoffset: Option<&i64>,
-        key: Option<&ULONG>
+        key: Option<&u32>
     ) -> NTSTATUS {
         STATUS_NOT_IMPLEMENTED
     }
@@ -447,9 +446,9 @@ compat_fn_with_fallback! {
         apccontext: *mut c_void,
         iostatusblock: &mut IO_STATUS_BLOCK,
         buffer: *const u8,
-        length: ULONG,
+        length: u32,
         byteoffset: Option<&i64>,
-        key: Option<&ULONG>
+        key: Option<&u32>
     ) -> NTSTATUS {
         STATUS_NOT_IMPLEMENTED
     }

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -7,7 +7,6 @@
 
 use crate::ffi::CStr;
 use crate::mem;
-use crate::num::NonZero;
 pub use crate::os::raw::c_int;
 use crate::os::raw::{c_char, c_long, c_longlong, c_uint, c_ulong, c_ushort, c_void};
 use crate::os::windows::io::{AsRawHandle, BorrowedHandle};
@@ -19,7 +18,6 @@ mod windows_sys;
 pub use windows_sys::*;
 
 pub type DWORD = c_ulong;
-pub type NonZeroDWORD = NonZero<c_ulong>;
 pub type LARGE_INTEGER = c_longlong;
 #[cfg_attr(target_vendor = "uwp", allow(unused))]
 pub type LONG = c_long;

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -8,7 +8,7 @@
 use crate::ffi::CStr;
 use crate::mem;
 pub use crate::os::raw::c_int;
-use crate::os::raw::{c_char, c_long, c_uint, c_ulong, c_ushort, c_void};
+use crate::os::raw::{c_char, c_uint, c_ulong, c_ushort, c_void};
 use crate::os::windows::io::{AsRawHandle, BorrowedHandle};
 use crate::ptr;
 
@@ -18,8 +18,6 @@ mod windows_sys;
 pub use windows_sys::*;
 
 pub type DWORD = c_ulong;
-#[cfg_attr(target_vendor = "uwp", allow(unused))]
-pub type LONG = c_long;
 pub type UINT = c_uint;
 pub type WCHAR = u16;
 pub type USHORT = c_ushort;

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -390,18 +390,18 @@ compat_fn_with_fallback! {
     #[cfg(target_vendor = "win7")]
     pub fn NtReleaseKeyedEvent(
         EventHandle: HANDLE,
-        Key: *mut c_void,
+        Key: *const c_void,
         Alertable: BOOLEAN,
-        Timeout: *mut c_longlong
+        Timeout: *mut i64
     ) -> NTSTATUS {
         panic!("keyed events not available")
     }
     #[cfg(target_vendor = "win7")]
     pub fn NtWaitForKeyedEvent(
         EventHandle: HANDLE,
-        Key: *mut c_void,
+        Key: *const c_void,
         Alertable: BOOLEAN,
-        Timeout: *mut c_longlong
+        Timeout: *mut i64
     ) -> NTSTATUS {
         panic!("keyed events not available")
     }

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -21,7 +21,6 @@ pub type DWORD = c_ulong;
 pub type WCHAR = u16;
 pub type ULONG = c_ulong;
 
-pub type LPSECURITY_ATTRIBUTES = *mut SECURITY_ATTRIBUTES;
 pub type LPVOID = *mut c_void;
 
 #[cfg(target_vendor = "win7")]

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -21,9 +21,6 @@ pub type DWORD = c_ulong;
 pub type WCHAR = u16;
 pub type ULONG = c_ulong;
 
-#[cfg(target_vendor = "win7")]
-pub type PSRWLOCK = *mut SRWLOCK;
-
 pub type socklen_t = c_int;
 pub type ADDRESS_FAMILY = c_ushort;
 pub use FD_SET as fd_set;

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -19,7 +19,6 @@ pub use windows_sys::*;
 
 pub type DWORD = c_ulong;
 pub type WCHAR = u16;
-pub type ULONG = c_ulong;
 
 pub type socklen_t = c_int;
 pub type ADDRESS_FAMILY = c_ushort;
@@ -252,9 +251,9 @@ pub unsafe fn NtReadFile(
     apccontext: *mut c_void,
     iostatusblock: &mut IO_STATUS_BLOCK,
     buffer: *mut crate::mem::MaybeUninit<u8>,
-    length: ULONG,
+    length: u32,
     byteoffset: Option<&i64>,
-    key: Option<&ULONG>,
+    key: Option<&u32>,
 ) -> NTSTATUS {
     windows_sys::NtReadFile(
         filehandle.as_raw_handle(),
@@ -275,9 +274,9 @@ pub unsafe fn NtWriteFile(
     apccontext: *mut c_void,
     iostatusblock: &mut IO_STATUS_BLOCK,
     buffer: *const u8,
-    length: ULONG,
+    length: u32,
     byteoffset: Option<&i64>,
-    key: Option<&ULONG>,
+    key: Option<&u32>,
 ) -> NTSTATUS {
     windows_sys::NtWriteFile(
         filehandle.as_raw_handle(),

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -21,7 +21,6 @@ pub type DWORD = c_ulong;
 pub type WCHAR = u16;
 pub type ULONG = c_ulong;
 
-pub type LPCVOID = *const c_void;
 pub type LPOVERLAPPED = *mut OVERLAPPED;
 pub type LPSECURITY_ATTRIBUTES = *mut SECURITY_ATTRIBUTES;
 pub type LPVOID = *mut c_void;

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -18,7 +18,6 @@ mod windows_sys;
 pub use windows_sys::*;
 
 pub type DWORD = c_ulong;
-pub type UINT = c_uint;
 pub type WCHAR = u16;
 pub type USHORT = c_ushort;
 pub type SIZE_T = usize;

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -28,8 +28,6 @@ pub type LPCVOID = *const c_void;
 pub type LPOVERLAPPED = *mut OVERLAPPED;
 pub type LPSECURITY_ATTRIBUTES = *mut SECURITY_ATTRIBUTES;
 pub type LPVOID = *mut c_void;
-pub type LPWCH = *mut WCHAR;
-pub type LPWSTR = *mut WCHAR;
 
 #[cfg(target_vendor = "win7")]
 pub type PSRWLOCK = *mut SRWLOCK;

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -19,7 +19,6 @@ pub use windows_sys::*;
 
 pub type DWORD = c_ulong;
 pub type WCHAR = u16;
-pub type USHORT = c_ushort;
 pub type SIZE_T = usize;
 pub type CHAR = c_char;
 pub type ULONG = c_ulong;
@@ -33,7 +32,7 @@ pub type LPVOID = *mut c_void;
 pub type PSRWLOCK = *mut SRWLOCK;
 
 pub type socklen_t = c_int;
-pub type ADDRESS_FAMILY = USHORT;
+pub type ADDRESS_FAMILY = c_ushort;
 pub use FD_SET as fd_set;
 pub use LINGER as linger;
 pub use TIMEVAL as timeval;
@@ -152,7 +151,7 @@ pub struct SOCKADDR_STORAGE_LH {
 #[derive(Copy, Clone)]
 pub struct sockaddr_in {
     pub sin_family: ADDRESS_FAMILY,
-    pub sin_port: USHORT,
+    pub sin_port: c_ushort,
     pub sin_addr: in_addr,
     pub sin_zero: [CHAR; 8],
 }
@@ -161,7 +160,7 @@ pub struct sockaddr_in {
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
     pub sin6_family: ADDRESS_FAMILY,
-    pub sin6_port: USHORT,
+    pub sin6_port: c_ushort,
     pub sin6_flowinfo: c_ulong,
     pub sin6_addr: in6_addr,
     pub sin6_scope_id: c_ulong,

--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -495,7 +495,7 @@ impl File {
             SeekFrom::End(n) => (c::FILE_END, n),
             SeekFrom::Current(n) => (c::FILE_CURRENT, n),
         };
-        let pos = pos as c::LARGE_INTEGER;
+        let pos = pos as i64;
         let mut newpos = 0;
         cvt(unsafe { c::SetFilePointerEx(self.handle.as_raw_handle(), pos, &mut newpos, whence) })?;
         Ok(newpos as u64)
@@ -1417,10 +1417,10 @@ pub fn canonicalize(p: &Path) -> io::Result<PathBuf> {
 
 pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
     unsafe extern "system" fn callback(
-        _TotalFileSize: c::LARGE_INTEGER,
-        _TotalBytesTransferred: c::LARGE_INTEGER,
-        _StreamSize: c::LARGE_INTEGER,
-        StreamBytesTransferred: c::LARGE_INTEGER,
+        _TotalFileSize: i64,
+        _TotalBytesTransferred: i64,
+        _StreamSize: i64,
+        StreamBytesTransferred: i64,
         dwStreamNumber: c::DWORD,
         _dwCallbackReason: c::DWORD,
         _hSourceFile: c::HANDLE,

--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -1425,7 +1425,7 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
         _dwCallbackReason: c::DWORD,
         _hSourceFile: c::HANDLE,
         _hDestinationFile: c::HANDLE,
-        lpData: c::LPCVOID,
+        lpData: *const c_void,
     ) -> c::DWORD {
         if dwStreamNumber == 1 {
             *(lpData as *mut i64) = StreamBytesTransferred;

--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -79,7 +79,7 @@ pub struct OpenOptions {
     attributes: c::DWORD,
     share_mode: c::DWORD,
     security_qos_flags: c::DWORD,
-    security_attributes: c::LPSECURITY_ATTRIBUTES,
+    security_attributes: *mut c::SECURITY_ATTRIBUTES,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -241,7 +241,7 @@ impl OpenOptions {
         // receive is `SECURITY_ANONYMOUS = 0x0`, which we can't check for later on.
         self.security_qos_flags = flags | c::SECURITY_SQOS_PRESENT;
     }
-    pub fn security_attributes(&mut self, attrs: c::LPSECURITY_ATTRIBUTES) {
+    pub fn security_attributes(&mut self, attrs: *mut c::SECURITY_ATTRIBUTES) {
         self.security_attributes = attrs;
     }
 

--- a/library/std/src/sys/pal/windows/handle.rs
+++ b/library/std/src/sys/pal/windows/handle.rs
@@ -141,7 +141,7 @@ impl Handle {
         buf: &mut [u8],
         overlapped: *mut c::OVERLAPPED,
     ) -> io::Result<Option<usize>> {
-        let len = cmp::min(buf.len(), <c::DWORD>::MAX as usize) as c::DWORD;
+        let len = cmp::min(buf.len(), u32::MAX as usize) as u32;
         let mut amt = 0;
         let res =
             cvt(c::ReadFile(self.as_raw_handle(), buf.as_mut_ptr(), len, &mut amt, overlapped));
@@ -209,12 +209,7 @@ impl Handle {
         Ok(Self(self.0.try_clone()?))
     }
 
-    pub fn duplicate(
-        &self,
-        access: c::DWORD,
-        inherit: bool,
-        options: c::DWORD,
-    ) -> io::Result<Self> {
+    pub fn duplicate(&self, access: u32, inherit: bool, options: u32) -> io::Result<Self> {
         Ok(Self(self.0.as_handle().duplicate(access, inherit, options)?))
     }
 
@@ -233,7 +228,7 @@ impl Handle {
         let mut io_status = c::IO_STATUS_BLOCK::PENDING;
 
         // The length is clamped at u32::MAX.
-        let len = cmp::min(len, c::DWORD::MAX as usize) as c::DWORD;
+        let len = cmp::min(len, u32::MAX as usize) as u32;
         let status = c::NtReadFile(
             self.as_handle(),
             ptr::null_mut(),
@@ -281,7 +276,7 @@ impl Handle {
         let mut io_status = c::IO_STATUS_BLOCK::PENDING;
 
         // The length is clamped at u32::MAX.
-        let len = cmp::min(buf.len(), c::DWORD::MAX as usize) as c::DWORD;
+        let len = cmp::min(buf.len(), u32::MAX as usize) as u32;
         let status = unsafe {
             c::NtWriteFile(
                 self.as_handle(),

--- a/library/std/src/sys/pal/windows/io.rs
+++ b/library/std/src/sys/pal/windows/io.rs
@@ -15,9 +15,9 @@ pub struct IoSlice<'a> {
 impl<'a> IoSlice<'a> {
     #[inline]
     pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
-        assert!(buf.len() <= c::ULONG::MAX as usize);
+        assert!(buf.len() <= u32::MAX as usize);
         IoSlice {
-            vec: c::WSABUF { len: buf.len() as c::ULONG, buf: buf.as_ptr() as *mut u8 },
+            vec: c::WSABUF { len: buf.len() as u32, buf: buf.as_ptr() as *mut u8 },
             _p: PhantomData,
         }
     }
@@ -29,7 +29,7 @@ impl<'a> IoSlice<'a> {
         }
 
         unsafe {
-            self.vec.len -= n as c::ULONG;
+            self.vec.len -= n as u32;
             self.vec.buf = self.vec.buf.add(n);
         }
     }
@@ -49,9 +49,9 @@ pub struct IoSliceMut<'a> {
 impl<'a> IoSliceMut<'a> {
     #[inline]
     pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
-        assert!(buf.len() <= c::ULONG::MAX as usize);
+        assert!(buf.len() <= u32::MAX as usize);
         IoSliceMut {
-            vec: c::WSABUF { len: buf.len() as c::ULONG, buf: buf.as_mut_ptr() },
+            vec: c::WSABUF { len: buf.len() as u32, buf: buf.as_mut_ptr() },
             _p: PhantomData,
         }
     }
@@ -63,7 +63,7 @@ impl<'a> IoSliceMut<'a> {
         }
 
         unsafe {
-            self.vec.len -= n as c::ULONG;
+            self.vec.len -= n as u32;
             self.vec.buf = self.vec.buf.add(n);
         }
     }

--- a/library/std/src/sys/pal/windows/mod.rs
+++ b/library/std/src/sys/pal/windows/mod.rs
@@ -75,7 +75,7 @@ pub fn is_interrupted(_errno: i32) -> bool {
 pub fn decode_error_kind(errno: i32) -> ErrorKind {
     use ErrorKind::*;
 
-    match errno as c::DWORD {
+    match errno as u32 {
         c::ERROR_ACCESS_DENIED => return PermissionDenied,
         c::ERROR_ALREADY_EXISTS => return AlreadyExists,
         c::ERROR_FILE_EXISTS => return AlreadyExists,
@@ -216,7 +216,7 @@ pub fn to_u16s<S: AsRef<OsStr>>(s: S) -> crate::io::Result<Vec<u16>> {
 // from this closure is then the return value of the function.
 pub fn fill_utf16_buf<F1, F2, T>(mut f1: F1, f2: F2) -> crate::io::Result<T>
 where
-    F1: FnMut(*mut u16, c::DWORD) -> c::DWORD,
+    F1: FnMut(*mut u16, u32) -> u32,
     F2: FnOnce(&[u16]) -> T,
 {
     // Start off with a stack buf but then spill over to the heap if we end up
@@ -238,7 +238,7 @@ where
                 // We used `reserve` and not `reserve_exact`, so in theory we
                 // may have gotten more than requested. If so, we'd like to use
                 // it... so long as we won't cause overflow.
-                n = heap_buf.capacity().min(c::DWORD::MAX as usize);
+                n = heap_buf.capacity().min(u32::MAX as usize);
                 // Safety: MaybeUninit<u16> does not need initialization
                 heap_buf.set_len(n);
                 &mut heap_buf[..]
@@ -254,13 +254,13 @@ where
             // error" is still 0 then we interpret it as a 0 length buffer and
             // not an actual error.
             c::SetLastError(0);
-            let k = match f1(buf.as_mut_ptr().cast::<u16>(), n as c::DWORD) {
+            let k = match f1(buf.as_mut_ptr().cast::<u16>(), n as u32) {
                 0 if api::get_last_error().code == 0 => 0,
                 0 => return Err(crate::io::Error::last_os_error()),
                 n => n,
             } as usize;
             if k == n && api::get_last_error().code == c::ERROR_INSUFFICIENT_BUFFER {
-                n = n.saturating_mul(2).min(c::DWORD::MAX as usize);
+                n = n.saturating_mul(2).min(u32::MAX as usize);
             } else if k > n {
                 n = k;
             } else if k == n {
@@ -308,7 +308,7 @@ pub fn cvt<I: IsZero>(i: I) -> crate::io::Result<I> {
     if i.is_zero() { Err(crate::io::Error::last_os_error()) } else { Ok(i) }
 }
 
-pub fn dur2timeout(dur: Duration) -> c::DWORD {
+pub fn dur2timeout(dur: Duration) -> u32 {
     // Note that a duration is a (u64, u32) (seconds, nanoseconds) pair, and the
     // timeouts in windows APIs are typically u32 milliseconds. To translate, we
     // have two pieces to take care of:
@@ -320,7 +320,7 @@ pub fn dur2timeout(dur: Duration) -> c::DWORD {
         .checked_mul(1000)
         .and_then(|ms| ms.checked_add((dur.subsec_nanos() as u64) / 1_000_000))
         .and_then(|ms| ms.checked_add(if dur.subsec_nanos() % 1_000_000 > 0 { 1 } else { 0 }))
-        .map(|ms| if ms > <c::DWORD>::MAX as u64 { c::INFINITE } else { ms as c::DWORD })
+        .map(|ms| if ms > <u32>::MAX as u64 { c::INFINITE } else { ms as u32 })
         .unwrap_or(c::INFINITE)
 }
 

--- a/library/std/src/sys/pal/windows/net.rs
+++ b/library/std/src/sys/pal/windows/net.rs
@@ -250,7 +250,7 @@ impl Socket {
     pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         // On unix when a socket is shut down all further reads return 0, so we
         // do the same on windows to map a shut down socket to returning EOF.
-        let length = cmp::min(bufs.len(), c::DWORD::MAX as usize) as c::DWORD;
+        let length = cmp::min(bufs.len(), u32::MAX as usize) as u32;
         let mut nread = 0;
         let mut flags = 0;
         let result = unsafe {
@@ -335,7 +335,7 @@ impl Socket {
     }
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        let length = cmp::min(bufs.len(), c::DWORD::MAX as usize) as c::DWORD;
+        let length = cmp::min(bufs.len(), u32::MAX as usize) as u32;
         let mut nwritten = 0;
         let result = unsafe {
             c::WSASend(
@@ -371,7 +371,7 @@ impl Socket {
     }
 
     pub fn timeout(&self, kind: c_int) -> io::Result<Option<Duration>> {
-        let raw: c::DWORD = net::getsockopt(self, c::SOL_SOCKET, kind)?;
+        let raw: u32 = net::getsockopt(self, c::SOL_SOCKET, kind)?;
         if raw == 0 {
             Ok(None)
         } else {

--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -81,7 +81,7 @@ pub fn error_string(mut errnum: i32) -> String {
 }
 
 pub struct Env {
-    base: c::LPWCH,
+    base: *mut c::WCHAR,
     iter: EnvIterator,
 }
 
@@ -126,7 +126,7 @@ impl Iterator for Env {
 }
 
 #[derive(Clone)]
-struct EnvIterator(c::LPWCH);
+struct EnvIterator(*mut c::WCHAR);
 
 impl Iterator for EnvIterator {
     type Item = (OsString, OsString);

--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -383,7 +383,7 @@ pub fn home_dir() -> Option<PathBuf> {
 }
 
 pub fn exit(code: i32) -> ! {
-    unsafe { c::ExitProcess(code as c::UINT) }
+    unsafe { c::ExitProcess(code as u32) }
 }
 
 pub fn getpid() -> u32 {

--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -52,10 +52,10 @@ pub fn error_string(mut errnum: i32) -> String {
         let res = c::FormatMessageW(
             flags | c::FORMAT_MESSAGE_FROM_SYSTEM | c::FORMAT_MESSAGE_IGNORE_INSERTS,
             module,
-            errnum as c::DWORD,
+            errnum as u32,
             0,
             buf.as_mut_ptr(),
-            buf.len() as c::DWORD,
+            buf.len() as u32,
             ptr::null(),
         ) as usize;
         if res == 0 {

--- a/library/std/src/sys/pal/windows/pipe.rs
+++ b/library/std/src/sys/pal/windows/pipe.rs
@@ -227,7 +227,7 @@ type AlertableIoFn = unsafe extern "system" fn(
     BorrowedHandle<'_>,
     c::LPVOID,
     c::DWORD,
-    c::LPOVERLAPPED,
+    *mut c::OVERLAPPED,
     c::LPOVERLAPPED_COMPLETION_ROUTINE,
 ) -> c::BOOL;
 

--- a/library/std/src/sys/pal/windows/pipe.rs
+++ b/library/std/src/sys/pal/windows/pipe.rs
@@ -156,7 +156,7 @@ pub fn anon_pipe(ours_readable: bool, their_handle_inheritable: bool) -> io::Res
         opts.share_mode(0);
         let size = mem::size_of::<c::SECURITY_ATTRIBUTES>();
         let mut sa = c::SECURITY_ATTRIBUTES {
-            nLength: size as c::DWORD,
+            nLength: size as u32,
             lpSecurityDescriptor: ptr::null_mut(),
             bInheritHandle: their_handle_inheritable as i32,
         };
@@ -226,7 +226,7 @@ fn random_number() -> usize {
 type AlertableIoFn = unsafe extern "system" fn(
     BorrowedHandle<'_>,
     *mut core::ffi::c_void,
-    c::DWORD,
+    u32,
     *mut c::OVERLAPPED,
     c::LPOVERLAPPED_COMPLETION_ROUTINE,
 ) -> c::BOOL;
@@ -244,7 +244,7 @@ impl AnonPipe {
 
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         let result = unsafe {
-            let len = crate::cmp::min(buf.len(), c::DWORD::MAX as usize) as c::DWORD;
+            let len = crate::cmp::min(buf.len(), u32::MAX as usize) as u32;
             self.alertable_io_internal(c::ReadFileEx, buf.as_mut_ptr() as _, len)
         };
 
@@ -260,7 +260,7 @@ impl AnonPipe {
 
     pub fn read_buf(&self, mut buf: BorrowedCursor<'_>) -> io::Result<()> {
         let result = unsafe {
-            let len = crate::cmp::min(buf.capacity(), c::DWORD::MAX as usize) as c::DWORD;
+            let len = crate::cmp::min(buf.capacity(), u32::MAX as usize) as u32;
             self.alertable_io_internal(c::ReadFileEx, buf.as_mut().as_mut_ptr() as _, len)
         };
 
@@ -295,7 +295,7 @@ impl AnonPipe {
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         unsafe {
-            let len = crate::cmp::min(buf.len(), c::DWORD::MAX as usize) as c::DWORD;
+            let len = crate::cmp::min(buf.len(), u32::MAX as usize) as u32;
             self.alertable_io_internal(c::WriteFileEx, buf.as_ptr() as _, len)
         }
     }
@@ -328,7 +328,7 @@ impl AnonPipe {
         &self,
         io: AlertableIoFn,
         buf: *mut core::ffi::c_void,
-        len: c::DWORD,
+        len: u32,
     ) -> io::Result<usize> {
         // Use "alertable I/O" to synchronize the pipe I/O.
         // This has four steps.

--- a/library/std/src/sys/pal/windows/pipe.rs
+++ b/library/std/src/sys/pal/windows/pipe.rs
@@ -225,7 +225,7 @@ fn random_number() -> usize {
 // Abstracts over `ReadFileEx` and `WriteFileEx`
 type AlertableIoFn = unsafe extern "system" fn(
     BorrowedHandle<'_>,
-    c::LPVOID,
+    *mut core::ffi::c_void,
     c::DWORD,
     *mut c::OVERLAPPED,
     c::LPOVERLAPPED_COMPLETION_ROUTINE,
@@ -327,7 +327,7 @@ impl AnonPipe {
     unsafe fn alertable_io_internal(
         &self,
         io: AlertableIoFn,
-        buf: c::LPVOID,
+        buf: *mut core::ffi::c_void,
         len: c::DWORD,
     ) -> io::Result<usize> {
         // Use "alertable I/O" to synchronize the pipe I/O.

--- a/library/std/src/sys/pal/windows/process.rs
+++ b/library/std/src/sys/pal/windows/process.rs
@@ -19,7 +19,7 @@ use crate::path::{Path, PathBuf};
 use crate::ptr;
 use crate::sync::Mutex;
 use crate::sys::args::{self, Arg};
-use crate::sys::c::{self, NonZeroDWORD, EXIT_FAILURE, EXIT_SUCCESS};
+use crate::sys::c::{self, EXIT_FAILURE, EXIT_SUCCESS};
 use crate::sys::cvt;
 use crate::sys::fs::{File, OpenOptions};
 use crate::sys::handle::Handle;
@@ -717,7 +717,7 @@ pub struct ExitStatus(c::DWORD);
 
 impl ExitStatus {
     pub fn exit_ok(&self) -> Result<(), ExitStatusError> {
-        match NonZeroDWORD::try_from(self.0) {
+        match NonZero::<u32>::try_from(self.0) {
             /* was nonzero */ Ok(failure) => Err(ExitStatusError(failure)),
             /* was zero, couldn't convert */ Err(_) => Ok(()),
         }
@@ -750,7 +750,7 @@ impl fmt::Display for ExitStatus {
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub struct ExitStatusError(c::NonZeroDWORD);
+pub struct ExitStatusError(NonZero<u32>);
 
 impl Into<ExitStatus> for ExitStatusError {
     fn into(self) -> ExitStatus {

--- a/library/std/src/sys/pal/windows/process.rs
+++ b/library/std/src/sys/pal/windows/process.rs
@@ -174,7 +174,7 @@ pub struct Command {
 
 pub enum Stdio {
     Inherit,
-    InheritSpecific { from_stdio_id: c::DWORD },
+    InheritSpecific { from_stdio_id: u32 },
     Null,
     MakePipe,
     Pipe(AnonPipe),
@@ -364,7 +364,7 @@ impl Command {
             };
             si_ptr = core::ptr::addr_of_mut!(si_ex) as _;
         } else {
-            si.cb = mem::size_of::<c::STARTUPINFOW>() as c::DWORD;
+            si.cb = mem::size_of::<c::STARTUPINFOW>() as u32;
             si_ptr = core::ptr::addr_of_mut!(si) as _;
         }
 
@@ -566,7 +566,7 @@ fn program_exists(path: &Path) -> Option<Vec<u16>> {
 }
 
 impl Stdio {
-    fn to_handle(&self, stdio_id: c::DWORD, pipe: &mut Option<AnonPipe>) -> io::Result<Handle> {
+    fn to_handle(&self, stdio_id: u32, pipe: &mut Option<AnonPipe>) -> io::Result<Handle> {
         let use_stdio_id = |stdio_id| match stdio::get_handle(stdio_id) {
             Ok(io) => unsafe {
                 let io = Handle::from_raw_handle(io);
@@ -601,7 +601,7 @@ impl Stdio {
             Stdio::Null => {
                 let size = mem::size_of::<c::SECURITY_ATTRIBUTES>();
                 let mut sa = c::SECURITY_ATTRIBUTES {
-                    nLength: size as c::DWORD,
+                    nLength: size as u32,
                     lpSecurityDescriptor: ptr::null_mut(),
                     bInheritHandle: 1,
                 };
@@ -713,7 +713,7 @@ impl Process {
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
-pub struct ExitStatus(c::DWORD);
+pub struct ExitStatus(u32);
 
 impl ExitStatus {
     pub fn exit_ok(&self) -> Result<(), ExitStatusError> {
@@ -727,9 +727,9 @@ impl ExitStatus {
     }
 }
 
-/// Converts a raw `c::DWORD` to a type-safe `ExitStatus` by wrapping it without copying.
-impl From<c::DWORD> for ExitStatus {
-    fn from(u: c::DWORD) -> ExitStatus {
+/// Converts a raw `u32` to a type-safe `ExitStatus` by wrapping it without copying.
+impl From<u32> for ExitStatus {
+    fn from(u: u32) -> ExitStatus {
         ExitStatus(u)
     }
 }
@@ -765,7 +765,7 @@ impl ExitStatusError {
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub struct ExitCode(c::DWORD);
+pub struct ExitCode(u32);
 
 impl ExitCode {
     pub const SUCCESS: ExitCode = ExitCode(EXIT_SUCCESS as _);
@@ -779,13 +779,13 @@ impl ExitCode {
 
 impl From<u8> for ExitCode {
     fn from(code: u8) -> Self {
-        ExitCode(c::DWORD::from(code))
+        ExitCode(u32::from(code))
     }
 }
 
 impl From<u32> for ExitCode {
     fn from(code: u32) -> Self {
-        ExitCode(c::DWORD::from(code))
+        ExitCode(u32::from(code))
     }
 }
 

--- a/library/std/src/sys/pal/windows/rand.rs
+++ b/library/std/src/sys/pal/windows/rand.rs
@@ -20,7 +20,7 @@ pub fn hashmap_random_keys() -> (u64, u64) {
 
     let mut v = (0, 0);
     let ret = unsafe {
-        c::RtlGenRandom(ptr::addr_of_mut!(v).cast::<c_void>(), mem::size_of_val(&v) as c::ULONG)
+        c::RtlGenRandom(ptr::addr_of_mut!(v).cast::<c_void>(), mem::size_of_val(&v) as u32)
     };
 
     if ret != 0 { v } else { panic!("RNG broken: {}", io::Error::last_os_error()) }

--- a/library/std/src/sys/pal/windows/stack_overflow.rs
+++ b/library/std/src/sys/pal/windows/stack_overflow.rs
@@ -11,7 +11,7 @@ pub unsafe fn reserve_stack() {
     debug_assert_ne!(result, 0, "failed to reserve stack space for exception handling");
 }
 
-unsafe extern "system" fn vectored_handler(ExceptionInfo: *mut c::EXCEPTION_POINTERS) -> c::LONG {
+unsafe extern "system" fn vectored_handler(ExceptionInfo: *mut c::EXCEPTION_POINTERS) -> i32 {
     unsafe {
         let rec = &(*(*ExceptionInfo).ExceptionRecord);
         let code = rec.ExceptionCode;

--- a/library/std/src/sys/pal/windows/stdio.rs
+++ b/library/std/src/sys/pal/windows/stdio.rs
@@ -355,7 +355,7 @@ fn read_u16s(handle: c::HANDLE, buf: &mut [MaybeUninit<u16>]) -> io::Result<usiz
             c::SetLastError(0);
             c::ReadConsoleW(
                 handle,
-                buf.as_mut_ptr() as c::LPVOID,
+                buf.as_mut_ptr() as *mut core::ffi::c_void,
                 buf.len() as u32,
                 &mut amount,
                 &input_control,

--- a/library/std/src/sys/pal/windows/stdio.rs
+++ b/library/std/src/sys/pal/windows/stdio.rs
@@ -181,9 +181,9 @@ fn write_valid_utf8_to_console(handle: c::HANDLE, utf8: &str) -> io::Result<usiz
             c::CP_UTF8,                          // CodePage
             c::MB_ERR_INVALID_CHARS,             // dwFlags
             utf8.as_ptr(),                       // lpMultiByteStr
-            utf8.len() as c::c_int,              // cbMultiByte
+            utf8.len() as i32,                   // cbMultiByte
             utf16.as_mut_ptr() as *mut c::WCHAR, // lpWideCharStr
-            utf16.len() as c::c_int,             // cchWideChar
+            utf16.len() as i32,                  // cchWideChar
         );
         assert!(result != 0, "Unexpected error in MultiByteToWideChar");
 
@@ -374,8 +374,8 @@ fn read_u16s(handle: c::HANDLE, buf: &mut [MaybeUninit<u16>]) -> io::Result<usiz
 }
 
 fn utf16_to_utf8(utf16: &[u16], utf8: &mut [u8]) -> io::Result<usize> {
-    debug_assert!(utf16.len() <= c::c_int::MAX as usize);
-    debug_assert!(utf8.len() <= c::c_int::MAX as usize);
+    debug_assert!(utf16.len() <= i32::MAX as usize);
+    debug_assert!(utf8.len() <= i32::MAX as usize);
 
     if utf16.is_empty() {
         return Ok(0);
@@ -386,9 +386,9 @@ fn utf16_to_utf8(utf16: &[u16], utf8: &mut [u8]) -> io::Result<usize> {
             c::CP_UTF8,              // CodePage
             c::WC_ERR_INVALID_CHARS, // dwFlags
             utf16.as_ptr(),          // lpWideCharStr
-            utf16.len() as c::c_int, // cchWideChar
+            utf16.len() as i32,      // cchWideChar
             utf8.as_mut_ptr(),       // lpMultiByteStr
-            utf8.len() as c::c_int,  // cbMultiByte
+            utf8.len() as i32,       // cbMultiByte
             ptr::null(),             // lpDefaultChar
             ptr::null_mut(),         // lpUsedDefaultChar
         )

--- a/library/std/src/sys/pal/windows/stdio.rs
+++ b/library/std/src/sys/pal/windows/stdio.rs
@@ -68,7 +68,7 @@ const MAX_BUFFER_SIZE: usize = 8192;
 // UTF-16 to UTF-8.
 pub const STDIN_BUF_SIZE: usize = MAX_BUFFER_SIZE / 2 * 3;
 
-pub fn get_handle(handle_id: c::DWORD) -> io::Result<c::HANDLE> {
+pub fn get_handle(handle_id: u32) -> io::Result<c::HANDLE> {
     let handle = unsafe { c::GetStdHandle(handle_id) };
     if handle == c::INVALID_HANDLE_VALUE {
         Err(io::Error::last_os_error())
@@ -87,11 +87,7 @@ fn is_console(handle: c::HANDLE) -> bool {
     unsafe { c::GetConsoleMode(handle, &mut mode) != 0 }
 }
 
-fn write(
-    handle_id: c::DWORD,
-    data: &[u8],
-    incomplete_utf8: &mut IncompleteUtf8,
-) -> io::Result<usize> {
+fn write(handle_id: u32, data: &[u8], incomplete_utf8: &mut IncompleteUtf8) -> io::Result<usize> {
     if data.is_empty() {
         return Ok(0);
     }

--- a/library/std/src/sys/pal/windows/stdio.rs
+++ b/library/std/src/sys/pal/windows/stdio.rs
@@ -182,12 +182,12 @@ fn write_valid_utf8_to_console(handle: c::HANDLE, utf8: &str) -> io::Result<usiz
         // Note that this theoretically checks validity twice in the (most common) case
         // where the underlying byte sequence is valid utf-8 (given the check in `write()`).
         let result = c::MultiByteToWideChar(
-            c::CP_UTF8,                      // CodePage
-            c::MB_ERR_INVALID_CHARS,         // dwFlags
-            utf8.as_ptr(),                   // lpMultiByteStr
-            utf8.len() as c::c_int,          // cbMultiByte
-            utf16.as_mut_ptr() as c::LPWSTR, // lpWideCharStr
-            utf16.len() as c::c_int,         // cchWideChar
+            c::CP_UTF8,                          // CodePage
+            c::MB_ERR_INVALID_CHARS,             // dwFlags
+            utf8.as_ptr(),                       // lpMultiByteStr
+            utf8.len() as c::c_int,              // cbMultiByte
+            utf16.as_mut_ptr() as *mut c::WCHAR, // lpWideCharStr
+            utf16.len() as c::c_int,             // cchWideChar
         );
         assert!(result != 0, "Unexpected error in MultiByteToWideChar");
 

--- a/library/std/src/sys/pal/windows/stdio.rs
+++ b/library/std/src/sys/pal/windows/stdio.rs
@@ -341,9 +341,9 @@ fn read_u16s(handle: c::HANDLE, buf: &mut [MaybeUninit<u16>]) -> io::Result<usiz
     // traditional DOS method to indicate end of character stream / user input (SUB).
     // See #38274 and https://stackoverflow.com/questions/43836040/win-api-readconsole.
     const CTRL_Z: u16 = 0x1A;
-    const CTRL_Z_MASK: c::ULONG = 1 << CTRL_Z;
+    const CTRL_Z_MASK: u32 = 1 << CTRL_Z;
     let input_control = c::CONSOLE_READCONSOLE_CONTROL {
-        nLength: crate::mem::size_of::<c::CONSOLE_READCONSOLE_CONTROL>() as c::ULONG,
+        nLength: crate::mem::size_of::<c::CONSOLE_READCONSOLE_CONTROL>() as u32,
         nInitialChars: 0,
         dwCtrlWakeupMask: CTRL_Z_MASK,
         dwControlKeyState: 0,

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -45,7 +45,7 @@ impl Thread {
             Err(io::Error::last_os_error())
         };
 
-        unsafe extern "system" fn thread_start(main: *mut c_void) -> c::DWORD {
+        unsafe extern "system" fn thread_start(main: *mut c_void) -> u32 {
             // Next, reserve some stack space for if we otherwise run out of stack.
             stack_overflow::reserve_stack();
             // Finally, let's run some code.

--- a/library/std/src/sys/pal/windows/time.rs
+++ b/library/std/src/sys/pal/windows/time.rs
@@ -76,8 +76,8 @@ impl SystemTime {
     fn from_intervals(intervals: i64) -> SystemTime {
         SystemTime {
             t: c::FILETIME {
-                dwLowDateTime: intervals as c::DWORD,
-                dwHighDateTime: (intervals >> 32) as c::DWORD,
+                dwLowDateTime: intervals as u32,
+                dwHighDateTime: (intervals >> 32) as u32,
             },
         }
     }

--- a/library/std/src/sys/pal/windows/time.rs
+++ b/library/std/src/sys/pal/windows/time.rs
@@ -172,7 +172,7 @@ mod perf_counter {
     use crate::time::Duration;
 
     pub struct PerformanceCounterInstant {
-        ts: c::LARGE_INTEGER,
+        ts: i64,
     }
     impl PerformanceCounterInstant {
         pub fn now() -> Self {
@@ -196,7 +196,7 @@ mod perf_counter {
         }
     }
 
-    fn frequency() -> c::LARGE_INTEGER {
+    fn frequency() -> i64 {
         // Either the cached result of `QueryPerformanceFrequency` or `0` for
         // uninitialized. Storing this as a single `AtomicU64` allows us to use
         // `Relaxed` operations, as we are only interested in the effects on a
@@ -206,7 +206,7 @@ mod perf_counter {
         let cached = FREQUENCY.load(Ordering::Relaxed);
         // If a previous thread has filled in this global state, use that.
         if cached != 0 {
-            return cached as c::LARGE_INTEGER;
+            return cached as i64;
         }
         // ... otherwise learn for ourselves ...
         let mut frequency = 0;
@@ -218,8 +218,8 @@ mod perf_counter {
         frequency
     }
 
-    fn query() -> c::LARGE_INTEGER {
-        let mut qpc_value: c::LARGE_INTEGER = 0;
+    fn query() -> i64 {
+        let mut qpc_value: i64 = 0;
         cvt(unsafe { c::QueryPerformanceCounter(&mut qpc_value) }).unwrap();
         qpc_value
     }

--- a/library/std/src/sys/sync/mutex/windows7.rs
+++ b/library/std/src/sys/sync/mutex/windows7.rs
@@ -25,7 +25,7 @@ unsafe impl Send for Mutex {}
 unsafe impl Sync for Mutex {}
 
 #[inline]
-pub unsafe fn raw(m: &Mutex) -> c::PSRWLOCK {
+pub unsafe fn raw(m: &Mutex) -> *mut c::SRWLOCK {
     m.srwlock.get()
 }
 

--- a/library/std/src/sys/thread_local/guard/windows.rs
+++ b/library/std/src/sys/thread_local/guard/windows.rs
@@ -75,9 +75,9 @@ pub fn enable() {
 
 #[link_section = ".CRT$XLB"]
 #[cfg_attr(miri, used)] // Miri only considers explicitly `#[used]` statics for `lookup_link_section`
-pub static CALLBACK: unsafe extern "system" fn(*mut c_void, c::DWORD, *mut c_void) = tls_callback;
+pub static CALLBACK: unsafe extern "system" fn(*mut c_void, u32, *mut c_void) = tls_callback;
 
-unsafe extern "system" fn tls_callback(_h: *mut c_void, dw_reason: c::DWORD, _pv: *mut c_void) {
+unsafe extern "system" fn tls_callback(_h: *mut c_void, dw_reason: u32, _pv: *mut c_void) {
     // See comments above for what this is doing. Note that we don't need this
     // trickery on GNU windows, just on MSVC.
     #[cfg(all(target_env = "msvc", not(target_thread_local)))]

--- a/library/std/src/sys/thread_local/guard/windows.rs
+++ b/library/std/src/sys/thread_local/guard/windows.rs
@@ -65,6 +65,7 @@
 
 use crate::ptr;
 use crate::sys::c;
+use core::ffi::c_void;
 
 pub fn enable() {
     // When destructors are used, we don't want LLVM eliminating CALLBACK for any
@@ -74,9 +75,9 @@ pub fn enable() {
 
 #[link_section = ".CRT$XLB"]
 #[cfg_attr(miri, used)] // Miri only considers explicitly `#[used]` statics for `lookup_link_section`
-pub static CALLBACK: unsafe extern "system" fn(c::LPVOID, c::DWORD, c::LPVOID) = tls_callback;
+pub static CALLBACK: unsafe extern "system" fn(*mut c_void, c::DWORD, *mut c_void) = tls_callback;
 
-unsafe extern "system" fn tls_callback(_h: c::LPVOID, dw_reason: c::DWORD, _pv: c::LPVOID) {
+unsafe extern "system" fn tls_callback(_h: *mut c_void, dw_reason: c::DWORD, _pv: *mut c_void) {
     // See comments above for what this is doing. Note that we don't need this
     // trickery on GNU windows, just on MSVC.
     #[cfg(all(target_env = "msvc", not(target_thread_local)))]

--- a/library/std/src/sys/thread_local/key/windows.rs
+++ b/library/std/src/sys/thread_local/key/windows.rs
@@ -33,11 +33,11 @@ use crate::sync::atomic::{
 use crate::sys::c;
 use crate::sys::thread_local::guard;
 
-pub type Key = c::DWORD;
+pub type Key = u32;
 type Dtor = unsafe extern "C" fn(*mut u8);
 
 pub struct LazyKey {
-    /// The key value shifted up by one. Since TLS_OUT_OF_INDEXES == DWORD::MAX
+    /// The key value shifted up by one. Since TLS_OUT_OF_INDEXES == u32::MAX
     /// is not a valid key value, this allows us to use zero as sentinel value
     /// without risking overflow.
     key: AtomicU32,

--- a/src/tools/miri/tests/fail/alloc/global_system_mixup.rs
+++ b/src/tools/miri/tests/fail/alloc/global_system_mixup.rs
@@ -4,7 +4,7 @@
 
 //@normalize-stderr-test: "using [A-Za-z]+ heap deallocation operation" -> "using PLATFORM heap deallocation operation"
 //@normalize-stderr-test: "\| +\^+" -> "| ^"
-//@normalize-stderr-test: "libc::free\([^()]*\)|unsafe \{ HeapFree\([^()]*\) \};" -> "FREE();"
+//@normalize-stderr-test: "libc::free\([^()]*\)|unsafe \{ HeapFree\([^}]*\};" -> "FREE();"
 
 #![feature(allocator_api, slice_ptr_get)]
 


### PR DESCRIPTION
Back in the olden days, C did not have fixed-width types so these type aliases were at least potentially useful. Nowadays, and especially in Rust, we don't need the aliases and they don't help with anything. Notably the windows bindings we use also don't bother with the aliases. And even when we have used aliases they're often only used once then forgotten about.

The only one that gives me pause is `DWORD` because it's used a fair bit. But it's still used inconsistently and we implicitly assume it's a `u32` anyway (e.g. `as` casting from an `i32`).