### PR TITLE
reenable some windows tests

### DIFF
--- a/tests/codegen/generic-debug.rs
+++ b/tests/codegen/generic-debug.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows
 //@ ignore-wasi wasi codegens the main symbol differently
 
 //@ compile-flags: -g -C no-prepopulate-passes

--- a/tests/codegen/issues/issue-58881.rs
+++ b/tests/codegen/issues/issue-58881.rs
@@ -1,7 +1,6 @@
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0
 //
 //@ only-x86_64
-//@ ignore-windows
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/mainsubprogram.rs
+++ b/tests/codegen/mainsubprogram.rs
@@ -1,7 +1,6 @@
 // This test depends on a patch that was committed to upstream LLVM
 // before 4.0, formerly backported to the Rust LLVM fork.
 
-//@ ignore-windows
 //@ ignore-apple
 //@ ignore-wasi
 

--- a/tests/codegen/mainsubprogramstart.rs
+++ b/tests/codegen/mainsubprogramstart.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows
 //@ ignore-apple
 //@ ignore-wasi wasi codegens the main symbol differently
 

--- a/tests/codegen/nounwind.rs
+++ b/tests/codegen/nounwind.rs
@@ -1,6 +1,5 @@
 //@ aux-build:nounwind.rs
 //@ compile-flags: -C no-prepopulate-passes -C panic=abort -C metadata=a
-//@ ignore-windows
 //@ ignore-android
 
 #![crate_type = "lib"]


### PR DESCRIPTION
Locally passing on `x86_64-pc-windows-msvc`, fingers crossed for `*-pc-windows-gnu`.

try-job: x86_64-msvc
try-job: x86_64-mingw