### PR TITLE
std: removes logarithms family function edge cases handling for solaris.

### DIFF
--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -520,7 +520,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln(self) -> f64 {
-        crate::sys::log_wrapper(self, |n| unsafe { intrinsics::logf64(n) })
+        unsafe { intrinsics::logf64(self) }
     }
 
     /// Returns the logarithm of the number with respect to an arbitrary base.
@@ -574,7 +574,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log2(self) -> f64 {
-        crate::sys::log_wrapper(self, crate::sys::log2f64)
+        crate::sys::log2f64(self)
     }
 
     /// Returns the base 10 logarithm of the number.
@@ -599,7 +599,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log10(self) -> f64 {
-        crate::sys::log_wrapper(self, |n| unsafe { intrinsics::log10f64(n) })
+        unsafe { intrinsics::log10f64(self) }
     }
 
     /// The positive difference of two numbers.

--- a/library/std/src/sys/pal/mod.rs
+++ b/library/std/src/sys/pal/mod.rs
@@ -94,36 +94,5 @@ cfg_if::cfg_if! {
     }
 }
 
-// Solaris/Illumos requires a wrapper around log, log2, and log10 functions
-// because of their non-standard behavior (e.g., log(-n) returns -Inf instead
-// of expected NaN).
-#[cfg(not(test))]
-#[cfg(any(target_os = "solaris", target_os = "illumos"))]
-#[inline]
-pub fn log_wrapper<F: Fn(f64) -> f64>(n: f64, log_fn: F) -> f64 {
-    if n.is_finite() {
-        if n > 0.0 {
-            log_fn(n)
-        } else if n == 0.0 {
-            f64::NEG_INFINITY // log(0) = -Inf
-        } else {
-            f64::NAN // log(-n) = NaN
-        }
-    } else if n.is_nan() {
-        n // log(NaN) = NaN
-    } else if n > 0.0 {
-        n // log(Inf) = Inf
-    } else {
-        f64::NAN // log(-Inf) = NaN
-    }
-}
-
-#[cfg(not(test))]
-#[cfg(not(any(target_os = "solaris", target_os = "illumos")))]
-#[inline]
-pub fn log_wrapper<F: Fn(f64) -> f64>(n: f64, log_fn: F) -> f64 {
-    log_fn(n)
-}
-
 #[cfg(not(target_os = "uefi"))]
 pub type RawOsError = i32;


### PR DESCRIPTION
Issue had been fixed over time with solaris, 11.x behaves correctly
 (and we support it as minimum), illumos works correctly too.