### PR TITLE
collect doc alias as tips during resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3809,6 +3809,7 @@ dependencies = [
  "rustc_abi",
  "rustc_ast",
  "rustc_attr_data_structures",
+ "rustc_attr_parsing",
  "rustc_data_structures",
  "rustc_errors",
  "rustc_fluent_macro",

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -90,7 +90,9 @@ pub mod parser;
 mod session_diagnostics;
 
 pub use attributes::cfg::*;
-pub use attributes::util::{find_crate_name, is_builtin_attr, parse_version};
+pub use attributes::util::{
+    find_crate_name, is_builtin_attr, is_doc_alias_attrs_contain_symbol, parse_version,
+};
 pub use context::{AttributeParser, OmitDoc};
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }

--- a/compiler/rustc_hir_typeck/Cargo.toml
+++ b/compiler/rustc_hir_typeck/Cargo.toml
@@ -9,6 +9,7 @@ itertools = "0.12"
 rustc_abi = { path = "../rustc_abi" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_attr_data_structures = { path = "../rustc_attr_data_structures" }
+rustc_attr_parsing = { path = "../rustc_attr_parsing" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_fluent_macro = { path = "../rustc_fluent_macro" }

--- a/tests/ui/attributes/auxiliary/use-doc-alias-name-extern.rs
+++ b/tests/ui/attributes/auxiliary/use-doc-alias-name-extern.rs
@@ -1,0 +1,24 @@
+#[doc(alias="DocAliasS1")]
+pub struct S1;
+
+#[doc(alias="DocAliasS2")]
+#[doc(alias("DocAliasS3", "DocAliasS4"))]
+pub struct S2;
+
+#[doc(alias("doc_alias_f1", "doc_alias_f2"))]
+pub fn f() {}
+
+pub mod m {
+    #[doc(alias="DocAliasS5")]
+    pub struct S5;
+
+    pub mod n {
+        #[doc(alias("DocAliasX"))]
+        pub mod x {
+            pub mod y {
+                #[doc(alias="DocAliasS6")]
+                pub struct S6;
+            }
+        }
+    }
+}

--- a/tests/ui/attributes/use-doc-alias-name.rs
+++ b/tests/ui/attributes/use-doc-alias-name.rs
@@ -1,0 +1,67 @@
+//@ aux-build: use-doc-alias-name-extern.rs
+
+// issue#124273
+
+extern crate use_doc_alias_name_extern;
+
+use use_doc_alias_name_extern::*;
+
+#[doc(alias="LocalDocAliasS")]
+struct S;
+
+fn main() {
+    LocalDocAliasS; // don't show help in local crate
+    //~^ ERROR: cannot find value `LocalDocAliasS` in this scope
+
+    DocAliasS1;
+    //~^ ERROR: cannot find value `DocAliasS1` in this scope
+    //~| HELP: `S1` has a name defined in the doc alias attribute as `DocAliasS1`
+
+    DocAliasS2;
+    //~^ ERROR: cannot find value `DocAliasS2` in this scope
+    //~| HELP: `S2` has a name defined in the doc alias attribute as `DocAliasS2`
+
+    DocAliasS3;
+    //~^ ERROR: cannot find value `DocAliasS3` in this scope
+    //~| HELP: `S2` has a name defined in the doc alias attribute as `DocAliasS3`
+
+    DocAliasS4;
+    //~^ ERROR: cannot find value `DocAliasS4` in this scope
+    //~| HELP: `S2` has a name defined in the doc alias attribute as `DocAliasS4`
+
+    doc_alias_f1();
+    //~^ ERROR: cannot find function `doc_alias_f1` in this scope
+    //~| HELP: `f` has a name defined in the doc alias attribute as `doc_alias_f1`
+
+    doc_alias_f2();
+    //~^ ERROR: cannot find function `doc_alias_f2` in this scope
+    //~| HELP: `f` has a name defined in the doc alias attribute as `doc_alias_f2`
+
+    m::DocAliasS5;
+    //~^ ERROR: cannot find value `DocAliasS5` in module `m`
+    //~| HELP: `S5` has a name defined in the doc alias attribute as `DocAliasS5`
+
+    not_exist_module::DocAliasS1;
+    //~^ ERROR: use of unresolved module or unlinked crate `not_exist_module`
+    //~| HELP: you might be missing a crate named `not_exist_module`
+
+    use_doc_alias_name_extern::DocAliasS1;
+    //~^ ERROR: cannot find value `DocAliasS1` in crate `use_doc_alias_name_extern
+    //~| HELP: `S1` has a name defined in the doc alias attribute as `DocAliasS1`
+
+    m::n::DocAliasX::y::S6;
+    //~^ ERROR: could not find `DocAliasX` in `n`
+    //~| HELP: `x` has a name defined in the doc alias attribute as `DocAliasX`
+
+    m::n::x::y::DocAliasS6;
+    //~^ ERROR: cannot find value `DocAliasS6` in module `m::n::x::y`
+    //~| HELP: `S6` has a name defined in the doc alias attribute as `DocAliasS6`
+}
+
+trait T {
+    fn f() {
+        DocAliasS1;
+        //~^ ERROR: cannot find value `DocAliasS1` in this scope
+        //~| HELP: `S1` has a name defined in the doc alias attribute as `DocAliasS1`
+    }
+}

--- a/tests/ui/attributes/use-doc-alias-name.stderr
+++ b/tests/ui/attributes/use-doc-alias-name.stderr
@@ -1,0 +1,150 @@
+error[E0433]: failed to resolve: could not find `DocAliasX` in `n`
+  --> $DIR/use-doc-alias-name.rs:52:11
+   |
+LL |     m::n::DocAliasX::y::S6;
+   |           ^^^^^^^^^ could not find `DocAliasX` in `n`
+   |
+help: `x` has a name defined in the doc alias attribute as `DocAliasX`
+   |
+LL -     m::n::DocAliasX::y::S6;
+LL +     m::n::x::y::S6;
+   |
+
+error[E0425]: cannot find value `LocalDocAliasS` in this scope
+  --> $DIR/use-doc-alias-name.rs:13:5
+   |
+LL |     LocalDocAliasS; // don't show help in local crate
+   |     ^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `DocAliasS1` in this scope
+  --> $DIR/use-doc-alias-name.rs:16:5
+   |
+LL |     DocAliasS1;
+   |     ^^^^^^^^^^
+   |
+help: `S1` has a name defined in the doc alias attribute as `DocAliasS1`
+   |
+LL -     DocAliasS1;
+LL +     S1;
+   |
+
+error[E0425]: cannot find value `DocAliasS2` in this scope
+  --> $DIR/use-doc-alias-name.rs:20:5
+   |
+LL |     DocAliasS2;
+   |     ^^^^^^^^^^
+   |
+help: `S2` has a name defined in the doc alias attribute as `DocAliasS2`
+   |
+LL -     DocAliasS2;
+LL +     S2;
+   |
+
+error[E0425]: cannot find value `DocAliasS3` in this scope
+  --> $DIR/use-doc-alias-name.rs:24:5
+   |
+LL |     DocAliasS3;
+   |     ^^^^^^^^^^
+   |
+help: `S2` has a name defined in the doc alias attribute as `DocAliasS3`
+   |
+LL -     DocAliasS3;
+LL +     S2;
+   |
+
+error[E0425]: cannot find value `DocAliasS4` in this scope
+  --> $DIR/use-doc-alias-name.rs:28:5
+   |
+LL |     DocAliasS4;
+   |     ^^^^^^^^^^
+   |
+help: `S2` has a name defined in the doc alias attribute as `DocAliasS4`
+   |
+LL -     DocAliasS4;
+LL +     S2;
+   |
+
+error[E0425]: cannot find value `DocAliasS5` in module `m`
+  --> $DIR/use-doc-alias-name.rs:40:8
+   |
+LL |     m::DocAliasS5;
+   |        ^^^^^^^^^^
+   |
+help: `S5` has a name defined in the doc alias attribute as `DocAliasS5`
+   |
+LL -     m::DocAliasS5;
+LL +     m::S5;
+   |
+
+error[E0425]: cannot find value `DocAliasS1` in crate `use_doc_alias_name_extern`
+  --> $DIR/use-doc-alias-name.rs:48:32
+   |
+LL |     use_doc_alias_name_extern::DocAliasS1;
+   |                                ^^^^^^^^^^
+   |
+help: `S1` has a name defined in the doc alias attribute as `DocAliasS1`
+   |
+LL -     use_doc_alias_name_extern::DocAliasS1;
+LL +     use_doc_alias_name_extern::S1;
+   |
+
+error[E0425]: cannot find value `DocAliasS6` in module `m::n::x::y`
+  --> $DIR/use-doc-alias-name.rs:56:17
+   |
+LL |     m::n::x::y::DocAliasS6;
+   |                 ^^^^^^^^^^
+   |
+help: `S6` has a name defined in the doc alias attribute as `DocAliasS6`
+   |
+LL -     m::n::x::y::DocAliasS6;
+LL +     m::n::x::y::S6;
+   |
+
+error[E0425]: cannot find value `DocAliasS1` in this scope
+  --> $DIR/use-doc-alias-name.rs:63:9
+   |
+LL |         DocAliasS1;
+   |         ^^^^^^^^^^
+   |
+help: `S1` has a name defined in the doc alias attribute as `DocAliasS1`
+   |
+LL -         DocAliasS1;
+LL +         S1;
+   |
+
+error[E0425]: cannot find function `doc_alias_f1` in this scope
+  --> $DIR/use-doc-alias-name.rs:32:5
+   |
+LL |     doc_alias_f1();
+   |     ^^^^^^^^^^^^
+   |
+help: `f` has a name defined in the doc alias attribute as `doc_alias_f1`
+   |
+LL -     doc_alias_f1();
+LL +     f();
+   |
+
+error[E0425]: cannot find function `doc_alias_f2` in this scope
+  --> $DIR/use-doc-alias-name.rs:36:5
+   |
+LL |     doc_alias_f2();
+   |     ^^^^^^^^^^^^
+   |
+help: `f` has a name defined in the doc alias attribute as `doc_alias_f2`
+   |
+LL -     doc_alias_f2();
+LL +     f();
+   |
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `not_exist_module`
+  --> $DIR/use-doc-alias-name.rs:44:5
+   |
+LL |     not_exist_module::DocAliasS1;
+   |     ^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `not_exist_module`
+   |
+   = help: you might be missing a crate named `not_exist_module`
+
+error: aborting due to 13 previous errors
+
+Some errors have detailed explanations: E0425, E0433.
+For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
Close #124273

Collect the symbol in the doc alias attributes and provide a tip when a match is found.

r? @estebank 