### PR TITLE
Fix and enforce `unsafe_op_in_unsafe_fn` in compiler

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -627,7 +627,7 @@ impl Step for Size {
 
     #[inline]
     unsafe fn forward_unchecked(start: Self, count: usize) -> Self {
-        Self::from_bytes(u64::forward_unchecked(start.bytes(), count))
+        Self::from_bytes(unsafe { u64::forward_unchecked(start.bytes(), count) })
     }
 
     #[inline]
@@ -642,7 +642,7 @@ impl Step for Size {
 
     #[inline]
     unsafe fn backward_unchecked(start: Self, count: usize) -> Self {
-        Self::from_bytes(u64::backward_unchecked(start.bytes(), count))
+        Self::from_bytes(unsafe { u64::backward_unchecked(start.bytes(), count) })
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/allocator.rs
+++ b/compiler/rustc_codegen_llvm/src/allocator.rs
@@ -21,14 +21,16 @@ pub(crate) unsafe fn codegen(
 ) {
     let llcx = &*module_llvm.llcx;
     let llmod = module_llvm.llmod();
-    let usize = match tcx.sess.target.pointer_width {
-        16 => llvm::LLVMInt16TypeInContext(llcx),
-        32 => llvm::LLVMInt32TypeInContext(llcx),
-        64 => llvm::LLVMInt64TypeInContext(llcx),
-        tws => bug!("Unsupported target word size for int: {}", tws),
+    let usize = unsafe {
+        match tcx.sess.target.pointer_width {
+            16 => llvm::LLVMInt16TypeInContext(llcx),
+            32 => llvm::LLVMInt32TypeInContext(llcx),
+            64 => llvm::LLVMInt64TypeInContext(llcx),
+            tws => bug!("Unsupported target word size for int: {}", tws),
+        }
     };
-    let i8 = llvm::LLVMInt8TypeInContext(llcx);
-    let i8p = llvm::LLVMPointerTypeInContext(llcx, 0);
+    let i8 = unsafe { llvm::LLVMInt8TypeInContext(llcx) };
+    let i8p = unsafe { llvm::LLVMPointerTypeInContext(llcx, 0) };
 
     if kind == AllocatorKind::Default {
         for method in ALLOCATOR_METHODS {
@@ -73,23 +75,25 @@ pub(crate) unsafe fn codegen(
         true,
     );
 
-    // __rust_alloc_error_handler_should_panic
-    let name = OomStrategy::SYMBOL;
-    let ll_g = llvm::LLVMRustGetOrInsertGlobal(llmod, name.as_ptr().cast(), name.len(), i8);
-    if tcx.sess.default_hidden_visibility() {
-        llvm::LLVMRustSetVisibility(ll_g, llvm::Visibility::Hidden);
-    }
-    let val = tcx.sess.opts.unstable_opts.oom.should_panic();
-    let llval = llvm::LLVMConstInt(i8, val as u64, False);
-    llvm::LLVMSetInitializer(ll_g, llval);
+    unsafe {
+        // __rust_alloc_error_handler_should_panic
+        let name = OomStrategy::SYMBOL;
+        let ll_g = llvm::LLVMRustGetOrInsertGlobal(llmod, name.as_ptr().cast(), name.len(), i8);
+        if tcx.sess.default_hidden_visibility() {
+            llvm::LLVMRustSetVisibility(ll_g, llvm::Visibility::Hidden);
+        }
+        let val = tcx.sess.opts.unstable_opts.oom.should_panic();
+        let llval = llvm::LLVMConstInt(i8, val as u64, False);
+        llvm::LLVMSetInitializer(ll_g, llval);
 
-    let name = NO_ALLOC_SHIM_IS_UNSTABLE;
-    let ll_g = llvm::LLVMRustGetOrInsertGlobal(llmod, name.as_ptr().cast(), name.len(), i8);
-    if tcx.sess.default_hidden_visibility() {
-        llvm::LLVMRustSetVisibility(ll_g, llvm::Visibility::Hidden);
+        let name = NO_ALLOC_SHIM_IS_UNSTABLE;
+        let ll_g = llvm::LLVMRustGetOrInsertGlobal(llmod, name.as_ptr().cast(), name.len(), i8);
+        if tcx.sess.default_hidden_visibility() {
+            llvm::LLVMRustSetVisibility(ll_g, llvm::Visibility::Hidden);
+        }
+        let llval = llvm::LLVMConstInt(i8, 0, False);
+        llvm::LLVMSetInitializer(ll_g, llval);
     }
-    let llval = llvm::LLVMConstInt(i8, 0, False);
-    llvm::LLVMSetInitializer(ll_g, llval);
 
     if tcx.sess.opts.debuginfo != DebugInfo::None {
         let dbg_cx = debuginfo::CodegenUnitDebugContext::new(llmod);

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -727,7 +727,7 @@ pub unsafe fn optimize_thin_module(
     // into that context. One day, however, we may do this for upstream
     // crates but for locally codegened modules we may be able to reuse
     // that LLVM Context and Module.
-    let llcx = llvm::LLVMRustContextCreate(cgcx.fewer_names);
+    let llcx = unsafe { llvm::LLVMRustContextCreate(cgcx.fewer_names) };
     let llmod_raw = parse_module(llcx, module_name, thin_module.data(), dcx)? as *const _;
     let mut module = ModuleCodegen {
         module_llvm: ModuleLlvm { llmod_raw, llcx, tm: ManuallyDrop::new(tm) },
@@ -750,7 +750,9 @@ pub unsafe fn optimize_thin_module(
         {
             let _timer =
                 cgcx.prof.generic_activity_with_arg("LLVM_thin_lto_rename", thin_module.name());
-            if !llvm::LLVMRustPrepareThinLTORename(thin_module.shared.data.0, llmod, target) {
+            if unsafe {
+                !llvm::LLVMRustPrepareThinLTORename(thin_module.shared.data.0, llmod, target)
+            } {
                 return Err(write::llvm_err(dcx, LlvmError::PrepareThinLtoModule));
             }
             save_temp_bitcode(cgcx, &module, "thin-lto-after-rename");
@@ -760,7 +762,8 @@ pub unsafe fn optimize_thin_module(
             let _timer = cgcx
                 .prof
                 .generic_activity_with_arg("LLVM_thin_lto_resolve_weak", thin_module.name());
-            if !llvm::LLVMRustPrepareThinLTOResolveWeak(thin_module.shared.data.0, llmod) {
+            if unsafe { !llvm::LLVMRustPrepareThinLTOResolveWeak(thin_module.shared.data.0, llmod) }
+            {
                 return Err(write::llvm_err(dcx, LlvmError::PrepareThinLtoModule));
             }
             save_temp_bitcode(cgcx, &module, "thin-lto-after-resolve");
@@ -770,7 +773,8 @@ pub unsafe fn optimize_thin_module(
             let _timer = cgcx
                 .prof
                 .generic_activity_with_arg("LLVM_thin_lto_internalize", thin_module.name());
-            if !llvm::LLVMRustPrepareThinLTOInternalize(thin_module.shared.data.0, llmod) {
+            if unsafe { !llvm::LLVMRustPrepareThinLTOInternalize(thin_module.shared.data.0, llmod) }
+            {
                 return Err(write::llvm_err(dcx, LlvmError::PrepareThinLtoModule));
             }
             save_temp_bitcode(cgcx, &module, "thin-lto-after-internalize");
@@ -779,7 +783,9 @@ pub unsafe fn optimize_thin_module(
         {
             let _timer =
                 cgcx.prof.generic_activity_with_arg("LLVM_thin_lto_import", thin_module.name());
-            if !llvm::LLVMRustPrepareThinLTOImport(thin_module.shared.data.0, llmod, target) {
+            if unsafe {
+                !llvm::LLVMRustPrepareThinLTOImport(thin_module.shared.data.0, llmod, target)
+            } {
                 return Err(write::llvm_err(dcx, LlvmError::PrepareThinLtoModule));
             }
             save_temp_bitcode(cgcx, &module, "thin-lto-after-import");

--- a/compiler/rustc_codegen_llvm/src/back/profiling.rs
+++ b/compiler/rustc_codegen_llvm/src/back/profiling.rs
@@ -46,13 +46,15 @@ pub unsafe extern "C" fn selfprofile_before_pass_callback(
     pass_name: *const c_char,
     ir_name: *const c_char,
 ) {
-    let llvm_self_profiler = &mut *(llvm_self_profiler as *mut LlvmSelfProfiler<'_>);
-    let pass_name = CStr::from_ptr(pass_name).to_str().expect("valid UTF-8");
-    let ir_name = CStr::from_ptr(ir_name).to_str().expect("valid UTF-8");
-    llvm_self_profiler.before_pass_callback(pass_name, ir_name);
+    unsafe {
+        let llvm_self_profiler = &mut *(llvm_self_profiler as *mut LlvmSelfProfiler<'_>);
+        let pass_name = CStr::from_ptr(pass_name).to_str().expect("valid UTF-8");
+        let ir_name = CStr::from_ptr(ir_name).to_str().expect("valid UTF-8");
+        llvm_self_profiler.before_pass_callback(pass_name, ir_name);
+    }
 }
 
 pub unsafe extern "C" fn selfprofile_after_pass_callback(llvm_self_profiler: *mut c_void) {
-    let llvm_self_profiler = &mut *(llvm_self_profiler as *mut LlvmSelfProfiler<'_>);
+    let llvm_self_profiler = unsafe { &mut *(llvm_self_profiler as *mut LlvmSelfProfiler<'_>) };
     llvm_self_profiler.after_pass_callback();
 }

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -216,7 +216,7 @@ impl WriteBackendMethods for LlvmCodegenBackend {
         module: &ModuleCodegen<Self::Module>,
         config: &ModuleConfig,
     ) -> Result<(), FatalError> {
-        back::write::optimize(cgcx, dcx, module, config)
+        unsafe { back::write::optimize(cgcx, dcx, module, config) }
     }
     fn optimize_fat(
         cgcx: &CodegenContext<Self>,
@@ -230,7 +230,7 @@ impl WriteBackendMethods for LlvmCodegenBackend {
         cgcx: &CodegenContext<Self>,
         thin: ThinModule<Self>,
     ) -> Result<ModuleCodegen<Self::Module>, FatalError> {
-        back::lto::optimize_thin_module(thin, cgcx)
+        unsafe { back::lto::optimize_thin_module(thin, cgcx) }
     }
     unsafe fn codegen(
         cgcx: &CodegenContext<Self>,
@@ -238,7 +238,7 @@ impl WriteBackendMethods for LlvmCodegenBackend {
         module: ModuleCodegen<Self::Module>,
         config: &ModuleConfig,
     ) -> Result<CompiledModule, FatalError> {
-        back::write::codegen(cgcx, dcx, module, config)
+        unsafe { back::write::codegen(cgcx, dcx, module, config) }
     }
     fn prepare_thin(
         module: ModuleCodegen<Self::Module>,

--- a/compiler/rustc_codegen_llvm/src/llvm/diagnostic.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/diagnostic.rs
@@ -40,7 +40,7 @@ impl<'ll> OptimizationDiagnostic<'ll> {
         let mut filename = None;
         let pass_name = super::build_string(|pass_name| {
             message = super::build_string(|message| {
-                filename = super::build_string(|filename| {
+                filename = super::build_string(|filename| unsafe {
                     super::LLVMRustUnpackOptimizationDiagnostic(
                         di,
                         pass_name,
@@ -91,7 +91,7 @@ impl SrcMgrDiagnostic {
         let mut ranges = [0; 8];
         let mut num_ranges = ranges.len() / 2;
         let message = super::build_string(|message| {
-            buffer = super::build_string(|buffer| {
+            buffer = super::build_string(|buffer| unsafe {
                 have_source = super::LLVMRustUnpackSMDiagnostic(
                     diag,
                     message,
@@ -134,7 +134,9 @@ impl InlineAsmDiagnostic {
         let mut message = None;
         let mut level = super::DiagnosticLevel::Error;
 
-        super::LLVMRustUnpackInlineAsmDiagnostic(di, &mut level, &mut cookie, &mut message);
+        unsafe {
+            super::LLVMRustUnpackInlineAsmDiagnostic(di, &mut level, &mut cookie, &mut message);
+        }
 
         InlineAsmDiagnostic {
             level,
@@ -146,7 +148,8 @@ impl InlineAsmDiagnostic {
 
     unsafe fn unpackSrcMgr(di: &DiagnosticInfo) -> Self {
         let mut cookie = 0;
-        let smdiag = SrcMgrDiagnostic::unpack(super::LLVMRustGetSMDiagnostic(di, &mut cookie));
+        let smdiag =
+            unsafe { SrcMgrDiagnostic::unpack(super::LLVMRustGetSMDiagnostic(di, &mut cookie)) };
         InlineAsmDiagnostic {
             level: smdiag.level,
             cookie: cookie.into(),
@@ -170,44 +173,46 @@ pub enum Diagnostic<'ll> {
 impl<'ll> Diagnostic<'ll> {
     pub unsafe fn unpack(di: &'ll DiagnosticInfo) -> Self {
         use super::DiagnosticKind as Dk;
-        let kind = super::LLVMRustGetDiagInfoKind(di);
 
-        match kind {
-            Dk::InlineAsm => InlineAsm(InlineAsmDiagnostic::unpackInlineAsm(di)),
+        unsafe {
+            let kind = super::LLVMRustGetDiagInfoKind(di);
+            match kind {
+                Dk::InlineAsm => InlineAsm(InlineAsmDiagnostic::unpackInlineAsm(di)),
 
-            Dk::OptimizationRemark => {
-                Optimization(OptimizationDiagnostic::unpack(OptimizationRemark, di))
+                Dk::OptimizationRemark => {
+                    Optimization(OptimizationDiagnostic::unpack(OptimizationRemark, di))
+                }
+                Dk::OptimizationRemarkOther => {
+                    Optimization(OptimizationDiagnostic::unpack(OptimizationRemarkOther, di))
+                }
+                Dk::OptimizationRemarkMissed => {
+                    Optimization(OptimizationDiagnostic::unpack(OptimizationMissed, di))
+                }
+
+                Dk::OptimizationRemarkAnalysis => {
+                    Optimization(OptimizationDiagnostic::unpack(OptimizationAnalysis, di))
+                }
+
+                Dk::OptimizationRemarkAnalysisFPCommute => {
+                    Optimization(OptimizationDiagnostic::unpack(OptimizationAnalysisFPCommute, di))
+                }
+
+                Dk::OptimizationRemarkAnalysisAliasing => {
+                    Optimization(OptimizationDiagnostic::unpack(OptimizationAnalysisAliasing, di))
+                }
+
+                Dk::OptimizationFailure => {
+                    Optimization(OptimizationDiagnostic::unpack(OptimizationFailure, di))
+                }
+
+                Dk::PGOProfile => PGO(di),
+                Dk::Linker => Linker(di),
+                Dk::Unsupported => Unsupported(di),
+
+                Dk::SrcMgr => InlineAsm(InlineAsmDiagnostic::unpackSrcMgr(di)),
+
+                _ => UnknownDiagnostic(di),
             }
-            Dk::OptimizationRemarkOther => {
-                Optimization(OptimizationDiagnostic::unpack(OptimizationRemarkOther, di))
-            }
-            Dk::OptimizationRemarkMissed => {
-                Optimization(OptimizationDiagnostic::unpack(OptimizationMissed, di))
-            }
-
-            Dk::OptimizationRemarkAnalysis => {
-                Optimization(OptimizationDiagnostic::unpack(OptimizationAnalysis, di))
-            }
-
-            Dk::OptimizationRemarkAnalysisFPCommute => {
-                Optimization(OptimizationDiagnostic::unpack(OptimizationAnalysisFPCommute, di))
-            }
-
-            Dk::OptimizationRemarkAnalysisAliasing => {
-                Optimization(OptimizationDiagnostic::unpack(OptimizationAnalysisAliasing, di))
-            }
-
-            Dk::OptimizationFailure => {
-                Optimization(OptimizationDiagnostic::unpack(OptimizationFailure, di))
-            }
-
-            Dk::PGOProfile => PGO(di),
-            Dk::Linker => Linker(di),
-            Dk::Unsupported => Unsupported(di),
-
-            Dk::SrcMgr => InlineAsm(InlineAsmDiagnostic::unpackSrcMgr(di)),
-
-            _ => UnknownDiagnostic(di),
         }
     }
 }

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -49,12 +49,16 @@ unsafe fn configure_llvm(sess: &Session) {
     let mut llvm_c_strs = Vec::with_capacity(n_args + 1);
     let mut llvm_args = Vec::with_capacity(n_args + 1);
 
-    llvm::LLVMRustInstallErrorHandlers();
+    unsafe {
+        llvm::LLVMRustInstallErrorHandlers();
+    }
     // On Windows, an LLVM assertion will open an Abort/Retry/Ignore dialog
     // box for the purpose of launching a debugger. However, on CI this will
     // cause it to hang until it times out, which can take several hours.
     if std::env::var_os("CI").is_some() {
-        llvm::LLVMRustDisableSystemDialogsOnCrash();
+        unsafe {
+            llvm::LLVMRustDisableSystemDialogsOnCrash();
+        }
     }
 
     fn llvm_arg_to_arg_name(full_arg: &str) -> &str {
@@ -124,12 +128,12 @@ unsafe fn configure_llvm(sess: &Session) {
     }
 
     if sess.opts.unstable_opts.llvm_time_trace {
-        llvm::LLVMRustTimeTraceProfilerInitialize();
+        unsafe { llvm::LLVMRustTimeTraceProfilerInitialize() };
     }
 
     rustc_llvm::initialize_available_targets();
 
-    llvm::LLVMRustSetLLVMOptions(llvm_args.len() as c_int, llvm_args.as_ptr());
+    unsafe { llvm::LLVMRustSetLLVMOptions(llvm_args.len() as c_int, llvm_args.as_ptr()) };
 }
 
 pub fn time_trace_profiler_finish(file_name: &Path) {
@@ -442,8 +446,8 @@ pub(crate) fn print(req: &PrintRequest, mut out: &mut String, sess: &Session) {
             let cpu_cstring = CString::new(handle_native(sess.target.cpu.as_ref()))
                 .unwrap_or_else(|e| bug!("failed to convert to cstring: {}", e));
             unsafe extern "C" fn callback(out: *mut c_void, string: *const c_char, len: usize) {
-                let out = &mut *(out as *mut &mut String);
-                let bytes = slice::from_raw_parts(string as *const u8, len);
+                let out = unsafe { &mut *(out as *mut &mut String) };
+                let bytes = unsafe { slice::from_raw_parts(string as *const u8, len) };
                 write!(out, "{}", String::from_utf8_lossy(bytes)).unwrap();
             }
             unsafe {

--- a/compiler/rustc_codegen_llvm/src/mono_item.rs
+++ b/compiler/rustc_codegen_llvm/src/mono_item.rs
@@ -108,8 +108,8 @@ impl CodegenCx<'_, '_> {
         llval: &llvm::Value,
         is_declaration: bool,
     ) -> bool {
-        let linkage = llvm::LLVMRustGetLinkage(llval);
-        let visibility = llvm::LLVMRustGetVisibility(llval);
+        let linkage = unsafe { llvm::LLVMRustGetLinkage(llval) };
+        let visibility = unsafe { llvm::LLVMRustGetVisibility(llval) };
 
         if matches!(linkage, llvm::Linkage::InternalLinkage | llvm::Linkage::PrivateLinkage) {
             return true;
@@ -145,8 +145,8 @@ impl CodegenCx<'_, '_> {
         }
 
         // Thread-local variables generally don't support copy relocations.
-        let is_thread_local_var = llvm::LLVMIsAGlobalVariable(llval)
-            .is_some_and(|v| llvm::LLVMIsThreadLocal(v) == llvm::True);
+        let is_thread_local_var = unsafe { llvm::LLVMIsAGlobalVariable(llval) }
+            .is_some_and(|v| unsafe { llvm::LLVMIsThreadLocal(v) } == llvm::True);
         if is_thread_local_var {
             return false;
         }

--- a/compiler/rustc_codegen_ssa/src/back/lto.rs
+++ b/compiler/rustc_codegen_ssa/src/back/lto.rs
@@ -72,7 +72,7 @@ impl<B: WriteBackendMethods> LtoModuleCodegen<B> {
                 B::optimize_fat(cgcx, &mut module)?;
                 Ok(module)
             }
-            LtoModuleCodegen::Thin(thin) => B::optimize_thin(cgcx, thin),
+            LtoModuleCodegen::Thin(thin) => unsafe { B::optimize_thin(cgcx, thin) },
         }
     }
 

--- a/compiler/rustc_llvm/src/lib.rs
+++ b/compiler/rustc_llvm/src/lib.rs
@@ -33,7 +33,7 @@ pub unsafe extern "C" fn LLVMRustStringWriteImpl(
     ptr: *const c_char,
     size: size_t,
 ) {
-    let slice = slice::from_raw_parts(ptr as *const u8, size);
+    let slice = unsafe { slice::from_raw_parts(ptr as *const u8, size) };
 
     sr.bytes.borrow_mut().extend_from_slice(slice);
 }

--- a/compiler/rustc_middle/src/ty/context/tls.rs
+++ b/compiler/rustc_middle/src/ty/context/tls.rs
@@ -67,7 +67,7 @@ fn erase(context: &ImplicitCtxt<'_, '_>) -> *const () {
 
 #[inline]
 unsafe fn downcast<'a, 'tcx>(context: *const ()) -> &'a ImplicitCtxt<'a, 'tcx> {
-    &*(context as *const ImplicitCtxt<'a, 'tcx>)
+    unsafe { &*(context as *const ImplicitCtxt<'a, 'tcx>) }
 }
 
 /// Sets `context` as the new current `ImplicitCtxt` for the duration of the function `f`.

--- a/compiler/rustc_span/src/analyze_source_file.rs
+++ b/compiler/rustc_span/src/analyze_source_file.rs
@@ -89,13 +89,13 @@ cfg_match! {
                 let ptr = src_bytes.as_ptr() as *const __m128i;
                 // We don't know if the pointer is aligned to 16 bytes, so we
                 // use `loadu`, which supports unaligned loading.
-                let chunk = _mm_loadu_si128(ptr.add(chunk_index));
+                let chunk = unsafe { _mm_loadu_si128(ptr.add(chunk_index)) };
 
                 // For character in the chunk, see if its byte value is < 0, which
                 // indicates that it's part of a UTF-8 char.
-                let multibyte_test = _mm_cmplt_epi8(chunk, _mm_set1_epi8(0));
+                let multibyte_test = unsafe { _mm_cmplt_epi8(chunk, _mm_set1_epi8(0)) };
                 // Create a bit mask from the comparison results.
-                let multibyte_mask = _mm_movemask_epi8(multibyte_test);
+                let multibyte_mask = unsafe { _mm_movemask_epi8(multibyte_test) };
 
                 // If the bit mask is all zero, we only have ASCII chars here:
                 if multibyte_mask == 0 {
@@ -104,19 +104,19 @@ cfg_match! {
                     // Check if there are any control characters in the chunk. All
                     // control characters that we can encounter at this point have a
                     // byte value less than 32 or ...
-                    let control_char_test0 = _mm_cmplt_epi8(chunk, _mm_set1_epi8(32));
-                    let control_char_mask0 = _mm_movemask_epi8(control_char_test0);
+                    let control_char_test0 = unsafe { _mm_cmplt_epi8(chunk, _mm_set1_epi8(32)) };
+                    let control_char_mask0 = unsafe { _mm_movemask_epi8(control_char_test0) };
 
                     // ... it's the ASCII 'DEL' character with a value of 127.
-                    let control_char_test1 = _mm_cmpeq_epi8(chunk, _mm_set1_epi8(127));
-                    let control_char_mask1 = _mm_movemask_epi8(control_char_test1);
+                    let control_char_test1 = unsafe { _mm_cmpeq_epi8(chunk, _mm_set1_epi8(127)) };
+                    let control_char_mask1 = unsafe { _mm_movemask_epi8(control_char_test1) };
 
                     let control_char_mask = control_char_mask0 | control_char_mask1;
 
                     if control_char_mask != 0 {
                         // Check for newlines in the chunk
-                        let newlines_test = _mm_cmpeq_epi8(chunk, _mm_set1_epi8(b'\n' as i8));
-                        let newlines_mask = _mm_movemask_epi8(newlines_test);
+                        let newlines_test = unsafe { _mm_cmpeq_epi8(chunk, _mm_set1_epi8(b'\n' as i8)) };
+                        let newlines_mask = unsafe { _mm_movemask_epi8(newlines_test) };
 
                         if control_char_mask == newlines_mask {
                             // All control characters are newlines, record them

--- a/compiler/rustc_span/src/analyze_source_file.rs
+++ b/compiler/rustc_span/src/analyze_source_file.rs
@@ -35,25 +35,25 @@ pub fn analyze_source_file(
 
 cfg_match! {
     cfg(any(target_arch = "x86", target_arch = "x86_64")) => {
-        fn analyze_source_file_dispatch(src: &str,
-                                    lines: &mut Vec<RelativeBytePos>,
-                                    multi_byte_chars: &mut Vec<MultiByteChar>,
-                                    non_narrow_chars: &mut Vec<NonNarrowChar>) {
+        fn analyze_source_file_dispatch(
+            src: &str,
+            lines: &mut Vec<RelativeBytePos>,
+            multi_byte_chars: &mut Vec<MultiByteChar>,
+            non_narrow_chars: &mut Vec<NonNarrowChar>,
+        ) {
             if is_x86_feature_detected!("sse2") {
                 unsafe {
-                    analyze_source_file_sse2(src,
-                                         lines,
-                                         multi_byte_chars,
-                                         non_narrow_chars);
+                    analyze_source_file_sse2(src, lines, multi_byte_chars, non_narrow_chars);
                 }
             } else {
-                analyze_source_file_generic(src,
-                                        src.len(),
-                                        RelativeBytePos::from_u32(0),
-                                        lines,
-                                        multi_byte_chars,
-                                        non_narrow_chars);
-
+                analyze_source_file_generic(
+                    src,
+                    src.len(),
+                    RelativeBytePos::from_u32(0),
+                    lines,
+                    multi_byte_chars,
+                    non_narrow_chars,
+                );
             }
         }
 
@@ -62,10 +62,12 @@ cfg_match! {
         /// function falls back to the generic implementation. Otherwise it uses
         /// SSE2 intrinsics to quickly find all newlines.
         #[target_feature(enable = "sse2")]
-        unsafe fn analyze_source_file_sse2(src: &str,
-                                       lines: &mut Vec<RelativeBytePos>,
-                                       multi_byte_chars: &mut Vec<MultiByteChar>,
-                                       non_narrow_chars: &mut Vec<NonNarrowChar>) {
+        unsafe fn analyze_source_file_sse2(
+            src: &str,
+            lines: &mut Vec<RelativeBytePos>,
+            multi_byte_chars: &mut Vec<MultiByteChar>,
+            non_narrow_chars: &mut Vec<NonNarrowChar>,
+        ) {
             #[cfg(target_arch = "x86")]
             use std::arch::x86::*;
             #[cfg(target_arch = "x86_64")]
@@ -83,7 +85,7 @@ cfg_match! {
             // handled it.
             let mut intra_chunk_offset = 0;
 
-            for chunk_index in 0 .. chunk_count {
+            for chunk_index in 0..chunk_count {
                 let ptr = src_bytes.as_ptr() as *const __m128i;
                 // We don't know if the pointer is aligned to 16 bytes, so we
                 // use `loadu`, which supports unaligned loading.
@@ -126,7 +128,7 @@ cfg_match! {
 
                                 if index >= CHUNK_SIZE as u32 {
                                     // We have arrived at the end of the chunk.
-                                    break
+                                    break;
                                 }
 
                                 lines.push(RelativeBytePos(index) + output_offset);
@@ -137,14 +139,14 @@ cfg_match! {
 
                             // We are done for this chunk. All control characters were
                             // newlines and we took care of those.
-                            continue
+                            continue;
                         } else {
                             // Some of the control characters are not newlines,
                             // fall through to the slow path below.
                         }
                     } else {
                         // No control characters, nothing to record for this chunk
-                        continue
+                        continue;
                     }
                 }
 
@@ -152,43 +154,48 @@ cfg_match! {
                 // There are control chars in here, fallback to generic decoding.
                 let scan_start = chunk_index * CHUNK_SIZE + intra_chunk_offset;
                 intra_chunk_offset = analyze_source_file_generic(
-                    &src[scan_start .. ],
+                    &src[scan_start..],
                     CHUNK_SIZE - intra_chunk_offset,
                     RelativeBytePos::from_usize(scan_start),
                     lines,
                     multi_byte_chars,
-                    non_narrow_chars
+                    non_narrow_chars,
                 );
             }
 
             // There might still be a tail left to analyze
             let tail_start = chunk_count * CHUNK_SIZE + intra_chunk_offset;
             if tail_start < src.len() {
-                analyze_source_file_generic(&src[tail_start ..],
-                                        src.len() - tail_start,
-                                        RelativeBytePos::from_usize(tail_start),
-                                        lines,
-                                        multi_byte_chars,
-                                        non_narrow_chars);
+                analyze_source_file_generic(
+                    &src[tail_start..],
+                    src.len() - tail_start,
+                    RelativeBytePos::from_usize(tail_start),
+                    lines,
+                    multi_byte_chars,
+                    non_narrow_chars,
+                );
             }
         }
     }
     _ => {
         // The target (or compiler version) does not support SSE2 ...
-        fn analyze_source_file_dispatch(src: &str,
-                                    lines: &mut Vec<RelativeBytePos>,
-                                    multi_byte_chars: &mut Vec<MultiByteChar>,
-                                    non_narrow_chars: &mut Vec<NonNarrowChar>) {
-            analyze_source_file_generic(src,
-                                    src.len(),
-                                    RelativeBytePos::from_u32(0),
-                                    lines,
-                                    multi_byte_chars,
-                                    non_narrow_chars);
+        fn analyze_source_file_dispatch(
+            src: &str,
+            lines: &mut Vec<RelativeBytePos>,
+            multi_byte_chars: &mut Vec<MultiByteChar>,
+            non_narrow_chars: &mut Vec<NonNarrowChar>,
+        ) {
+            analyze_source_file_generic(
+                src,
+                src.len(),
+                RelativeBytePos::from_u32(0),
+                lines,
+                multi_byte_chars,
+                non_narrow_chars,
+            );
         }
     }
 }
-
 // `scan_len` determines the number of bytes in `src` to scan. Note that the
 // function can read past `scan_len` if a multi-byte character start within the
 // range but extends past it. The overflow is returned by the function.

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -2001,6 +2001,7 @@ impl<'a> Builder<'a> {
             // FIXME(edition_2024): Change this to `-Wrust_2024_idioms` when all
             // of the individual lints are satisfied.
             rustflags.arg("-Wkeyword_idents_2024");
+            rustflags.arg("-Wunsafe_op_in_unsafe_fn");
         }
 
         if self.config.rust_frame_pointers {


### PR DESCRIPTION
In preparation for edition 2024, this PR previews the fallout of enabling the `unsafe_op_in_unsafe_fn` lint in the compiler, since it's defaulting to warn in the new edition (#112038).

The major annoyance comes primarily from the `rustc_codegen_llvm` module, where there's a ton of unsafe calls. I tended to wrap individual calls to unsafe fns in `unsafe {}`, but there a handful of places I chose to just wrap several calls in an `unsafe {}` block just because it would've been excessive to wrap each call individually.

This doesn't enable the lint for the standard library, since I'm not totally certain what T-libs prefers w/ this lint.