### PR TITLE
Mark `f16` and `f128` as incomplete features.

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -464,9 +464,9 @@ declare_features! (
     /// Allows defining `extern type`s.
     (unstable, extern_types, "1.23.0", Some(43467)),
     /// Allow using 128-bit (quad precision) floating point numbers.
-    (unstable, f128, "1.78.0", Some(116909)),
+    (incomplete, f128, "1.78.0", Some(116909)),
     /// Allow using 16-bit (half precision) floating point numbers.
-    (unstable, f16, "1.78.0", Some(116909)),
+    (incomplete, f16, "1.78.0", Some(116909)),
     /// Allows the use of `#[ffi_const]` on foreign functions.
     (unstable, ffi_const, "1.45.0", Some(58328)),
     /// Allows the use of `#[ffi_pure]` on foreign functions.

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -249,6 +249,7 @@
 #![warn(missing_debug_implementations)]
 #![allow(explicit_outlives_requirements)]
 #![allow(unused_lifetimes)]
+#![allow(incomplete_features)]
 #![allow(internal_features)]
 #![deny(rustc::existing_doc_keyword)]
 #![deny(fuzzy_provenance_casts)]


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/116909#issuecomment-2227514184.

Unfortunately this will probably have a lot that needs to be updated, just getting this started to figure out exactly what that will be.

<!-- homu-ignore:start -->
(moved from https://github.com/rust-lang/rust/pull/127739, github didn't like my branch typo fix)

r? @scottmcm 
<!-- homu-ignore:end -->
