### PR TITLE
Implement `Clone` for `BufReader`, `BufWriter` and `LineWriter`

### DIFF
--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -401,6 +401,18 @@ impl<R: ?Sized + Read> BufRead for BufReader<R> {
     }
 }
 
+#[stable(feature = "io_buf_clone", since = "CURRENT_RUSTC_VERSION")]
+impl<R: Clone> Clone for BufReader<R> {
+    fn clone(&self) -> Self {
+        Self { buf: self.buf.clone(), inner: self.inner.clone() }
+    }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.buf.clone_from(&other.buf);
+        self.inner.clone_from(&other.inner);
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<R> fmt::Debug for BufReader<R>
 where

--- a/library/std/src/io/buffered/bufreader/buffer.rs
+++ b/library/std/src/io/buffered/bufreader/buffer.rs
@@ -121,3 +121,21 @@ impl Buffer {
         Ok(self.buffer())
     }
 }
+
+impl Clone for Buffer {
+    fn clone(&self) -> Self {
+        Self {
+            buf: self.buf.clone(),
+            pos: self.pos,
+            filled: self.filled,
+            initialized: self.initialized,
+        }
+    }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.buf.clone_from(&other.buf);
+        self.pos = other.pos;
+        self.filled = other.filled;
+        self.initialized = other.initialized;
+    }
+}

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -643,6 +643,19 @@ impl<W: ?Sized + Write> Write for BufWriter<W> {
     }
 }
 
+#[stable(feature = "io_buf_clone", since = "CURRENT_RUSTC_VERSION")]
+impl<W: Clone + Write> Clone for BufWriter<W> {
+    fn clone(&self) -> Self {
+        Self { buf: self.buf.clone(), panicked: self.panicked, inner: self.inner.clone() }
+    }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.buf.clone_from(&other.buf);
+        self.panicked = other.panicked;
+        self.inner.clone_from(&other.inner);
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<W: ?Sized + Write> fmt::Debug for BufWriter<W>
 where

--- a/library/std/src/io/buffered/linewriter.rs
+++ b/library/std/src/io/buffered/linewriter.rs
@@ -217,6 +217,17 @@ impl<W: ?Sized + Write> Write for LineWriter<W> {
     }
 }
 
+#[stable(feature = "io_buf_clone", since = "CURRENT_RUSTC_VERSION")]
+impl<W: Clone + Write> Clone for LineWriter<W> {
+    fn clone(&self) -> Self {
+        Self { inner: self.inner.clone() }
+    }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.inner.clone_from(&other.inner);
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<W: ?Sized + Write> fmt::Debug for LineWriter<W>
 where


### PR DESCRIPTION
This is sometimes very useful, and I could not find any reason why this does not exist.