### PR TITLE
[DO NOT MERGE] Build musl targets for crater run

### DIFF
--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -25,6 +25,7 @@ shift
 # Apparently applying `-fPIC` everywhere allows them to link successfully.
 export CFLAGS="-fPIC $CFLAGS"
 
+# insignificant change
 MUSL=musl-1.2.3
 
 # may have been downloaded in a previous run


### PR DESCRIPTION
Using to test #125692 

try-job: dist-x86_64-musl
try-job: dist-i586-gnu-i586-i686-musl
try-job: dist-x86_64-linux

r? @ghost