### PR TITLE
Don't use implicit features in `Cargo.toml` in `compiler/`

### DIFF
--- a/compiler/rustc/Cargo.toml
+++ b/compiler/rustc/Cargo.toml
@@ -27,7 +27,7 @@ features = ['unprefixed_malloc_on_supported_platforms']
 
 [features]
 # tidy-alphabetical-start
-jemalloc = ['jemalloc-sys']
+jemalloc = ['dep:jemalloc-sys']
 llvm = ['rustc_driver_impl/llvm']
 max_level_info = ['rustc_driver_impl/max_level_info']
 rustc_use_parallel_compiler = ['rustc_driver_impl/rustc_use_parallel_compiler']

--- a/compiler/rustc/src/main.rs
+++ b/compiler/rustc/src/main.rs
@@ -34,7 +34,7 @@
 
 fn main() {
     // See the comment at the top of this file for an explanation of this.
-    #[cfg(feature = "jemalloc-sys")]
+    #[cfg(feature = "jemalloc")]
     {
         use std::os::raw::{c_int, c_void};
 

--- a/compiler/rustc_abi/Cargo.toml
+++ b/compiler/rustc_abi/Cargo.toml
@@ -21,10 +21,10 @@ default = ["nightly", "randomize"]
 # rust-analyzer depends on this crate and we therefore require it to built on a stable toolchain
 # without depending on rustc_data_structures, rustc_macros and rustc_serialize
 nightly = [
-    "rustc_data_structures",
+    "dep:rustc_data_structures",
+    "dep:rustc_macros",
+    "dep:rustc_serialize",
     "rustc_index/nightly",
-    "rustc_macros",
-    "rustc_serialize",
 ]
-randomize = ["rand", "rand_xoshiro", "nightly"]
+randomize = ["dep:rand", "dep:rand_xoshiro", "nightly"]
 # tidy-alphabetical-end

--- a/compiler/rustc_ast_ir/Cargo.toml
+++ b/compiler/rustc_ast_ir/Cargo.toml
@@ -14,8 +14,8 @@ rustc_span = { path = "../rustc_span", optional = true }
 [features]
 default = ["nightly"]
 nightly = [
-    "rustc_serialize",
-    "rustc_data_structures",
-    "rustc_macros",
-    "rustc_span",
+    "dep:rustc_serialize",
+    "dep:rustc_data_structures",
+    "dep:rustc_macros",
+    "dep:rustc_span",
 ]

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -56,5 +56,5 @@ portable-atomic = "1.5.1"
 
 [features]
 # tidy-alphabetical-start
-rustc_use_parallel_compiler = ["indexmap/rustc-rayon", "rustc-rayon"]
+rustc_use_parallel_compiler = ["indexmap/rustc-rayon", "dep:rustc-rayon"]
 # tidy-alphabetical-end

--- a/compiler/rustc_index/Cargo.toml
+++ b/compiler/rustc_index/Cargo.toml
@@ -15,5 +15,9 @@ smallvec = "1.8.1"
 [features]
 # tidy-alphabetical-start
 default = ["nightly"]
-nightly = ["rustc_serialize", "rustc_macros", "rustc_index_macros/nightly"]
+nightly = [
+    "dep:rustc_serialize",
+    "dep:rustc_macros",
+    "rustc_index_macros/nightly",
+]
 # tidy-alphabetical-end

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "rustc_serialize")]
+#[cfg(feature = "nightly")]
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 use std::borrow::{Borrow, BorrowMut};
@@ -322,14 +322,14 @@ impl<I: Idx, T, const N: usize> From<[T; N]> for IndexVec<I, T> {
     }
 }
 
-#[cfg(feature = "rustc_serialize")]
+#[cfg(feature = "nightly")]
 impl<S: Encoder, I: Idx, T: Encodable<S>> Encodable<S> for IndexVec<I, T> {
     fn encode(&self, s: &mut S) {
         Encodable::encode(&self.raw, s);
     }
 }
 
-#[cfg(feature = "rustc_serialize")]
+#[cfg(feature = "nightly")]
 impl<D: Decoder, I: Idx, T: Decodable<D>> Decodable<D> for IndexVec<I, T> {
     fn decode(d: &mut D) -> Self {
         IndexVec::from_raw(Vec::<T>::decode(d))

--- a/compiler/rustc_interface/Cargo.toml
+++ b/compiler/rustc_interface/Cargo.toml
@@ -53,6 +53,11 @@ tracing = "0.1"
 
 [features]
 # tidy-alphabetical-start
-llvm = ['rustc_codegen_llvm']
-rustc_use_parallel_compiler = ['rustc-rayon', 'rustc-rayon-core', 'rustc_query_impl/rustc_use_parallel_compiler', 'rustc_errors/rustc_use_parallel_compiler']
+llvm = ['dep:rustc_codegen_llvm']
+rustc_use_parallel_compiler = [
+    'dep:rustc-rayon',
+    'dep:rustc-rayon-core',
+    'rustc_query_impl/rustc_use_parallel_compiler',
+    'rustc_errors/rustc_use_parallel_compiler'
+]
 # tidy-alphabetical-end

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -40,5 +40,5 @@ tracing = "0.1"
 
 [features]
 # tidy-alphabetical-start
-rustc_use_parallel_compiler = ["rustc-rayon-core"]
+rustc_use_parallel_compiler = ["dep:rustc-rayon-core"]
 # tidy-alphabetical-end

--- a/compiler/rustc_next_trait_solver/Cargo.toml
+++ b/compiler/rustc_next_trait_solver/Cargo.toml
@@ -20,10 +20,10 @@ tracing = "0.1"
 [features]
 default = ["nightly"]
 nightly = [
+    "dep:rustc_data_structures",
+    "dep:rustc_macros",
+    "dep:rustc_serialize",
     "rustc_ast_ir/nightly",
-    "rustc_data_structures",
     "rustc_index/nightly",
-    "rustc_macros",
-    "rustc_serialize",
     "rustc_type_ir/nightly",
 ]

--- a/compiler/rustc_query_system/Cargo.toml
+++ b/compiler/rustc_query_system/Cargo.toml
@@ -26,5 +26,5 @@ tracing = "0.1"
 
 [features]
 # tidy-alphabetical-start
-rustc_use_parallel_compiler = ["rustc-rayon-core"]
+rustc_use_parallel_compiler = ["dep:rustc-rayon-core"]
 # tidy-alphabetical-end

--- a/compiler/rustc_transmute/Cargo.toml
+++ b/compiler/rustc_transmute/Cargo.toml
@@ -18,13 +18,13 @@ tracing = "0.1"
 
 [features]
 rustc = [
-    "rustc_hir",
-    "rustc_infer",
-    "rustc_macros",
-    "rustc_middle",
-    "rustc_span",
-    "rustc_target",
-    "rustc_ast_ir",
+    "dep:rustc_hir",
+    "dep:rustc_infer",
+    "dep:rustc_macros",
+    "dep:rustc_middle",
+    "dep:rustc_span",
+    "dep:rustc_target",
+    "dep:rustc_ast_ir",
 ]
 
 [dev-dependencies]

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -22,12 +22,12 @@ tracing = "0.1"
 [features]
 default = ["nightly"]
 nightly = [
+    "dep:rustc_serialize",
+    "dep:rustc_span",
+    "dep:rustc_data_structures",
+    "dep:rustc_macros",
     "smallvec/may_dangle",
     "smallvec/union",
     "rustc_index/nightly",
-    "rustc_serialize",
-    "rustc_span",
-    "rustc_data_structures",
-    "rustc_macros",
     "rustc_ast_ir/nightly"
 ]


### PR DESCRIPTION
Fixes compiler crates to stop using implicit features (https://github.com/rust-lang/cargo/issues/12826) which are denied in in edition 2024.