### PR TITLE
Put the dots back in RTN pretty printing

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1214,11 +1214,14 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             && let ty::Alias(_, alias_ty) =
                 self.tcx().fn_sig(fn_def_id).skip_binder().output().skip_binder().kind()
             && alias_ty.def_id == def_id
+            && let generics = self.tcx().generics_of(fn_def_id)
+            // FIXME(return_type_notation): We only support lifetime params for now.
+            && generics.own_params.iter().all(|param| matches!(param.kind, ty::GenericParamDefKind::Lifetime))
         {
-            let num_args = self.tcx().generics_of(fn_def_id).count();
+            let num_args = generics.count();
             write!(self, " {{ ")?;
             self.print_def_path(fn_def_id, &args[..num_args])?;
-            write!(self, "() }}")?;
+            write!(self, "(..) }}")?;
         }
 
         Ok(())

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.without.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.without.stderr
@@ -13,12 +13,12 @@ error: future cannot be sent between threads safely
 LL |     is_send(foo::<T>());
    |             ^^^^^^^^^^ future returned by `foo` is not `Send`
    |
-   = help: within `impl Future<Output = Result<(), ()>>`, the trait `Send` is not implemented for `impl Future<Output = Result<(), ()>> { <T as Foo>::method() }`, which is required by `impl Future<Output = Result<(), ()>>: Send`
+   = help: within `impl Future<Output = Result<(), ()>>`, the trait `Send` is not implemented for `impl Future<Output = Result<(), ()>> { <T as Foo>::method(..) }`, which is required by `impl Future<Output = Result<(), ()>>: Send`
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/basic.rs:13:5
    |
 LL |     T::method().await?;
-   |     ^^^^^^^^^^^ await occurs here on type `impl Future<Output = Result<(), ()>> { <T as Foo>::method() }`, which is not `Send`
+   |     ^^^^^^^^^^^ await occurs here on type `impl Future<Output = Result<(), ()>> { <T as Foo>::method(..) }`, which is not `Send`
 note: required by a bound in `is_send`
   --> $DIR/basic.rs:17:20
    |

--- a/tests/ui/associated-type-bounds/return-type-notation/display.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/display.rs
@@ -1,0 +1,25 @@
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Trait {}
+fn needs_trait(_: impl Trait) {}
+
+trait Assoc {
+    fn method() -> impl Sized;
+    fn method_with_lt() -> impl Sized;
+    fn method_with_ty<T>() -> impl Sized;
+    fn method_with_ct<const N: usize>() -> impl Sized;
+}
+
+fn foo<T: Assoc>(t: T) {
+    needs_trait(T::method());
+    //~^ ERROR the trait bound
+    needs_trait(T::method_with_lt());
+    //~^ ERROR the trait bound
+    needs_trait(T::method_with_ty());
+    //~^ ERROR the trait bound
+    needs_trait(T::method_with_ct());
+    //~^ ERROR the trait bound
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/display.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/display.stderr
@@ -1,0 +1,78 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/display.rs:1:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0277]: the trait bound `impl Sized { <T as Assoc>::method(..) }: Trait` is not satisfied
+  --> $DIR/display.rs:15:17
+   |
+LL |     needs_trait(T::method());
+   |     ----------- ^^^^^^^^^^^ the trait `Trait` is not implemented for `impl Sized { <T as Assoc>::method(..) }`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `needs_trait`
+  --> $DIR/display.rs:5:24
+   |
+LL | fn needs_trait(_: impl Trait) {}
+   |                        ^^^^^ required by this bound in `needs_trait`
+
+error[E0277]: the trait bound `impl Sized { <T as Assoc>::method_with_lt(..) }: Trait` is not satisfied
+  --> $DIR/display.rs:17:17
+   |
+LL |     needs_trait(T::method_with_lt());
+   |     ----------- ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `impl Sized { <T as Assoc>::method_with_lt(..) }`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `needs_trait`
+  --> $DIR/display.rs:5:24
+   |
+LL | fn needs_trait(_: impl Trait) {}
+   |                        ^^^^^ required by this bound in `needs_trait`
+
+error[E0277]: the trait bound `impl Sized: Trait` is not satisfied
+  --> $DIR/display.rs:19:17
+   |
+LL |     needs_trait(T::method_with_ty());
+   |     ----------- ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `impl Sized`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/display.rs:4:1
+   |
+LL | trait Trait {}
+   | ^^^^^^^^^^^
+note: required by a bound in `needs_trait`
+  --> $DIR/display.rs:5:24
+   |
+LL | fn needs_trait(_: impl Trait) {}
+   |                        ^^^^^ required by this bound in `needs_trait`
+
+error[E0277]: the trait bound `impl Sized: Trait` is not satisfied
+  --> $DIR/display.rs:21:17
+   |
+LL |     needs_trait(T::method_with_ct());
+   |     ----------- ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `impl Sized`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/display.rs:4:1
+   |
+LL | trait Trait {}
+   | ^^^^^^^^^^^
+note: required by a bound in `needs_trait`
+  --> $DIR/display.rs:5:24
+   |
+LL | fn needs_trait(_: impl Trait) {}
+   |                        ^^^^^ required by this bound in `needs_trait`
+
+error: aborting due to 4 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.stderr
@@ -18,8 +18,8 @@ LL | |         }
 LL | |     });
    | |______^ implementation of `Send` is not general enough
    |
-   = note: `Send` would have to be implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'0>() }`, for any two lifetimes `'0` and `'1`...
-   = note: ...but `Send` is actually implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'2>() }`, for some specific lifetime `'2`
+   = note: `Send` would have to be implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'0>(..) }`, for any two lifetimes `'0` and `'1`...
+   = note: ...but `Send` is actually implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'2>(..) }`, for some specific lifetime `'2`
 
 error: implementation of `Send` is not general enough
   --> $DIR/issue-110963-early.rs:14:5
@@ -32,8 +32,8 @@ LL | |         }
 LL | |     });
    | |______^ implementation of `Send` is not general enough
    |
-   = note: `Send` would have to be implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'0>() }`, for any two lifetimes `'0` and `'1`...
-   = note: ...but `Send` is actually implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'2>() }`, for some specific lifetime `'2`
+   = note: `Send` would have to be implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'0>(..) }`, for any two lifetimes `'0` and `'1`...
+   = note: ...but `Send` is actually implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'2>(..) }`, for some specific lifetime `'2`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors; 1 warning emitted


### PR DESCRIPTION
Also don't render RTN-like bounds for methods with ty/const params.