### PR TITLE
run-make-support: update gimli to 0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,6 +1619,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,7 +3432,7 @@ dependencies = [
  "ar",
  "bstr",
  "build_helper",
- "gimli 0.28.1",
+ "gimli 0.31.0",
  "object 0.34.0",
  "regex",
  "similar",

--- a/src/tools/run-make-support/Cargo.toml
+++ b/src/tools/run-make-support/Cargo.toml
@@ -9,7 +9,7 @@ object = "0.34.0"
 similar = "2.5.0"
 wasmparser = "0.118.2"
 regex = "1.8" # 1.8 to avoid memchr 2.6.0, as 2.5.0 is pinned in the workspace
-gimli = "0.28.1"
+gimli = "0.31.0"
 ar = "0.9.0"
 
 build_helper = { path = "../build_helper" }


### PR DESCRIPTION
This version bump is required for the tests in #126985 as suggested [here](https://github.com/rust-lang/rust/pull/126985#issuecomment-2196745112).

r​? tgross35
(^ that didn't work. cc @tgross35)

try-job: x86_64-msvc
try-job: x86_64-mingw
try-job: aarch64-apple
try-job: test-various
try-job: armhf-gnu
try-job: dist-x86_64-linux

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
