### PR TITLE
Rename `tcx` to `cx` in `rustc_type_ir`

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -309,7 +309,7 @@ impl<'me, 'bccx, 'tcx> NllTypeRelating<'me, 'bccx, 'tcx> {
 }
 
 impl<'bccx, 'tcx> TypeRelation<TyCtxt<'tcx>> for NllTypeRelating<'_, 'bccx, 'tcx> {
-    fn tcx(&self) -> TyCtxt<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
         self.type_checker.infcx.tcx
     }
 
@@ -370,7 +370,7 @@ impl<'bccx, 'tcx> TypeRelation<TyCtxt<'tcx>> for NllTypeRelating<'_, 'bccx, 'tcx
                     // shouldn't ever fail. Instead, it unconditionally emits an
                     // alias-relate goal.
                     assert!(!self.type_checker.infcx.next_trait_solver());
-                    self.tcx().dcx().span_delayed_bug(
+                    self.cx().dcx().span_delayed_bug(
                         self.span(),
                         "failure to relate an opaque to itself should result in an error later on",
                     );
@@ -540,7 +540,7 @@ impl<'bccx, 'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for NllTypeRelating
         &mut self,
         obligations: impl IntoIterator<Item: ty::Upcast<TyCtxt<'tcx>, ty::Predicate<'tcx>>>,
     ) {
-        let tcx = self.tcx();
+        let tcx = self.cx();
         let param_env = self.param_env();
         self.register_goals(
             obligations.into_iter().map(|to_pred| Goal::new(tcx, param_env, to_pred)),
@@ -559,7 +559,7 @@ impl<'bccx, 'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for NllTypeRelating
                     .into_iter()
                     .map(|goal| {
                         Obligation::new(
-                            self.tcx(),
+                            self.cx(),
                             ObligationCause::dummy_with_span(self.span()),
                             goal.param_env,
                             goal.predicate,

--- a/compiler/rustc_infer/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_infer/src/error_reporting/infer/mod.rs
@@ -1930,7 +1930,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 struct SameTypeModuloInfer<'a, 'tcx>(&'a InferCtxt<'tcx>);
 
 impl<'tcx> TypeRelation<TyCtxt<'tcx>> for SameTypeModuloInfer<'_, 'tcx> {
-    fn tcx(&self) -> TyCtxt<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
         self.0.tcx
     }
 

--- a/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
+++ b/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
@@ -137,7 +137,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for MatchAgainstHigherRankedOutlives<'tcx>
         "MatchAgainstHigherRankedOutlives"
     }
 
-    fn tcx(&self) -> TyCtxt<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }
 

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -372,7 +372,7 @@ impl<'tcx> Generalizer<'_, 'tcx> {
 
         let is_nested_alias = mem::replace(&mut self.in_alias, true);
         let result = match self.relate(alias, alias) {
-            Ok(alias) => Ok(alias.to_ty(self.tcx())),
+            Ok(alias) => Ok(alias.to_ty(self.cx())),
             Err(e) => {
                 if is_nested_alias {
                     return Err(e);
@@ -397,7 +397,7 @@ impl<'tcx> Generalizer<'_, 'tcx> {
 }
 
 impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Generalizer<'_, 'tcx> {
-    fn tcx(&self) -> TyCtxt<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
         self.infcx.tcx
     }
 
@@ -417,7 +417,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Generalizer<'_, 'tcx> {
             // (e.g., #41849).
             relate::relate_args_invariantly(self, a_arg, b_arg)
         } else {
-            let tcx = self.tcx();
+            let tcx = self.cx();
             let opt_variances = tcx.variances_of(item_def_id);
             relate::relate_args_with_variances(
                 self,
@@ -525,7 +525,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Generalizer<'_, 'tcx> {
                             }
 
                             debug!("replacing original vid={:?} with new={:?}", vid, new_var_id);
-                            Ok(Ty::new_var(self.tcx(), new_var_id))
+                            Ok(Ty::new_var(self.cx(), new_var_id))
                         }
                     }
                 }
@@ -654,7 +654,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Generalizer<'_, 'tcx> {
                             {
                                 variable_table.union(vid, new_var_id);
                             }
-                            Ok(ty::Const::new_var(self.tcx(), new_var_id))
+                            Ok(ty::Const::new_var(self.cx(), new_var_id))
                         }
                     }
                 }
@@ -672,7 +672,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Generalizer<'_, 'tcx> {
                     args,
                     args,
                 )?;
-                Ok(ty::Const::new_unevaluated(self.tcx(), ty::UnevaluatedConst { def, args }))
+                Ok(ty::Const::new_unevaluated(self.cx(), ty::UnevaluatedConst { def, args }))
             }
             ty::ConstKind::Placeholder(placeholder) => {
                 if self.for_universe.can_name(placeholder.universe) {

--- a/compiler/rustc_infer/src/infer/relate/glb.rs
+++ b/compiler/rustc_infer/src/infer/relate/glb.rs
@@ -27,7 +27,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Glb<'_, '_, 'tcx> {
         "Glb"
     }
 
-    fn tcx(&self) -> TyCtxt<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
         self.fields.tcx()
     }
 
@@ -61,7 +61,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Glb<'_, '_, 'tcx> {
         let origin = SubregionOrigin::Subtype(Box::new(self.fields.trace.clone()));
         // GLB(&'static u8, &'a u8) == &RegionLUB('static, 'a) u8 == &'static u8
         Ok(self.fields.infcx.inner.borrow_mut().unwrap_region_constraints().lub_regions(
-            self.tcx(),
+            self.cx(),
             origin,
             a,
             b,

--- a/compiler/rustc_infer/src/infer/relate/lub.rs
+++ b/compiler/rustc_infer/src/infer/relate/lub.rs
@@ -27,7 +27,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Lub<'_, '_, 'tcx> {
         "Lub"
     }
 
-    fn tcx(&self) -> TyCtxt<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
         self.fields.tcx()
     }
 
@@ -61,7 +61,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Lub<'_, '_, 'tcx> {
         let origin = SubregionOrigin::Subtype(Box::new(self.fields.trace.clone()));
         // LUB(&'static u8, &'a u8) == &RegionGLB('static, 'a) u8 == &'a u8
         Ok(self.fields.infcx.inner.borrow_mut().unwrap_region_constraints().glb_regions(
-            self.tcx(),
+            self.cx(),
             origin,
             a,
             b,

--- a/compiler/rustc_infer/src/infer/relate/type_relating.rs
+++ b/compiler/rustc_infer/src/infer/relate/type_relating.rs
@@ -32,7 +32,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for TypeRelating<'_, '_, 'tcx> {
         "TypeRelating"
     }
 
-    fn tcx(&self) -> TyCtxt<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
         self.fields.infcx.tcx
     }
 
@@ -48,7 +48,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for TypeRelating<'_, '_, 'tcx> {
             // (e.g., #41849).
             relate_args_invariantly(self, a_arg, b_arg)
         } else {
-            let tcx = self.tcx();
+            let tcx = self.cx();
             let opt_variances = tcx.variances_of(item_def_id);
             relate_args_with_variances(self, item_def_id, opt_variances, a_arg, b_arg, false)
         }
@@ -88,7 +88,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for TypeRelating<'_, '_, 'tcx> {
                         // can't make progress on `A <: B` if both A and B are
                         // type variables, so record an obligation.
                         self.fields.goals.push(Goal::new(
-                            self.tcx(),
+                            self.cx(),
                             self.fields.param_env,
                             ty::Binder::dummy(ty::PredicateKind::Subtype(ty::SubtypePredicate {
                                 a_is_expected: true,
@@ -101,7 +101,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for TypeRelating<'_, '_, 'tcx> {
                         // can't make progress on `B <: A` if both A and B are
                         // type variables, so record an obligation.
                         self.fields.goals.push(Goal::new(
-                            self.tcx(),
+                            self.cx(),
                             self.fields.param_env,
                             ty::Binder::dummy(ty::PredicateKind::Subtype(ty::SubtypePredicate {
                                 a_is_expected: false,
@@ -134,7 +134,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for TypeRelating<'_, '_, 'tcx> {
 
             (&ty::Error(e), _) | (_, &ty::Error(e)) => {
                 infcx.set_tainted_by_errors(e);
-                return Ok(Ty::new_error(self.tcx(), e));
+                return Ok(Ty::new_error(self.cx(), e));
             }
 
             (

--- a/compiler/rustc_macros/src/lift.rs
+++ b/compiler/rustc_macros/src/lift.rs
@@ -45,7 +45,7 @@ pub fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStre
         quote! {
             type Lifted = #lifted;
 
-            fn lift_to_tcx(self, __tcx: ::rustc_middle::ty::TyCtxt<'__lifted>) -> Option<#lifted> {
+            fn lift_to_interner(self, __tcx: ::rustc_middle::ty::TyCtxt<'__lifted>) -> Option<#lifted> {
                 Some(match self { #body })
             }
         },

--- a/compiler/rustc_middle/src/macros.rs
+++ b/compiler/rustc_middle/src/macros.rs
@@ -59,7 +59,7 @@ macro_rules! TrivialLiftImpls {
         $(
             impl<'tcx> $crate::ty::Lift<$crate::ty::TyCtxt<'tcx>> for $ty {
                 type Lifted = Self;
-                fn lift_to_tcx(self, _: $crate::ty::TyCtxt<'tcx>) -> Option<Self> {
+                fn lift_to_interner(self, _: $crate::ty::TyCtxt<'tcx>) -> Option<Self> {
                     Some(self)
                 }
             }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1484,7 +1484,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     pub fn lift<T: Lift<TyCtxt<'tcx>>>(self, value: T) -> Option<T::Lifted> {
-        value.lift_to_tcx(self)
+        value.lift_to_interner(self)
     }
 
     /// Creates a type context. To use the context call `fn enter` which
@@ -2087,7 +2087,7 @@ macro_rules! nop_lift {
     ($set:ident; $ty:ty => $lifted:ty) => {
         impl<'a, 'tcx> Lift<TyCtxt<'tcx>> for $ty {
             type Lifted = $lifted;
-            fn lift_to_tcx(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
+            fn lift_to_interner(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
                 // Assert that the set has the right type.
                 // Given an argument that has an interned type, the return type has the type of
                 // the corresponding interner set. This won't actually return anything, we're
@@ -2122,7 +2122,7 @@ macro_rules! nop_list_lift {
     ($set:ident; $ty:ty => $lifted:ty) => {
         impl<'a, 'tcx> Lift<TyCtxt<'tcx>> for &'a List<$ty> {
             type Lifted = &'tcx List<$lifted>;
-            fn lift_to_tcx(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
+            fn lift_to_interner(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
                 // Assert that the set has the right type.
                 if false {
                     let _x: &InternedSet<'tcx, List<$lifted>> = &tcx.interners.$set;
@@ -2160,7 +2160,7 @@ macro_rules! nop_slice_lift {
     ($ty:ty => $lifted:ty) => {
         impl<'a, 'tcx> Lift<TyCtxt<'tcx>> for &'a [$ty] {
             type Lifted = &'tcx [$lifted];
-            fn lift_to_tcx(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
+            fn lift_to_interner(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
                 if self.is_empty() {
                     return Some(&[]);
                 }

--- a/compiler/rustc_middle/src/ty/generic_args.rs
+++ b/compiler/rustc_middle/src/ty/generic_args.rs
@@ -308,7 +308,7 @@ impl<'tcx> GenericArg<'tcx> {
 impl<'a, 'tcx> Lift<TyCtxt<'tcx>> for GenericArg<'a> {
     type Lifted = GenericArg<'tcx>;
 
-    fn lift_to_tcx(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
+    fn lift_to_interner(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
         match self.unpack() {
             GenericArgKind::Lifetime(lt) => tcx.lift(lt).map(|lt| lt.into()),
             GenericArgKind::Type(ty) => tcx.lift(ty).map(|ty| ty.into()),

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -69,7 +69,7 @@ impl<'tcx> Relate<TyCtxt<'tcx>> for ty::Pattern<'tcx> {
                 if inc_a != inc_b {
                     todo!()
                 }
-                Ok(relation.tcx().mk_pat(ty::PatternKind::Range { start, end, include_end: inc_a }))
+                Ok(relation.cx().mk_pat(ty::PatternKind::Range { start, end, include_end: inc_a }))
             }
         }
     }
@@ -81,7 +81,7 @@ impl<'tcx> Relate<TyCtxt<'tcx>> for &'tcx ty::List<ty::PolyExistentialPredicate<
         a: Self,
         b: Self,
     ) -> RelateResult<'tcx, Self> {
-        let tcx = relation.tcx();
+        let tcx = relation.cx();
 
         // FIXME: this is wasteful, but want to do a perf run to see how slow it is.
         // We need to perform this deduplication as we sometimes generate duplicate projections

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -283,7 +283,7 @@ TrivialTypeTraversalAndLiftImpls! {
 
 impl<'tcx, T: Lift<TyCtxt<'tcx>>> Lift<TyCtxt<'tcx>> for Option<T> {
     type Lifted = Option<T::Lifted>;
-    fn lift_to_tcx(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
+    fn lift_to_interner(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
         Some(match self {
             Some(x) => Some(tcx.lift(x)?),
             None => None,
@@ -293,7 +293,7 @@ impl<'tcx, T: Lift<TyCtxt<'tcx>>> Lift<TyCtxt<'tcx>> for Option<T> {
 
 impl<'a, 'tcx> Lift<TyCtxt<'tcx>> for Term<'a> {
     type Lifted = ty::Term<'tcx>;
-    fn lift_to_tcx(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
+    fn lift_to_interner(self, tcx: TyCtxt<'tcx>) -> Option<Self::Lifted> {
         match self.unpack() {
             TermKind::Ty(ty) => tcx.lift(ty).map(Into::into),
             TermKind::Const(c) => tcx.lift(c).map(Into::into),

--- a/compiler/rustc_trait_selection/src/traits/select/_match.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/_match.rs
@@ -36,7 +36,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for MatchAgainstFreshVars<'tcx> {
         "MatchAgainstFreshVars"
     }
 
-    fn tcx(&self) -> TyCtxt<'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }
 
@@ -77,7 +77,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for MatchAgainstFreshVars<'tcx> {
                 Err(TypeError::Sorts(ExpectedFound::new(true, a, b)))
             }
 
-            (&ty::Error(guar), _) | (_, &ty::Error(guar)) => Ok(Ty::new_error(self.tcx(), guar)),
+            (&ty::Error(guar), _) | (_, &ty::Error(guar)) => Ok(Ty::new_error(self.cx(), guar)),
 
             _ => structurally_relate_tys(self, a, b),
         }

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -49,10 +49,10 @@ where
 {
     type Lifted = Binder<U, T::Lifted>;
 
-    fn lift_to_interner(self, tcx: U) -> Option<Self::Lifted> {
+    fn lift_to_interner(self, cx: U) -> Option<Self::Lifted> {
         Some(Binder {
-            value: self.value.lift_to_interner(tcx)?,
-            bound_vars: self.bound_vars.lift_to_interner(tcx)?,
+            value: self.value.lift_to_interner(cx)?,
+            bound_vars: self.bound_vars.lift_to_interner(cx)?,
         })
     }
 }
@@ -439,11 +439,11 @@ impl<I: Interner, Iter: IntoIterator> EarlyBinder<I, Iter>
 where
     Iter::Item: TypeFoldable<I>,
 {
-    pub fn iter_instantiated<A>(self, tcx: I, args: A) -> IterInstantiated<I, Iter, A>
+    pub fn iter_instantiated<A>(self, cx: I, args: A) -> IterInstantiated<I, Iter, A>
     where
         A: SliceLike<Item = I::GenericArg>,
     {
-        IterInstantiated { it: self.value.into_iter(), tcx, args }
+        IterInstantiated { it: self.value.into_iter(), cx, args }
     }
 
     /// Similar to [`instantiate_identity`](EarlyBinder::instantiate_identity),
@@ -455,7 +455,7 @@ where
 
 pub struct IterInstantiated<I: Interner, Iter: IntoIterator, A> {
     it: Iter::IntoIter,
-    tcx: I,
+    cx: I,
     args: A,
 }
 
@@ -469,7 +469,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         Some(
             EarlyBinder { value: self.it.next()?, _tcx: PhantomData }
-                .instantiate(self.tcx, self.args),
+                .instantiate(self.cx, self.args),
         )
     }
 
@@ -487,7 +487,7 @@ where
     fn next_back(&mut self) -> Option<Self::Item> {
         Some(
             EarlyBinder { value: self.it.next_back()?, _tcx: PhantomData }
-                .instantiate(self.tcx, self.args),
+                .instantiate(self.cx, self.args),
         )
     }
 }
@@ -507,10 +507,10 @@ where
 {
     pub fn iter_instantiated_copied(
         self,
-        tcx: I,
+        cx: I,
         args: &'s [I::GenericArg],
     ) -> IterInstantiatedCopied<'s, I, Iter> {
-        IterInstantiatedCopied { it: self.value.into_iter(), tcx, args }
+        IterInstantiatedCopied { it: self.value.into_iter(), cx, args }
     }
 
     /// Similar to [`instantiate_identity`](EarlyBinder::instantiate_identity),
@@ -522,7 +522,7 @@ where
 
 pub struct IterInstantiatedCopied<'a, I: Interner, Iter: IntoIterator> {
     it: Iter::IntoIter,
-    tcx: I,
+    cx: I,
     args: &'a [I::GenericArg],
 }
 
@@ -535,7 +535,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         self.it.next().map(|value| {
-            EarlyBinder { value: *value, _tcx: PhantomData }.instantiate(self.tcx, self.args)
+            EarlyBinder { value: *value, _tcx: PhantomData }.instantiate(self.cx, self.args)
         })
     }
 
@@ -552,7 +552,7 @@ where
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.it.next_back().map(|value| {
-            EarlyBinder { value: *value, _tcx: PhantomData }.instantiate(self.tcx, self.args)
+            EarlyBinder { value: *value, _tcx: PhantomData }.instantiate(self.cx, self.args)
         })
     }
 }
@@ -589,11 +589,11 @@ impl<I: Interner, T: Iterator> Iterator for EarlyBinderIter<I, T> {
 }
 
 impl<I: Interner, T: TypeFoldable<I>> ty::EarlyBinder<I, T> {
-    pub fn instantiate<A>(self, tcx: I, args: A) -> T
+    pub fn instantiate<A>(self, cx: I, args: A) -> T
     where
         A: SliceLike<Item = I::GenericArg>,
     {
-        let mut folder = ArgFolder { tcx, args: args.as_slice(), binders_passed: 0 };
+        let mut folder = ArgFolder { cx, args: args.as_slice(), binders_passed: 0 };
         self.value.fold_with(&mut folder)
     }
 
@@ -619,7 +619,7 @@ impl<I: Interner, T: TypeFoldable<I>> ty::EarlyBinder<I, T> {
 // The actual instantiation engine itself is a type folder.
 
 struct ArgFolder<'a, I: Interner> {
-    tcx: I,
+    cx: I,
     args: &'a [I::GenericArg],
 
     /// Number of region binders we have passed through while doing the instantiation
@@ -629,7 +629,7 @@ struct ArgFolder<'a, I: Interner> {
 impl<'a, I: Interner> TypeFolder<I> for ArgFolder<'a, I> {
     #[inline]
     fn cx(&self) -> I {
-        self.tcx
+        self.cx
     }
 
     fn fold_binder<T: TypeFoldable<I>>(&mut self, t: ty::Binder<I, T>) -> ty::Binder<I, T> {
@@ -858,6 +858,6 @@ impl<'a, I: Interner> ArgFolder<'a, I> {
         if self.binders_passed == 0 || !region.has_escaping_bound_vars() {
             return region;
         }
-        ty::fold::shift_region(self.tcx, region, self.binders_passed)
+        ty::fold::shift_region(self.cx, region, self.binders_passed)
     }
 }

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -49,10 +49,10 @@ where
 {
     type Lifted = Binder<U, T::Lifted>;
 
-    fn lift_to_tcx(self, tcx: U) -> Option<Self::Lifted> {
+    fn lift_to_interner(self, tcx: U) -> Option<Self::Lifted> {
         Some(Binder {
-            value: self.value.lift_to_tcx(tcx)?,
-            bound_vars: self.bound_vars.lift_to_tcx(tcx)?,
+            value: self.value.lift_to_interner(tcx)?,
+            bound_vars: self.bound_vars.lift_to_interner(tcx)?,
         })
     }
 }

--- a/compiler/rustc_type_ir/src/canonical.rs
+++ b/compiler/rustc_type_ir/src/canonical.rs
@@ -330,25 +330,25 @@ impl<I: Interner> CanonicalVarValues<I> {
 
     // Given a list of canonical variables, construct a set of values which are
     // the identity response.
-    pub fn make_identity(tcx: I, infos: I::CanonicalVars) -> CanonicalVarValues<I> {
+    pub fn make_identity(cx: I, infos: I::CanonicalVars) -> CanonicalVarValues<I> {
         CanonicalVarValues {
-            var_values: tcx.mk_args_from_iter(infos.iter().enumerate().map(
+            var_values: cx.mk_args_from_iter(infos.iter().enumerate().map(
                 |(i, info)| -> I::GenericArg {
                     match info.kind {
                         CanonicalVarKind::Ty(_) | CanonicalVarKind::PlaceholderTy(_) => {
-                            Ty::new_anon_bound(tcx, ty::INNERMOST, ty::BoundVar::from_usize(i))
+                            Ty::new_anon_bound(cx, ty::INNERMOST, ty::BoundVar::from_usize(i))
                                 .into()
                         }
                         CanonicalVarKind::Region(_) | CanonicalVarKind::PlaceholderRegion(_) => {
-                            Region::new_anon_bound(tcx, ty::INNERMOST, ty::BoundVar::from_usize(i))
+                            Region::new_anon_bound(cx, ty::INNERMOST, ty::BoundVar::from_usize(i))
                                 .into()
                         }
                         CanonicalVarKind::Effect => {
-                            Const::new_anon_bound(tcx, ty::INNERMOST, ty::BoundVar::from_usize(i))
+                            Const::new_anon_bound(cx, ty::INNERMOST, ty::BoundVar::from_usize(i))
                                 .into()
                         }
                         CanonicalVarKind::Const(_) | CanonicalVarKind::PlaceholderConst(_) => {
-                            Const::new_anon_bound(tcx, ty::INNERMOST, ty::BoundVar::from_usize(i))
+                            Const::new_anon_bound(cx, ty::INNERMOST, ty::BoundVar::from_usize(i))
                                 .into()
                         }
                     }

--- a/compiler/rustc_type_ir/src/effects.rs
+++ b/compiler/rustc_type_ir/src/effects.rs
@@ -10,38 +10,38 @@ pub enum EffectKind {
 }
 
 impl EffectKind {
-    pub fn try_from_def_id<I: Interner>(tcx: I, def_id: I::DefId) -> Option<EffectKind> {
-        if tcx.is_lang_item(def_id, EffectsMaybe) {
+    pub fn try_from_def_id<I: Interner>(cx: I, def_id: I::DefId) -> Option<EffectKind> {
+        if cx.is_lang_item(def_id, EffectsMaybe) {
             Some(EffectKind::Maybe)
-        } else if tcx.is_lang_item(def_id, EffectsRuntime) {
+        } else if cx.is_lang_item(def_id, EffectsRuntime) {
             Some(EffectKind::Runtime)
-        } else if tcx.is_lang_item(def_id, EffectsNoRuntime) {
+        } else if cx.is_lang_item(def_id, EffectsNoRuntime) {
             Some(EffectKind::NoRuntime)
         } else {
             None
         }
     }
 
-    pub fn to_def_id<I: Interner>(self, tcx: I) -> I::DefId {
+    pub fn to_def_id<I: Interner>(self, cx: I) -> I::DefId {
         let lang_item = match self {
             EffectKind::Maybe => EffectsMaybe,
             EffectKind::NoRuntime => EffectsNoRuntime,
             EffectKind::Runtime => EffectsRuntime,
         };
 
-        tcx.require_lang_item(lang_item)
+        cx.require_lang_item(lang_item)
     }
 
-    pub fn try_from_ty<I: Interner>(tcx: I, ty: I::Ty) -> Option<EffectKind> {
+    pub fn try_from_ty<I: Interner>(cx: I, ty: I::Ty) -> Option<EffectKind> {
         if let crate::Adt(def, _) = ty.kind() {
-            Self::try_from_def_id(tcx, def.def_id())
+            Self::try_from_def_id(cx, def.def_id())
         } else {
             None
         }
     }
 
-    pub fn to_ty<I: Interner>(self, tcx: I) -> I::Ty {
-        I::Ty::new_adt(tcx, tcx.adt_def(self.to_def_id(tcx)), Default::default())
+    pub fn to_ty<I: Interner>(self, cx: I) -> I::Ty {
+        I::Ty::new_adt(cx, cx.adt_def(self.to_def_id(cx)), Default::default())
     }
 
     /// Returns an intersection between two effect kinds. If one effect kind

--- a/compiler/rustc_type_ir/src/elaborate.rs
+++ b/compiler/rustc_type_ir/src/elaborate.rs
@@ -258,17 +258,17 @@ pub fn supertrait_def_ids<I: Interner>(
 }
 
 pub fn supertraits<I: Interner>(
-    tcx: I,
+    cx: I,
     trait_ref: ty::Binder<I, ty::TraitRef<I>>,
 ) -> FilterToTraits<I, Elaborator<I, I::Clause>> {
-    elaborate(tcx, [trait_ref.upcast(tcx)]).filter_only_self().filter_to_traits()
+    elaborate(cx, [trait_ref.upcast(cx)]).filter_only_self().filter_to_traits()
 }
 
 pub fn transitive_bounds<I: Interner>(
-    tcx: I,
+    cx: I,
     trait_refs: impl Iterator<Item = ty::Binder<I, ty::TraitRef<I>>>,
 ) -> FilterToTraits<I, Elaborator<I, I::Clause>> {
-    elaborate(tcx, trait_refs.map(|trait_ref| trait_ref.upcast(tcx)))
+    elaborate(cx, trait_refs.map(|trait_ref| trait_ref.upcast(cx)))
         .filter_only_self()
         .filter_to_traits()
 }

--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -105,7 +105,7 @@ pub enum TreatParams {
 ///
 /// ¹ meaning that if the outermost layers are different, then the whole types are also different.
 pub fn simplify_type<I: Interner>(
-    tcx: I,
+    cx: I,
     ty: I::Ty,
     treat_params: TreatParams,
 ) -> Option<SimplifiedType<I::DefId>> {
@@ -119,10 +119,10 @@ pub fn simplify_type<I: Interner>(
         ty::Str => Some(SimplifiedType::Str),
         ty::Array(..) => Some(SimplifiedType::Array),
         ty::Slice(..) => Some(SimplifiedType::Slice),
-        ty::Pat(ty, ..) => simplify_type(tcx, ty, treat_params),
+        ty::Pat(ty, ..) => simplify_type(cx, ty, treat_params),
         ty::RawPtr(_, mutbl) => Some(SimplifiedType::Ptr(mutbl)),
         ty::Dynamic(trait_info, ..) => match trait_info.principal_def_id() {
-            Some(principal_def_id) if !tcx.trait_is_auto(principal_def_id) => {
+            Some(principal_def_id) if !cx.trait_is_auto(principal_def_id) => {
                 Some(SimplifiedType::Trait(principal_def_id))
             }
             _ => Some(SimplifiedType::MarkerTraitObject),

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -475,7 +475,7 @@ pub trait Clause<I: Interner<Clause = Self>>:
     /// poly-trait-ref to supertraits that must hold if that
     /// poly-trait-ref holds. This is slightly different from a normal
     /// instantiation in terms of what happens with bound regions.
-    fn instantiate_supertrait(self, tcx: I, trait_ref: ty::Binder<I, ty::TraitRef<I>>) -> Self;
+    fn instantiate_supertrait(self, cx: I, trait_ref: ty::Binder<I, ty::TraitRef<I>>) -> Self;
 }
 
 /// Common capabilities of placeholder kinds

--- a/compiler/rustc_type_ir/src/lift.rs
+++ b/compiler/rustc_type_ir/src/lift.rs
@@ -17,5 +17,5 @@
 /// e.g., `()` or `u8`, was interned in a different context.
 pub trait Lift<I>: std::fmt::Debug {
     type Lifted: std::fmt::Debug;
-    fn lift_to_interner(self, tcx: I) -> Option<Self::Lifted>;
+    fn lift_to_interner(self, cx: I) -> Option<Self::Lifted>;
 }

--- a/compiler/rustc_type_ir/src/lift.rs
+++ b/compiler/rustc_type_ir/src/lift.rs
@@ -17,5 +17,5 @@
 /// e.g., `()` or `u8`, was interned in a different context.
 pub trait Lift<I>: std::fmt::Debug {
     type Lifted: std::fmt::Debug;
-    fn lift_to_tcx(self, tcx: I) -> Option<Self::Lifted>;
+    fn lift_to_interner(self, tcx: I) -> Option<Self::Lifted>;
 }

--- a/compiler/rustc_type_ir/src/opaque_ty.rs
+++ b/compiler/rustc_type_ir/src/opaque_ty.rs
@@ -22,8 +22,8 @@ pub struct OpaqueTypeKey<I: Interner> {
 }
 
 impl<I: Interner> OpaqueTypeKey<I> {
-    pub fn iter_captured_args(self, tcx: I) -> impl Iterator<Item = (usize, I::GenericArg)> {
-        let variances = tcx.variances_of(self.def_id.into());
+    pub fn iter_captured_args(self, cx: I) -> impl Iterator<Item = (usize, I::GenericArg)> {
+        let variances = cx.variances_of(self.def_id.into());
         std::iter::zip(self.args.iter(), variances.iter()).enumerate().filter_map(
             |(i, (arg, v))| match (arg.kind(), v) {
                 (_, ty::Invariant) => Some((i, arg)),
@@ -35,18 +35,18 @@ impl<I: Interner> OpaqueTypeKey<I> {
 
     pub fn fold_captured_lifetime_args(
         self,
-        tcx: I,
+        cx: I,
         mut f: impl FnMut(I::Region) -> I::Region,
     ) -> Self {
         let Self { def_id, args } = self;
-        let variances = tcx.variances_of(def_id.into());
+        let variances = cx.variances_of(def_id.into());
         let args =
             std::iter::zip(args.iter(), variances.iter()).map(|(arg, v)| match (arg.kind(), v) {
                 (ty::GenericArgKind::Lifetime(_), ty::Bivariant) => arg,
                 (ty::GenericArgKind::Lifetime(lt), _) => f(lt).into(),
                 _ => arg,
             });
-        let args = tcx.mk_args_from_iter(args);
+        let args = cx.mk_args_from_iter(args);
         Self { def_id, args }
     }
 }

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -34,8 +34,8 @@ where
 {
     type Lifted = OutlivesPredicate<U, A::Lifted>;
 
-    fn lift_to_tcx(self, tcx: U) -> Option<Self::Lifted> {
-        Some(OutlivesPredicate(self.0.lift_to_tcx(tcx)?, self.1.lift_to_tcx(tcx)?))
+    fn lift_to_interner(self, tcx: U) -> Option<Self::Lifted> {
+        Some(OutlivesPredicate(self.0.lift_to_interner(tcx)?, self.1.lift_to_interner(tcx)?))
     }
 }
 

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -34,8 +34,8 @@ where
 {
     type Lifted = OutlivesPredicate<U, A::Lifted>;
 
-    fn lift_to_interner(self, tcx: U) -> Option<Self::Lifted> {
-        Some(OutlivesPredicate(self.0.lift_to_interner(tcx)?, self.1.lift_to_interner(tcx)?))
+    fn lift_to_interner(self, cx: U) -> Option<Self::Lifted> {
+        Some(OutlivesPredicate(self.0.lift_to_interner(cx)?, self.1.lift_to_interner(cx)?))
     }
 }
 
@@ -267,25 +267,23 @@ impl<I: Interner> ty::Binder<I, ExistentialPredicate<I>> {
     /// Given an existential predicate like `?Self: PartialEq<u32>` (e.g., derived from `dyn PartialEq<u32>`),
     /// and a concrete type `self_ty`, returns a full predicate where the existentially quantified variable `?Self`
     /// has been replaced with `self_ty` (e.g., `self_ty: PartialEq<u32>`, in our example).
-    pub fn with_self_ty(&self, tcx: I, self_ty: I::Ty) -> I::Clause {
+    pub fn with_self_ty(&self, cx: I, self_ty: I::Ty) -> I::Clause {
         match self.skip_binder() {
-            ExistentialPredicate::Trait(tr) => {
-                self.rebind(tr).with_self_ty(tcx, self_ty).upcast(tcx)
-            }
+            ExistentialPredicate::Trait(tr) => self.rebind(tr).with_self_ty(cx, self_ty).upcast(cx),
             ExistentialPredicate::Projection(p) => {
-                self.rebind(p.with_self_ty(tcx, self_ty)).upcast(tcx)
+                self.rebind(p.with_self_ty(cx, self_ty)).upcast(cx)
             }
             ExistentialPredicate::AutoTrait(did) => {
-                let generics = tcx.generics_of(did);
+                let generics = cx.generics_of(did);
                 let trait_ref = if generics.count() == 1 {
-                    ty::TraitRef::new(tcx, did, [self_ty])
+                    ty::TraitRef::new(cx, did, [self_ty])
                 } else {
                     // If this is an ill-formed auto trait, then synthesize
                     // new error args for the missing generics.
-                    let err_args = GenericArgs::extend_with_error(tcx, did, &[self_ty.into()]);
-                    ty::TraitRef::new_from_args(tcx, did, err_args)
+                    let err_args = GenericArgs::extend_with_error(cx, did, &[self_ty.into()]);
+                    ty::TraitRef::new_from_args(cx, did, err_args)
                 };
-                self.rebind(trait_ref).upcast(tcx)
+                self.rebind(trait_ref).upcast(cx)
             }
         }
     }
@@ -345,8 +343,8 @@ impl<I: Interner> ty::Binder<I, ExistentialTraitRef<I>> {
     /// we convert the principal trait-ref into a normal trait-ref,
     /// you must give *some* self type. A common choice is `mk_err()`
     /// or some placeholder type.
-    pub fn with_self_ty(&self, tcx: I, self_ty: I::Ty) -> ty::Binder<I, TraitRef<I>> {
-        self.map_bound(|trait_ref| trait_ref.with_self_ty(tcx, self_ty))
+    pub fn with_self_ty(&self, cx: I, self_ty: I::Ty) -> ty::Binder<I, TraitRef<I>> {
+        self.map_bound(|trait_ref| trait_ref.with_self_ty(cx, self_ty))
     }
 }
 
@@ -406,8 +404,8 @@ impl<I: Interner> ExistentialProjection<I> {
 }
 
 impl<I: Interner> ty::Binder<I, ExistentialProjection<I>> {
-    pub fn with_self_ty(&self, tcx: I, self_ty: I::Ty) -> ty::Binder<I, ProjectionPredicate<I>> {
-        self.map_bound(|p| p.with_self_ty(tcx, self_ty))
+    pub fn with_self_ty(&self, cx: I, self_ty: I::Ty) -> ty::Binder<I, ProjectionPredicate<I>> {
+        self.map_bound(|p| p.with_self_ty(cx, self_ty))
     }
 
     pub fn item_def_id(&self) -> I::DefId {
@@ -669,21 +667,21 @@ impl<I: Interner> ProjectionPredicate<I> {
 impl<I: Interner> ty::Binder<I, ProjectionPredicate<I>> {
     /// Returns the `DefId` of the trait of the associated item being projected.
     #[inline]
-    pub fn trait_def_id(&self, tcx: I) -> I::DefId {
-        self.skip_binder().projection_term.trait_def_id(tcx)
+    pub fn trait_def_id(&self, cx: I) -> I::DefId {
+        self.skip_binder().projection_term.trait_def_id(cx)
     }
 
     /// Get the trait ref required for this projection to be well formed.
     /// Note that for generic associated types the predicates of the associated
     /// type also need to be checked.
     #[inline]
-    pub fn required_poly_trait_ref(&self, tcx: I) -> ty::Binder<I, TraitRef<I>> {
+    pub fn required_poly_trait_ref(&self, cx: I) -> ty::Binder<I, TraitRef<I>> {
         // Note: unlike with `TraitRef::to_poly_trait_ref()`,
         // `self.0.trait_ref` is permitted to have escaping regions.
         // This is because here `self` has a `Binder` and so does our
         // return value, so we are preserving the number of binding
         // levels.
-        self.map_bound(|predicate| predicate.projection_term.trait_ref(tcx))
+        self.map_bound(|predicate| predicate.projection_term.trait_ref(cx))
     }
 
     pub fn term(&self) -> ty::Binder<I, I::Term> {

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -106,13 +106,13 @@ pub struct Goal<I: Interner, P> {
 }
 
 impl<I: Interner, P> Goal<I, P> {
-    pub fn new(tcx: I, param_env: I::ParamEnv, predicate: impl Upcast<I, P>) -> Goal<I, P> {
-        Goal { param_env, predicate: predicate.upcast(tcx) }
+    pub fn new(cx: I, param_env: I::ParamEnv, predicate: impl Upcast<I, P>) -> Goal<I, P> {
+        Goal { param_env, predicate: predicate.upcast(cx) }
     }
 
     /// Updates the goal to one with a different `predicate` but the same `param_env`.
-    pub fn with<Q>(self, tcx: I, predicate: impl Upcast<I, Q>) -> Goal<I, Q> {
-        Goal { param_env: self.param_env, predicate: predicate.upcast(tcx) }
+    pub fn with<Q>(self, cx: I, predicate: impl Upcast<I, Q>) -> Goal<I, Q> {
+        Goal { param_env: self.param_env, predicate: predicate.upcast(cx) }
     }
 }
 

--- a/compiler/rustc_type_ir/src/ty_kind/closure.rs
+++ b/compiler/rustc_type_ir/src/ty_kind/closure.rs
@@ -136,9 +136,9 @@ pub struct ClosureArgsParts<I: Interner> {
 impl<I: Interner> ClosureArgs<I> {
     /// Construct `ClosureArgs` from `ClosureArgsParts`, containing `Args`
     /// for the closure parent, alongside additional closure-specific components.
-    pub fn new(tcx: I, parts: ClosureArgsParts<I>) -> ClosureArgs<I> {
+    pub fn new(cx: I, parts: ClosureArgsParts<I>) -> ClosureArgs<I> {
         ClosureArgs {
-            args: tcx.mk_args_from_iter(parts.parent_args.iter().chain([
+            args: cx.mk_args_from_iter(parts.parent_args.iter().chain([
                 parts.closure_kind_ty.into(),
                 parts.closure_sig_as_fn_ptr_ty.into(),
                 parts.tupled_upvars_ty.into(),
@@ -258,9 +258,9 @@ pub struct CoroutineClosureArgsParts<I: Interner> {
 }
 
 impl<I: Interner> CoroutineClosureArgs<I> {
-    pub fn new(tcx: I, parts: CoroutineClosureArgsParts<I>) -> CoroutineClosureArgs<I> {
+    pub fn new(cx: I, parts: CoroutineClosureArgsParts<I>) -> CoroutineClosureArgs<I> {
         CoroutineClosureArgs {
-            args: tcx.mk_args_from_iter(parts.parent_args.iter().chain([
+            args: cx.mk_args_from_iter(parts.parent_args.iter().chain([
                 parts.closure_kind_ty.into(),
                 parts.signature_parts_ty.into(),
                 parts.tupled_upvars_ty.into(),
@@ -409,14 +409,14 @@ impl<I: Interner> CoroutineClosureSignature<I> {
     /// When the kind and upvars are known, use the other helper functions.
     pub fn to_coroutine(
         self,
-        tcx: I,
+        cx: I,
         parent_args: I::GenericArgsSlice,
         coroutine_kind_ty: I::Ty,
         coroutine_def_id: I::DefId,
         tupled_upvars_ty: I::Ty,
     ) -> I::Ty {
         let coroutine_args = ty::CoroutineArgs::new(
-            tcx,
+            cx,
             ty::CoroutineArgsParts {
                 parent_args,
                 kind_ty: coroutine_kind_ty,
@@ -428,7 +428,7 @@ impl<I: Interner> CoroutineClosureSignature<I> {
             },
         );
 
-        Ty::new_coroutine(tcx, coroutine_def_id, coroutine_args.args)
+        Ty::new_coroutine(cx, coroutine_def_id, coroutine_args.args)
     }
 
     /// Given known upvars and a [`ClosureKind`](ty::ClosureKind), compute the coroutine
@@ -438,7 +438,7 @@ impl<I: Interner> CoroutineClosureSignature<I> {
     /// that the `ClosureKind` is actually supported by the coroutine-closure.
     pub fn to_coroutine_given_kind_and_upvars(
         self,
-        tcx: I,
+        cx: I,
         parent_args: I::GenericArgsSlice,
         coroutine_def_id: I::DefId,
         goal_kind: ty::ClosureKind,
@@ -447,7 +447,7 @@ impl<I: Interner> CoroutineClosureSignature<I> {
         coroutine_captures_by_ref_ty: I::Ty,
     ) -> I::Ty {
         let tupled_upvars_ty = Self::tupled_upvars_by_closure_kind(
-            tcx,
+            cx,
             goal_kind,
             self.tupled_inputs_ty,
             closure_tupled_upvars_ty,
@@ -456,9 +456,9 @@ impl<I: Interner> CoroutineClosureSignature<I> {
         );
 
         self.to_coroutine(
-            tcx,
+            cx,
             parent_args,
-            Ty::from_coroutine_closure_kind(tcx, goal_kind),
+            Ty::from_coroutine_closure_kind(cx, goal_kind),
             coroutine_def_id,
             tupled_upvars_ty,
         )
@@ -474,7 +474,7 @@ impl<I: Interner> CoroutineClosureSignature<I> {
     /// lifetimes are related to the lifetime of the borrow on the closure made for
     /// the call. This allows borrowck to enforce the self-borrows correctly.
     pub fn tupled_upvars_by_closure_kind(
-        tcx: I,
+        cx: I,
         kind: ty::ClosureKind,
         tupled_inputs_ty: I::Ty,
         closure_tupled_upvars_ty: I::Ty,
@@ -488,12 +488,12 @@ impl<I: Interner> CoroutineClosureSignature<I> {
                 };
                 let coroutine_captures_by_ref_ty =
                     sig.output().skip_binder().fold_with(&mut FoldEscapingRegions {
-                        interner: tcx,
+                        interner: cx,
                         region: env_region,
                         debruijn: ty::INNERMOST,
                     });
                 Ty::new_tup_from_iter(
-                    tcx,
+                    cx,
                     tupled_inputs_ty
                         .tuple_fields()
                         .iter()
@@ -501,7 +501,7 @@ impl<I: Interner> CoroutineClosureSignature<I> {
                 )
             }
             ty::ClosureKind::FnOnce => Ty::new_tup_from_iter(
-                tcx,
+                cx,
                 tupled_inputs_ty
                     .tuple_fields()
                     .iter()
@@ -615,9 +615,9 @@ pub struct CoroutineArgsParts<I: Interner> {
 impl<I: Interner> CoroutineArgs<I> {
     /// Construct `CoroutineArgs` from `CoroutineArgsParts`, containing `Args`
     /// for the coroutine parent, alongside additional coroutine-specific components.
-    pub fn new(tcx: I, parts: CoroutineArgsParts<I>) -> CoroutineArgs<I> {
+    pub fn new(cx: I, parts: CoroutineArgsParts<I>) -> CoroutineArgs<I> {
         CoroutineArgs {
-            args: tcx.mk_args_from_iter(parts.parent_args.iter().chain([
+            args: cx.mk_args_from_iter(parts.parent_args.iter().chain([
                 parts.kind_ty.into(),
                 parts.resume_ty.into(),
                 parts.yield_ty.into(),

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -71,7 +71,7 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
             wc.push(parse_quote! { #ty: ::rustc_type_ir::lift::Lift<J, Lifted = #lifted_ty> });
             let bind = &bindings[index];
             quote! {
-                #bind.lift_to_tcx(interner)?
+                #bind.lift_to_interner(interner)?
             }
         })
     });
@@ -89,7 +89,7 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
         quote! {
             type Lifted = #lifted_ty;
 
-            fn lift_to_tcx(
+            fn lift_to_interner(
                 self,
                 interner: J,
             ) -> Option<Self::Lifted> {


### PR DESCRIPTION
Self-explanatory. Forgot that we had to do this in type_ir too, and not just the new solver crate lol.

r? lcnr