### PR TITLE
zkvm: add `#[forbid(unsafe_op_in_unsafe_fn)]` in `stdlib`

### DIFF
--- a/library/std/src/sys/pal/zkvm/alloc.rs
+++ b/library/std/src/sys/pal/zkvm/alloc.rs
@@ -5,7 +5,7 @@ use crate::alloc::{GlobalAlloc, Layout, System};
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        abi::sys_alloc_aligned(layout.size(), layout.align())
+        unsafe { abi::sys_alloc_aligned(layout.size(), layout.align()) }
     }
 
     #[inline]

--- a/library/std/src/sys/pal/zkvm/mod.rs
+++ b/library/std/src/sys/pal/zkvm/mod.rs
@@ -6,6 +6,7 @@
 //! This is all super highly experimental and not actually intended for
 //! wide/production use yet, it's still all in the experimental category. This
 //! will likely change over time.
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 const WORD_SIZE: usize = core::mem::size_of::<u32>();
 


### PR DESCRIPTION
This also adds an additional `unsafe` block to address compiler errors.
This PR is intended to address https://github.com/rust-lang/rust/issues/127747 for the zkvm target.
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
