### PR TITLE
Fix ICE in suggestion caused by `⩵` being recovered as `==`

### DIFF
--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -660,9 +660,8 @@ pub(crate) struct RemoveLet {
 #[diag(parse_use_eq_instead)]
 pub(crate) struct UseEqInstead {
     #[primary_span]
+    #[suggestion(style = "verbose", applicability = "machine-applicable", code = "=")]
     pub span: Span,
-    #[suggestion(style = "verbose", applicability = "machine-applicable", code = "")]
-    pub suggestion: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -566,10 +566,7 @@ impl<'a> Parser<'a> {
             && expected.iter().any(|tok| matches!(tok, TokenType::Token(TokenKind::Eq)))
         {
             // Likely typo: `=` → `==` in let expr or enum item
-            return Err(self.dcx().create_err(UseEqInstead {
-                span: self.token.span,
-                suggestion: self.token.span.with_lo(self.token.span.lo() + BytePos(1)),
-            }));
+            return Err(self.dcx().create_err(UseEqInstead { span: self.token.span }));
         }
 
         if self.token.is_keyword(kw::Move) && self.prev_token.is_keyword(kw::Async) {

--- a/tests/ui/parser/issues/issue-101477-enum.stderr
+++ b/tests/ui/parser/issues/issue-101477-enum.stderr
@@ -7,9 +7,8 @@ LL |     B == 2
    = help: enum variants can be `Variant`, `Variant = <integer>`, `Variant(Type, ..., TypeN)` or `Variant { fields: Types }`
 help: try using `=` instead
    |
-LL -     B == 2
-LL +     B = 2
-   |
+LL |     B = 2
+   |       ~
 
 error: expected item, found `==`
   --> $DIR/issue-101477-enum.rs:6:7

--- a/tests/ui/parser/issues/issue-101477-let.stderr
+++ b/tests/ui/parser/issues/issue-101477-let.stderr
@@ -6,9 +6,8 @@ LL |     let x == 2;
    |
 help: try using `=` instead
    |
-LL -     let x == 2;
-LL +     let x = 2;
-   |
+LL |     let x = 2;
+   |           ~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/recover/unicode-double-equals-recovery.rs
+++ b/tests/ui/parser/recover/unicode-double-equals-recovery.rs
@@ -1,0 +1,3 @@
+const A: usize ⩵ 2;
+//~^ ERROR unknown start of token: \u{2a75}
+//~| ERROR unexpected `==`

--- a/tests/ui/parser/recover/unicode-double-equals-recovery.stderr
+++ b/tests/ui/parser/recover/unicode-double-equals-recovery.stderr
@@ -1,0 +1,24 @@
+error: unknown start of token: \u{2a75}
+  --> $DIR/unicode-double-equals-recovery.rs:1:16
+   |
+LL | const A: usize ⩵ 2;
+   |                ^
+   |
+help: Unicode character '⩵' (Two Consecutive Equals Signs) looks like '==' (Double Equals Sign), but it is not
+   |
+LL | const A: usize == 2;
+   |                ~~
+
+error: unexpected `==`
+  --> $DIR/unicode-double-equals-recovery.rs:1:16
+   |
+LL | const A: usize ⩵ 2;
+   |                ^
+   |
+help: try using `=` instead
+   |
+LL | const A: usize = 2;
+   |                ~
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
The second suggestion shown here would previously incorrectly assume that the span corresponding to `⩵` was 2 bytes wide composed by 2 1 byte wide chars, so a span pointing at `==` could point only at one of the `=` to remove it. Instead, we now replace the whole thing (as we should have the whole time):

```
error: unknown start of token: \u{2a75}
  --> $DIR/unicode-double-equals-recovery.rs:1:16
   |
LL | const A: usize ⩵ 2;
   |                ^
   |
help: Unicode character '⩵' (Two Consecutive Equals Signs) looks like '==' (Double Equals Sign), but it is not
   |
LL | const A: usize == 2;
   |                ~~

error: unexpected `==`
  --> $DIR/unicode-double-equals-recovery.rs:1:16
   |
LL | const A: usize ⩵ 2;
   |                ^
   |
help: try using `=` instead
   |
LL | const A: usize = 2;
   |                ~
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->


Fix #127823.