### PR TITLE
std: Forbid unwrapped unsafe ops in xous and uefi modules

### DIFF
--- a/library/std/src/os/uefi/mod.rs
+++ b/library/std/src/os/uefi/mod.rs
@@ -2,6 +2,7 @@
 
 #![unstable(feature = "uefi_std", issue = "100499")]
 #![doc(cfg(target_os = "uefi"))]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 pub mod env;
 #[path = "../windows/ffi.rs"]

--- a/library/std/src/os/xous/mod.rs
+++ b/library/std/src/os/xous/mod.rs
@@ -1,5 +1,6 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 #![doc(cfg(target_os = "xous"))]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 pub mod ffi;
 

--- a/library/std/src/sys/pal/uefi/mod.rs
+++ b/library/std/src/sys/pal/uefi/mod.rs
@@ -11,6 +11,7 @@
 //!
 //! [`OsStr`]: crate::ffi::OsStr
 //! [`OsString`]: crate::ffi::OsString
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 pub mod alloc;
 pub mod args;

--- a/library/std/src/sys/pal/xous/mod.rs
+++ b/library/std/src/sys/pal/xous/mod.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 pub mod alloc;
 #[path = "../unsupported/args.rs"]


### PR DESCRIPTION
<!-- homu-ignore:start -->

Per the maintainer comments:
- https://github.com/rust-lang/rust/issues/127747#issuecomment-2229827868
- https://github.com/rust-lang/rust/issues/127747#issuecomment-2231676215

<!-- homu-ignore:end -->
