### PR TITLE
Fix git safe-directory path for docker images

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -19,7 +19,7 @@ if [ "$NO_CHANGE_USER" = "" ]; then
     # already be running with the right user.
     #
     # For NO_CHANGE_USER done in the small number of Dockerfiles affected.
-    echo -e '[safe]\n\tdirectory = *' > /home/user/gitconfig
+    echo -e '[safe]\n\tdirectory = *' > /home/user/.gitconfig
 
     exec su --preserve-environment -c "env PATH=$PATH \"$0\"" user
   fi


### PR DESCRIPTION
This fixes the path for configuring the git safe.directory setting inside docker images. AFAIK, `~/gitconfig` without a dot is not something that git uses ([ref](https://git-scm.com/docs/git-config)). This was needed in my environment to avoid the ` fatal: detected dubious ownership in repository at '/checkout'` error. For context, this was added in #99967.

