### PR TITLE
Remove invalid further restricting suggestion for type bound

### DIFF
--- a/tests/ui/associated-types/associated-types-invalid-trait-ref-issue-18865.stderr
+++ b/tests/ui/associated-types/associated-types-invalid-trait-ref-issue-18865.stderr
@@ -3,11 +3,6 @@ error[E0277]: the trait bound `T: Foo<usize>` is not satisfied
    |
 LL |     let u: <T as Foo<usize>>::Bar = t.get_bar();
    |             ^ the trait `Foo<usize>` is not implemented for `T`
-   |
-help: consider further restricting this bound
-   |
-LL | fn f<T:Foo<isize> + Foo<usize>>(t: &T) {
-   |                   ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/remove-invalid-type-bound-suggest-issue-127555.rs
+++ b/tests/ui/associated-types/remove-invalid-type-bound-suggest-issue-127555.rs
@@ -1,0 +1,23 @@
+//@ edition:2021
+// issue: rust-lang/rust#127555
+
+pub trait Foo {
+    fn bar<F>(&mut self, func: F) -> impl std::future::Future<Output = ()> + Send
+    where
+        F: FnMut();
+}
+
+struct Baz {}
+
+impl Foo for Baz {
+    async fn bar<F>(&mut self, _func: F) -> ()
+    //~^ ERROR `F` cannot be sent between threads safely
+    where
+        F: FnMut() + Send,
+        //~^ ERROR impl has stricter requirements than trait
+    {
+        ()
+    }
+}
+
+fn main() {}

--- a/tests/ui/associated-types/remove-invalid-type-bound-suggest-issue-127555.stderr
+++ b/tests/ui/associated-types/remove-invalid-type-bound-suggest-issue-127555.stderr
@@ -1,0 +1,33 @@
+error[E0277]: `F` cannot be sent between threads safely
+  --> $DIR/remove-invalid-type-bound-suggest-issue-127555.rs:13:5
+   |
+LL | /     async fn bar<F>(&mut self, _func: F) -> ()
+LL | |
+LL | |     where
+LL | |         F: FnMut() + Send,
+   | |__________________________^ `F` cannot be sent between threads safely
+   |
+note: required by a bound in `<Baz as Foo>::bar`
+  --> $DIR/remove-invalid-type-bound-suggest-issue-127555.rs:16:22
+   |
+LL |     async fn bar<F>(&mut self, _func: F) -> ()
+   |              --- required by a bound in this associated function
+...
+LL |         F: FnMut() + Send,
+   |                      ^^^^ required by this bound in `<Baz as Foo>::bar`
+
+error[E0276]: impl has stricter requirements than trait
+  --> $DIR/remove-invalid-type-bound-suggest-issue-127555.rs:16:22
+   |
+LL | /     fn bar<F>(&mut self, func: F) -> impl std::future::Future<Output = ()> + Send
+LL | |     where
+LL | |         F: FnMut();
+   | |___________________- definition of `bar` from trait
+...
+LL |           F: FnMut() + Send,
+   |                        ^^^^ impl has extra requirement `F: Send`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0276, E0277.
+For more information about an error, try `rustc --explain E0276`.

--- a/tests/ui/async-await/in-trait/unconstrained-impl-region.stderr
+++ b/tests/ui/async-await/in-trait/unconstrained-impl-region.stderr
@@ -9,10 +9,6 @@ note: required by a bound in `<() as Actor>::on_mount`
    |
 LL |     async fn on_mount(self, _: impl Inbox<&'a ()>) {}
    |                                     ^^^^^^^^^^^^^ required by this bound in `<() as Actor>::on_mount`
-help: consider further restricting this bound
-   |
-LL |     async fn on_mount(self, _: impl Inbox<&'a ()> + Inbox<&'a ()>) {}
-   |                                                   +++++++++++++++
 
 error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
   --> $DIR/unconstrained-impl-region.rs:13:6

--- a/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-2.next.stderr
+++ b/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-2.next.stderr
@@ -9,10 +9,6 @@ note: required by a bound in `impl_hr`
    |
 LL | fn impl_hr<'b, T: for<'a> Trait<'a, 'b>>() {}
    |                   ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `impl_hr`
-help: consider further restricting this bound
-   |
-LL | fn not_hr<'a, T: for<'b> Trait<'a, 'b> + OtherTrait<'static> + for<'a> Trait<'a, '_>>() {
-   |                                                              +++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-project.next.stderr
+++ b/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-project.next.stderr
@@ -9,10 +9,6 @@ note: required by a bound in `trait_bound`
    |
 LL | fn trait_bound<T: for<'a> Trait<'a>>() {}
    |                   ^^^^^^^^^^^^^^^^^ required by this bound in `trait_bound`
-help: consider further restricting this bound
-   |
-LL | fn function1<T: Trait<'static> + for<'a> Trait<'a>>() {
-   |                                +++++++++++++++++++
 
 error[E0277]: the trait bound `for<'a> T: Trait<'a>` is not satisfied
   --> $DIR/candidate-from-env-universe-err-project.rs:38:24
@@ -25,10 +21,6 @@ note: required by a bound in `projection_bound`
    |
 LL | fn projection_bound<T: for<'a> Trait<'a, Assoc = usize>>() {}
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `projection_bound`
-help: consider further restricting this bound
-   |
-LL | fn function2<T: Trait<'static, Assoc = usize> + for<'a> Trait<'a>>() {
-   |                                               +++++++++++++++++++
 
 error[E0271]: type mismatch resolving `<T as Trait<'a>>::Assoc == usize`
   --> $DIR/candidate-from-env-universe-err-project.rs:38:24

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.stderr
@@ -11,10 +11,6 @@ note: required by a bound in `want_foo_for_any_tcx`
    |
 LL | fn want_foo_for_any_tcx<F: for<'tcx> Foo<'tcx>>(f: &F) {
    |                            ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_foo_for_any_tcx`
-help: consider further restricting this bound
-   |
-LL | fn want_foo_for_some_tcx<'x, F: Foo<'x> + for<'tcx> Foo<'tcx>>(f: &'x F) {
-   |                                         +++++++++++++++++++++
 
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:28:26
@@ -29,10 +25,6 @@ note: required by a bound in `want_bar_for_any_ccx`
    |
 LL | fn want_bar_for_any_ccx<B: for<'ccx> Bar<'ccx>>(b: &B) {
    |                            ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_bar_for_any_ccx`
-help: consider further restricting this bound
-   |
-LL | fn want_bar_for_some_ccx<'x, B: Bar<'x> + for<'ccx> Bar<'ccx>>(b: &B) {
-   |                                         +++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
@@ -22,10 +22,6 @@ note: required by a bound in `<Bar as Foo<char>>::foo`
    |
 LL |     fn foo<F2: Foo<u8>>(self) -> impl Foo<u8> {
    |                ^^^^^^^ required by this bound in `<Bar as Foo<char>>::foo`
-help: consider further restricting this bound
-   |
-LL |     fn foo<F2: Foo<u8> + Foo<u8>>(self) -> impl Foo<u8> {
-   |                        +++++++++
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/return-dont-satisfy-bounds.rs:8:16


### PR DESCRIPTION
This PR partially addresses #127555, it will remove the obvious error suggestion:

```console
   |                      ^^^^ required by this bound in `<Baz as Foo>::bar`
help: consider further restricting this bound
   |
12 |         F: FnMut() + Send + std::marker::Send,
   |                           +++++++++++++++++++
```

I may create another PR to get a better diagnostic for `impl has stricter requirements than trait` scenario.