### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/std/src/sys/os_str/mod.rs
+++ b/library/std/src/sys/os_str/mod.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_op_in_unsafe_fn)]
+
 cfg_if::cfg_if! {
     if #[cfg(any(
         target_os = "windows",

--- a/library/std/src/sys/os_str/wtf8.rs
+++ b/library/std/src/sys/os_str/wtf8.rs
@@ -1,5 +1,6 @@
 //! The underlying OsString/OsStr implementation on Windows is a
 //! wrapper around the "WTF-8" encoding; see the `wtf8` module for more.
+#![deny(unsafe_op_in_unsafe_fn)]
 
 use crate::borrow::Cow;
 use crate::collections::TryReserveError;
@@ -71,7 +72,7 @@ impl Buf {
 
     #[inline]
     pub unsafe fn from_encoded_bytes_unchecked(s: Vec<u8>) -> Self {
-        Self { inner: Wtf8Buf::from_bytes_unchecked(s) }
+        unsafe { Self { inner: Wtf8Buf::from_bytes_unchecked(s) } }
     }
 
     pub fn with_capacity(capacity: usize) -> Buf {
@@ -190,7 +191,7 @@ impl Slice {
 
     #[inline]
     pub unsafe fn from_encoded_bytes_unchecked(s: &[u8]) -> &Slice {
-        mem::transmute(Wtf8::from_bytes_unchecked(s))
+        unsafe { mem::transmute(Wtf8::from_bytes_unchecked(s)) }
     }
 
     #[track_caller]

--- a/library/std/src/sys/os_str/wtf8.rs
+++ b/library/std/src/sys/os_str/wtf8.rs
@@ -1,7 +1,5 @@
 //! The underlying OsString/OsStr implementation on Windows is a
 //! wrapper around the "WTF-8" encoding; see the `wtf8` module for more.
-#![deny(unsafe_op_in_unsafe_fn)]
-
 use crate::borrow::Cow;
 use crate::collections::TryReserveError;
 use crate::fmt;

--- a/library/std/src/sys/pal/windows/alloc.rs
+++ b/library/std/src/sys/pal/windows/alloc.rs
@@ -1,5 +1,3 @@
-#![deny(unsafe_op_in_unsafe_fn)]
-
 use crate::alloc::{GlobalAlloc, Layout, System};
 use crate::ffi::c_void;
 use crate::ptr;

--- a/library/std/src/sys/pal/windows/futex.rs
+++ b/library/std/src/sys/pal/windows/futex.rs
@@ -15,6 +15,7 @@ pub type SmallAtomic = AtomicU8;
 /// Must be the underlying type of SmallAtomic
 pub type SmallPrimitive = u8;
 
+pub unsafe trait Futex {}
 pub unsafe trait Waitable {
     type Atomic;
 }
@@ -24,6 +25,7 @@ macro_rules! unsafe_waitable_int {
             unsafe impl Waitable for $int {
                 type Atomic = $atomic;
             }
+            unsafe impl Futex for $atomic {}
         )*
     };
 }
@@ -46,6 +48,7 @@ unsafe impl<T> Waitable for *const T {
 unsafe impl<T> Waitable for *mut T {
     type Atomic = AtomicPtr<T>;
 }
+unsafe impl<T> Futex for AtomicPtr<T> {}
 
 pub fn wait_on_address<W: Waitable>(
     address: &W::Atomic,
@@ -61,14 +64,14 @@ pub fn wait_on_address<W: Waitable>(
     }
 }
 
-pub fn wake_by_address_single<T>(address: &T) {
+pub fn wake_by_address_single<T: Futex>(address: &T) {
     unsafe {
         let addr = ptr::from_ref(address).cast::<c_void>();
         c::WakeByAddressSingle(addr);
     }
 }
 
-pub fn wake_by_address_all<T>(address: &T) {
+pub fn wake_by_address_all<T: Futex>(address: &T) {
     unsafe {
         let addr = ptr::from_ref(address).cast::<c_void>();
         c::WakeByAddressAll(addr);
@@ -80,11 +83,11 @@ pub fn futex_wait<W: Waitable>(futex: &W::Atomic, expected: W, timeout: Option<D
     wait_on_address(futex, expected, timeout) || api::get_last_error() != WinError::TIMEOUT
 }
 
-pub fn futex_wake<T>(futex: &T) -> bool {
+pub fn futex_wake<T: Futex>(futex: &T) -> bool {
     wake_by_address_single(futex);
     false
 }
 
-pub fn futex_wake_all<T>(futex: &T) {
+pub fn futex_wake_all<T: Futex>(futex: &T) {
     wake_by_address_all(futex)
 }

--- a/library/std/src/sys/pal/windows/handle.rs
+++ b/library/std/src/sys/pal/windows/handle.rs
@@ -1,5 +1,4 @@
 #![unstable(issue = "none", feature = "windows_handle")]
-#![allow(unsafe_op_in_unsafe_fn)]
 
 #[cfg(test)]
 mod tests;
@@ -73,7 +72,7 @@ impl IntoRawHandle for Handle {
 
 impl FromRawHandle for Handle {
     unsafe fn from_raw_handle(raw_handle: RawHandle) -> Self {
-        Self(FromRawHandle::from_raw_handle(raw_handle))
+        unsafe { Self(FromRawHandle::from_raw_handle(raw_handle)) }
     }
 }
 
@@ -142,19 +141,23 @@ impl Handle {
         buf: &mut [u8],
         overlapped: *mut c::OVERLAPPED,
     ) -> io::Result<Option<usize>> {
-        let len = cmp::min(buf.len(), u32::MAX as usize) as u32;
-        let mut amt = 0;
-        let res =
-            cvt(c::ReadFile(self.as_raw_handle(), buf.as_mut_ptr(), len, &mut amt, overlapped));
-        match res {
-            Ok(_) => Ok(Some(amt as usize)),
-            Err(e) => {
-                if e.raw_os_error() == Some(c::ERROR_IO_PENDING as i32) {
-                    Ok(None)
-                } else if e.raw_os_error() == Some(c::ERROR_BROKEN_PIPE as i32) {
-                    Ok(Some(0))
-                } else {
-                    Err(e)
+        // SAFETY: We have exclusive access to the buffer and it's up to the caller to
+        // ensure the OVERLAPPED pointer is valid for the lifetime of this function.
+        unsafe {
+            let len = cmp::min(buf.len(), u32::MAX as usize) as u32;
+            let mut amt = 0;
+            let res =
+                cvt(c::ReadFile(self.as_raw_handle(), buf.as_mut_ptr(), len, &mut amt, overlapped));
+            match res {
+                Ok(_) => Ok(Some(amt as usize)),
+                Err(e) => {
+                    if e.raw_os_error() == Some(c::ERROR_IO_PENDING as i32) {
+                        Ok(None)
+                    } else if e.raw_os_error() == Some(c::ERROR_BROKEN_PIPE as i32) {
+                        Ok(Some(0))
+                    } else {
+                        Err(e)
+                    }
                 }
             }
         }
@@ -230,20 +233,24 @@ impl Handle {
 
         // The length is clamped at u32::MAX.
         let len = cmp::min(len, u32::MAX as usize) as u32;
-        let status = c::NtReadFile(
-            self.as_handle(),
-            ptr::null_mut(),
-            None,
-            ptr::null_mut(),
-            &mut io_status,
-            buf,
-            len,
-            offset.map(|n| n as _).as_ref(),
-            None,
-        );
+        // SAFETY: It's up to the caller to ensure `buf` is writeable up to
+        // the provided `len`.
+        let status = unsafe {
+            c::NtReadFile(
+                self.as_handle(),
+                ptr::null_mut(),
+                None,
+                ptr::null_mut(),
+                &mut io_status,
+                buf,
+                len,
+                offset.map(|n| n as _).as_ref(),
+                None,
+            )
+        };
 
         let status = if status == c::STATUS_PENDING {
-            c::WaitForSingleObject(self.as_raw_handle(), c::INFINITE);
+            unsafe { c::WaitForSingleObject(self.as_raw_handle(), c::INFINITE) };
             io_status.status()
         } else {
             status
@@ -261,7 +268,7 @@ impl Handle {
             status if c::nt_success(status) => Ok(io_status.Information),
 
             status => {
-                let error = c::RtlNtStatusToDosError(status);
+                let error = unsafe { c::RtlNtStatusToDosError(status) };
                 Err(io::Error::from_raw_os_error(error as _))
             }
         }

--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -1,7 +1,6 @@
 //! Implementation of `std::os` functionality for Windows.
 
 #![allow(nonstandard_style)]
-#![allow(unsafe_op_in_unsafe_fn)]
 
 #[cfg(test)]
 mod tests;
@@ -305,15 +304,21 @@ pub fn getenv(k: &OsStr) -> Option<OsString> {
 }
 
 pub unsafe fn setenv(k: &OsStr, v: &OsStr) -> io::Result<()> {
-    let k = to_u16s(k)?;
-    let v = to_u16s(v)?;
+    // SAFETY: We ensure that k and v are null-terminated wide strings.
+    unsafe {
+        let k = to_u16s(k)?;
+        let v = to_u16s(v)?;
 
-    cvt(c::SetEnvironmentVariableW(k.as_ptr(), v.as_ptr())).map(drop)
+        cvt(c::SetEnvironmentVariableW(k.as_ptr(), v.as_ptr())).map(drop)
+    }
 }
 
 pub unsafe fn unsetenv(n: &OsStr) -> io::Result<()> {
-    let v = to_u16s(n)?;
-    cvt(c::SetEnvironmentVariableW(v.as_ptr(), ptr::null())).map(drop)
+    // SAFETY: We ensure that v is a null-terminated wide strings.
+    unsafe {
+        let v = to_u16s(n)?;
+        cvt(c::SetEnvironmentVariableW(v.as_ptr(), ptr::null())).map(drop)
+    }
 }
 
 pub fn temp_dir() -> PathBuf {

--- a/library/std/src/sys/pal/windows/pipe.rs
+++ b/library/std/src/sys/pal/windows/pipe.rs
@@ -1,4 +1,3 @@
-#![allow(unsafe_op_in_unsafe_fn)]
 use crate::os::windows::prelude::*;
 
 use crate::ffi::OsStr;
@@ -325,6 +324,7 @@ impl AnonPipe {
     /// [`ReadFileEx`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfileex
     /// [`WriteFileEx`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefileex
     /// [Asynchronous Procedure Call]: https://docs.microsoft.com/en-us/windows/win32/sync/asynchronous-procedure-calls
+    #[allow(unsafe_op_in_unsafe_fn)]
     unsafe fn alertable_io_internal(
         &self,
         io: AlertableIoFn,
@@ -561,6 +561,7 @@ impl<'a> Drop for AsyncPipe<'a> {
     }
 }
 
+#[allow(unsafe_op_in_unsafe_fn)]
 unsafe fn slice_to_end(v: &mut Vec<u8>) -> &mut [u8] {
     if v.capacity() == 0 {
         v.reserve(16);
@@ -568,5 +569,6 @@ unsafe fn slice_to_end(v: &mut Vec<u8>) -> &mut [u8] {
     if v.capacity() == v.len() {
         v.reserve(1);
     }
+    // FIXME: Isn't this just spare_capacity_mut but worse?
     slice::from_raw_parts_mut(v.as_mut_ptr().add(v.len()), v.capacity() - v.len())
 }

--- a/library/std/src/sys/pal/windows/stack_overflow.rs
+++ b/library/std/src/sys/pal/windows/stack_overflow.rs
@@ -1,18 +1,18 @@
 #![cfg_attr(test, allow(dead_code))]
-#![allow(unsafe_op_in_unsafe_fn)]
 
 use crate::sys::c;
 use crate::thread;
 
 /// Reserve stack space for use in stack overflow exceptions.
-pub unsafe fn reserve_stack() {
-    let result = c::SetThreadStackGuarantee(&mut 0x5000);
+pub fn reserve_stack() {
+    let result = unsafe { c::SetThreadStackGuarantee(&mut 0x5000) };
     // Reserving stack space is not critical so we allow it to fail in the released build of libstd.
     // We still use debug assert here so that CI will test that we haven't made a mistake calling the function.
     debug_assert_ne!(result, 0, "failed to reserve stack space for exception handling");
 }
 
 unsafe extern "system" fn vectored_handler(ExceptionInfo: *mut c::EXCEPTION_POINTERS) -> i32 {
+    // SAFETY: It's up to the caller (which in this case is the OS) to ensure that `ExceptionInfo` is valid.
     unsafe {
         let rec = &(*(*ExceptionInfo).ExceptionRecord);
         let code = rec.ExceptionCode;
@@ -27,11 +27,14 @@ unsafe extern "system" fn vectored_handler(ExceptionInfo: *mut c::EXCEPTION_POIN
     }
 }
 
-pub unsafe fn init() {
-    let result = c::AddVectoredExceptionHandler(0, Some(vectored_handler));
-    // Similar to the above, adding the stack overflow handler is allowed to fail
-    // but a debug assert is used so CI will still test that it normally works.
-    debug_assert!(!result.is_null(), "failed to install exception handler");
+pub fn init() {
+    // SAFETY: `vectored_handler` has the correct ABI and is safe to call during exception handling.
+    unsafe {
+        let result = c::AddVectoredExceptionHandler(0, Some(vectored_handler));
+        // Similar to the above, adding the stack overflow handler is allowed to fail
+        // but a debug assert is used so CI will still test that it normally works.
+        debug_assert!(!result.is_null(), "failed to install exception handler");
+    }
     // Set the thread stack guarantee for the main thread.
     reserve_stack();
 }

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -22,28 +22,30 @@ pub struct Thread {
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    #[allow(unsafe_op_in_unsafe_fn)]
-    // FIXME: check the internal safety
     pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
         let p = Box::into_raw(Box::new(p));
 
         // CreateThread rounds up values for the stack size to the nearest page size (at least 4kb).
         // If a value of zero is given then the default stack size is used instead.
-        let ret = c::CreateThread(
-            ptr::null_mut(),
-            stack,
-            Some(thread_start),
-            p as *mut _,
-            c::STACK_SIZE_PARAM_IS_A_RESERVATION,
-            ptr::null_mut(),
-        );
-        let ret = HandleOrNull::from_raw_handle(ret);
+        // SAFETY: `thread_start` has the right ABI for a thread's entry point.
+        // `p` is simply passed through to the new thread without being touched.
+        let ret = unsafe {
+            let ret = c::CreateThread(
+                ptr::null_mut(),
+                stack,
+                Some(thread_start),
+                p as *mut _,
+                c::STACK_SIZE_PARAM_IS_A_RESERVATION,
+                ptr::null_mut(),
+            );
+            HandleOrNull::from_raw_handle(ret)
+        };
         return if let Ok(handle) = ret.try_into() {
             Ok(Thread { handle: Handle::from_inner(handle) })
         } else {
             // The thread failed to start and as a result p was not consumed. Therefore, it is
             // safe to reconstruct the box so that it gets deallocated.
-            drop(Box::from_raw(p));
+            unsafe { drop(Box::from_raw(p)) };
             Err(io::Error::last_os_error())
         };
 
@@ -51,7 +53,9 @@ impl Thread {
             // Next, reserve some stack space for if we otherwise run out of stack.
             stack_overflow::reserve_stack();
             // Finally, let's run some code.
-            Box::from_raw(main as *mut Box<dyn FnOnce()>)();
+            // SAFETY: We are simply recreating the box that was leaked earlier.
+            // It's the responsibility of the one who call `Thread::new` to ensure this is safe to call here.
+            unsafe { Box::from_raw(main as *mut Box<dyn FnOnce()>)() };
             0
         }
     }

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -1,4 +1,3 @@
-#![allow(unsafe_op_in_unsafe_fn)]
 use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZero;
@@ -23,6 +22,8 @@ pub struct Thread {
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
+    #[allow(unsafe_op_in_unsafe_fn)]
+    // FIXME: check the internal safety
     pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
         let p = Box::into_raw(Box::new(p));
 
@@ -70,7 +71,7 @@ impl Thread {
     ///
     /// `name` must end with a zero value
     pub unsafe fn set_name_wide(name: &[u16]) {
-        c::SetThreadDescription(c::GetCurrentThread(), name.as_ptr());
+        unsafe { c::SetThreadDescription(c::GetCurrentThread(), name.as_ptr()) };
     }
 
     pub fn join(self) {

--- a/library/std/src/sys/sync/once/futex.rs
+++ b/library/std/src/sys/sync/once/futex.rs
@@ -57,7 +57,7 @@ impl<'a> Drop for CompletionGuard<'a> {
         // up on the Once. `futex_wake_all` does its own synchronization, hence
         // we do not need `AcqRel`.
         if self.state.swap(self.set_state_on_drop_to, Release) == QUEUED {
-            futex_wake_all(&self.state);
+            futex_wake_all(self.state);
         }
     }
 }

--- a/tests/ui/codegen/equal-pointers-unequal/README.md
+++ b/tests/ui/codegen/equal-pointers-unequal/README.md
@@ -1,0 +1,22 @@
+See https://github.com/rust-lang/rust/issues/107975
+
+Basically, if you have two pointers with the same address but from two different allocations,
+the compiler gets confused whether their addresses are equal or not,
+resulting in some self-contradictory behavior of the compiled code.
+
+This folder contains some examples.
+They all boil down to allocating a variable on the stack, taking its address,
+getting rid of the variable, and then doing it all again.
+This way we end up with two addresses stored in two `usize`s (`a` and `b`).
+The addresses are (probably) equal but (definitely) come from two different allocations.
+Logically, we would expect that exactly one of the following options holds true:
+1. `a == b`
+2. `a != b`
+Sadly, the compiler does not always agree.
+
+Due to Rust having at least three meaningfully different ways
+to get a variable's address as an `usize`,
+each example is provided in three versions, each in the corresponding subfolder:
+1. `./as-cast/` for `&v as *const _ as usize`,
+2. `./strict-provenance/` for `addr_of!(v).addr()`,
+2. `./exposed-provenance/` for `addr_of!(v).expose_provenance()`.

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/basic.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/basic.rs
@@ -1,0 +1,21 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+
+fn main() {
+    let a: usize = {
+        let v = 0u8;
+        &v as *const _ as usize
+    };
+    let b: usize = {
+        let v = 0u8;
+        &v as *const _ as usize
+    };
+
+    // `a` and `b` are not equal.
+    assert_ne!(a, b);
+    // But they are the same number.
+    assert_eq!(format!("{a}"), format!("{b}"));
+    // And they are equal.
+    assert_eq!(a, b);
+}

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/function.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/function.rs
@@ -1,0 +1,22 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+
+// Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1434203908
+
+fn f() -> usize {
+    let v = 0;
+    &v as *const _ as usize
+}
+
+fn main() {
+    let a = f();
+    let b = f();
+
+    // `a` and `b` are not equal.
+    assert_ne!(a, b);
+    // But they are the same number.
+    assert_eq!(format!("{a}"), format!("{b}"));
+    // And they are equal.
+    assert_eq!(a, b);
+}

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/inline1.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/inline1.rs
@@ -1,0 +1,30 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
+
+#[inline(never)]
+fn cmp(a: usize, b: usize) -> bool {
+    a == b
+}
+
+#[inline(always)]
+fn cmp_in(a: usize, b: usize) -> bool {
+    a == b
+}
+
+fn main() {
+    let a = {
+        let v = 0;
+        &v as *const _ as usize
+    };
+    let b = {
+        let v = 0;
+        &v as *const _ as usize
+    };
+    println!("{a:?} == {b:?} -> ==: {}, cmp_in: {}, cmp: {}", a == b, cmp_in(a, b), cmp(a, b));
+    assert_eq!(a.to_string(), b.to_string());
+}

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/inline1.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/inline1.run.stdout
@@ -1,0 +1,1 @@
+<..> == <..> -> ==: false, cmp_in: false, cmp: true

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/inline2.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/inline2.rs
@@ -1,0 +1,30 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
+
+#[inline(never)]
+fn cmp(a: usize, b: usize) -> bool {
+    a == b
+}
+
+#[inline(always)]
+fn cmp_in(a: usize, b: usize) -> bool {
+    a == b
+}
+
+fn main() {
+    let a = {
+        let v = 0;
+        &v as *const _ as usize
+    };
+    let b = {
+        let v = 0;
+        &v as *const _ as usize
+    };
+    assert_eq!(a.to_string(), b.to_string());
+    println!("{a:?} == {b:?} -> ==: {}, cmp_in: {}, cmp: {}", a == b, cmp_in(a, b), cmp(a, b));
+}

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/inline2.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/inline2.run.stdout
@@ -1,0 +1,1 @@
+<..> == <..> -> ==: true, cmp_in: true, cmp: true

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/print.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/print.rs
@@ -1,0 +1,22 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// https://github.com/rust-lang/rust/issues/107975#issuecomment-1430704499
+
+fn main() {
+    let a = {
+        let v = 0;
+        &v as *const _ as usize
+    };
+    let b = {
+        let v = 0;
+        &v as *const _ as usize
+    };
+
+    println!("{}", a == b); // prints false
+    println!("{a}"); // or b
+    println!("{}", a == b); // prints true
+}

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/print.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/print.run.stdout
@@ -1,0 +1,3 @@
+false
+<..>
+true

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/print3.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/print3.rs
@@ -1,0 +1,25 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// https://github.com/rust-lang/rust/issues/107975#issuecomment-1430704499
+
+fn main() {
+    let a = {
+        let v = 0;
+        &v as *const _ as usize
+    };
+    let b = {
+        let v = 0;
+        &v as *const _ as usize
+    };
+
+    println!("{}", a == b); // false
+    println!("{}", a == b); // false
+    let c = a;
+    println!("{} {} {}", a == b, a == c, b == c); // false true false
+    println!("{a} {b}");
+    println!("{} {} {}", a == b, a == c, b == c); // true true true
+}

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/print3.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/print3.run.stdout
@@ -1,0 +1,5 @@
+false
+false
+false true false
+<..> <..>
+true true true

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/segfault.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/segfault.rs
@@ -1,0 +1,35 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-fail
+//@ check-run-results
+
+// This one should segfault.
+// I don't know a better way to check for segfault other than
+// check that it fails and that the output is empty.
+
+// https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
+
+use std::cell::RefCell;
+
+fn main() {
+    let a = {
+        let v = 0u8;
+        &v as *const _ as usize
+    };
+    let b = {
+        let v = 0u8;
+        &v as *const _ as usize
+    };
+    let i = b - a;
+    let arr = [
+        RefCell::new(Some(Box::new(1))),
+        RefCell::new(None),
+        RefCell::new(None),
+        RefCell::new(None),
+    ];
+    assert_ne!(i, 0);
+    let r = arr[i].borrow();
+    let r = r.as_ref().unwrap();
+    *arr[0].borrow_mut() = None;
+    println!("{}", *r);
+}

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/zero.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/zero.rs
@@ -1,0 +1,28 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+
+// Derived from https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
+
+fn main() {
+    let a: usize = {
+        let v = 0u8;
+        &v as *const _ as usize
+    };
+    let b: usize = {
+        let v = 0u8;
+        &v as *const _ as usize
+    };
+
+    // So, are `a` and `b` equal?
+
+    // Let's check their difference.
+    let i: usize = a - b;
+    // It's not zero, which means `a` and `b` are not equal.
+    assert_ne!(i, 0);
+    // But it looks like zero...
+    assert_eq!(i.to_string(), "0");
+    // ...and now it *is* zero?
+    assert_eq!(i, 0);
+    // So `a` and `b` are equal after all?
+}

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/basic.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/basic.rs
@@ -1,0 +1,25 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+
+#![feature(exposed_provenance)]
+
+use std::ptr::addr_of;
+
+fn main() {
+    let a: usize = {
+        let v = 0u8;
+        addr_of!(v).expose_provenance()
+    };
+    let b: usize = {
+        let v = 0u8;
+        addr_of!(v).expose_provenance()
+    };
+
+    // `a` and `b` are not equal.
+    assert_ne!(a, b);
+    // But they are the same number.
+    assert_eq!(format!("{a}"), format!("{b}"));
+    // And they are equal.
+    assert_eq!(a, b);
+}

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/function.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/function.rs
@@ -1,0 +1,26 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+
+// Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1434203908
+
+#![feature(exposed_provenance)]
+
+use std::ptr::addr_of;
+
+fn f() -> usize {
+    let v = 0;
+    addr_of!(v).expose_provenance()
+}
+
+fn main() {
+    let a = f();
+    let b = f();
+
+    // `a` and `b` are not equal.
+    assert_ne!(a, b);
+    // But they are the same number.
+    assert_eq!(format!("{a}"), format!("{b}"));
+    // And they are equal.
+    assert_eq!(a, b);
+}

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline1.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline1.rs
@@ -1,0 +1,35 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
+
+
+#![feature(exposed_provenance)]
+
+use std::ptr::addr_of;
+
+#[inline(never)]
+fn cmp(a: usize, b: usize) -> bool {
+    a == b
+}
+
+#[inline(always)]
+fn cmp_in(a: usize, b: usize) -> bool {
+    a == b
+}
+
+fn main() {
+    let a = {
+        let v = 0;
+        addr_of!(v).expose_provenance()
+    };
+    let b = {
+        let v = 0;
+        addr_of!(v).expose_provenance()
+    };
+    println!("{a:?} == {b:?} -> ==: {}, cmp_in: {}, cmp: {}", a == b, cmp_in(a, b), cmp(a, b));
+    assert_eq!(a.to_string(), b.to_string());
+}

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline1.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline1.run.stdout
@@ -1,0 +1,1 @@
+<..> == <..> -> ==: false, cmp_in: false, cmp: true

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline2.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline2.rs
@@ -1,0 +1,34 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
+
+#![feature(exposed_provenance)]
+
+use std::ptr::addr_of;
+
+#[inline(never)]
+fn cmp(a: usize, b: usize) -> bool {
+    a == b
+}
+
+#[inline(always)]
+fn cmp_in(a: usize, b: usize) -> bool {
+    a == b
+}
+
+fn main() {
+    let a = {
+        let v = 0;
+        addr_of!(v).expose_provenance()
+    };
+    let b = {
+        let v = 0;
+        addr_of!(v).expose_provenance()
+    };
+    assert_eq!(a.to_string(), b.to_string());
+    println!("{a:?} == {b:?} -> ==: {}, cmp_in: {}, cmp: {}", a == b, cmp_in(a, b), cmp(a, b));
+}

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline2.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline2.run.stdout
@@ -1,0 +1,1 @@
+<..> == <..> -> ==: true, cmp_in: true, cmp: true

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/print.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/print.rs
@@ -1,0 +1,26 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// https://github.com/rust-lang/rust/issues/107975#issuecomment-1430704499
+
+#![feature(exposed_provenance)]
+
+use std::ptr::addr_of;
+
+fn main() {
+    let a = {
+        let v = 0;
+        addr_of!(v).expose_provenance()
+    };
+    let b = {
+        let v = 0;
+        addr_of!(v).expose_provenance()
+    };
+
+    println!("{}", a == b); // prints false
+    println!("{a}"); // or b
+    println!("{}", a == b); // prints true
+}

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/print.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/print.run.stdout
@@ -1,0 +1,3 @@
+false
+<..>
+true

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/print3.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/print3.rs
@@ -1,0 +1,29 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// https://github.com/rust-lang/rust/issues/107975#issuecomment-1430704499
+
+#![feature(exposed_provenance)]
+
+use std::ptr::addr_of;
+
+fn main() {
+    let a = {
+        let v = 0;
+        addr_of!(v).expose_provenance()
+    };
+    let b = {
+        let v = 0;
+        addr_of!(v).expose_provenance()
+    };
+
+    println!("{}", a == b); // false
+    println!("{}", a == b); // false
+    let c = a;
+    println!("{} {} {}", a == b, a == c, b == c); // false true false
+    println!("{a} {b}");
+    println!("{} {} {}", a == b, a == c, b == c); // true true true
+}

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/print3.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/print3.run.stdout
@@ -1,0 +1,5 @@
+false
+false
+false true false
+<..> <..>
+true true true

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/segfault.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/segfault.rs
@@ -1,0 +1,37 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-fail
+//@ check-run-results
+
+// This one should segfault.
+// I don't know a better way to check for segfault other than
+// check that it fails and that the output is empty.
+
+// https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
+
+#![feature(exposed_provenance)]
+
+use std::{cell::RefCell, ptr::addr_of};
+
+fn main() {
+    let a = {
+        let v = 0u8;
+        addr_of!(v).expose_provenance()
+    };
+    let b = {
+        let v = 0u8;
+        addr_of!(v).expose_provenance()
+    };
+    let i = b - a;
+    let arr = [
+        RefCell::new(Some(Box::new(1))),
+        RefCell::new(None),
+        RefCell::new(None),
+        RefCell::new(None),
+    ];
+    assert_ne!(i, 0);
+    let r = arr[i].borrow();
+    let r = r.as_ref().unwrap();
+    *arr[0].borrow_mut() = None;
+    println!("{}", *r);
+}

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/zero.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/zero.rs
@@ -1,0 +1,32 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+
+// Derived from https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
+
+#![feature(exposed_provenance)]
+
+use std::ptr::addr_of;
+
+fn main() {
+    let a: usize = {
+        let v = 0u8;
+        addr_of!(v).expose_provenance()
+    };
+    let b: usize = {
+        let v = 0u8;
+        addr_of!(v).expose_provenance()
+    };
+
+    // So, are `a` and `b` equal?
+
+    // Let's check their difference.
+    let i: usize = a - b;
+    // It's not zero, which means `a` and `b` are not equal.
+    assert_ne!(i, 0);
+    // But it looks like zero...
+    assert_eq!(i.to_string(), "0");
+    // ...and now it *is* zero?
+    assert_eq!(i, 0);
+    // So `a` and `b` are equal after all?
+}

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/basic.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/basic.rs
@@ -1,0 +1,25 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+
+#![feature(strict_provenance)]
+
+use std::ptr::addr_of;
+
+fn main() {
+    let a: usize = {
+        let v = 0u8;
+        addr_of!(v).addr()
+    };
+    let b: usize = {
+        let v = 0u8;
+        addr_of!(v).addr()
+    };
+
+    // `a` and `b` are not equal.
+    assert_ne!(a, b);
+    // But they are the same number.
+    assert_eq!(format!("{a}"), format!("{b}"));
+    // And they are equal.
+    assert_eq!(a, b);
+}

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/function.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/function.rs
@@ -1,0 +1,26 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+
+// Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1434203908
+
+#![feature(strict_provenance)]
+
+use std::ptr::addr_of;
+
+fn f() -> usize {
+    let v = 0;
+    addr_of!(v).addr()
+}
+
+fn main() {
+    let a = f();
+    let b = f();
+
+    // `a` and `b` are not equal.
+    assert_ne!(a, b);
+    // But they are the same number.
+    assert_eq!(format!("{a}"), format!("{b}"));
+    // And they are equal.
+    assert_eq!(a, b);
+}

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline1.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline1.rs
@@ -1,0 +1,35 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
+
+
+#![feature(strict_provenance)]
+
+use std::ptr::addr_of;
+
+#[inline(never)]
+fn cmp(a: usize, b: usize) -> bool {
+    a == b
+}
+
+#[inline(always)]
+fn cmp_in(a: usize, b: usize) -> bool {
+    a == b
+}
+
+fn main() {
+    let a = {
+        let v = 0;
+        addr_of!(v).addr()
+    };
+    let b = {
+        let v = 0;
+        addr_of!(v).addr()
+    };
+    println!("{a:?} == {b:?} -> ==: {}, cmp_in: {}, cmp: {}", a == b, cmp_in(a, b), cmp(a, b));
+    assert_eq!(a.to_string(), b.to_string());
+}

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline1.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline1.run.stdout
@@ -1,0 +1,1 @@
+<..> == <..> -> ==: false, cmp_in: false, cmp: true

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline2.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline2.rs
@@ -1,0 +1,34 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
+
+#![feature(strict_provenance)]
+
+use std::ptr::addr_of;
+
+#[inline(never)]
+fn cmp(a: usize, b: usize) -> bool {
+    a == b
+}
+
+#[inline(always)]
+fn cmp_in(a: usize, b: usize) -> bool {
+    a == b
+}
+
+fn main() {
+    let a = {
+        let v = 0;
+        addr_of!(v).addr()
+    };
+    let b = {
+        let v = 0;
+        addr_of!(v).addr()
+    };
+    assert_eq!(a.to_string(), b.to_string());
+    println!("{a:?} == {b:?} -> ==: {}, cmp_in: {}, cmp: {}", a == b, cmp_in(a, b), cmp(a, b));
+}

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline2.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline2.run.stdout
@@ -1,0 +1,1 @@
+<..> == <..> -> ==: true, cmp_in: true, cmp: true

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/print.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/print.rs
@@ -1,0 +1,26 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// https://github.com/rust-lang/rust/issues/107975#issuecomment-1430704499
+
+#![feature(strict_provenance)]
+
+use std::ptr::addr_of;
+
+fn main() {
+    let a = {
+        let v = 0;
+        addr_of!(v).addr()
+    };
+    let b = {
+        let v = 0;
+        addr_of!(v).addr()
+    };
+
+    println!("{}", a == b); // prints false
+    println!("{a}"); // or b
+    println!("{}", a == b); // prints true
+}

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/print.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/print.run.stdout
@@ -1,0 +1,3 @@
+false
+<..>
+true

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/print3.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/print3.rs
@@ -1,0 +1,29 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+//@ check-run-results
+//@ normalize-stdout-test: "\d+" -> "<..>"
+
+// https://github.com/rust-lang/rust/issues/107975#issuecomment-1430704499
+
+#![feature(strict_provenance)]
+
+use std::ptr::addr_of;
+
+fn main() {
+    let a = {
+        let v = 0;
+        addr_of!(v).addr()
+    };
+    let b = {
+        let v = 0;
+        addr_of!(v).addr()
+    };
+
+    println!("{}", a == b); // false
+    println!("{}", a == b); // false
+    let c = a;
+    println!("{} {} {}", a == b, a == c, b == c); // false true false
+    println!("{a} {b}");
+    println!("{} {} {}", a == b, a == c, b == c); // true true true
+}

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/print3.run.stdout
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/print3.run.stdout
@@ -1,0 +1,5 @@
+false
+false
+false true false
+<..> <..>
+true true true

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/segfault.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/segfault.rs
@@ -1,0 +1,37 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-fail
+//@ check-run-results
+
+// This one should segfault.
+// I don't know a better way to check for segfault other than
+// check that it fails and that the output is empty.
+
+// https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
+
+#![feature(strict_provenance)]
+
+use std::{cell::RefCell, ptr::addr_of};
+
+fn main() {
+    let a = {
+        let v = 0u8;
+        addr_of!(v).addr()
+    };
+    let b = {
+        let v = 0u8;
+        addr_of!(v).addr()
+    };
+    let i = b - a;
+    let arr = [
+        RefCell::new(Some(Box::new(1))),
+        RefCell::new(None),
+        RefCell::new(None),
+        RefCell::new(None),
+    ];
+    assert_ne!(i, 0);
+    let r = arr[i].borrow();
+    let r = r.as_ref().unwrap();
+    *arr[0].borrow_mut() = None;
+    println!("{}", *r);
+}

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/zero.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/zero.rs
@@ -1,0 +1,32 @@
+//@ known-bug: #107975
+//@ compile-flags: -Copt-level=2
+//@ run-pass
+
+// Derived from https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
+
+#![feature(strict_provenance)]
+
+use std::ptr::addr_of;
+
+fn main() {
+    let a: usize = {
+        let v = 0u8;
+        addr_of!(v).addr()
+    };
+    let b: usize = {
+        let v = 0u8;
+        addr_of!(v).addr()
+    };
+
+    // So, are `a` and `b` equal?
+
+    // Let's check their difference.
+    let i: usize = a - b;
+    // It's not zero, which means `a` and `b` are not equal.
+    assert_ne!(i, 0);
+    // But it looks like zero...
+    assert_eq!(i.to_string(), "0");
+    // ...and now it *is* zero?
+    assert_eq!(i, 0);
+    // So `a` and `b` are equal after all?
+}


### PR DESCRIPTION
Successful merges:

 - #127003 (Add a test for #107975)
 - #127763 (Make more Windows functions `#![deny(unsafe_op_in_unsafe_fn)]`)
 - #127813 (Prevent double reference in generic futex)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=127003,127763,127813)
<!-- homu-ignore:end -->