### PR TITLE
deps: dedup object, wasmparser, wasm-encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,18 +2571,6 @@ dependencies = [
  "indexmap",
  "memchr",
  "ruzstd 0.5.0",
- "wasmparser 0.118.2",
-]
-
-[[package]]
-name = "object"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7090bae93f8585aad99e595b7073c5de9ba89fbd6b4e9f0cdd7a10177273ac8"
-dependencies = [
- "flate2",
- "memchr",
- "ruzstd 0.6.0",
 ]
 
 [[package]]
@@ -2596,14 +2584,20 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "compiler_builtins",
+ "crc32fast",
+ "flate2",
+ "hashbrown",
+ "indexmap",
  "memchr",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
+ "ruzstd 0.7.0",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
@@ -3334,10 +3328,10 @@ dependencies = [
  "bstr",
  "build_helper",
  "gimli 0.31.0",
- "object 0.34.0",
+ "object 0.36.2",
  "regex",
  "similar",
- "wasmparser 0.118.2",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
@@ -3643,7 +3637,7 @@ dependencies = [
  "itertools",
  "libc",
  "measureme",
- "object 0.32.2",
+ "object 0.36.2",
  "rustc-demangle",
  "rustc_ast",
  "rustc_attr",
@@ -3682,7 +3676,7 @@ dependencies = [
  "itertools",
  "jobserver",
  "libc",
- "object 0.32.2",
+ "object 0.36.2",
  "pathdiff",
  "regex",
  "rustc_arena",
@@ -3712,7 +3706,7 @@ dependencies = [
  "thin-vec",
  "thorin-dwp",
  "tracing",
- "wasm-encoder 0.200.0",
+ "wasm-encoder 0.210.0",
  "windows",
 ]
 
@@ -4666,7 +4660,7 @@ name = "rustc_target"
 version = "0.0.0"
 dependencies = [
  "bitflags 2.5.0",
- "object 0.32.2",
+ "object 0.36.2",
  "rustc_abi",
  "rustc_data_structures",
  "rustc_feature",
@@ -4951,12 +4945,11 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
+checksum = "5022b253619b1ba797f243056276bed8ed1a73b0f5a7ce7225d524067644bf8f"
 dependencies = [
  "byteorder",
- "derive_more",
  "twox-hash",
 ]
 
@@ -5242,7 +5235,7 @@ dependencies = [
  "hermit-abi 0.4.0",
  "libc",
  "miniz_oxide",
- "object 0.36.0",
+ "object 0.36.2",
  "panic_abort",
  "panic_unwind",
  "profiler_builtins",
@@ -6181,15 +6174,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.200.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e3fb0c8fbddd78aa6095b850dfeedbc7506cf5f81e633f69cf8f2333ab84b9"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.210.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e3764d9d6edabd8c9e16195e177be0d20f6ab942ad18af52860f12f82bc59a"
@@ -6224,16 +6208,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.118.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f1154f1ab868e2a01d9834a805faca7bf8b50d041b4ca714d005d0dab1c50c"
-dependencies = [
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.210.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7bbcd21e7581619d9f6ca00f8c4f08f1cacfe58bf63f83af57cd0476f1026f5"
@@ -6244,6 +6218,16 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
+dependencies = [
+ "bitflags 2.5.0",
+ "indexmap",
 ]
 
 [[package]]

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -12,7 +12,7 @@ bitflags = "2.4.1"
 itertools = "0.12"
 libc = "0.2"
 measureme = "11"
-object = { version = "0.32.0", default-features = false, features = ["std", "read"] }
+object = { version = "0.36.2", default-features = false, features = ["std", "read"] }
 rustc-demangle = "0.1.21"
 rustc_ast = { path = "../rustc_ast" }
 rustc_attr = { path = "../rustc_attr" }

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -41,7 +41,7 @@ tempfile = "3.2"
 thin-vec = "0.2.12"
 thorin-dwp = "0.7"
 tracing = "0.1"
-wasm-encoder = "0.200.0"
+wasm-encoder = "0.210.0"
 # tidy-alphabetical-end
 
 [target.'cfg(unix)'.dependencies]
@@ -50,7 +50,7 @@ libc = "0.2.50"
 # tidy-alphabetical-end
 
 [dependencies.object]
-version = "0.32.1"
+version = "0.36.2"
 default-features = false
 features = ["read_core", "elf", "macho", "pe", "xcoff", "unaligned", "archive", "write", "wasm"]
 

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -110,13 +110,11 @@ impl<'a> ArArchiveBuilder<'a> {
 }
 
 fn try_filter_fat_archs(
-    archs: object::read::Result<&[impl FatArch]>,
+    archs: &[impl FatArch],
     target_arch: object::Architecture,
     archive_path: &Path,
     archive_map_data: &[u8],
 ) -> io::Result<Option<PathBuf>> {
-    let archs = archs.map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-
     let desired = match archs.iter().find(|a| a.architecture() == target_arch) {
         Some(a) => a,
         None => return Ok(None),
@@ -146,17 +144,15 @@ pub fn try_extract_macho_fat_archive(
         _ => return Ok(None),
     };
 
-    match object::macho::FatHeader::parse(&*archive_map) {
-        Ok(h) if h.magic.get(object::endian::BigEndian) == object::macho::FAT_MAGIC => {
-            let archs = object::macho::FatHeader::parse_arch32(&*archive_map);
-            try_filter_fat_archs(archs, target_arch, archive_path, &*archive_map)
-        }
-        Ok(h) if h.magic.get(object::endian::BigEndian) == object::macho::FAT_MAGIC_64 => {
-            let archs = object::macho::FatHeader::parse_arch64(&*archive_map);
-            try_filter_fat_archs(archs, target_arch, archive_path, &*archive_map)
-        }
+    if let Ok(h) = object::read::macho::MachOFatFile32::parse(&*archive_map) {
+        let archs = h.arches();
+        try_filter_fat_archs(archs, target_arch, archive_path, &*archive_map)
+    } else if let Ok(h) = object::read::macho::MachOFatFile64::parse(&*archive_map) {
+        let archs = h.arches();
+        try_filter_fat_archs(archs, target_arch, archive_path, &*archive_map)
+    } else {
         // Not a FatHeader at all, just return None.
-        _ => Ok(None),
+        Ok(None)
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -700,7 +700,7 @@ fn link_dwarf_object(sess: &Session, cg_results: &CodegenResults, executable_out
                 .truncate(true)
                 .open(dwp_out_filename)?,
         );
-        let mut output_stream = object::write::StreamingBuffer::new(output_stream);
+        let mut output_stream = thorin::object::write::StreamingBuffer::new(output_stream);
         package.finish()?.emit(&mut output_stream)?;
         output_stream.result()?;
         output_stream.into_inner().flush()?;

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -656,7 +656,13 @@ pub fn create_metadata_file_for_wasm(sess: &Session, data: &[u8], section_name: 
         imports.import(
             "env",
             "__linear_memory",
-            wasm_encoder::MemoryType { minimum: 0, maximum: None, memory64: true, shared: false },
+            wasm_encoder::MemoryType {
+                minimum: 0,
+                maximum: None,
+                memory64: true,
+                shared: false,
+                page_size_log2: None,
+            },
         );
     }
 

--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -22,5 +22,5 @@ tracing = "0.1"
 # tidy-alphabetical-start
 default-features = false
 features = ["elf", "macho"]
-version = "0.32.0"
+version = "0.36.2"
 # tidy-alphabetical-end

--- a/src/tools/run-make-support/Cargo.toml
+++ b/src/tools/run-make-support/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 bstr = "1.6.0"
-object = "0.34.0"
+object = "0.36.2"
 similar = "2.5.0"
-wasmparser = "0.118.2"
+wasmparser = { version = "0.214", default-features = false, features = ["std"] }
 regex = "1.8" # 1.8 to avoid memchr 2.6.0, as 2.5.0 is pinned in the workspace
 gimli = "0.31.0"
 build_helper = { path = "../build_helper" }


### PR DESCRIPTION
* dedups one `object`, additional dupe will be removed, with next `thorin-dwp` update
* `wasmparser` pinned to minor versions, so full merge isn't possible
* same with `wasm-encoder`

Turned off some features for `wasmparser` (see features https://github.com/bytecodealliance/wasm-tools/blob/v1.208.1/crates/wasmparser/Cargo.toml) in `run-make-support`, looks working?