### PR TITLE
Change `wait_with_output` to borrow instead of taking ownership

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1613,7 +1613,7 @@ fn exec_linker(
     // will read all its options out of there instead of looking at the command line.
     if !cmd.very_likely_to_exceed_some_spawn_limit() {
         match cmd.command().stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
-            Ok(child) => {
+            Ok(mut child) => {
                 let output = child.wait_with_output();
                 flush_linked_file(&output, out_filename)?;
                 return output;

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2238,7 +2238,7 @@ impl Child {
     /// ```should_panic
     /// use std::process::{Command, Stdio};
     ///
-    /// let child = Command::new("/bin/cat")
+    /// let mut child = Command::new("/bin/cat")
     ///     .arg("file.txt")
     ///     .stdout(Stdio::piped())
     ///     .spawn()
@@ -2252,7 +2252,7 @@ impl Child {
     /// ```
     ///
     #[stable(feature = "process", since = "1.0.0")]
-    pub fn wait_with_output(mut self) -> io::Result<Output> {
+    pub fn wait_with_output(&mut self) -> io::Result<Output> {
         drop(self.stdin.take());
 
         let (mut stdout, mut stderr) = (Vec::new(), Vec::new());

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -233,7 +233,7 @@ fn test_finish_twice() {
 #[test]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
 fn test_wait_with_output_once() {
-    let prog = if cfg!(target_os = "windows") {
+    let mut prog = if cfg!(target_os = "windows") {
         Command::new("cmd").args(&["/C", "echo hello"]).stdout(Stdio::piped()).spawn().unwrap()
     } else {
         shell_cmd().arg("-c").arg("echo hello").stdout(Stdio::piped()).spawn().unwrap()


### PR DESCRIPTION
### Context & Motivation

To implement the timeout feature for the `xshell` crate, as discussed in [this pull request](https://github.com/matklad/xshell/pull/92#discussion_r1679223828), the child process will use `wait_with_output` until the timeout occurs, at which point it will be terminated.

>
> ```rust
>         let out_res = if let Some(timeout) = self.data.timeout {
>             let (tx, rx) = mpsc::channel();
>             let handle = thread::spawn(move || {
>                 let output = child.wait_with_output();
>                 let _ = tx.send(output);
>             });
>             handle.join().unwrap();
>             match rx.recv_timeout(timeout) {
>                 Ok(output) => output,
>                 Err(err) => {
>                     // FIXME: Kill the child, borrow of moved value: `child`
>                     // child.kill();
>                     return Err(Error::new_timeout(self, err));
>                 }
>             }
>         } else {
>             child.wait_with_output()
>         };
> ```
> Since `.wait_with_output` need the child's ownership, when spawned, I can't use it to call `.kill` anymore. I tried Arc<Mutex> way, but it still failed:
> ```
> error[E0507]: cannot move out of dereference of MutexGuard<'_, Child>
> ```
> 

It appears that both `wait` and `try_wait` only require borrowing `&mut self`. We could consider refactoring `wait_with_output` to require borrowing instead of taking ownership.

### Breaking change?

This is my first time submitting a PR to the Rust standard library. It appears this change could be breaking. I'm unsure if we can refactor this method in this manner. If any additional actions are required, I will follow through.

r?  @matklad 
