### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc/Cargo.toml
+++ b/compiler/rustc/Cargo.toml
@@ -27,7 +27,7 @@ features = ['unprefixed_malloc_on_supported_platforms']
 
 [features]
 # tidy-alphabetical-start
-jemalloc = ['jemalloc-sys']
+jemalloc = ['dep:jemalloc-sys']
 llvm = ['rustc_driver_impl/llvm']
 max_level_info = ['rustc_driver_impl/max_level_info']
 rustc_use_parallel_compiler = ['rustc_driver_impl/rustc_use_parallel_compiler']

--- a/compiler/rustc/src/main.rs
+++ b/compiler/rustc/src/main.rs
@@ -34,7 +34,7 @@
 
 fn main() {
     // See the comment at the top of this file for an explanation of this.
-    #[cfg(feature = "jemalloc-sys")]
+    #[cfg(feature = "jemalloc")]
     {
         use std::os::raw::{c_int, c_void};
 

--- a/compiler/rustc_abi/Cargo.toml
+++ b/compiler/rustc_abi/Cargo.toml
@@ -21,10 +21,10 @@ default = ["nightly", "randomize"]
 # rust-analyzer depends on this crate and we therefore require it to built on a stable toolchain
 # without depending on rustc_data_structures, rustc_macros and rustc_serialize
 nightly = [
-    "rustc_data_structures",
+    "dep:rustc_data_structures",
+    "dep:rustc_macros",
+    "dep:rustc_serialize",
     "rustc_index/nightly",
-    "rustc_macros",
-    "rustc_serialize",
 ]
-randomize = ["rand", "rand_xoshiro", "nightly"]
+randomize = ["dep:rand", "dep:rand_xoshiro", "nightly"]
 # tidy-alphabetical-end

--- a/compiler/rustc_ast_ir/Cargo.toml
+++ b/compiler/rustc_ast_ir/Cargo.toml
@@ -14,8 +14,8 @@ rustc_span = { path = "../rustc_span", optional = true }
 [features]
 default = ["nightly"]
 nightly = [
-    "rustc_serialize",
-    "rustc_data_structures",
-    "rustc_macros",
-    "rustc_span",
+    "dep:rustc_serialize",
+    "dep:rustc_data_structures",
+    "dep:rustc_macros",
+    "dep:rustc_span",
 ]

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -205,9 +205,17 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                     is_loop_move = true;
                 }
 
+                let mut has_suggest_reborrow = false;
                 if !seen_spans.contains(&move_span) {
                     if !closure {
-                        self.suggest_ref_or_clone(mpi, &mut err, &mut in_pattern, move_spans);
+                        self.suggest_ref_or_clone(
+                            mpi,
+                            &mut err,
+                            &mut in_pattern,
+                            move_spans,
+                            moved_place.as_ref(),
+                            &mut has_suggest_reborrow,
+                        );
                     }
 
                     let msg_opt = CapturedMessageOpt {
@@ -215,6 +223,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                         is_loop_message,
                         is_move_msg,
                         is_loop_move,
+                        has_suggest_reborrow,
                         maybe_reinitialized_locations_is_empty: maybe_reinitialized_locations
                             .is_empty(),
                     };
@@ -259,17 +268,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
             if is_loop_move & !in_pattern && !matches!(use_spans, UseSpans::ClosureUse { .. }) {
                 if let ty::Ref(_, _, hir::Mutability::Mut) = ty.kind() {
                     // We have a `&mut` ref, we need to reborrow on each iteration (#62112).
-                    err.span_suggestion_verbose(
-                        span.shrink_to_lo(),
-                        format!(
-                            "consider creating a fresh reborrow of {} here",
-                            self.describe_place(moved_place)
-                                .map(|n| format!("`{n}`"))
-                                .unwrap_or_else(|| "the mutable reference".to_string()),
-                        ),
-                        "&mut *",
-                        Applicability::MachineApplicable,
-                    );
+                    self.suggest_reborrow(&mut err, span, moved_place);
                 }
             }
 
@@ -346,6 +345,8 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
         err: &mut Diag<'infcx>,
         in_pattern: &mut bool,
         move_spans: UseSpans<'tcx>,
+        moved_place: PlaceRef<'tcx>,
+        has_suggest_reborrow: &mut bool,
     ) {
         let move_span = match move_spans {
             UseSpans::ClosureUse { capture_kind_span, .. } => capture_kind_span,
@@ -435,20 +436,44 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                 let parent = self.infcx.tcx.parent_hir_node(expr.hir_id);
                 let (def_id, args, offset) = if let hir::Node::Expr(parent_expr) = parent
                     && let hir::ExprKind::MethodCall(_, _, args, _) = parent_expr.kind
-                    && let Some(def_id) = typeck.type_dependent_def_id(parent_expr.hir_id)
                 {
-                    (def_id.as_local(), args, 1)
+                    (typeck.type_dependent_def_id(parent_expr.hir_id), args, 1)
                 } else if let hir::Node::Expr(parent_expr) = parent
                     && let hir::ExprKind::Call(call, args) = parent_expr.kind
                     && let ty::FnDef(def_id, _) = typeck.node_type(call.hir_id).kind()
                 {
-                    (def_id.as_local(), args, 0)
+                    (Some(*def_id), args, 0)
                 } else {
                     (None, &[][..], 0)
                 };
+
+                // If the moved value is a mut reference, it is used in a
+                // generic function and it's type is a generic param, it can be
+                // reborrowed to avoid moving.
+                // for example:
+                // struct Y(u32);
+                // x's type is '& mut Y' and it is used in `fn generic<T>(x: T) {}`.
+                if let Some(def_id) = def_id
+                    && self.infcx.tcx.def_kind(def_id).is_fn_like()
+                    && let Some(pos) = args.iter().position(|arg| arg.hir_id == expr.hir_id)
+                    && let ty::Param(_) =
+                        self.infcx.tcx.fn_sig(def_id).skip_binder().skip_binder().inputs()
+                            [pos + offset]
+                            .kind()
+                {
+                    let place = &self.move_data.move_paths[mpi].place;
+                    let ty = place.ty(self.body, self.infcx.tcx).ty;
+                    if let ty::Ref(_, _, hir::Mutability::Mut) = ty.kind() {
+                        *has_suggest_reborrow = true;
+                        self.suggest_reborrow(err, expr.span, moved_place);
+                        return;
+                    }
+                }
+
                 let mut can_suggest_clone = true;
                 if let Some(def_id) = def_id
-                    && let node = self.infcx.tcx.hir_node_by_def_id(def_id)
+                    && let Some(local_def_id) = def_id.as_local()
+                    && let node = self.infcx.tcx.hir_node_by_def_id(local_def_id)
                     && let Some(fn_sig) = node.fn_sig()
                     && let Some(ident) = node.ident()
                     && let Some(pos) = args.iter().position(|arg| arg.hir_id == expr.hir_id)
@@ -620,6 +645,25 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
                 Applicability::MachineApplicable,
             );
         }
+    }
+
+    pub fn suggest_reborrow(
+        &self,
+        err: &mut Diag<'infcx>,
+        span: Span,
+        moved_place: PlaceRef<'tcx>,
+    ) {
+        err.span_suggestion_verbose(
+            span.shrink_to_lo(),
+            format!(
+                "consider creating a fresh reborrow of {} here",
+                self.describe_place(moved_place)
+                    .map(|n| format!("`{n}`"))
+                    .unwrap_or_else(|| "the mutable reference".to_string()),
+            ),
+            "&mut *",
+            Applicability::MachineApplicable,
+        );
     }
 
     fn report_use_of_uninitialized(

--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -554,6 +554,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
             is_loop_message: false,
             is_move_msg: false,
             is_loop_move: false,
+            has_suggest_reborrow: false,
             maybe_reinitialized_locations_is_empty: true,
         };
         if let Some(use_spans) = use_spans {

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -56,5 +56,5 @@ portable-atomic = "1.5.1"
 
 [features]
 # tidy-alphabetical-start
-rustc_use_parallel_compiler = ["indexmap/rustc-rayon", "rustc-rayon"]
+rustc_use_parallel_compiler = ["indexmap/rustc-rayon", "dep:rustc-rayon"]
 # tidy-alphabetical-end

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1094,7 +1094,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     } else {
                         "".to_string()
                     };
-                    labels.push((provided_span, format!("unexpected argument{provided_ty_name}")));
+                    let idx = if provided_arg_tys.len() == 1 {
+                        "".to_string()
+                    } else {
+                        format!(" #{}", arg_idx.as_usize() + 1)
+                    };
+                    labels.push((
+                        provided_span,
+                        format!("unexpected argument{idx}{provided_ty_name}"),
+                    ));
                     let mut span = provided_span;
                     if span.can_be_used_for_suggestions()
                         && error_span.can_be_used_for_suggestions()
@@ -1175,7 +1183,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             } else {
                                 "".to_string()
                             };
-                            labels.push((span, format!("an argument{rendered} is missing")));
+                            labels.push((
+                                span,
+                                format!(
+                                    "argument #{}{rendered} is missing",
+                                    expected_idx.as_usize() + 1
+                                ),
+                            ));
+
                             suggestion_text = match suggestion_text {
                                 SuggestionText::None => SuggestionText::Provide(false),
                                 SuggestionText::Provide(_) => SuggestionText::Provide(true),

--- a/compiler/rustc_index/Cargo.toml
+++ b/compiler/rustc_index/Cargo.toml
@@ -15,5 +15,9 @@ smallvec = "1.8.1"
 [features]
 # tidy-alphabetical-start
 default = ["nightly"]
-nightly = ["rustc_serialize", "rustc_macros", "rustc_index_macros/nightly"]
+nightly = [
+    "dep:rustc_serialize",
+    "dep:rustc_macros",
+    "rustc_index_macros/nightly",
+]
 # tidy-alphabetical-end

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "rustc_serialize")]
+#[cfg(feature = "nightly")]
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 use std::borrow::{Borrow, BorrowMut};
@@ -322,14 +322,14 @@ impl<I: Idx, T, const N: usize> From<[T; N]> for IndexVec<I, T> {
     }
 }
 
-#[cfg(feature = "rustc_serialize")]
+#[cfg(feature = "nightly")]
 impl<S: Encoder, I: Idx, T: Encodable<S>> Encodable<S> for IndexVec<I, T> {
     fn encode(&self, s: &mut S) {
         Encodable::encode(&self.raw, s);
     }
 }
 
-#[cfg(feature = "rustc_serialize")]
+#[cfg(feature = "nightly")]
 impl<D: Decoder, I: Idx, T: Decodable<D>> Decodable<D> for IndexVec<I, T> {
     fn decode(d: &mut D) -> Self {
         IndexVec::from_raw(Vec::<T>::decode(d))

--- a/compiler/rustc_interface/Cargo.toml
+++ b/compiler/rustc_interface/Cargo.toml
@@ -53,6 +53,11 @@ tracing = "0.1"
 
 [features]
 # tidy-alphabetical-start
-llvm = ['rustc_codegen_llvm']
-rustc_use_parallel_compiler = ['rustc-rayon', 'rustc-rayon-core', 'rustc_query_impl/rustc_use_parallel_compiler', 'rustc_errors/rustc_use_parallel_compiler']
+llvm = ['dep:rustc_codegen_llvm']
+rustc_use_parallel_compiler = [
+    'dep:rustc-rayon',
+    'dep:rustc-rayon-core',
+    'rustc_query_impl/rustc_use_parallel_compiler',
+    'rustc_errors/rustc_use_parallel_compiler'
+]
 # tidy-alphabetical-end

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -40,5 +40,5 @@ tracing = "0.1"
 
 [features]
 # tidy-alphabetical-start
-rustc_use_parallel_compiler = ["rustc-rayon-core"]
+rustc_use_parallel_compiler = ["dep:rustc-rayon-core"]
 # tidy-alphabetical-end

--- a/compiler/rustc_mir_build/src/build/block.rs
+++ b/compiler/rustc_mir_build/src/build/block.rs
@@ -282,7 +282,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         )
                     } else {
                         let scope = (*init_scope, source_info);
-                        unpack!(this.in_scope(scope, *lint_level, |this| {
+                        let _: BlockAnd<()> = this.in_scope(scope, *lint_level, |this| {
                             this.declare_bindings(
                                 visibility_scope,
                                 remainder_span,
@@ -291,7 +291,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 None,
                             );
                             block.unit()
-                        }));
+                        });
 
                         debug!("ast_block_stmts: pattern={:?}", pattern);
                         this.visit_primary_bindings(

--- a/compiler/rustc_mir_build/src/build/block.rs
+++ b/compiler/rustc_mir_build/src/build/block.rs
@@ -71,11 +71,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 StmtKind::Expr { scope, expr } => {
                     this.block_context.push(BlockFrame::Statement { ignores_expr_result: true });
                     let si = (*scope, source_info);
-                    unpack!(
-                        block = this.in_scope(si, LintLevel::Inherited, |this| {
+                    block = this
+                        .in_scope(si, LintLevel::Inherited, |this| {
                             this.stmt_expr(block, *expr, Some(*scope))
                         })
-                    );
+                        .into_block();
                 }
                 StmtKind::Let {
                     remainder_scope,
@@ -166,14 +166,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     let dummy_place = this.temp(this.tcx.types.never, else_block_span);
                     let failure_entry = this.cfg.start_new_block();
                     let failure_block;
-                    unpack!(
-                        failure_block = this.ast_block(
+                    failure_block = this
+                        .ast_block(
                             dummy_place,
                             failure_entry,
                             *else_block,
                             this.source_info(else_block_span),
                         )
-                    );
+                        .into_block();
                     this.cfg.terminate(
                         failure_block,
                         this.source_info(else_block_span),
@@ -267,8 +267,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         let initializer_span = this.thir[init].span;
                         let scope = (*init_scope, source_info);
 
-                        unpack!(
-                            block = this.in_scope(scope, *lint_level, |this| {
+                        block = this
+                            .in_scope(scope, *lint_level, |this| {
                                 this.declare_bindings(
                                     visibility_scope,
                                     remainder_span,
@@ -279,7 +279,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 this.expr_into_pattern(block, &pattern, init)
                                 // irrefutable pattern
                             })
-                        )
+                            .into_block();
                     } else {
                         let scope = (*init_scope, source_info);
                         let _: BlockAnd<()> = this.in_scope(scope, *lint_level, |this| {
@@ -333,7 +333,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             this.block_context
                 .push(BlockFrame::TailExpr { tail_result_is_ignored, span: expr.span });
 
-            unpack!(block = this.expr_into_dest(destination, block, expr_id));
+            block = this.expr_into_dest(destination, block, expr_id).into_block();
             let popped = this.block_context.pop();
 
             assert!(popped.is_some_and(|bf| bf.is_tail_expr()));
@@ -355,7 +355,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // Finally, we pop all the let scopes before exiting out from the scope of block
         // itself.
         for scope in let_scope_stack.into_iter().rev() {
-            unpack!(block = this.pop_scope((*scope, source_info), block));
+            block = this.pop_scope((*scope, source_info), block).into_block();
         }
         // Restore the original source scope.
         this.source_scope = outer_source_scope;

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -486,7 +486,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block.and(Rvalue::Aggregate(result, operands))
             }
             ExprKind::Assign { .. } | ExprKind::AssignOp { .. } => {
-                block = unpack!(this.stmt_expr(block, expr_id, None));
+                block = this.stmt_expr(block, expr_id, None).into_block();
                 block.and(Rvalue::Use(Operand::Constant(Box::new(ConstOperand {
                     span: expr_span,
                     user_ty: None,

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -185,13 +185,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 this.cfg.push_assign(block, source_info, Place::from(result), box_);
 
                 // initialize the box contents:
-                unpack!(
-                    block = this.expr_into_dest(
-                        this.tcx.mk_place_deref(Place::from(result)),
-                        block,
-                        value,
-                    )
-                );
+                block = this
+                    .expr_into_dest(this.tcx.mk_place_deref(Place::from(result)), block, value)
+                    .into_block();
                 block.and(Rvalue::Use(Operand::Move(Place::from(result))))
             }
             ExprKind::Cast { source } => {

--- a/compiler/rustc_mir_build/src/build/expr/as_temp.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_temp.rs
@@ -112,7 +112,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
         }
 
-        unpack!(block = this.expr_into_dest(temp_place, block, expr_id));
+        block = this.expr_into_dest(temp_place, block, expr_id).into_block();
 
         if let Some(temp_lifetime) = temp_lifetime {
             this.schedule_drop(expr_span, temp_lifetime, temp, DropKind::Value);

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -107,7 +107,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                 // If there is an `else` arm, lower it into `else_blk`.
                 if let Some(else_expr) = else_opt {
-                    unpack!(else_blk = this.expr_into_dest(destination, else_blk, else_expr));
+                    else_blk = this.expr_into_dest(destination, else_blk, else_expr).into_block();
                 } else {
                     // There is no `else` arm, so we know both arms have type `()`.
                     // Generate the implicit `else {}` by assigning unit.
@@ -506,7 +506,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             // These cases don't actually need a destination
             ExprKind::Assign { .. } | ExprKind::AssignOp { .. } => {
-                unpack!(block = this.stmt_expr(block, expr_id, None));
+                block = this.stmt_expr(block, expr_id, None).into_block();
                 this.cfg.push_assign_unit(block, source_info, destination, this.tcx);
                 block.unit()
             }
@@ -515,7 +515,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::Break { .. }
             | ExprKind::Return { .. }
             | ExprKind::Become { .. } => {
-                unpack!(block = this.stmt_expr(block, expr_id, None));
+                block = this.stmt_expr(block, expr_id, None).into_block();
                 // No assign, as these have type `!`.
                 block.unit()
             }

--- a/compiler/rustc_mir_build/src/build/expr/stmt.rs
+++ b/compiler/rustc_mir_build/src/build/expr/stmt.rs
@@ -42,7 +42,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 if lhs_expr.ty.needs_drop(this.tcx, this.param_env) {
                     let rhs = unpack!(block = this.as_local_rvalue(block, rhs));
                     let lhs = unpack!(block = this.as_place(block, lhs));
-                    unpack!(block = this.build_drop_and_replace(block, lhs_expr.span, lhs, rhs));
+                    block =
+                        this.build_drop_and_replace(block, lhs_expr.span, lhs, rhs).into_block();
                 } else {
                     let rhs = unpack!(block = this.as_local_rvalue(block, rhs));
                     let lhs = unpack!(block = this.as_place(block, lhs));

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -625,7 +625,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     OutsideGuard,
                     ScheduleDrops::Yes,
                 );
-                unpack!(block = self.expr_into_dest(place, block, initializer_id));
+                block = self.expr_into_dest(place, block, initializer_id).into_block();
 
                 // Inject a fake read, see comments on `FakeReadCause::ForLet`.
                 let source_info = self.source_info(irrefutable_pat.span);
@@ -664,7 +664,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     OutsideGuard,
                     ScheduleDrops::Yes,
                 );
-                unpack!(block = self.expr_into_dest(place, block, initializer_id));
+                block = self.expr_into_dest(place, block, initializer_id).into_block();
 
                 // Inject a fake read, see comments on `FakeReadCause::ForLet`.
                 let pattern_source_info = self.source_info(irrefutable_pat.span);

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -121,8 +121,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         match expr.kind {
             ExprKind::LogicalOp { op: op @ LogicalOp::And, lhs, rhs } => {
                 this.visit_coverage_branch_operation(op, expr_span);
-                let lhs_then_block = unpack!(this.then_else_break_inner(block, lhs, args));
-                let rhs_then_block = unpack!(this.then_else_break_inner(lhs_then_block, rhs, args));
+                let lhs_then_block = this.then_else_break_inner(block, lhs, args).into_block();
+                let rhs_then_block =
+                    this.then_else_break_inner(lhs_then_block, rhs, args).into_block();
                 rhs_then_block.unit()
             }
             ExprKind::LogicalOp { op: op @ LogicalOp::Or, lhs, rhs } => {
@@ -139,14 +140,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             },
                         )
                     });
-                let rhs_success_block = unpack!(this.then_else_break_inner(
-                    failure_block,
-                    rhs,
-                    ThenElseArgs {
-                        declare_let_bindings: DeclareLetBindings::LetNotPermitted,
-                        ..args
-                    },
-                ));
+                let rhs_success_block = this
+                    .then_else_break_inner(
+                        failure_block,
+                        rhs,
+                        ThenElseArgs {
+                            declare_let_bindings: DeclareLetBindings::LetNotPermitted,
+                            ..args
+                        },
+                    )
+                    .into_block();
 
                 // Make the LHS and RHS success arms converge to a common block.
                 // (We can't just make LHS goto RHS, because `rhs_success_block`
@@ -451,7 +454,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         outer_source_info: SourceInfo,
         fake_borrow_temps: Vec<(Place<'tcx>, Local, FakeBorrowKind)>,
     ) -> BlockAnd<()> {
-        let arm_end_blocks: Vec<_> = arm_candidates
+        let arm_end_blocks: Vec<BasicBlock> = arm_candidates
             .into_iter()
             .map(|(arm, candidate)| {
                 debug!("lowering arm {:?}\ncandidate = {:?}", arm, candidate);
@@ -502,6 +505,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                     this.expr_into_dest(destination, arm_block, arm.body)
                 })
+                .into_block()
             })
             .collect();
 
@@ -512,10 +516,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             outer_source_info.span.with_lo(outer_source_info.span.hi() - BytePos::from_usize(1)),
         );
         for arm_block in arm_end_blocks {
-            let block = &self.cfg.basic_blocks[arm_block.0];
+            let block = &self.cfg.basic_blocks[arm_block];
             let last_location = block.statements.last().map(|s| s.source_info);
 
-            self.cfg.goto(unpack!(arm_block), last_location.unwrap_or(end_brace), end_block);
+            self.cfg.goto(arm_block, last_location.unwrap_or(end_brace), end_block);
         }
 
         self.source_scope = outer_source_info.scope;

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -403,6 +403,15 @@ enum NeedsTemporary {
 #[must_use = "if you don't use one of these results, you're leaving a dangling edge"]
 struct BlockAnd<T>(BasicBlock, T);
 
+impl BlockAnd<()> {
+    /// Unpacks `BlockAnd<()>` into a [`BasicBlock`].
+    #[must_use]
+    fn into_block(self) -> BasicBlock {
+        let Self(block, ()) = self;
+        block
+    }
+}
+
 trait BlockAndExtension {
     fn and<T>(self, v: T) -> BlockAnd<T>;
     fn unit(self) -> BlockAnd<()>;
@@ -425,11 +434,6 @@ macro_rules! unpack {
         let BlockAnd(b, v) = $c;
         $x = b;
         v
-    }};
-
-    ($c:expr) => {{
-        let BlockAnd(b, ()) = $c;
-        b
     }};
 }
 
@@ -516,21 +520,22 @@ fn construct_fn<'tcx>(
         region::Scope { id: body.id().hir_id.local_id, data: region::ScopeData::Arguments };
     let source_info = builder.source_info(span);
     let call_site_s = (call_site_scope, source_info);
-    unpack!(builder.in_scope(call_site_s, LintLevel::Inherited, |builder| {
+    let _: BlockAnd<()> = builder.in_scope(call_site_s, LintLevel::Inherited, |builder| {
         let arg_scope_s = (arg_scope, source_info);
         // Attribute epilogue to function's closing brace
         let fn_end = span_with_body.shrink_to_hi();
-        let return_block =
-            unpack!(builder.in_breakable_scope(None, Place::return_place(), fn_end, |builder| {
+        let return_block = builder
+            .in_breakable_scope(None, Place::return_place(), fn_end, |builder| {
                 Some(builder.in_scope(arg_scope_s, LintLevel::Inherited, |builder| {
                     builder.args_and_body(START_BLOCK, arguments, arg_scope, expr)
                 }))
-            }));
+            })
+            .into_block();
         let source_info = builder.source_info(fn_end);
         builder.cfg.terminate(return_block, source_info, TerminatorKind::Return);
         builder.build_drop_trees();
         return_block.unit()
-    }));
+    });
 
     let mut body = builder.finish();
 

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -584,7 +584,7 @@ fn construct_const<'a, 'tcx>(
         Builder::new(thir, infcx, def, hir_id, span, 0, const_ty, const_ty_span, None);
 
     let mut block = START_BLOCK;
-    unpack!(block = builder.expr_into_dest(Place::return_place(), block, expr));
+    block = builder.expr_into_dest(Place::return_place(), block, expr).into_block();
 
     let source_info = builder.source_info(span);
     builder.cfg.terminate(block, source_info, TerminatorKind::Return);
@@ -966,7 +966,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         Some((Some(&place), span)),
                     );
                     let place_builder = PlaceBuilder::from(local);
-                    unpack!(block = self.place_into_pattern(block, pat, place_builder, false));
+                    block = self.place_into_pattern(block, pat, place_builder, false).into_block();
                 }
             }
             self.source_scope = original_source_scope;

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -587,7 +587,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.push_scope(region_scope);
         let mut block;
         let rv = unpack!(block = f(self));
-        unpack!(block = self.pop_scope(region_scope, block));
+        block = self.pop_scope(region_scope, block).into_block();
         self.source_scope = source_scope;
         debug!(?block);
         block.and(rv)
@@ -659,7 +659,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             (Some(destination), Some(value)) => {
                 debug!("stmt_expr Break val block_context.push(SubExpr)");
                 self.block_context.push(BlockFrame::SubExpr);
-                unpack!(block = self.expr_into_dest(destination, block, value));
+                block = self.expr_into_dest(destination, block, value).into_block();
                 self.block_context.pop();
             }
             (Some(destination), None) => {

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -510,12 +510,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let target = self.cfg.start_new_block();
                 let source_info = self.source_info(span);
                 self.cfg.terminate(
-                    unpack!(normal_block),
+                    normal_block.into_block(),
                     source_info,
                     TerminatorKind::Goto { target },
                 );
                 self.cfg.terminate(
-                    unpack!(exit_block),
+                    exit_block.into_block(),
                     source_info,
                     TerminatorKind::Goto { target },
                 );
@@ -552,14 +552,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let scope = IfThenScope { region_scope, else_drops: DropTree::new() };
         let previous_scope = mem::replace(&mut self.scopes.if_then_scope, Some(scope));
 
-        let then_block = unpack!(f(self));
+        let then_block = f(self).into_block();
 
         let if_then_scope = mem::replace(&mut self.scopes.if_then_scope, previous_scope).unwrap();
         assert!(if_then_scope.region_scope == region_scope);
 
-        let else_block = self
-            .build_exit_tree(if_then_scope.else_drops, region_scope, span, None)
-            .map_or_else(|| self.cfg.start_new_block(), |else_block_and| unpack!(else_block_and));
+        let else_block =
+            self.build_exit_tree(if_then_scope.else_drops, region_scope, span, None).map_or_else(
+                || self.cfg.start_new_block(),
+                |else_block_and| else_block_and.into_block(),
+            );
 
         (then_block, else_block)
     }
@@ -753,7 +755,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let unwind_to = if needs_cleanup { self.diverge_cleanup() } else { DropIdx::MAX };
 
         let scope = self.scopes.scopes.last().expect("leave_top_scope called with no scopes");
-        unpack!(build_scope_drops(
+        build_scope_drops(
             &mut self.cfg,
             &mut self.scopes.unwind_drops,
             scope,
@@ -761,7 +763,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             unwind_to,
             is_coroutine && needs_cleanup,
             self.arg_count,
-        ))
+        )
+        .into_block()
     }
 
     /// Possibly creates a new source scope if `current_root` and `parent_root`

--- a/compiler/rustc_next_trait_solver/Cargo.toml
+++ b/compiler/rustc_next_trait_solver/Cargo.toml
@@ -20,10 +20,10 @@ tracing = "0.1"
 [features]
 default = ["nightly"]
 nightly = [
+    "dep:rustc_data_structures",
+    "dep:rustc_macros",
+    "dep:rustc_serialize",
     "rustc_ast_ir/nightly",
-    "rustc_data_structures",
     "rustc_index/nightly",
-    "rustc_macros",
-    "rustc_serialize",
     "rustc_type_ir/nightly",
 ]

--- a/compiler/rustc_query_system/Cargo.toml
+++ b/compiler/rustc_query_system/Cargo.toml
@@ -26,5 +26,5 @@ tracing = "0.1"
 
 [features]
 # tidy-alphabetical-start
-rustc_use_parallel_compiler = ["rustc-rayon-core"]
+rustc_use_parallel_compiler = ["dep:rustc-rayon-core"]
 # tidy-alphabetical-end

--- a/compiler/rustc_transmute/Cargo.toml
+++ b/compiler/rustc_transmute/Cargo.toml
@@ -18,13 +18,13 @@ tracing = "0.1"
 
 [features]
 rustc = [
-    "rustc_hir",
-    "rustc_infer",
-    "rustc_macros",
-    "rustc_middle",
-    "rustc_span",
-    "rustc_target",
-    "rustc_ast_ir",
+    "dep:rustc_hir",
+    "dep:rustc_infer",
+    "dep:rustc_macros",
+    "dep:rustc_middle",
+    "dep:rustc_span",
+    "dep:rustc_target",
+    "dep:rustc_ast_ir",
 ]
 
 [dev-dependencies]

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -22,12 +22,12 @@ tracing = "0.1"
 [features]
 default = ["nightly"]
 nightly = [
+    "dep:rustc_serialize",
+    "dep:rustc_span",
+    "dep:rustc_data_structures",
+    "dep:rustc_macros",
     "smallvec/may_dangle",
     "smallvec/union",
     "rustc_index/nightly",
-    "rustc_serialize",
-    "rustc_span",
-    "rustc_data_structures",
-    "rustc_macros",
     "rustc_ast_ir/nightly"
 ]

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -947,7 +947,6 @@ extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "const_unreachable_unchecked", since = "1.57.0")]
     #[rustc_nounwind]
     pub fn unreachable() -> !;
-
 }
 
 /// Informs the optimizer that a condition is always true.
@@ -1018,78 +1017,40 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn breakpoint();
 
-    /// The size of a type in bytes.
-    ///
-    /// Note that, unlike most intrinsics, this is safe to call;
-    /// it does not require an `unsafe` block.
-    /// Therefore, implementations must not require the user to uphold
-    /// any safety invariants.
-    ///
-    /// More specifically, this is the offset in bytes between successive
-    /// items of the same type, including alignment padding.
-    ///
-    /// The stabilized version of this intrinsic is [`core::mem::size_of`].
+    #[cfg(bootstrap)]
     #[rustc_const_stable(feature = "const_size_of", since = "1.40.0")]
     #[rustc_safe_intrinsic]
     #[rustc_nounwind]
     pub fn size_of<T>() -> usize;
 
-    /// The minimum alignment of a type.
-    ///
-    /// Note that, unlike most intrinsics, this is safe to call;
-    /// it does not require an `unsafe` block.
-    /// Therefore, implementations must not require the user to uphold
-    /// any safety invariants.
-    ///
-    /// The stabilized version of this intrinsic is [`core::mem::align_of`].
+    #[cfg(bootstrap)]
     #[rustc_const_stable(feature = "const_min_align_of", since = "1.40.0")]
     #[rustc_safe_intrinsic]
     #[rustc_nounwind]
     pub fn min_align_of<T>() -> usize;
-    /// The preferred alignment of a type.
-    ///
-    /// This intrinsic does not have a stable counterpart.
-    /// It's "tracking issue" is [#91971](https://github.com/rust-lang/rust/issues/91971).
+
+    #[cfg(bootstrap)]
     #[rustc_const_unstable(feature = "const_pref_align_of", issue = "91971")]
     #[rustc_nounwind]
     pub fn pref_align_of<T>() -> usize;
 
-    /// The size of the referenced value in bytes.
-    ///
-    /// The stabilized version of this intrinsic is [`crate::mem::size_of_val`].
+    #[cfg(bootstrap)]
     #[rustc_const_unstable(feature = "const_size_of_val", issue = "46571")]
     #[rustc_nounwind]
     pub fn size_of_val<T: ?Sized>(_: *const T) -> usize;
-    /// The required alignment of the referenced value.
-    ///
-    /// The stabilized version of this intrinsic is [`core::mem::align_of_val`].
+
+    #[cfg(bootstrap)]
     #[rustc_const_unstable(feature = "const_align_of_val", issue = "46571")]
     #[rustc_nounwind]
     pub fn min_align_of_val<T: ?Sized>(_: *const T) -> usize;
 
-    /// Gets a static string slice containing the name of a type.
-    ///
-    /// Note that, unlike most intrinsics, this is safe to call;
-    /// it does not require an `unsafe` block.
-    /// Therefore, implementations must not require the user to uphold
-    /// any safety invariants.
-    ///
-    /// The stabilized version of this intrinsic is [`core::any::type_name`].
+    #[cfg(bootstrap)]
     #[rustc_const_unstable(feature = "const_type_name", issue = "63084")]
     #[rustc_safe_intrinsic]
     #[rustc_nounwind]
     pub fn type_name<T: ?Sized>() -> &'static str;
 
-    /// Gets an identifier which is globally unique to the specified type. This
-    /// function will return the same value for a type regardless of whichever
-    /// crate it is invoked in.
-    ///
-    /// Note that, unlike most intrinsics, this is safe to call;
-    /// it does not require an `unsafe` block.
-    /// Therefore, implementations must not require the user to uphold
-    /// any safety invariants.
-    ///
-    /// The stabilized version of this intrinsic is [`core::any::TypeId::of`].
+    #[cfg(bootstrap)]
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     #[rustc_safe_intrinsic]
     #[rustc_nounwind]
@@ -2424,15 +2385,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
 
-    /// Returns the number of variants of the type `T` cast to a `usize`;
-    /// if `T` has no variants, returns `0`. Uninhabited variants will be counted.
-    ///
-    /// Note that, unlike most intrinsics, this is safe to call;
-    /// it does not require an `unsafe` block.
-    /// Therefore, implementations must not require the user to uphold
-    /// any safety invariants.
-    ///
-    /// The to-be-stabilized version of this intrinsic is [`crate::mem::variant_count`].
+    #[cfg(bootstrap)]
     #[rustc_const_unstable(feature = "variant_count", issue = "73662")]
     #[rustc_safe_intrinsic]
     #[rustc_nounwind]
@@ -2790,6 +2743,142 @@ pub unsafe fn vtable_size(_ptr: *const ()) -> usize {
 #[rustc_intrinsic]
 #[rustc_intrinsic_must_be_overridden]
 pub unsafe fn vtable_align(_ptr: *const ()) -> usize {
+    unreachable!()
+}
+
+/// The size of a type in bytes.
+///
+/// Note that, unlike most intrinsics, this is safe to call;
+/// it does not require an `unsafe` block.
+/// Therefore, implementations must not require the user to uphold
+/// any safety invariants.
+///
+/// More specifically, this is the offset in bytes between successive
+/// items of the same type, including alignment padding.
+///
+/// The stabilized version of this intrinsic is [`core::mem::size_of`].
+#[rustc_nounwind]
+#[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_const_stable(feature = "const_size_of", since = "1.40.0")]
+#[rustc_intrinsic]
+#[rustc_intrinsic_must_be_overridden]
+#[cfg(not(bootstrap))]
+pub const fn size_of<T>() -> usize {
+    unreachable!()
+}
+
+/// The minimum alignment of a type.
+///
+/// Note that, unlike most intrinsics, this is safe to call;
+/// it does not require an `unsafe` block.
+/// Therefore, implementations must not require the user to uphold
+/// any safety invariants.
+///
+/// The stabilized version of this intrinsic is [`core::mem::align_of`].
+#[rustc_nounwind]
+#[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_const_stable(feature = "const_min_align_of", since = "1.40.0")]
+#[rustc_intrinsic]
+#[rustc_intrinsic_must_be_overridden]
+#[cfg(not(bootstrap))]
+pub const fn min_align_of<T>() -> usize {
+    unreachable!()
+}
+
+/// The preferred alignment of a type.
+///
+/// This intrinsic does not have a stable counterpart.
+/// It's "tracking issue" is [#91971](https://github.com/rust-lang/rust/issues/91971).
+#[rustc_nounwind]
+#[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_const_unstable(feature = "const_pref_align_of", issue = "91971")]
+#[rustc_intrinsic]
+#[rustc_intrinsic_must_be_overridden]
+#[cfg(not(bootstrap))]
+pub const unsafe fn pref_align_of<T>() -> usize {
+    unreachable!()
+}
+
+/// Returns the number of variants of the type `T` cast to a `usize`;
+/// if `T` has no variants, returns `0`. Uninhabited variants will be counted.
+///
+/// Note that, unlike most intrinsics, this is safe to call;
+/// it does not require an `unsafe` block.
+/// Therefore, implementations must not require the user to uphold
+/// any safety invariants.
+///
+/// The to-be-stabilized version of this intrinsic is [`crate::mem::variant_count`].
+#[rustc_nounwind]
+#[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_const_unstable(feature = "variant_count", issue = "73662")]
+#[rustc_intrinsic]
+#[rustc_intrinsic_must_be_overridden]
+#[cfg(not(bootstrap))]
+pub const fn variant_count<T>() -> usize {
+    unreachable!()
+}
+
+/// The size of the referenced value in bytes.
+///
+/// The stabilized version of this intrinsic is [`crate::mem::size_of_val`].
+#[rustc_nounwind]
+#[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_const_unstable(feature = "const_size_of_val", issue = "46571")]
+#[rustc_intrinsic]
+#[rustc_intrinsic_must_be_overridden]
+#[cfg(not(bootstrap))]
+pub const unsafe fn size_of_val<T: ?Sized>(_ptr: *const T) -> usize {
+    unreachable!()
+}
+
+/// The required alignment of the referenced value.
+///
+/// The stabilized version of this intrinsic is [`core::mem::align_of_val`].
+#[rustc_nounwind]
+#[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_const_unstable(feature = "const_align_of_val", issue = "46571")]
+#[rustc_intrinsic]
+#[rustc_intrinsic_must_be_overridden]
+#[cfg(not(bootstrap))]
+pub const unsafe fn min_align_of_val<T: ?Sized>(_ptr: *const T) -> usize {
+    unreachable!()
+}
+
+/// Gets a static string slice containing the name of a type.
+///
+/// Note that, unlike most intrinsics, this is safe to call;
+/// it does not require an `unsafe` block.
+/// Therefore, implementations must not require the user to uphold
+/// any safety invariants.
+///
+/// The stabilized version of this intrinsic is [`core::any::type_name`].
+#[rustc_nounwind]
+#[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_const_unstable(feature = "const_type_name", issue = "63084")]
+#[rustc_intrinsic]
+#[rustc_intrinsic_must_be_overridden]
+#[cfg(not(bootstrap))]
+pub const fn type_name<T: ?Sized>() -> &'static str {
+    unreachable!()
+}
+
+/// Gets an identifier which is globally unique to the specified type. This
+/// function will return the same value for a type regardless of whichever
+/// crate it is invoked in.
+///
+/// Note that, unlike most intrinsics, this is safe to call;
+/// it does not require an `unsafe` block.
+/// Therefore, implementations must not require the user to uphold
+/// any safety invariants.
+///
+/// The stabilized version of this intrinsic is [`core::any::TypeId::of`].
+#[rustc_nounwind]
+#[unstable(feature = "core_intrinsics", issue = "none")]
+#[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
+#[rustc_intrinsic]
+#[rustc_intrinsic_must_be_overridden]
+#[cfg(not(bootstrap))]
+pub const fn type_id<T: ?Sized + 'static>() -> u128 {
     unreachable!()
 }
 

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2726,8 +2726,11 @@ pub const unsafe fn const_deallocate(_ptr: *mut u8, _size: usize, _align: usize)
     // Runtime NOP
 }
 
-/// `ptr` must point to a vtable.
 /// The intrinsic will return the size stored in that vtable.
+///
+/// # Safety
+///
+/// `ptr` must point to a vtable.
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
@@ -2736,8 +2739,11 @@ pub unsafe fn vtable_size(_ptr: *const ()) -> usize {
     unreachable!()
 }
 
-/// `ptr` must point to a vtable.
 /// The intrinsic will return the alignment stored in that vtable.
+///
+/// # Safety
+///
+/// `ptr` must point to a vtable.
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
@@ -2821,6 +2827,10 @@ pub const fn variant_count<T>() -> usize {
 /// The size of the referenced value in bytes.
 ///
 /// The stabilized version of this intrinsic is [`crate::mem::size_of_val`].
+///
+/// # Safety
+///
+/// See [`crate::mem::size_of_val_raw`] for safety conditions.
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_const_unstable(feature = "const_size_of_val", issue = "46571")]
@@ -2834,6 +2844,10 @@ pub const unsafe fn size_of_val<T: ?Sized>(_ptr: *const T) -> usize {
 /// The required alignment of the referenced value.
 ///
 /// The stabilized version of this intrinsic is [`core::mem::align_of_val`].
+///
+/// # Safety
+///
+/// See [`crate::mem::align_of_val_raw`] for safety conditions.
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_const_unstable(feature = "const_align_of_val", issue = "46571")]

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -15,6 +15,7 @@
 	--desktop-sidebar-width: 200px;
 	--src-sidebar-width: 300px;
 	--desktop-sidebar-z-index: 100;
+	--sidebar-elems-left-padding: 24px;
 }
 
 /* See FiraSans-LICENSE.txt for the Fira Sans license. */
@@ -559,8 +560,11 @@ ul.block, .block li {
 .sidebar > h2 a {
 	display: block;
 	padding: 0.25rem; /* 4px */
-	margin-left: -0.25rem;
 	margin-right: 0.25rem;
+	/* extend click target to far edge of screen (mile wide bar) */
+	border-left: solid var(--sidebar-elems-left-padding) transparent;
+	margin-left: calc(-0.25rem - var(--sidebar-elems-left-padding));
+	background-clip: padding-box;
 }
 
 .sidebar h2 {
@@ -578,7 +582,7 @@ ul.block, .block li {
 .sidebar-elems,
 .sidebar > .version,
 .sidebar > h2 {
-	padding-left: 24px;
+	padding-left: var(--sidebar-elems-left-padding);
 }
 
 .sidebar a {
@@ -632,13 +636,17 @@ ul.block, .block li {
 .sidebar-crate .logo-container {
 	/* The logo is expected to have 8px "slop" along its edges, so we can optically
 		center it. */
-	margin: 0 -16px 0 -16px;
+	margin: 0 calc(-16px - var(--sidebar-elems-left-padding));
+	padding: 0 var(--sidebar-elems-left-padding);
 	text-align: center;
 }
 
 .sidebar-crate h2 a {
 	display: block;
-	margin: 0 calc(-24px + 0.25rem) 0 -0.2rem;
+	/* extend click target to far edge of screen (mile wide bar) */
+	border-left: solid var(--sidebar-elems-left-padding) transparent;
+	background-clip: padding-box;
+	margin: 0 calc(-24px + 0.25rem) 0 calc(-0.2rem - var(--sidebar-elems-left-padding));
 	/* Align the sidebar crate link with the search bar, which have different
 		font sizes.
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -564,7 +564,7 @@ ul.block, .block li {
 	/* extend click target to far edge of screen (mile wide bar) */
 	border-left: solid var(--sidebar-elems-left-padding) transparent;
 	margin-left: calc(-0.25rem - var(--sidebar-elems-left-padding));
-	background-clip: padding-box;
+	background-clip: border-box;
 }
 
 .sidebar h2 {
@@ -641,11 +641,50 @@ ul.block, .block li {
 	text-align: center;
 }
 
+.sidebar-crate .logo-container img {
+	/* When in a horizontal logo lockup, the highlight color of the crate name menu item
+		extends underneath the actual logo (in a vertical lockup, that background highlight
+		extends to the left edge of the screen).
+
+		To prevent a weird-looking colored band from appearing under the logo, cover it up
+		with the sidebar's background. Additionally, the crate name extends slightly above
+		the logo, so that its highlight has a bit of space to let the ascenders breath while
+		also having those ascenders meet exactly with the top of the logo.
+
+		In ANSI art, make it look like this:
+		|        ┌─────┐
+		|    (R) │ std │
+		|        └─────┘
+
+		Not like this (which would happen without the z-index):
+		|     ┌────────┐
+		|    (│    std │
+		|     └────────┘
+
+		Not like this (which would happen without the background):
+		|     ┌────────┐
+		|    (R)   std │
+		|     └────────┘
+
+		Nor like this (which would happen without the negative margin):
+		|     ─────────┐
+		|    (R) │ std │
+		|        └─────┘
+		*/
+	margin-top: -16px;
+	border-top: solid 16px transparent;
+	box-sizing: content-box;
+	position: relative;
+	background-color: var(--sidebar-background-color);
+	background-clip: border-box;
+	z-index: 1;
+}
+
 .sidebar-crate h2 a {
 	display: block;
 	/* extend click target to far edge of screen (mile wide bar) */
 	border-left: solid var(--sidebar-elems-left-padding) transparent;
-	background-clip: padding-box;
+	background-clip: border-box;
 	margin: 0 calc(-24px + 0.25rem) 0 calc(-0.2rem - var(--sidebar-elems-left-padding));
 	/* Align the sidebar crate link with the search bar, which have different
 		font sizes.

--- a/tests/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.panic-abort.diff
+++ b/tests/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.panic-abort.diff
@@ -3,8 +3,8 @@
   
   fn non_const() -> usize {
       let mut _0: usize;
-      let _1: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>};
-      let mut _2: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>};
+      let _1: fn() -> usize {std::intrinsics::size_of::<T>};
+      let mut _2: fn() -> usize {std::intrinsics::size_of::<T>};
       scope 1 {
           debug size_of_t => _1;
       }

--- a/tests/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.panic-unwind.diff
+++ b/tests/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.panic-unwind.diff
@@ -3,8 +3,8 @@
   
   fn non_const() -> usize {
       let mut _0: usize;
-      let _1: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>};
-      let mut _2: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>};
+      let _1: fn() -> usize {std::intrinsics::size_of::<T>};
+      let mut _2: fn() -> usize {std::intrinsics::size_of::<T>};
       scope 1 {
           debug size_of_t => _1;
       }

--- a/tests/rustdoc-gui/huge-logo.goml
+++ b/tests/rustdoc-gui/huge-logo.goml
@@ -5,8 +5,8 @@ go-to: "file://" + |DOC_PATH| + "/huge_logo/index.html"
 set-window-size: (1280, 1024)
 // offsetWidth = width of sidebar + left and right margins
 assert-property: (".sidebar-crate .logo-container", {"offsetWidth": "96", "offsetHeight": 48})
-// offsetWidth = width of sidebar
-assert-property: (".sidebar-crate .logo-container img", {"offsetWidth": "48", "offsetHeight": 48})
+// offsetWidth = width of sidebar, offsetHeight = height + top padding
+assert-property: (".sidebar-crate .logo-container img", {"offsetWidth": "48", "offsetHeight": 64})
 
 set-window-size: (400, 600)
 // offset = size + margin

--- a/tests/rustdoc-gui/huge-logo.goml
+++ b/tests/rustdoc-gui/huge-logo.goml
@@ -7,6 +7,7 @@ set-window-size: (1280, 1024)
 assert-property: (".sidebar-crate .logo-container", {"offsetWidth": "96", "offsetHeight": 48})
 // offsetWidth = width of sidebar, offsetHeight = height + top padding
 assert-property: (".sidebar-crate .logo-container img", {"offsetWidth": "48", "offsetHeight": 64})
+assert-css: (".sidebar-crate .logo-container img", {"border-top-width": "16px", "margin-top": "-16px"})
 
 set-window-size: (400, 600)
 // offset = size + margin

--- a/tests/rustdoc-gui/huge-logo.goml
+++ b/tests/rustdoc-gui/huge-logo.goml
@@ -3,8 +3,9 @@
 go-to: "file://" + |DOC_PATH| + "/huge_logo/index.html"
 
 set-window-size: (1280, 1024)
+// offsetWidth = width of sidebar + left and right margins
+assert-property: (".sidebar-crate .logo-container", {"offsetWidth": "96", "offsetHeight": 48})
 // offsetWidth = width of sidebar
-assert-property: (".sidebar-crate .logo-container", {"offsetWidth": "48", "offsetHeight": 48})
 assert-property: (".sidebar-crate .logo-container img", {"offsetWidth": "48", "offsetHeight": 48})
 
 set-window-size: (400, 600)

--- a/tests/rustdoc-gui/sidebar.goml
+++ b/tests/rustdoc-gui/sidebar.goml
@@ -179,3 +179,18 @@ assert-property: (".sidebar .sidebar-crate h2 a", {
     "offsetTop": |index_sidebar_y|,
     "offsetLeft": |index_sidebar_x|,
 })
+
+// Check that the sidebar links touch the left side of the box
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+assert-position: (".sidebar .block a", {"x": -4})
+assert-position: (".sidebar-crate > h2 > a", {"x": -3})
+
+// Check that the main sidebar links touch the left side of the box
+// but the crate name doesn't, because the logo takes that space
+go-to: "file://" + |DOC_PATH| + "/huge_logo/index.html"
+assert-position: (".sidebar .block a", {"x": -4})
+// when side-by-side, it's not line wrapped
+assert-position-false: (".sidebar-crate > h2 > a", {"x": -3})
+// when line-wrapped, see that it becomes flush-left again
+drag-and-drop: ((205, 100), (108, 100))
+assert-position: (".sidebar-crate > h2 > a", {"x": -3})

--- a/tests/ui/argument-suggestions/basic.stderr
+++ b/tests/ui/argument-suggestions/basic.stderr
@@ -33,7 +33,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/basic.rs:22:5
    |
 LL |     missing();
-   |     ^^^^^^^-- an argument of type `u32` is missing
+   |     ^^^^^^^-- argument #1 of type `u32` is missing
    |
 note: function defined here
   --> $DIR/basic.rs:15:4
@@ -86,7 +86,7 @@ error[E0057]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/basic.rs:27:5
    |
 LL |     closure();
-   |     ^^^^^^^-- an argument is missing
+   |     ^^^^^^^-- argument #1 is missing
    |
 note: closure defined here
   --> $DIR/basic.rs:26:19

--- a/tests/ui/argument-suggestions/display-is-suggestable.stderr
+++ b/tests/ui/argument-suggestions/display-is-suggestable.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/display-is-suggestable.rs:6:5
    |
 LL |     foo();
-   |     ^^^-- an argument of type `&dyn std::fmt::Display + Send` is missing
+   |     ^^^-- argument #1 of type `&dyn std::fmt::Display + Send` is missing
    |
 note: function defined here
   --> $DIR/display-is-suggestable.rs:3:4

--- a/tests/ui/argument-suggestions/extern-fn-arg-names.stderr
+++ b/tests/ui/argument-suggestions/extern-fn-arg-names.stderr
@@ -8,7 +8,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/extern-fn-arg-names.rs:7:5
    |
 LL |     dstfn(1);
-   |     ^^^^^--- an argument is missing
+   |     ^^^^^--- argument #2 is missing
    |
 note: function defined here
   --> $DIR/extern-fn-arg-names.rs:2:8

--- a/tests/ui/argument-suggestions/extra_arguments.stderr
+++ b/tests/ui/argument-suggestions/extra_arguments.stderr
@@ -19,9 +19,9 @@ error[E0061]: this function takes 0 arguments but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:20:3
    |
 LL |   empty(1, 1);
-   |   ^^^^^ -  - unexpected argument of type `{integer}`
+   |   ^^^^^ -  - unexpected argument #2 of type `{integer}`
    |         |
-   |         unexpected argument of type `{integer}`
+   |         unexpected argument #1 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:1:4
@@ -38,7 +38,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:22:3
    |
 LL |   one_arg(1, 1);
-   |   ^^^^^^^    - unexpected argument of type `{integer}`
+   |   ^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -55,7 +55,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:23:3
    |
 LL |   one_arg(1, "");
-   |   ^^^^^^^    -- unexpected argument of type `&'static str`
+   |   ^^^^^^^    -- unexpected argument #2 of type `&'static str`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -72,9 +72,9 @@ error[E0061]: this function takes 1 argument but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:24:3
    |
 LL |   one_arg(1, "", 1.0);
-   |   ^^^^^^^    --  --- unexpected argument of type `{float}`
+   |   ^^^^^^^    --  --- unexpected argument #3 of type `{float}`
    |              |
-   |              unexpected argument of type `&'static str`
+   |              unexpected argument #2 of type `&'static str`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -91,7 +91,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:26:3
    |
 LL |   two_arg_same(1, 1, 1);
-   |   ^^^^^^^^^^^^       - unexpected argument of type `{integer}`
+   |   ^^^^^^^^^^^^       - unexpected argument #3 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:3:4
@@ -108,7 +108,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:27:3
    |
 LL |   two_arg_same(1, 1, 1.0);
-   |   ^^^^^^^^^^^^       --- unexpected argument of type `{float}`
+   |   ^^^^^^^^^^^^       --- unexpected argument #3 of type `{float}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:3:4
@@ -125,7 +125,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:29:3
    |
 LL |   two_arg_diff(1, 1, "");
-   |   ^^^^^^^^^^^^    - unexpected argument of type `{integer}`
+   |   ^^^^^^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -142,7 +142,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:30:3
    |
 LL |   two_arg_diff(1, "", "");
-   |   ^^^^^^^^^^^^        -- unexpected argument of type `&'static str`
+   |   ^^^^^^^^^^^^        -- unexpected argument #3 of type `&'static str`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -159,9 +159,9 @@ error[E0061]: this function takes 2 arguments but 4 arguments were supplied
   --> $DIR/extra_arguments.rs:31:3
    |
 LL |   two_arg_diff(1, 1, "", "");
-   |   ^^^^^^^^^^^^    -      -- unexpected argument of type `&'static str`
+   |   ^^^^^^^^^^^^    -      -- unexpected argument #4 of type `&'static str`
    |                   |
-   |                   unexpected argument of type `{integer}`
+   |                   unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -178,9 +178,9 @@ error[E0061]: this function takes 2 arguments but 4 arguments were supplied
   --> $DIR/extra_arguments.rs:32:3
    |
 LL |   two_arg_diff(1, "", 1, "");
-   |   ^^^^^^^^^^^^        -  -- unexpected argument of type `&'static str`
+   |   ^^^^^^^^^^^^        -  -- unexpected argument #4 of type `&'static str`
    |                       |
-   |                       unexpected argument of type `{integer}`
+   |                       unexpected argument #3 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -197,7 +197,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:35:3
    |
 LL |   two_arg_same(1, 1,     "");
-   |   ^^^^^^^^^^^^           -- unexpected argument of type `&'static str`
+   |   ^^^^^^^^^^^^           -- unexpected argument #3 of type `&'static str`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:3:4
@@ -214,7 +214,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/extra_arguments.rs:36:3
    |
 LL |   two_arg_diff(1, 1,     "");
-   |   ^^^^^^^^^^^^    - unexpected argument of type `{integer}`
+   |   ^^^^^^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -234,7 +234,7 @@ LL |   two_arg_same(
    |   ^^^^^^^^^^^^
 ...
 LL |     ""
-   |     -- unexpected argument of type `&'static str`
+   |     -- unexpected argument #3 of type `&'static str`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:3:4
@@ -255,7 +255,7 @@ LL |   two_arg_diff(
    |   ^^^^^^^^^^^^
 LL |     1,
 LL |     1,
-   |     - unexpected argument of type `{integer}`
+   |     - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:4:4
@@ -271,12 +271,12 @@ error[E0061]: this function takes 0 arguments but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:8:9
    |
 LL |         empty($x, 1);
-   |         ^^^^^     - unexpected argument of type `{integer}`
+   |         ^^^^^     - unexpected argument #2 of type `{integer}`
 ...
 LL |   foo!(1, ~);
    |   ----------
    |   |    |
-   |   |    unexpected argument of type `{integer}`
+   |   |    unexpected argument #1 of type `{integer}`
    |   in this macro invocation
    |
 note: function defined here
@@ -290,12 +290,12 @@ error[E0061]: this function takes 0 arguments but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:14:9
    |
 LL |         empty(1, $y);
-   |         ^^^^^ - unexpected argument of type `{integer}`
+   |         ^^^^^ - unexpected argument #1 of type `{integer}`
 ...
 LL |   foo!(~, 1);
    |   ----------
    |   |       |
-   |   |       unexpected argument of type `{integer}`
+   |   |       unexpected argument #2 of type `{integer}`
    |   in this macro invocation
    |
 note: function defined here
@@ -314,8 +314,8 @@ LL |         empty($x, $y);
 LL |   foo!(1, 1);
    |   ----------
    |   |    |  |
-   |   |    |  unexpected argument of type `{integer}`
-   |   |    unexpected argument of type `{integer}`
+   |   |    |  unexpected argument #2 of type `{integer}`
+   |   |    unexpected argument #1 of type `{integer}`
    |   in this macro invocation
    |
 note: function defined here
@@ -329,7 +329,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:53:3
    |
 LL |   one_arg(1, panic!());
-   |   ^^^^^^^    -------- unexpected argument
+   |   ^^^^^^^    -------- unexpected argument #2
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -346,7 +346,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:54:3
    |
 LL |   one_arg(panic!(), 1);
-   |   ^^^^^^^           - unexpected argument of type `{integer}`
+   |   ^^^^^^^           - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -363,7 +363,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:55:3
    |
 LL |   one_arg(stringify!($e), 1);
-   |   ^^^^^^^                 - unexpected argument of type `{integer}`
+   |   ^^^^^^^                 - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4
@@ -380,7 +380,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:60:3
    |
 LL |   one_arg(for _ in 1.. {}, 1);
-   |   ^^^^^^^                  - unexpected argument of type `{integer}`
+   |   ^^^^^^^                  - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4

--- a/tests/ui/argument-suggestions/issue-100478.stderr
+++ b/tests/ui/argument-suggestions/issue-100478.stderr
@@ -4,8 +4,8 @@ error[E0061]: this function takes 3 arguments but 1 argument was supplied
 LL |     three_diff(T2::new(0));
    |     ^^^^^^^^^^------------
    |               ||
-   |               |an argument of type `T1` is missing
-   |               an argument of type `T3` is missing
+   |               |argument #1 of type `T1` is missing
+   |               argument #3 of type `T3` is missing
    |
 note: function defined here
   --> $DIR/issue-100478.rs:30:4
@@ -63,7 +63,7 @@ LL |     foo(
    |     ^^^
 ...
 LL |         p3, p4, p5, p6, p7, p8,
-   |         -- an argument of type `Arc<T2>` is missing
+   |         -- argument #2 of type `Arc<T2>` is missing
    |
 note: function defined here
   --> $DIR/issue-100478.rs:29:4

--- a/tests/ui/argument-suggestions/issue-101097.stderr
+++ b/tests/ui/argument-suggestions/issue-101097.stderr
@@ -4,7 +4,7 @@ error[E0061]: this function takes 6 arguments but 7 arguments were supplied
 LL |     f(C, A, A, A, B, B, C);
    |     ^ -     -  -  - expected `C`, found `B`
    |       |     |  |
-   |       |     |  unexpected argument of type `A`
+   |       |     |  unexpected argument #4 of type `A`
    |       |     expected `B`, found `A`
    |       expected `A`, found `C`
    |
@@ -64,8 +64,8 @@ error[E0308]: arguments to this function are incorrect
 LL |     f(A, A, D, D, B, B);
    |     ^       -  -  ---- two arguments of type `C` and `C` are missing
    |             |  |
-   |             |  unexpected argument of type `D`
-   |             unexpected argument of type `D`
+   |             |  unexpected argument #4 of type `D`
+   |             unexpected argument #3 of type `D`
    |
 note: function defined here
   --> $DIR/issue-101097.rs:6:4

--- a/tests/ui/argument-suggestions/issue-109425.stderr
+++ b/tests/ui/argument-suggestions/issue-109425.stderr
@@ -2,9 +2,9 @@ error[E0061]: this function takes 0 arguments but 2 arguments were supplied
   --> $DIR/issue-109425.rs:10:5
    |
 LL |     f(0, 1,);        // f()
-   |     ^ -  - unexpected argument of type `{integer}`
+   |     ^ -  - unexpected argument #2 of type `{integer}`
    |       |
-   |       unexpected argument of type `{integer}`
+   |       unexpected argument #1 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-109425.rs:3:4
@@ -21,9 +21,9 @@ error[E0061]: this function takes 1 argument but 3 arguments were supplied
   --> $DIR/issue-109425.rs:12:5
    |
 LL |     i(0, 1, 2,);     // i(0,)
-   |     ^    -  - unexpected argument of type `{integer}`
+   |     ^    -  - unexpected argument #3 of type `{integer}`
    |          |
-   |          unexpected argument of type `{integer}`
+   |          unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-109425.rs:4:4
@@ -40,9 +40,9 @@ error[E0061]: this function takes 1 argument but 3 arguments were supplied
   --> $DIR/issue-109425.rs:14:5
    |
 LL |     i(0, 1, 2);      // i(0)
-   |     ^    -  - unexpected argument of type `{integer}`
+   |     ^    -  - unexpected argument #3 of type `{integer}`
    |          |
-   |          unexpected argument of type `{integer}`
+   |          unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-109425.rs:4:4
@@ -59,9 +59,9 @@ error[E0061]: this function takes 2 arguments but 4 arguments were supplied
   --> $DIR/issue-109425.rs:16:5
    |
 LL |     is(0, 1, 2, ""); // is(0, "")
-   |     ^^    -  - unexpected argument of type `{integer}`
+   |     ^^    -  - unexpected argument #3 of type `{integer}`
    |           |
-   |           unexpected argument of type `{integer}`
+   |           unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-109425.rs:5:4
@@ -78,9 +78,9 @@ error[E0061]: this function takes 1 argument but 3 arguments were supplied
   --> $DIR/issue-109425.rs:18:5
    |
 LL |     s(0, 1, "");     // s("")
-   |     ^ -  - unexpected argument of type `{integer}`
+   |     ^ -  - unexpected argument #2 of type `{integer}`
    |       |
-   |       unexpected argument of type `{integer}`
+   |       unexpected argument #1 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-109425.rs:6:4

--- a/tests/ui/argument-suggestions/issue-109831.stderr
+++ b/tests/ui/argument-suggestions/issue-109831.stderr
@@ -29,7 +29,7 @@ error[E0061]: this function takes 3 arguments but 4 arguments were supplied
   --> $DIR/issue-109831.rs:7:5
    |
 LL |     f(A, A, B, C);
-   |     ^ -  -     - unexpected argument
+   |     ^ -  -     - unexpected argument #4
    |       |  |
    |       |  expected `B`, found `A`
    |       expected `B`, found `A`

--- a/tests/ui/argument-suggestions/issue-112507.stderr
+++ b/tests/ui/argument-suggestions/issue-112507.stderr
@@ -4,12 +4,12 @@ error[E0061]: this enum variant takes 1 argument but 4 arguments were supplied
 LL |     let _a = Value::Float(
    |              ^^^^^^^^^^^^
 LL |         0,
-   |         - unexpected argument of type `{integer}`
+   |         - unexpected argument #1 of type `{integer}`
 LL |         None,
 LL |         None,
-   |         ---- unexpected argument of type `Option<_>`
+   |         ---- unexpected argument #3 of type `Option<_>`
 LL |         0,
-   |         - unexpected argument of type `{integer}`
+   |         - unexpected argument #4 of type `{integer}`
    |
 note: tuple variant defined here
   --> $DIR/issue-112507.rs:2:5

--- a/tests/ui/argument-suggestions/issue-96638.stderr
+++ b/tests/ui/argument-suggestions/issue-96638.stderr
@@ -4,7 +4,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
 LL |     f(&x, "");
    |     ^ --  -- expected `usize`, found `&str`
    |       |
-   |       an argument of type `usize` is missing
+   |       argument #1 of type `usize` is missing
    |
 note: function defined here
   --> $DIR/issue-96638.rs:1:4

--- a/tests/ui/argument-suggestions/issue-97484.stderr
+++ b/tests/ui/argument-suggestions/issue-97484.stderr
@@ -2,11 +2,11 @@ error[E0061]: this function takes 4 arguments but 7 arguments were supplied
   --> $DIR/issue-97484.rs:12:5
    |
 LL |     foo(&&A, B, C, D, E, F, G);
-   |     ^^^      -  -     -  - unexpected argument of type `F`
+   |     ^^^      -  -     -  - unexpected argument #6 of type `F`
    |              |  |     |
    |              |  |     expected `&E`, found `E`
-   |              |  unexpected argument of type `C`
-   |              unexpected argument of type `B`
+   |              |  unexpected argument #3 of type `C`
+   |              unexpected argument #2 of type `B`
    |
 note: function defined here
   --> $DIR/issue-97484.rs:9:4

--- a/tests/ui/argument-suggestions/issue-98894.stderr
+++ b/tests/ui/argument-suggestions/issue-98894.stderr
@@ -2,7 +2,7 @@ error[E0057]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/issue-98894.rs:2:5
    |
 LL |     (|_, ()| ())(if true {} else {return;});
-   |     ^^^^^^^^^^^^--------------------------- an argument of type `()` is missing
+   |     ^^^^^^^^^^^^--------------------------- argument #2 of type `()` is missing
    |
 note: closure defined here
   --> $DIR/issue-98894.rs:2:6

--- a/tests/ui/argument-suggestions/issue-98897.stderr
+++ b/tests/ui/argument-suggestions/issue-98897.stderr
@@ -2,7 +2,7 @@ error[E0057]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/issue-98897.rs:2:5
    |
 LL |     (|_, ()| ())([return, ()]);
-   |     ^^^^^^^^^^^^-------------- an argument of type `()` is missing
+   |     ^^^^^^^^^^^^-------------- argument #2 of type `()` is missing
    |
 note: closure defined here
   --> $DIR/issue-98897.rs:2:6

--- a/tests/ui/argument-suggestions/issue-99482.stderr
+++ b/tests/ui/argument-suggestions/issue-99482.stderr
@@ -2,7 +2,7 @@ error[E0057]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/issue-99482.rs:3:14
    |
 LL |     let _f = f(main);
-   |              ^ ---- an argument of type `()` is missing
+   |              ^ ---- argument #1 of type `()` is missing
    |
 note: closure defined here
   --> $DIR/issue-99482.rs:2:13

--- a/tests/ui/argument-suggestions/missing_arguments.stderr
+++ b/tests/ui/argument-suggestions/missing_arguments.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/missing_arguments.rs:10:3
    |
 LL |   one_arg();
-   |   ^^^^^^^-- an argument of type `i32` is missing
+   |   ^^^^^^^-- argument #1 of type `i32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:1:4
@@ -34,7 +34,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:15:3
    |
 LL |   two_same(   1           );
-   |   ^^^^^^^^----------------- an argument of type `i32` is missing
+   |   ^^^^^^^^----------------- argument #2 of type `i32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:2:4
@@ -66,7 +66,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:17:3
    |
 LL |   two_diff(   1           );
-   |   ^^^^^^^^----------------- an argument of type `f32` is missing
+   |   ^^^^^^^^----------------- argument #2 of type `f32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:3:4
@@ -82,7 +82,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing_arguments.rs:18:3
    |
 LL |   two_diff(          1.0  );
-   |   ^^^^^^^^           --- an argument of type `i32` is missing
+   |   ^^^^^^^^           --- argument #1 of type `i32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:3:4
@@ -130,7 +130,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:23:3
    |
 LL |   three_same(   1,      1           );
-   |   ^^^^^^^^^^------------------------- an argument of type `i32` is missing
+   |   ^^^^^^^^^^------------------------- argument #3 of type `i32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:4:4
@@ -146,7 +146,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:26:3
    |
 LL |   three_diff(          1.0,     ""  );
-   |   ^^^^^^^^^^           --- an argument of type `i32` is missing
+   |   ^^^^^^^^^^           --- argument #1 of type `i32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:5:4
@@ -162,7 +162,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:27:3
    |
 LL |   three_diff(   1,              ""  );
-   |   ^^^^^^^^^^                    -- an argument of type `f32` is missing
+   |   ^^^^^^^^^^                    -- argument #2 of type `f32` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:5:4
@@ -178,7 +178,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:28:3
    |
 LL |   three_diff(   1,     1.0          );
-   |   ^^^^^^^^^^------------------------- an argument of type `&str` is missing
+   |   ^^^^^^^^^^------------------------- argument #3 of type `&str` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:5:4
@@ -212,8 +212,8 @@ error[E0061]: this function takes 3 arguments but 1 argument was supplied
 LL |   three_diff(          1.0          );
    |   ^^^^^^^^^^-------------------------
    |             |          |
-   |             |          an argument of type `i32` is missing
-   |             an argument of type `&str` is missing
+   |             |          argument #1 of type `i32` is missing
+   |             argument #3 of type `&str` is missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:5:4

--- a/tests/ui/argument-suggestions/mixed_cases.stderr
+++ b/tests/ui/argument-suggestions/mixed_cases.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/mixed_cases.rs:10:3
    |
 LL |   two_args(1, "", X {});
-   |   ^^^^^^^^    --  ---- unexpected argument of type `X`
+   |   ^^^^^^^^    --  ---- unexpected argument #3 of type `X`
    |               |
    |               expected `f32`, found `&str`
    |
@@ -21,10 +21,10 @@ error[E0061]: this function takes 3 arguments but 4 arguments were supplied
   --> $DIR/mixed_cases.rs:11:3
    |
 LL |   three_args(1, "", X {}, "");
-   |   ^^^^^^^^^^    --  ----  -- unexpected argument of type `&'static str`
+   |   ^^^^^^^^^^    --  ----  -- unexpected argument #4 of type `&'static str`
    |                 |   |
-   |                 |   unexpected argument of type `X`
-   |                 an argument of type `f32` is missing
+   |                 |   unexpected argument #3 of type `X`
+   |                 argument #2 of type `f32` is missing
    |
 note: function defined here
   --> $DIR/mixed_cases.rs:6:4
@@ -43,7 +43,7 @@ LL |   three_args(1, X {});
    |   ^^^^^^^^^^---------
    |             |   |
    |             |   expected `f32`, found `X`
-   |             an argument of type `&str` is missing
+   |             argument #3 of type `&str` is missing
    |
 note: function defined here
   --> $DIR/mixed_cases.rs:6:4
@@ -59,9 +59,9 @@ error[E0308]: arguments to this function are incorrect
   --> $DIR/mixed_cases.rs:17:3
    |
 LL |   three_args(1, "", X {});
-   |   ^^^^^^^^^^    --  ---- unexpected argument of type `X`
+   |   ^^^^^^^^^^    --  ---- unexpected argument #3 of type `X`
    |                 |
-   |                 an argument of type `f32` is missing
+   |                 argument #2 of type `f32` is missing
    |
 note: function defined here
   --> $DIR/mixed_cases.rs:6:4
@@ -98,7 +98,7 @@ error[E0061]: this function takes 3 arguments but 2 arguments were supplied
 LL |   three_args("", 1);
    |   ^^^^^^^^^^ --  -
    |              |   |
-   |              |   an argument of type `f32` is missing
+   |              |   argument #2 of type `f32` is missing
    |              |   expected `&str`, found `{integer}`
    |              expected `i32`, found `&'static str`
    |

--- a/tests/ui/argument-suggestions/suggest-better-removing-issue-126246.stderr
+++ b/tests/ui/argument-suggestions/suggest-better-removing-issue-126246.stderr
@@ -32,7 +32,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:10:5
    |
 LL |     add_one(2, 2);
-   |     ^^^^^^^    - unexpected argument of type `{integer}`
+   |     ^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:1:4
@@ -49,7 +49,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:11:5
    |
 LL |     add_one(no_such_local, 10);
-   |     ^^^^^^^ ------------- unexpected argument
+   |     ^^^^^^^ ------------- unexpected argument #1
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:1:4
@@ -66,7 +66,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:13:5
    |
 LL |     add_one(10, no_such_local);
-   |     ^^^^^^^     ------------- unexpected argument
+   |     ^^^^^^^     ------------- unexpected argument #2
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:1:4
@@ -83,7 +83,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:15:5
    |
 LL |     add_two(10, no_such_local, 10);
-   |     ^^^^^^^     ------------- unexpected argument
+   |     ^^^^^^^     ------------- unexpected argument #2
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:5:4
@@ -100,7 +100,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:17:5
    |
 LL |     add_two(no_such_local, 10, 10);
-   |     ^^^^^^^ ------------- unexpected argument
+   |     ^^^^^^^ ------------- unexpected argument #1
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:5:4
@@ -117,7 +117,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/suggest-better-removing-issue-126246.rs:19:5
    |
 LL |     add_two(10, 10, no_such_local);
-   |     ^^^^^^^         ------------- unexpected argument
+   |     ^^^^^^^         ------------- unexpected argument #3
    |
 note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:5:4

--- a/tests/ui/associated-inherent-types/issue-109768.stderr
+++ b/tests/ui/associated-inherent-types/issue-109768.stderr
@@ -34,7 +34,7 @@ error[E0061]: this struct takes 1 argument but 0 arguments were supplied
   --> $DIR/issue-109768.rs:10:56
    |
 LL |     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper();
-   |                                                        ^^^^^^^-- an argument is missing
+   |                                                        ^^^^^^^-- argument #1 is missing
    |
 note: tuple struct defined here
   --> $DIR/issue-109768.rs:3:8

--- a/tests/ui/associated-types/associated-types-invalid-trait-ref-issue-18865.stderr
+++ b/tests/ui/associated-types/associated-types-invalid-trait-ref-issue-18865.stderr
@@ -3,11 +3,6 @@ error[E0277]: the trait bound `T: Foo<usize>` is not satisfied
    |
 LL |     let u: <T as Foo<usize>>::Bar = t.get_bar();
    |             ^ the trait `Foo<usize>` is not implemented for `T`
-   |
-help: consider further restricting this bound
-   |
-LL | fn f<T:Foo<isize> + Foo<usize>>(t: &T) {
-   |                   ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/remove-invalid-type-bound-suggest-issue-127555.rs
+++ b/tests/ui/associated-types/remove-invalid-type-bound-suggest-issue-127555.rs
@@ -1,0 +1,23 @@
+//@ edition:2021
+// issue: rust-lang/rust#127555
+
+pub trait Foo {
+    fn bar<F>(&mut self, func: F) -> impl std::future::Future<Output = ()> + Send
+    where
+        F: FnMut();
+}
+
+struct Baz {}
+
+impl Foo for Baz {
+    async fn bar<F>(&mut self, _func: F) -> ()
+    //~^ ERROR `F` cannot be sent between threads safely
+    where
+        F: FnMut() + Send,
+        //~^ ERROR impl has stricter requirements than trait
+    {
+        ()
+    }
+}
+
+fn main() {}

--- a/tests/ui/associated-types/remove-invalid-type-bound-suggest-issue-127555.stderr
+++ b/tests/ui/associated-types/remove-invalid-type-bound-suggest-issue-127555.stderr
@@ -1,0 +1,33 @@
+error[E0277]: `F` cannot be sent between threads safely
+  --> $DIR/remove-invalid-type-bound-suggest-issue-127555.rs:13:5
+   |
+LL | /     async fn bar<F>(&mut self, _func: F) -> ()
+LL | |
+LL | |     where
+LL | |         F: FnMut() + Send,
+   | |__________________________^ `F` cannot be sent between threads safely
+   |
+note: required by a bound in `<Baz as Foo>::bar`
+  --> $DIR/remove-invalid-type-bound-suggest-issue-127555.rs:16:22
+   |
+LL |     async fn bar<F>(&mut self, _func: F) -> ()
+   |              --- required by a bound in this associated function
+...
+LL |         F: FnMut() + Send,
+   |                      ^^^^ required by this bound in `<Baz as Foo>::bar`
+
+error[E0276]: impl has stricter requirements than trait
+  --> $DIR/remove-invalid-type-bound-suggest-issue-127555.rs:16:22
+   |
+LL | /     fn bar<F>(&mut self, func: F) -> impl std::future::Future<Output = ()> + Send
+LL | |     where
+LL | |         F: FnMut();
+   | |___________________- definition of `bar` from trait
+...
+LL |           F: FnMut() + Send,
+   |                        ^^^^ impl has extra requirement `F: Send`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0276, E0277.
+For more information about an error, try `rustc --explain E0276`.

--- a/tests/ui/async-await/in-trait/unconstrained-impl-region.stderr
+++ b/tests/ui/async-await/in-trait/unconstrained-impl-region.stderr
@@ -9,10 +9,6 @@ note: required by a bound in `<() as Actor>::on_mount`
    |
 LL |     async fn on_mount(self, _: impl Inbox<&'a ()>) {}
    |                                     ^^^^^^^^^^^^^ required by this bound in `<() as Actor>::on_mount`
-help: consider further restricting this bound
-   |
-LL |     async fn on_mount(self, _: impl Inbox<&'a ()> + Inbox<&'a ()>) {}
-   |                                                   +++++++++++++++
 
 error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
   --> $DIR/unconstrained-impl-region.rs:13:6

--- a/tests/ui/borrowck/moved-value-suggest-reborrow-issue-127285.fixed
+++ b/tests/ui/borrowck/moved-value-suggest-reborrow-issue-127285.fixed
@@ -1,0 +1,17 @@
+//@ run-rustfix
+
+#![allow(dead_code)]
+
+struct X(u32);
+
+impl X {
+    fn f(&mut self) {
+        generic(&mut *self);
+        self.0 += 1;
+        //~^ ERROR: use of moved value: `self` [E0382]
+    }
+}
+
+fn generic<T>(_x: T) {}
+
+fn main() {}

--- a/tests/ui/borrowck/moved-value-suggest-reborrow-issue-127285.rs
+++ b/tests/ui/borrowck/moved-value-suggest-reborrow-issue-127285.rs
@@ -1,0 +1,17 @@
+//@ run-rustfix
+
+#![allow(dead_code)]
+
+struct X(u32);
+
+impl X {
+    fn f(&mut self) {
+        generic(self);
+        self.0 += 1;
+        //~^ ERROR: use of moved value: `self` [E0382]
+    }
+}
+
+fn generic<T>(_x: T) {}
+
+fn main() {}

--- a/tests/ui/borrowck/moved-value-suggest-reborrow-issue-127285.stderr
+++ b/tests/ui/borrowck/moved-value-suggest-reborrow-issue-127285.stderr
@@ -1,0 +1,18 @@
+error[E0382]: use of moved value: `self`
+  --> $DIR/moved-value-suggest-reborrow-issue-127285.rs:10:9
+   |
+LL |     fn f(&mut self) {
+   |          --------- move occurs because `self` has type `&mut X`, which does not implement the `Copy` trait
+LL |         generic(self);
+   |                 ---- value moved here
+LL |         self.0 += 1;
+   |         ^^^^^^^^^^^ value used here after move
+   |
+help: consider creating a fresh reborrow of `self` here
+   |
+LL |         generic(&mut *self);
+   |                 ++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/borrowck/mut-borrow-in-loop-2.stderr
+++ b/tests/ui/borrowck/mut-borrow-in-loop-2.stderr
@@ -8,19 +8,10 @@ LL |     for _ in 0..3 {
 LL |         Other::handle(value);
    |                       ^^^^^ value moved here, in previous iteration of loop
    |
-note: consider changing this parameter type in function `handle` to borrow instead if owning the value isn't necessary
-  --> $DIR/mut-borrow-in-loop-2.rs:8:22
+help: consider creating a fresh reborrow of `value` here
    |
-LL |     fn handle(value: T) -> Self;
-   |        ------        ^ this parameter takes ownership of the value
-   |        |
-   |        in this function
-help: consider moving the expression out of the loop so it is only moved once
-   |
-LL ~     let mut value = Other::handle(value);
-LL ~     for _ in 0..3 {
-LL ~         value;
-   |
+LL |         Other::handle(&mut *value);
+   |                       ++++++
 help: consider creating a fresh reborrow of `value` here
    |
 LL |         Other::handle(&mut *value);

--- a/tests/ui/c-variadic/variadic-ffi-1.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-1.stderr
@@ -24,7 +24,7 @@ error[E0060]: this function takes at least 2 arguments but 1 argument was suppli
   --> $DIR/variadic-ffi-1.rs:23:9
    |
 LL |         foo(1);
-   |         ^^^--- an argument of type `u8` is missing
+   |         ^^^--- argument #2 of type `u8` is missing
    |
 note: function defined here
   --> $DIR/variadic-ffi-1.rs:15:8

--- a/tests/ui/cast/ice-cast-type-with-error-124848.stderr
+++ b/tests/ui/cast/ice-cast-type-with-error-124848.stderr
@@ -39,7 +39,7 @@ error[E0061]: this struct takes 2 arguments but 1 argument was supplied
   --> $DIR/ice-cast-type-with-error-124848.rs:12:24
    |
 LL |     let mut unpinned = MyType(Cell::new(None));
-   |                        ^^^^^^----------------- an argument is missing
+   |                        ^^^^^^----------------- argument #2 is missing
    |
 note: tuple struct defined here
   --> $DIR/ice-cast-type-with-error-124848.rs:7:8

--- a/tests/ui/coroutine/issue-102645.stderr
+++ b/tests/ui/coroutine/issue-102645.stderr
@@ -2,7 +2,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> $DIR/issue-102645.rs:15:22
    |
 LL |     Pin::new(&mut b).resume();
-   |                      ^^^^^^-- an argument of type `()` is missing
+   |                      ^^^^^^-- argument #1 of type `()` is missing
    |
 note: method defined here
   --> $SRC_DIR/core/src/ops/coroutine.rs:LL:COL

--- a/tests/ui/error-codes/E0057.stderr
+++ b/tests/ui/error-codes/E0057.stderr
@@ -2,7 +2,7 @@ error[E0057]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/E0057.rs:3:13
    |
 LL |     let a = f();
-   |             ^-- an argument is missing
+   |             ^-- argument #1 is missing
    |
 note: closure defined here
   --> $DIR/E0057.rs:2:13
@@ -18,7 +18,7 @@ error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/E0057.rs:5:13
    |
 LL |     let c = f(2, 3);
-   |             ^    - unexpected argument of type `{integer}`
+   |             ^    - unexpected argument #2 of type `{integer}`
    |
 note: closure defined here
   --> $DIR/E0057.rs:2:13

--- a/tests/ui/error-codes/E0060.stderr
+++ b/tests/ui/error-codes/E0060.stderr
@@ -2,7 +2,7 @@ error[E0060]: this function takes at least 1 argument but 0 arguments were suppl
   --> $DIR/E0060.rs:6:14
    |
 LL |     unsafe { printf(); }
-   |              ^^^^^^-- an argument of type `*const u8` is missing
+   |              ^^^^^^-- argument #1 of type `*const u8` is missing
    |
 note: function defined here
   --> $DIR/E0060.rs:2:8

--- a/tests/ui/error-codes/E0061.stderr
+++ b/tests/ui/error-codes/E0061.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/E0061.rs:6:5
    |
 LL |     f(0);
-   |     ^--- an argument of type `&str` is missing
+   |     ^--- argument #2 of type `&str` is missing
    |
 note: function defined here
   --> $DIR/E0061.rs:1:4
@@ -18,7 +18,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/E0061.rs:9:5
    |
 LL |     f2();
-   |     ^^-- an argument of type `u16` is missing
+   |     ^^-- argument #1 of type `u16` is missing
    |
 note: function defined here
   --> $DIR/E0061.rs:3:4

--- a/tests/ui/extern/issue-18819.stderr
+++ b/tests/ui/extern/issue-18819.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/issue-18819.rs:16:5
    |
 LL |     print_x(X);
-   |     ^^^^^^^--- an argument of type `&str` is missing
+   |     ^^^^^^^--- argument #2 of type `&str` is missing
    |
 note: expected `&dyn Foo<Item = bool>`, found `X`
   --> $DIR/issue-18819.rs:16:13

--- a/tests/ui/fn/issue-3044.stderr
+++ b/tests/ui/fn/issue-3044.stderr
@@ -5,7 +5,7 @@ LL |       needlesArr.iter().fold(|x, y| {
    |  _______________________^^^^-
 LL | |
 LL | |     });
-   | |______- an argument is missing
+   | |______- argument #2 is missing
    |
 note: method defined here
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL

--- a/tests/ui/generic-associated-types/issue-91139.migrate.stderr
+++ b/tests/ui/generic-associated-types/issue-91139.migrate.stderr
@@ -1,7 +1,6 @@
 error: expected identifier, found `<<`
   --> $DIR/issue-91139.rs:1:1
    |
-LL | <<<<<<< HEAD
    | ^^ expected identifier
 
 error: aborting due to 1 previous error

--- a/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-2.next.stderr
+++ b/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-2.next.stderr
@@ -9,10 +9,6 @@ note: required by a bound in `impl_hr`
    |
 LL | fn impl_hr<'b, T: for<'a> Trait<'a, 'b>>() {}
    |                   ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `impl_hr`
-help: consider further restricting this bound
-   |
-LL | fn not_hr<'a, T: for<'b> Trait<'a, 'b> + OtherTrait<'static> + for<'a> Trait<'a, '_>>() {
-   |                                                              +++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-project.next.stderr
+++ b/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-project.next.stderr
@@ -9,10 +9,6 @@ note: required by a bound in `trait_bound`
    |
 LL | fn trait_bound<T: for<'a> Trait<'a>>() {}
    |                   ^^^^^^^^^^^^^^^^^ required by this bound in `trait_bound`
-help: consider further restricting this bound
-   |
-LL | fn function1<T: Trait<'static> + for<'a> Trait<'a>>() {
-   |                                +++++++++++++++++++
 
 error[E0277]: the trait bound `for<'a> T: Trait<'a>` is not satisfied
   --> $DIR/candidate-from-env-universe-err-project.rs:38:24
@@ -25,10 +21,6 @@ note: required by a bound in `projection_bound`
    |
 LL | fn projection_bound<T: for<'a> Trait<'a, Assoc = usize>>() {}
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `projection_bound`
-help: consider further restricting this bound
-   |
-LL | fn function2<T: Trait<'static, Assoc = usize> + for<'a> Trait<'a>>() {
-   |                                               +++++++++++++++++++
 
 error[E0271]: type mismatch resolving `<T as Trait<'a>>::Assoc == usize`
   --> $DIR/candidate-from-env-universe-err-project.rs:38:24

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.stderr
@@ -11,10 +11,6 @@ note: required by a bound in `want_foo_for_any_tcx`
    |
 LL | fn want_foo_for_any_tcx<F: for<'tcx> Foo<'tcx>>(f: &F) {
    |                            ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_foo_for_any_tcx`
-help: consider further restricting this bound
-   |
-LL | fn want_foo_for_some_tcx<'x, F: Foo<'x> + for<'tcx> Foo<'tcx>>(f: &'x F) {
-   |                                         +++++++++++++++++++++
 
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:28:26
@@ -29,10 +25,6 @@ note: required by a bound in `want_bar_for_any_ccx`
    |
 LL | fn want_bar_for_any_ccx<B: for<'ccx> Bar<'ccx>>(b: &B) {
    |                            ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_bar_for_any_ccx`
-help: consider further restricting this bound
-   |
-LL | fn want_bar_for_some_ccx<'x, B: Bar<'x> + for<'ccx> Bar<'ccx>>(b: &B) {
-   |                                         +++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/higher-ranked/trait-bounds/issue-58451.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/issue-58451.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/issue-58451.rs:12:9
    |
 LL |     f(&[f()]);
-   |         ^-- an argument is missing
+   |         ^-- argument #1 is missing
    |
 note: function defined here
   --> $DIR/issue-58451.rs:5:4

--- a/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
@@ -22,10 +22,6 @@ note: required by a bound in `<Bar as Foo<char>>::foo`
    |
 LL |     fn foo<F2: Foo<u8>>(self) -> impl Foo<u8> {
    |                ^^^^^^^ required by this bound in `<Bar as Foo<char>>::foo`
-help: consider further restricting this bound
-   |
-LL |     fn foo<F2: Foo<u8> + Foo<u8>>(self) -> impl Foo<u8> {
-   |                        +++++++++
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/return-dont-satisfy-bounds.rs:8:16

--- a/tests/ui/issues/issue-4935.stderr
+++ b/tests/ui/issues/issue-4935.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/issue-4935.rs:5:13
    |
 LL | fn main() { foo(5, 6) }
-   |             ^^^    - unexpected argument of type `{integer}`
+   |             ^^^    - unexpected argument #2 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-4935.rs:3:4

--- a/tests/ui/lifetimes/issue-26638.stderr
+++ b/tests/ui/lifetimes/issue-26638.stderr
@@ -50,7 +50,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/issue-26638.rs:4:47
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
-   |                                               ^^^^-- an argument of type `&u8` is missing
+   |                                               ^^^^-- argument #1 of type `&u8` is missing
    |
 help: provide the argument
    |

--- a/tests/ui/methods/method-call-err-msg.stderr
+++ b/tests/ui/methods/method-call-err-msg.stderr
@@ -19,7 +19,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> $DIR/method-call-err-msg.rs:14:7
    |
 LL |      .one()
-   |       ^^^-- an argument of type `isize` is missing
+   |       ^^^-- argument #1 of type `isize` is missing
    |
 note: method defined here
   --> $DIR/method-call-err-msg.rs:6:8
@@ -35,7 +35,7 @@ error[E0061]: this method takes 2 arguments but 1 argument was supplied
   --> $DIR/method-call-err-msg.rs:15:7
    |
 LL |      .two(0);
-   |       ^^^--- an argument of type `isize` is missing
+   |       ^^^--- argument #2 of type `isize` is missing
    |
 note: method defined here
   --> $DIR/method-call-err-msg.rs:7:8

--- a/tests/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/tests/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -16,7 +16,7 @@ error[E0057]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:35:15
    |
 LL |     let ans = s();
-   |               ^-- an argument of type `isize` is missing
+   |               ^-- argument #1 of type `isize` is missing
    |
 note: implementation defined here
   --> $DIR/overloaded-calls-bad.rs:10:1
@@ -32,7 +32,7 @@ error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:37:15
    |
 LL |     let ans = s("burma", "shave");
-   |               ^ -------  ------- unexpected argument of type `&'static str`
+   |               ^ -------  ------- unexpected argument #2 of type `&'static str`
    |                 |
    |                 expected `isize`, found `&str`
    |

--- a/tests/ui/not-enough-arguments.stderr
+++ b/tests/ui/not-enough-arguments.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 4 arguments but 3 arguments were supplied
   --> $DIR/not-enough-arguments.rs:27:3
    |
 LL |   foo(1, 2, 3);
-   |   ^^^--------- an argument of type `isize` is missing
+   |   ^^^--------- argument #4 of type `isize` is missing
    |
 note: function defined here
   --> $DIR/not-enough-arguments.rs:5:4

--- a/tests/ui/span/issue-34264.stderr
+++ b/tests/ui/span/issue-34264.stderr
@@ -54,7 +54,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/issue-34264.rs:7:5
    |
 LL |     foo(Some(42), 2, "");
-   |     ^^^              -- unexpected argument of type `&'static str`
+   |     ^^^              -- unexpected argument #3 of type `&'static str`
    |
 note: function defined here
   --> $DIR/issue-34264.rs:1:4
@@ -85,7 +85,7 @@ error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/issue-34264.rs:10:5
    |
 LL |     bar(1, 2, 3);
-   |     ^^^       - unexpected argument of type `{integer}`
+   |     ^^^       - unexpected argument #3 of type `{integer}`
    |
 note: function defined here
   --> $DIR/issue-34264.rs:3:4

--- a/tests/ui/span/missing-unit-argument.stderr
+++ b/tests/ui/span/missing-unit-argument.stderr
@@ -2,7 +2,7 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:11:33
    |
 LL |     let _: Result<(), String> = Ok();
-   |                                 ^^-- an argument of type `()` is missing
+   |                                 ^^-- argument #1 of type `()` is missing
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -31,7 +31,7 @@ error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing-unit-argument.rs:13:5
    |
 LL |     foo(());
-   |     ^^^---- an argument of type `()` is missing
+   |     ^^^---- argument #2 of type `()` is missing
    |
 note: function defined here
   --> $DIR/missing-unit-argument.rs:1:4
@@ -47,7 +47,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:14:5
    |
 LL |     bar();
-   |     ^^^-- an argument of type `()` is missing
+   |     ^^^-- argument #1 of type `()` is missing
    |
 note: function defined here
   --> $DIR/missing-unit-argument.rs:2:4
@@ -63,7 +63,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:15:7
    |
 LL |     S.baz();
-   |       ^^^-- an argument of type `()` is missing
+   |       ^^^-- argument #1 of type `()` is missing
    |
 note: method defined here
   --> $DIR/missing-unit-argument.rs:6:8
@@ -79,7 +79,7 @@ error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:16:7
    |
 LL |     S.generic::<()>();
-   |       ^^^^^^^^^^^^^-- an argument of type `()` is missing
+   |       ^^^^^^^^^^^^^-- argument #1 of type `()` is missing
    |
 note: method defined here
   --> $DIR/missing-unit-argument.rs:7:8

--- a/tests/ui/suggestions/args-instead-of-tuple-errors.stderr
+++ b/tests/ui/suggestions/args-instead-of-tuple-errors.stderr
@@ -2,7 +2,7 @@ error[E0061]: this enum variant takes 1 argument but 2 arguments were supplied
   --> $DIR/args-instead-of-tuple-errors.rs:6:34
    |
 LL |     let _: Option<(i32, bool)> = Some(1, 2);
-   |                                  ^^^^    - unexpected argument of type `{integer}`
+   |                                  ^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: expected `(i32, bool)`, found integer
   --> $DIR/args-instead-of-tuple-errors.rs:6:39
@@ -30,7 +30,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/args-instead-of-tuple-errors.rs:8:5
    |
 LL |     int_bool(1, 2);
-   |     ^^^^^^^^    - unexpected argument of type `{integer}`
+   |     ^^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: expected `(i32, bool)`, found integer
   --> $DIR/args-instead-of-tuple-errors.rs:8:14
@@ -54,7 +54,7 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/args-instead-of-tuple-errors.rs:11:28
    |
 LL |     let _: Option<(i8,)> = Some();
-   |                            ^^^^-- an argument of type `(i8,)` is missing
+   |                            ^^^^-- argument #1 of type `(i8,)` is missing
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/ui/suggestions/args-instead-of-tuple.stderr
+++ b/tests/ui/suggestions/args-instead-of-tuple.stderr
@@ -28,7 +28,7 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/args-instead-of-tuple.rs:11:25
    |
 LL |     let _: Option<()> = Some();
-   |                         ^^^^-- an argument of type `()` is missing
+   |                         ^^^^-- argument #1 of type `()` is missing
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/ui/suggestions/issue-109396.stderr
+++ b/tests/ui/suggestions/issue-109396.stderr
@@ -11,14 +11,14 @@ LL |         let mut mutex = std::mem::zeroed(
    |                         ^^^^^^^^^^^^^^^^
 LL |
 LL |             file.as_raw_fd(),
-   |             ---------------- unexpected argument
+   |             ---------------- unexpected argument #1
 LL |
 LL |             0,
-   |             - unexpected argument of type `{integer}`
+   |             - unexpected argument #2 of type `{integer}`
 LL |             0,
-   |             - unexpected argument of type `{integer}`
+   |             - unexpected argument #3 of type `{integer}`
 LL |             0,
-   |             - unexpected argument of type `{integer}`
+   |             - unexpected argument #4 of type `{integer}`
    |
 note: function defined here
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL

--- a/tests/ui/suggestions/issue-109854.stderr
+++ b/tests/ui/suggestions/issue-109854.stderr
@@ -7,9 +7,9 @@ LL |       String::with_capacity(
 LL | /     r#"
 LL | | pub(crate) struct Person<T: Clone> {}
 LL | | "#,
-   | |__- unexpected argument of type `&'static str`
+   | |__- unexpected argument #2 of type `&'static str`
 LL |        r#""#,
-   |        ----- unexpected argument of type `&'static str`
+   |        ----- unexpected argument #3 of type `&'static str`
    |
 note: expected `usize`, found fn item
   --> $DIR/issue-109854.rs:4:5

--- a/tests/ui/tuple/wrong_argument_ice-3.stderr
+++ b/tests/ui/tuple/wrong_argument_ice-3.stderr
@@ -2,7 +2,7 @@ error[E0061]: this method takes 1 argument but 2 arguments were supplied
   --> $DIR/wrong_argument_ice-3.rs:9:16
    |
 LL |         groups.push(new_group, vec![process]);
-   |                ^^^^            ------------- unexpected argument of type `Vec<&Process>`
+   |                ^^^^            ------------- unexpected argument #2 of type `Vec<&Process>`
    |
 note: expected `(Vec<String>, Vec<Process>)`, found `Vec<String>`
   --> $DIR/wrong_argument_ice-3.rs:9:21

--- a/tests/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
+++ b/tests/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
@@ -2,7 +2,7 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/enum-variant-priority-higher-than-other-inherent.rs:21:5
    |
 LL |     <E>::V();
-   |     ^^^^^^-- an argument of type `u8` is missing
+   |     ^^^^^^-- argument #1 of type `u8` is missing
    |
 note: tuple variant defined here
   --> $DIR/enum-variant-priority-higher-than-other-inherent.rs:5:5

--- a/tests/ui/type/type-ascription-instead-of-initializer.stderr
+++ b/tests/ui/type/type-ascription-instead-of-initializer.stderr
@@ -11,7 +11,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/type-ascription-instead-of-initializer.rs:2:12
    |
 LL |     let x: Vec::with_capacity(10, 20);
-   |            ^^^^^^^^^^^^^^^^^^     -- unexpected argument of type `{integer}`
+   |            ^^^^^^^^^^^^^^^^^^     -- unexpected argument #2 of type `{integer}`
    |
 note: associated function defined here
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL

--- a/tests/ui/type/type-check/point-at-inference-4.rs
+++ b/tests/ui/type/type-check/point-at-inference-4.rs
@@ -13,7 +13,7 @@ fn main() {
     //~^ ERROR this method takes 2 arguments but 1 argument was supplied
     //~| NOTE this argument has type `i32`...
     //~| NOTE ... which causes `s` to have type `S<i32, _>`
-    //~| NOTE an argument is missing
+    //~| NOTE argument #2 is missing
     //~| HELP provide the argument
     //~| HELP change the type of the numeric literal from `i32` to `u32`
     let t: S<u32, _> = s;

--- a/tests/ui/type/type-check/point-at-inference-4.stderr
+++ b/tests/ui/type/type-check/point-at-inference-4.stderr
@@ -2,7 +2,7 @@ error[E0061]: this method takes 2 arguments but 1 argument was supplied
   --> $DIR/point-at-inference-4.rs:12:7
    |
 LL |     s.infer(0i32);
-   |       ^^^^^------ an argument is missing
+   |       ^^^^^------ argument #2 is missing
    |
 note: method defined here
   --> $DIR/point-at-inference-4.rs:4:8

--- a/tests/ui/typeck/cyclic_type_ice.stderr
+++ b/tests/ui/typeck/cyclic_type_ice.stderr
@@ -13,7 +13,7 @@ error[E0057]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/cyclic_type_ice.rs:3:5
    |
 LL |     f(f);
-   |     ^--- an argument is missing
+   |     ^--- argument #2 is missing
    |
 note: closure defined here
   --> $DIR/cyclic_type_ice.rs:2:13

--- a/tests/ui/typeck/remove-extra-argument.stderr
+++ b/tests/ui/typeck/remove-extra-argument.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/remove-extra-argument.rs:6:5
    |
 LL |     l(vec![], vec![])
-   |     ^         ------ unexpected argument of type `Vec<_>`
+   |     ^         ------ unexpected argument #2 of type `Vec<_>`
    |
 note: function defined here
   --> $DIR/remove-extra-argument.rs:3:4

--- a/tests/ui/typeck/struct-enum-wrong-args.stderr
+++ b/tests/ui/typeck/struct-enum-wrong-args.stderr
@@ -2,7 +2,7 @@ error[E0061]: this enum variant takes 1 argument but 2 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:6:13
    |
 LL |     let _ = Some(3, 2);
-   |             ^^^^    - unexpected argument of type `{integer}`
+   |             ^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -16,9 +16,9 @@ error[E0061]: this enum variant takes 1 argument but 3 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:7:13
    |
 LL |     let _ = Ok(3, 6, 2);
-   |             ^^    -  - unexpected argument of type `{integer}`
+   |             ^^    -  - unexpected argument #3 of type `{integer}`
    |                   |
-   |                   unexpected argument of type `{integer}`
+   |                   unexpected argument #2 of type `{integer}`
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -32,7 +32,7 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:8:13
    |
 LL |     let _ = Ok();
-   |             ^^-- an argument is missing
+   |             ^^-- argument #1 is missing
    |
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -45,7 +45,7 @@ error[E0061]: this struct takes 1 argument but 0 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:9:13
    |
 LL |     let _ = Wrapper();
-   |             ^^^^^^^-- an argument of type `i32` is missing
+   |             ^^^^^^^-- argument #1 of type `i32` is missing
    |
 note: tuple struct defined here
   --> $DIR/struct-enum-wrong-args.rs:2:8
@@ -61,7 +61,7 @@ error[E0061]: this struct takes 1 argument but 2 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:10:13
    |
 LL |     let _ = Wrapper(5, 2);
-   |             ^^^^^^^    - unexpected argument of type `{integer}`
+   |             ^^^^^^^    - unexpected argument #2 of type `{integer}`
    |
 note: tuple struct defined here
   --> $DIR/struct-enum-wrong-args.rs:2:8
@@ -94,7 +94,7 @@ error[E0061]: this struct takes 2 arguments but 1 argument was supplied
   --> $DIR/struct-enum-wrong-args.rs:12:13
    |
 LL |     let _ = DoubleWrapper(5);
-   |             ^^^^^^^^^^^^^--- an argument of type `i32` is missing
+   |             ^^^^^^^^^^^^^--- argument #2 of type `i32` is missing
    |
 note: tuple struct defined here
   --> $DIR/struct-enum-wrong-args.rs:3:8
@@ -110,7 +110,7 @@ error[E0061]: this struct takes 2 arguments but 3 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:13:13
    |
 LL |     let _ = DoubleWrapper(5, 2, 7);
-   |             ^^^^^^^^^^^^^       - unexpected argument of type `{integer}`
+   |             ^^^^^^^^^^^^^       - unexpected argument #3 of type `{integer}`
    |
 note: tuple struct defined here
   --> $DIR/struct-enum-wrong-args.rs:3:8

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -928,6 +928,7 @@ compiler-team-contributors = [
     "@fee1-dead",
     "@jieyouxu",
     "@BoxyUwU",
+    "@chenyukang",
 ]
 compiler = [
     "compiler-team",
@@ -976,6 +977,7 @@ diagnostics = [
     "@estebank",
     "@oli-obk",
     "@TaKO8Ki",
+    "@chenyukang",
 ]
 parser = [
     "@compiler-errors",
@@ -989,6 +991,7 @@ lexer = [
     "@nnethercote",
     "@petrochenkov",
     "@estebank",
+    "@chenyukang",
 ]
 arena = [
     "@nnethercote",


### PR DESCRIPTION
Successful merges:

 - #125042 (Use ordinal number in argument error)
 - #127229 (rustdoc: click target for sidebar items flush left)
 - #127337 (Move a few intrinsics to Rust abi)
 - #127472 (MIR building: Stop using `unpack!` for `BlockAnd<()>`)
 - #127579 (Solve a error `.clone()` suggestion when moving a mutable reference)
 - #127769 (Don't use implicit features in `Cargo.toml` in `compiler/`)
 - #127844 (Remove invalid further restricting suggestion for type bound)
 - #127855 (Add myself to review rotation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=125042,127229,127337,127472,127579,127769,127844,127855)
<!-- homu-ignore:end -->