### PR TITLE
Fix associated item removal suggestion

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -1257,14 +1257,12 @@ pub fn prohibit_assoc_item_constraint(
             };
 
             // Now emit the suggestion
-            if let Ok(suggestion) = tcx.sess.source_map().span_to_snippet(removal_span) {
-                e.span_suggestion_verbose(
-                    removal_span,
-                    format!("consider removing this associated item {}", constraint.kind.descr()),
-                    suggestion,
-                    Applicability::MaybeIncorrect,
-                );
-            }
+            e.span_suggestion_verbose(
+                removal_span,
+                format!("consider removing this associated item {}", constraint.kind.descr()),
+                "",
+                Applicability::MaybeIncorrect,
+            );
         };
 
         // Suggest replacing the associated item binding with a generic argument.

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
@@ -1,0 +1,11 @@
+error[E0432]: unresolved import `inner`
+  --> $DIR/ice-unresolved-import-100241.rs:9:13
+   |
+LL |     pub use inner::S;
+   |             ^^^^^ maybe a missing crate `inner`?
+   |
+   = help: consider adding `extern crate inner` to use the `inner` crate
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/rustdoc-ui/invalid_associated_const.stderr
+++ b/tests/rustdoc-ui/invalid_associated_const.stderr
@@ -6,8 +6,9 @@ LL |     type A: S<C<X = 0i32> = 34>;
    |
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<X = 0i32> = 34>;
-   |                ~~~~~~~~~~
+LL -     type A: S<C<X = 0i32> = 34>;
+LL +     type A: S<C = 34>;
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/invalid_associated_const.rs:4:17
@@ -18,8 +19,9 @@ LL |     type A: S<C<X = 0i32> = 34>;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<X = 0i32> = 34>;
-   |                ~~~~~~~~~~
+LL -     type A: S<C<X = 0i32> = 34>;
+LL +     type A: S<C = 34>;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/rustdoc-ui/issue-102467.stderr
+++ b/tests/rustdoc-ui/issue-102467.stderr
@@ -6,8 +6,9 @@ LL |     type A: S<C<X = 0i32> = 34>;
    |
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<X = 0i32> = 34>;
-   |                ~~~~~~~~~~
+LL -     type A: S<C<X = 0i32> = 34>;
+LL +     type A: S<C = 34>;
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/issue-102467.rs:7:17
@@ -18,8 +19,9 @@ LL |     type A: S<C<X = 0i32> = 34>;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<X = 0i32> = 34>;
-   |                ~~~~~~~~~~
+LL -     type A: S<C<X = 0i32> = 34>;
+LL +     type A: S<C = 34>;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/associated-consts/issue-102335-const.stderr
+++ b/tests/ui/associated-consts/issue-102335-const.stderr
@@ -6,8 +6,9 @@ LL |     type A: S<C<X = 0i32> = 34>;
    |
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<X = 0i32> = 34>;
-   |                ~~~~~~~~~~
+LL -     type A: S<C<X = 0i32> = 34>;
+LL +     type A: S<C = 34>;
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/issue-102335-const.rs:4:17
@@ -18,8 +19,9 @@ LL |     type A: S<C<X = 0i32> = 34>;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<X = 0i32> = 34>;
-   |                ~~~~~~~~~~
+LL -     type A: S<C<X = 0i32> = 34>;
+LL +     type A: S<C = 34>;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/associated-type-bounds/issue-102335-ty.stderr
+++ b/tests/ui/associated-type-bounds/issue-102335-ty.stderr
@@ -6,8 +6,9 @@ LL |     type A: S<C<i32 = u32> = ()>; // Just one erroneous equality constraint
    |
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<i32 = u32> = ()>; // Just one erroneous equality constraint
-   |                ~~~~~~~~~~~
+LL -     type A: S<C<i32 = u32> = ()>; // Just one erroneous equality constraint
+LL +     type A: S<C = ()>; // Just one erroneous equality constraint
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/issue-102335-ty.rs:2:17
@@ -18,8 +19,9 @@ LL |     type A: S<C<i32 = u32> = ()>; // Just one erroneous equality constraint
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<i32 = u32> = ()>; // Just one erroneous equality constraint
-   |                ~~~~~~~~~~~
+LL -     type A: S<C<i32 = u32> = ()>; // Just one erroneous equality constraint
+LL +     type A: S<C = ()>; // Just one erroneous equality constraint
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/issue-102335-ty.rs:8:17
@@ -29,8 +31,9 @@ LL |     type A: S<C<i32 = u32, X = i32> = ()>; // More than one erroneous equal
    |
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<i32 = u32, X = i32> = ()>; // More than one erroneous equality constraints
-   |                 ~~~~~~~~~~
+LL -     type A: S<C<i32 = u32, X = i32> = ()>; // More than one erroneous equality constraints
+LL +     type A: S<C<X = i32> = ()>; // More than one erroneous equality constraints
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/issue-102335-ty.rs:8:17
@@ -41,8 +44,9 @@ LL |     type A: S<C<i32 = u32, X = i32> = ()>; // More than one erroneous equal
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<i32 = u32, X = i32> = ()>; // More than one erroneous equality constraints
-   |                 ~~~~~~~~~~
+LL -     type A: S<C<i32 = u32, X = i32> = ()>; // More than one erroneous equality constraints
+LL +     type A: S<C<X = i32> = ()>; // More than one erroneous equality constraints
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/associated-type-bounds/no-gat-position.stderr
+++ b/tests/ui/associated-type-bounds/no-gat-position.stderr
@@ -6,8 +6,9 @@ LL |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a, As1: Copy>>;
    |
 help: consider removing this associated item constraint
    |
-LL |     fn next<'a>(&'a mut self) -> Option<Self::Item<'a, As1: Copy>>;
-   |                                                      ~~~~~~~~~~~
+LL -     fn next<'a>(&'a mut self) -> Option<Self::Item<'a, As1: Copy>>;
+LL +     fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/associated-types-eq-2.stderr
+++ b/tests/ui/associated-types/associated-types-eq-2.stderr
@@ -50,8 +50,9 @@ LL | impl Tr1<A = usize> for usize {
    |
 help: consider removing this associated item binding
    |
-LL | impl Tr1<A = usize> for usize {
-   |         ~~~~~~~~~~~
+LL - impl Tr1<A = usize> for usize {
+LL + impl Tr1 for usize {
+   |
 
 error[E0046]: not all trait items implemented, missing: `A`
   --> $DIR/associated-types-eq-2.rs:20:1
@@ -70,8 +71,9 @@ LL | fn baz<I: Tr1>(_x: &<I as Tr1<A=Bar>>::A) {}
    |
 help: consider removing this associated item binding
    |
-LL | fn baz<I: Tr1>(_x: &<I as Tr1<A=Bar>>::A) {}
-   |                              ~~~~~~~
+LL - fn baz<I: Tr1>(_x: &<I as Tr1<A=Bar>>::A) {}
+LL + fn baz<I: Tr1>(_x: &<I as Tr1>::A) {}
+   |
 
 error[E0107]: trait takes 3 generic arguments but 1 generic argument was supplied
   --> $DIR/associated-types-eq-2.rs:40:6
@@ -128,8 +130,9 @@ LL | impl Tr2<i32, t2 = Qux, T3 = usize> for Qux {
    |
 help: consider removing this associated item binding
    |
-LL | impl Tr2<i32, t2 = Qux, T3 = usize> for Qux {
-   |             ~~~~~~~~~~
+LL - impl Tr2<i32, t2 = Qux, T3 = usize> for Qux {
+LL + impl Tr2<i32, T3 = usize> for Qux {
+   |
 
 error[E0107]: trait takes 3 generic arguments but 1 generic argument was supplied
   --> $DIR/associated-types-eq-2.rs:54:6
@@ -157,8 +160,9 @@ LL | impl Tr2<i32, X = Qux, Y = usize> for Bar {
    |
 help: consider removing this associated item binding
    |
-LL | impl Tr2<i32, X = Qux, Y = usize> for Bar {
-   |             ~~~~~~~~~
+LL - impl Tr2<i32, X = Qux, Y = usize> for Bar {
+LL + impl Tr2<i32, Y = usize> for Bar {
+   |
 
 error[E0107]: trait takes 3 generic arguments but 2 generic arguments were supplied
   --> $DIR/associated-types-eq-2.rs:61:6
@@ -228,8 +232,9 @@ LL | impl Tr3<n = 42, T2 = Qux, T3 = usize> for Qux {
    |
 help: consider removing this associated item binding
    |
-LL | impl Tr3<n = 42, T2 = Qux, T3 = usize> for Qux {
-   |          ~~~~~~~
+LL - impl Tr3<n = 42, T2 = Qux, T3 = usize> for Qux {
+LL + impl Tr3<T2 = Qux, T3 = usize> for Qux {
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/associated-types-eq-2.rs:92:10
@@ -239,8 +244,9 @@ LL | impl Tr3<N = u32, T2 = Qux, T3 = usize> for Bar {
    |
 help: consider removing this associated item binding
    |
-LL | impl Tr3<N = u32, T2 = Qux, T3 = usize> for Bar {
-   |          ~~~~~~~~
+LL - impl Tr3<N = u32, T2 = Qux, T3 = usize> for Bar {
+LL + impl Tr3<T2 = Qux, T3 = usize> for Bar {
+   |
 
 error[E0107]: trait takes 3 generic arguments but 1 generic argument was supplied
   --> $DIR/associated-types-eq-2.rs:98:6
@@ -268,8 +274,9 @@ LL | impl Tr3<42, T2 = 42, T3 = usize> for Bar {
    |
 help: consider removing this associated item binding
    |
-LL | impl Tr3<42, T2 = 42, T3 = usize> for Bar {
-   |            ~~~~~~~~~
+LL - impl Tr3<42, T2 = 42, T3 = usize> for Bar {
+LL + impl Tr3<42, T3 = usize> for Bar {
+   |
 
 error[E0107]: trait takes 3 generic arguments but 0 generic arguments were supplied
   --> $DIR/associated-types-eq-2.rs:106:6
@@ -295,8 +302,9 @@ LL | impl Tr3<X = 42, Y = Qux, Z = usize> for Bar {
    |
 help: consider removing this associated item binding
    |
-LL | impl Tr3<X = 42, Y = Qux, Z = usize> for Bar {
-   |          ~~~~~~~
+LL - impl Tr3<X = 42, Y = Qux, Z = usize> for Bar {
+LL + impl Tr3<Y = Qux, Z = usize> for Bar {
+   |
 
 error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/associated-types-eq-2.rs:117:13

--- a/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
+++ b/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
@@ -15,8 +15,9 @@ LL | impl Super1<'_, bar(..): Send> for () {}
    |
 help: consider removing this associated item constraint
    |
-LL | impl Super1<'_, bar(..): Send> for () {}
-   |               ~~~~~~~~~~~~~~~
+LL - impl Super1<'_, bar(..): Send> for () {}
+LL + impl Super1<'_> for () {}
+   |
 
 error[E0046]: not all trait items implemented, missing: `bar`
   --> $DIR/rtn-in-impl-signature.rs:10:1

--- a/tests/ui/error-codes/E0229.stderr
+++ b/tests/ui/error-codes/E0229.stderr
@@ -6,8 +6,9 @@ LL | fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
    |
 help: consider removing this associated item binding
    |
-LL | fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
-   |                        ~~~~~~~~~
+LL - fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
+LL + fn baz<I>(x: &<I as Foo>::A) {}
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/E0229.rs:13:25
@@ -18,8 +19,9 @@ LL | fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider removing this associated item binding
    |
-LL | fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
-   |                        ~~~~~~~~~
+LL - fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
+LL + fn baz<I>(x: &<I as Foo>::A) {}
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/E0229.rs:13:25
@@ -30,8 +32,9 @@ LL | fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider removing this associated item binding
    |
-LL | fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
-   |                        ~~~~~~~~~
+LL - fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
+LL + fn baz<I>(x: &<I as Foo>::A) {}
+   |
 
 error[E0277]: the trait bound `I: Foo` is not satisfied
   --> $DIR/E0229.rs:13:15

--- a/tests/ui/generic-associated-types/issue-102335-gat.stderr
+++ b/tests/ui/generic-associated-types/issue-102335-gat.stderr
@@ -6,8 +6,9 @@ LL |     type A: S<C<(), i32 = ()> = ()>;
    |
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<(), i32 = ()> = ()>;
-   |                   ~~~~~~~~~~
+LL -     type A: S<C<(), i32 = ()> = ()>;
+LL +     type A: S<C<()> = ()>;
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/issue-102335-gat.rs:2:21
@@ -18,8 +19,9 @@ LL |     type A: S<C<(), i32 = ()> = ()>;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider removing this associated item binding
    |
-LL |     type A: S<C<(), i32 = ()> = ()>;
-   |                   ~~~~~~~~~~
+LL -     type A: S<C<(), i32 = ()> = ()>;
+LL +     type A: S<C<()> = ()>;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/issue-83753-invalid-associated-type-supertrait-hrtb.stderr
+++ b/tests/ui/lifetimes/issue-83753-invalid-associated-type-supertrait-hrtb.stderr
@@ -6,8 +6,9 @@ LL |     fn bar(foo: Foo<Target = usize>) {}
    |
 help: consider removing this associated item binding
    |
-LL |     fn bar(foo: Foo<Target = usize>) {}
-   |                    ~~~~~~~~~~~~~~~~
+LL -     fn bar(foo: Foo<Target = usize>) {}
+LL +     fn bar(foo: Foo) {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-85347.stderr
+++ b/tests/ui/suggestions/issue-85347.stderr
@@ -22,8 +22,9 @@ LL |     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
    |
 help: consider removing this associated item binding
    |
-LL |     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
-   |                                             ~~~~~~~~~~~~~~~
+LL -     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
+LL +     type Bar<'a>: Deref<Target = <Self>::Bar>;
+   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/issue-85347.rs:3:42
@@ -51,8 +52,9 @@ LL |     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider removing this associated item binding
    |
-LL |     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
-   |                                             ~~~~~~~~~~~~~~~
+LL -     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
+LL +     type Bar<'a>: Deref<Target = <Self>::Bar>;
+   |
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
We were previously telling people to write what was already there, instead of removal (treating it as a `help`). We now properly suggest to remove the code that needs to be removed.

```
error[E0229]: associated item constraints are not allowed here
  --> $DIR/E0229.rs:13:25
   |
LL | fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
   |                         ^^^^^^^ associated item constraint not allowed here
   |
help: consider removing this associated item binding
   |
LL - fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
LL + fn baz<I>(x: &<I as Foo>::A) {}
   |
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
