### PR TITLE
Don't elaborate associated types with Sized bounds in `trait_object_ty` in cfi

### DIFF
--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -230,6 +230,7 @@ fn trait_object_ty<'tcx>(tcx: TyCtxt<'tcx>, poly_trait_ref: ty::PolyTraitRef<'tc
             tcx.associated_items(super_poly_trait_ref.def_id())
                 .in_definition_order()
                 .filter(|item| item.kind == ty::AssocKind::Type)
+                .filter(|item| !tcx.generics_require_sized_self(item.def_id))
                 .map(move |assoc_ty| {
                     super_poly_trait_ref.map_bound(|super_trait_ref| {
                         let alias_ty =

--- a/tests/ui/sanitizer/cfi-sized-associated-ty.rs
+++ b/tests/ui/sanitizer/cfi-sized-associated-ty.rs
@@ -1,0 +1,38 @@
+// Check that we only elaborate non-`Self: Sized` associated types when
+// erasing the receiver from trait ref.
+
+//@ revisions: cfi kcfi
+// FIXME(#122848) Remove only-linux once OSX CFI binaries work
+//@ only-linux
+//@ [cfi] needs-sanitizer-cfi
+//@ [kcfi] needs-sanitizer-kcfi
+//@ compile-flags: -C target-feature=-crt-static
+//@ [cfi] compile-flags: -C codegen-units=1 -C lto -C prefer-dynamic=off -C opt-level=0
+//@ [cfi] compile-flags: -Z sanitizer=cfi
+//@ [kcfi] compile-flags: -Z sanitizer=kcfi
+//@ [kcfi] compile-flags: -C panic=abort -C prefer-dynamic=off
+//@ run-pass
+
+trait Foo {
+    type Bar<'a>
+    where
+        Self: Sized;
+
+    fn test(&self);
+}
+
+impl Foo for () {
+    type Bar<'a> = ()
+    where
+        Self: Sized;
+
+    fn test(&self) {}
+}
+
+fn test(x: &dyn Foo) {
+    x.test();
+}
+
+fn main() {
+    test(&());
+}


### PR DESCRIPTION
The elaboration mechanism introduced in #123005 didn't filter for associated types with `Self: Sized` bounds, which since #112319 has excluded them from the object type.

Fixes #127881
cc @maurer @rcvalle 