### PR TITLE
Accurate `use` rename suggestion span

### DIFF
--- a/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
@@ -1,0 +1,11 @@
+error[E0432]: unresolved import `inner`
+  --> $DIR/ice-unresolved-import-100241.rs:9:13
+   |
+LL |     pub use inner::S;
+   |             ^^^^^ maybe a missing crate `inner`?
+   |
+   = help: consider adding `extern crate inner` to use the `inner` crate
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/blind/blind-item-block-item-shadow.stderr
+++ b/tests/ui/blind/blind-item-block-item-shadow.stderr
@@ -10,7 +10,7 @@ LL |         use foo::Bar;
 help: you can use `as` to change the binding name of the import
    |
 LL |         use foo::Bar as OtherBar;
-   |             ~~~~~~~~~~~~~~~~~~~~
+   |                      +++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/blind/blind-item-item-shadow.stderr
+++ b/tests/ui/blind/blind-item-item-shadow.stderr
@@ -11,7 +11,7 @@ LL | use foo::foo;
 help: you can use `as` to change the binding name of the import
    |
 LL | use foo::foo as other_foo;
-   |     ~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/duplicate/duplicate-check-macro-exports.stderr
+++ b/tests/ui/duplicate/duplicate-check-macro-exports.stderr
@@ -11,7 +11,7 @@ LL | macro_rules! panic { () => {} }
 help: you can use `as` to change the binding name of the import
    |
 LL | pub use std::panic as other_panic;
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0252.stderr
+++ b/tests/ui/error-codes/E0252.stderr
@@ -10,7 +10,7 @@ LL | use bar::baz;
 help: you can use `as` to change the binding name of the import
    |
 LL | use bar::baz as other_baz;
-   |     ~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0254.stderr
+++ b/tests/ui/error-codes/E0254.stderr
@@ -11,7 +11,7 @@ LL | use foo::alloc;
 help: you can use `as` to change the binding name of the import
    |
 LL | use foo::alloc as other_alloc;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0255.stderr
+++ b/tests/ui/error-codes/E0255.stderr
@@ -11,7 +11,7 @@ LL | fn foo() {}
 help: you can use `as` to change the binding name of the import
    |
 LL | use bar::foo as other_foo;
-   |     ~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/double-import.stderr
+++ b/tests/ui/imports/double-import.stderr
@@ -10,7 +10,7 @@ LL | use sub2::foo;
 help: you can use `as` to change the binding name of the import
    |
 LL | use sub2::foo as other_foo;
-   |     ~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-19498.stderr
+++ b/tests/ui/imports/issue-19498.stderr
@@ -11,7 +11,7 @@ LL | mod A {}
 help: you can use `as` to change the binding name of the import
    |
 LL | use self::A as OtherA;
-   |     ~~~~~~~~~~~~~~~~~
+   |             +++++++++
 
 error[E0255]: the name `B` is defined multiple times
   --> $DIR/issue-19498.rs:5:1
@@ -26,7 +26,7 @@ LL | pub mod B {}
 help: you can use `as` to change the binding name of the import
    |
 LL | use self::B as OtherB;
-   |     ~~~~~~~~~~~~~~~~~
+   |             +++++++++
 
 error[E0255]: the name `D` is defined multiple times
   --> $DIR/issue-19498.rs:9:5
@@ -40,7 +40,7 @@ LL |     mod D {}
 help: you can use `as` to change the binding name of the import
    |
 LL |     use C::D as OtherD;
-   |         ~~~~~~~~~~~~~~
+   |              +++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/imports/issue-24081.stderr
+++ b/tests/ui/imports/issue-24081.stderr
@@ -11,7 +11,7 @@ LL | type Add = bool;
 help: you can use `as` to change the binding name of the import
    |
 LL | use std::ops::Add as OtherAdd;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                   +++++++++++
 
 error[E0255]: the name `Sub` is defined multiple times
   --> $DIR/issue-24081.rs:9:1
@@ -26,7 +26,7 @@ LL | struct Sub { x: f32 }
 help: you can use `as` to change the binding name of the import
    |
 LL | use std::ops::Sub as OtherSub;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                   +++++++++++
 
 error[E0255]: the name `Mul` is defined multiple times
   --> $DIR/issue-24081.rs:11:1
@@ -41,7 +41,7 @@ LL | enum Mul { A, B }
 help: you can use `as` to change the binding name of the import
    |
 LL | use std::ops::Mul as OtherMul;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                   +++++++++++
 
 error[E0255]: the name `Div` is defined multiple times
   --> $DIR/issue-24081.rs:13:1
@@ -56,7 +56,7 @@ LL | mod Div { }
 help: you can use `as` to change the binding name of the import
    |
 LL | use std::ops::Div as OtherDiv;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                   +++++++++++
 
 error[E0255]: the name `Rem` is defined multiple times
   --> $DIR/issue-24081.rs:15:1
@@ -71,7 +71,7 @@ LL | trait Rem {  }
 help: you can use `as` to change the binding name of the import
    |
 LL | use std::ops::Rem as OtherRem;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                   +++++++++++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/imports/issue-25396.stderr
+++ b/tests/ui/imports/issue-25396.stderr
@@ -10,7 +10,7 @@ LL | use bar::baz;
 help: you can use `as` to change the binding name of the import
    |
 LL | use bar::baz as other_baz;
-   |     ~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++
 
 error[E0252]: the name `Quux` is defined multiple times
   --> $DIR/issue-25396.rs:7:5
@@ -24,7 +24,7 @@ LL | use bar::Quux;
 help: you can use `as` to change the binding name of the import
    |
 LL | use bar::Quux as OtherQuux;
-   |     ~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++
 
 error[E0252]: the name `blah` is defined multiple times
   --> $DIR/issue-25396.rs:10:5
@@ -38,7 +38,7 @@ LL | use bar::blah;
 help: you can use `as` to change the binding name of the import
    |
 LL | use bar::blah as other_blah;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~
+   |               +++++++++++++
 
 error[E0252]: the name `WOMP` is defined multiple times
   --> $DIR/issue-25396.rs:13:5
@@ -52,7 +52,7 @@ LL | use bar::WOMP;
 help: you can use `as` to change the binding name of the import
    |
 LL | use bar::WOMP as OtherWOMP;
-   |     ~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/imports/issue-32354-suggest-import-rename.stderr
+++ b/tests/ui/imports/issue-32354-suggest-import-rename.stderr
@@ -10,7 +10,7 @@ LL | use extension2::ConstructorExtension;
 help: you can use `as` to change the binding name of the import
    |
 LL | use extension2::ConstructorExtension as OtherConstructorExtension;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                      ++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-45829/import-self.stderr
+++ b/tests/ui/imports/issue-45829/import-self.stderr
@@ -48,7 +48,7 @@ LL | use foo::self;
 help: you can use `as` to change the binding name of the import
    |
 LL | use foo as other_foo;
-   |     ~~~~~~~~~~~~~~~~
+   |         ~~~~~~~~~~~~
 
 error[E0252]: the name `A` is defined multiple times
   --> $DIR/import-self.rs:16:11

--- a/tests/ui/imports/issue-45829/issue-45829.stderr
+++ b/tests/ui/imports/issue-45829/issue-45829.stderr
@@ -10,7 +10,7 @@ LL | use foo::{A, B as A};
 help: you can use `as` to change the binding name of the import
    |
 LL | use foo::{A, B as OtherA};
-   |              ~~~~~~~~~~~
+   |                ~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-45829/rename-use-vs-extern.stderr
+++ b/tests/ui/imports/issue-45829/rename-use-vs-extern.stderr
@@ -10,7 +10,7 @@ LL | use std as issue_45829_b;
 help: you can use `as` to change the binding name of the import
    |
 LL | use std as other_issue_45829_b;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |         ~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-45829/rename-use-with-tabs.stderr
+++ b/tests/ui/imports/issue-45829/rename-use-with-tabs.stderr
@@ -10,7 +10,7 @@ LL | use foo::{A, bar::B    as    A};
 help: you can use `as` to change the binding name of the import
    |
 LL | use foo::{A, bar::B as OtherA};
-   |              ~~~~~~~~~~~~~~~~
+   |                     ~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-45829/rename-with-path.stderr
+++ b/tests/ui/imports/issue-45829/rename-with-path.stderr
@@ -10,7 +10,7 @@ LL | use std::{collections::HashMap as A, sync::Arc as A};
 help: you can use `as` to change the binding name of the import
    |
 LL | use std::{collections::HashMap as A, sync::Arc as OtherA};
-   |                                      ~~~~~~~~~~~~~~~~~~~
+   |                                                ~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-45829/rename.stderr
+++ b/tests/ui/imports/issue-45829/rename.stderr
@@ -10,7 +10,7 @@ LL | use std as core;
 help: you can use `as` to change the binding name of the import
    |
 LL | use std as other_core;
-   |     ~~~~~~~~~~~~~~~~~
+   |         ~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-52891.stderr
+++ b/tests/ui/imports/issue-52891.stderr
@@ -98,7 +98,7 @@ LL | use issue_52891::b::inner;
 help: you can use `as` to change the binding name of the import
    |
 LL | use issue_52891::b::inner as other_inner;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                           ++++++++++++++
 
 error[E0254]: the name `issue_52891` is defined multiple times
   --> $DIR/issue-52891.rs:31:19

--- a/tests/ui/imports/issue-8640.stderr
+++ b/tests/ui/imports/issue-8640.stderr
@@ -10,7 +10,7 @@ LL |     mod bar {}
 help: you can use `as` to change the binding name of the import
    |
 LL |     use baz::bar as other_bar;
-   |         ~~~~~~~~~~~~~~~~~~~~~
+   |                  ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/resolve-conflict-import-vs-extern-crate.stderr
+++ b/tests/ui/resolve/resolve-conflict-import-vs-extern-crate.stderr
@@ -8,7 +8,7 @@ LL | use std::slice as std;
 help: you can use `as` to change the binding name of the import
    |
 LL | use std::slice as other_std;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~
+   |                ~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/resolve-conflict-item-vs-import.stderr
+++ b/tests/ui/resolve/resolve-conflict-item-vs-import.stderr
@@ -11,7 +11,7 @@ LL | fn transmute() {}
 help: you can use `as` to change the binding name of the import
    |
 LL | use std::mem::transmute as other_transmute;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                         ++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/resolve-conflict-type-vs-import.stderr
+++ b/tests/ui/resolve/resolve-conflict-type-vs-import.stderr
@@ -11,7 +11,7 @@ LL | struct Iter;
 help: you can use `as` to change the binding name of the import
    |
 LL | use std::slice::Iter as OtherIter;
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/variants/variant-namespacing.stderr
+++ b/tests/ui/variants/variant-namespacing.stderr
@@ -11,7 +11,7 @@ LL | pub use variant_namespacing::XE::{XStruct, XTuple, XUnit};
 help: you can use `as` to change the binding name of the import
    |
 LL | pub use variant_namespacing::XE::{XStruct as OtherXStruct, XTuple, XUnit};
-   |                                   ~~~~~~~~~~~~~~~~~~~~~~~
+   |                                           +++++++++++++++
 
 error[E0255]: the name `XTuple` is defined multiple times
   --> $DIR/variant-namespacing.rs:24:44
@@ -26,7 +26,7 @@ LL | pub use variant_namespacing::XE::{XStruct, XTuple, XUnit};
 help: you can use `as` to change the binding name of the import
    |
 LL | pub use variant_namespacing::XE::{XStruct, XTuple as OtherXTuple, XUnit};
-   |                                            ~~~~~~~~~~~~~~~~~~~~~
+   |                                                   ++++++++++++++
 
 error[E0255]: the name `XUnit` is defined multiple times
   --> $DIR/variant-namespacing.rs:24:52
@@ -41,7 +41,7 @@ LL | pub use variant_namespacing::XE::{XStruct, XTuple, XUnit};
 help: you can use `as` to change the binding name of the import
    |
 LL | pub use variant_namespacing::XE::{XStruct, XTuple, XUnit as OtherXUnit};
-   |                                                    ~~~~~~~~~~~~~~~~~~~
+   |                                                          +++++++++++++
 
 error[E0255]: the name `Struct` is defined multiple times
   --> $DIR/variant-namespacing.rs:28:13
@@ -56,7 +56,7 @@ LL | pub use E::{Struct, Tuple, Unit};
 help: you can use `as` to change the binding name of the import
    |
 LL | pub use E::{Struct as OtherStruct, Tuple, Unit};
-   |             ~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++
 
 error[E0255]: the name `Tuple` is defined multiple times
   --> $DIR/variant-namespacing.rs:28:21
@@ -71,7 +71,7 @@ LL | pub use E::{Struct, Tuple, Unit};
 help: you can use `as` to change the binding name of the import
    |
 LL | pub use E::{Struct, Tuple as OtherTuple, Unit};
-   |                     ~~~~~~~~~~~~~~~~~~~
+   |                           +++++++++++++
 
 error[E0255]: the name `Unit` is defined multiple times
   --> $DIR/variant-namespacing.rs:28:28
@@ -86,7 +86,7 @@ LL | pub use E::{Struct, Tuple, Unit};
 help: you can use `as` to change the binding name of the import
    |
 LL | pub use E::{Struct, Tuple, Unit as OtherUnit};
-   |                            ~~~~~~~~~~~~~~~~~
+   |                                 ++++++++++++
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
When suggesting to rename an import with `as`, use a smaller span to render the suggestion with a better format:

```
error[E0252]: the name `baz` is defined multiple times
  --> $DIR/issue-25396.rs:4:5
   |
LL | use foo::baz;
   |     -------- previous import of the module `baz` here
LL | use bar::baz;
   |     ^^^^^^^^ `baz` reimported here
   |
   = note: `baz` must be defined only once in the type namespace of this module
help: you can use `as` to change the binding name of the import
   |
LL | use bar::baz as other_baz;
   |              ++++++++++++
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
