### PR TITLE
Add trailing newline check for `rustc --print` in `run-make-support`

### DIFF
--- a/src/tools/run-make-support/src/command.rs
+++ b/src/tools/run-make-support/src/command.rs
@@ -239,6 +239,18 @@ impl CompletedProcess {
         self
     }
 
+    /// Checks that `stdout` ends with a newline if it is not empty.
+    #[track_caller]
+    pub fn assert_stdout_ends_with_newline(&self) -> &Self {
+        if !self.stdout_utf8().is_empty() {
+            assert!(
+                self.stdout_utf8().ends_with(['\r', '\n'].as_slice()),
+                "stdout does not end with newline"
+            );
+        }
+        self
+    }
+
     /// Checks that trimmed `stderr` matches trimmed `expected`.
     #[track_caller]
     pub fn assert_stderr_equals<S: AsRef<str>>(&self, expected: S) -> &Self {

--- a/src/tools/run-make-support/src/external_deps/rustc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustc.rs
@@ -272,9 +272,15 @@ impl Rustc {
     }
 
     /// Specify the print request.
+    ///
+    /// Also checks that the [`CompletedProcess`](crate::command::CompletedProcess)
+    /// `stdout` ends with a newline.
     pub fn print(&mut self, request: &str) -> &mut Self {
         self.cmd.arg("--print");
         self.cmd.arg(request);
+        self.cmd.add_completed_process_check("`--print` ends with newline", |completed_process| {
+            completed_process.assert_stdout_ends_with_newline();
+        });
         self
     }
 

--- a/tests/run-make/link-arg/rmake.rs
+++ b/tests/run-make/link-arg/rmake.rs
@@ -17,5 +17,4 @@ fn main() {
         .run_unchecked();
     out.assert_stdout_contains("lfoo");
     out.assert_stdout_contains("lbar");
-    assert!(out.stdout_utf8().ends_with('\n'));
 }


### PR DESCRIPTION
From [this comment](https://github.com/rust-lang/rust/pull/127877#issuecomment-2234363580).

Checks that `rustc --print` stdout ends with a newline. 
Adds `CompletedProcess` check closures to `Command`. 
Unfortunately, this means that `#[derive(Debug)]` macro for `Command` no longer works.  

Part of #121876.

r? @jieyouxu