### PR TITLE
More accurate span for type parameter suggestion

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -1340,11 +1340,13 @@ pub fn prohibit_assoc_item_constraint(
                                 format!("<{lifetimes}{type_with_constraints}>"),
                             )
                         };
-                        let suggestions =
-                            vec![param_decl, (constraint.span, format!("{}", matching_param.name))];
+                        let suggestions = vec![
+                            param_decl,
+                            (constraint.span.with_lo(constraint.ident.span.hi()), String::new()),
+                        ];
 
                         err.multipart_suggestion_verbose(
-                            format!("declare the type parameter right after the `impl` keyword"),
+                            "declare the type parameter right after the `impl` keyword",
                             suggestions,
                             Applicability::MaybeIncorrect,
                         );

--- a/tests/ui/generics/impl-block-params-declared-in-wrong-spot-issue-113073.stderr
+++ b/tests/ui/generics/impl-block-params-declared-in-wrong-spot-issue-113073.stderr
@@ -14,8 +14,9 @@ LL | impl Foo<T: Default> for String {}
    |
 help: declare the type parameter right after the `impl` keyword
    |
-LL | impl<T: Default> Foo<T> for String {}
-   |     ++++++++++++     ~
+LL - impl Foo<T: Default> for String {}
+LL + impl<T: Default> Foo<T> for String {}
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:7:10
@@ -25,8 +26,9 @@ LL | impl Foo<T: 'a + Default> for u8 {}
    |
 help: declare the type parameter right after the `impl` keyword
    |
-LL | impl<'a, T: 'a + Default> Foo<T> for u8 {}
-   |     +++++++++++++++++++++     ~
+LL - impl Foo<T: 'a + Default> for u8 {}
+LL + impl<'a, T: 'a + Default> Foo<T> for u8 {}
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:13:13
@@ -36,8 +38,9 @@ LL | impl<T> Foo<T: Default> for u16 {}
    |
 help: declare the type parameter right after the `impl` keyword
    |
-LL | impl<T, T: Default> Foo<T> for u16 {}
-   |       ++++++++++++      ~
+LL - impl<T> Foo<T: Default> for u16 {}
+LL + impl<T, T: Default> Foo<T> for u16 {}
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:17:14
@@ -47,8 +50,9 @@ LL | impl<'a> Foo<T: 'a + Default> for u32 {}
    |
 help: declare the type parameter right after the `impl` keyword
    |
-LL | impl<'a, 'a, T: 'a + Default> Foo<T> for u32 {}
-   |        +++++++++++++++++++++      ~
+LL - impl<'a> Foo<T: 'a + Default> for u32 {}
+LL + impl<'a, 'a, T: 'a + Default> Foo<T> for u32 {}
+   |
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:23:10
@@ -58,8 +62,9 @@ LL | impl Bar<T: Default, K: Default> for String {}
    |
 help: declare the type parameter right after the `impl` keyword
    |
-LL | impl<T: Default> Bar<T, K: Default> for String {}
-   |     ++++++++++++     ~
+LL - impl Bar<T: Default, K: Default> for String {}
+LL + impl<T: Default> Bar<T, K: Default> for String {}
+   |
 
 error[E0107]: trait takes 2 generic arguments but 1 generic argument was supplied
   --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:27:9
@@ -87,8 +92,9 @@ LL | impl<T> Bar<T, K: Default> for u8 {}
    |
 help: declare the type parameter right after the `impl` keyword
    |
-LL | impl<T, K: Default> Bar<T, K> for u8 {}
-   |       ++++++++++++         ~
+LL - impl<T> Bar<T, K: Default> for u8 {}
+LL + impl<T, K: Default> Bar<T, K> for u8 {}
+   |
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
After:

```
error[E0229]: associated item constraints are not allowed here
  --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:3:10
   |
LL | impl Foo<T: Default> for String {}
   |          ^^^^^^^^^^ associated item constraint not allowed here
   |
help: declare the type parameter right after the `impl` keyword
   |
LL - impl Foo<T: Default> for String {}
LL + impl<T: Default> Foo<T> for String {}
   |
```

Before:

```
error[E0229]: associated item constraints are not allowed here
  --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:3:10
   |
LL | impl Foo<T: Default> for String {}
   |          ^^^^^^^^^^ associated item constraint not allowed here
   |
help: declare the type parameter right after the `impl` keyword
   |
LL | impl<T: Default> Foo<T> for String {}
   |     ++++++++++++     ~
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
