### PR TITLE
Tweak suggestions when using incorrect type of enum literal

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -1087,7 +1087,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     );
 
                     let adt_def = qself_ty.ty_adt_def().expect("enum is not an ADT");
-                    if let Some(suggested_name) = find_best_match_for_name(
+                    if let Some(variant_name) = find_best_match_for_name(
                         &adt_def
                             .variants()
                             .iter()
@@ -1095,12 +1095,66 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                             .collect::<Vec<Symbol>>(),
                         assoc_ident.name,
                         None,
-                    ) {
-                        err.span_suggestion(
-                            assoc_ident.span,
+                    ) && let Some(variant) =
+                        adt_def.variants().iter().find(|s| s.name == variant_name)
+                    {
+                        let mut suggestion = vec![(assoc_ident.span, variant_name.to_string())];
+                        if let hir::Node::Stmt(hir::Stmt {
+                            kind: hir::StmtKind::Semi(ref expr),
+                            ..
+                        })
+                        | hir::Node::Expr(ref expr) = tcx.parent_hir_node(hir_ref_id)
+                            && let hir::ExprKind::Struct(..) = expr.kind
+                        {
+                            match variant.ctor {
+                                None => {
+                                    // struct
+                                    suggestion = vec![(
+                                        assoc_ident.span.with_hi(expr.span.hi()),
+                                        if variant.fields.is_empty() {
+                                            format!("{variant_name} {{}}")
+                                        } else {
+                                            format!(
+                                                "{variant_name} {{ {} }}",
+                                                variant
+                                                    .fields
+                                                    .iter()
+                                                    .map(|f| format!("{}: /* value */", f.name))
+                                                    .collect::<Vec<_>>()
+                                                    .join(", ")
+                                            )
+                                        },
+                                    )];
+                                }
+                                Some((hir::def::CtorKind::Fn, def_id)) => {
+                                    // tuple
+                                    let fn_sig = tcx.fn_sig(def_id).instantiate_identity();
+                                    let inputs = fn_sig.inputs().skip_binder();
+                                    suggestion = vec![(
+                                        assoc_ident.span.with_hi(expr.span.hi()),
+                                        format!(
+                                            "{variant_name}({})",
+                                            inputs
+                                                .iter()
+                                                .map(|i| format!("/* {i} */"))
+                                                .collect::<Vec<_>>()
+                                                .join(", ")
+                                        ),
+                                    )];
+                                }
+                                Some((hir::def::CtorKind::Const, _)) => {
+                                    // unit
+                                    suggestion = vec![(
+                                        assoc_ident.span.with_hi(expr.span.hi()),
+                                        variant_name.to_string(),
+                                    )];
+                                }
+                            }
+                        }
+                        err.multipart_suggestion_verbose(
                             "there is a variant with a similar name",
-                            suggested_name,
-                            Applicability::MaybeIncorrect,
+                            suggestion,
+                            Applicability::HasPlaceholders,
                         );
                     } else {
                         err.span_label(

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -519,7 +519,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 Ty::new_error(tcx, e)
             }
             Res::Def(DefKind::Variant, _) => {
-                let e = report_unexpected_variant_res(tcx, res, qpath, expr.span, E0533, "value");
+                let e = report_unexpected_variant_res(
+                    tcx,
+                    res,
+                    Some(expr),
+                    qpath,
+                    expr.span,
+                    E0533,
+                    "value",
+                );
                 Ty::new_error(tcx, e)
             }
             _ => {

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2218,8 +2218,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         );
 
         let variant_ident_span = self.tcx.def_ident_span(variant.def_id).unwrap();
-        match variant.ctor_kind() {
-            Some(CtorKind::Fn) => match ty.kind() {
+        match variant.ctor {
+            Some((CtorKind::Fn, def_id)) => match ty.kind() {
                 ty::Adt(adt, ..) if adt.is_enum() => {
                     err.span_label(
                         variant_ident_span,
@@ -2230,28 +2230,44 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         ),
                     );
                     err.span_label(field.ident.span, "field does not exist");
+                    let fn_sig = self.tcx.fn_sig(def_id).instantiate_identity();
+                    let inputs = fn_sig.inputs().skip_binder();
+                    let fields = format!(
+                        "({})",
+                        inputs.iter().map(|i| format!("/* {i} */")).collect::<Vec<_>>().join(", ")
+                    );
+                    let (replace_span, sugg) = match expr.kind {
+                        hir::ExprKind::Struct(qpath, ..) => {
+                            (qpath.span().shrink_to_hi().with_hi(expr.span.hi()), fields)
+                        }
+                        _ => {
+                            (expr.span, format!("{ty}::{variant}{fields}", variant = variant.name))
+                        }
+                    };
                     err.span_suggestion_verbose(
-                        expr.span,
+                        replace_span,
                         format!(
                             "`{adt}::{variant}` is a tuple {kind_name}, use the appropriate syntax",
                             adt = ty,
                             variant = variant.name,
                         ),
-                        format!(
-                            "{adt}::{variant}(/* fields */)",
-                            adt = ty,
-                            variant = variant.name,
-                        ),
+                        sugg,
                         Applicability::HasPlaceholders,
                     );
                 }
                 _ => {
                     err.span_label(variant_ident_span, format!("`{ty}` defined here"));
                     err.span_label(field.ident.span, "field does not exist");
+                    let fn_sig = self.tcx.fn_sig(def_id).instantiate_identity();
+                    let inputs = fn_sig.inputs().skip_binder();
+                    let fields = format!(
+                        "({})",
+                        inputs.iter().map(|i| format!("/* {i} */")).collect::<Vec<_>>().join(", ")
+                    );
                     err.span_suggestion_verbose(
                         expr.span,
                         format!("`{ty}` is a tuple {kind_name}, use the appropriate syntax",),
-                        format!("{ty}(/* fields */)"),
+                        format!("{ty}{fields}"),
                         Applicability::HasPlaceholders,
                     );
                 }

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -1023,7 +1023,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             Res::Def(DefKind::AssocFn | DefKind::Ctor(_, CtorKind::Fn) | DefKind::Variant, _) => {
                 let expected = "unit struct, unit variant or constant";
-                let e = report_unexpected_variant_res(tcx, res, qpath, pat.span, E0533, expected);
+                let e =
+                    report_unexpected_variant_res(tcx, res, None, qpath, pat.span, E0533, expected);
                 return Ty::new_error(tcx, e);
             }
             Res::SelfCtor(def_id) => {
@@ -1036,6 +1037,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let e = report_unexpected_variant_res(
                         tcx,
                         res,
+                        None,
                         qpath,
                         pat.span,
                         E0533,
@@ -1189,7 +1191,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
         let report_unexpected_res = |res: Res| {
             let expected = "tuple struct or tuple variant";
-            let e = report_unexpected_variant_res(tcx, res, qpath, pat.span, E0164, expected);
+            let e = report_unexpected_variant_res(tcx, res, None, qpath, pat.span, E0164, expected);
             on_error(e);
             e
         };

--- a/tests/ui/empty/empty-struct-braces-expr.stderr
+++ b/tests/ui/empty/empty-struct-braces-expr.stderr
@@ -71,12 +71,22 @@ error[E0533]: expected value, found struct variant `E::Empty3`
    |
 LL |     let e3 = E::Empty3;
    |              ^^^^^^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     let e3 = E::Empty3 {};
+   |                        ++
 
 error[E0533]: expected value, found struct variant `E::Empty3`
   --> $DIR/empty-struct-braces-expr.rs:19:14
    |
 LL |     let e3 = E::Empty3();
    |              ^^^^^^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     let e3 = E::Empty3 {};
+   |                        ~~
 
 error[E0423]: expected function, tuple struct or tuple variant, found struct `XEmpty1`
   --> $DIR/empty-struct-braces-expr.rs:23:15
@@ -104,25 +114,34 @@ error[E0599]: no variant or associated item named `Empty3` found for enum `empty
   --> $DIR/empty-struct-braces-expr.rs:25:19
    |
 LL |     let xe3 = XE::Empty3;
-   |                   ^^^^^^
-   |                   |
-   |                   variant or associated item not found in `XE`
-   |                   help: there is a variant with a similar name: `XEmpty3`
+   |                   ^^^^^^ variant or associated item not found in `XE`
+   |
+help: there is a variant with a similar name
+   |
+LL |     let xe3 = XE::XEmpty3;
+   |                   ~~~~~~~
 
 error[E0599]: no variant or associated item named `Empty3` found for enum `empty_struct::XE` in the current scope
   --> $DIR/empty-struct-braces-expr.rs:26:19
    |
 LL |     let xe3 = XE::Empty3();
-   |                   ^^^^^^
-   |                   |
-   |                   variant or associated item not found in `XE`
-   |                   help: there is a variant with a similar name: `XEmpty3`
+   |                   ^^^^^^ variant or associated item not found in `XE`
+   |
+help: there is a variant with a similar name
+   |
+LL |     let xe3 = XE::XEmpty3 {};
+   |                   ~~~~~~~~~~
 
 error[E0599]: no variant named `Empty1` found for enum `empty_struct::XE`
   --> $DIR/empty-struct-braces-expr.rs:28:9
    |
 LL |     XE::Empty1 {};
-   |         ^^^^^^ help: there is a variant with a similar name: `XEmpty3`
+   |         ^^^^^^
+   |
+help: there is a variant with a similar name
+   |
+LL |     XE::XEmpty3 {};
+   |         ~~~~~~~~~~
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/enum/error-variant-with-turbofishes.stderr
+++ b/tests/ui/enum/error-variant-with-turbofishes.stderr
@@ -3,6 +3,11 @@ error[E0533]: expected value, found struct variant `Struct<0>::Variant`
    |
 LL |     let x = Struct::<0>::Variant;
    |             ^^^^^^^^^^^^^^^^^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     let x = Struct::<0>::Variant { x: /* value */ };
+   |                                  ++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/expr/issue-22933-2.stderr
+++ b/tests/ui/expr/issue-22933-2.stderr
@@ -5,10 +5,12 @@ LL | enum Delicious {
    | -------------- variant or associated item `PIE` not found for this enum
 ...
 LL |     ApplePie = Delicious::Apple as isize | Delicious::PIE as isize,
-   |                                                       ^^^
-   |                                                       |
-   |                                                       variant or associated item not found in `Delicious`
-   |                                                       help: there is a variant with a similar name: `Pie`
+   |                                                       ^^^ variant or associated item not found in `Delicious`
+   |
+help: there is a variant with a similar name
+   |
+LL |     ApplePie = Delicious::Apple as isize | Delicious::Pie as isize,
+   |                                                       ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-23217.stderr
+++ b/tests/ui/issues/issue-23217.stderr
@@ -4,10 +4,12 @@ error[E0599]: no variant or associated item named `A` found for enum `SomeEnum` 
 LL | pub enum SomeEnum {
    | ----------------- variant or associated item `A` not found for this enum
 LL |     B = SomeEnum::A,
-   |                   ^
-   |                   |
-   |                   variant or associated item not found in `SomeEnum`
-   |                   help: there is a variant with a similar name: `B`
+   |                   ^ variant or associated item not found in `SomeEnum`
+   |
+help: there is a variant with a similar name
+   |
+LL |     B = SomeEnum::B,
+   |                   ~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-28971.stderr
+++ b/tests/ui/issues/issue-28971.stderr
@@ -5,10 +5,12 @@ LL | enum Foo {
    | -------- variant or associated item `Baz` not found for this enum
 ...
 LL |             Foo::Baz(..) => (),
-   |                  ^^^
-   |                  |
-   |                  variant or associated item not found in `Foo`
-   |                  help: there is a variant with a similar name: `Bar`
+   |                  ^^^ variant or associated item not found in `Foo`
+   |
+help: there is a variant with a similar name
+   |
+LL |             Foo::Bar(..) => (),
+   |                  ~~~
 
 error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
   --> $DIR/issue-28971.rs:15:5

--- a/tests/ui/issues/issue-34209.stderr
+++ b/tests/ui/issues/issue-34209.stderr
@@ -5,7 +5,12 @@ LL | enum S {
    | ------ variant `B` not found here
 ...
 LL |         S::B {} => {},
-   |            ^ help: there is a variant with a similar name: `A`
+   |            ^
+   |
+help: there is a variant with a similar name
+   |
+LL |         S::A {} => {},
+   |            ~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-4736.stderr
+++ b/tests/ui/issues/issue-4736.stderr
@@ -9,8 +9,8 @@ LL |     let z = NonCopyable{ p: () };
    |
 help: `NonCopyable` is a tuple struct, use the appropriate syntax
    |
-LL |     let z = NonCopyable(/* fields */);
-   |             ~~~~~~~~~~~~~~~~~~~~~~~~~
+LL |     let z = NonCopyable(/* () */);
+   |             ~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-80607.stderr
+++ b/tests/ui/issues/issue-80607.stderr
@@ -9,8 +9,8 @@ LL |     Enum::V1 { x }
    |
 help: `Enum::V1` is a tuple variant, use the appropriate syntax
    |
-LL |     Enum::V1(/* fields */)
-   |     ~~~~~~~~~~~~~~~~~~~~~~
+LL |     Enum::V1(/* i32 */)
+   |             ~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/numeric/numeric-fields.stderr
+++ b/tests/ui/numeric/numeric-fields.stderr
@@ -9,8 +9,8 @@ LL |     let s = S{0b1: 10, 0: 11};
    |
 help: `S` is a tuple struct, use the appropriate syntax
    |
-LL |     let s = S(/* fields */);
-   |             ~~~~~~~~~~~~~~~
+LL |     let s = S(/* u8 */, /* u16 */);
+   |             ~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0026]: struct `S` does not have a field named `0x1`
   --> $DIR/numeric-fields.rs:7:17

--- a/tests/ui/parser/struct-literal-variant-in-if.stderr
+++ b/tests/ui/parser/struct-literal-variant-in-if.stderr
@@ -47,6 +47,11 @@ error[E0533]: expected value, found struct variant `E::V`
    |
 LL |     if x == E::V { field } {}
    |             ^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     if x == (E::V { field }) {}
+   |             +              +
 
 error[E0308]: mismatched types
   --> $DIR/struct-literal-variant-in-if.rs:10:20

--- a/tests/ui/resolve/issue-18252.stderr
+++ b/tests/ui/resolve/issue-18252.stderr
@@ -3,6 +3,11 @@ error[E0533]: expected value, found struct variant `Foo::Variant`
    |
 LL |     let f = Foo::Variant(42);
    |             ^^^^^^^^^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     let f = Foo::Variant { x: /* value */ };
+   |                          ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-19452.stderr
+++ b/tests/ui/resolve/issue-19452.stderr
@@ -3,12 +3,22 @@ error[E0533]: expected value, found struct variant `Homura::Madoka`
    |
 LL |     let homura = Homura::Madoka;
    |                  ^^^^^^^^^^^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     let homura = Homura::Madoka { age: /* value */ };
+   |                                 ++++++++++++++++++++
 
 error[E0533]: expected value, found struct variant `issue_19452_aux::Homura::Madoka`
   --> $DIR/issue-19452.rs:13:18
    |
 LL |     let homura = issue_19452_aux::Homura::Madoka;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     let homura = issue_19452_aux::Homura::Madoka { age: /* value */ };
+   |                                                  ++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -295,6 +295,11 @@ error[E0533]: expected value, found struct variant `Z::Struct`
    |
 LL |         let _: Z = Z::Struct;
    |                    ^^^^^^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |         let _: Z = Z::Struct { s: /* value */ };
+   |                              ++++++++++++++++++
 
 error[E0618]: expected function, found enum variant `Z::Unit`
   --> $DIR/privacy-enum-ctor.rs:31:17
@@ -336,6 +341,11 @@ error[E0533]: expected value, found struct variant `m::E::Struct`
    |
 LL |     let _: E = m::E::Struct;
    |                ^^^^^^^^^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     let _: E = m::E::Struct { s: /* value */ };
+   |                             ++++++++++++++++++
 
 error[E0618]: expected function, found enum variant `m::E::Unit`
   --> $DIR/privacy-enum-ctor.rs:47:16
@@ -377,6 +387,11 @@ error[E0533]: expected value, found struct variant `E::Struct`
    |
 LL |     let _: E = E::Struct;
    |                ^^^^^^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     let _: E = E::Struct { s: /* value */ };
+   |                          ++++++++++++++++++
 
 error[E0618]: expected function, found enum variant `E::Unit`
   --> $DIR/privacy-enum-ctor.rs:55:16
@@ -400,6 +415,11 @@ error[E0533]: expected value, found struct variant `m::n::Z::Struct`
    |
 LL |     let _: Z = m::n::Z::Struct;
    |                ^^^^^^^^^^^^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     let _: Z = m::n::Z::Struct { s: /* value */ };
+   |                                ++++++++++++++++++
 
 error: aborting due to 23 previous errors
 

--- a/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -129,6 +129,11 @@ error[E0533]: expected value, found struct variant `E::B`
    |
 LL |     let _: E = E::B;
    |                ^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     let _: E = E::B { a: /* value */ };
+   |                     ++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:37:20

--- a/tests/ui/suggestions/incorrect-variant-literal.rs
+++ b/tests/ui/suggestions/incorrect-variant-literal.rs
@@ -1,0 +1,55 @@
+//@ only-linux
+//@ compile-flags: --error-format=human --color=always
+
+enum Enum {
+    Unit,
+    Tuple(i32),
+    Struct { x: i32 },
+}
+
+fn main() {
+    Enum::Unit;
+    Enum::Tuple;
+    Enum::Struct;
+    Enum::Unit();
+    Enum::Tuple();
+    Enum::Struct();
+    Enum::Unit {};
+    Enum::Tuple {};
+    Enum::Struct {};
+    Enum::Unit(0);
+    Enum::Tuple(0);
+    Enum::Struct(0);
+    Enum::Unit { x: 0 };
+    Enum::Tuple { x: 0 };
+    Enum::Struct { x: 0 }; // ok
+    Enum::Unit(0, 0);
+    Enum::Tuple(0, 0);
+    Enum::Struct(0, 0);
+    Enum::Unit { x: 0, y: 0 };
+
+    Enum::Tuple { x: 0, y: 0 };
+
+    Enum::Struct { x: 0, y: 0 };
+    Enum::unit;
+    Enum::tuple;
+    Enum::r#struct;
+    Enum::unit();
+    Enum::tuple();
+    Enum::r#struct();
+    Enum::unit {};
+    Enum::tuple {};
+    Enum::r#struct {};
+    Enum::unit(0);
+    Enum::tuple(0);
+    Enum::r#struct(0);
+    Enum::unit { x: 0 };
+    Enum::tuple { x: 0 };
+    Enum::r#struct { x: 0 };
+    Enum::unit(0, 0);
+    Enum::tuple(0, 0);
+    Enum::r#struct(0, 0);
+    Enum::unit { x: 0, y: 0 };
+    Enum::tuple { x: 0, y: 0 };
+    Enum::r#struct { x: 0, y: 0 };
+}

--- a/tests/ui/suggestions/incorrect-variant-literal.svg
+++ b/tests/ui/suggestions/incorrect-variant-literal.svg
@@ -1,4 +1,4 @@
-<svg width="886px" height="7436px" xmlns="http://www.w3.org/2000/svg">
+<svg width="886px" height="9038px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -31,795 +31,795 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
 </tspan>
-    <tspan x="10px" y="118px">
+    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found enum variant `Enum::Unit`</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: you might have meant to create a new value of the struct</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:14:5</tspan>
+    <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-010"> { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
+    <tspan x="10px" y="190px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-010">++++++++++++++++++</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">enum variant `Enum::Unit` defined here</tspan>
+    <tspan x="10px" y="208px">
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found enum variant `Enum::Unit`</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit();</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:14:5</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">--</tspan>
+    <tspan x="10px" y="262px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
+    <tspan x="10px" y="298px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">enum variant `Enum::Unit` defined here</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Unit` is a unit enum variant, and does not take parentheses to be constructed</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit();</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="352px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">--</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Unit</tspan><tspan class="fg-ansi256-009">()</tspan><tspan>;</tspan>
+    <tspan x="10px" y="370px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Unit;</tspan>
+    <tspan x="10px" y="388px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
 </tspan>
     <tspan x="10px" y="406px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="424px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Unit` is a unit enum variant, and does not take parentheses to be constructed</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan class="fg-ansi256-009 bold">error[E0061]</tspan><tspan class="bold">: this enum variant takes 1 argument but 0 arguments were supplied</tspan>
+    <tspan x="10px" y="442px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:15:5</tspan>
+    <tspan x="10px" y="460px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Unit</tspan><tspan class="fg-ansi256-009">()</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="478px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Unit;</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple();</tspan>
+    <tspan x="10px" y="496px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">--</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">argument #1 of type `i32` is missing</tspan>
+    <tspan x="10px" y="514px">
 </tspan>
-    <tspan x="10px" y="532px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="532px"><tspan class="fg-ansi256-009 bold">error[E0061]</tspan><tspan class="bold">: this enum variant takes 1 argument but 0 arguments were supplied</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: tuple variant defined here</tspan>
+    <tspan x="10px" y="550px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:15:5</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:6:5</tspan>
+    <tspan x="10px" y="568px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="586px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple();</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+    <tspan x="10px" y="604px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">--</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">argument #1 of type `i32` is missing</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^^^^^</tspan>
+    <tspan x="10px" y="622px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: provide the argument</tspan>
+    <tspan x="10px" y="640px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: tuple variant defined here</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="658px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:6:5</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="676px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~</tspan>
+    <tspan x="10px" y="694px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
 </tspan>
-    <tspan x="10px" y="712px">
+    <tspan x="10px" y="712px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
+    <tspan x="10px" y="730px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: provide the argument</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:16:5</tspan>
+    <tspan x="10px" y="748px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="766px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct();</tspan>
+    <tspan x="10px" y="784px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
+    <tspan x="10px" y="802px">
 </tspan>
-    <tspan x="10px" y="820px">
+    <tspan x="10px" y="820px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan class="fg-ansi256-009 bold">error[E0063]</tspan><tspan class="bold">: missing field `0` in initializer of `Enum`</tspan>
+    <tspan x="10px" y="838px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:16:5</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:18:5</tspan>
+    <tspan x="10px" y="856px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="874px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct();</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple {};</tspan>
+    <tspan x="10px" y="892px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">missing `0`</tspan>
+    <tspan x="10px" y="910px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="928px">
+    <tspan x="10px" y="928px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: you might have meant to create a new value of the struct</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan class="fg-ansi256-009 bold">error[E0063]</tspan><tspan class="bold">: missing field `x` in initializer of `Enum`</tspan>
+    <tspan x="10px" y="946px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:19:5</tspan>
+    <tspan x="10px" y="964px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-010"> { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="982px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct {};</tspan>
+    <tspan x="10px" y="1000px">
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">missing `x`</tspan>
+    <tspan x="10px" y="1018px"><tspan class="fg-ansi256-009 bold">error[E0063]</tspan><tspan class="bold">: missing field `0` in initializer of `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="1036px">
+    <tspan x="10px" y="1036px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:18:5</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found `Enum`</tspan>
+    <tspan x="10px" y="1054px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:20:5</tspan>
+    <tspan x="10px" y="1072px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple {};</tspan>
 </tspan>
-    <tspan x="10px" y="1090px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1090px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">missing `0`</tspan>
 </tspan>
-    <tspan x="10px" y="1108px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
+    <tspan x="10px" y="1108px">
 </tspan>
-    <tspan x="10px" y="1126px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Unit` defined here</tspan>
+    <tspan x="10px" y="1126px"><tspan class="fg-ansi256-009 bold">error[E0063]</tspan><tspan class="bold">: missing field `x` in initializer of `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="1144px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="1144px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:19:5</tspan>
 </tspan>
-    <tspan x="10px" y="1162px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit(0);</tspan>
+    <tspan x="10px" y="1162px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1180px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">---</tspan>
+    <tspan x="10px" y="1180px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct {};</tspan>
 </tspan>
-    <tspan x="10px" y="1198px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1198px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">missing `x`</tspan>
 </tspan>
-    <tspan x="10px" y="1216px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
+    <tspan x="10px" y="1216px">
 </tspan>
-    <tspan x="10px" y="1234px">
+    <tspan x="10px" y="1234px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="1252px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
+    <tspan x="10px" y="1252px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:20:5</tspan>
 </tspan>
-    <tspan x="10px" y="1270px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:22:5</tspan>
+    <tspan x="10px" y="1270px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1288px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1288px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
 </tspan>
-    <tspan x="10px" y="1306px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct(0);</tspan>
+    <tspan x="10px" y="1306px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Unit` defined here</tspan>
 </tspan>
-    <tspan x="10px" y="1324px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
+    <tspan x="10px" y="1324px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="1342px">
+    <tspan x="10px" y="1342px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit(0);</tspan>
 </tspan>
-    <tspan x="10px" y="1360px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `x`</tspan>
+    <tspan x="10px" y="1360px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">---</tspan>
 </tspan>
-    <tspan x="10px" y="1378px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:23:18</tspan>
+    <tspan x="10px" y="1378px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1396px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1396px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
 </tspan>
-    <tspan x="10px" y="1414px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0 };</tspan>
+    <tspan x="10px" y="1414px">
 </tspan>
-    <tspan x="10px" y="1432px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
+    <tspan x="10px" y="1432px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
 </tspan>
-    <tspan x="10px" y="1450px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1450px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:22:5</tspan>
 </tspan>
-    <tspan x="10px" y="1468px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+    <tspan x="10px" y="1468px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1486px">
+    <tspan x="10px" y="1486px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct(0);</tspan>
 </tspan>
-    <tspan x="10px" y="1504px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `x`</tspan>
+    <tspan x="10px" y="1504px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
 </tspan>
-    <tspan x="10px" y="1522px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:24:19</tspan>
+    <tspan x="10px" y="1522px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1540px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1540px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: you might have meant to create a new value of the struct</tspan>
 </tspan>
-    <tspan x="10px" y="1558px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+    <tspan x="10px" y="1558px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1576px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
+    <tspan x="10px" y="1576px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-010"> { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="1594px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="1594px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="1612px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0 };</tspan>
+    <tspan x="10px" y="1612px">
 </tspan>
-    <tspan x="10px" y="1630px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                   </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
+    <tspan x="10px" y="1630px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `x`</tspan>
 </tspan>
-    <tspan x="10px" y="1648px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1648px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:23:18</tspan>
 </tspan>
-    <tspan x="10px" y="1666px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
+    <tspan x="10px" y="1666px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1684px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1684px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="1702px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="1702px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
 </tspan>
-    <tspan x="10px" y="1720px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
+    <tspan x="10px" y="1720px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1738px">
+    <tspan x="10px" y="1738px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
 </tspan>
-    <tspan x="10px" y="1756px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found `Enum`</tspan>
+    <tspan x="10px" y="1756px">
 </tspan>
-    <tspan x="10px" y="1774px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:26:5</tspan>
+    <tspan x="10px" y="1774px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `x`</tspan>
 </tspan>
-    <tspan x="10px" y="1792px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1792px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:24:19</tspan>
 </tspan>
-    <tspan x="10px" y="1810px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
+    <tspan x="10px" y="1810px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1828px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Unit` defined here</tspan>
+    <tspan x="10px" y="1828px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
 </tspan>
-    <tspan x="10px" y="1846px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="1846px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
 </tspan>
-    <tspan x="10px" y="1864px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit(0, 0);</tspan>
+    <tspan x="10px" y="1864px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="1882px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">------</tspan>
+    <tspan x="10px" y="1882px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="1900px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1900px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                   </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
 </tspan>
-    <tspan x="10px" y="1918px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
+    <tspan x="10px" y="1918px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1936px">
+    <tspan x="10px" y="1936px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
 </tspan>
-    <tspan x="10px" y="1954px"><tspan class="fg-ansi256-009 bold">error[E0061]</tspan><tspan class="bold">: this enum variant takes 1 argument but 2 arguments were supplied</tspan>
+    <tspan x="10px" y="1954px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1972px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:27:5</tspan>
+    <tspan x="10px" y="1972px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="1990px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1990px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="2008px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple(0, 0);</tspan>
+    <tspan x="10px" y="2008px">
 </tspan>
-    <tspan x="10px" y="2026px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan>    </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">unexpected argument #2 of type `{integer}`</tspan>
+    <tspan x="10px" y="2026px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="2044px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2044px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:26:5</tspan>
 </tspan>
-    <tspan x="10px" y="2062px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: tuple variant defined here</tspan>
+    <tspan x="10px" y="2062px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2080px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:6:5</tspan>
+    <tspan x="10px" y="2080px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
 </tspan>
-    <tspan x="10px" y="2098px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2098px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Unit` defined here</tspan>
 </tspan>
-    <tspan x="10px" y="2116px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+    <tspan x="10px" y="2116px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="2134px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^^^^^</tspan>
+    <tspan x="10px" y="2134px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit(0, 0);</tspan>
 </tspan>
-    <tspan x="10px" y="2152px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: remove the extra argument</tspan>
+    <tspan x="10px" y="2152px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">------</tspan>
 </tspan>
-    <tspan x="10px" y="2170px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2170px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2188px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple(0</tspan><tspan class="fg-ansi256-009">, 0</tspan><tspan>);</tspan>
+    <tspan x="10px" y="2188px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
 </tspan>
-    <tspan x="10px" y="2206px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple(0);</tspan>
+    <tspan x="10px" y="2206px">
 </tspan>
-    <tspan x="10px" y="2224px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2224px"><tspan class="fg-ansi256-009 bold">error[E0061]</tspan><tspan class="bold">: this enum variant takes 1 argument but 2 arguments were supplied</tspan>
 </tspan>
-    <tspan x="10px" y="2242px">
+    <tspan x="10px" y="2242px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:27:5</tspan>
 </tspan>
-    <tspan x="10px" y="2260px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
+    <tspan x="10px" y="2260px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2278px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:28:5</tspan>
+    <tspan x="10px" y="2278px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple(0, 0);</tspan>
 </tspan>
-    <tspan x="10px" y="2296px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2296px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan>    </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">unexpected argument #2 of type `{integer}`</tspan>
 </tspan>
-    <tspan x="10px" y="2314px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct(0, 0);</tspan>
+    <tspan x="10px" y="2314px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2332px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
+    <tspan x="10px" y="2332px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: tuple variant defined here</tspan>
 </tspan>
-    <tspan x="10px" y="2350px">
+    <tspan x="10px" y="2350px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:6:5</tspan>
 </tspan>
-    <tspan x="10px" y="2368px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `x`</tspan>
+    <tspan x="10px" y="2368px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2386px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:29:18</tspan>
+    <tspan x="10px" y="2386px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
 </tspan>
-    <tspan x="10px" y="2404px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2404px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="2422px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="2422px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: remove the extra argument</tspan>
 </tspan>
-    <tspan x="10px" y="2440px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
+    <tspan x="10px" y="2440px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2458px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2458px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple(0</tspan><tspan class="fg-ansi256-009">, 0</tspan><tspan>);</tspan>
 </tspan>
-    <tspan x="10px" y="2476px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+    <tspan x="10px" y="2476px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple(0);</tspan>
 </tspan>
-    <tspan x="10px" y="2494px">
+    <tspan x="10px" y="2494px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2512px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `y`</tspan>
+    <tspan x="10px" y="2512px">
 </tspan>
-    <tspan x="10px" y="2530px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:29:24</tspan>
+    <tspan x="10px" y="2530px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
 </tspan>
-    <tspan x="10px" y="2548px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2548px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:28:5</tspan>
 </tspan>
-    <tspan x="10px" y="2566px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="2566px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2584px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                        </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
+    <tspan x="10px" y="2584px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct(0, 0);</tspan>
 </tspan>
-    <tspan x="10px" y="2602px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2602px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
 </tspan>
-    <tspan x="10px" y="2620px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+    <tspan x="10px" y="2620px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2638px">
+    <tspan x="10px" y="2638px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: you might have meant to create a new value of the struct</tspan>
 </tspan>
-    <tspan x="10px" y="2656px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `x`</tspan>
+    <tspan x="10px" y="2656px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2674px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:31:19</tspan>
+    <tspan x="10px" y="2674px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-010"> { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="2692px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2692px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="2710px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+    <tspan x="10px" y="2710px">
 </tspan>
-    <tspan x="10px" y="2728px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
+    <tspan x="10px" y="2728px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `x`</tspan>
 </tspan>
-    <tspan x="10px" y="2746px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="2746px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:29:18</tspan>
 </tspan>
-    <tspan x="10px" y="2764px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="2764px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2782px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                   </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
+    <tspan x="10px" y="2782px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="2800px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2800px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
 </tspan>
-    <tspan x="10px" y="2818px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
+    <tspan x="10px" y="2818px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2836px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2836px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
 </tspan>
-    <tspan x="10px" y="2854px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="2854px">
 </tspan>
-    <tspan x="10px" y="2872px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
+    <tspan x="10px" y="2872px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `y`</tspan>
 </tspan>
-    <tspan x="10px" y="2890px">
+    <tspan x="10px" y="2890px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:29:24</tspan>
 </tspan>
-    <tspan x="10px" y="2908px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `y`</tspan>
+    <tspan x="10px" y="2908px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2926px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:31:25</tspan>
+    <tspan x="10px" y="2926px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="2944px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2944px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                        </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
 </tspan>
-    <tspan x="10px" y="2962px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+    <tspan x="10px" y="2962px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2980px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
+    <tspan x="10px" y="2980px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
 </tspan>
-    <tspan x="10px" y="2998px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="2998px">
 </tspan>
-    <tspan x="10px" y="3016px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="3016px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `x`</tspan>
 </tspan>
-    <tspan x="10px" y="3034px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                         </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
+    <tspan x="10px" y="3034px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:31:19</tspan>
 </tspan>
     <tspan x="10px" y="3052px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3070px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
+    <tspan x="10px" y="3070px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
 </tspan>
-    <tspan x="10px" y="3088px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3088px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
 </tspan>
-    <tspan x="10px" y="3106px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="3106px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="3124px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
+    <tspan x="10px" y="3124px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="3142px">
+    <tspan x="10px" y="3142px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                   </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
 </tspan>
-    <tspan x="10px" y="3160px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Struct` has no field named `y`</tspan>
+    <tspan x="10px" y="3160px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3178px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:33:26</tspan>
+    <tspan x="10px" y="3178px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
 </tspan>
     <tspan x="10px" y="3196px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3214px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="3214px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="3232px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                          </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Struct` does not have this field</tspan>
+    <tspan x="10px" y="3232px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="3250px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3250px">
 </tspan>
-    <tspan x="10px" y="3268px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+    <tspan x="10px" y="3268px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `y`</tspan>
 </tspan>
-    <tspan x="10px" y="3286px">
+    <tspan x="10px" y="3286px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:31:25</tspan>
 </tspan>
-    <tspan x="10px" y="3304px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="3304px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3322px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:34:11</tspan>
+    <tspan x="10px" y="3322px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
 </tspan>
-    <tspan x="10px" y="3340px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3340px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
 </tspan>
-    <tspan x="10px" y="3358px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="3358px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="3376px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+    <tspan x="10px" y="3376px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="3394px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="3394px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                         </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
 </tspan>
-    <tspan x="10px" y="3412px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit;</tspan>
+    <tspan x="10px" y="3412px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3430px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+    <tspan x="10px" y="3430px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
 </tspan>
-    <tspan x="10px" y="3448px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="3448px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3466px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="3466px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="3484px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+    <tspan x="10px" y="3484px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
 </tspan>
     <tspan x="10px" y="3502px">
 </tspan>
-    <tspan x="10px" y="3520px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="3520px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Struct` has no field named `y`</tspan>
 </tspan>
-    <tspan x="10px" y="3538px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:35:11</tspan>
+    <tspan x="10px" y="3538px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:33:26</tspan>
 </tspan>
     <tspan x="10px" y="3556px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3574px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="3574px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="3592px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+    <tspan x="10px" y="3592px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                          </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Struct` does not have this field</tspan>
 </tspan>
-    <tspan x="10px" y="3610px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="3610px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3628px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple;</tspan>
+    <tspan x="10px" y="3628px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
 </tspan>
-    <tspan x="10px" y="3646px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+    <tspan x="10px" y="3646px">
 </tspan>
-    <tspan x="10px" y="3664px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="3664px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="3682px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="3682px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:34:11</tspan>
 </tspan>
-    <tspan x="10px" y="3700px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+    <tspan x="10px" y="3700px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3718px">
+    <tspan x="10px" y="3718px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="3736px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="3736px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="3754px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:36:11</tspan>
+    <tspan x="10px" y="3754px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="3772px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3772px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit;</tspan>
 </tspan>
-    <tspan x="10px" y="3790px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="3790px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="3808px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+    <tspan x="10px" y="3808px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3826px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="3826px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name (notice the capitalization difference)</tspan>
 </tspan>
-    <tspan x="10px" y="3844px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct;</tspan>
+    <tspan x="10px" y="3844px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3862px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+    <tspan x="10px" y="3862px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="3880px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="3880px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="3898px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="3898px">
 </tspan>
-    <tspan x="10px" y="3916px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+    <tspan x="10px" y="3916px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="3934px">
+    <tspan x="10px" y="3934px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:35:11</tspan>
 </tspan>
-    <tspan x="10px" y="3952px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="3952px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3970px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:37:11</tspan>
+    <tspan x="10px" y="3970px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="3988px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3988px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="4006px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="4006px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="4024px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+    <tspan x="10px" y="4024px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple;</tspan>
 </tspan>
-    <tspan x="10px" y="4042px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="4042px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="4060px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit();</tspan>
+    <tspan x="10px" y="4060px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4078px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+    <tspan x="10px" y="4078px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="4096px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="4096px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4114px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="4114px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="4132px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+    <tspan x="10px" y="4132px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~</tspan>
 </tspan>
     <tspan x="10px" y="4150px">
 </tspan>
-    <tspan x="10px" y="4168px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="4168px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="4186px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:38:11</tspan>
+    <tspan x="10px" y="4186px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:36:11</tspan>
 </tspan>
     <tspan x="10px" y="4204px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
     <tspan x="10px" y="4222px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="4240px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+    <tspan x="10px" y="4240px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
 </tspan>
     <tspan x="10px" y="4258px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="4276px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple();</tspan>
+    <tspan x="10px" y="4276px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct;</tspan>
 </tspan>
-    <tspan x="10px" y="4294px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+    <tspan x="10px" y="4294px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="4312px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="4312px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4330px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="4330px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="4348px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+    <tspan x="10px" y="4348px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4366px">
+    <tspan x="10px" y="4366px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="4384px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="4384px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="4402px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:39:11</tspan>
+    <tspan x="10px" y="4402px">
 </tspan>
-    <tspan x="10px" y="4420px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4420px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="4438px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="4438px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:37:11</tspan>
 </tspan>
-    <tspan x="10px" y="4456px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+    <tspan x="10px" y="4456px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4474px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="4474px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="4492px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct();</tspan>
+    <tspan x="10px" y="4492px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="4510px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+    <tspan x="10px" y="4510px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="4528px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="4528px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit();</tspan>
 </tspan>
-    <tspan x="10px" y="4546px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="4546px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="4564px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+    <tspan x="10px" y="4564px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4582px">
+    <tspan x="10px" y="4582px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="4600px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
+    <tspan x="10px" y="4600px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4618px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:40:11</tspan>
+    <tspan x="10px" y="4618px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="4636px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4636px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="4654px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="4654px">
 </tspan>
-    <tspan x="10px" y="4672px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
+    <tspan x="10px" y="4672px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="4690px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="4690px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:38:11</tspan>
 </tspan>
-    <tspan x="10px" y="4708px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit {};</tspan>
+    <tspan x="10px" y="4708px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4726px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+    <tspan x="10px" y="4726px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="4744px">
+    <tspan x="10px" y="4744px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="4762px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
+    <tspan x="10px" y="4762px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="4780px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:41:11</tspan>
+    <tspan x="10px" y="4780px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple();</tspan>
 </tspan>
-    <tspan x="10px" y="4798px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4798px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="4816px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="4816px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4834px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
+    <tspan x="10px" y="4834px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="4852px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="4852px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4870px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple {};</tspan>
+    <tspan x="10px" y="4870px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="4888px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+    <tspan x="10px" y="4888px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~</tspan>
 </tspan>
     <tspan x="10px" y="4906px">
 </tspan>
-    <tspan x="10px" y="4924px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
+    <tspan x="10px" y="4924px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="4942px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:42:11</tspan>
+    <tspan x="10px" y="4942px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:39:11</tspan>
 </tspan>
     <tspan x="10px" y="4960px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
     <tspan x="10px" y="4978px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="4996px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
+    <tspan x="10px" y="4996px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
 </tspan>
     <tspan x="10px" y="5014px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="5032px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct {};</tspan>
+    <tspan x="10px" y="5032px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct();</tspan>
 </tspan>
-    <tspan x="10px" y="5050px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+    <tspan x="10px" y="5050px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="5068px">
+    <tspan x="10px" y="5068px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5086px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="5086px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="5104px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:43:11</tspan>
+    <tspan x="10px" y="5104px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5122px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5122px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="5140px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="5140px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="5158px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+    <tspan x="10px" y="5158px">
 </tspan>
-    <tspan x="10px" y="5176px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="5176px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="5194px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit(0);</tspan>
+    <tspan x="10px" y="5194px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:40:11</tspan>
 </tspan>
-    <tspan x="10px" y="5212px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+    <tspan x="10px" y="5212px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5230px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="5230px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="5248px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="5248px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="5266px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+    <tspan x="10px" y="5266px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="5284px">
+    <tspan x="10px" y="5284px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit {};</tspan>
 </tspan>
-    <tspan x="10px" y="5302px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="5302px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="5320px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:44:11</tspan>
+    <tspan x="10px" y="5320px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5338px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5338px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="5356px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="5356px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5374px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+    <tspan x="10px" y="5374px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="5392px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="5392px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="5410px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple(0);</tspan>
+    <tspan x="10px" y="5410px">
 </tspan>
-    <tspan x="10px" y="5428px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+    <tspan x="10px" y="5428px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="5446px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="5446px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:41:11</tspan>
 </tspan>
-    <tspan x="10px" y="5464px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="5464px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5482px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+    <tspan x="10px" y="5482px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="5500px">
+    <tspan x="10px" y="5500px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="5518px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="5518px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="5536px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:45:11</tspan>
+    <tspan x="10px" y="5536px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple {};</tspan>
 </tspan>
-    <tspan x="10px" y="5554px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5554px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="5572px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="5572px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5590px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+    <tspan x="10px" y="5590px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="5608px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="5608px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5626px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct(0);</tspan>
+    <tspan x="10px" y="5626px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="5644px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+    <tspan x="10px" y="5644px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="5662px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="5662px">
 </tspan>
-    <tspan x="10px" y="5680px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="5680px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="5698px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+    <tspan x="10px" y="5698px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:42:11</tspan>
 </tspan>
-    <tspan x="10px" y="5716px">
+    <tspan x="10px" y="5716px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5734px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
+    <tspan x="10px" y="5734px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="5752px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:46:11</tspan>
+    <tspan x="10px" y="5752px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="5770px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5770px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="5788px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="5788px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct {};</tspan>
 </tspan>
-    <tspan x="10px" y="5806px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
+    <tspan x="10px" y="5806px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="5824px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="5824px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5842px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit { x: 0 };</tspan>
+    <tspan x="10px" y="5842px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="5860px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+    <tspan x="10px" y="5860px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5878px">
+    <tspan x="10px" y="5878px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="5896px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
+    <tspan x="10px" y="5896px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="5914px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:47:11</tspan>
+    <tspan x="10px" y="5914px">
 </tspan>
-    <tspan x="10px" y="5932px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5932px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="5950px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="5950px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:43:11</tspan>
 </tspan>
-    <tspan x="10px" y="5968px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
+    <tspan x="10px" y="5968px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5986px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="5986px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="6004px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple { x: 0 };</tspan>
+    <tspan x="10px" y="6004px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="6022px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+    <tspan x="10px" y="6022px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="6040px">
+    <tspan x="10px" y="6040px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit(0);</tspan>
 </tspan>
-    <tspan x="10px" y="6058px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
+    <tspan x="10px" y="6058px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="6076px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:48:11</tspan>
+    <tspan x="10px" y="6076px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6094px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6094px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="6112px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="6112px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6130px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
+    <tspan x="10px" y="6130px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="6148px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="6148px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="6166px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct { x: 0 };</tspan>
+    <tspan x="10px" y="6166px">
 </tspan>
-    <tspan x="10px" y="6184px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+    <tspan x="10px" y="6184px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="6202px">
+    <tspan x="10px" y="6202px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:44:11</tspan>
 </tspan>
-    <tspan x="10px" y="6220px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="6220px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6238px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:49:11</tspan>
+    <tspan x="10px" y="6238px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="6256px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6256px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="6274px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="6274px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="6292px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+    <tspan x="10px" y="6292px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple(0);</tspan>
 </tspan>
-    <tspan x="10px" y="6310px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="6310px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="6328px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit(0, 0);</tspan>
+    <tspan x="10px" y="6328px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6346px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+    <tspan x="10px" y="6346px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="6364px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="6364px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6382px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="6382px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple</tspan><tspan>(0);</tspan>
 </tspan>
-    <tspan x="10px" y="6400px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+    <tspan x="10px" y="6400px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~</tspan>
 </tspan>
     <tspan x="10px" y="6418px">
 </tspan>
-    <tspan x="10px" y="6436px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="6436px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="6454px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:50:11</tspan>
+    <tspan x="10px" y="6454px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:45:11</tspan>
 </tspan>
     <tspan x="10px" y="6472px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
     <tspan x="10px" y="6490px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="6508px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+    <tspan x="10px" y="6508px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
 </tspan>
     <tspan x="10px" y="6526px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="6544px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple(0, 0);</tspan>
+    <tspan x="10px" y="6544px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct(0);</tspan>
 </tspan>
-    <tspan x="10px" y="6562px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+    <tspan x="10px" y="6562px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="6580px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="6580px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6598px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="6598px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="6616px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+    <tspan x="10px" y="6616px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6634px">
+    <tspan x="10px" y="6634px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="6652px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="6652px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="6670px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:51:11</tspan>
+    <tspan x="10px" y="6670px">
 </tspan>
-    <tspan x="10px" y="6688px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6688px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="6706px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="6706px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:46:11</tspan>
 </tspan>
-    <tspan x="10px" y="6724px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+    <tspan x="10px" y="6724px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6742px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="6742px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="6760px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct(0, 0);</tspan>
+    <tspan x="10px" y="6760px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="6778px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+    <tspan x="10px" y="6778px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="6796px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+    <tspan x="10px" y="6796px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit { x: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="6814px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="6814px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="6832px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+    <tspan x="10px" y="6832px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6850px">
+    <tspan x="10px" y="6850px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="6868px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
+    <tspan x="10px" y="6868px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6886px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:52:11</tspan>
+    <tspan x="10px" y="6886px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="6904px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6904px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~</tspan>
 </tspan>
-    <tspan x="10px" y="6922px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="6922px">
 </tspan>
-    <tspan x="10px" y="6940px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
+    <tspan x="10px" y="6940px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="6958px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="6958px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:47:11</tspan>
 </tspan>
-    <tspan x="10px" y="6976px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="6976px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6994px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+    <tspan x="10px" y="6994px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="7012px">
+    <tspan x="10px" y="7012px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="7030px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
+    <tspan x="10px" y="7030px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="7048px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:53:11</tspan>
+    <tspan x="10px" y="7048px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple { x: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="7066px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7066px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="7084px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="7084px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7102px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
+    <tspan x="10px" y="7102px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="7120px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="7120px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7138px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="7138px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="7156px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+    <tspan x="10px" y="7156px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~</tspan>
 </tspan>
     <tspan x="10px" y="7174px">
 </tspan>
     <tspan x="10px" y="7192px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="7210px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:54:11</tspan>
+    <tspan x="10px" y="7210px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:48:11</tspan>
 </tspan>
     <tspan x="10px" y="7228px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
@@ -829,21 +829,199 @@
 </tspan>
     <tspan x="10px" y="7282px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="7300px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="7300px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct { x: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="7318px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+    <tspan x="10px" y="7318px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="7336px">
+    <tspan x="10px" y="7336px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7354px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 39 previous errors</tspan>
+    <tspan x="10px" y="7354px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="7372px">
+    <tspan x="10px" y="7372px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7390px"><tspan class="bold">Some errors have detailed explanations: E0061, E0063, E0533, E0559, E0599, E0618.</tspan>
+    <tspan x="10px" y="7390px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="7408px"><tspan class="bold">For more information about an error, try `rustc --explain E0061`.</tspan>
+    <tspan x="10px" y="7408px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
 </tspan>
     <tspan x="10px" y="7426px">
+</tspan>
+    <tspan x="10px" y="7444px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="7462px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:49:11</tspan>
+</tspan>
+    <tspan x="10px" y="7480px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="7498px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="7516px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="7534px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="7552px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit(0, 0);</tspan>
+</tspan>
+    <tspan x="10px" y="7570px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="7588px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="7606px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+</tspan>
+    <tspan x="10px" y="7624px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="7642px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
+</tspan>
+    <tspan x="10px" y="7660px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~</tspan>
+</tspan>
+    <tspan x="10px" y="7678px">
+</tspan>
+    <tspan x="10px" y="7696px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="7714px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:50:11</tspan>
+</tspan>
+    <tspan x="10px" y="7732px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="7750px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="7768px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="7786px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="7804px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple(0, 0);</tspan>
+</tspan>
+    <tspan x="10px" y="7822px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="7840px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="7858px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+</tspan>
+    <tspan x="10px" y="7876px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="7894px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple</tspan><tspan>(</tspan><tspan class="fg-ansi256-010">/* i32 */</tspan><tspan>);</tspan>
+</tspan>
+    <tspan x="10px" y="7912px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~</tspan><tspan> </tspan><tspan class="fg-ansi256-010">~~~~~~~~~</tspan>
+</tspan>
+    <tspan x="10px" y="7930px">
+</tspan>
+    <tspan x="10px" y="7948px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="7966px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:51:11</tspan>
+</tspan>
+    <tspan x="10px" y="7984px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8002px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="8020px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="8038px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="8056px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct(0, 0);</tspan>
+</tspan>
+    <tspan x="10px" y="8074px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="8092px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8110px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+</tspan>
+    <tspan x="10px" y="8128px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8146px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
+</tspan>
+    <tspan x="10px" y="8164px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
+</tspan>
+    <tspan x="10px" y="8182px">
+</tspan>
+    <tspan x="10px" y="8200px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="8218px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:52:11</tspan>
+</tspan>
+    <tspan x="10px" y="8236px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8254px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="8272px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="8290px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="8308px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit { x: 0, y: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="8326px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="8344px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8362px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+</tspan>
+    <tspan x="10px" y="8380px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8398px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
+</tspan>
+    <tspan x="10px" y="8416px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~</tspan>
+</tspan>
+    <tspan x="10px" y="8434px">
+</tspan>
+    <tspan x="10px" y="8452px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="8470px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:53:11</tspan>
+</tspan>
+    <tspan x="10px" y="8488px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8506px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="8524px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="8542px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="8560px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple { x: 0, y: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="8578px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="8596px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8614px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+</tspan>
+    <tspan x="10px" y="8632px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8650px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
+</tspan>
+    <tspan x="10px" y="8668px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~</tspan>
+</tspan>
+    <tspan x="10px" y="8686px">
+</tspan>
+    <tspan x="10px" y="8704px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="8722px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:54:11</tspan>
+</tspan>
+    <tspan x="10px" y="8740px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8758px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="8776px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="8794px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="8812px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct { x: 0, y: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="8830px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="8848px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8866px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+</tspan>
+    <tspan x="10px" y="8884px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="8902px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
+</tspan>
+    <tspan x="10px" y="8920px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
+</tspan>
+    <tspan x="10px" y="8938px">
+</tspan>
+    <tspan x="10px" y="8956px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 39 previous errors</tspan>
+</tspan>
+    <tspan x="10px" y="8974px">
+</tspan>
+    <tspan x="10px" y="8992px"><tspan class="bold">Some errors have detailed explanations: E0061, E0063, E0533, E0559, E0599, E0618.</tspan>
+</tspan>
+    <tspan x="10px" y="9010px"><tspan class="bold">For more information about an error, try `rustc --explain E0061`.</tspan>
+</tspan>
+    <tspan x="10px" y="9028px">
 </tspan>
   </text>
 

--- a/tests/ui/suggestions/incorrect-variant-literal.svg
+++ b/tests/ui/suggestions/incorrect-variant-literal.svg
@@ -1,0 +1,850 @@
+<svg width="886px" height="7436px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-ansi256-009 { fill: #FF5555 }
+    .fg-ansi256-010 { fill: #55FF55 }
+    .fg-ansi256-012 { fill: #5555FF }
+    .fg-ansi256-014 { fill: #55FFFF }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:13:5</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct;</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
+</tspan>
+    <tspan x="10px" y="118px">
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found enum variant `Enum::Unit`</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:14:5</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">enum variant `Enum::Unit` defined here</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit();</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">--</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
+</tspan>
+    <tspan x="10px" y="316px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Unit` is a unit enum variant, and does not take parentheses to be constructed</tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Unit</tspan><tspan class="fg-ansi256-009">()</tspan><tspan>;</tspan>
+</tspan>
+    <tspan x="10px" y="388px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Unit;</tspan>
+</tspan>
+    <tspan x="10px" y="406px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="424px">
+</tspan>
+    <tspan x="10px" y="442px"><tspan class="fg-ansi256-009 bold">error[E0061]</tspan><tspan class="bold">: this enum variant takes 1 argument but 0 arguments were supplied</tspan>
+</tspan>
+    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:15:5</tspan>
+</tspan>
+    <tspan x="10px" y="478px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="496px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple();</tspan>
+</tspan>
+    <tspan x="10px" y="514px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">--</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">argument #1 of type `i32` is missing</tspan>
+</tspan>
+    <tspan x="10px" y="532px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="550px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: tuple variant defined here</tspan>
+</tspan>
+    <tspan x="10px" y="568px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:6:5</tspan>
+</tspan>
+    <tspan x="10px" y="586px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="604px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+</tspan>
+    <tspan x="10px" y="622px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="640px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: provide the argument</tspan>
+</tspan>
+    <tspan x="10px" y="658px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="676px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
+</tspan>
+    <tspan x="10px" y="694px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~</tspan>
+</tspan>
+    <tspan x="10px" y="712px">
+</tspan>
+    <tspan x="10px" y="730px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
+</tspan>
+    <tspan x="10px" y="748px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:16:5</tspan>
+</tspan>
+    <tspan x="10px" y="766px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="784px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct();</tspan>
+</tspan>
+    <tspan x="10px" y="802px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
+</tspan>
+    <tspan x="10px" y="820px">
+</tspan>
+    <tspan x="10px" y="838px"><tspan class="fg-ansi256-009 bold">error[E0063]</tspan><tspan class="bold">: missing field `0` in initializer of `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="856px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:18:5</tspan>
+</tspan>
+    <tspan x="10px" y="874px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="892px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple {};</tspan>
+</tspan>
+    <tspan x="10px" y="910px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">missing `0`</tspan>
+</tspan>
+    <tspan x="10px" y="928px">
+</tspan>
+    <tspan x="10px" y="946px"><tspan class="fg-ansi256-009 bold">error[E0063]</tspan><tspan class="bold">: missing field `x` in initializer of `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="964px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:19:5</tspan>
+</tspan>
+    <tspan x="10px" y="982px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1000px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct {};</tspan>
+</tspan>
+    <tspan x="10px" y="1018px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">missing `x`</tspan>
+</tspan>
+    <tspan x="10px" y="1036px">
+</tspan>
+    <tspan x="10px" y="1054px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="1072px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:20:5</tspan>
+</tspan>
+    <tspan x="10px" y="1090px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1108px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
+</tspan>
+    <tspan x="10px" y="1126px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Unit` defined here</tspan>
+</tspan>
+    <tspan x="10px" y="1144px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="1162px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit(0);</tspan>
+</tspan>
+    <tspan x="10px" y="1180px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">---</tspan>
+</tspan>
+    <tspan x="10px" y="1198px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1216px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
+</tspan>
+    <tspan x="10px" y="1234px">
+</tspan>
+    <tspan x="10px" y="1252px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
+</tspan>
+    <tspan x="10px" y="1270px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:22:5</tspan>
+</tspan>
+    <tspan x="10px" y="1288px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1306px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct(0);</tspan>
+</tspan>
+    <tspan x="10px" y="1324px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
+</tspan>
+    <tspan x="10px" y="1342px">
+</tspan>
+    <tspan x="10px" y="1360px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `x`</tspan>
+</tspan>
+    <tspan x="10px" y="1378px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:23:18</tspan>
+</tspan>
+    <tspan x="10px" y="1396px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1414px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="1432px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
+</tspan>
+    <tspan x="10px" y="1450px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1468px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+</tspan>
+    <tspan x="10px" y="1486px">
+</tspan>
+    <tspan x="10px" y="1504px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `x`</tspan>
+</tspan>
+    <tspan x="10px" y="1522px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:24:19</tspan>
+</tspan>
+    <tspan x="10px" y="1540px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1558px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+</tspan>
+    <tspan x="10px" y="1576px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
+</tspan>
+    <tspan x="10px" y="1594px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="1612px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="1630px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                   </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
+</tspan>
+    <tspan x="10px" y="1648px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1666px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
+</tspan>
+    <tspan x="10px" y="1684px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1702px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
+</tspan>
+    <tspan x="10px" y="1720px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
+</tspan>
+    <tspan x="10px" y="1738px">
+</tspan>
+    <tspan x="10px" y="1756px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="1774px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:26:5</tspan>
+</tspan>
+    <tspan x="10px" y="1792px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1810px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
+</tspan>
+    <tspan x="10px" y="1828px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Unit` defined here</tspan>
+</tspan>
+    <tspan x="10px" y="1846px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="1864px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit(0, 0);</tspan>
+</tspan>
+    <tspan x="10px" y="1882px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">------</tspan>
+</tspan>
+    <tspan x="10px" y="1900px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1918px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
+</tspan>
+    <tspan x="10px" y="1936px">
+</tspan>
+    <tspan x="10px" y="1954px"><tspan class="fg-ansi256-009 bold">error[E0061]</tspan><tspan class="bold">: this enum variant takes 1 argument but 2 arguments were supplied</tspan>
+</tspan>
+    <tspan x="10px" y="1972px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:27:5</tspan>
+</tspan>
+    <tspan x="10px" y="1990px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2008px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple(0, 0);</tspan>
+</tspan>
+    <tspan x="10px" y="2026px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan>    </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">unexpected argument #2 of type `{integer}`</tspan>
+</tspan>
+    <tspan x="10px" y="2044px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2062px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: tuple variant defined here</tspan>
+</tspan>
+    <tspan x="10px" y="2080px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:6:5</tspan>
+</tspan>
+    <tspan x="10px" y="2098px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2116px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+</tspan>
+    <tspan x="10px" y="2134px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="2152px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: remove the extra argument</tspan>
+</tspan>
+    <tspan x="10px" y="2170px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2188px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple(0</tspan><tspan class="fg-ansi256-009">, 0</tspan><tspan>);</tspan>
+</tspan>
+    <tspan x="10px" y="2206px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple(0);</tspan>
+</tspan>
+    <tspan x="10px" y="2224px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2242px">
+</tspan>
+    <tspan x="10px" y="2260px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
+</tspan>
+    <tspan x="10px" y="2278px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:28:5</tspan>
+</tspan>
+    <tspan x="10px" y="2296px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2314px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct(0, 0);</tspan>
+</tspan>
+    <tspan x="10px" y="2332px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
+</tspan>
+    <tspan x="10px" y="2350px">
+</tspan>
+    <tspan x="10px" y="2368px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `x`</tspan>
+</tspan>
+    <tspan x="10px" y="2386px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:29:18</tspan>
+</tspan>
+    <tspan x="10px" y="2404px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2422px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0, y: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="2440px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
+</tspan>
+    <tspan x="10px" y="2458px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2476px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+</tspan>
+    <tspan x="10px" y="2494px">
+</tspan>
+    <tspan x="10px" y="2512px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `y`</tspan>
+</tspan>
+    <tspan x="10px" y="2530px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:29:24</tspan>
+</tspan>
+    <tspan x="10px" y="2548px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2566px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0, y: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="2584px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                        </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
+</tspan>
+    <tspan x="10px" y="2602px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2620px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+</tspan>
+    <tspan x="10px" y="2638px">
+</tspan>
+    <tspan x="10px" y="2656px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `x`</tspan>
+</tspan>
+    <tspan x="10px" y="2674px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:31:19</tspan>
+</tspan>
+    <tspan x="10px" y="2692px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2710px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+</tspan>
+    <tspan x="10px" y="2728px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
+</tspan>
+    <tspan x="10px" y="2746px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="2764px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0, y: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="2782px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                   </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
+</tspan>
+    <tspan x="10px" y="2800px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2818px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
+</tspan>
+    <tspan x="10px" y="2836px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2854px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
+</tspan>
+    <tspan x="10px" y="2872px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
+</tspan>
+    <tspan x="10px" y="2890px">
+</tspan>
+    <tspan x="10px" y="2908px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `y`</tspan>
+</tspan>
+    <tspan x="10px" y="2926px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:31:25</tspan>
+</tspan>
+    <tspan x="10px" y="2944px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2962px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+</tspan>
+    <tspan x="10px" y="2980px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
+</tspan>
+    <tspan x="10px" y="2998px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="3016px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0, y: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="3034px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                         </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
+</tspan>
+    <tspan x="10px" y="3052px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3070px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
+</tspan>
+    <tspan x="10px" y="3088px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3106px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
+</tspan>
+    <tspan x="10px" y="3124px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
+</tspan>
+    <tspan x="10px" y="3142px">
+</tspan>
+    <tspan x="10px" y="3160px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Struct` has no field named `y`</tspan>
+</tspan>
+    <tspan x="10px" y="3178px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:33:26</tspan>
+</tspan>
+    <tspan x="10px" y="3196px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3214px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct { x: 0, y: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="3232px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                          </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Struct` does not have this field</tspan>
+</tspan>
+    <tspan x="10px" y="3250px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3268px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+</tspan>
+    <tspan x="10px" y="3286px">
+</tspan>
+    <tspan x="10px" y="3304px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="3322px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:34:11</tspan>
+</tspan>
+    <tspan x="10px" y="3340px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3358px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="3376px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="3394px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="3412px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit;</tspan>
+</tspan>
+    <tspan x="10px" y="3430px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="3448px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3466px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="3484px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+</tspan>
+    <tspan x="10px" y="3502px">
+</tspan>
+    <tspan x="10px" y="3520px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="3538px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:35:11</tspan>
+</tspan>
+    <tspan x="10px" y="3556px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3574px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="3592px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="3610px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="3628px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple;</tspan>
+</tspan>
+    <tspan x="10px" y="3646px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="3664px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3682px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="3700px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+</tspan>
+    <tspan x="10px" y="3718px">
+</tspan>
+    <tspan x="10px" y="3736px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="3754px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:36:11</tspan>
+</tspan>
+    <tspan x="10px" y="3772px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3790px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="3808px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="3826px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="3844px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct;</tspan>
+</tspan>
+    <tspan x="10px" y="3862px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="3880px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3898px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="3916px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+</tspan>
+    <tspan x="10px" y="3934px">
+</tspan>
+    <tspan x="10px" y="3952px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="3970px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:37:11</tspan>
+</tspan>
+    <tspan x="10px" y="3988px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4006px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="4024px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="4042px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="4060px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit();</tspan>
+</tspan>
+    <tspan x="10px" y="4078px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="4096px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4114px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="4132px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+</tspan>
+    <tspan x="10px" y="4150px">
+</tspan>
+    <tspan x="10px" y="4168px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="4186px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:38:11</tspan>
+</tspan>
+    <tspan x="10px" y="4204px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4222px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="4240px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="4258px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="4276px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple();</tspan>
+</tspan>
+    <tspan x="10px" y="4294px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="4312px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4330px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="4348px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+</tspan>
+    <tspan x="10px" y="4366px">
+</tspan>
+    <tspan x="10px" y="4384px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="4402px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:39:11</tspan>
+</tspan>
+    <tspan x="10px" y="4420px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4438px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="4456px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="4474px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="4492px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct();</tspan>
+</tspan>
+    <tspan x="10px" y="4510px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="4528px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4546px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="4564px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+</tspan>
+    <tspan x="10px" y="4582px">
+</tspan>
+    <tspan x="10px" y="4600px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="4618px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:40:11</tspan>
+</tspan>
+    <tspan x="10px" y="4636px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4654px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="4672px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="4690px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="4708px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit {};</tspan>
+</tspan>
+    <tspan x="10px" y="4726px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+</tspan>
+    <tspan x="10px" y="4744px">
+</tspan>
+    <tspan x="10px" y="4762px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="4780px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:41:11</tspan>
+</tspan>
+    <tspan x="10px" y="4798px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4816px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="4834px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="4852px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="4870px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple {};</tspan>
+</tspan>
+    <tspan x="10px" y="4888px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+</tspan>
+    <tspan x="10px" y="4906px">
+</tspan>
+    <tspan x="10px" y="4924px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="4942px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:42:11</tspan>
+</tspan>
+    <tspan x="10px" y="4960px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4978px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="4996px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="5014px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="5032px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct {};</tspan>
+</tspan>
+    <tspan x="10px" y="5050px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+</tspan>
+    <tspan x="10px" y="5068px">
+</tspan>
+    <tspan x="10px" y="5086px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="5104px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:43:11</tspan>
+</tspan>
+    <tspan x="10px" y="5122px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="5140px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="5158px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="5176px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="5194px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit(0);</tspan>
+</tspan>
+    <tspan x="10px" y="5212px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="5230px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="5248px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="5266px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+</tspan>
+    <tspan x="10px" y="5284px">
+</tspan>
+    <tspan x="10px" y="5302px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="5320px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:44:11</tspan>
+</tspan>
+    <tspan x="10px" y="5338px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="5356px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="5374px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="5392px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="5410px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple(0);</tspan>
+</tspan>
+    <tspan x="10px" y="5428px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="5446px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="5464px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="5482px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+</tspan>
+    <tspan x="10px" y="5500px">
+</tspan>
+    <tspan x="10px" y="5518px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="5536px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:45:11</tspan>
+</tspan>
+    <tspan x="10px" y="5554px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="5572px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="5590px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="5608px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="5626px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct(0);</tspan>
+</tspan>
+    <tspan x="10px" y="5644px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="5662px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="5680px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="5698px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+</tspan>
+    <tspan x="10px" y="5716px">
+</tspan>
+    <tspan x="10px" y="5734px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="5752px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:46:11</tspan>
+</tspan>
+    <tspan x="10px" y="5770px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="5788px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="5806px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="5824px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="5842px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit { x: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="5860px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+</tspan>
+    <tspan x="10px" y="5878px">
+</tspan>
+    <tspan x="10px" y="5896px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="5914px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:47:11</tspan>
+</tspan>
+    <tspan x="10px" y="5932px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="5950px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="5968px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="5986px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="6004px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple { x: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="6022px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+</tspan>
+    <tspan x="10px" y="6040px">
+</tspan>
+    <tspan x="10px" y="6058px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="6076px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:48:11</tspan>
+</tspan>
+    <tspan x="10px" y="6094px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="6112px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="6130px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="6148px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="6166px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct { x: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="6184px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+</tspan>
+    <tspan x="10px" y="6202px">
+</tspan>
+    <tspan x="10px" y="6220px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="6238px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:49:11</tspan>
+</tspan>
+    <tspan x="10px" y="6256px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="6274px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="6292px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="6310px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="6328px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit(0, 0);</tspan>
+</tspan>
+    <tspan x="10px" y="6346px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="6364px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="6382px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="6400px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+</tspan>
+    <tspan x="10px" y="6418px">
+</tspan>
+    <tspan x="10px" y="6436px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="6454px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:50:11</tspan>
+</tspan>
+    <tspan x="10px" y="6472px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="6490px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="6508px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="6526px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="6544px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple(0, 0);</tspan>
+</tspan>
+    <tspan x="10px" y="6562px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="6580px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="6598px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="6616px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+</tspan>
+    <tspan x="10px" y="6634px">
+</tspan>
+    <tspan x="10px" y="6652px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+</tspan>
+    <tspan x="10px" y="6670px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:51:11</tspan>
+</tspan>
+    <tspan x="10px" y="6688px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="6706px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="6724px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+</tspan>
+    <tspan x="10px" y="6742px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="6760px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct(0, 0);</tspan>
+</tspan>
+    <tspan x="10px" y="6778px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="6796px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="6814px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="6832px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+</tspan>
+    <tspan x="10px" y="6850px">
+</tspan>
+    <tspan x="10px" y="6868px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="6886px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:52:11</tspan>
+</tspan>
+    <tspan x="10px" y="6904px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="6922px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="6940px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="6958px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="6976px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit { x: 0, y: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="6994px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name (notice the capitalization): `Unit`</tspan>
+</tspan>
+    <tspan x="10px" y="7012px">
+</tspan>
+    <tspan x="10px" y="7030px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="7048px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:53:11</tspan>
+</tspan>
+    <tspan x="10px" y="7066px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="7084px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="7102px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="7120px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="7138px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple { x: 0, y: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="7156px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Tuple`</tspan>
+</tspan>
+    <tspan x="10px" y="7174px">
+</tspan>
+    <tspan x="10px" y="7192px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
+</tspan>
+    <tspan x="10px" y="7210px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:54:11</tspan>
+</tspan>
+    <tspan x="10px" y="7228px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="7246px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+</tspan>
+    <tspan x="10px" y="7264px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
+</tspan>
+    <tspan x="10px" y="7282px"><tspan class="fg-ansi256-012 bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="7300px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct { x: 0, y: 0 };</tspan>
+</tspan>
+    <tspan x="10px" y="7318px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">help: there is a variant with a similar name: `Struct`</tspan>
+</tspan>
+    <tspan x="10px" y="7336px">
+</tspan>
+    <tspan x="10px" y="7354px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 39 previous errors</tspan>
+</tspan>
+    <tspan x="10px" y="7372px">
+</tspan>
+    <tspan x="10px" y="7390px"><tspan class="bold">Some errors have detailed explanations: E0061, E0063, E0533, E0559, E0599, E0618.</tspan>
+</tspan>
+    <tspan x="10px" y="7408px"><tspan class="bold">For more information about an error, try `rustc --explain E0061`.</tspan>
+</tspan>
+    <tspan x="10px" y="7426px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/ui/suggestions/incorrect-variant-literal.svg
+++ b/tests/ui/suggestions/incorrect-variant-literal.svg
@@ -237,9 +237,9 @@
 </tspan>
     <tspan x="10px" y="1954px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1972px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="1972px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="1990px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
+    <tspan x="10px" y="1990px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~</tspan>
 </tspan>
     <tspan x="10px" y="2008px">
 </tspan>
@@ -375,9 +375,9 @@
 </tspan>
     <tspan x="10px" y="3196px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3214px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="3214px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="3232px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
+    <tspan x="10px" y="3232px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~</tspan>
 </tspan>
     <tspan x="10px" y="3250px">
 </tspan>
@@ -403,9 +403,9 @@
 </tspan>
     <tspan x="10px" y="3448px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3466px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    </tspan><tspan class="fg-ansi256-010">Enum::Tuple(/* fields */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="3466px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="3484px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~~~~~~~~~~~~~~~</tspan>
+    <tspan x="10px" y="3484px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                </tspan><tspan class="fg-ansi256-010">~~~~~~~~~~~</tspan>
 </tspan>
     <tspan x="10px" y="3502px">
 </tspan>

--- a/tests/ui/suggestions/nested-non-tuple-tuple-struct.stderr
+++ b/tests/ui/suggestions/nested-non-tuple-tuple-struct.stderr
@@ -9,8 +9,8 @@ LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
    |
 help: `S` is a tuple struct, use the appropriate syntax
    |
-LL |     let _x = (S(/* fields */), S { x: 3.0, y: 4.0 });
-   |               ~~~~~~~~~~~~~~~
+LL |     let _x = (S(/* f32 */, /* f32 */), S { x: 3.0, y: 4.0 });
+   |               ~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0560]: struct `S` has no field named `y`
   --> $DIR/nested-non-tuple-tuple-struct.rs:8:27
@@ -23,8 +23,8 @@ LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
    |
 help: `S` is a tuple struct, use the appropriate syntax
    |
-LL |     let _x = (S(/* fields */), S { x: 3.0, y: 4.0 });
-   |               ~~~~~~~~~~~~~~~
+LL |     let _x = (S(/* f32 */, /* f32 */), S { x: 3.0, y: 4.0 });
+   |               ~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0560]: struct `S` has no field named `x`
   --> $DIR/nested-non-tuple-tuple-struct.rs:8:41
@@ -37,8 +37,8 @@ LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
    |
 help: `S` is a tuple struct, use the appropriate syntax
    |
-LL |     let _x = (S { x: 1.0, y: 2.0 }, S(/* fields */));
-   |                                     ~~~~~~~~~~~~~~~
+LL |     let _x = (S { x: 1.0, y: 2.0 }, S(/* f32 */, /* f32 */));
+   |                                     ~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0560]: struct `S` has no field named `y`
   --> $DIR/nested-non-tuple-tuple-struct.rs:8:49
@@ -51,8 +51,8 @@ LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
    |
 help: `S` is a tuple struct, use the appropriate syntax
    |
-LL |     let _x = (S { x: 1.0, y: 2.0 }, S(/* fields */));
-   |                                     ~~~~~~~~~~~~~~~
+LL |     let _x = (S { x: 1.0, y: 2.0 }, S(/* f32 */, /* f32 */));
+   |                                     ~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0559]: variant `E::V` has no field named `x`
   --> $DIR/nested-non-tuple-tuple-struct.rs:13:22
@@ -65,8 +65,8 @@ LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
    |
 help: `E::V` is a tuple variant, use the appropriate syntax
    |
-LL |     let _y = (E::V(/* fields */), E::V { x: 3.0, y: 4.0 });
-   |               ~~~~~~~~~~~~~~~~~~
+LL |     let _y = (E::V(/* f32 */, /* f32 */), E::V { x: 3.0, y: 4.0 });
+   |                   ~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0559]: variant `E::V` has no field named `y`
   --> $DIR/nested-non-tuple-tuple-struct.rs:13:30
@@ -79,8 +79,8 @@ LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
    |
 help: `E::V` is a tuple variant, use the appropriate syntax
    |
-LL |     let _y = (E::V(/* fields */), E::V { x: 3.0, y: 4.0 });
-   |               ~~~~~~~~~~~~~~~~~~
+LL |     let _y = (E::V(/* f32 */, /* f32 */), E::V { x: 3.0, y: 4.0 });
+   |                   ~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0559]: variant `E::V` has no field named `x`
   --> $DIR/nested-non-tuple-tuple-struct.rs:13:47
@@ -93,8 +93,8 @@ LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
    |
 help: `E::V` is a tuple variant, use the appropriate syntax
    |
-LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V(/* fields */));
-   |                                        ~~~~~~~~~~~~~~~~~~
+LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V(/* f32 */, /* f32 */));
+   |                                            ~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0559]: variant `E::V` has no field named `y`
   --> $DIR/nested-non-tuple-tuple-struct.rs:13:55
@@ -107,8 +107,8 @@ LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
    |
 help: `E::V` is a tuple variant, use the appropriate syntax
    |
-LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V(/* fields */));
-   |                                        ~~~~~~~~~~~~~~~~~~
+LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V(/* f32 */, /* f32 */));
+   |                                            ~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/suggestions/suggest-variants.stderr
+++ b/tests/ui/suggestions/suggest-variants.stderr
@@ -5,7 +5,12 @@ LL | enum Shape {
    | ---------- variant `Squareee` not found here
 ...
 LL |     println!("My shape is {:?}", Shape::Squareee { size: 5});
-   |                                         ^^^^^^^^ help: there is a variant with a similar name: `Square`
+   |                                         ^^^^^^^^
+   |
+help: there is a variant with a similar name
+   |
+LL |     println!("My shape is {:?}", Shape::Square { size: 5});
+   |                                         ~~~~~~
 
 error[E0599]: no variant named `Circl` found for enum `Shape`
   --> $DIR/suggest-variants.rs:13:41
@@ -14,7 +19,12 @@ LL | enum Shape {
    | ---------- variant `Circl` not found here
 ...
 LL |     println!("My shape is {:?}", Shape::Circl { size: 5});
-   |                                         ^^^^^ help: there is a variant with a similar name: `Circle`
+   |                                         ^^^^^
+   |
+help: there is a variant with a similar name
+   |
+LL |     println!("My shape is {:?}", Shape::Circle { size: 5});
+   |                                         ~~~~~~
 
 error[E0599]: no variant named `Rombus` found for enum `Shape`
   --> $DIR/suggest-variants.rs:14:41
@@ -32,10 +42,12 @@ LL | enum Shape {
    | ---------- variant or associated item `Squareee` not found for this enum
 ...
 LL |     Shape::Squareee;
-   |            ^^^^^^^^
-   |            |
-   |            variant or associated item not found in `Shape`
-   |            help: there is a variant with a similar name: `Square`
+   |            ^^^^^^^^ variant or associated item not found in `Shape`
+   |
+help: there is a variant with a similar name
+   |
+LL |     Shape::Square { size: /* value */ };
+   |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0599]: no variant or associated item named `Circl` found for enum `Shape` in the current scope
   --> $DIR/suggest-variants.rs:16:12
@@ -44,10 +56,12 @@ LL | enum Shape {
    | ---------- variant or associated item `Circl` not found for this enum
 ...
 LL |     Shape::Circl;
-   |            ^^^^^
-   |            |
-   |            variant or associated item not found in `Shape`
-   |            help: there is a variant with a similar name: `Circle`
+   |            ^^^^^ variant or associated item not found in `Shape`
+   |
+help: there is a variant with a similar name
+   |
+LL |     Shape::Circle { radius: /* value */ };
+   |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0599]: no variant or associated item named `Rombus` found for enum `Shape` in the current scope
   --> $DIR/suggest-variants.rs:17:12

--- a/tests/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
+++ b/tests/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
@@ -3,6 +3,11 @@ error[E0533]: expected value, found struct variant `Alias::Braced`
    |
 LL |     Alias::Braced;
    |     ^^^^^^^^^^^^^ not a value
+   |
+help: you might have meant to create a new value of the struct
+   |
+LL |     Alias::Braced {};
+   |                   ++
 
 error[E0533]: expected unit struct, unit variant or constant, found struct variant `Alias::Braced`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:10:9


### PR DESCRIPTION
More accurate suggestions when writing wrong style of enum variant literal:

```
error[E0533]: expected value, found struct variant `E::Empty3`
  --> $DIR/empty-struct-braces-expr.rs:18:14
   |
LL |     let e3 = E::Empty3;
   |              ^^^^^^^^^ not a value
   |
help: you might have meant to create a new value of the struct
   |
LL |     let e3 = E::Empty3 {};
   |                        ++
```
```
error[E0533]: expected value, found struct variant `E::V`
  --> $DIR/struct-literal-variant-in-if.rs:10:13
   |
LL |     if x == E::V { field } {}
   |             ^^^^ not a value
   |
help: you might have meant to create a new value of the struct
   |
LL |     if x == (E::V { field }) {}
   |             +              +
```
```
error[E0618]: expected function, found enum variant `Enum::Unit`
  --> $DIR/suggestion-highlights.rs:15:5
   |
LL |     Unit,
   |     ---- enum variant `Enum::Unit` defined here
...
LL |     Enum::Unit();
   |     ^^^^^^^^^^--
   |     |
   |     call expression requires function
   |
help: `Enum::Unit` is a unit enum variant, and does not take parentheses to be constructed
   |
LL -     Enum::Unit();
LL +     Enum::Unit;
   |
```
```
error[E0599]: no variant or associated item named `tuple` found for enum `Enum` in the current scope
  --> $DIR/suggestion-highlights.rs:36:11
   |
LL | enum Enum {
   | --------- variant or associated item `tuple` not found for this enum
...
LL |     Enum::tuple;
   |           ^^^^^ variant or associated item not found in `Enum`
   |
help: there is a variant with a similar name
   |
LL |     Enum::Tuple(/* i32 */);
   |           ~~~~~~~~~~~~~~~~;
   |
```

Tweak "field not found" suggestion when giving struct literal for tuple struct type:

```
error[E0560]: struct `S` has no field named `x`
  --> $DIR/nested-non-tuple-tuple-struct.rs:8:19
   |
LL | pub struct S(f32, f32);
   |            - `S` defined here
...
LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
   |                   ^ field does not exist
   |
help: `S` is a tuple struct, use the appropriate syntax
   |
LL |     let _x = (S(/* f32 */, /* f32 */), S { x: 3.0, y: 4.0 });
   |               ~~~~~~~~~~~~~~~~~~~~~~~
