### PR TITLE
Add missing GHA group for building `llvm-bitcode-linker`

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -858,6 +858,15 @@ impl Step for LlvmBitcodeLinker {
             &self.extra_features,
         );
 
+        let _guard = builder.msg_tool(
+            Kind::Build,
+            Mode::ToolRustc,
+            bin_name,
+            self.compiler.stage,
+            &self.compiler.host,
+            &self.target,
+        );
+
         cargo.into_cmd().run(builder);
 
         let tool_out = builder


### PR DESCRIPTION
Found while investigating https://github.com/rust-lang/rust/issues/127869.

r? @onur-ozkan