### PR TITLE
Allow a git command for getting the current branch in bootstrap to fail

### DIFF
--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -535,6 +535,7 @@ impl Build {
             // even though that has no relation to the upstream for the submodule.
             let current_branch = helpers::git(Some(&self.src))
                 .capture_stdout()
+                .allow_failure()
                 .run_always()
                 .args(["symbolic-ref", "--short", "HEAD"])
                 .run(self)


### PR DESCRIPTION
Found by @lukas-code [here](https://github.com/rust-lang/rust/pull/127680#discussion_r1682868094). The bug was introduced in https://github.com/rust-lang/rust/pull/127680 (before, the command was allowed to fail).

r? @onur-ozkan