### PR TITLE
Use more accurate span for `addr_of!` suggestion

### DIFF
--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1500,33 +1500,33 @@ pub struct StaticMutRef<'a> {
     #[label]
     pub span: Span,
     #[subdiagnostic]
-    pub sugg: StaticMutRefSugg,
+    pub sugg: MutRefSugg,
     pub shared: &'a str,
 }
 
 #[derive(Subdiagnostic)]
-pub enum StaticMutRefSugg {
-    #[suggestion(
+pub enum MutRefSugg {
+    #[multipart_suggestion(
         hir_analysis_suggestion,
         style = "verbose",
-        code = "addr_of!({var})",
         applicability = "maybe-incorrect"
     )]
     Shared {
-        #[primary_span]
-        span: Span,
-        var: String,
+        #[suggestion_part(code = "addr_of!(")]
+        lo: Span,
+        #[suggestion_part(code = ")")]
+        hi: Span,
     },
-    #[suggestion(
+    #[multipart_suggestion(
         hir_analysis_suggestion_mut,
         style = "verbose",
-        code = "addr_of_mut!({var})",
         applicability = "maybe-incorrect"
     )]
     Mut {
-        #[primary_span]
-        span: Span,
-        var: String,
+        #[suggestion_part(code = "addr_of_mut!(")]
+        lo: Span,
+        #[suggestion_part(code = ")")]
+        hi: Span,
     },
 }
 
@@ -1539,34 +1539,8 @@ pub struct RefOfMutStatic<'a> {
     #[label]
     pub span: Span,
     #[subdiagnostic]
-    pub sugg: RefOfMutStaticSugg,
+    pub sugg: MutRefSugg,
     pub shared: &'a str,
-}
-
-#[derive(Subdiagnostic)]
-pub enum RefOfMutStaticSugg {
-    #[suggestion(
-        hir_analysis_suggestion,
-        style = "verbose",
-        code = "addr_of!({var})",
-        applicability = "maybe-incorrect"
-    )]
-    Shared {
-        #[primary_span]
-        span: Span,
-        var: String,
-    },
-    #[suggestion(
-        hir_analysis_suggestion_mut,
-        style = "verbose",
-        code = "addr_of_mut!({var})",
-        applicability = "maybe-incorrect"
-    )]
-    Mut {
-        #[primary_span]
-        span: Span,
-        var: String,
-    },
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui/abi/statics/static-mut-foreign.stderr
+++ b/tests/ui/abi/statics/static-mut-foreign.stderr
@@ -11,7 +11,7 @@ LL |     static_bound(&rust_dbg_static_mut);
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |     static_bound(addr_of!(rust_dbg_static_mut));
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                  ~~~~~~~~~                   +
 
 warning: creating a mutable reference to mutable static is discouraged
   --> $DIR/static-mut-foreign.rs:33:22
@@ -25,7 +25,7 @@ LL |     static_bound_set(&mut rust_dbg_static_mut);
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |     static_bound_set(addr_of_mut!(rust_dbg_static_mut));
-   |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ~~~~~~~~~~~~~                   +
 
 warning: 2 warnings emitted
 

--- a/tests/ui/borrowck/borrowck-access-permissions.stderr
+++ b/tests/ui/borrowck/borrowck-access-permissions.stderr
@@ -11,7 +11,7 @@ LL |             let _y2 = &mut static_x_mut;
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |             let _y2 = addr_of_mut!(static_x_mut);
-   |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ~~~~~~~~~~~~~            +
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-access-permissions.rs:10:19

--- a/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
+++ b/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
@@ -11,7 +11,7 @@ LL |         let sfoo: *mut Foo = &mut SFOO;
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |         let sfoo: *mut Foo = addr_of_mut!(SFOO);
-   |                              ~~~~~~~~~~~~~~~~~~
+   |                              ~~~~~~~~~~~~~    +
 
 warning: 1 warning emitted
 

--- a/tests/ui/borrowck/issue-20801.stderr
+++ b/tests/ui/borrowck/issue-20801.stderr
@@ -11,7 +11,7 @@ LL |     unsafe { &mut GLOBAL_MUT_T }
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |     unsafe { addr_of_mut!(GLOBAL_MUT_T) }
-   |              ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |              ~~~~~~~~~~~~~            +
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/issue-20801.rs:27:22

--- a/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.stderr
+++ b/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.stderr
@@ -11,7 +11,7 @@ LL |             c1(&mut Y);
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |             c1(addr_of_mut!(Y));
-   |                ~~~~~~~~~~~~~~~
+   |                ~~~~~~~~~~~~~ +
 
 warning: creating a mutable reference to mutable static is discouraged
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:27:16
@@ -25,7 +25,7 @@ LL |             c1(&mut Z);
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |             c1(addr_of_mut!(Z));
-   |                ~~~~~~~~~~~~~~~
+   |                ~~~~~~~~~~~~~ +
 
 warning: creating a mutable reference to mutable static is discouraged
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:64:37
@@ -39,7 +39,7 @@ LL |         borrowck_closures_unique::e(&mut X);
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |         borrowck_closures_unique::e(addr_of_mut!(X));
-   |                                     ~~~~~~~~~~~~~~~
+   |                                     ~~~~~~~~~~~~~ +
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:9:46

--- a/tests/ui/consts/const_let_assign2.stderr
+++ b/tests/ui/consts/const_let_assign2.stderr
@@ -11,7 +11,7 @@ LL |     let ptr = unsafe { &mut BB };
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |     let ptr = unsafe { addr_of_mut!(BB) };
-   |                        ~~~~~~~~~~~~~~~~
+   |                        ~~~~~~~~~~~~~  +
 
 warning: 1 warning emitted
 

--- a/tests/ui/drop/issue-23338-ensure-param-drop-order.stderr
+++ b/tests/ui/drop/issue-23338-ensure-param-drop-order.stderr
@@ -11,7 +11,7 @@ LL |             (mem::size_of_val(&trails) * 8) as u32
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |             (mem::size_of_val(addr_of!(trails)) * 8) as u32
-   |                               ~~~~~~~~~~~~~~~~
+   |                               ~~~~~~~~~      +
 
 warning: 1 warning emitted
 

--- a/tests/ui/drop/issue-23611-enum-swap-in-drop.stderr
+++ b/tests/ui/drop/issue-23611-enum-swap-in-drop.stderr
@@ -11,7 +11,7 @@ LL |             (mem::size_of_val(&trails) * 8) as u32
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |             (mem::size_of_val(addr_of!(trails)) * 8) as u32
-   |                               ~~~~~~~~~~~~~~~~
+   |                               ~~~~~~~~~      +
 
 warning: 1 warning emitted
 

--- a/tests/ui/issues/issue-54410.stderr
+++ b/tests/ui/issues/issue-54410.stderr
@@ -19,7 +19,7 @@ LL |     println!("{:p}", unsafe { &symbol });
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |     println!("{:p}", unsafe { addr_of!(symbol) });
-   |                               ~~~~~~~~~~~~~~~~
+   |                               ~~~~~~~~~      +
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
+++ b/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
@@ -11,7 +11,7 @@ LL |         S1 { a: unsafe { &mut X1 } }
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |         S1 { a: unsafe { addr_of_mut!(X1) } }
-   |                          ~~~~~~~~~~~~~~~~
+   |                          ~~~~~~~~~~~~~  +
 
 warning: 1 warning emitted
 

--- a/tests/ui/static/reference-to-mut-static-safe.e2021.stderr
+++ b/tests/ui/static/reference-to-mut-static-safe.e2021.stderr
@@ -11,7 +11,7 @@ LL |     let _x = &X;
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |     let _x = addr_of!(X);
-   |              ~~~~~~~~~~~
+   |              ~~~~~~~~~ +
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
   --> $DIR/reference-to-mut-static-safe.rs:9:15

--- a/tests/ui/static/reference-to-mut-static-safe.e2024.stderr
+++ b/tests/ui/static/reference-to-mut-static-safe.e2024.stderr
@@ -8,7 +8,7 @@ LL |     let _x = &X;
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |     let _x = addr_of!(X);
-   |              ~~~~~~~~~~~
+   |              ~~~~~~~~~ +
 
 error[E0133]: use of mutable static is unsafe and requires unsafe block
   --> $DIR/reference-to-mut-static-safe.rs:9:15

--- a/tests/ui/static/reference-to-mut-static-unsafe-fn.stderr
+++ b/tests/ui/static/reference-to-mut-static-unsafe-fn.stderr
@@ -8,7 +8,7 @@ LL |         let _y = &X;
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         let _y = addr_of!(X);
-   |                  ~~~~~~~~~~~
+   |                  ~~~~~~~~~ +
 
 error[E0796]: creating a shared reference to a mutable static
   --> $DIR/reference-to-mut-static-unsafe-fn.rs:13:22
@@ -20,7 +20,7 @@ LL |         let ref _a = X;
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         let ref _a = addr_of!(X);
-   |                      ~~~~~~~~~~~
+   |                      +++++++++ +
 
 error[E0796]: creating a mutable reference to a mutable static
   --> $DIR/reference-to-mut-static-unsafe-fn.rs:16:26
@@ -32,7 +32,7 @@ LL |         let ref mut _a = X;
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |         let ref mut _a = addr_of_mut!(X);
-   |                          ~~~~~~~~~~~~~~~
+   |                          +++++++++++++ +
 
 error[E0796]: creating a shared reference to a mutable static
   --> $DIR/reference-to-mut-static-unsafe-fn.rs:19:25
@@ -44,7 +44,7 @@ LL |         let (_b, _c) = (&X, &mut Y);
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         let (_b, _c) = (addr_of!(X), &mut Y);
-   |                         ~~~~~~~~~~~
+   |                         ~~~~~~~~~ +
 
 error[E0796]: creating a mutable reference to a mutable static
   --> $DIR/reference-to-mut-static-unsafe-fn.rs:19:29
@@ -56,7 +56,7 @@ LL |         let (_b, _c) = (&X, &mut Y);
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |         let (_b, _c) = (&X, addr_of_mut!(Y));
-   |                             ~~~~~~~~~~~~~~~
+   |                             ~~~~~~~~~~~~~ +
 
 error[E0796]: creating a shared reference to a mutable static
   --> $DIR/reference-to-mut-static-unsafe-fn.rs:23:13
@@ -68,7 +68,7 @@ LL |         foo(&X);
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         foo(addr_of!(X));
-   |             ~~~~~~~~~~~
+   |             ~~~~~~~~~ +
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/static/reference-to-mut-static.e2021.stderr
+++ b/tests/ui/static/reference-to-mut-static.e2021.stderr
@@ -15,7 +15,7 @@ LL | #![deny(static_mut_refs)]
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         let _y = addr_of!(X);
-   |                  ~~~~~~~~~~~
+   |                  ~~~~~~~~~ +
 
 error: creating a mutable reference to mutable static is discouraged
   --> $DIR/reference-to-mut-static.rs:20:18
@@ -29,7 +29,7 @@ LL |         let _y = &mut X;
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |         let _y = addr_of_mut!(X);
-   |                  ~~~~~~~~~~~~~~~
+   |                  ~~~~~~~~~~~~~ +
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/reference-to-mut-static.rs:28:22
@@ -43,7 +43,7 @@ LL |         let ref _a = X;
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         let ref _a = addr_of!(X);
-   |                      ~~~~~~~~~~~
+   |                      +++++++++ +
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/reference-to-mut-static.rs:32:25
@@ -57,7 +57,7 @@ LL |         let (_b, _c) = (&X, &Y);
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         let (_b, _c) = (addr_of!(X), &Y);
-   |                         ~~~~~~~~~~~
+   |                         ~~~~~~~~~ +
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/reference-to-mut-static.rs:32:29
@@ -71,7 +71,7 @@ LL |         let (_b, _c) = (&X, &Y);
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         let (_b, _c) = (&X, addr_of!(Y));
-   |                             ~~~~~~~~~~~
+   |                             ~~~~~~~~~ +
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/reference-to-mut-static.rs:38:13
@@ -85,7 +85,7 @@ LL |         foo(&X);
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         foo(addr_of!(X));
-   |             ~~~~~~~~~~~
+   |             ~~~~~~~~~ +
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/static/reference-to-mut-static.e2024.stderr
+++ b/tests/ui/static/reference-to-mut-static.e2024.stderr
@@ -8,7 +8,7 @@ LL |         let _y = &X;
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         let _y = addr_of!(X);
-   |                  ~~~~~~~~~~~
+   |                  ~~~~~~~~~ +
 
 error[E0796]: creating a mutable reference to a mutable static
   --> $DIR/reference-to-mut-static.rs:20:18
@@ -20,7 +20,7 @@ LL |         let _y = &mut X;
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |         let _y = addr_of_mut!(X);
-   |                  ~~~~~~~~~~~~~~~
+   |                  ~~~~~~~~~~~~~ +
 
 error[E0796]: creating a shared reference to a mutable static
   --> $DIR/reference-to-mut-static.rs:28:22
@@ -32,7 +32,7 @@ LL |         let ref _a = X;
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         let ref _a = addr_of!(X);
-   |                      ~~~~~~~~~~~
+   |                      +++++++++ +
 
 error[E0796]: creating a shared reference to a mutable static
   --> $DIR/reference-to-mut-static.rs:32:25
@@ -44,7 +44,7 @@ LL |         let (_b, _c) = (&X, &Y);
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         let (_b, _c) = (addr_of!(X), &Y);
-   |                         ~~~~~~~~~~~
+   |                         ~~~~~~~~~ +
 
 error[E0796]: creating a shared reference to a mutable static
   --> $DIR/reference-to-mut-static.rs:32:29
@@ -56,7 +56,7 @@ LL |         let (_b, _c) = (&X, &Y);
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         let (_b, _c) = (&X, addr_of!(Y));
-   |                             ~~~~~~~~~~~
+   |                             ~~~~~~~~~ +
 
 error[E0796]: creating a shared reference to a mutable static
   --> $DIR/reference-to-mut-static.rs:38:13
@@ -68,7 +68,7 @@ LL |         foo(&X);
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |         foo(addr_of!(X));
-   |             ~~~~~~~~~~~
+   |             ~~~~~~~~~ +
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/static/safe-extern-statics-mut.stderr
+++ b/tests/ui/static/safe-extern-statics-mut.stderr
@@ -11,7 +11,7 @@ LL |     let rb = &B;
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |     let rb = addr_of!(B);
-   |              ~~~~~~~~~~~
+   |              ~~~~~~~~~ +
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/safe-extern-statics-mut.rs:15:15
@@ -25,7 +25,7 @@ LL |     let xrb = &XB;
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |     let xrb = addr_of!(XB);
-   |               ~~~~~~~~~~~~
+   |               ~~~~~~~~~  +
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
   --> $DIR/safe-extern-statics-mut.rs:11:13

--- a/tests/ui/statics/issue-15261.stderr
+++ b/tests/ui/statics/issue-15261.stderr
@@ -11,7 +11,7 @@ LL | static n: &'static usize = unsafe { &n_mut };
 help: use `addr_of!` instead to create a raw pointer
    |
 LL | static n: &'static usize = unsafe { addr_of!(n_mut) };
-   |                                     ~~~~~~~~~~~~~~~
+   |                                     ~~~~~~~~~     +
 
 warning: 1 warning emitted
 

--- a/tests/ui/statics/static-mut-xc.stderr
+++ b/tests/ui/statics/static-mut-xc.stderr
@@ -11,7 +11,7 @@ LL |     static_bound(&static_mut_xc::a);
 help: use `addr_of!` instead to create a raw pointer
    |
 LL |     static_bound(addr_of!(static_mut_xc::a));
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                  ~~~~~~~~~                +
 
 warning: creating a mutable reference to mutable static is discouraged
   --> $DIR/static-mut-xc.rs:30:22
@@ -25,7 +25,7 @@ LL |     static_bound_set(&mut static_mut_xc::a);
 help: use `addr_of_mut!` instead to create a raw pointer
    |
 LL |     static_bound_set(addr_of_mut!(static_mut_xc::a));
-   |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ~~~~~~~~~~~~~                +
 
 warning: 2 warnings emitted
 

--- a/tests/ui/statics/static-recursive.stderr
+++ b/tests/ui/statics/static-recursive.stderr
@@ -11,7 +11,7 @@ LL | static mut S: *const u8 = unsafe { &S as *const *const u8 as *const u8 };
 help: use `addr_of!` instead to create a raw pointer
    |
 LL | static mut S: *const u8 = unsafe { addr_of!(S) as *const *const u8 as *const u8 };
-   |                                    ~~~~~~~~~~~
+   |                                    ~~~~~~~~~ +
 
 warning: 1 warning emitted
 


### PR DESCRIPTION
Use a multipart suggestion instead of a single whole-span replacement:

```
error[E0796]: creating a shared reference to a mutable static
  --> $DIR/reference-to-mut-static-unsafe-fn.rs:10:18
   |
LL |         let _y = &X;
   |                  ^^ shared reference to mutable static
   |
   = note: this shared reference has lifetime `'static`, but if the static ever gets mutated, or a mutable reference is created, then any further use of this shared reference is Undefined Behavior
help: use `addr_of!` instead to create a raw pointer
   |
LL |         let _y = addr_of!(X);
   |                  ~~~~~~~~~ +
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
