### PR TITLE
implement conversion from IP to byte arrays

### DIFF
--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -1159,6 +1159,25 @@ impl From<u32> for Ipv4Addr {
     }
 }
 
+// FIXME correct way to set stability attributes
+#[stable(feature = "ip_to_array", since = "CURRENT_RUSTC_VERSION")]
+impl From<Ipv4Addr> for [u8; 4] {
+    /// Converts to the four eight-bit integers that make up this address.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::Ipv4Addr;
+    ///
+    /// let addr = Ipv4Addr::new(127, 0, 0, 1);
+    /// assert_eq!(Into::<[u8; 4]>::into(addr), [127, 0, 0, 1]);
+    /// ```
+    #[inline]
+    fn from(ip: Ipv4Addr) -> [u8; 4] {
+        ip.octets
+    }
+}
+
 #[stable(feature = "from_slice_v4", since = "1.9.0")]
 impl From<[u8; 4]> for Ipv4Addr {
     /// Creates an `Ipv4Addr` from a four element byte array.
@@ -2076,6 +2095,24 @@ impl From<u128> for Ipv6Addr {
     #[inline]
     fn from(ip: u128) -> Ipv6Addr {
         Ipv6Addr::from_bits(ip)
+    }
+}
+
+// FIXME correct way to set stability attributes
+#[stable(feature = "ip_to_array", since = "CURRENT_RUSTC_VERSION")]
+impl From<Ipv6Addr> for [u8; 16] {
+    /// Converts to the sixteen eight-bit integers that make up this address.
+    ///
+    /// ```
+    /// use std::net::Ipv6Addr;
+    ///
+    /// let addr = Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0);
+    /// assert_eq!(Into::<[u8; 16]>::into(addr),
+    ///            [255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    /// ```
+    #[inline]
+    fn from(ip: Ipv6Addr) -> [u8; 16] {
+        ip.octets
     }
 }
 


### PR DESCRIPTION
This is very close to the included `.octets()` method but it enables declaring trait bounds for `Into<[u8; N]>` on `IpvNAddr`. It is also symmetric with the existing `From<[u8; N]>` counterparts which are already there.

Converting IP addresses to/from `[u8]` is a natural thing in the networking world since this is how they are written to and read from packets and how humans parse them. It also happens to be the same as the internal implementation of the IpvNAddr structs which should make it an efficient operation. But, that is inconsequential from an API point of view, it is just an aside.

As an example of real-world use, I'm currently starting code to implement IP sets and tables which will store IP address keys in a generic way, only requiring that they be convertible to and from the fixed-sized array representation. They'll be stored efficiently in special-purpose, [u8]-based, trie data structures. I have looked through current Rust implementations of IP-trie data structures and found that they don't quite meet my needs.