### PR TITLE
Improve error when a compiler/library build fails in `checktools.sh`

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
@@ -8,6 +8,10 @@ X_PY="$1"
 
 # Try to test the toolstate-tracked tools and store the build/test success in the TOOLSTATE_FILE.
 
+# Pre-build the compiler and the library first to output a better error message when the build
+# itself fails (see https://github.com/rust-lang/rust/issues/127869 for context).
+python3 "$X_PY" build --stage 2 compiler rustdoc
+
 set +e
 python3 "$X_PY" test --stage 2 --no-fail-fast \
     src/doc/book \


### PR DESCRIPTION
Suggested by @RalfJung [here](https://github.com/rust-lang/rust/issues/127869#issuecomment-2235829643).

`x86_64-gnu-tools` should take ~45 minutes, let's see if this doesn't regress it.

r? @onur-ozkan