### PR TITLE
Change `binary_asm_labels` to only fire on x86 and x86_64

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -403,8 +403,9 @@ lint_inner_macro_attribute_unstable = inner macro attributes are unstable
 
 lint_invalid_asm_label_binary = avoid using labels containing only the digits `0` and `1` in inline assembly
     .label = use a different label that doesn't start with `0` or `1`
-    .note = an LLVM bug makes these labels ambiguous with a binary literal number
-    .note = see <https://bugs.llvm.org/show_bug.cgi?id=36144> for more information
+    .help = start numbering with `2` instead
+    .note1 = an LLVM bug makes these labels ambiguous with a binary literal number on x86
+    .note2 = see <https://github.com/llvm/llvm-project/issues/99547> for more information
 
 lint_invalid_asm_label_format_arg = avoid using named labels in inline assembly
     .help = only local labels of the form `<number>:` should be used in inline asm

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2740,8 +2740,9 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust,compile_fail
-    /// # #![feature(asm_experimental_arch)]
+    /// ```rust,ignore (fails on non-x86_64)
+    /// #![cfg(target_arch = "x86_64")]
+    ///
     /// use std::arch::asm;
     ///
     /// fn main() {
@@ -2751,19 +2752,32 @@ declare_lint! {
     /// }
     /// ```
     ///
-    /// {{produces}}
+    /// This will produce:
+    ///
+    /// ```text
+    /// error: avoid using labels containing only the digits `0` and `1` in inline assembly
+    ///  --> <source>:7:15
+    ///   |
+    /// 7 |         asm!("0: jmp 0b");
+    ///   |               ^ use a different label that doesn't start with `0` or `1`
+    ///   |
+    ///   = help: start numbering with `2` instead
+    ///   = note: an LLVM bug makes these labels ambiguous with a binary literal number on x86
+    ///   = note: see <https://github.com/llvm/llvm-project/issues/99547> for more information
+    ///   = note: `#[deny(binary_asm_labels)]` on by default
+    /// ```
     ///
     /// ### Explanation
     ///
-    /// A [LLVM bug] causes this code to fail to compile because it interprets the `0b` as a binary
-    /// literal instead of a reference to the previous local label `0`. Note that even though the
-    /// bug is marked as fixed, it only fixes a specific usage of intel syntax within standalone
-    /// files, not inline assembly. To work around this bug, don't use labels that could be
-    /// confused with a binary literal.
+    /// An [LLVM bug] causes this code to fail to compile because it interprets the `0b` as a binary
+    /// literal instead of a reference to the previous local label `0`. To work around this bug,
+    /// don't use labels that could be confused with a binary literal.
+    ///
+    /// This behavior is platform-specific to x86 and x86-64.
     ///
     /// See the explanation in [Rust By Example] for more details.
     ///
-    /// [LLVM bug]: https://bugs.llvm.org/show_bug.cgi?id=36144
+    /// [LLVM bug]: https://github.com/llvm/llvm-project/issues/99547
     /// [Rust By Example]: https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels
     pub BINARY_ASM_LABELS,
     Deny,

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2066,7 +2066,9 @@ pub enum InvalidAsmLabel {
         missing_precise_span: bool,
     },
     #[diag(lint_invalid_asm_label_binary)]
-    #[note]
+    #[help]
+    #[note(lint_note1)]
+    #[note(lint_note2)]
     Binary {
         #[note(lint_invalid_asm_label_no_span)]
         missing_precise_span: bool,

--- a/tests/ui/asm/binary_asm_labels.stderr
+++ b/tests/ui/asm/binary_asm_labels.stderr
@@ -4,7 +4,9 @@ error: avoid using labels containing only the digits `0` and `1` in inline assem
 LL |         asm!("0: jmp 0b");
    |               ^ use a different label that doesn't start with `0` or `1`
    |
-   = note: an LLVM bug makes these labels ambiguous with a binary literal number
+   = help: start numbering with `2` instead
+   = note: an LLVM bug makes these labels ambiguous with a binary literal number on x86
+   = note: see <https://github.com/llvm/llvm-project/issues/99547> for more information
    = note: `#[deny(binary_asm_labels)]` on by default
 
 error: avoid using labels containing only the digits `0` and `1` in inline assembly
@@ -13,7 +15,9 @@ error: avoid using labels containing only the digits `0` and `1` in inline assem
 LL |         asm!("1: jmp 1b");
    |               ^ use a different label that doesn't start with `0` or `1`
    |
-   = note: an LLVM bug makes these labels ambiguous with a binary literal number
+   = help: start numbering with `2` instead
+   = note: an LLVM bug makes these labels ambiguous with a binary literal number on x86
+   = note: see <https://github.com/llvm/llvm-project/issues/99547> for more information
 
 error: avoid using labels containing only the digits `0` and `1` in inline assembly
   --> $DIR/binary_asm_labels.rs:13:15
@@ -21,7 +25,9 @@ error: avoid using labels containing only the digits `0` and `1` in inline assem
 LL |         asm!("10: jmp 10b");
    |               ^^ use a different label that doesn't start with `0` or `1`
    |
-   = note: an LLVM bug makes these labels ambiguous with a binary literal number
+   = help: start numbering with `2` instead
+   = note: an LLVM bug makes these labels ambiguous with a binary literal number on x86
+   = note: see <https://github.com/llvm/llvm-project/issues/99547> for more information
 
 error: avoid using labels containing only the digits `0` and `1` in inline assembly
   --> $DIR/binary_asm_labels.rs:14:15
@@ -29,7 +35,9 @@ error: avoid using labels containing only the digits `0` and `1` in inline assem
 LL |         asm!("01: jmp 01b");
    |               ^^ use a different label that doesn't start with `0` or `1`
    |
-   = note: an LLVM bug makes these labels ambiguous with a binary literal number
+   = help: start numbering with `2` instead
+   = note: an LLVM bug makes these labels ambiguous with a binary literal number on x86
+   = note: see <https://github.com/llvm/llvm-project/issues/99547> for more information
 
 error: avoid using labels containing only the digits `0` and `1` in inline assembly
   --> $DIR/binary_asm_labels.rs:15:15
@@ -37,7 +45,9 @@ error: avoid using labels containing only the digits `0` and `1` in inline assem
 LL |         asm!("1001101: jmp 1001101b");
    |               ^^^^^^^ use a different label that doesn't start with `0` or `1`
    |
-   = note: an LLVM bug makes these labels ambiguous with a binary literal number
+   = help: start numbering with `2` instead
+   = note: an LLVM bug makes these labels ambiguous with a binary literal number on x86
+   = note: see <https://github.com/llvm/llvm-project/issues/99547> for more information
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/asm/binary_asm_labels_allowed.rs
+++ b/tests/ui/asm/binary_asm_labels_allowed.rs
@@ -1,0 +1,17 @@
+//@ build-pass
+//@ only-aarch64
+
+// The `binary_asm_labels` lint should only be raised on `x86`. Make sure it
+// doesn't get raised on other platforms.
+
+use std::arch::asm;
+
+fn main() {
+    unsafe {
+        asm!("0: bl 0b");
+        asm!("1: bl 1b");
+        asm!("10: bl 10b");
+        asm!("01: bl 01b");
+        asm!("1001101: bl 1001101b");
+    }
+}


### PR DESCRIPTION
In <https://github.com/rust-lang/rust/pull/126922>, the `binary_asm_labels` lint was added which flags labels such as `0:` and `1:`. Before that change, LLVM was giving a confusing error on x86/x86_64 because of an incorrect interpretation.

However, targets other than x86 and x86_64 never had the error message and have not been a problem. This means that the lint was causing code that previously worked to start failing (e.g. `compiler_builtins`), rather than only providing a more clear messages where there has always been an error.

Adjust the lint to only fire on x86 and x86_64 assembly to avoid this regression.

Also update the help message.

Fixes: https://github.com/rust-lang/rust/issues/127821

<!-- homu-ignore:start -->
<!-- homu-ignore:end -->
