### PR TITLE
Always set `result` during `finish()` in debug builders

### DIFF
--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -402,6 +402,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     }
 }
 
+/// A helper used to print list-like items with no special formatting.
 struct DebugInner<'a, 'b: 'a> {
     fmt: &'a mut fmt::Formatter<'b>,
     result: fmt::Result,
@@ -578,7 +579,8 @@ impl<'a, 'b: 'a> DebugSet<'a, 'b> {
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
     pub fn finish(&mut self) -> fmt::Result {
-        self.inner.result.and_then(|_| self.inner.fmt.write_str("}"))
+        self.inner.result = self.inner.result.and_then(|_| self.inner.fmt.write_str("}"));
+        self.inner.result
     }
 }
 
@@ -721,7 +723,8 @@ impl<'a, 'b: 'a> DebugList<'a, 'b> {
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
     pub fn finish(&mut self) -> fmt::Result {
-        self.inner.result.and_then(|_| self.inner.fmt.write_str("]"))
+        self.inner.result = self.inner.result.and_then(|_| self.inner.fmt.write_str("]"));
+        self.inner.result
     }
 }
 
@@ -1002,11 +1005,12 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
     pub fn finish(&mut self) -> fmt::Result {
-        self.result.and_then(|_| {
+        self.result = self.result.and_then(|_| {
             assert!(!self.has_key, "attempted to finish a map with a partial entry");
 
             self.fmt.write_str("}")
-        })
+        });
+        self.result
     }
 
     fn is_pretty(&self) -> bool {


### PR DESCRIPTION
Most functions for format builders set `self.result` after writing strings. This ensures that any further writing fails immediately rather than trying to write again.

A few `.finish()` methods and the `.finish_non_exhaustive` did have this same behavior, so update the remaining `.finish()` methods to make it consistent here.

<!-- homu-ignore:start -->
<!-- homu-ignore:end -->