### PR TITLE
Use `#[rustfmt::skip]` on some `use` groups to prevent reordering.

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -34,6 +34,8 @@ use super::{
     Pointer, Projectable, Scalar, ValueVisitor,
 };
 
+// for the validation errors
+#[rustfmt::skip]
 use super::InterpError::UndefinedBehavior as Ub;
 use super::InterpError::Unsupported as Unsup;
 use super::UndefinedBehaviorInfo::*;

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -120,6 +120,7 @@ use types::*;
 use unit_bindings::*;
 use unused::*;
 
+#[rustfmt::skip]
 pub use builtin::{MissingDoc, SoftLints};
 pub use context::{CheckLintNameResult, FindLintError, LintStore};
 pub use context::{EarlyContext, LateContext, LintContext};

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -24,6 +24,8 @@ mod convert;
 mod decode;
 mod methods;
 
+// stable re-exports
+#[rustfmt::skip]
 #[stable(feature = "try_from", since = "1.34.0")]
 pub use self::convert::CharTryFromError;
 #[stable(feature = "char_from_str", since = "1.20.0")]
@@ -31,11 +33,14 @@ pub use self::convert::ParseCharError;
 #[stable(feature = "decode_utf16", since = "1.9.0")]
 pub use self::decode::{DecodeUtf16, DecodeUtf16Error};
 
+// perma-unstable re-exports
+#[rustfmt::skip]
 #[unstable(feature = "char_internals", reason = "exposed only for libstd", issue = "none")]
 pub use self::methods::encode_utf16_raw; // perma-unstable
 #[unstable(feature = "char_internals", reason = "exposed only for libstd", issue = "none")]
 pub use self::methods::encode_utf8_raw; // perma-unstable
 
+#[rustfmt::skip]
 use crate::ascii;
 use crate::error::Error;
 use crate::escape;

--- a/library/core/src/unicode/mod.rs
+++ b/library/core/src/unicode/mod.rs
@@ -1,13 +1,15 @@
 #![unstable(feature = "unicode_internals", issue = "none")]
 #![allow(missing_docs)]
 
-// The `pub use` ones are for use in alloc, and are not re-exported in std.
-
-pub(crate) use unicode_data::alphabetic::lookup as Alphabetic;
+// for use in alloc, not re-exported in std.
+#[rustfmt::skip]
 pub use unicode_data::case_ignorable::lookup as Case_Ignorable;
 pub use unicode_data::cased::lookup as Cased;
-pub(crate) use unicode_data::cc::lookup as Cc;
 pub use unicode_data::conversions;
+
+#[rustfmt::skip]
+pub(crate) use unicode_data::alphabetic::lookup as Alphabetic;
+pub(crate) use unicode_data::cc::lookup as Cc;
 pub(crate) use unicode_data::grapheme_extend::lookup as Grapheme_Extend;
 pub(crate) use unicode_data::lowercase::lookup as Lowercase;
 pub(crate) use unicode_data::n::lookup as N;

--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -16,9 +16,11 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(unused_macros)]
 
+#[rustfmt::skip]
 pub use crate::panicking::{begin_panic, panic_count};
 pub use core::panicking::{panic_display, panic_fmt};
 
+#[rustfmt::skip]
 use crate::sync::Once;
 use crate::sys;
 use crate::thread::{self, Thread};


### PR DESCRIPTION
`use` declarations will be reformatted in #125443. Very rarely, there is a desire to force a group of `use` declarations together in a way that auto-formatting will break up. E.g. when you want a single comment to apply to a group. #126776 dealt with all of these in the codebase, ensuring that no comments intended for multiple `use` declarations would end up in the wrong place. But some people were unhappy with it.

This commit uses `#[rustfmt::skip]` to create these custom `use` groups in an idiomatic way for a few of the cases changed in #126776. This works because rustfmt treats any `use` item annotated with `#[rustfmt::skip]` as a barrier and won't reorder other `use` items around it.

r? @cuviper 