### PR TITLE
[compiletest] Search *.a when getting dynamic libraries on AIX

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -94,6 +94,8 @@ fn get_lib_name(lib: &str, aux_type: AuxType) -> Option<String> {
             format!("{}.dll", lib)
         } else if cfg!(target_vendor = "apple") {
             format!("lib{}.dylib", lib)
+        } else if cfg!(target_os = "aix") {
+            format!("lib{}.a", lib)
         } else {
             format!("lib{}.so", lib)
         }),
@@ -278,11 +280,19 @@ impl<'test> TestCx<'test> {
             Ui | MirOpt => false,
             mode => panic!("unimplemented for mode {:?}", mode),
         };
-        if test_should_run { self.run_if_enabled() } else { WillExecute::No }
+        if test_should_run {
+            self.run_if_enabled()
+        } else {
+            WillExecute::No
+        }
     }
 
     fn run_if_enabled(&self) -> WillExecute {
-        if self.config.run_enabled() { WillExecute::Yes } else { WillExecute::Disabled }
+        if self.config.run_enabled() {
+            WillExecute::Yes
+        } else {
+            WillExecute::Disabled
+        }
     }
 
     fn should_run_successfully(&self, pm: Option<PassMode>) -> bool {
@@ -2441,7 +2451,11 @@ impl<'test> TestCx<'test> {
     /// The revision, ignored for incremental compilation since it wants all revisions in
     /// the same directory.
     fn safe_revision(&self) -> Option<&str> {
-        if self.config.mode == Incremental { None } else { self.revision }
+        if self.config.mode == Incremental {
+            None
+        } else {
+            self.revision
+        }
     }
 
     /// Gets the absolute path to the directory where all output for the given
@@ -2665,7 +2679,11 @@ impl<'test> TestCx<'test> {
 
     fn charset() -> &'static str {
         // FreeBSD 10.1 defaults to GDB 6.1.1 which doesn't support "auto" charset
-        if cfg!(target_os = "freebsd") { "ISO-8859-1" } else { "UTF-8" }
+        if cfg!(target_os = "freebsd") {
+            "ISO-8859-1"
+        } else {
+            "UTF-8"
+        }
     }
 
     fn run_rustdoc_test(&self) {
@@ -4488,7 +4506,11 @@ impl<'test> TestCx<'test> {
         for output_file in files {
             println!("Actual {} saved to {}", kind, output_file.display());
         }
-        if self.config.bless { 0 } else { 1 }
+        if self.config.bless {
+            0
+        } else {
+            1
+        }
     }
 
     fn check_and_prune_duplicate_outputs(

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -280,19 +280,11 @@ impl<'test> TestCx<'test> {
             Ui | MirOpt => false,
             mode => panic!("unimplemented for mode {:?}", mode),
         };
-        if test_should_run {
-            self.run_if_enabled()
-        } else {
-            WillExecute::No
-        }
+        if test_should_run { self.run_if_enabled() } else { WillExecute::No }
     }
 
     fn run_if_enabled(&self) -> WillExecute {
-        if self.config.run_enabled() {
-            WillExecute::Yes
-        } else {
-            WillExecute::Disabled
-        }
+        if self.config.run_enabled() { WillExecute::Yes } else { WillExecute::Disabled }
     }
 
     fn should_run_successfully(&self, pm: Option<PassMode>) -> bool {
@@ -2451,11 +2443,7 @@ impl<'test> TestCx<'test> {
     /// The revision, ignored for incremental compilation since it wants all revisions in
     /// the same directory.
     fn safe_revision(&self) -> Option<&str> {
-        if self.config.mode == Incremental {
-            None
-        } else {
-            self.revision
-        }
+        if self.config.mode == Incremental { None } else { self.revision }
     }
 
     /// Gets the absolute path to the directory where all output for the given
@@ -2679,11 +2667,7 @@ impl<'test> TestCx<'test> {
 
     fn charset() -> &'static str {
         // FreeBSD 10.1 defaults to GDB 6.1.1 which doesn't support "auto" charset
-        if cfg!(target_os = "freebsd") {
-            "ISO-8859-1"
-        } else {
-            "UTF-8"
-        }
+        if cfg!(target_os = "freebsd") { "ISO-8859-1" } else { "UTF-8" }
     }
 
     fn run_rustdoc_test(&self) {
@@ -4506,11 +4490,7 @@ impl<'test> TestCx<'test> {
         for output_file in files {
             println!("Actual {} saved to {}", kind, output_file.display());
         }
-        if self.config.bless {
-            0
-        } else {
-            1
-        }
+        if self.config.bless { 0 } else { 1 }
     }
 
     fn check_and_prune_duplicate_outputs(


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
AIX uses `.a` as dylib suffix. Support it in compiletest.
