### PR TITLE
Add limit for unclosed delimiters in lexer diagnostic

### DIFF
--- a/compiler/rustc_parse/src/lexer/tokentrees.rs
+++ b/compiler/rustc_parse/src/lexer/tokentrees.rs
@@ -72,14 +72,29 @@ impl<'psess, 'src> TokenTreesReader<'psess, 'src> {
     fn eof_err(&mut self) -> PErr<'psess> {
         let msg = "this file contains an unclosed delimiter";
         let mut err = self.string_reader.dcx().struct_span_err(self.token.span, msg);
-        for &(_, sp) in &self.diag_info.open_braces {
-            err.span_label(sp, "unclosed delimiter");
+
+        let unclosed_delimiter_show_limit = 5;
+        let len = usize::min(unclosed_delimiter_show_limit, self.diag_info.open_braces.len());
+        for &(_, span) in &self.diag_info.open_braces[..len] {
+            err.span_label(span, "unclosed delimiter");
             self.diag_info.unmatched_delims.push(UnmatchedDelim {
                 found_delim: None,
                 found_span: self.token.span,
-                unclosed_span: Some(sp),
+                unclosed_span: Some(span),
                 candidate_span: None,
             });
+        }
+
+        if let Some((_, span)) = self.diag_info.open_braces.get(unclosed_delimiter_show_limit)
+            && self.diag_info.open_braces.len() >= unclosed_delimiter_show_limit + 2
+        {
+            err.span_label(
+                *span,
+                format!(
+                    "another {} unclosed delimiters begin from here",
+                    self.diag_info.open_braces.len() - unclosed_delimiter_show_limit
+                ),
+            );
         }
 
         if let Some((delim, _)) = self.diag_info.open_braces.last() {

--- a/tests/ui/parser/brace-in-let-chain.stderr
+++ b/tests/ui/parser/brace-in-let-chain.stderr
@@ -17,14 +17,8 @@ LL | fn qux() {
    |          - unclosed delimiter
 ...
 LL | fn foo() {
-   |          - unclosed delimiter
+   |          - another 3 unclosed delimiters begin from here
 ...
-LL | fn bar() {
-   |          - unclosed delimiter
-...
-LL | fn baz() {
-   |          - unclosed delimiter
-LL |     if false {
 LL |         {
    |         - this delimiter might not be properly closed...
 LL |             && let () = ()

--- a/tests/ui/parser/mismatched-delimiter-corner-case-issue-127868.rs
+++ b/tests/ui/parser/mismatched-delimiter-corner-case-issue-127868.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-trailing-newlines
 // issue: rust-lang/rust#127868
 
 fn main() {

--- a/tests/ui/parser/mismatched-delimiter-corner-case-issue-127868.rs
+++ b/tests/ui/parser/mismatched-delimiter-corner-case-issue-127868.rs
@@ -1,0 +1,7 @@
+// ignore-tidy-trailing-newlines
+// issue: rust-lang/rust#127868
+
+fn main() {
+    let a = [[[[[[[[[[[[[[[[[[[[1, {, (, [,;
+} //~ ERROR mismatched closing delimiter: `}`
+//~ ERROR this file contains an unclosed delimiter

--- a/tests/ui/parser/mismatched-delimiter-corner-case-issue-127868.stderr
+++ b/tests/ui/parser/mismatched-delimiter-corner-case-issue-127868.stderr
@@ -1,0 +1,45 @@
+error: mismatched closing delimiter: `}`
+  --> $DIR/mismatched-delimiter-corner-case-issue-127868.rs:5:42
+   |
+LL | fn main() {
+   |           - closing delimiter possibly meant for this
+LL |     let a = [[[[[[[[[[[[[[[[[[[[1, {, (, [,;
+   |                                          ^ unclosed delimiter
+LL | }
+   | ^ mismatched closing delimiter
+
+error: this file contains an unclosed delimiter
+  --> $DIR/mismatched-delimiter-corner-case-issue-127868.rs:7:51
+   |
+LL | fn main() {
+   |           - unclosed delimiter
+LL |     let a = [[[[[[[[[[[[[[[[[[[[1, {, (, [,;
+   |             --------------------   - this delimiter might not be properly closed...
+   |             ||||||||||||||||||||
+   |             |||||||||||||||||||unclosed delimiter
+   |             ||||||||||||||||||unclosed delimiter
+   |             |||||||||||||||||unclosed delimiter
+   |             ||||||||||||||||unclosed delimiter
+   |             |||||||||||||||unclosed delimiter
+   |             ||||||||||||||unclosed delimiter
+   |             |||||||||||||unclosed delimiter
+   |             ||||||||||||unclosed delimiter
+   |             |||||||||||unclosed delimiter
+   |             ||||||||||unclosed delimiter
+   |             |||||||||unclosed delimiter
+   |             ||||||||unclosed delimiter
+   |             |||||||unclosed delimiter
+   |             ||||||unclosed delimiter
+   |             |||||unclosed delimiter
+   |             ||||unclosed delimiter
+   |             |||unclosed delimiter
+   |             ||unclosed delimiter
+   |             |unclosed delimiter
+   |             unclosed delimiter
+LL | }
+   | - ...as it matches this but it has different indentation
+LL |
+   |                                                   ^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/parser/mismatched-delimiter-corner-case-issue-127868.stderr
+++ b/tests/ui/parser/mismatched-delimiter-corner-case-issue-127868.stderr
@@ -1,5 +1,5 @@
 error: mismatched closing delimiter: `}`
-  --> $DIR/mismatched-delimiter-corner-case-issue-127868.rs:5:42
+  --> $DIR/mismatched-delimiter-corner-case-issue-127868.rs:4:42
    |
 LL | fn main() {
    |           - closing delimiter possibly meant for this
@@ -9,29 +9,14 @@ LL | }
    | ^ mismatched closing delimiter
 
 error: this file contains an unclosed delimiter
-  --> $DIR/mismatched-delimiter-corner-case-issue-127868.rs:7:51
+  --> $DIR/mismatched-delimiter-corner-case-issue-127868.rs:6:52
    |
 LL | fn main() {
    |           - unclosed delimiter
 LL |     let a = [[[[[[[[[[[[[[[[[[[[1, {, (, [,;
-   |             --------------------   - this delimiter might not be properly closed...
-   |             ||||||||||||||||||||
-   |             |||||||||||||||||||unclosed delimiter
-   |             ||||||||||||||||||unclosed delimiter
-   |             |||||||||||||||||unclosed delimiter
-   |             ||||||||||||||||unclosed delimiter
-   |             |||||||||||||||unclosed delimiter
-   |             ||||||||||||||unclosed delimiter
-   |             |||||||||||||unclosed delimiter
-   |             ||||||||||||unclosed delimiter
-   |             |||||||||||unclosed delimiter
-   |             ||||||||||unclosed delimiter
-   |             |||||||||unclosed delimiter
-   |             ||||||||unclosed delimiter
-   |             |||||||unclosed delimiter
-   |             ||||||unclosed delimiter
-   |             |||||unclosed delimiter
-   |             ||||unclosed delimiter
+   |             -----                  - this delimiter might not be properly closed...
+   |             |||||
+   |             ||||another 16 unclosed delimiters begin from here
    |             |||unclosed delimiter
    |             ||unclosed delimiter
    |             |unclosed delimiter


### PR DESCRIPTION
Fixes #127868

The first commit shows the original diagnostic, and the second commit shows the changes.