### PR TITLE
Cleanup dll/exe filename calculations in `run_make_support`

### DIFF
--- a/src/tools/run-make-support/src/artifact_names.rs
+++ b/src/tools/run-make-support/src/artifact_names.rs
@@ -1,7 +1,9 @@
 //! A collection of helpers to construct artifact names, such as names of dynamic or static
 //! librarys which are target-dependent.
 
-use crate::targets::{is_darwin, is_msvc, is_windows};
+// FIXME(jieyouxu): convert these to return `PathBuf`s instead of strings!
+
+use crate::targets::is_msvc;
 
 /// Construct the static library name based on the target.
 #[must_use]
@@ -31,41 +33,15 @@ pub fn static_lib_name(name: &str) -> String {
 /// Construct the dynamic library name based on the target.
 #[must_use]
 pub fn dynamic_lib_name(name: &str) -> String {
-    // See tools.mk (irrelevant lines omitted):
-    //
-    // ```makefile
-    // ifeq ($(UNAME),Darwin)
-    //     DYLIB = $(TMPDIR)/lib$(1).dylib
-    // else
-    //     ifdef IS_WINDOWS
-    //         DYLIB = $(TMPDIR)/$(1).dll
-    //     else
-    //         DYLIB = $(TMPDIR)/lib$(1).so
-    //     endif
-    // endif
-    // ```
     assert!(!name.contains(char::is_whitespace), "dynamic library name cannot contain whitespace");
 
-    let extension = dynamic_lib_extension();
-    if is_darwin() {
-        format!("lib{name}.{extension}")
-    } else if is_windows() {
-        format!("{name}.{extension}")
-    } else {
-        format!("lib{name}.{extension}")
-    }
+    format!("{}{name}.{}", std::env::consts::DLL_PREFIX, std::env::consts::DLL_EXTENSION)
 }
 
 /// Construct the dynamic library extension based on the target.
 #[must_use]
 pub fn dynamic_lib_extension() -> &'static str {
-    if is_darwin() {
-        "dylib"
-    } else if is_windows() {
-        "dll"
-    } else {
-        "so"
-    }
+    std::env::consts::DLL_EXTENSION
 }
 
 /// Construct the name of a rust library (rlib).
@@ -77,5 +53,5 @@ pub fn rust_lib_name(name: &str) -> String {
 /// Construct the binary (executable) name based on the target.
 #[must_use]
 pub fn bin_name(name: &str) -> String {
-    if is_windows() { format!("{name}.exe") } else { name.to_string() }
+    format!("{name}{}", std::env::consts::EXE_SUFFIX)
 }


### PR DESCRIPTION
Use `std::env::consts` constants since now we have access to them (unlike in Makefiles!) ^^

cc @bzEq (this is one of the places in our test suites that tries to compute e.g. dylib extension; using `std::env::consts::DLL_EXTENSION` should correctly return `a` for AIX)

r? @fmease (thank you for the suggestion in https://github.com/rust-lang/rust/pull/127760#discussion_r1678079698, this also improves correctness for the support library!)

try-job: aarch64-apple
try-job: armhf-gnu
try-job: test-various
try-job: x86_64-msvc
try-job: x86_64-gnu-llvm-18