### PR TITLE
Fix display of logo "border"

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -675,7 +675,6 @@ ul.block, .block li {
 	border-top: solid 16px transparent;
 	box-sizing: content-box;
 	position: relative;
-	background-color: var(--sidebar-background-color);
 	background-clip: border-box;
 	z-index: 1;
 }


### PR DESCRIPTION
Before:

![Screenshot from 2024-07-19 13-32-17](https://github.com/user-attachments/assets/381bb9c8-0ae0-408b-8476-9785ef1b5fd4)

After:

![Screenshot from 2024-07-19 13-37-46](https://github.com/user-attachments/assets/19cdb71f-3912-4fcd-95de-99b9f86a8293)

r? @notriddle 