### PR TITLE
Disable run-make/split-debuginfo test for RISC-V 64

### DIFF
--- a/tests/run-make/split-debuginfo/Makefile
+++ b/tests/run-make/split-debuginfo/Makefile
@@ -1,4 +1,6 @@
 # ignore-cross-compile
+# ignore-riscv64 On this platform only `-Csplit-debuginfo=off` is supported, see #120518
+
 include ../tools.mk
 
 all: off packed unpacked


### PR DESCRIPTION
Together with @Hoverbear, we've been improving the state of the riscv64gc-unknown-linux-gnu target.

This is in relation to https://github.com/rust-lang/rust/pull/125220 where `tests/ui/debuginfo/debuginfo-emit-llvm-ir-and-split-debuginfo.rs` was disabled for RISC-V 64 in that another test, `tests/run-make/split-debuginfo` also needs to be disabled due to https://github.com/llvm/llvm-project/issues/56642 and the changes made in https://github.com/rust-lang/rust/pull/120518.

This test appears to be a host test, not a target test, so it isn't seen failing in https://github.com/rust-lang/rust/pull/126641, however, we are in the process of testing host tools for riscv64-gc-unknown-linux-gnu so this test has now been noticed to be a problem.