### PR TITLE
Update jsondocck directives to follow ui_test-style

### DIFF
--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -266,6 +266,7 @@ def get_known_directive_names():
 # To prevent duplicating the list of commmands between `compiletest` and `htmldocck`, we put
 # it into a common file which is included in rust code and parsed here.
 # FIXME: This setup is temporary until we figure out how to improve this situation.
+#        See <https://github.com/rust-lang/rust/issues/125813#issuecomment-2141953780>.
 KNOWN_DIRECTIVE_NAMES = get_known_directive_names()
 
 LINE_PATTERN = re.compile(r'''

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -66,14 +66,17 @@ impl CommandKind {
         };
 
         if !count {
-            print_err(&format!("Incorrect number of arguments to `@{}`", self), lineno);
+            print_err(&format!("Incorrect number of arguments to `{}`", self), lineno);
             return false;
         }
 
         if let CommandKind::Count = self {
             if args[1].parse::<usize>().is_err() {
                 print_err(
-                    &format!("Second argument to @count must be a valid usize (got `{}`)", args[1]),
+                    &format!(
+                        "Second argument to `count` must be a valid usize (got `{}`)",
+                        args[1]
+                    ),
                     lineno,
                 );
                 return false;
@@ -101,7 +104,8 @@ static LINE_PATTERN: OnceLock<Regex> = OnceLock::new();
 fn line_pattern() -> Regex {
     RegexBuilder::new(
         r#"
-        \s(?P<invalid>!?)@(?P<negated>!?)
+        //@\s+
+        (?P<negated>!?)
         (?P<cmd>[A-Za-z]+(?:-[A-Za-z]+)*)
         (?P<args>.*)$
     "#,
@@ -115,6 +119,10 @@ fn line_pattern() -> Regex {
 fn print_err(msg: &str, lineno: usize) {
     eprintln!("Invalid command: {} on line {}", msg, lineno)
 }
+
+// FIXME: This setup is temporary until we figure out how to improve this situation.
+//        See <https://github.com/rust-lang/rust/issues/125813#issuecomment-2141953780>.
+include!(concat!(env!("CARGO_MANIFEST_DIR"), "/../compiletest/src/command-list.rs"));
 
 /// Get a list of commands from a file. Does the work of ensuring the commands
 /// are syntactically valid.
@@ -132,35 +140,21 @@ fn get_commands(template: &str) -> Result<Vec<Command>, ()> {
         };
 
         let negated = cap.name("negated").unwrap().as_str() == "!";
-        let cmd = cap.name("cmd").unwrap().as_str();
 
-        let cmd = match cmd {
+        let cmd = match cap.name("cmd").unwrap().as_str() {
             "has" => CommandKind::Has,
             "count" => CommandKind::Count,
             "is" => CommandKind::Is,
             "ismany" => CommandKind::IsMany,
             "set" => CommandKind::Set,
-            _ => {
-                print_err(&format!("Unrecognized command name `@{}`", cmd), lineno);
+            // FIXME: See the comment above the `include!(...)`.
+            cmd if KNOWN_DIRECTIVE_NAMES.contains(&cmd) => continue,
+            cmd => {
+                print_err(&format!("Unrecognized command name `{cmd}`"), lineno);
                 errors = true;
                 continue;
             }
         };
-
-        if let Some(m) = cap.name("invalid") {
-            if m.as_str() == "!" {
-                print_err(
-                    &format!(
-                        "`!@{0}{1}`, (help: try with `@!{1}`)",
-                        if negated { "!" } else { "" },
-                        cmd,
-                    ),
-                    lineno,
-                );
-                errors = true;
-                continue;
-            }
-        }
 
         let args = cap.name("args").map_or(Some(vec![]), |m| shlex::split(m.as_str()));
 
@@ -197,19 +191,19 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
     let result = match command.kind {
         CommandKind::Has => {
             match command.args.len() {
-                // @has <jsonpath> = check path exists
+                // `has <jsonpath>`: Check that `jsonpath` exists.
                 1 => {
                     let val = cache.value();
                     let results = select(val, &command.args[0]).unwrap();
                     !results.is_empty()
                 }
-                // @has <jsonpath> <value> = check *any* item matched by path equals value
+                // `has <jsonpath> <value>`: Check *any* item matched by `jsonpath` equals `value`.
                 2 => {
                     let val = cache.value().clone();
                     let results = select(&val, &command.args[0]).unwrap();
                     let pat = string_to_value(&command.args[1], cache);
                     let has = results.contains(&pat.as_ref());
-                    // Give better error for when @has check fails
+                    // Give better error for when `has` check fails.
                     if !command.negated && !has {
                         return Err(CkError::FailedCheck(
                             format!(
@@ -227,8 +221,9 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
                 _ => unreachable!(),
             }
         }
+        // `ismany <path> <jsonpath> <value...>`
         CommandKind::IsMany => {
-            // @ismany <path> <jsonpath> <value>...
+            assert!(!command.negated, "`ismany` may not be negated");
             let (query, values) = if let [query, values @ ..] = &command.args[..] {
                 (query, values)
             } else {
@@ -236,7 +231,6 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
             };
             let val = cache.value();
             let got_values = select(val, &query).unwrap();
-            assert!(!command.negated, "`@!ismany` is not supported");
 
             // Serde json doesn't implement Ord or Hash for Value, so we must
             // use a Vec here. While in theory that makes setwize equality
@@ -265,8 +259,8 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
             }
             true
         }
+        // `count <jsonpath> <count>`: Check that `jsonpath` matches exactly `count` times.
         CommandKind::Count => {
-            // @count <jsonpath> <count> = Check that the jsonpath matches exactly [count] times
             assert_eq!(command.args.len(), 2);
             let expected: usize = command.args[1].parse().unwrap();
             let val = cache.value();
@@ -287,8 +281,8 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
                 eq
             }
         }
+        // `has <jsonpath> <value>`: Check` *exactly one* item matched by `jsonpath`, and it equals `value`.
         CommandKind::Is => {
-            // @has <jsonpath> <value> = check *exactly one* item matched by path, and it equals value
             assert_eq!(command.args.len(), 2);
             let val = cache.value().clone();
             let results = select(&val, &command.args[0]).unwrap();
@@ -308,8 +302,9 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
                 is
             }
         }
+        // `set <name> = <jsonpath>`
         CommandKind::Set => {
-            // @set <name> = <jsonpath>
+            assert!(!command.negated, "`set` may not be negated");
             assert_eq!(command.args.len(), 3);
             assert_eq!(command.args[1], "=", "Expected an `=`");
             let val = cache.value().clone();
@@ -317,7 +312,7 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
             assert_eq!(
                 results.len(),
                 1,
-                "Expected 1 match for `{}` (because of @set): matched to {:?}",
+                "Expected 1 match for `{}` (because of `set`): matched to {:?}",
                 command.args[2],
                 results
             );
@@ -330,7 +325,7 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
                 }
                 _ => {
                     panic!(
-                        "Got multiple results in `@set` for `{}`: {:?}",
+                        "Got multiple results in `set` for `{}`: {:?}",
                         &command.args[2], results,
                     );
                 }
@@ -341,18 +336,14 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
     if result == command.negated {
         if command.negated {
             Err(CkError::FailedCheck(
-                format!(
-                    "`@!{} {}` matched when it shouldn't",
-                    command.kind,
-                    command.args.join(" ")
-                ),
+                format!("`!{} {}` matched when it shouldn't", command.kind, command.args.join(" ")),
                 command,
             ))
         } else {
             // FIXME: In the future, try 'peeling back' each step, and see at what level the match failed
             Err(CkError::FailedCheck(
                 format!(
-                    "`@{} {}` didn't match when it should",
+                    "`{} {}` didn't match when it should",
                     command.kind,
                     command.args.join(" ")
                 ),

--- a/tests/rustdoc-json/assoc_items.rs
+++ b/tests/rustdoc-json/assoc_items.rs
@@ -3,32 +3,32 @@
 pub struct Simple;
 
 impl Simple {
-    // @has "$.index[*][?(@.name=='CONSTANT')].inner.assoc_const"
+    //@ has "$.index[*][?(@.name=='CONSTANT')].inner.assoc_const"
     pub const CONSTANT: usize = 0;
 }
 
 pub trait EasyToImpl {
-    // @has "$.index[*][?(@.docs=='ToDeclare trait')].inner.assoc_type"
-    // @is "$.index[*][?(@.docs=='ToDeclare trait')].inner.assoc_type.default" null
-    // @is "$.index[*][?(@.docs=='ToDeclare trait')].inner.assoc_type.bounds" []
+    //@ has "$.index[*][?(@.docs=='ToDeclare trait')].inner.assoc_type"
+    //@ is "$.index[*][?(@.docs=='ToDeclare trait')].inner.assoc_type.default" null
+    //@ is "$.index[*][?(@.docs=='ToDeclare trait')].inner.assoc_type.bounds" []
     /// ToDeclare trait
     type ToDeclare;
-    // @has "$.index[*][?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const"
-    // @is "$.index[*][?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const.default" null
-    // @is "$.index[*][?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const.type.primitive" '"usize"'
+    //@ has "$.index[*][?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const"
+    //@ is "$.index[*][?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const.default" null
+    //@ is "$.index[*][?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const.type.primitive" '"usize"'
     /// AN_ATTRIBUTE trait
     const AN_ATTRIBUTE: usize;
 }
 
 impl EasyToImpl for Simple {
-    // @has "$.index[*][?(@.docs=='ToDeclare impl')].inner.assoc_type"
-    // @is "$.index[*][?(@.docs=='ToDeclare impl')].inner.assoc_type.default.primitive" \"usize\"
+    //@ has "$.index[*][?(@.docs=='ToDeclare impl')].inner.assoc_type"
+    //@ is "$.index[*][?(@.docs=='ToDeclare impl')].inner.assoc_type.default.primitive" \"usize\"
     /// ToDeclare impl
     type ToDeclare = usize;
 
-    // @has "$.index[*][?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const"
-    // @is "$.index[*][?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const.type.primitive" \"usize\"
-    // @is "$.index[*][?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const.default" \"12\"
+    //@ has "$.index[*][?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const"
+    //@ is "$.index[*][?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const.type.primitive" \"usize\"
+    //@ is "$.index[*][?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const.default" \"12\"
     /// AN_ATTRIBUTE impl
     const AN_ATTRIBUTE: usize = 12;
 }

--- a/tests/rustdoc-json/assoc_type.rs
+++ b/tests/rustdoc-json/assoc_type.rs
@@ -1,9 +1,9 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/98547>.
 
-// @has "$.index[*][?(@.name=='Trait')]"
-// @has "$.index[*][?(@.name=='AssocType')]"
-// @has "$.index[*][?(@.name=='S')]"
-// @has "$.index[*][?(@.name=='S2')]"
+//@ has "$.index[*][?(@.name=='Trait')]"
+//@ has "$.index[*][?(@.name=='AssocType')]"
+//@ has "$.index[*][?(@.name=='S')]"
+//@ has "$.index[*][?(@.name=='S2')]"
 
 pub trait Trait {
     type AssocType;

--- a/tests/rustdoc-json/blanket_impls.rs
+++ b/tests/rustdoc-json/blanket_impls.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 
-// @has "$.index[*][?(@.name=='Error')].inner.assoc_type"
-// @has "$.index[*][?(@.name=='Error')].inner.assoc_type.default.resolved_path"
-// @has "$.index[*][?(@.name=='Error')].inner.assoc_type.default.resolved_path.name" \"Infallible\"
+//@ has "$.index[*][?(@.name=='Error')].inner.assoc_type"
+//@ has "$.index[*][?(@.name=='Error')].inner.assoc_type.default.resolved_path"
+//@ has "$.index[*][?(@.name=='Error')].inner.assoc_type.default.resolved_path.name" \"Infallible\"
 pub struct ForBlanketTryFromImpl;

--- a/tests/rustdoc-json/doc_hidden_failure.rs
+++ b/tests/rustdoc-json/doc_hidden_failure.rs
@@ -11,8 +11,8 @@ mod auto {
     }
 }
 
-// @count "$.index[*][?(@.name=='builders')]" 1
-// @has "$.index[*][?(@.name == 'ActionRowBuilder')"]
+//@ count "$.index[*][?(@.name=='builders')]" 1
+//@ has "$.index[*][?(@.name == 'ActionRowBuilder')"]
 pub use auto::*;
 
 pub mod builders {

--- a/tests/rustdoc-json/enums/discriminant/basic.rs
+++ b/tests/rustdoc-json/enums/discriminant/basic.rs
@@ -1,12 +1,12 @@
 #[repr(i8)]
 pub enum Ordering {
-    // @is "$.index[*][?(@.name=='Less')].inner.variant.discriminant.expr" '"-1"'
-    // @is "$.index[*][?(@.name=='Less')].inner.variant.discriminant.value" '"-1"'
+    //@ is "$.index[*][?(@.name=='Less')].inner.variant.discriminant.expr" '"-1"'
+    //@ is "$.index[*][?(@.name=='Less')].inner.variant.discriminant.value" '"-1"'
     Less = -1,
-    // @is "$.index[*][?(@.name=='Equal')].inner.variant.discriminant.expr" '"0"'
-    // @is "$.index[*][?(@.name=='Equal')].inner.variant.discriminant.value" '"0"'
+    //@ is "$.index[*][?(@.name=='Equal')].inner.variant.discriminant.expr" '"0"'
+    //@ is "$.index[*][?(@.name=='Equal')].inner.variant.discriminant.value" '"0"'
     Equal = 0,
-    // @is "$.index[*][?(@.name=='Greater')].inner.variant.discriminant.expr" '"1"'
-    // @is "$.index[*][?(@.name=='Greater')].inner.variant.discriminant.value" '"1"'
+    //@ is "$.index[*][?(@.name=='Greater')].inner.variant.discriminant.expr" '"1"'
+    //@ is "$.index[*][?(@.name=='Greater')].inner.variant.discriminant.value" '"1"'
     Greater = 1,
 }

--- a/tests/rustdoc-json/enums/discriminant/expr.rs
+++ b/tests/rustdoc-json/enums/discriminant/expr.rs
@@ -1,30 +1,30 @@
 pub enum Foo {
-    // @is "$.index[*][?(@.name=='Addition')].inner.variant.discriminant.value" '"0"'
-    // @is "$.index[*][?(@.name=='Addition')].inner.variant.discriminant.expr" '"{ _ }"'
+    //@ is "$.index[*][?(@.name=='Addition')].inner.variant.discriminant.value" '"0"'
+    //@ is "$.index[*][?(@.name=='Addition')].inner.variant.discriminant.expr" '"{ _ }"'
     Addition = 0 + 0,
-    // @is "$.index[*][?(@.name=='Bin')].inner.variant.discriminant.value" '"1"'
-    // @is "$.index[*][?(@.name=='Bin')].inner.variant.discriminant.expr" '"0b1"'
+    //@ is "$.index[*][?(@.name=='Bin')].inner.variant.discriminant.value" '"1"'
+    //@ is "$.index[*][?(@.name=='Bin')].inner.variant.discriminant.expr" '"0b1"'
     Bin = 0b1,
-    // @is "$.index[*][?(@.name=='Oct')].inner.variant.discriminant.value" '"2"'
-    // @is "$.index[*][?(@.name=='Oct')].inner.variant.discriminant.expr" '"0o2"'
+    //@ is "$.index[*][?(@.name=='Oct')].inner.variant.discriminant.value" '"2"'
+    //@ is "$.index[*][?(@.name=='Oct')].inner.variant.discriminant.expr" '"0o2"'
     Oct = 0o2,
-    // @is "$.index[*][?(@.name=='PubConst')].inner.variant.discriminant.value" '"3"'
-    // @is "$.index[*][?(@.name=='PubConst')].inner.variant.discriminant.expr" '"THREE"'
+    //@ is "$.index[*][?(@.name=='PubConst')].inner.variant.discriminant.value" '"3"'
+    //@ is "$.index[*][?(@.name=='PubConst')].inner.variant.discriminant.expr" '"THREE"'
     PubConst = THREE,
-    // @is "$.index[*][?(@.name=='Hex')].inner.variant.discriminant.value" '"4"'
-    // @is "$.index[*][?(@.name=='Hex')].inner.variant.discriminant.expr" '"0x4"'
+    //@ is "$.index[*][?(@.name=='Hex')].inner.variant.discriminant.value" '"4"'
+    //@ is "$.index[*][?(@.name=='Hex')].inner.variant.discriminant.expr" '"0x4"'
     Hex = 0x4,
-    // @is "$.index[*][?(@.name=='Cast')].inner.variant.discriminant.value" '"5"'
-    // @is "$.index[*][?(@.name=='Cast')].inner.variant.discriminant.expr" '"{ _ }"'
+    //@ is "$.index[*][?(@.name=='Cast')].inner.variant.discriminant.value" '"5"'
+    //@ is "$.index[*][?(@.name=='Cast')].inner.variant.discriminant.expr" '"{ _ }"'
     Cast = 5 as isize,
-    // @is "$.index[*][?(@.name=='PubCall')].inner.variant.discriminant.value" '"6"'
-    // @is "$.index[*][?(@.name=='PubCall')].inner.variant.discriminant.expr" '"{ _ }"'
+    //@ is "$.index[*][?(@.name=='PubCall')].inner.variant.discriminant.value" '"6"'
+    //@ is "$.index[*][?(@.name=='PubCall')].inner.variant.discriminant.expr" '"{ _ }"'
     PubCall = six(),
-    // @is "$.index[*][?(@.name=='PrivCall')].inner.variant.discriminant.value" '"7"'
-    // @is "$.index[*][?(@.name=='PrivCall')].inner.variant.discriminant.expr" '"{ _ }"'
+    //@ is "$.index[*][?(@.name=='PrivCall')].inner.variant.discriminant.value" '"7"'
+    //@ is "$.index[*][?(@.name=='PrivCall')].inner.variant.discriminant.expr" '"{ _ }"'
     PrivCall = seven(),
-    // @is "$.index[*][?(@.name=='PrivConst')].inner.variant.discriminant.value" '"8"'
-    // @is "$.index[*][?(@.name=='PrivConst')].inner.variant.discriminant.expr" '"EIGHT"'
+    //@ is "$.index[*][?(@.name=='PrivConst')].inner.variant.discriminant.value" '"8"'
+    //@ is "$.index[*][?(@.name=='PrivConst')].inner.variant.discriminant.expr" '"EIGHT"'
     PrivConst = EIGHT,
 }
 

--- a/tests/rustdoc-json/enums/discriminant/limits.rs
+++ b/tests/rustdoc-json/enums/discriminant/limits.rs
@@ -4,40 +4,40 @@
 
 #[repr(u64)]
 pub enum U64 {
-    // @is "$.index[*][?(@.name=='U64Min')].inner.variant.discriminant.value" '"0"'
-    // @is "$.index[*][?(@.name=='U64Min')].inner.variant.discriminant.expr" '"u64::MIN"'
+    //@ is "$.index[*][?(@.name=='U64Min')].inner.variant.discriminant.value" '"0"'
+    //@ is "$.index[*][?(@.name=='U64Min')].inner.variant.discriminant.expr" '"u64::MIN"'
     U64Min = u64::MIN,
-    // @is "$.index[*][?(@.name=='U64Max')].inner.variant.discriminant.value" '"18446744073709551615"'
-    // @is "$.index[*][?(@.name=='U64Max')].inner.variant.discriminant.expr" '"u64::MAX"'
+    //@ is "$.index[*][?(@.name=='U64Max')].inner.variant.discriminant.value" '"18446744073709551615"'
+    //@ is "$.index[*][?(@.name=='U64Max')].inner.variant.discriminant.expr" '"u64::MAX"'
     U64Max = u64::MAX,
 }
 
 #[repr(i64)]
 pub enum I64 {
-    // @is "$.index[*][?(@.name=='I64Min')].inner.variant.discriminant.value" '"-9223372036854775808"'
-    // @is "$.index[*][?(@.name=='I64Min')].inner.variant.discriminant.expr" '"i64::MIN"'
+    //@ is "$.index[*][?(@.name=='I64Min')].inner.variant.discriminant.value" '"-9223372036854775808"'
+    //@ is "$.index[*][?(@.name=='I64Min')].inner.variant.discriminant.expr" '"i64::MIN"'
     I64Min = i64::MIN,
-    // @is "$.index[*][?(@.name=='I64Max')].inner.variant.discriminant.value" '"9223372036854775807"'
-    // @is "$.index[*][?(@.name=='I64Max')].inner.variant.discriminant.expr" '"i64::MAX"'
+    //@ is "$.index[*][?(@.name=='I64Max')].inner.variant.discriminant.value" '"9223372036854775807"'
+    //@ is "$.index[*][?(@.name=='I64Max')].inner.variant.discriminant.expr" '"i64::MAX"'
     I64Max = i64::MAX,
 }
 
 #[repr(u128)]
 pub enum U128 {
-    // @is "$.index[*][?(@.name=='U128Min')].inner.variant.discriminant.value" '"0"'
-    // @is "$.index[*][?(@.name=='U128Min')].inner.variant.discriminant.expr" '"u128::MIN"'
+    //@ is "$.index[*][?(@.name=='U128Min')].inner.variant.discriminant.value" '"0"'
+    //@ is "$.index[*][?(@.name=='U128Min')].inner.variant.discriminant.expr" '"u128::MIN"'
     U128Min = u128::MIN,
-    // @is "$.index[*][?(@.name=='U128Max')].inner.variant.discriminant.value" '"340282366920938463463374607431768211455"'
-    // @is "$.index[*][?(@.name=='U128Max')].inner.variant.discriminant.expr" '"u128::MAX"'
+    //@ is "$.index[*][?(@.name=='U128Max')].inner.variant.discriminant.value" '"340282366920938463463374607431768211455"'
+    //@ is "$.index[*][?(@.name=='U128Max')].inner.variant.discriminant.expr" '"u128::MAX"'
     U128Max = u128::MAX,
 }
 
 #[repr(i128)]
 pub enum I128 {
-    // @is "$.index[*][?(@.name=='I128Min')].inner.variant.discriminant.value" '"-170141183460469231731687303715884105728"'
-    // @is "$.index[*][?(@.name=='I128Min')].inner.variant.discriminant.expr" '"i128::MIN"'
+    //@ is "$.index[*][?(@.name=='I128Min')].inner.variant.discriminant.value" '"-170141183460469231731687303715884105728"'
+    //@ is "$.index[*][?(@.name=='I128Min')].inner.variant.discriminant.expr" '"i128::MIN"'
     I128Min = i128::MIN,
-    // @is "$.index[*][?(@.name=='I128Max')].inner.variant.discriminant.value" '"170141183460469231731687303715884105727"'
-    // @is "$.index[*][?(@.name=='I128Max')].inner.variant.discriminant.expr" '"i128::MAX"'
+    //@ is "$.index[*][?(@.name=='I128Max')].inner.variant.discriminant.value" '"170141183460469231731687303715884105727"'
+    //@ is "$.index[*][?(@.name=='I128Max')].inner.variant.discriminant.expr" '"i128::MAX"'
     I128Max = i128::MAX,
 }

--- a/tests/rustdoc-json/enums/discriminant/num_underscore_and_suffix.rs
+++ b/tests/rustdoc-json/enums/discriminant/num_underscore_and_suffix.rs
@@ -2,16 +2,16 @@
 
 #[repr(u32)]
 pub enum Foo {
-    // @is "$.index[*][?(@.name=='Basic')].inner.variant.discriminant.value" '"0"'
-    // @is "$.index[*][?(@.name=='Basic')].inner.variant.discriminant.expr" '"0"'
+    //@ is "$.index[*][?(@.name=='Basic')].inner.variant.discriminant.value" '"0"'
+    //@ is "$.index[*][?(@.name=='Basic')].inner.variant.discriminant.expr" '"0"'
     Basic = 0,
-    // @is "$.index[*][?(@.name=='Suffix')].inner.variant.discriminant.value" '"10"'
-    // @is "$.index[*][?(@.name=='Suffix')].inner.variant.discriminant.expr" '"10u32"'
+    //@ is "$.index[*][?(@.name=='Suffix')].inner.variant.discriminant.value" '"10"'
+    //@ is "$.index[*][?(@.name=='Suffix')].inner.variant.discriminant.expr" '"10u32"'
     Suffix = 10u32,
-    // @is "$.index[*][?(@.name=='Underscore')].inner.variant.discriminant.value" '"100"'
-    // @is "$.index[*][?(@.name=='Underscore')].inner.variant.discriminant.expr" '"1_0_0"'
+    //@ is "$.index[*][?(@.name=='Underscore')].inner.variant.discriminant.value" '"100"'
+    //@ is "$.index[*][?(@.name=='Underscore')].inner.variant.discriminant.expr" '"1_0_0"'
     Underscore = 1_0_0,
-    // @is "$.index[*][?(@.name=='SuffixUnderscore')].inner.variant.discriminant.value" '"1000"'
-    // @is "$.index[*][?(@.name=='SuffixUnderscore')].inner.variant.discriminant.expr" '"1_0_0_0u32"'
+    //@ is "$.index[*][?(@.name=='SuffixUnderscore')].inner.variant.discriminant.value" '"1000"'
+    //@ is "$.index[*][?(@.name=='SuffixUnderscore')].inner.variant.discriminant.expr" '"1_0_0_0u32"'
     SuffixUnderscore = 1_0_0_0u32,
 }

--- a/tests/rustdoc-json/enums/discriminant/only_some_have_discriminant.rs
+++ b/tests/rustdoc-json/enums/discriminant/only_some_have_discriminant.rs
@@ -1,12 +1,12 @@
 // ignore-tidy-linelength
 
 pub enum Foo {
-    // @is "$.index[*][?(@.name=='Has')].inner.variant.discriminant" '{"expr":"0", "value":"0"}'
+    //@ is "$.index[*][?(@.name=='Has')].inner.variant.discriminant" '{"expr":"0", "value":"0"}'
     Has = 0,
-    // @is "$.index[*][?(@.name=='Doesnt')].inner.variant.discriminant" null
+    //@ is "$.index[*][?(@.name=='Doesnt')].inner.variant.discriminant" null
     Doesnt,
-    // @is "$.index[*][?(@.name=='AlsoDoesnt')].inner.variant.discriminant" null
+    //@ is "$.index[*][?(@.name=='AlsoDoesnt')].inner.variant.discriminant" null
     AlsoDoesnt,
-    // @is "$.index[*][?(@.name=='AlsoHas')].inner.variant.discriminant" '{"expr":"44", "value":"44"}'
+    //@ is "$.index[*][?(@.name=='AlsoHas')].inner.variant.discriminant" '{"expr":"44", "value":"44"}'
     AlsoHas = 44,
 }

--- a/tests/rustdoc-json/enums/discriminant/struct.rs
+++ b/tests/rustdoc-json/enums/discriminant/struct.rs
@@ -1,15 +1,15 @@
 // ignore-tidy-linelength
 
 #[repr(i32)]
-// @is "$.index[*][?(@.name=='Foo')].attrs" '["#[repr(i32)]"]'
+//@ is "$.index[*][?(@.name=='Foo')].attrs" '["#[repr(i32)]"]'
 pub enum Foo {
-    // @is    "$.index[*][?(@.name=='Struct')].inner.variant.discriminant" null
-    // @count "$.index[*][?(@.name=='Struct')].inner.variant.kind.struct.fields[*]" 0
+    //@ is    "$.index[*][?(@.name=='Struct')].inner.variant.discriminant" null
+    //@ count "$.index[*][?(@.name=='Struct')].inner.variant.kind.struct.fields[*]" 0
     Struct {},
-    // @is    "$.index[*][?(@.name=='StructWithDiscr')].inner.variant.discriminant" '{"expr": "42", "value": "42"}'
-    // @count "$.index[*][?(@.name=='StructWithDiscr')].inner.variant.kind.struct.fields[*]" 1
+    //@ is    "$.index[*][?(@.name=='StructWithDiscr')].inner.variant.discriminant" '{"expr": "42", "value": "42"}'
+    //@ count "$.index[*][?(@.name=='StructWithDiscr')].inner.variant.kind.struct.fields[*]" 1
     StructWithDiscr { x: i32 } = 42,
-    // @is    "$.index[*][?(@.name=='StructWithHexDiscr')].inner.variant.discriminant"  '{"expr": "0x42", "value": "66"}'
-    // @count "$.index[*][?(@.name=='StructWithHexDiscr')].inner.variant.kind.struct.fields[*]" 2
+    //@ is    "$.index[*][?(@.name=='StructWithHexDiscr')].inner.variant.discriminant"  '{"expr": "0x42", "value": "66"}'
+    //@ count "$.index[*][?(@.name=='StructWithHexDiscr')].inner.variant.kind.struct.fields[*]" 2
     StructWithHexDiscr { x: i32, y: bool } = 0x42,
 }

--- a/tests/rustdoc-json/enums/discriminant/tuple.rs
+++ b/tests/rustdoc-json/enums/discriminant/tuple.rs
@@ -1,15 +1,15 @@
 // ignore-tidy-linelength
 
 #[repr(u32)]
-// @is "$.index[*][?(@.name=='Foo')].attrs" '["#[repr(u32)]"]'
+//@ is "$.index[*][?(@.name=='Foo')].attrs" '["#[repr(u32)]"]'
 pub enum Foo {
-    // @is    "$.index[*][?(@.name=='Tuple')].inner.variant.discriminant" null
-    // @count "$.index[*][?(@.name=='Tuple')].inner.variant.kind.tuple[*]" 0
+    //@ is    "$.index[*][?(@.name=='Tuple')].inner.variant.discriminant" null
+    //@ count "$.index[*][?(@.name=='Tuple')].inner.variant.kind.tuple[*]" 0
     Tuple(),
-    // @is    "$.index[*][?(@.name=='TupleWithDiscr')].inner.variant.discriminant" '{"expr": "1", "value": "1"}'
-    // @count "$.index[*][?(@.name=='TupleWithDiscr')].inner.variant.kind.tuple[*]" 1
+    //@ is    "$.index[*][?(@.name=='TupleWithDiscr')].inner.variant.discriminant" '{"expr": "1", "value": "1"}'
+    //@ count "$.index[*][?(@.name=='TupleWithDiscr')].inner.variant.kind.tuple[*]" 1
     TupleWithDiscr(i32) = 1,
-    // @is    "$.index[*][?(@.name=='TupleWithBinDiscr')].inner.variant.discriminant" '{"expr": "0b10", "value": "2"}'
-    // @count "$.index[*][?(@.name=='TupleWithBinDiscr')].inner.variant.kind.tuple[*]" 2
+    //@ is    "$.index[*][?(@.name=='TupleWithBinDiscr')].inner.variant.discriminant" '{"expr": "0b10", "value": "2"}'
+    //@ count "$.index[*][?(@.name=='TupleWithBinDiscr')].inner.variant.kind.tuple[*]" 2
     TupleWithBinDiscr(i32, i32) = 0b10,
 }

--- a/tests/rustdoc-json/enums/doc_link_to_foreign_variant.rs
+++ b/tests/rustdoc-json/enums/doc_link_to_foreign_variant.rs
@@ -5,7 +5,7 @@
 extern crate color;
 use color::Color::Red;
 
-// @set red = "$.index[*][?(@.inner.module.is_crate)].links.Red"
+//@ set red = "$.index[*][?(@.inner.module.is_crate)].links.Red"
 
-// @!has "$.index[*][?(@.name == 'Red')]"
-// @!has "$.index[*][?(@.name == 'Color')]"
+//@ !has "$.index[*][?(@.name == 'Red')]"
+//@ !has "$.index[*][?(@.name == 'Color')]"

--- a/tests/rustdoc-json/enums/field_hidden.rs
+++ b/tests/rustdoc-json/enums/field_hidden.rs
@@ -1,9 +1,9 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/100529>.
 
-// @has "$.index[*][?(@.name=='ParseError')]"
-// @has "$.index[*][?(@.name=='UnexpectedEndTag')]"
-// @is "$.index[*][?(@.name=='UnexpectedEndTag')].inner.variant.kind.tuple" [null]
-// @is "$.index[*][?(@.name=='UnexpectedEndTag')].inner.variant.discriminant" null
+//@ has "$.index[*][?(@.name=='ParseError')]"
+//@ has "$.index[*][?(@.name=='UnexpectedEndTag')]"
+//@ is "$.index[*][?(@.name=='UnexpectedEndTag')].inner.variant.kind.tuple" [null]
+//@ is "$.index[*][?(@.name=='UnexpectedEndTag')].inner.variant.discriminant" null
 
 pub enum ParseError {
     UnexpectedEndTag(#[doc(hidden)] u32),

--- a/tests/rustdoc-json/enums/field_order.rs
+++ b/tests/rustdoc-json/enums/field_order.rs
@@ -17,24 +17,24 @@ pub enum Whatever {
     },
 }
 
-// @set 0 = '$.index[*][?(@.name == "ews_0")].id'
-// @set 1 = '$.index[*][?(@.name == "dik_1")].id'
-// @set 2 = '$.index[*][?(@.name == "hsk_2")].id'
-// @set 3 = '$.index[*][?(@.name == "djt_3")].id'
-// @set 4 = '$.index[*][?(@.name == "jnr_4")].id'
-// @set 5 = '$.index[*][?(@.name == "dfs_5")].id'
-// @set 6 = '$.index[*][?(@.name == "bja_6")].id'
-// @set 7 = '$.index[*][?(@.name == "lyc_7")].id'
-// @set 8 = '$.index[*][?(@.name == "yqd_8")].id'
-// @set 9 = '$.index[*][?(@.name == "vll_9")].id'
+//@ set 0 = '$.index[*][?(@.name == "ews_0")].id'
+//@ set 1 = '$.index[*][?(@.name == "dik_1")].id'
+//@ set 2 = '$.index[*][?(@.name == "hsk_2")].id'
+//@ set 3 = '$.index[*][?(@.name == "djt_3")].id'
+//@ set 4 = '$.index[*][?(@.name == "jnr_4")].id'
+//@ set 5 = '$.index[*][?(@.name == "dfs_5")].id'
+//@ set 6 = '$.index[*][?(@.name == "bja_6")].id'
+//@ set 7 = '$.index[*][?(@.name == "lyc_7")].id'
+//@ set 8 = '$.index[*][?(@.name == "yqd_8")].id'
+//@ set 9 = '$.index[*][?(@.name == "vll_9")].id'
 
-// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[0]' $0
-// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[1]' $1
-// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[2]' $2
-// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[3]' $3
-// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[4]' $4
-// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[5]' $5
-// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[6]' $6
-// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[7]' $7
-// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[8]' $8
-// @is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[9]' $9
+//@ is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[0]' $0
+//@ is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[1]' $1
+//@ is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[2]' $2
+//@ is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[3]' $3
+//@ is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[4]' $4
+//@ is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[5]' $5
+//@ is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[6]' $6
+//@ is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[7]' $7
+//@ is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[8]' $8
+//@ is '$.index[*][?(@.name == "Foo")].inner.variant.kind.struct.fields[9]' $9

--- a/tests/rustdoc-json/enums/kind.rs
+++ b/tests/rustdoc-json/enums/kind.rs
@@ -1,29 +1,29 @@
 // ignore-tidy-linelength
 
 pub enum Foo {
-    // @set Unit = "$.index[*][?(@.name=='Unit')].id"
-    // @is "$.index[*][?(@.name=='Unit')].inner.variant.kind" '"plain"'
+    //@ set Unit = "$.index[*][?(@.name=='Unit')].id"
+    //@ is "$.index[*][?(@.name=='Unit')].inner.variant.kind" '"plain"'
     Unit,
-    // @set Named = "$.index[*][?(@.name=='Named')].id"
-    // @is "$.index[*][?(@.name=='Named')].inner.variant.kind.struct" '{"fields": [], "fields_stripped": false}'
+    //@ set Named = "$.index[*][?(@.name=='Named')].id"
+    //@ is "$.index[*][?(@.name=='Named')].inner.variant.kind.struct" '{"fields": [], "fields_stripped": false}'
     Named {},
-    // @set Tuple = "$.index[*][?(@.name=='Tuple')].id"
-    // @is "$.index[*][?(@.name=='Tuple')].inner.variant.kind.tuple" []
+    //@ set Tuple = "$.index[*][?(@.name=='Tuple')].id"
+    //@ is "$.index[*][?(@.name=='Tuple')].inner.variant.kind.tuple" []
     Tuple(),
-    // @set NamedField = "$.index[*][?(@.name=='NamedField')].id"
-    // @set x = "$.index[*][?(@.name=='x' && @.inner.struct_field)].id"
-    // @is "$.index[*][?(@.name=='NamedField')].inner.variant.kind.struct.fields[*]" $x
-    // @is "$.index[*][?(@.name=='NamedField')].inner.variant.kind.struct.fields_stripped" false
+    //@ set NamedField = "$.index[*][?(@.name=='NamedField')].id"
+    //@ set x = "$.index[*][?(@.name=='x' && @.inner.struct_field)].id"
+    //@ is "$.index[*][?(@.name=='NamedField')].inner.variant.kind.struct.fields[*]" $x
+    //@ is "$.index[*][?(@.name=='NamedField')].inner.variant.kind.struct.fields_stripped" false
     NamedField { x: i32 },
-    // @set TupleField = "$.index[*][?(@.name=='TupleField')].id"
-    // @set tup_field = "$.index[*][?(@.name=='0' && @.inner.struct_field)].id"
-    // @is "$.index[*][?(@.name=='TupleField')].inner.variant.kind.tuple[*]" $tup_field
+    //@ set TupleField = "$.index[*][?(@.name=='TupleField')].id"
+    //@ set tup_field = "$.index[*][?(@.name=='0' && @.inner.struct_field)].id"
+    //@ is "$.index[*][?(@.name=='TupleField')].inner.variant.kind.tuple[*]" $tup_field
     TupleField(i32),
 }
 
-// @is    "$.index[*][?(@.name=='Foo')].inner.enum.variants[0]" $Unit
-// @is    "$.index[*][?(@.name=='Foo')].inner.enum.variants[1]" $Named
-// @is    "$.index[*][?(@.name=='Foo')].inner.enum.variants[2]" $Tuple
-// @is    "$.index[*][?(@.name=='Foo')].inner.enum.variants[3]" $NamedField
-// @is    "$.index[*][?(@.name=='Foo')].inner.enum.variants[4]" $TupleField
-// @count "$.index[*][?(@.name=='Foo')].inner.enum.variants[*]" 5
+//@ is    "$.index[*][?(@.name=='Foo')].inner.enum.variants[0]" $Unit
+//@ is    "$.index[*][?(@.name=='Foo')].inner.enum.variants[1]" $Named
+//@ is    "$.index[*][?(@.name=='Foo')].inner.enum.variants[2]" $Tuple
+//@ is    "$.index[*][?(@.name=='Foo')].inner.enum.variants[3]" $NamedField
+//@ is    "$.index[*][?(@.name=='Foo')].inner.enum.variants[4]" $TupleField
+//@ count "$.index[*][?(@.name=='Foo')].inner.enum.variants[*]" 5

--- a/tests/rustdoc-json/enums/struct_field_hidden.rs
+++ b/tests/rustdoc-json/enums/struct_field_hidden.rs
@@ -2,15 +2,15 @@ pub enum Foo {
     Variant {
         #[doc(hidden)]
         a: i32,
-        // @set b = "$.index[*][?(@.name=='b')].id"
+        //@ set b = "$.index[*][?(@.name=='b')].id"
         b: i32,
         #[doc(hidden)]
         x: i32,
-        // @set y = "$.index[*][?(@.name=='y')].id"
+        //@ set y = "$.index[*][?(@.name=='y')].id"
         y: i32,
     },
-    // @is "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields_stripped" true
-    // @is "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields[0]" $b
-    // @is "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields[1]" $y
-    // @count "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields[*]" 2
+    //@ is "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields_stripped" true
+    //@ is "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields[0]" $b
+    //@ is "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields[1]" $y
+    //@ count "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields[*]" 2
 }

--- a/tests/rustdoc-json/enums/tuple_fields_hidden.rs
+++ b/tests/rustdoc-json/enums/tuple_fields_hidden.rs
@@ -1,80 +1,80 @@
-// @set 1.1.0 = "$.index[*][?(@.docs=='1.1.0')].id"
-// @set 2.1.0 = "$.index[*][?(@.docs=='2.1.0')].id"
-// @set 2.1.1 = "$.index[*][?(@.docs=='2.1.1')].id"
-// @set 2.2.1 = "$.index[*][?(@.docs=='2.2.1')].id"
-// @set 2.3.0 = "$.index[*][?(@.docs=='2.3.0')].id"
-// @set 3.1.1 = "$.index[*][?(@.docs=='3.1.1')].id"
-// @set 3.1.2 = "$.index[*][?(@.docs=='3.1.2')].id"
-// @set 3.2.0 = "$.index[*][?(@.docs=='3.2.0')].id"
-// @set 3.2.2 = "$.index[*][?(@.docs=='3.2.2')].id"
-// @set 3.3.0 = "$.index[*][?(@.docs=='3.3.0')].id"
-// @set 3.3.1 = "$.index[*][?(@.docs=='3.3.1')].id"
+//@ set 1.1.0 = "$.index[*][?(@.docs=='1.1.0')].id"
+//@ set 2.1.0 = "$.index[*][?(@.docs=='2.1.0')].id"
+//@ set 2.1.1 = "$.index[*][?(@.docs=='2.1.1')].id"
+//@ set 2.2.1 = "$.index[*][?(@.docs=='2.2.1')].id"
+//@ set 2.3.0 = "$.index[*][?(@.docs=='2.3.0')].id"
+//@ set 3.1.1 = "$.index[*][?(@.docs=='3.1.1')].id"
+//@ set 3.1.2 = "$.index[*][?(@.docs=='3.1.2')].id"
+//@ set 3.2.0 = "$.index[*][?(@.docs=='3.2.0')].id"
+//@ set 3.2.2 = "$.index[*][?(@.docs=='3.2.2')].id"
+//@ set 3.3.0 = "$.index[*][?(@.docs=='3.3.0')].id"
+//@ set 3.3.1 = "$.index[*][?(@.docs=='3.3.1')].id"
 
 pub enum EnumWithStrippedTupleVariants {
-    // @count "$.index[*][?(@.name=='None')].inner.variant.kind.tuple[*]" 0
+    //@ count "$.index[*][?(@.name=='None')].inner.variant.kind.tuple[*]" 0
     None(),
 
-    // @count "$.index[*][?(@.name=='One')].inner.variant.kind.tuple[*]" 1
-    // @is    "$.index[*][?(@.name=='One')].inner.variant.kind.tuple[0]" $1.1.0
+    //@ count "$.index[*][?(@.name=='One')].inner.variant.kind.tuple[*]" 1
+    //@ is    "$.index[*][?(@.name=='One')].inner.variant.kind.tuple[0]" $1.1.0
     One(/** 1.1.0*/ bool),
-    // @count "$.index[*][?(@.name=='OneHidden')].inner.variant.kind.tuple[*]" 1
-    // @is    "$.index[*][?(@.name=='OneHidden')].inner.variant.kind.tuple[0]" null
+    //@ count "$.index[*][?(@.name=='OneHidden')].inner.variant.kind.tuple[*]" 1
+    //@ is    "$.index[*][?(@.name=='OneHidden')].inner.variant.kind.tuple[0]" null
     OneHidden(#[doc(hidden)] bool),
 
-    // @count "$.index[*][?(@.name=='Two')].inner.variant.kind.tuple[*]" 2
-    // @is    "$.index[*][?(@.name=='Two')].inner.variant.kind.tuple[0]" $2.1.0
-    // @is    "$.index[*][?(@.name=='Two')].inner.variant.kind.tuple[1]" $2.1.1
+    //@ count "$.index[*][?(@.name=='Two')].inner.variant.kind.tuple[*]" 2
+    //@ is    "$.index[*][?(@.name=='Two')].inner.variant.kind.tuple[0]" $2.1.0
+    //@ is    "$.index[*][?(@.name=='Two')].inner.variant.kind.tuple[1]" $2.1.1
     Two(/** 2.1.0*/ bool, /** 2.1.1*/ bool),
-    // @count "$.index[*][?(@.name=='TwoLeftHidden')].inner.variant.kind.tuple[*]" 2
-    // @is    "$.index[*][?(@.name=='TwoLeftHidden')].inner.variant.kind.tuple[0]" null
-    // @is    "$.index[*][?(@.name=='TwoLeftHidden')].inner.variant.kind.tuple[1]" $2.2.1
+    //@ count "$.index[*][?(@.name=='TwoLeftHidden')].inner.variant.kind.tuple[*]" 2
+    //@ is    "$.index[*][?(@.name=='TwoLeftHidden')].inner.variant.kind.tuple[0]" null
+    //@ is    "$.index[*][?(@.name=='TwoLeftHidden')].inner.variant.kind.tuple[1]" $2.2.1
     TwoLeftHidden(#[doc(hidden)] bool, /** 2.2.1*/ bool),
-    // @count "$.index[*][?(@.name=='TwoRightHidden')].inner.variant.kind.tuple[*]" 2
-    // @is    "$.index[*][?(@.name=='TwoRightHidden')].inner.variant.kind.tuple[0]" $2.3.0
-    // @is    "$.index[*][?(@.name=='TwoRightHidden')].inner.variant.kind.tuple[1]" null
+    //@ count "$.index[*][?(@.name=='TwoRightHidden')].inner.variant.kind.tuple[*]" 2
+    //@ is    "$.index[*][?(@.name=='TwoRightHidden')].inner.variant.kind.tuple[0]" $2.3.0
+    //@ is    "$.index[*][?(@.name=='TwoRightHidden')].inner.variant.kind.tuple[1]" null
     TwoRightHidden(/** 2.3.0*/ bool, #[doc(hidden)] bool),
-    // @count "$.index[*][?(@.name=='TwoBothHidden')].inner.variant.kind.tuple[*]" 2
-    // @is    "$.index[*][?(@.name=='TwoBothHidden')].inner.variant.kind.tuple[0]" null
-    // @is    "$.index[*][?(@.name=='TwoBothHidden')].inner.variant.kind.tuple[1]" null
+    //@ count "$.index[*][?(@.name=='TwoBothHidden')].inner.variant.kind.tuple[*]" 2
+    //@ is    "$.index[*][?(@.name=='TwoBothHidden')].inner.variant.kind.tuple[0]" null
+    //@ is    "$.index[*][?(@.name=='TwoBothHidden')].inner.variant.kind.tuple[1]" null
     TwoBothHidden(#[doc(hidden)] bool, #[doc(hidden)] bool),
 
-    // @count "$.index[*][?(@.name=='Three1')].inner.variant.kind.tuple[*]" 3
-    // @is    "$.index[*][?(@.name=='Three1')].inner.variant.kind.tuple[0]" null
-    // @is    "$.index[*][?(@.name=='Three1')].inner.variant.kind.tuple[1]" $3.1.1
-    // @is    "$.index[*][?(@.name=='Three1')].inner.variant.kind.tuple[2]" $3.1.2
+    //@ count "$.index[*][?(@.name=='Three1')].inner.variant.kind.tuple[*]" 3
+    //@ is    "$.index[*][?(@.name=='Three1')].inner.variant.kind.tuple[0]" null
+    //@ is    "$.index[*][?(@.name=='Three1')].inner.variant.kind.tuple[1]" $3.1.1
+    //@ is    "$.index[*][?(@.name=='Three1')].inner.variant.kind.tuple[2]" $3.1.2
     Three1(#[doc(hidden)] bool, /** 3.1.1*/ bool, /** 3.1.2*/ bool),
-    // @count "$.index[*][?(@.name=='Three2')].inner.variant.kind.tuple[*]" 3
-    // @is    "$.index[*][?(@.name=='Three2')].inner.variant.kind.tuple[0]" $3.2.0
-    // @is    "$.index[*][?(@.name=='Three2')].inner.variant.kind.tuple[1]" null
-    // @is    "$.index[*][?(@.name=='Three2')].inner.variant.kind.tuple[2]" $3.2.2
+    //@ count "$.index[*][?(@.name=='Three2')].inner.variant.kind.tuple[*]" 3
+    //@ is    "$.index[*][?(@.name=='Three2')].inner.variant.kind.tuple[0]" $3.2.0
+    //@ is    "$.index[*][?(@.name=='Three2')].inner.variant.kind.tuple[1]" null
+    //@ is    "$.index[*][?(@.name=='Three2')].inner.variant.kind.tuple[2]" $3.2.2
     Three2(/** 3.2.0*/ bool, #[doc(hidden)] bool, /** 3.2.2*/ bool),
-    // @count "$.index[*][?(@.name=='Three3')].inner.variant.kind.tuple[*]" 3
-    // @is    "$.index[*][?(@.name=='Three3')].inner.variant.kind.tuple[0]" $3.3.0
-    // @is    "$.index[*][?(@.name=='Three3')].inner.variant.kind.tuple[1]" $3.3.1
-    // @is    "$.index[*][?(@.name=='Three3')].inner.variant.kind.tuple[2]" null
+    //@ count "$.index[*][?(@.name=='Three3')].inner.variant.kind.tuple[*]" 3
+    //@ is    "$.index[*][?(@.name=='Three3')].inner.variant.kind.tuple[0]" $3.3.0
+    //@ is    "$.index[*][?(@.name=='Three3')].inner.variant.kind.tuple[1]" $3.3.1
+    //@ is    "$.index[*][?(@.name=='Three3')].inner.variant.kind.tuple[2]" null
     Three3(/** 3.3.0*/ bool, /** 3.3.1*/ bool, #[doc(hidden)] bool),
 }
 
-// @is "$.index[*][?(@.docs=='1.1.0')].name" '"0"'
-// @is "$.index[*][?(@.docs=='2.1.0')].name" '"0"'
-// @is "$.index[*][?(@.docs=='2.1.1')].name" '"1"'
-// @is "$.index[*][?(@.docs=='2.2.1')].name" '"1"'
-// @is "$.index[*][?(@.docs=='2.3.0')].name" '"0"'
-// @is "$.index[*][?(@.docs=='3.1.1')].name" '"1"'
-// @is "$.index[*][?(@.docs=='3.1.2')].name" '"2"'
-// @is "$.index[*][?(@.docs=='3.2.0')].name" '"0"'
-// @is "$.index[*][?(@.docs=='3.2.2')].name" '"2"'
-// @is "$.index[*][?(@.docs=='3.3.0')].name" '"0"'
-// @is "$.index[*][?(@.docs=='3.3.1')].name" '"1"'
+//@ is "$.index[*][?(@.docs=='1.1.0')].name" '"0"'
+//@ is "$.index[*][?(@.docs=='2.1.0')].name" '"0"'
+//@ is "$.index[*][?(@.docs=='2.1.1')].name" '"1"'
+//@ is "$.index[*][?(@.docs=='2.2.1')].name" '"1"'
+//@ is "$.index[*][?(@.docs=='2.3.0')].name" '"0"'
+//@ is "$.index[*][?(@.docs=='3.1.1')].name" '"1"'
+//@ is "$.index[*][?(@.docs=='3.1.2')].name" '"2"'
+//@ is "$.index[*][?(@.docs=='3.2.0')].name" '"0"'
+//@ is "$.index[*][?(@.docs=='3.2.2')].name" '"2"'
+//@ is "$.index[*][?(@.docs=='3.3.0')].name" '"0"'
+//@ is "$.index[*][?(@.docs=='3.3.1')].name" '"1"'
 
-// @is "$.index[*][?(@.docs=='1.1.0')].inner.struct_field" '{"primitive": "bool"}'
-// @is "$.index[*][?(@.docs=='2.1.0')].inner.struct_field" '{"primitive": "bool"}'
-// @is "$.index[*][?(@.docs=='2.1.1')].inner.struct_field" '{"primitive": "bool"}'
-// @is "$.index[*][?(@.docs=='2.2.1')].inner.struct_field" '{"primitive": "bool"}'
-// @is "$.index[*][?(@.docs=='2.3.0')].inner.struct_field" '{"primitive": "bool"}'
-// @is "$.index[*][?(@.docs=='3.1.1')].inner.struct_field" '{"primitive": "bool"}'
-// @is "$.index[*][?(@.docs=='3.1.2')].inner.struct_field" '{"primitive": "bool"}'
-// @is "$.index[*][?(@.docs=='3.2.0')].inner.struct_field" '{"primitive": "bool"}'
-// @is "$.index[*][?(@.docs=='3.2.2')].inner.struct_field" '{"primitive": "bool"}'
-// @is "$.index[*][?(@.docs=='3.3.0')].inner.struct_field" '{"primitive": "bool"}'
-// @is "$.index[*][?(@.docs=='3.3.1')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.index[*][?(@.docs=='1.1.0')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.index[*][?(@.docs=='2.1.0')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.index[*][?(@.docs=='2.1.1')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.index[*][?(@.docs=='2.2.1')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.index[*][?(@.docs=='2.3.0')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.index[*][?(@.docs=='3.1.1')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.index[*][?(@.docs=='3.1.2')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.index[*][?(@.docs=='3.2.0')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.index[*][?(@.docs=='3.2.2')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.index[*][?(@.docs=='3.3.0')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.index[*][?(@.docs=='3.3.1')].inner.struct_field" '{"primitive": "bool"}'

--- a/tests/rustdoc-json/enums/use_glob.rs
+++ b/tests/rustdoc-json/enums/use_glob.rs
@@ -1,15 +1,15 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/104942>
 
-// @set Color = "$.index[*][?(@.name == 'Color')].id"
+//@ set Color = "$.index[*][?(@.name == 'Color')].id"
 pub enum Color {
     Red,
     Green,
     Blue,
 }
 
-// @set use_Color = "$.index[*][?(@.inner.import)].id"
-// @is "$.index[*][?(@.inner.import)].inner.import.id" $Color
-// @is "$.index[*][?(@.inner.import)].inner.import.glob" true
+//@ set use_Color = "$.index[*][?(@.inner.import)].id"
+//@ is "$.index[*][?(@.inner.import)].inner.import.id" $Color
+//@ is "$.index[*][?(@.inner.import)].inner.import.glob" true
 pub use Color::*;
 
-// @ismany "$.index[*][?(@.name == 'use_glob')].inner.module.items[*]" $Color $use_Color
+//@ ismany "$.index[*][?(@.name == 'use_glob')].inner.module.items[*]" $Color $use_Color

--- a/tests/rustdoc-json/enums/use_variant.rs
+++ b/tests/rustdoc-json/enums/use_variant.rs
@@ -1,12 +1,12 @@
-// @set AlwaysNone = "$.index[*][?(@.name == 'AlwaysNone')].id"
+//@ set AlwaysNone = "$.index[*][?(@.name == 'AlwaysNone')].id"
 pub enum AlwaysNone {
-    // @set None = "$.index[*][?(@.name == 'None')].id"
+    //@ set None = "$.index[*][?(@.name == 'None')].id"
     None,
 }
-// @is "$.index[*][?(@.name == 'AlwaysNone')].inner.enum.variants[*]" $None
+//@ is "$.index[*][?(@.name == 'AlwaysNone')].inner.enum.variants[*]" $None
 
-// @set use_None = "$.index[*][?(@.inner.import)].id"
-// @is "$.index[*][?(@.inner.import)].inner.import.id" $None
+//@ set use_None = "$.index[*][?(@.inner.import)].id"
+//@ is "$.index[*][?(@.inner.import)].inner.import.id" $None
 pub use AlwaysNone::None;
 
-// @ismany "$.index[*][?(@.name == 'use_variant')].inner.module.items[*]" $AlwaysNone $use_None
+//@ ismany "$.index[*][?(@.name == 'use_variant')].inner.module.items[*]" $AlwaysNone $use_None

--- a/tests/rustdoc-json/enums/use_variant_foreign.rs
+++ b/tests/rustdoc-json/enums/use_variant_foreign.rs
@@ -2,8 +2,8 @@
 
 extern crate color;
 
-// @has "$.index[*].inner.import[?(@.name == 'Red')]"
+//@ has "$.index[*].inner.import[?(@.name == 'Red')]"
 pub use color::Color::Red;
 
-// @!has "$.index[*][?(@.name == 'Red')]"
-// @!has "$.index[*][?(@.name == 'Color')]"
+//@ !has "$.index[*][?(@.name == 'Red')]"
+//@ !has "$.index[*][?(@.name == 'Color')]"

--- a/tests/rustdoc-json/enums/variant_order.rs
+++ b/tests/rustdoc-json/enums/variant_order.rs
@@ -15,24 +15,24 @@ pub enum Foo {
     Vll9,
 }
 
-// @set 0 = '$.index[*][?(@.name == "Ews0")].id'
-// @set 1 = '$.index[*][?(@.name == "Dik1")].id'
-// @set 2 = '$.index[*][?(@.name == "Hsk2")].id'
-// @set 3 = '$.index[*][?(@.name == "Djt3")].id'
-// @set 4 = '$.index[*][?(@.name == "Jnr4")].id'
-// @set 5 = '$.index[*][?(@.name == "Dfs5")].id'
-// @set 6 = '$.index[*][?(@.name == "Bja6")].id'
-// @set 7 = '$.index[*][?(@.name == "Lyc7")].id'
-// @set 8 = '$.index[*][?(@.name == "Yqd8")].id'
-// @set 9 = '$.index[*][?(@.name == "Vll9")].id'
+//@ set 0 = '$.index[*][?(@.name == "Ews0")].id'
+//@ set 1 = '$.index[*][?(@.name == "Dik1")].id'
+//@ set 2 = '$.index[*][?(@.name == "Hsk2")].id'
+//@ set 3 = '$.index[*][?(@.name == "Djt3")].id'
+//@ set 4 = '$.index[*][?(@.name == "Jnr4")].id'
+//@ set 5 = '$.index[*][?(@.name == "Dfs5")].id'
+//@ set 6 = '$.index[*][?(@.name == "Bja6")].id'
+//@ set 7 = '$.index[*][?(@.name == "Lyc7")].id'
+//@ set 8 = '$.index[*][?(@.name == "Yqd8")].id'
+//@ set 9 = '$.index[*][?(@.name == "Vll9")].id'
 
-// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[0]' $0
-// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[1]' $1
-// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[2]' $2
-// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[3]' $3
-// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[4]' $4
-// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[5]' $5
-// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[6]' $6
-// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[7]' $7
-// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[8]' $8
-// @is '$.index[*][?(@.name == "Foo")].inner.enum.variants[9]' $9
+//@ is '$.index[*][?(@.name == "Foo")].inner.enum.variants[0]' $0
+//@ is '$.index[*][?(@.name == "Foo")].inner.enum.variants[1]' $1
+//@ is '$.index[*][?(@.name == "Foo")].inner.enum.variants[2]' $2
+//@ is '$.index[*][?(@.name == "Foo")].inner.enum.variants[3]' $3
+//@ is '$.index[*][?(@.name == "Foo")].inner.enum.variants[4]' $4
+//@ is '$.index[*][?(@.name == "Foo")].inner.enum.variants[5]' $5
+//@ is '$.index[*][?(@.name == "Foo")].inner.enum.variants[6]' $6
+//@ is '$.index[*][?(@.name == "Foo")].inner.enum.variants[7]' $7
+//@ is '$.index[*][?(@.name == "Foo")].inner.enum.variants[8]' $8
+//@ is '$.index[*][?(@.name == "Foo")].inner.enum.variants[9]' $9

--- a/tests/rustdoc-json/enums/variant_struct.rs
+++ b/tests/rustdoc-json/enums/variant_struct.rs
@@ -1,10 +1,10 @@
-// @is "$.index[*][?(@.name=='EnumStruct')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='EnumStruct')].inner.enum"
+//@ is "$.index[*][?(@.name=='EnumStruct')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='EnumStruct')].inner.enum"
 pub enum EnumStruct {
-    // @has "$.index[*][?(@.name=='x')].inner.struct_field"
-    // @set x = "$.index[*][?(@.name=='x')].id"
-    // @has "$.index[*][?(@.name=='y')].inner.struct_field"
-    // @set y = "$.index[*][?(@.name=='y')].id"
-    // @ismany "$.index[*][?(@.name=='VariantS')].inner.variant.kind.struct.fields[*]" $x $y
+    //@ has "$.index[*][?(@.name=='x')].inner.struct_field"
+    //@ set x = "$.index[*][?(@.name=='x')].id"
+    //@ has "$.index[*][?(@.name=='y')].inner.struct_field"
+    //@ set y = "$.index[*][?(@.name=='y')].id"
+    //@ ismany "$.index[*][?(@.name=='VariantS')].inner.variant.kind.struct.fields[*]" $x $y
     VariantS { x: u32, y: String },
 }

--- a/tests/rustdoc-json/enums/variant_tuple_struct.rs
+++ b/tests/rustdoc-json/enums/variant_tuple_struct.rs
@@ -1,10 +1,10 @@
-// @is "$.index[*][?(@.name=='EnumTupleStruct')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='EnumTupleStruct')].inner.enum"
+//@ is "$.index[*][?(@.name=='EnumTupleStruct')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='EnumTupleStruct')].inner.enum"
 pub enum EnumTupleStruct {
-    // @has "$.index[*][?(@.name=='0')].inner.struct_field"
-    // @set f0 = "$.index[*][?(@.name=='0')].id"
-    // @has "$.index[*][?(@.name=='1')].inner.struct_field"
-    // @set f1 = "$.index[*][?(@.name=='1')].id"
-    // @ismany "$.index[*][?(@.name=='VariantA')].inner.variant.kind.tuple[*]" $f0 $f1
+    //@ has "$.index[*][?(@.name=='0')].inner.struct_field"
+    //@ set f0 = "$.index[*][?(@.name=='0')].id"
+    //@ has "$.index[*][?(@.name=='1')].inner.struct_field"
+    //@ set f1 = "$.index[*][?(@.name=='1')].id"
+    //@ ismany "$.index[*][?(@.name=='VariantA')].inner.variant.kind.tuple[*]" $f0 $f1
     VariantA(u32, String),
 }

--- a/tests/rustdoc-json/fn_pointer/abi.rs
+++ b/tests/rustdoc-json/fn_pointer/abi.rs
@@ -2,23 +2,23 @@
 
 #![feature(abi_vectorcall)]
 
-// @is "$.index[*][?(@.name=='AbiRust')].inner.type_alias.type.function_pointer.header.abi" \"Rust\"
+//@ is "$.index[*][?(@.name=='AbiRust')].inner.type_alias.type.function_pointer.header.abi" \"Rust\"
 pub type AbiRust = fn();
 
-// @is "$.index[*][?(@.name=='AbiC')].inner.type_alias.type.function_pointer.header.abi" '{"C": {"unwind": false}}'
+//@ is "$.index[*][?(@.name=='AbiC')].inner.type_alias.type.function_pointer.header.abi" '{"C": {"unwind": false}}'
 pub type AbiC = extern "C" fn();
 
-// @is "$.index[*][?(@.name=='AbiSystem')].inner.type_alias.type.function_pointer.header.abi" '{"System": {"unwind": false}}'
+//@ is "$.index[*][?(@.name=='AbiSystem')].inner.type_alias.type.function_pointer.header.abi" '{"System": {"unwind": false}}'
 pub type AbiSystem = extern "system" fn();
 
-// @is "$.index[*][?(@.name=='AbiCUnwind')].inner.type_alias.type.function_pointer.header.abi" '{"C": {"unwind": true}}'
+//@ is "$.index[*][?(@.name=='AbiCUnwind')].inner.type_alias.type.function_pointer.header.abi" '{"C": {"unwind": true}}'
 pub type AbiCUnwind = extern "C-unwind" fn();
 
-// @is "$.index[*][?(@.name=='AbiSystemUnwind')].inner.type_alias.type.function_pointer.header.abi" '{"System": {"unwind": true}}'
+//@ is "$.index[*][?(@.name=='AbiSystemUnwind')].inner.type_alias.type.function_pointer.header.abi" '{"System": {"unwind": true}}'
 pub type AbiSystemUnwind = extern "system-unwind" fn();
 
-// @is "$.index[*][?(@.name=='AbiVecorcall')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"vectorcall\""'
+//@ is "$.index[*][?(@.name=='AbiVecorcall')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"vectorcall\""'
 pub type AbiVecorcall = extern "vectorcall" fn();
 
-// @is "$.index[*][?(@.name=='AbiVecorcallUnwind')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"vectorcall-unwind\""'
+//@ is "$.index[*][?(@.name=='AbiVecorcallUnwind')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"vectorcall-unwind\""'
 pub type AbiVecorcallUnwind = extern "vectorcall-unwind" fn();

--- a/tests/rustdoc-json/fn_pointer/generics.rs
+++ b/tests/rustdoc-json/fn_pointer/generics.rs
@@ -1,10 +1,10 @@
 // ignore-tidy-linelength
 
-// @count "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[*]" 1
-// @is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[0][0]" '"val"'
-// @is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[0][1].borrowed_ref.lifetime" \"\'c\"
-// @is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.output.primitive" \"i32\"
-// @count "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[*]" 1
-// @is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[0].name" \"\'c\"
-// @is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
+//@ count "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[*]" 1
+//@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[0][0]" '"val"'
+//@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[0][1].borrowed_ref.lifetime" \"\'c\"
+//@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.output.primitive" \"i32\"
+//@ count "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[*]" 1
+//@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[0].name" \"\'c\"
+//@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
 pub type WithHigherRankTraitBounds = for<'c> fn(val: &'c i32) -> i32;

--- a/tests/rustdoc-json/fn_pointer/qualifiers.rs
+++ b/tests/rustdoc-json/fn_pointer/qualifiers.rs
@@ -1,11 +1,11 @@
 // ignore-tidy-linelength
 
-// @is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.unsafe" false
-// @is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.const" false
-// @is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.async" false
+//@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.unsafe" false
+//@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.const" false
+//@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.async" false
 pub type FnPointer = fn();
 
-// @is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.unsafe" true
-// @is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.const" false
-// @is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.async" false
+//@ is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.unsafe" true
+//@ is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.const" false
+//@ is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.async" false
 pub type UnsafePointer = unsafe fn();

--- a/tests/rustdoc-json/fns/abi.rs
+++ b/tests/rustdoc-json/fns/abi.rs
@@ -2,23 +2,23 @@
 
 #![feature(abi_vectorcall)]
 
-// @is "$.index[*][?(@.name=='abi_rust')].inner.function.header.abi" \"Rust\"
+//@ is "$.index[*][?(@.name=='abi_rust')].inner.function.header.abi" \"Rust\"
 pub fn abi_rust() {}
 
-// @is "$.index[*][?(@.name=='abi_c')].inner.function.header.abi" '{"C": {"unwind": false}}'
+//@ is "$.index[*][?(@.name=='abi_c')].inner.function.header.abi" '{"C": {"unwind": false}}'
 pub extern "C" fn abi_c() {}
 
-// @is "$.index[*][?(@.name=='abi_system')].inner.function.header.abi" '{"System": {"unwind": false}}'
+//@ is "$.index[*][?(@.name=='abi_system')].inner.function.header.abi" '{"System": {"unwind": false}}'
 pub extern "system" fn abi_system() {}
 
-// @is "$.index[*][?(@.name=='abi_c_unwind')].inner.function.header.abi" '{"C": {"unwind": true}}'
+//@ is "$.index[*][?(@.name=='abi_c_unwind')].inner.function.header.abi" '{"C": {"unwind": true}}'
 pub extern "C-unwind" fn abi_c_unwind() {}
 
-// @is "$.index[*][?(@.name=='abi_system_unwind')].inner.function.header.abi" '{"System": {"unwind": true}}'
+//@ is "$.index[*][?(@.name=='abi_system_unwind')].inner.function.header.abi" '{"System": {"unwind": true}}'
 pub extern "system-unwind" fn abi_system_unwind() {}
 
-// @is "$.index[*][?(@.name=='abi_vectorcall')].inner.function.header.abi.Other" '"\"vectorcall\""'
+//@ is "$.index[*][?(@.name=='abi_vectorcall')].inner.function.header.abi.Other" '"\"vectorcall\""'
 pub extern "vectorcall" fn abi_vectorcall() {}
 
-// @is "$.index[*][?(@.name=='abi_vectorcall_unwind')].inner.function.header.abi.Other" '"\"vectorcall-unwind\""'
+//@ is "$.index[*][?(@.name=='abi_vectorcall_unwind')].inner.function.header.abi.Other" '"\"vectorcall-unwind\""'
 pub extern "vectorcall-unwind" fn abi_vectorcall_unwind() {}

--- a/tests/rustdoc-json/fns/async_return.rs
+++ b/tests/rustdoc-json/fns/async_return.rs
@@ -5,30 +5,30 @@
 
 use std::future::Future;
 
-// @is "$.index[*][?(@.name=='get_int')].inner.function.decl.output.primitive" \"i32\"
-// @is "$.index[*][?(@.name=='get_int')].inner.function.header.async" false
+//@ is "$.index[*][?(@.name=='get_int')].inner.function.decl.output.primitive" \"i32\"
+//@ is "$.index[*][?(@.name=='get_int')].inner.function.header.async" false
 pub fn get_int() -> i32 {
     42
 }
 
-// @is "$.index[*][?(@.name=='get_int_async')].inner.function.decl.output.primitive" \"i32\"
-// @is "$.index[*][?(@.name=='get_int_async')].inner.function.header.async" true
+//@ is "$.index[*][?(@.name=='get_int_async')].inner.function.decl.output.primitive" \"i32\"
+//@ is "$.index[*][?(@.name=='get_int_async')].inner.function.header.async" true
 pub async fn get_int_async() -> i32 {
     42
 }
 
-// @is "$.index[*][?(@.name=='get_int_future')].inner.function.decl.output.impl_trait[0].trait_bound.trait.name" '"Future"'
-// @is "$.index[*][?(@.name=='get_int_future')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].name" '"Output"'
-// @is "$.index[*][?(@.name=='get_int_future')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].binding.equality.type.primitive"  \"i32\"
-// @is "$.index[*][?(@.name=='get_int_future')].inner.function.header.async" false
+//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.decl.output.impl_trait[0].trait_bound.trait.name" '"Future"'
+//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].name" '"Output"'
+//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].binding.equality.type.primitive"  \"i32\"
+//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.header.async" false
 pub fn get_int_future() -> impl Future<Output = i32> {
     async { 42 }
 }
 
-// @is "$.index[*][?(@.name=='get_int_future_async')].inner.function.decl.output.impl_trait[0].trait_bound.trait.name" '"Future"'
-// @is "$.index[*][?(@.name=='get_int_future_async')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].name" '"Output"'
-// @is "$.index[*][?(@.name=='get_int_future_async')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].binding.equality.type.primitive" \"i32\"
-// @is "$.index[*][?(@.name=='get_int_future_async')].inner.function.header.async" true
+//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.decl.output.impl_trait[0].trait_bound.trait.name" '"Future"'
+//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].name" '"Output"'
+//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].binding.equality.type.primitive" \"i32\"
+//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.header.async" true
 pub async fn get_int_future_async() -> impl Future<Output = i32> {
     async { 42 }
 }

--- a/tests/rustdoc-json/fns/extern_c_variadic.rs
+++ b/tests/rustdoc-json/fns/extern_c_variadic.rs
@@ -1,6 +1,6 @@
 extern "C" {
-    // @is "$.index[*][?(@.name == 'not_variadic')].inner.function.decl.c_variadic" false
+    //@ is "$.index[*][?(@.name == 'not_variadic')].inner.function.decl.c_variadic" false
     pub fn not_variadic(_: i32);
-    // @is "$.index[*][?(@.name == 'variadic')].inner.function.decl.c_variadic" true
+    //@ is "$.index[*][?(@.name == 'variadic')].inner.function.decl.c_variadic" true
     pub fn variadic(_: i32, ...);
 }

--- a/tests/rustdoc-json/fns/generic_args.rs
+++ b/tests/rustdoc-json/fns/generic_args.rs
@@ -1,60 +1,60 @@
 // ignore-tidy-linelength
 
-// @set foo = "$.index[*][?(@.name=='Foo')].id"
+//@ set foo = "$.index[*][?(@.name=='Foo')].id"
 pub trait Foo {}
 
-// @set generic_foo = "$.index[*][?(@.name=='GenericFoo')].id"
+//@ set generic_foo = "$.index[*][?(@.name=='GenericFoo')].id"
 pub trait GenericFoo<'a> {}
 
-// @is "$.index[*][?(@.name=='generics')].inner.function.generics.where_predicates" "[]"
-// @count "$.index[*][?(@.name=='generics')].inner.function.generics.params[*]" 1
-// @is "$.index[*][?(@.name=='generics')].inner.function.generics.params[0].name" '"F"'
-// @is "$.index[*][?(@.name=='generics')].inner.function.generics.params[0].kind.type.default" 'null'
-// @count "$.index[*][?(@.name=='generics')].inner.function.generics.params[0].kind.type.bounds[*]" 1
-// @is "$.index[*][?(@.name=='generics')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" '$foo'
-// @count "$.index[*][?(@.name=='generics')].inner.function.decl.inputs[*]" 1
-// @is "$.index[*][?(@.name=='generics')].inner.function.decl.inputs[0][0]" '"f"'
-// @is "$.index[*][?(@.name=='generics')].inner.function.decl.inputs[0][1].generic" '"F"'
+//@ is "$.index[*][?(@.name=='generics')].inner.function.generics.where_predicates" "[]"
+//@ count "$.index[*][?(@.name=='generics')].inner.function.generics.params[*]" 1
+//@ is "$.index[*][?(@.name=='generics')].inner.function.generics.params[0].name" '"F"'
+//@ is "$.index[*][?(@.name=='generics')].inner.function.generics.params[0].kind.type.default" 'null'
+//@ count "$.index[*][?(@.name=='generics')].inner.function.generics.params[0].kind.type.bounds[*]" 1
+//@ is "$.index[*][?(@.name=='generics')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" '$foo'
+//@ count "$.index[*][?(@.name=='generics')].inner.function.decl.inputs[*]" 1
+//@ is "$.index[*][?(@.name=='generics')].inner.function.decl.inputs[0][0]" '"f"'
+//@ is "$.index[*][?(@.name=='generics')].inner.function.decl.inputs[0][1].generic" '"F"'
 pub fn generics<F: Foo>(f: F) {}
 
-// @is "$.index[*][?(@.name=='impl_trait')].inner.function.generics.where_predicates" "[]"
-// @count "$.index[*][?(@.name=='impl_trait')].inner.function.generics.params[*]" 1
-// @is "$.index[*][?(@.name=='impl_trait')].inner.function.generics.params[0].name" '"impl Foo"'
-// @is "$.index[*][?(@.name=='impl_trait')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $foo
-// @count "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[*]" 1
-// @is "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[0][0]" '"f"'
-// @count "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[0][1].impl_trait[*]" 1
-// @is "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[0][1].impl_trait[0].trait_bound.trait.id" $foo
+//@ is "$.index[*][?(@.name=='impl_trait')].inner.function.generics.where_predicates" "[]"
+//@ count "$.index[*][?(@.name=='impl_trait')].inner.function.generics.params[*]" 1
+//@ is "$.index[*][?(@.name=='impl_trait')].inner.function.generics.params[0].name" '"impl Foo"'
+//@ is "$.index[*][?(@.name=='impl_trait')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $foo
+//@ count "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[*]" 1
+//@ is "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[0][0]" '"f"'
+//@ count "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[0][1].impl_trait[*]" 1
+//@ is "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[0][1].impl_trait[0].trait_bound.trait.id" $foo
 pub fn impl_trait(f: impl Foo) {}
 
-// @count "$.index[*][?(@.name=='where_clase')].inner.function.generics.params[*]" 3
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.params[0].name" '"F"'
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.params[0].kind" '{"type": {"bounds": [], "default": null, "synthetic": false}}'
-// @count "$.index[*][?(@.name=='where_clase')].inner.function.decl.inputs[*]" 3
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.decl.inputs[0][0]" '"f"'
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.decl.inputs[0][1].generic" '"F"'
-// @count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[*]" 3
+//@ count "$.index[*][?(@.name=='where_clase')].inner.function.generics.params[*]" 3
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.params[0].name" '"F"'
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.params[0].kind" '{"type": {"bounds": [], "default": null, "synthetic": false}}'
+//@ count "$.index[*][?(@.name=='where_clase')].inner.function.decl.inputs[*]" 3
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.decl.inputs[0][0]" '"f"'
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.decl.inputs[0][1].generic" '"F"'
+//@ count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[*]" 3
 
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.type.generic" \"F\"
-// @count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.bounds[*]" 1
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.bounds[0].trait_bound.trait.id" $foo
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.type.generic" \"F\"
+//@ count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.bounds[*]" 1
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.bounds[0].trait_bound.trait.id" $foo
 
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.type.generic" \"G\"
-// @count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[*]" 1
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.trait.id" $generic_foo
-// @count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[*]" 1
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].name" \"\'a\"
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].kind.lifetime.outlives" "[]"
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.generic_params" "[]"
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.type.generic" \"G\"
+//@ count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[*]" 1
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.trait.id" $generic_foo
+//@ count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[*]" 1
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].name" \"\'a\"
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].kind.lifetime.outlives" "[]"
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.generic_params" "[]"
 
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.type.borrowed_ref.lifetime" \"\'b\"
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.type.borrowed_ref.type.generic" \"H\"
-// @count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[*]" 1
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.trait.id" $foo
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.generic_params" "[]"
-// @count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.generic_params[*]" 1
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.generic_params[0].name" \"\'b\"
-// @is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.generic_params[0].kind.lifetime.outlives" "[]"
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.type.borrowed_ref.lifetime" \"\'b\"
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.type.borrowed_ref.type.generic" \"H\"
+//@ count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[*]" 1
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.trait.id" $foo
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.generic_params" "[]"
+//@ count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.generic_params[*]" 1
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.generic_params[0].name" \"\'b\"
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.generic_params[0].kind.lifetime.outlives" "[]"
 pub fn where_clase<F, G, H>(f: F, g: G, h: H)
 where
     F: Foo,

--- a/tests/rustdoc-json/fns/generic_returns.rs
+++ b/tests/rustdoc-json/fns/generic_returns.rs
@@ -1,13 +1,13 @@
 // ignore-tidy-linelength
 
-// @count "$.index[*][?(@.name=='generic_returns')].inner.module.items[*]" 2
+//@ count "$.index[*][?(@.name=='generic_returns')].inner.module.items[*]" 2
 
-// @set foo = "$.index[*][?(@.name=='Foo')].id"
+//@ set foo = "$.index[*][?(@.name=='Foo')].id"
 pub trait Foo {}
 
-// @is "$.index[*][?(@.name=='get_foo')].inner.function.decl.inputs" []
-// @count "$.index[*][?(@.name=='get_foo')].inner.function.decl.output.impl_trait[*]" 1
-// @is "$.index[*][?(@.name=='get_foo')].inner.function.decl.output.impl_trait[0].trait_bound.trait.id" $foo
+//@ is "$.index[*][?(@.name=='get_foo')].inner.function.decl.inputs" []
+//@ count "$.index[*][?(@.name=='get_foo')].inner.function.decl.output.impl_trait[*]" 1
+//@ is "$.index[*][?(@.name=='get_foo')].inner.function.decl.output.impl_trait[0].trait_bound.trait.id" $foo
 pub fn get_foo() -> impl Foo {
     Fooer {}
 }

--- a/tests/rustdoc-json/fns/generics.rs
+++ b/tests/rustdoc-json/fns/generics.rs
@@ -1,22 +1,22 @@
 // ignore-tidy-linelength
 
-// @set wham_id = "$.index[*][?(@.name=='Wham')].id"
+//@ set wham_id = "$.index[*][?(@.name=='Wham')].id"
 pub trait Wham {}
 
-// @is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.where_predicates" []
-// @count "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[*]" 1
-// @is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].name" '"T"'
-// @is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].kind.type.synthetic" false
-// @is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
-// @is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.decl.inputs" '[["w", {"generic": "T"}]]'
+//@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.where_predicates" []
+//@ count "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[*]" 1
+//@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].name" '"T"'
+//@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].kind.type.synthetic" false
+//@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
+//@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.decl.inputs" '[["w", {"generic": "T"}]]'
 pub fn one_generic_param_fn<T: Wham>(w: T) {}
 
-// @is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.where_predicates" []
-// @count "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[*]" 1
-// @is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].name" '"impl Wham"'
-// @is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].kind.type.synthetic" true
-// @is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
-// @count "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.decl.inputs[*]" 1
-// @is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.decl.inputs[0][0]" '"w"'
-// @is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.decl.inputs[0][1].impl_trait[0].trait_bound.trait.id" $wham_id
+//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.where_predicates" []
+//@ count "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[*]" 1
+//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].name" '"impl Wham"'
+//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].kind.type.synthetic" true
+//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
+//@ count "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.decl.inputs[*]" 1
+//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.decl.inputs[0][0]" '"w"'
+//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.decl.inputs[0][1].impl_trait[0].trait_bound.trait.id" $wham_id
 pub fn one_synthetic_generic_param_fn(w: impl Wham) {}

--- a/tests/rustdoc-json/fns/pattern_arg.rs
+++ b/tests/rustdoc-json/fns/pattern_arg.rs
@@ -1,7 +1,7 @@
-// @is "$.index[*][?(@.name=='fst')].inner.function.decl.inputs[0][0]" '"(x, _)"'
+//@ is "$.index[*][?(@.name=='fst')].inner.function.decl.inputs[0][0]" '"(x, _)"'
 pub fn fst<X, Y>((x, _): (X, Y)) -> X {
     x
 }
 
-// @is "$.index[*][?(@.name=='drop_int')].inner.function.decl.inputs[0][0]" '"_"'
+//@ is "$.index[*][?(@.name=='drop_int')].inner.function.decl.inputs[0][0]" '"_"'
 pub fn drop_int(_: i32) {}

--- a/tests/rustdoc-json/fns/qualifiers.rs
+++ b/tests/rustdoc-json/fns/qualifiers.rs
@@ -1,33 +1,33 @@
 //@ edition:2018
 
-// @is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.async" false
-// @is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.const"  false
-// @is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.unsafe" false
+//@ is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.async" false
+//@ is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.const"  false
+//@ is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.unsafe" false
 pub fn nothing_fn() {}
 
-// @is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.async"  false
-// @is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.const"  false
-// @is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.unsafe" true
+//@ is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.async"  false
+//@ is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.const"  false
+//@ is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.unsafe" true
 pub unsafe fn unsafe_fn() {}
 
-// @is "$.index[*][?(@.name=='const_fn')].inner.function.header.async"  false
-// @is "$.index[*][?(@.name=='const_fn')].inner.function.header.const"  true
-// @is "$.index[*][?(@.name=='const_fn')].inner.function.header.unsafe" false
+//@ is "$.index[*][?(@.name=='const_fn')].inner.function.header.async"  false
+//@ is "$.index[*][?(@.name=='const_fn')].inner.function.header.const"  true
+//@ is "$.index[*][?(@.name=='const_fn')].inner.function.header.unsafe" false
 pub const fn const_fn() {}
 
-// @is "$.index[*][?(@.name=='async_fn')].inner.function.header.async"  true
-// @is "$.index[*][?(@.name=='async_fn')].inner.function.header.const"  false
-// @is "$.index[*][?(@.name=='async_fn')].inner.function.header.unsafe" false
+//@ is "$.index[*][?(@.name=='async_fn')].inner.function.header.async"  true
+//@ is "$.index[*][?(@.name=='async_fn')].inner.function.header.const"  false
+//@ is "$.index[*][?(@.name=='async_fn')].inner.function.header.unsafe" false
 pub async fn async_fn() {}
 
-// @is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.async"  true
-// @is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.const"  false
-// @is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.unsafe" true
+//@ is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.async"  true
+//@ is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.const"  false
+//@ is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.unsafe" true
 pub async unsafe fn async_unsafe_fn() {}
 
-// @is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.async"  false
-// @is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.const"  true
-// @is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.unsafe" true
+//@ is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.async"  false
+//@ is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.const"  true
+//@ is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.unsafe" true
 pub const unsafe fn const_unsafe_fn() {}
 
 // It's impossible for a function to be both const and async, so no test for that

--- a/tests/rustdoc-json/fns/return_type_alias.rs
+++ b/tests/rustdoc-json/fns/return_type_alias.rs
@@ -1,9 +1,9 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/104851>
 
-/// @set foo = "$.index[*][?(@.name=='Foo')].id"
+///@ set foo = "$.index[*][?(@.name=='Foo')].id"
 pub type Foo = i32;
 
-// @is "$.index[*][?(@.name=='demo')].inner.function.decl.output.resolved_path.id" $foo
+//@ is "$.index[*][?(@.name=='demo')].inner.function.decl.output.resolved_path.id" $foo
 pub fn demo() -> Foo {
     42
 }

--- a/tests/rustdoc-json/generic-associated-types/gats.rs
+++ b/tests/rustdoc-json/generic-associated-types/gats.rs
@@ -3,32 +3,32 @@
 pub trait Display {}
 
 pub trait LendingIterator {
-    // @count "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.generics.params[*]" 1
-    // @is "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.generics.params[*].name" \"\'a\"
-    // @count "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.generics.where_predicates[*]" 1
-    // @is "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.generics.where_predicates[*].bound_predicate.type.generic" \"Self\"
-    // @is "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.generics.where_predicates[*].bound_predicate.bounds[*].outlives" \"\'a\"
-    // @count "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.bounds[*]" 1
+    //@ count "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.generics.params[*]" 1
+    //@ is "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.generics.params[*].name" \"\'a\"
+    //@ count "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.generics.where_predicates[*]" 1
+    //@ is "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.generics.where_predicates[*].bound_predicate.type.generic" \"Self\"
+    //@ is "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.generics.where_predicates[*].bound_predicate.bounds[*].outlives" \"\'a\"
+    //@ count "$.index[*][?(@.name=='LendingItem')].inner.assoc_type.bounds[*]" 1
     type LendingItem<'a>: Display
     where
         Self: 'a;
 
-    // @count "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.args.angle_bracketed.args[*]" 1
-    // @count "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.args.angle_bracketed.bindings[*]" 0
-    // @is "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.self_type.generic" \"Self\"
-    // @is "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.name" \"LendingItem\"
+    //@ count "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.args.angle_bracketed.args[*]" 1
+    //@ count "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.args.angle_bracketed.bindings[*]" 0
+    //@ is "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.self_type.generic" \"Self\"
+    //@ is "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.name" \"LendingItem\"
     fn lending_next<'a>(&'a self) -> Self::LendingItem<'a>;
 }
 
 pub trait Iterator {
-    // @count "$.index[*][?(@.name=='Item')].inner.assoc_type.generics.params[*]" 0
-    // @count "$.index[*][?(@.name=='Item')].inner.assoc_type.generics.where_predicates[*]" 0
-    // @count "$.index[*][?(@.name=='Item')].inner.assoc_type.bounds[*]" 1
+    //@ count "$.index[*][?(@.name=='Item')].inner.assoc_type.generics.params[*]" 0
+    //@ count "$.index[*][?(@.name=='Item')].inner.assoc_type.generics.where_predicates[*]" 0
+    //@ count "$.index[*][?(@.name=='Item')].inner.assoc_type.bounds[*]" 1
     type Item: Display;
 
-    // @count "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.args.angle_bracketed.args[*]" 0
-    // @count "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.args.angle_bracketed.bindings[*]" 0
-    // @is "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.self_type.generic" \"Self\"
-    // @is "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.name" \"Item\"
+    //@ count "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.args.angle_bracketed.args[*]" 0
+    //@ count "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.args.angle_bracketed.bindings[*]" 0
+    //@ is "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.self_type.generic" \"Self\"
+    //@ is "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.name" \"Item\"
     fn next<'a>(&'a self) -> Self::Item;
 }

--- a/tests/rustdoc-json/generic_impl.rs
+++ b/tests/rustdoc-json/generic_impl.rs
@@ -1,8 +1,8 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/97986>.
 
-// @has "$.index[*][?(@.name=='f')]"
-// @has "$.index[*][?(@.name=='AssocTy')]"
-// @has "$.index[*][?(@.name=='AssocConst')]"
+//@ has "$.index[*][?(@.name=='f')]"
+//@ has "$.index[*][?(@.name=='AssocTy')]"
+//@ has "$.index[*][?(@.name=='AssocConst')]"
 
 pub mod m {
     pub struct S;

--- a/tests/rustdoc-json/glob_import.rs
+++ b/tests/rustdoc-json/glob_import.rs
@@ -2,8 +2,8 @@
 
 #![no_std]
 
-// @has "$.index[*][?(@.name=='glob')]"
-// @has "$.index[*][?(@.inner.import)].inner.import.name" \"*\"
+//@ has "$.index[*][?(@.name=='glob')]"
+//@ has "$.index[*][?(@.inner.import)].inner.import.name" \"*\"
 
 mod m1 {
     pub fn f() {}

--- a/tests/rustdoc-json/impl-trait-precise-capturing.rs
+++ b/tests/rustdoc-json/impl-trait-precise-capturing.rs
@@ -1,6 +1,6 @@
 #![feature(precise_capturing)]
 
-// @is "$.index[*][?(@.name=='hello')].inner.function.decl.output.impl_trait[1].use[0]" \"\'a\"
-// @is "$.index[*][?(@.name=='hello')].inner.function.decl.output.impl_trait[1].use[1]" \"T\"
-// @is "$.index[*][?(@.name=='hello')].inner.function.decl.output.impl_trait[1].use[2]" \"N\"
+//@ is "$.index[*][?(@.name=='hello')].inner.function.decl.output.impl_trait[1].use[0]" \"\'a\"
+//@ is "$.index[*][?(@.name=='hello')].inner.function.decl.output.impl_trait[1].use[1]" \"T\"
+//@ is "$.index[*][?(@.name=='hello')].inner.function.decl.output.impl_trait[1].use[2]" \"N\"
 pub fn hello<'a, T, const N: usize>() -> impl Sized + use<'a, T, N> {}

--- a/tests/rustdoc-json/impls/auto.rs
+++ b/tests/rustdoc-json/impls/auto.rs
@@ -15,8 +15,8 @@ impl Foo {
 }
 
 // Testing spans, so all tests below code
-// @is "$.index[*][?(@.docs=='has span')].span.begin" "[13, 0]"
-// @is "$.index[*][?(@.docs=='has span')].span.end" "[15, 1]"
+//@ is "$.index[*][?(@.docs=='has span')].span.begin" "[13, 0]"
+//@ is "$.index[*][?(@.docs=='has span')].span.end" "[15, 1]"
 // FIXME: this doesn't work due to https://github.com/freestrings/jsonpath/issues/91
 // is "$.index[*][?(@.inner.impl.synthetic==true)].span" null
 pub struct Foo;

--- a/tests/rustdoc-json/impls/blanket_with_local.rs
+++ b/tests/rustdoc-json/impls/blanket_with_local.rs
@@ -1,11 +1,11 @@
 // Test for the ICE in rust/83718
 // A blanket impl plus a local type together shouldn't result in mismatched ID issues
 
-// @has "$.index[*][?(@.name=='Load')]"
+//@ has "$.index[*][?(@.name=='Load')]"
 pub trait Load {
-    // @has "$.index[*][?(@.name=='load')]"
+    //@ has "$.index[*][?(@.name=='load')]"
     fn load() {}
-    // @has "$.index[*][?(@.name=='write')]"
+    //@ has "$.index[*][?(@.name=='write')]"
     fn write(self) {}
 }
 
@@ -14,5 +14,5 @@ impl<P> Load for P {
     fn write(self) {}
 }
 
-// @has "$.index[*][?(@.name=='Wrapper')]"
+//@ has "$.index[*][?(@.name=='Wrapper')]"
 pub struct Wrapper {}

--- a/tests/rustdoc-json/impls/foreign_for_local.rs
+++ b/tests/rustdoc-json/impls/foreign_for_local.rs
@@ -3,16 +3,16 @@ extern crate foreign_trait;
 
 /// ForeignTrait id hack
 pub use foreign_trait::ForeignTrait as _;
-// @set ForeignTrait = "$.index[*][?(@.docs=='ForeignTrait id hack')].inner.import.id"
+//@ set ForeignTrait = "$.index[*][?(@.docs=='ForeignTrait id hack')].inner.import.id"
 
 pub struct LocalStruct;
-// @set LocalStruct = "$.index[*][?(@.name=='LocalStruct')].id"
+//@ set LocalStruct = "$.index[*][?(@.name=='LocalStruct')].id"
 
 /// foreign for local
 impl foreign_trait::ForeignTrait for LocalStruct {}
 
-// @set impl = "$.index[*][?(@.docs=='foreign for local')].id"
-// @is "$.index[*][?(@.docs=='foreign for local')].inner.impl.for.resolved_path.id" $LocalStruct
-// @is "$.index[*][?(@.docs=='foreign for local')].inner.impl.trait.id" $ForeignTrait
+//@ set impl = "$.index[*][?(@.docs=='foreign for local')].id"
+//@ is "$.index[*][?(@.docs=='foreign for local')].inner.impl.for.resolved_path.id" $LocalStruct
+//@ is "$.index[*][?(@.docs=='foreign for local')].inner.impl.trait.id" $ForeignTrait
 
-// @has "$.index[*][?(@.name=='LocalStruct')].inner.struct.impls[*]" $impl
+//@ has "$.index[*][?(@.name=='LocalStruct')].inner.struct.impls[*]" $impl

--- a/tests/rustdoc-json/impls/impl_item_visibility.rs
+++ b/tests/rustdoc-json/impls/impl_item_visibility.rs
@@ -4,13 +4,13 @@ pub struct Foo;
 impl Foo {
     fn baz() {}
 }
-// @!has '$.index[*][?(@.docs=="impl Foo priv")]'
+//@ !has '$.index[*][?(@.docs=="impl Foo priv")]'
 
 /// impl Foo pub
 impl Foo {
     pub fn qux() {}
 }
-// @is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
+//@ is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
 
 /// impl Foo hidden
 impl Foo {
@@ -18,4 +18,4 @@ impl Foo {
     pub fn __quazl() {}
 }
 // FIXME(#111564): Is this the right behaviour?
-// @is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'
+//@ is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'

--- a/tests/rustdoc-json/impls/impl_item_visibility_show_hidden.rs
+++ b/tests/rustdoc-json/impls/impl_item_visibility_show_hidden.rs
@@ -7,13 +7,13 @@ impl Foo {
     fn baz() {}
 }
 // FIXME(#111564): Is this the right behaviour?
-// @is '$.index[*][?(@.docs=="impl Foo priv")].visibility' '"default"'
+//@ is '$.index[*][?(@.docs=="impl Foo priv")].visibility' '"default"'
 
 /// impl Foo pub
 impl Foo {
     pub fn qux() {}
 }
-// @is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
+//@ is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
 
 /// impl Foo hidden
 impl Foo {
@@ -21,4 +21,4 @@ impl Foo {
     pub fn __quazl() {}
 }
 // FIXME(#111564): Is this the right behaviour?
-// @is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'
+//@ is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'

--- a/tests/rustdoc-json/impls/impl_item_visibility_show_private.rs
+++ b/tests/rustdoc-json/impls/impl_item_visibility_show_private.rs
@@ -6,13 +6,13 @@ pub struct Foo;
 impl Foo {
     fn baz() {}
 }
-// @is '$.index[*][?(@.docs=="impl Foo priv")].visibility' '"default"'
+//@ is '$.index[*][?(@.docs=="impl Foo priv")].visibility' '"default"'
 
 /// impl Foo pub
 impl Foo {
     pub fn qux() {}
 }
-// @is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
+//@ is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
 
 /// impl Foo hidden
 impl Foo {
@@ -20,4 +20,4 @@ impl Foo {
     pub fn __quazl() {}
 }
 // FIXME(#111564): Is this the right behaviour?
-// @is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'
+//@ is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'

--- a/tests/rustdoc-json/impls/import_from_private.rs
+++ b/tests/rustdoc-json/impls/import_from_private.rs
@@ -1,20 +1,20 @@
 // https://github.com/rust-lang/rust/issues/100252
 
 mod bar {
-    // @set baz = "$.index[*][?(@.name == 'Baz')].id"
+    //@ set baz = "$.index[*][?(@.name == 'Baz')].id"
     pub struct Baz;
-    // @set impl = "$.index[*][?(@.docs == 'impl')].id"
+    //@ set impl = "$.index[*][?(@.docs == 'impl')].id"
     /// impl
     impl Baz {
-        // @set doit = "$.index[*][?(@.name == 'doit')].id"
+        //@ set doit = "$.index[*][?(@.name == 'doit')].id"
         pub fn doit() {}
     }
 }
 
-// @set import = "$.index[*][?(@.inner.import)].id"
+//@ set import = "$.index[*][?(@.inner.import)].id"
 pub use bar::Baz;
 
-// @is "$.index[*].inner.module.items[*]" $import
-// @is "$.index[*].inner.import.id" $baz
-// @has "$.index[*][?(@.name == 'Baz')].inner.struct.impls[*]" $impl
-// @is "$.index[*][?(@.docs=='impl')].inner.impl.items[*]" $doit
+//@ is "$.index[*].inner.module.items[*]" $import
+//@ is "$.index[*].inner.import.id" $baz
+//@ has "$.index[*][?(@.name == 'Baz')].inner.struct.impls[*]" $impl
+//@ is "$.index[*][?(@.docs=='impl')].inner.impl.items[*]" $doit

--- a/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id-2.rs
+++ b/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id-2.rs
@@ -1,8 +1,8 @@
-// @has "$.index[*][?(@.docs=='Here')]"
-// @!has "$.index[*][?(@.docs=='Not Here')]"
-// @!has "$.index[*][?(@.name == 'HiddenPubStruct')]"
-// @has "$.index[*][?(@.name == 'NotHiddenPubStruct')]"
-// @has "$.index[*][?(@.name=='PubTrait')]"
+//@ has "$.index[*][?(@.docs=='Here')]"
+//@ !has "$.index[*][?(@.docs=='Not Here')]"
+//@ !has "$.index[*][?(@.name == 'HiddenPubStruct')]"
+//@ has "$.index[*][?(@.name == 'NotHiddenPubStruct')]"
+//@ has "$.index[*][?(@.name=='PubTrait')]"
 pub trait PubTrait {}
 
 #[doc(hidden)]

--- a/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id-3.rs
+++ b/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id-3.rs
@@ -1,8 +1,8 @@
 //@ compile-flags: --document-hidden-items
 
-// @has "$.index[*][?(@.name == 'HiddenPubStruct')]"
-// @has "$.index[*][?(@.inner.impl)]"
-// @has "$.index[*][?(@.name=='PubTrait')]"
+//@ has "$.index[*][?(@.name == 'HiddenPubStruct')]"
+//@ has "$.index[*][?(@.inner.impl)]"
+//@ has "$.index[*][?(@.name=='PubTrait')]"
 pub trait PubTrait {}
 
 #[doc(hidden)]

--- a/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id.rs
+++ b/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id.rs
@@ -1,21 +1,21 @@
-// @has "$.index[*][?(@.name=='PubTrait')]"
+//@ has "$.index[*][?(@.name=='PubTrait')]"
 pub trait PubTrait {}
 
 #[doc(hidden)]
 pub mod hidden {
-    // @!has "$.index[*][?(@.name == 'HiddenPubStruct')]"
+    //@ !has "$.index[*][?(@.name == 'HiddenPubStruct')]"
     pub struct HiddenPubStruct;
 
-    // @!has "$.index[*][?(@.docs == 'Not Here')]"
+    //@ !has "$.index[*][?(@.docs == 'Not Here')]"
     /// Not Here
     impl crate::PubTrait for HiddenPubStruct {}
 }
 
 pub mod not_hidden {
-    // @has "$.index[*][?(@.name == 'NotHiddenPubStruct')]"
+    //@ has "$.index[*][?(@.name == 'NotHiddenPubStruct')]"
     pub struct NotHiddenPubStruct;
 
-    // @has "$.index[*][?(@.docs == 'Here')]"
+    //@ has "$.index[*][?(@.docs == 'Here')]"
     /// Here
     impl crate::PubTrait for NotHiddenPubStruct {}
 }

--- a/tests/rustdoc-json/impls/local_for_foreign.rs
+++ b/tests/rustdoc-json/impls/local_for_foreign.rs
@@ -3,16 +3,16 @@ extern crate foreign_struct;
 
 /// ForeignStruct id hack
 pub use foreign_struct::ForeignStruct as _;
-// @set ForeignStruct = "$.index[*][?(@.docs=='ForeignStruct id hack')].inner.import.id"
+//@ set ForeignStruct = "$.index[*][?(@.docs=='ForeignStruct id hack')].inner.import.id"
 
 pub trait LocalTrait {}
-// @set LocalTrait = "$.index[*][?(@.name=='LocalTrait')].id"
+//@ set LocalTrait = "$.index[*][?(@.name=='LocalTrait')].id"
 
 /// local for foreign
 impl LocalTrait for foreign_struct::ForeignStruct {}
 
-// @set impl = "$.index[*][?(@.docs=='local for foreign')].id"
-// @is "$.index[*][?(@.docs=='local for foreign')].inner.impl.trait.id" $LocalTrait
-// @is "$.index[*][?(@.docs=='local for foreign')].inner.impl.for.resolved_path.id" $ForeignStruct
+//@ set impl = "$.index[*][?(@.docs=='local for foreign')].id"
+//@ is "$.index[*][?(@.docs=='local for foreign')].inner.impl.trait.id" $LocalTrait
+//@ is "$.index[*][?(@.docs=='local for foreign')].inner.impl.for.resolved_path.id" $ForeignStruct
 
-// @is "$.index[*][?(@.name=='LocalTrait')].inner.trait.implementations[*]" $impl
+//@ is "$.index[*][?(@.name=='LocalTrait')].inner.trait.implementations[*]" $impl

--- a/tests/rustdoc-json/impls/local_for_local.rs
+++ b/tests/rustdoc-json/impls/local_for_local.rs
@@ -1,12 +1,12 @@
-// @set struct = "$.index[*][?(@.name=='Struct')].id"
+//@ set struct = "$.index[*][?(@.name=='Struct')].id"
 pub struct Struct;
-// @set trait = "$.index[*][?(@.name=='Trait')].id"
+//@ set trait = "$.index[*][?(@.name=='Trait')].id"
 pub trait Trait {}
-// @set impl = "$.index[*][?(@.docs=='impl')].id"
+//@ set impl = "$.index[*][?(@.docs=='impl')].id"
 /// impl
 impl Trait for Struct {}
 
-// @has "$.index[*][?(@.name=='Struct')].inner.struct.impls[*]" $impl
-// @is "$.index[*][?(@.name=='Trait')].inner.trait.implementations[*]" $impl
-// @is "$.index[*][?(@.docs=='impl')].inner.impl.trait.id" $trait
-// @is "$.index[*][?(@.docs=='impl')].inner.impl.for.resolved_path.id" $struct
+//@ has "$.index[*][?(@.name=='Struct')].inner.struct.impls[*]" $impl
+//@ is "$.index[*][?(@.name=='Trait')].inner.trait.implementations[*]" $impl
+//@ is "$.index[*][?(@.docs=='impl')].inner.impl.trait.id" $trait
+//@ is "$.index[*][?(@.docs=='impl')].inner.impl.for.resolved_path.id" $struct

--- a/tests/rustdoc-json/impls/local_for_local_primitive.rs
+++ b/tests/rustdoc-json/impls/local_for_local_primitive.rs
@@ -1,18 +1,18 @@
 #![feature(rustc_attrs)]
 
-// @set Local = "$.index[*][?(@.name=='Local')].id"
+//@ set Local = "$.index[*][?(@.name=='Local')].id"
 pub trait Local {}
 
-// @is "$.index[*][?(@.docs=='Local for bool')].inner.impl.trait.id" $Local
-// @is "$.index[*][?(@.docs=='Local for bool')].inner.impl.for.primitive" '"bool"'
+//@ is "$.index[*][?(@.docs=='Local for bool')].inner.impl.trait.id" $Local
+//@ is "$.index[*][?(@.docs=='Local for bool')].inner.impl.for.primitive" '"bool"'
 /// Local for bool
 impl Local for bool {}
 
-// @set impl =  "$.index[*][?(@.docs=='Local for bool')].id"
-// @is "$.index[*][?(@.name=='Local')].inner.trait.implementations[*]" $impl
+//@ set impl =  "$.index[*][?(@.docs=='Local for bool')].id"
+//@ is "$.index[*][?(@.name=='Local')].inner.trait.implementations[*]" $impl
 
 // FIXME(#101695): Test bool's `impls` include "Local for bool"
-// @has "$.index[*][?(@.name=='bool')]"
+//@ has "$.index[*][?(@.name=='bool')]"
 #[rustc_doc_primitive = "bool"]
 /// Boolean docs
 mod prim_bool {}

--- a/tests/rustdoc-json/impls/local_for_primitive.rs
+++ b/tests/rustdoc-json/impls/local_for_primitive.rs
@@ -1,7 +1,7 @@
-// @set local = "$.index[*][?(@.name=='Local')]"
+//@ set local = "$.index[*][?(@.name=='Local')]"
 pub trait Local {}
 
-// @set impl = "$.index[*][?(@.docs=='local for bool')].id"
-// @is "$.index[*][?(@.name=='Local')].inner.trait.implementations[*]" $impl
+//@ set impl = "$.index[*][?(@.docs=='local for bool')].id"
+//@ is "$.index[*][?(@.name=='Local')].inner.trait.implementations[*]" $impl
 /// local for bool
 impl Local for bool {}

--- a/tests/rustdoc-json/intra-doc-links/foreign_variant.rs
+++ b/tests/rustdoc-json/intra-doc-links/foreign_variant.rs
@@ -8,6 +8,6 @@ pub struct Local;
 /// local impl
 impl enum_variant_in_trait_method::Trait for Local {}
 
-// @!has "$.index[*][?(@.name == 'Trait')]"
-// @!has "$.index[*][?(@.name == 'method')]"
-// @count "$.index[*][?(@.docs == 'local impl')].inner.items[*]" 0
+//@ !has "$.index[*][?(@.name == 'Trait')]"
+//@ !has "$.index[*][?(@.name == 'method')]"
+//@ count "$.index[*][?(@.docs == 'local impl')].inner.items[*]" 0

--- a/tests/rustdoc-json/intra-doc-links/non_page.rs
+++ b/tests/rustdoc-json/intra-doc-links/non_page.rs
@@ -7,17 +7,17 @@
 //! [`Trait::ASSOC_CONST`]
 //! [`Trait::method`]
 
-// @set struct_field = "$.index[*][?(@.name=='struct_field')].id"
-// @set Variant = "$.index[*][?(@.name=='Variant')].id"
-// @set AssocType = "$.index[*][?(@.name=='AssocType')].id"
-// @set ASSOC_CONST = "$.index[*][?(@.name=='ASSOC_CONST')].id"
-// @set method = "$.index[*][?(@.name=='method')].id"
+//@ set struct_field = "$.index[*][?(@.name=='struct_field')].id"
+//@ set Variant = "$.index[*][?(@.name=='Variant')].id"
+//@ set AssocType = "$.index[*][?(@.name=='AssocType')].id"
+//@ set ASSOC_CONST = "$.index[*][?(@.name=='ASSOC_CONST')].id"
+//@ set method = "$.index[*][?(@.name=='method')].id"
 
-// @is "$.index[*][?(@.name=='non_page')].links['`Struct::struct_field`']" $struct_field
-// @is "$.index[*][?(@.name=='non_page')].links['`Enum::Variant`']" $Variant
-// @is "$.index[*][?(@.name=='non_page')].links['`Trait::AssocType`']" $AssocType
-// @is "$.index[*][?(@.name=='non_page')].links['`Trait::ASSOC_CONST`']" $ASSOC_CONST
-// @is "$.index[*][?(@.name=='non_page')].links['`Trait::method`']" $method
+//@ is "$.index[*][?(@.name=='non_page')].links['`Struct::struct_field`']" $struct_field
+//@ is "$.index[*][?(@.name=='non_page')].links['`Enum::Variant`']" $Variant
+//@ is "$.index[*][?(@.name=='non_page')].links['`Trait::AssocType`']" $AssocType
+//@ is "$.index[*][?(@.name=='non_page')].links['`Trait::ASSOC_CONST`']" $ASSOC_CONST
+//@ is "$.index[*][?(@.name=='non_page')].links['`Trait::method`']" $method
 
 pub struct Struct {
     pub struct_field: i32,

--- a/tests/rustdoc-json/intra-doc-links/user_written.rs
+++ b/tests/rustdoc-json/intra-doc-links/user_written.rs
@@ -4,5 +4,5 @@
 /// To test rustdoc json
 pub fn foo() {}
 
-// @set foo = "$.index[*][?(@.name=='foo')].id"
-// @is "$.index[*][?(@.name=='user_written')].links['foo#reasons']" $foo
+//@ set foo = "$.index[*][?(@.name=='foo')].id"
+//@ is "$.index[*][?(@.name=='user_written')].links['foo#reasons']" $foo

--- a/tests/rustdoc-json/keyword.rs
+++ b/tests/rustdoc-json/keyword.rs
@@ -6,15 +6,15 @@
 #![feature(rustdoc_internals)]
 #![no_std]
 
-// @!has "$.index[*][?(@.name=='match')]"
-// @has "$.index[*][?(@.name=='foo')]"
+//@ !has "$.index[*][?(@.name=='match')]"
+//@ has "$.index[*][?(@.name=='foo')]"
 
 #[doc(keyword = "match")]
 /// this is a test!
 pub mod foo {}
 
-// @!has "$.index[*][?(@.name=='hello')]"
-// @!has "$.index[*][?(@.name=='bar')]"
+//@ !has "$.index[*][?(@.name=='hello')]"
+//@ !has "$.index[*][?(@.name=='bar')]"
 #[doc(keyword = "hello")]
 /// hello
 mod bar {}

--- a/tests/rustdoc-json/keyword_private.rs
+++ b/tests/rustdoc-json/keyword_private.rs
@@ -3,18 +3,18 @@
 //@ compile-flags: --document-private-items
 #![feature(rustdoc_internals)]
 
-// @!has "$.index[*][?(@.name=='match')]"
-// @has  "$.index[*][?(@.name=='foo')]"
-// @is   "$.index[*][?(@.name=='foo')].attrs" '["#[doc(keyword = \"match\")]"]'
-// @is   "$.index[*][?(@.name=='foo')].docs" '"this is a test!"'
+//@ !has "$.index[*][?(@.name=='match')]"
+//@ has  "$.index[*][?(@.name=='foo')]"
+//@ is   "$.index[*][?(@.name=='foo')].attrs" '["#[doc(keyword = \"match\")]"]'
+//@ is   "$.index[*][?(@.name=='foo')].docs" '"this is a test!"'
 #[doc(keyword = "match")]
 /// this is a test!
 pub mod foo {}
 
-// @!has "$.index[*][?(@.name=='hello')]"
-// @has "$.index[*][?(@.name=='bar')]"
-// @is   "$.index[*][?(@.name=='bar')].attrs" '["#[doc(keyword = \"hello\")]"]'
-// @is   "$.index[*][?(@.name=='bar')].docs" '"hello"'
+//@ !has "$.index[*][?(@.name=='hello')]"
+//@ has "$.index[*][?(@.name=='bar')]"
+//@ is   "$.index[*][?(@.name=='bar')].attrs" '["#[doc(keyword = \"hello\")]"]'
+//@ is   "$.index[*][?(@.name=='bar')].docs" '"hello"'
 #[doc(keyword = "hello")]
 /// hello
 mod bar {}

--- a/tests/rustdoc-json/lifetime/longest.rs
+++ b/tests/rustdoc-json/lifetime/longest.rs
@@ -1,26 +1,26 @@
 // ignore-tidy-linelength
 
-// @is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].name"  \"\'a\"
-// @is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].kind"  '{"lifetime": {"outlives": []}}'
-// @is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].kind"  '{"lifetime": {"outlives": []}}'
-// @count "$.index[*][?(@.name=='longest')].inner.function.generics.params[*]" 1
-// @is "$.index[*][?(@.name=='longest')].inner.function.generics.where_predicates" []
+//@ is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].name"  \"\'a\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].kind"  '{"lifetime": {"outlives": []}}'
+//@ is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].kind"  '{"lifetime": {"outlives": []}}'
+//@ count "$.index[*][?(@.name=='longest')].inner.function.generics.params[*]" 1
+//@ is "$.index[*][?(@.name=='longest')].inner.function.generics.where_predicates" []
 
-// @count "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[*]" 2
-// @is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][0]" '"l"'
-// @is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][0]" '"r"'
+//@ count "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[*]" 2
+//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][0]" '"l"'
+//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][0]" '"r"'
 
-// @is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][1].borrowed_ref.lifetime" \"\'a\"
-// @is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][1].borrowed_ref.mutable" false
-// @is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][1].borrowed_ref.type.primitive" \"str\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][1].borrowed_ref.lifetime" \"\'a\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][1].borrowed_ref.mutable" false
+//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][1].borrowed_ref.type.primitive" \"str\"
 
-// @is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][1].borrowed_ref.lifetime" \"\'a\"
-// @is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][1].borrowed_ref.mutable" false
-// @is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][1].borrowed_ref.type.primitive" \"str\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][1].borrowed_ref.lifetime" \"\'a\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][1].borrowed_ref.mutable" false
+//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][1].borrowed_ref.type.primitive" \"str\"
 
-// @is "$.index[*][?(@.name=='longest')].inner.function.decl.output.borrowed_ref.lifetime" \"\'a\"
-// @is "$.index[*][?(@.name=='longest')].inner.function.decl.output.borrowed_ref.mutable" false
-// @is "$.index[*][?(@.name=='longest')].inner.function.decl.output.borrowed_ref.type.primitive" \"str\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.output.borrowed_ref.lifetime" \"\'a\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.output.borrowed_ref.mutable" false
+//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.output.borrowed_ref.type.primitive" \"str\"
 
 pub fn longest<'a>(l: &'a str, r: &'a str) -> &'a str {
     if l.len() > r.len() { l } else { r }

--- a/tests/rustdoc-json/lifetime/outlives.rs
+++ b/tests/rustdoc-json/lifetime/outlives.rs
@@ -1,18 +1,18 @@
 // ignore-tidy-linelength
 
-// @count "$.index[*][?(@.name=='foo')].inner.function.generics.params[*]" 3
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates" []
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.params[0].name" \"\'a\"
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.params[1].name" \"\'b\"
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.params[2].name" '"T"'
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.params[0].kind.lifetime.outlives" []
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.params[1].kind.lifetime.outlives" [\"\'a\"]
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.params[2].kind.type.default" null
-// @count "$.index[*][?(@.name=='foo')].inner.function.generics.params[2].kind.type.bounds[*]" 1
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.params[2].kind.type.bounds[0].outlives" \"\'b\"
-// @is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.lifetime" \"\'a\"
-// @is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.mutable" false
-// @is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.type.borrowed_ref.lifetime" \"\'b\"
-// @is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.type.borrowed_ref.mutable" false
-// @is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.type.borrowed_ref.type.generic" \"T\"
+//@ count "$.index[*][?(@.name=='foo')].inner.function.generics.params[*]" 3
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates" []
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.params[0].name" \"\'a\"
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.params[1].name" \"\'b\"
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.params[2].name" '"T"'
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.params[0].kind.lifetime.outlives" []
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.params[1].kind.lifetime.outlives" [\"\'a\"]
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.params[2].kind.type.default" null
+//@ count "$.index[*][?(@.name=='foo')].inner.function.generics.params[2].kind.type.bounds[*]" 1
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.params[2].kind.type.bounds[0].outlives" \"\'b\"
+//@ is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.lifetime" \"\'a\"
+//@ is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.mutable" false
+//@ is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.type.borrowed_ref.lifetime" \"\'b\"
+//@ is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.type.borrowed_ref.mutable" false
+//@ is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.type.borrowed_ref.type.generic" \"T\"
 pub fn foo<'a, 'b: 'a, T: 'b>(_: &'a &'b T) {}

--- a/tests/rustdoc-json/lifetime/outlives_in_param.rs
+++ b/tests/rustdoc-json/lifetime/outlives_in_param.rs
@@ -1,8 +1,8 @@
 // ignore-tidy-linelength
 
-// @count '$.index[*][?(@.name=="outlives")].inner.function.generics.params[*]' 2
-// @is    '$.index[*][?(@.name=="outlives")].inner.function.generics.params[0].name' \"\'a\"
-// @is    '$.index[*][?(@.name=="outlives")].inner.function.generics.params[0].kind.lifetime.outlives' []
-// @is    '$.index[*][?(@.name=="outlives")].inner.function.generics.params[1].name' '"T"'
-// @is    '$.index[*][?(@.name=="outlives")].inner.function.generics.params[1].kind.type.bounds' '[{"outlives": "'\''a"}]'
+//@ count '$.index[*][?(@.name=="outlives")].inner.function.generics.params[*]' 2
+//@ is    '$.index[*][?(@.name=="outlives")].inner.function.generics.params[0].name' \"\'a\"
+//@ is    '$.index[*][?(@.name=="outlives")].inner.function.generics.params[0].kind.lifetime.outlives' []
+//@ is    '$.index[*][?(@.name=="outlives")].inner.function.generics.params[1].name' '"T"'
+//@ is    '$.index[*][?(@.name=="outlives")].inner.function.generics.params[1].kind.type.bounds' '[{"outlives": "'\''a"}]'
 pub fn outlives<'a, T: 'a>() {}

--- a/tests/rustdoc-json/lifetime/outlives_in_where.rs
+++ b/tests/rustdoc-json/lifetime/outlives_in_where.rs
@@ -1,22 +1,22 @@
 // ignore-tidy-linelength
 
-// @is '$.index[*][?(@.name=="on_lifetimes")].inner.function.generics.where_predicates' '[{"lifetime_predicate": {"lifetime": "'\''all", "outlives": ["'\''a", "'\''b", "'\''c"]}}]'
+//@ is '$.index[*][?(@.name=="on_lifetimes")].inner.function.generics.where_predicates' '[{"lifetime_predicate": {"lifetime": "'\''all", "outlives": ["'\''a", "'\''b", "'\''c"]}}]'
 pub fn on_lifetimes<'a, 'b, 'c, 'all>()
 where
     'all: 'a + 'b + 'c,
 {
 }
 
-// @count '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[*]' 2
-// @is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[0].name' \"\'a\"
-// @is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[0].kind.lifetime.outlives' []
-// @is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[1].name' '"T"'
-// @is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[1].kind.type.bounds' []
-// @is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[1].kind.type.bounds' []
-// @count '$.index[*][?(@.name=="on_trait")].inner.function.generics.where_predicates[*]' 1
-// @is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.where_predicates[0].bound_predicate.type.generic' '"T"'
-// @count '$.index[*][?(@.name=="on_trait")].inner.function.generics.where_predicates[0].bound_predicate.bounds[*]' 1
-// @is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.where_predicates[0].bound_predicate.bounds[0].outlives' \"\'a\"
+//@ count '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[*]' 2
+//@ is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[0].name' \"\'a\"
+//@ is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[0].kind.lifetime.outlives' []
+//@ is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[1].name' '"T"'
+//@ is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[1].kind.type.bounds' []
+//@ is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.params[1].kind.type.bounds' []
+//@ count '$.index[*][?(@.name=="on_trait")].inner.function.generics.where_predicates[*]' 1
+//@ is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.where_predicates[0].bound_predicate.type.generic' '"T"'
+//@ count '$.index[*][?(@.name=="on_trait")].inner.function.generics.where_predicates[0].bound_predicate.bounds[*]' 1
+//@ is    '$.index[*][?(@.name=="on_trait")].inner.function.generics.where_predicates[0].bound_predicate.bounds[0].outlives' \"\'a\"
 pub fn on_trait<'a, T>()
 where
     T: 'a,

--- a/tests/rustdoc-json/methods/abi.rs
+++ b/tests/rustdoc-json/methods/abi.rs
@@ -2,51 +2,51 @@
 
 #![feature(abi_vectorcall)]
 
-// @has "$.index[*][?(@.name=='Foo')]"
+//@ has "$.index[*][?(@.name=='Foo')]"
 pub struct Foo;
 
 impl Foo {
-    // @is "$.index[*][?(@.name=='abi_rust')].inner.function.header.abi" \"Rust\"
+    //@ is "$.index[*][?(@.name=='abi_rust')].inner.function.header.abi" \"Rust\"
     pub fn abi_rust() {}
 
-    // @is "$.index[*][?(@.name=='abi_c')].inner.function.header.abi" '{"C": {"unwind": false}}'
+    //@ is "$.index[*][?(@.name=='abi_c')].inner.function.header.abi" '{"C": {"unwind": false}}'
     pub extern "C" fn abi_c() {}
 
-    // @is "$.index[*][?(@.name=='abi_system')].inner.function.header.abi" '{"System": {"unwind": false}}'
+    //@ is "$.index[*][?(@.name=='abi_system')].inner.function.header.abi" '{"System": {"unwind": false}}'
     pub extern "system" fn abi_system() {}
 
-    // @is "$.index[*][?(@.name=='abi_c_unwind')].inner.function.header.abi" '{"C": {"unwind": true}}'
+    //@ is "$.index[*][?(@.name=='abi_c_unwind')].inner.function.header.abi" '{"C": {"unwind": true}}'
     pub extern "C-unwind" fn abi_c_unwind() {}
 
-    // @is "$.index[*][?(@.name=='abi_system_unwind')].inner.function.header.abi" '{"System": {"unwind": true}}'
+    //@ is "$.index[*][?(@.name=='abi_system_unwind')].inner.function.header.abi" '{"System": {"unwind": true}}'
     pub extern "system-unwind" fn abi_system_unwind() {}
 
-    // @is "$.index[*][?(@.name=='abi_vectorcall')].inner.function.header.abi.Other" '"\"vectorcall\""'
+    //@ is "$.index[*][?(@.name=='abi_vectorcall')].inner.function.header.abi.Other" '"\"vectorcall\""'
     pub extern "vectorcall" fn abi_vectorcall() {}
 
-    // @is "$.index[*][?(@.name=='abi_vectorcall_unwind')].inner.function.header.abi.Other" '"\"vectorcall-unwind\""'
+    //@ is "$.index[*][?(@.name=='abi_vectorcall_unwind')].inner.function.header.abi.Other" '"\"vectorcall-unwind\""'
     pub extern "vectorcall-unwind" fn abi_vectorcall_unwind() {}
 }
 
 pub trait Bar {
-    // @is "$.index[*][?(@.name=='trait_abi_rust')].inner.function.header.abi" \"Rust\"
+    //@ is "$.index[*][?(@.name=='trait_abi_rust')].inner.function.header.abi" \"Rust\"
     fn trait_abi_rust() {}
 
-    // @is "$.index[*][?(@.name=='trait_abi_c')].inner.function.header.abi" '{"C": {"unwind": false}}'
+    //@ is "$.index[*][?(@.name=='trait_abi_c')].inner.function.header.abi" '{"C": {"unwind": false}}'
     extern "C" fn trait_abi_c() {}
 
-    // @is "$.index[*][?(@.name=='trait_abi_system')].inner.function.header.abi" '{"System": {"unwind": false}}'
+    //@ is "$.index[*][?(@.name=='trait_abi_system')].inner.function.header.abi" '{"System": {"unwind": false}}'
     extern "system" fn trait_abi_system() {}
 
-    // @is "$.index[*][?(@.name=='trait_abi_c_unwind')].inner.function.header.abi" '{"C": {"unwind": true}}'
+    //@ is "$.index[*][?(@.name=='trait_abi_c_unwind')].inner.function.header.abi" '{"C": {"unwind": true}}'
     extern "C-unwind" fn trait_abi_c_unwind() {}
 
-    // @is "$.index[*][?(@.name=='trait_abi_system_unwind')].inner.function.header.abi" '{"System": {"unwind": true}}'
+    //@ is "$.index[*][?(@.name=='trait_abi_system_unwind')].inner.function.header.abi" '{"System": {"unwind": true}}'
     extern "system-unwind" fn trait_abi_system_unwind() {}
 
-    // @is "$.index[*][?(@.name=='trait_abi_vectorcall')].inner.function.header.abi.Other" '"\"vectorcall\""'
+    //@ is "$.index[*][?(@.name=='trait_abi_vectorcall')].inner.function.header.abi.Other" '"\"vectorcall\""'
     extern "vectorcall" fn trait_abi_vectorcall() {}
 
-    // @is "$.index[*][?(@.name=='trait_abi_vectorcall_unwind')].inner.function.header.abi.Other" '"\"vectorcall-unwind\""'
+    //@ is "$.index[*][?(@.name=='trait_abi_vectorcall_unwind')].inner.function.header.abi.Other" '"\"vectorcall-unwind\""'
     extern "vectorcall-unwind" fn trait_abi_vectorcall_unwind() {}
 }

--- a/tests/rustdoc-json/methods/qualifiers.rs
+++ b/tests/rustdoc-json/methods/qualifiers.rs
@@ -3,34 +3,34 @@
 pub struct Foo;
 
 impl Foo {
-    // @is "$.index[*][?(@.name=='const_meth')].inner.function.header.async" false
-    // @is "$.index[*][?(@.name=='const_meth')].inner.function.header.const"  true
-    // @is "$.index[*][?(@.name=='const_meth')].inner.function.header.unsafe" false
+    //@ is "$.index[*][?(@.name=='const_meth')].inner.function.header.async" false
+    //@ is "$.index[*][?(@.name=='const_meth')].inner.function.header.const"  true
+    //@ is "$.index[*][?(@.name=='const_meth')].inner.function.header.unsafe" false
     pub const fn const_meth() {}
 
-    // @is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.async"  false
-    // @is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.const"  false
-    // @is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.unsafe" false
+    //@ is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.async"  false
+    //@ is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.const"  false
+    //@ is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.unsafe" false
     pub fn nothing_meth() {}
 
-    // @is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.async"  false
-    // @is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.const"  false
-    // @is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.unsafe" true
+    //@ is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.async"  false
+    //@ is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.const"  false
+    //@ is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.unsafe" true
     pub unsafe fn unsafe_meth() {}
 
-    // @is "$.index[*][?(@.name=='async_meth')].inner.function.header.async"  true
-    // @is "$.index[*][?(@.name=='async_meth')].inner.function.header.const"  false
-    // @is "$.index[*][?(@.name=='async_meth')].inner.function.header.unsafe" false
+    //@ is "$.index[*][?(@.name=='async_meth')].inner.function.header.async"  true
+    //@ is "$.index[*][?(@.name=='async_meth')].inner.function.header.const"  false
+    //@ is "$.index[*][?(@.name=='async_meth')].inner.function.header.unsafe" false
     pub async fn async_meth() {}
 
-    // @is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.async"  true
-    // @is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.const"  false
-    // @is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.unsafe" true
+    //@ is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.async"  true
+    //@ is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.const"  false
+    //@ is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.unsafe" true
     pub async unsafe fn async_unsafe_meth() {}
 
-    // @is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.async"  false
-    // @is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.const"  true
-    // @is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.unsafe" true
+    //@ is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.async"  false
+    //@ is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.const"  true
+    //@ is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.unsafe" true
     pub const unsafe fn const_unsafe_meth() {}
 
     // It's impossible for a method to be both const and async, so no test for that

--- a/tests/rustdoc-json/nested.rs
+++ b/tests/rustdoc-json/nested.rs
@@ -1,32 +1,32 @@
 //@ edition:2018
 //@ compile-flags: --crate-version 1.0.0
 
-// @is "$.crate_version" \"1.0.0\"
-// @has "$.index[*][?(@.name=='nested')].inner.module"
-// @is "$.index[*][?(@.name=='nested')].inner.module.is_crate" true
+//@ is "$.crate_version" \"1.0.0\"
+//@ has "$.index[*][?(@.name=='nested')].inner.module"
+//@ is "$.index[*][?(@.name=='nested')].inner.module.is_crate" true
 
-// @set l1_id = "$.index[*][?(@.name=='l1')].id"
-// @ismany "$.index[*][?(@.name=='nested')].inner.module.items[*]" $l1_id
+//@ set l1_id = "$.index[*][?(@.name=='l1')].id"
+//@ ismany "$.index[*][?(@.name=='nested')].inner.module.items[*]" $l1_id
 
-// @has "$.index[*][?(@.name=='l1')].inner.module"
-// @is "$.index[*][?(@.name=='l1')].inner.module.is_crate" false
+//@ has "$.index[*][?(@.name=='l1')].inner.module"
+//@ is "$.index[*][?(@.name=='l1')].inner.module.is_crate" false
 pub mod l1 {
-    // @has "$.index[*][?(@.name=='l3')].inner.module"
-    // @is "$.index[*][?(@.name=='l3')].inner.module.is_crate" false
-    // @set l3_id = "$.index[*][?(@.name=='l3')].id"
+    //@ has "$.index[*][?(@.name=='l3')].inner.module"
+    //@ is "$.index[*][?(@.name=='l3')].inner.module.is_crate" false
+    //@ set l3_id = "$.index[*][?(@.name=='l3')].id"
     pub mod l3 {
 
-        // @has "$.index[*][?(@.name=='L4')].inner.struct"
-        // @is "$.index[*][?(@.name=='L4')].inner.struct.kind" '"unit"'
-        // @set l4_id = "$.index[*][?(@.name=='L4')].id"
-        // @ismany "$.index[*][?(@.name=='l3')].inner.module.items[*]" $l4_id
+        //@ has "$.index[*][?(@.name=='L4')].inner.struct"
+        //@ is "$.index[*][?(@.name=='L4')].inner.struct.kind" '"unit"'
+        //@ set l4_id = "$.index[*][?(@.name=='L4')].id"
+        //@ ismany "$.index[*][?(@.name=='l3')].inner.module.items[*]" $l4_id
         pub struct L4;
     }
-    // @is "$.index[*][?(@.inner.import)].inner.import.glob" false
-    // @is "$.index[*][?(@.inner.import)].inner.import.source" '"l3::L4"'
-    // @is "$.index[*][?(@.inner.import)].inner.import.glob" false
-    // @is "$.index[*][?(@.inner.import)].inner.import.id" $l4_id
-    // @set l4_use_id = "$.index[*][?(@.inner.import)].id"
+    //@ is "$.index[*][?(@.inner.import)].inner.import.glob" false
+    //@ is "$.index[*][?(@.inner.import)].inner.import.source" '"l3::L4"'
+    //@ is "$.index[*][?(@.inner.import)].inner.import.glob" false
+    //@ is "$.index[*][?(@.inner.import)].inner.import.id" $l4_id
+    //@ set l4_use_id = "$.index[*][?(@.inner.import)].id"
     pub use l3::L4;
 }
-// @ismany "$.index[*][?(@.name=='l1')].inner.module.items[*]" $l3_id $l4_use_id
+//@ ismany "$.index[*][?(@.name=='l1')].inner.module.items[*]" $l3_id $l4_use_id

--- a/tests/rustdoc-json/non_lifetime_binders.rs
+++ b/tests/rustdoc-json/non_lifetime_binders.rs
@@ -7,11 +7,11 @@ pub trait Trait {}
 
 pub struct Wrapper<T_>(std::marker::PhantomData<T_>);
 
-// @count "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[*]" 2
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[0].name" \"\'a\"
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[1].name" \"T\"
-// @is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[1].kind" '{ "type": { "bounds": [], "default": null, "synthetic": false } }'
+//@ count "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[*]" 2
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[0].name" \"\'a\"
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[1].name" \"T\"
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[1].kind" '{ "type": { "bounds": [], "default": null, "synthetic": false } }'
 pub fn foo()
 where
     for<'a, T> &'a Wrapper<T>: Trait,

--- a/tests/rustdoc-json/output_generics.rs
+++ b/tests/rustdoc-json/output_generics.rs
@@ -2,11 +2,11 @@
 
 // This is a regression test for #98009.
 
-// @has "$.index[*][?(@.name=='this_compiles')]"
-// @has "$.index[*][?(@.name=='this_does_not')]"
-// @has "$.index[*][?(@.name=='Events')]"
-// @has "$.index[*][?(@.name=='Other')]"
-// @has "$.index[*][?(@.name=='Trait')]"
+//@ has "$.index[*][?(@.name=='this_compiles')]"
+//@ has "$.index[*][?(@.name=='this_does_not')]"
+//@ has "$.index[*][?(@.name=='Events')]"
+//@ has "$.index[*][?(@.name=='Other')]"
+//@ has "$.index[*][?(@.name=='Trait')]"
 
 struct Events<R>(R);
 

--- a/tests/rustdoc-json/primitives/local_primitive.rs
+++ b/tests/rustdoc-json/primitives/local_primitive.rs
@@ -11,11 +11,11 @@
 #[rustc_doc_primitive = "i32"]
 mod prim_i32 {}
 
-// @set local_i32 = "$.index[*][?(@.name=='i32')].id"
+//@ set local_i32 = "$.index[*][?(@.name=='i32')].id"
 
-// @has "$.index[*][?(@.name=='local_primitive')]"
-// @ismany "$.index[*][?(@.name=='local_primitive')].inner.module.items[*]" $local_i32
-// @is "$.index[*][?(@.name=='local_primitive')].links['prim@i32']" $local_i32
+//@ has "$.index[*][?(@.name=='local_primitive')]"
+//@ ismany "$.index[*][?(@.name=='local_primitive')].inner.module.items[*]" $local_i32
+//@ is "$.index[*][?(@.name=='local_primitive')].links['prim@i32']" $local_i32
 
 // Let's ensure the `prim_i32` module isn't present in the output JSON:
-// @!has "$.index[*][?(@.name=='prim_i32')]"
+//@ !has "$.index[*][?(@.name=='prim_i32')]"

--- a/tests/rustdoc-json/primitives/primitive_impls.rs
+++ b/tests/rustdoc-json/primitives/primitive_impls.rs
@@ -4,23 +4,23 @@
 #![no_core]
 #![rustc_coherence_is_core]
 
-// @set impl_i32 = "$.index[*][?(@.docs=='Only core can do this')].id"
+//@ set impl_i32 = "$.index[*][?(@.docs=='Only core can do this')].id"
 
 /// Only core can do this
 impl i32 {
-    // @set identity = "$.index[*][?(@.docs=='Do Nothing')].id"
+    //@ set identity = "$.index[*][?(@.docs=='Do Nothing')].id"
 
     /// Do Nothing
     pub fn identity(self) -> Self {
         self
     }
 
-    // @is "$.index[*][?(@.docs=='Only core can do this')].inner.impl.items[*]" $identity
+    //@ is "$.index[*][?(@.docs=='Only core can do this')].inner.impl.items[*]" $identity
 }
 
-// @set Trait = "$.index[*][?(@.name=='Trait')].id"
+//@ set Trait = "$.index[*][?(@.name=='Trait')].id"
 pub trait Trait {}
-// @set impl_trait_for_i32 = "$.index[*][?(@.docs=='impl Trait for i32')].id"
+//@ set impl_trait_for_i32 = "$.index[*][?(@.docs=='impl Trait for i32')].id"
 /// impl Trait for i32
 impl Trait for i32 {}
 
@@ -28,7 +28,7 @@ impl Trait for i32 {}
 #[rustc_doc_primitive = "i32"]
 mod prim_i32 {}
 
-// @set i32 = "$.index[*][?(@.docs=='i32')].id"
-// @is "$.index[*][?(@.docs=='i32')].name" '"i32"'
-// @is "$.index[*][?(@.docs=='i32')].inner.primitive.name" '"i32"'
-// @ismany "$.index[*][?(@.docs=='i32')].inner.primitive.impls[*]" $impl_i32 $impl_trait_for_i32
+//@ set i32 = "$.index[*][?(@.docs=='i32')].id"
+//@ is "$.index[*][?(@.docs=='i32')].name" '"i32"'
+//@ is "$.index[*][?(@.docs=='i32')].inner.primitive.name" '"i32"'
+//@ ismany "$.index[*][?(@.docs=='i32')].inner.primitive.impls[*]" $impl_i32 $impl_trait_for_i32

--- a/tests/rustdoc-json/primitives/primitive_overloading.rs
+++ b/tests/rustdoc-json/primitives/primitive_overloading.rs
@@ -4,8 +4,8 @@
 
 #![feature(rustc_attrs)]
 
-// @has "$.index[*][?(@.name=='usize')]"
-// @has "$.index[*][?(@.name=='prim')]"
+//@ has "$.index[*][?(@.name=='usize')]"
+//@ has "$.index[*][?(@.name=='prim')]"
 
 #[rustc_doc_primitive = "usize"]
 /// This is the built-in type `usize`.

--- a/tests/rustdoc-json/primitives/primitive_type.rs
+++ b/tests/rustdoc-json/primitives/primitive_type.rs
@@ -1,17 +1,17 @@
 #![feature(never_type)]
 
-// @is "$.index[*][?(@.name=='PrimNever')].visibility" \"public\"
-// @is "$.index[*][?(@.name=='PrimNever')].inner.type_alias.type.primitive" \"never\"
+//@ is "$.index[*][?(@.name=='PrimNever')].visibility" \"public\"
+//@ is "$.index[*][?(@.name=='PrimNever')].inner.type_alias.type.primitive" \"never\"
 pub type PrimNever = !;
 
-// @is "$.index[*][?(@.name=='PrimStr')].inner.type_alias.type.primitive" \"str\"
+//@ is "$.index[*][?(@.name=='PrimStr')].inner.type_alias.type.primitive" \"str\"
 pub type PrimStr = str;
 
-// @is "$.index[*][?(@.name=='PrimBool')].inner.type_alias.type.primitive" \"bool\"
+//@ is "$.index[*][?(@.name=='PrimBool')].inner.type_alias.type.primitive" \"bool\"
 pub type PrimBool = bool;
 
-// @is "$.index[*][?(@.name=='PrimChar')].inner.type_alias.type.primitive" \"char\"
+//@ is "$.index[*][?(@.name=='PrimChar')].inner.type_alias.type.primitive" \"char\"
 pub type PrimChar = char;
 
-// @is "$.index[*][?(@.name=='PrimU8')].inner.type_alias.type.primitive" \"u8\"
+//@ is "$.index[*][?(@.name=='PrimU8')].inner.type_alias.type.primitive" \"u8\"
 pub type PrimU8 = u8;

--- a/tests/rustdoc-json/primitives/use_primitive.rs
+++ b/tests/rustdoc-json/primitives/use_primitive.rs
@@ -5,16 +5,16 @@
 #[rustc_doc_primitive = "usize"]
 mod usize {}
 
-// @set local_crate_id = "$.index[*][?(@.name=='use_primitive')].crate_id"
+//@ set local_crate_id = "$.index[*][?(@.name=='use_primitive')].crate_id"
 
-// @has "$.index[*][?(@.name=='ilog10')]"
-// @!is "$.index[*][?(@.name=='ilog10')].crate_id" $local_crate_id
-// @has "$.index[*][?(@.name=='checked_add')]"
-// @!is "$.index[*][?(@.name=='checked_add')]" $local_crate_id
-// @!has "$.index[*][?(@.name=='is_ascii_uppercase')]"
+//@ has "$.index[*][?(@.name=='ilog10')]"
+//@ !is "$.index[*][?(@.name=='ilog10')].crate_id" $local_crate_id
+//@ has "$.index[*][?(@.name=='checked_add')]"
+//@ !is "$.index[*][?(@.name=='checked_add')]" $local_crate_id
+//@ !has "$.index[*][?(@.name=='is_ascii_uppercase')]"
 
-// @is "$.index[*].inner.import[?(@.name=='my_i32')].id" null
+//@ is "$.index[*].inner.import[?(@.name=='my_i32')].id" null
 pub use i32 as my_i32;
 
-// @is "$.index[*].inner.import[?(@.name=='u32')].id" null
+//@ is "$.index[*].inner.import[?(@.name=='u32')].id" null
 pub use u32;

--- a/tests/rustdoc-json/reexport/doc_inline_external_crate.rs
+++ b/tests/rustdoc-json/reexport/doc_inline_external_crate.rs
@@ -5,7 +5,7 @@
 #[doc(inline)]
 pub extern crate enum_with_discriminant;
 
-// @!has '$.index[*][?(@.docs == "Should not be inlined")]'
-// @has '$.index[*][?(@.name == "enum_with_discriminant")].inner.extern_crate'
-// @set enum_with_discriminant = '$.index[*][?(@.name == "enum_with_discriminant")].id'
-// @is '$.index[*][?(@.name == "doc_inline_external_crate")].inner.module.items[*]' $enum_with_discriminant
+//@ !has '$.index[*][?(@.docs == "Should not be inlined")]'
+//@ has '$.index[*][?(@.name == "enum_with_discriminant")].inner.extern_crate'
+//@ set enum_with_discriminant = '$.index[*][?(@.name == "enum_with_discriminant")].id'
+//@ is '$.index[*][?(@.name == "doc_inline_external_crate")].inner.module.items[*]' $enum_with_discriminant

--- a/tests/rustdoc-json/reexport/export_extern_crate_as_self.rs
+++ b/tests/rustdoc-json/reexport/export_extern_crate_as_self.rs
@@ -4,5 +4,5 @@
 
 // ignore-tidy-linelength
 
-// @is "$.index[*][?(@.inner.module)].name" \"export_extern_crate_as_self\"
+//@ is "$.index[*][?(@.inner.module)].name" \"export_extern_crate_as_self\"
 pub extern crate self as export_extern_crate_as_self; // Must be the same name as the crate already has

--- a/tests/rustdoc-json/reexport/extern_crate_glob.rs
+++ b/tests/rustdoc-json/reexport/extern_crate_glob.rs
@@ -5,7 +5,7 @@ extern crate enum_with_discriminant;
 #[doc(inline)]
 pub use enum_with_discriminant::*;
 
-// @!has '$.index[*][?(@.docs == "Should not be inlined")]'
-// @is '$.index[*][?(@.inner.import)].inner.import.name' \"enum_with_discriminant\"
-// @set use = '$.index[*][?(@.inner.import)].id'
-// @is '$.index[*][?(@.name == "extern_crate_glob")].inner.module.items[*]' $use
+//@ !has '$.index[*][?(@.docs == "Should not be inlined")]'
+//@ is '$.index[*][?(@.inner.import)].inner.import.name' \"enum_with_discriminant\"
+//@ set use = '$.index[*][?(@.inner.import)].id'
+//@ is '$.index[*][?(@.name == "extern_crate_glob")].inner.module.items[*]' $use

--- a/tests/rustdoc-json/reexport/glob_collision.rs
+++ b/tests/rustdoc-json/reexport/glob_collision.rs
@@ -1,27 +1,27 @@
 // Regression test for https://github.com/rust-lang/rust/issues/100973
 
-// @set m1 = "$.index[*][?(@.name == 'm1' && @.inner.module)].id"
-// @is "$.index[*][?(@.name == 'm1')].inner.module.items" []
-// @is "$.index[*][?(@.name == 'm1')].inner.module.is_stripped" true
+//@ set m1 = "$.index[*][?(@.name == 'm1' && @.inner.module)].id"
+//@ is "$.index[*][?(@.name == 'm1')].inner.module.items" []
+//@ is "$.index[*][?(@.name == 'm1')].inner.module.is_stripped" true
 mod m1 {
     pub fn f() {}
 }
-// @set m2 = "$.index[*][?(@.name == 'm2' && @.inner.module)].id"
-// @is "$.index[*][?(@.name == 'm2')].inner.module.items" []
-// @is "$.index[*][?(@.name == 'm2')].inner.module.is_stripped" true
+//@ set m2 = "$.index[*][?(@.name == 'm2' && @.inner.module)].id"
+//@ is "$.index[*][?(@.name == 'm2')].inner.module.items" []
+//@ is "$.index[*][?(@.name == 'm2')].inner.module.is_stripped" true
 mod m2 {
     pub fn f(_: u8) {}
 }
 
-// @set m1_use = "$.index[*][?(@.docs=='m1 re-export')].id"
-// @is "$.index[*].inner.import[?(@.name=='m1')].id" $m1
-// @is "$.index[*].inner.import[?(@.name=='m1')].glob" true
+//@ set m1_use = "$.index[*][?(@.docs=='m1 re-export')].id"
+//@ is "$.index[*].inner.import[?(@.name=='m1')].id" $m1
+//@ is "$.index[*].inner.import[?(@.name=='m1')].glob" true
 /// m1 re-export
 pub use m1::*;
-// @set m2_use = "$.index[*][?(@.docs=='m2 re-export')].id"
-// @is "$.index[*].inner.import[?(@.name=='m2')].id" $m2
-// @is "$.index[*].inner.import[?(@.name=='m2')].glob" true
+//@ set m2_use = "$.index[*][?(@.docs=='m2 re-export')].id"
+//@ is "$.index[*].inner.import[?(@.name=='m2')].id" $m2
+//@ is "$.index[*].inner.import[?(@.name=='m2')].glob" true
 /// m2 re-export
 pub use m2::*;
 
-// @ismany "$.index[*].inner.module[?(@.is_crate==true)].items[*]" $m1_use $m2_use
+//@ ismany "$.index[*].inner.module[?(@.is_crate==true)].items[*]" $m1_use $m2_use

--- a/tests/rustdoc-json/reexport/glob_empty_mod.rs
+++ b/tests/rustdoc-json/reexport/glob_empty_mod.rs
@@ -1,8 +1,8 @@
 // Regression test for https://github.com/rust-lang/rust/issues/100973
 
-// @is "$.index[*][?(@.name=='m1' && @.inner.module)].inner.module.is_stripped" true
-// @set m1 = "$.index[*][?(@.name=='m1')].id"
+//@ is "$.index[*][?(@.name=='m1' && @.inner.module)].inner.module.is_stripped" true
+//@ set m1 = "$.index[*][?(@.name=='m1')].id"
 mod m1 {}
 
-// @is "$.index[*][?(@.inner.import)].inner.import.id" $m1
+//@ is "$.index[*][?(@.inner.import)].inner.import.id" $m1
 pub use m1::*;

--- a/tests/rustdoc-json/reexport/glob_extern.rs
+++ b/tests/rustdoc-json/reexport/glob_extern.rs
@@ -1,19 +1,19 @@
 //@ edition:2018
 
-// @is "$.index[*][?(@.name=='mod1')].inner.module.is_stripped" "true"
+//@ is "$.index[*][?(@.name=='mod1')].inner.module.is_stripped" "true"
 mod mod1 {
     extern "C" {
-        // @set public_fn_id = "$.index[*][?(@.name=='public_fn')].id"
+        //@ set public_fn_id = "$.index[*][?(@.name=='public_fn')].id"
         pub fn public_fn();
-        // @!has "$.index[*][?(@.name=='private_fn')]"
+        //@ !has "$.index[*][?(@.name=='private_fn')]"
         fn private_fn();
     }
-    // @ismany "$.index[*][?(@.name=='mod1')].inner.module.items[*]" $public_fn_id
-    // @set mod1_id = "$.index[*][?(@.name=='mod1')].id"
+    //@ ismany "$.index[*][?(@.name=='mod1')].inner.module.items[*]" $public_fn_id
+    //@ set mod1_id = "$.index[*][?(@.name=='mod1')].id"
 }
 
-// @is "$.index[*][?(@.inner.import)].inner.import.glob" true
-// @is "$.index[*][?(@.inner.import)].inner.import.id" $mod1_id
-// @set use_id = "$.index[*][?(@.inner.import)].id"
-// @ismany "$.index[*][?(@.name=='glob_extern')].inner.module.items[*]" $use_id
+//@ is "$.index[*][?(@.inner.import)].inner.import.glob" true
+//@ is "$.index[*][?(@.inner.import)].inner.import.id" $mod1_id
+//@ set use_id = "$.index[*][?(@.inner.import)].id"
+//@ ismany "$.index[*][?(@.name=='glob_extern')].inner.module.items[*]" $use_id
 pub use mod1::*;

--- a/tests/rustdoc-json/reexport/glob_private.rs
+++ b/tests/rustdoc-json/reexport/glob_private.rs
@@ -1,32 +1,32 @@
 //@ edition:2018
 
-// @is "$.index[*][?(@.name=='mod1')].inner.module.is_stripped" "true"
+//@ is "$.index[*][?(@.name=='mod1')].inner.module.is_stripped" "true"
 mod mod1 {
-    // @is "$.index[*][?(@.name=='mod2')].inner.module.is_stripped" "true"
+    //@ is "$.index[*][?(@.name=='mod2')].inner.module.is_stripped" "true"
     mod mod2 {
-        // @set m2pub_id = "$.index[*][?(@.name=='Mod2Public')].id"
+        //@ set m2pub_id = "$.index[*][?(@.name=='Mod2Public')].id"
         pub struct Mod2Public;
 
-        // @!has "$.index[*][?(@.name=='Mod2Private')]"
+        //@ !has "$.index[*][?(@.name=='Mod2Private')]"
         struct Mod2Private;
     }
 
-    // @set mod2_use_id = "$.index[*][?(@.docs=='Mod2 re-export')].id"
-    // @is "$.index[*][?(@.docs=='Mod2 re-export')].inner.import.name" \"mod2\"
+    //@ set mod2_use_id = "$.index[*][?(@.docs=='Mod2 re-export')].id"
+    //@ is "$.index[*][?(@.docs=='Mod2 re-export')].inner.import.name" \"mod2\"
     /// Mod2 re-export
     pub use self::mod2::*;
 
-    // @set m1pub_id = "$.index[*][?(@.name=='Mod1Public')].id"
+    //@ set m1pub_id = "$.index[*][?(@.name=='Mod1Public')].id"
     pub struct Mod1Public;
-    // @!has "$.index[*][?(@.name=='Mod1Private')]"
+    //@ !has "$.index[*][?(@.name=='Mod1Private')]"
     struct Mod1Private;
 }
 
-// @set mod1_use_id = "$.index[*][?(@.docs=='Mod1 re-export')].id"
-// @is "$.index[*][?(@.docs=='Mod1 re-export')].inner.import.name" \"mod1\"
+//@ set mod1_use_id = "$.index[*][?(@.docs=='Mod1 re-export')].id"
+//@ is "$.index[*][?(@.docs=='Mod1 re-export')].inner.import.name" \"mod1\"
 /// Mod1 re-export
 pub use mod1::*;
 
-// @ismany "$.index[*][?(@.name=='mod2')].inner.module.items[*]" $m2pub_id
-// @ismany "$.index[*][?(@.name=='mod1')].inner.module.items[*]" $m1pub_id $mod2_use_id
-// @ismany "$.index[*][?(@.name=='glob_private')].inner.module.items[*]" $mod1_use_id
+//@ ismany "$.index[*][?(@.name=='mod2')].inner.module.items[*]" $m2pub_id
+//@ ismany "$.index[*][?(@.name=='mod1')].inner.module.items[*]" $m1pub_id $mod2_use_id
+//@ ismany "$.index[*][?(@.name=='glob_private')].inner.module.items[*]" $mod1_use_id

--- a/tests/rustdoc-json/reexport/in_root_and_mod.rs
+++ b/tests/rustdoc-json/reexport/in_root_and_mod.rs
@@ -1,13 +1,13 @@
-// @!has "$.index[*][?(@.name=='foo')]"
+//@ !has "$.index[*][?(@.name=='foo')]"
 mod foo {
-    // @has "$.index[*][?(@.name=='Foo')]"
+    //@ has "$.index[*][?(@.name=='Foo')]"
     pub struct Foo;
 }
 
-// @has "$.index[*].inner[?(@.import.source=='foo::Foo')]"
+//@ has "$.index[*].inner[?(@.import.source=='foo::Foo')]"
 pub use foo::Foo;
 
 pub mod bar {
-    // @has "$.index[*].inner[?(@.import.source=='crate::foo::Foo')]"
+    //@ has "$.index[*].inner[?(@.import.source=='crate::foo::Foo')]"
     pub use crate::foo::Foo;
 }

--- a/tests/rustdoc-json/reexport/in_root_and_mod_pub.rs
+++ b/tests/rustdoc-json/reexport/in_root_and_mod_pub.rs
@@ -1,19 +1,19 @@
 pub mod foo {
-    // @set bar_id = "$.index[*][?(@.name=='Bar')].id"
-    // @ismany "$.index[*][?(@.name=='foo')].inner.module.items[*]" $bar_id
+    //@ set bar_id = "$.index[*][?(@.name=='Bar')].id"
+    //@ ismany "$.index[*][?(@.name=='foo')].inner.module.items[*]" $bar_id
     pub struct Bar;
 }
 
-// @set root_import_id = "$.index[*][?(@.docs=='Outer re-export')].id"
-// @is "$.index[*].inner[?(@.import.source=='foo::Bar')].import.id" $bar_id
-// @has "$.index[*][?(@.name=='in_root_and_mod_pub')].inner.module.items[*]" $root_import_id
+//@ set root_import_id = "$.index[*][?(@.docs=='Outer re-export')].id"
+//@ is "$.index[*].inner[?(@.import.source=='foo::Bar')].import.id" $bar_id
+//@ has "$.index[*][?(@.name=='in_root_and_mod_pub')].inner.module.items[*]" $root_import_id
 /// Outer re-export
 pub use foo::Bar;
 
 pub mod baz {
-    // @set baz_import_id = "$.index[*][?(@.docs=='Inner re-export')].id"
-    // @is "$.index[*].inner[?(@.import.source=='crate::foo::Bar')].import.id" $bar_id
-    // @ismany "$.index[*][?(@.name=='baz')].inner.module.items[*]" $baz_import_id
+    //@ set baz_import_id = "$.index[*][?(@.docs=='Inner re-export')].id"
+    //@ is "$.index[*].inner[?(@.import.source=='crate::foo::Bar')].import.id" $bar_id
+    //@ ismany "$.index[*][?(@.name=='baz')].inner.module.items[*]" $baz_import_id
     /// Inner re-export
     pub use crate::foo::Bar;
 }

--- a/tests/rustdoc-json/reexport/macro.rs
+++ b/tests/rustdoc-json/reexport/macro.rs
@@ -1,13 +1,13 @@
 //@ edition:2018
 
-// @set repro_id = "$.index[*][?(@.name=='repro')].id"
+//@ set repro_id = "$.index[*][?(@.name=='repro')].id"
 #[macro_export]
 macro_rules! repro {
     () => {};
 }
 
-// @set repro2_id = "$.index[*][?(@.docs=='Re-export')].id"
+//@ set repro2_id = "$.index[*][?(@.docs=='Re-export')].id"
 /// Re-export
 pub use crate::repro as repro2;
 
-// @ismany "$.index[*][?(@.name=='macro')].inner.module.items[*]" $repro_id $repro2_id
+//@ ismany "$.index[*][?(@.name=='macro')].inner.module.items[*]" $repro_id $repro2_id

--- a/tests/rustdoc-json/reexport/mod_not_included.rs
+++ b/tests/rustdoc-json/reexport/mod_not_included.rs
@@ -6,6 +6,6 @@ mod m1 {
 
 pub use m1::x;
 
-// @has "$.index[*][?(@.name=='x' && @.inner.function)]"
-// @has "$.index[*].inner[?(@.import.name=='x')].import.source" '"m1::x"'
-// @!has "$.index[*][?(@.name=='m1')]"
+//@ has "$.index[*][?(@.name=='x' && @.inner.function)]"
+//@ has "$.index[*].inner[?(@.import.name=='x')].import.source" '"m1::x"'
+//@ !has "$.index[*][?(@.name=='m1')]"

--- a/tests/rustdoc-json/reexport/private_twice_one_inline.rs
+++ b/tests/rustdoc-json/reexport/private_twice_one_inline.rs
@@ -6,19 +6,19 @@
 
 extern crate pub_struct as foo;
 #[doc(inline)]
-// @set crate_use_id = "$.index[*][?(@.docs=='Hack A')].id"
-// @set foo_id = "$.index[*][?(@.docs=='Hack A')].inner.import.id"
+//@ set crate_use_id = "$.index[*][?(@.docs=='Hack A')].id"
+//@ set foo_id = "$.index[*][?(@.docs=='Hack A')].inner.import.id"
 /// Hack A
 pub use foo::Foo;
 
-// @set bar_id = "$.index[*][?(@.name=='bar')].id"
+//@ set bar_id = "$.index[*][?(@.name=='bar')].id"
 pub mod bar {
-    // @is "$.index[*][?(@.docs=='Hack B')].inner.import.id" $foo_id
-    // @set bar_use_id = "$.index[*][?(@.docs=='Hack B')].id"
-    // @ismany "$.index[*][?(@.name=='bar')].inner.module.items[*]" $bar_use_id
+    //@ is "$.index[*][?(@.docs=='Hack B')].inner.import.id" $foo_id
+    //@ set bar_use_id = "$.index[*][?(@.docs=='Hack B')].id"
+    //@ ismany "$.index[*][?(@.name=='bar')].inner.module.items[*]" $bar_use_id
     /// Hack B
     pub use foo::Foo;
 }
 
-// @ismany "$.index[*][?(@.inner.import)].id" $crate_use_id $bar_use_id
-// @ismany "$.index[*][?(@.name=='private_twice_one_inline')].inner.module.items[*]" $bar_id $crate_use_id
+//@ ismany "$.index[*][?(@.inner.import)].id" $crate_use_id $bar_use_id
+//@ ismany "$.index[*][?(@.name=='private_twice_one_inline')].inner.module.items[*]" $bar_id $crate_use_id

--- a/tests/rustdoc-json/reexport/private_two_names.rs
+++ b/tests/rustdoc-json/reexport/private_two_names.rs
@@ -3,21 +3,21 @@
 // Test for the ICE in https://github.com/rust-lang/rust/issues/83720
 // A pub-in-private type re-exported under two different names shouldn't cause an error
 
-// @!has "$.index[*][?(@.name=='style')]"
+//@ !has "$.index[*][?(@.name=='style')]"
 mod style {
-    // @set color_struct_id = "$.index[*][?(@.inner.struct && @.name=='Color')].id"
+    //@ set color_struct_id = "$.index[*][?(@.inner.struct && @.name=='Color')].id"
     pub struct Color;
 }
 
-// @is "$.index[*][?(@.docs=='First re-export')].inner.import.id" $color_struct_id
-// @is "$.index[*][?(@.docs=='First re-export')].inner.import.name" \"Color\"
-// @set color_export_id = "$.index[*][?(@.docs=='First re-export')].id"
+//@ is "$.index[*][?(@.docs=='First re-export')].inner.import.id" $color_struct_id
+//@ is "$.index[*][?(@.docs=='First re-export')].inner.import.name" \"Color\"
+//@ set color_export_id = "$.index[*][?(@.docs=='First re-export')].id"
 /// First re-export
 pub use style::Color;
-// @is "$.index[*][?(@.docs=='Second re-export')].inner.import.id" $color_struct_id
-// @is "$.index[*][?(@.docs=='Second re-export')].inner.import.name" \"Colour\"
-// @set colour_export_id = "$.index[*][?(@.docs=='Second re-export')].id"
+//@ is "$.index[*][?(@.docs=='Second re-export')].inner.import.id" $color_struct_id
+//@ is "$.index[*][?(@.docs=='Second re-export')].inner.import.name" \"Colour\"
+//@ set colour_export_id = "$.index[*][?(@.docs=='Second re-export')].id"
 /// Second re-export
 pub use style::Color as Colour;
 
-// @ismany "$.index[*][?(@.name=='private_two_names')].inner.module.items[*]" $color_export_id $colour_export_id
+//@ ismany "$.index[*][?(@.name=='private_two_names')].inner.module.items[*]" $color_export_id $colour_export_id

--- a/tests/rustdoc-json/reexport/pub_use_doc_hidden.rs
+++ b/tests/rustdoc-json/reexport/pub_use_doc_hidden.rs
@@ -9,5 +9,5 @@ mod repeat_n {
 /// not here
 pub use repeat_n::RepeatN;
 
-// @count "$.index[*][?(@.name=='pub_use_doc_hidden')].inner.items[*]" 0
-// @!has "$.index[*][?(@.docs == 'not here')]"
+//@ count "$.index[*][?(@.name=='pub_use_doc_hidden')].inner.items[*]" 0
+//@ !has "$.index[*][?(@.docs == 'not here')]"

--- a/tests/rustdoc-json/reexport/reexport_method_from_private_module.rs
+++ b/tests/rustdoc-json/reexport/reexport_method_from_private_module.rs
@@ -1,11 +1,11 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/102583>.
 
-// @set impl_S = "$.index[*][?(@.docs=='impl S')].id"
-// @has "$.index[*][?(@.name=='S')].inner.struct.impls[*]" $impl_S
-// @set is_present = "$.index[*][?(@.name=='is_present')].id"
-// @is "$.index[*][?(@.docs=='impl S')].inner.impl.items[*]" $is_present
-// @!has "$.index[*][?(@.name=='hidden_impl')]"
-// @!has "$.index[*][?(@.name=='hidden_fn')]"
+//@ set impl_S = "$.index[*][?(@.docs=='impl S')].id"
+//@ has "$.index[*][?(@.name=='S')].inner.struct.impls[*]" $impl_S
+//@ set is_present = "$.index[*][?(@.name=='is_present')].id"
+//@ is "$.index[*][?(@.docs=='impl S')].inner.impl.items[*]" $is_present
+//@ !has "$.index[*][?(@.name=='hidden_impl')]"
+//@ !has "$.index[*][?(@.name=='hidden_fn')]"
 
 #![no_std]
 

--- a/tests/rustdoc-json/reexport/reexport_of_hidden.rs
+++ b/tests/rustdoc-json/reexport/reexport_of_hidden.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: --document-hidden-items
 
-// @has "$.index[*].inner[?(@.import.name=='UsedHidden')]"
-// @has "$.index[*][?(@.name=='Hidden')]"
+//@ has "$.index[*].inner[?(@.import.name=='UsedHidden')]"
+//@ has "$.index[*][?(@.name=='Hidden')]"
 pub mod submodule {
     #[doc(hidden)]
     pub struct Hidden {}

--- a/tests/rustdoc-json/reexport/rename_private.rs
+++ b/tests/rustdoc-json/reexport/rename_private.rs
@@ -1,10 +1,10 @@
 //@ edition:2018
 
-// @!has "$.index[*][?(@.name=='inner')]"
+//@ !has "$.index[*][?(@.name=='inner')]"
 mod inner {
-    // @has "$.index[*][?(@.name=='Public')]"
+    //@ has "$.index[*][?(@.name=='Public')]"
     pub struct Public;
 }
 
-// @is "$.index[*][?(@.inner.import)].inner.import.name" \"NewName\"
+//@ is "$.index[*][?(@.inner.import)].inner.import.name" \"NewName\"
 pub use inner::Public as NewName;

--- a/tests/rustdoc-json/reexport/rename_public.rs
+++ b/tests/rustdoc-json/reexport/rename_public.rs
@@ -1,15 +1,15 @@
 //@ edition:2018
 
-// @set inner_id = "$.index[*][?(@.name=='inner')].id"
+//@ set inner_id = "$.index[*][?(@.name=='inner')].id"
 pub mod inner {
-    // @set public_id = "$.index[*][?(@.name=='Public')].id"
-    // @ismany "$.index[*][?(@.name=='inner')].inner.module.items[*]" $public_id
+    //@ set public_id = "$.index[*][?(@.name=='Public')].id"
+    //@ ismany "$.index[*][?(@.name=='inner')].inner.module.items[*]" $public_id
     pub struct Public;
 }
-// @set import_id = "$.index[*][?(@.docs=='Re-export')].id"
-// @!has "$.index[*].inner[?(@.import.name=='Public')]"
-// @is "$.index[*].inner[?(@.import.name=='NewName')].import.source" \"inner::Public\"
+//@ set import_id = "$.index[*][?(@.docs=='Re-export')].id"
+//@ !has "$.index[*].inner[?(@.import.name=='Public')]"
+//@ is "$.index[*].inner[?(@.import.name=='NewName')].import.source" \"inner::Public\"
 /// Re-export
 pub use inner::Public as NewName;
 
-// @ismany "$.index[*][?(@.name=='rename_public')].inner.module.items[*]" $inner_id $import_id
+//@ ismany "$.index[*][?(@.name=='rename_public')].inner.module.items[*]" $inner_id $import_id

--- a/tests/rustdoc-json/reexport/same_name_different_types.rs
+++ b/tests/rustdoc-json/reexport/same_name_different_types.rs
@@ -1,22 +1,22 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/107677>.
 
 pub mod nested {
-    // @set foo_struct = "$.index[*][?(@.docs == 'Foo the struct')].id"
+    //@ set foo_struct = "$.index[*][?(@.docs == 'Foo the struct')].id"
 
     /// Foo the struct
     pub struct Foo {}
 
-    // @set foo_fn = "$.index[*][?(@.docs == 'Foo the function')].id"
+    //@ set foo_fn = "$.index[*][?(@.docs == 'Foo the function')].id"
 
     #[allow(non_snake_case)]
     /// Foo the function
     pub fn Foo() {}
 }
 
-// @ismany "$.index[*].inner[?(@.import.name == 'Foo')].import.id" $foo_fn $foo_struct
-// @ismany "$.index[*].inner[?(@.import.name == 'Bar')].import.id" $foo_fn $foo_struct
+//@ ismany "$.index[*].inner[?(@.import.name == 'Foo')].import.id" $foo_fn $foo_struct
+//@ ismany "$.index[*].inner[?(@.import.name == 'Bar')].import.id" $foo_fn $foo_struct
 
-// @count "$.index[*].inner[?(@.import.name == 'Foo')]" 2
+//@ count "$.index[*].inner[?(@.import.name == 'Foo')]" 2
 pub use nested::Foo;
-// @count "$.index[*].inner[?(@.import.name == 'Bar')]" 2
+//@ count "$.index[*].inner[?(@.import.name == 'Bar')]" 2
 pub use Foo as Bar;

--- a/tests/rustdoc-json/reexport/same_type_reexported_more_than_once.rs
+++ b/tests/rustdoc-json/reexport/same_type_reexported_more_than_once.rs
@@ -5,17 +5,17 @@
 #![no_std]
 
 mod inner {
-    // @set trait_id = "$.index[*][?(@.name=='Trait')].id"
+    //@ set trait_id = "$.index[*][?(@.name=='Trait')].id"
     pub trait Trait {}
 }
 
-// @set export_id = "$.index[*][?(@.docs=='First re-export')].id"
-// @is "$.index[*].inner[?(@.import.name=='Trait')].import.id" $trait_id
+//@ set export_id = "$.index[*][?(@.docs=='First re-export')].id"
+//@ is "$.index[*].inner[?(@.import.name=='Trait')].import.id" $trait_id
 /// First re-export
 pub use inner::Trait;
-// @set reexport_id = "$.index[*][?(@.docs=='Second re-export')].id"
-// @is "$.index[*].inner[?(@.import.name=='Reexport')].import.id" $trait_id
+//@ set reexport_id = "$.index[*][?(@.docs=='Second re-export')].id"
+//@ is "$.index[*].inner[?(@.import.name=='Reexport')].import.id" $trait_id
 /// Second re-export
 pub use inner::Trait as Reexport;
 
-// @ismany "$.index[*][?(@.name=='same_type_reexported_more_than_once')].inner.module.items[*]" $reexport_id $export_id
+//@ ismany "$.index[*][?(@.name=='same_type_reexported_more_than_once')].inner.module.items[*]" $reexport_id $export_id

--- a/tests/rustdoc-json/reexport/simple_private.rs
+++ b/tests/rustdoc-json/reexport/simple_private.rs
@@ -1,14 +1,14 @@
 //@ edition:2018
 
-// @!has "$.index[*][?(@.name=='inner')]"
+//@ !has "$.index[*][?(@.name=='inner')]"
 mod inner {
-    // @set pub_id = "$.index[*][?(@.name=='Public')].id"
+    //@ set pub_id = "$.index[*][?(@.name=='Public')].id"
     pub struct Public;
 }
 
-// @is "$.index[*][?(@.inner.import)].inner.import.name" \"Public\"
-// @is "$.index[*][?(@.inner.import)].inner.import.id" $pub_id
-// @set use_id = "$.index[*][?(@.inner.import)].id"
+//@ is "$.index[*][?(@.inner.import)].inner.import.name" \"Public\"
+//@ is "$.index[*][?(@.inner.import)].inner.import.id" $pub_id
+//@ set use_id = "$.index[*][?(@.inner.import)].id"
 pub use inner::Public;
 
-// @ismany "$.index[*][?(@.name=='simple_private')].inner.module.items[*]" $use_id
+//@ ismany "$.index[*][?(@.name=='simple_private')].inner.module.items[*]" $use_id

--- a/tests/rustdoc-json/reexport/simple_public.rs
+++ b/tests/rustdoc-json/reexport/simple_public.rs
@@ -1,16 +1,16 @@
 //@ edition:2018
 
-// @set inner_id = "$.index[*][?(@.name=='inner')].id"
+//@ set inner_id = "$.index[*][?(@.name=='inner')].id"
 pub mod inner {
 
-    // @set public_id = "$.index[*][?(@.name=='Public')].id"
-    // @ismany "$.index[*][?(@.name=='inner')].inner.module.items[*]" $public_id
+    //@ set public_id = "$.index[*][?(@.name=='Public')].id"
+    //@ ismany "$.index[*][?(@.name=='inner')].inner.module.items[*]" $public_id
     pub struct Public;
 }
 
-// @set import_id = "$.index[*][?(@.docs=='Outer')].id"
-// @is "$.index[*][?(@.docs=='Outer')].inner.import.source" \"inner::Public\"
+//@ set import_id = "$.index[*][?(@.docs=='Outer')].id"
+//@ is "$.index[*][?(@.docs=='Outer')].inner.import.source" \"inner::Public\"
 /// Outer
 pub use inner::Public;
 
-// @ismany "$.index[*][?(@.name=='simple_public')].inner.module.items[*]" $import_id $inner_id
+//@ ismany "$.index[*][?(@.name=='simple_public')].inner.module.items[*]" $import_id $inner_id

--- a/tests/rustdoc-json/reexport/synthesize_trait_with_docs.rs
+++ b/tests/rustdoc-json/reexport/synthesize_trait_with_docs.rs
@@ -7,4 +7,4 @@ pub struct Local;
 
 impl trait_with_docs::HasDocs for Local {}
 
-// @!has "$.index[*][?(@.name == 'HasDocs')]"
+//@ !has "$.index[*][?(@.name == 'HasDocs')]"

--- a/tests/rustdoc-json/return_private.rs
+++ b/tests/rustdoc-json/return_private.rs
@@ -5,8 +5,8 @@ mod secret {
     pub struct Secret;
 }
 
-// @has "$.index[*][?(@.name=='get_secret')].inner.function"
-// @is "$.index[*][?(@.name=='get_secret')].inner.function.decl.output.resolved_path.name" \"secret::Secret\"
+//@ has "$.index[*][?(@.name=='get_secret')].inner.function"
+//@ is "$.index[*][?(@.name=='get_secret')].inner.function.decl.output.resolved_path.name" \"secret::Secret\"
 pub fn get_secret() -> secret::Secret {
     secret::Secret
 }

--- a/tests/rustdoc-json/stripped_modules.rs
+++ b/tests/rustdoc-json/stripped_modules.rs
@@ -1,17 +1,17 @@
-// @!has "$.index[*][?(@.name=='no_pub_inner')]"
+//@ !has "$.index[*][?(@.name=='no_pub_inner')]"
 mod no_pub_inner {
     fn priv_inner() {}
 }
 
-// @!has "$.index[*][?(@.name=='pub_inner_unreachable')]"
+//@ !has "$.index[*][?(@.name=='pub_inner_unreachable')]"
 mod pub_inner_unreachable {
-    // @!has "$.index[*][?(@.name=='pub_inner_1')]"
+    //@ !has "$.index[*][?(@.name=='pub_inner_1')]"
     pub fn pub_inner_1() {}
 }
 
-// @!has "$.index[*][?(@.name=='pub_inner_reachable')]"
+//@ !has "$.index[*][?(@.name=='pub_inner_reachable')]"
 mod pub_inner_reachable {
-    // @has "$.index[*][?(@.name=='pub_inner_2')]"
+    //@ has "$.index[*][?(@.name=='pub_inner_2')]"
     pub fn pub_inner_2() {}
 }
 

--- a/tests/rustdoc-json/structs/field_order.rs
+++ b/tests/rustdoc-json/structs/field_order.rs
@@ -15,24 +15,24 @@ pub struct Foo {
     pub vll_9: i32,
 }
 
-// @set 0 = '$.index[*][?(@.name == "ews_0")].id'
-// @set 1 = '$.index[*][?(@.name == "dik_1")].id'
-// @set 2 = '$.index[*][?(@.name == "hsk_2")].id'
-// @set 3 = '$.index[*][?(@.name == "djt_3")].id'
-// @set 4 = '$.index[*][?(@.name == "jnr_4")].id'
-// @set 5 = '$.index[*][?(@.name == "dfs_5")].id'
-// @set 6 = '$.index[*][?(@.name == "bja_6")].id'
-// @set 7 = '$.index[*][?(@.name == "lyc_7")].id'
-// @set 8 = '$.index[*][?(@.name == "yqd_8")].id'
-// @set 9 = '$.index[*][?(@.name == "vll_9")].id'
+//@ set 0 = '$.index[*][?(@.name == "ews_0")].id'
+//@ set 1 = '$.index[*][?(@.name == "dik_1")].id'
+//@ set 2 = '$.index[*][?(@.name == "hsk_2")].id'
+//@ set 3 = '$.index[*][?(@.name == "djt_3")].id'
+//@ set 4 = '$.index[*][?(@.name == "jnr_4")].id'
+//@ set 5 = '$.index[*][?(@.name == "dfs_5")].id'
+//@ set 6 = '$.index[*][?(@.name == "bja_6")].id'
+//@ set 7 = '$.index[*][?(@.name == "lyc_7")].id'
+//@ set 8 = '$.index[*][?(@.name == "yqd_8")].id'
+//@ set 9 = '$.index[*][?(@.name == "vll_9")].id'
 
-// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[0]' $0
-// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[1]' $1
-// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[2]' $2
-// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[3]' $3
-// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[4]' $4
-// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[5]' $5
-// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[6]' $6
-// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[7]' $7
-// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[8]' $8
-// @is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[9]' $9
+//@ is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[0]' $0
+//@ is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[1]' $1
+//@ is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[2]' $2
+//@ is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[3]' $3
+//@ is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[4]' $4
+//@ is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[5]' $5
+//@ is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[6]' $6
+//@ is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[7]' $7
+//@ is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[8]' $8
+//@ is '$.index[*][?(@.name == "Foo")].inner.struct.kind.plain.fields[9]' $9

--- a/tests/rustdoc-json/structs/plain_all_pub.rs
+++ b/tests/rustdoc-json/structs/plain_all_pub.rs
@@ -3,9 +3,9 @@ pub struct Demo {
     pub y: i32,
 }
 
-// @set x = "$.index[*][?(@.name=='x')].id"
-// @set y = "$.index[*][?(@.name=='y')].id"
-// @is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[0]" $x
-// @is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[1]" $y
-// @count "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[*]" 2
-// @is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields_stripped" false
+//@ set x = "$.index[*][?(@.name=='x')].id"
+//@ set y = "$.index[*][?(@.name=='y')].id"
+//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[0]" $x
+//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[1]" $y
+//@ count "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[*]" 2
+//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields_stripped" false

--- a/tests/rustdoc-json/structs/plain_doc_hidden.rs
+++ b/tests/rustdoc-json/structs/plain_doc_hidden.rs
@@ -4,8 +4,8 @@ pub struct Demo {
     pub y: i32,
 }
 
-// @set x = "$.index[*][?(@.name=='x')].id"
-// @!has "$.index[*][?(@.name=='y')].id"
-// @is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[0]" $x
-// @count "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[*]" 1
-// @is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields_stripped" true
+//@ set x = "$.index[*][?(@.name=='x')].id"
+//@ !has "$.index[*][?(@.name=='y')].id"
+//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[0]" $x
+//@ count "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[*]" 1
+//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields_stripped" true

--- a/tests/rustdoc-json/structs/plain_empty.rs
+++ b/tests/rustdoc-json/structs/plain_empty.rs
@@ -1,5 +1,5 @@
-// @is "$.index[*][?(@.name=='PlainEmpty')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='PlainEmpty')].inner.struct"
-// @is "$.index[*][?(@.name=='PlainEmpty')].inner.struct.kind.plain.fields_stripped" false
-// @is "$.index[*][?(@.name=='PlainEmpty')].inner.struct.kind.plain.fields" []
+//@ is "$.index[*][?(@.name=='PlainEmpty')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='PlainEmpty')].inner.struct"
+//@ is "$.index[*][?(@.name=='PlainEmpty')].inner.struct.kind.plain.fields_stripped" false
+//@ is "$.index[*][?(@.name=='PlainEmpty')].inner.struct.kind.plain.fields" []
 pub struct PlainEmpty {}

--- a/tests/rustdoc-json/structs/plain_pub_priv.rs
+++ b/tests/rustdoc-json/structs/plain_pub_priv.rs
@@ -3,7 +3,7 @@ pub struct Demo {
     y: i32,
 }
 
-// @set x = "$.index[*][?(@.name=='x')].id"
-// @is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[0]" $x
-// @count "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[*]" 1
-// @is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields_stripped" true
+//@ set x = "$.index[*][?(@.name=='x')].id"
+//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[0]" $x
+//@ count "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[*]" 1
+//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields_stripped" true

--- a/tests/rustdoc-json/structs/tuple.rs
+++ b/tests/rustdoc-json/structs/tuple.rs
@@ -1,4 +1,4 @@
-// @is "$.index[*][?(@.name=='Tuple')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='Tuple')].inner.struct"
-// @is "$.index[*][?(@.name=='Tuple')].inner.struct.kind.tuple" '[null, null]'
+//@ is "$.index[*][?(@.name=='Tuple')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='Tuple')].inner.struct"
+//@ is "$.index[*][?(@.name=='Tuple')].inner.struct.kind.tuple" '[null, null]'
 pub struct Tuple(u32, String);

--- a/tests/rustdoc-json/structs/tuple_empty.rs
+++ b/tests/rustdoc-json/structs/tuple_empty.rs
@@ -1,2 +1,2 @@
-// @is "$.index[*][?(@.name=='TupleUnit')].inner.struct.kind.tuple" []
+//@ is "$.index[*][?(@.name=='TupleUnit')].inner.struct.kind.tuple" []
 pub struct TupleUnit();

--- a/tests/rustdoc-json/structs/tuple_pub_priv.rs
+++ b/tests/rustdoc-json/structs/tuple_pub_priv.rs
@@ -5,9 +5,9 @@ pub struct Demo(
     #[doc(hidden)] i32,
 );
 
-// @set field = "$.index[*][?(@.docs=='field')].id"
+//@ set field = "$.index[*][?(@.docs=='field')].id"
 
-// @is    "$.index[*][?(@.name=='Demo')].inner.struct.kind.tuple[0]" null
-// @is    "$.index[*][?(@.name=='Demo')].inner.struct.kind.tuple[1]" $field
-// @is    "$.index[*][?(@.name=='Demo')].inner.struct.kind.tuple[2]" null
-// @count "$.index[*][?(@.name=='Demo')].inner.struct.kind.tuple[*]" 3
+//@ is    "$.index[*][?(@.name=='Demo')].inner.struct.kind.tuple[0]" null
+//@ is    "$.index[*][?(@.name=='Demo')].inner.struct.kind.tuple[1]" $field
+//@ is    "$.index[*][?(@.name=='Demo')].inner.struct.kind.tuple[2]" null
+//@ count "$.index[*][?(@.name=='Demo')].inner.struct.kind.tuple[*]" 3

--- a/tests/rustdoc-json/structs/unit.rs
+++ b/tests/rustdoc-json/structs/unit.rs
@@ -1,4 +1,4 @@
-// @is "$.index[*][?(@.name=='Unit')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='Unit')].inner.struct"
-// @is "$.index[*][?(@.name=='Unit')].inner.struct.kind" \"unit\"
+//@ is "$.index[*][?(@.name=='Unit')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='Unit')].inner.struct"
+//@ is "$.index[*][?(@.name=='Unit')].inner.struct.kind" \"unit\"
 pub struct Unit;

--- a/tests/rustdoc-json/structs/with_generics.rs
+++ b/tests/rustdoc-json/structs/with_generics.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
-// @is "$.index[*][?(@.name=='WithGenerics')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='WithGenerics')].inner.struct"
-// @is "$.index[*][?(@.name=='WithGenerics')].inner.struct.generics.params[0].name" \"T\"
-// @is "$.index[*][?(@.name=='WithGenerics')].inner.struct.generics.params[0].kind.type.bounds" []
-// @is "$.index[*][?(@.name=='WithGenerics')].inner.struct.generics.params[1].name" \"U\"
-// @is "$.index[*][?(@.name=='WithGenerics')].inner.struct.generics.params[1].kind.type.bounds" []
-// @is "$.index[*][?(@.name=='WithGenerics')].inner.struct.kind.plain.fields_stripped" true
-// @is "$.index[*][?(@.name=='WithGenerics')].inner.struct.kind.plain.fields" []
+//@ is "$.index[*][?(@.name=='WithGenerics')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='WithGenerics')].inner.struct"
+//@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.generics.params[0].name" \"T\"
+//@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.generics.params[0].kind.type.bounds" []
+//@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.generics.params[1].name" \"U\"
+//@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.generics.params[1].kind.type.bounds" []
+//@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.kind.plain.fields_stripped" true
+//@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.kind.plain.fields" []
 pub struct WithGenerics<T, U> {
     stuff: Vec<T>,
     things: HashMap<U, U>,

--- a/tests/rustdoc-json/structs/with_primitives.rs
+++ b/tests/rustdoc-json/structs/with_primitives.rs
@@ -1,11 +1,11 @@
 // ignore-tidy-linelength
 
-// @is "$.index[*][?(@.name=='WithPrimitives')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='WithPrimitives')].inner.struct"
-// @is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.generics.params[0].name" \"\'a\"
-// @is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.generics.params[0].kind.lifetime.outlives" []
-// @is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.kind.plain.fields_stripped" true
-// @is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.kind.plain.fields" []
+//@ is "$.index[*][?(@.name=='WithPrimitives')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='WithPrimitives')].inner.struct"
+//@ is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.generics.params[0].name" \"\'a\"
+//@ is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.generics.params[0].kind.lifetime.outlives" []
+//@ is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.kind.plain.fields_stripped" true
+//@ is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.kind.plain.fields" []
 pub struct WithPrimitives<'a> {
     num: u32,
     s: &'a str,

--- a/tests/rustdoc-json/trait_alias.rs
+++ b/tests/rustdoc-json/trait_alias.rs
@@ -1,18 +1,18 @@
 // ignore-tidy-linelength
 #![feature(trait_alias)]
 
-// @set StrLike = "$.index[*][?(@.name=='StrLike')].id"
-// @is "$.index[*][?(@.name=='StrLike')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='StrLike')].inner.trait_alias"
-// @is "$.index[*][?(@.name=='StrLike')].span.filename" $FILE
+//@ set StrLike = "$.index[*][?(@.name=='StrLike')].id"
+//@ is "$.index[*][?(@.name=='StrLike')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='StrLike')].inner.trait_alias"
+//@ is "$.index[*][?(@.name=='StrLike')].span.filename" $FILE
 pub trait StrLike = AsRef<str>;
 
-// @is "$.index[*][?(@.name=='f')].inner.function.decl.output.impl_trait[0].trait_bound.trait.id" $StrLike
+//@ is "$.index[*][?(@.name=='f')].inner.function.decl.output.impl_trait[0].trait_bound.trait.id" $StrLike
 pub fn f() -> impl StrLike {
     "heya"
 }
 
-// @!is "$.index[*][?(@.name=='g')].inner.function.decl.output.impl_trait[0].trait_bound.trait.id" $StrLike
+//@ !is "$.index[*][?(@.name=='g')].inner.function.decl.output.impl_trait[0].trait_bound.trait.id" $StrLike
 pub fn g() -> impl AsRef<str> {
     "heya"
 }

--- a/tests/rustdoc-json/traits/has_body.rs
+++ b/tests/rustdoc-json/traits/has_body.rs
@@ -1,21 +1,21 @@
-// @has "$.index[*][?(@.name=='Foo')]"
+//@ has "$.index[*][?(@.name=='Foo')]"
 pub trait Foo {
-    // @is "$.index[*][?(@.name=='no_self')].inner.function.has_body" false
+    //@ is "$.index[*][?(@.name=='no_self')].inner.function.has_body" false
     fn no_self();
-    // @is "$.index[*][?(@.name=='move_self')].inner.function.has_body" false
+    //@ is "$.index[*][?(@.name=='move_self')].inner.function.has_body" false
     fn move_self(self);
-    // @is "$.index[*][?(@.name=='ref_self')].inner.function.has_body" false
+    //@ is "$.index[*][?(@.name=='ref_self')].inner.function.has_body" false
     fn ref_self(&self);
 
-    // @is "$.index[*][?(@.name=='no_self_def')].inner.function.has_body" true
+    //@ is "$.index[*][?(@.name=='no_self_def')].inner.function.has_body" true
     fn no_self_def() {}
-    // @is "$.index[*][?(@.name=='move_self_def')].inner.function.has_body" true
+    //@ is "$.index[*][?(@.name=='move_self_def')].inner.function.has_body" true
     fn move_self_def(self) {}
-    // @is "$.index[*][?(@.name=='ref_self_def')].inner.function.has_body" true
+    //@ is "$.index[*][?(@.name=='ref_self_def')].inner.function.has_body" true
     fn ref_self_def(&self) {}
 }
 
 pub trait Bar: Clone {
-    // @is "$.index[*][?(@.name=='method')].inner.function.has_body" false
+    //@ is "$.index[*][?(@.name=='method')].inner.function.has_body" false
     fn method(&self, param: usize);
 }

--- a/tests/rustdoc-json/traits/implementors.rs
+++ b/tests/rustdoc-json/traits/implementors.rs
@@ -5,14 +5,14 @@ pub struct GeorgeMichael {}
 impl Wham for GeorgeMichael {}
 
 // Find IDs.
-// @set wham = "$.index[*][?(@.name=='Wham')].id"
-// @set gmWham = "$.index[*][?(@.docs=='Wham for George Michael')].id"
-// @set gm = "$.index[*][?(@.name=='GeorgeMichael')].id"
+//@ set wham = "$.index[*][?(@.name=='Wham')].id"
+//@ set gmWham = "$.index[*][?(@.docs=='Wham for George Michael')].id"
+//@ set gm = "$.index[*][?(@.name=='GeorgeMichael')].id"
 
 // Both struct and trait point to impl.
-// @has "$.index[*][?(@.name=='GeorgeMichael')].inner.struct.impls[*]" $gmWham
-// @is "$.index[*][?(@.name=='Wham')].inner.trait.implementations[*]" $gmWham
+//@ has "$.index[*][?(@.name=='GeorgeMichael')].inner.struct.impls[*]" $gmWham
+//@ is "$.index[*][?(@.name=='Wham')].inner.trait.implementations[*]" $gmWham
 
 // Impl points to both struct and trait.
-// @is "$.index[*][?(@.docs == 'Wham for George Michael')].inner.impl.trait.id" $wham
-// @is "$.index[*][?(@.docs == 'Wham for George Michael')].inner.impl.for.resolved_path.id" $gm
+//@ is "$.index[*][?(@.docs == 'Wham for George Michael')].inner.impl.trait.id" $wham
+//@ is "$.index[*][?(@.docs == 'Wham for George Michael')].inner.impl.for.resolved_path.id" $gm

--- a/tests/rustdoc-json/traits/is_object_safe.rs
+++ b/tests/rustdoc-json/traits/is_object_safe.rs
@@ -1,19 +1,19 @@
 #![no_std]
 
-// @has "$.index[*][?(@.name=='FooUnsafe')]"
-// @is "$.index[*][?(@.name=='FooUnsafe')].inner.trait.is_object_safe" false
+//@ has "$.index[*][?(@.name=='FooUnsafe')]"
+//@ is "$.index[*][?(@.name=='FooUnsafe')].inner.trait.is_object_safe" false
 pub trait FooUnsafe {
     fn foo() -> Self;
 }
 
-// @has "$.index[*][?(@.name=='BarUnsafe')]"
-// @is "$.index[*][?(@.name=='BarUnsafe')].inner.trait.is_object_safe" false
+//@ has "$.index[*][?(@.name=='BarUnsafe')]"
+//@ is "$.index[*][?(@.name=='BarUnsafe')].inner.trait.is_object_safe" false
 pub trait BarUnsafe<T> {
     fn foo(i: T);
 }
 
-// @has "$.index[*][?(@.name=='FooSafe')]"
-// @is "$.index[*][?(@.name=='FooSafe')].inner.trait.is_object_safe" true
+//@ has "$.index[*][?(@.name=='FooSafe')]"
+//@ is "$.index[*][?(@.name=='FooSafe')].inner.trait.is_object_safe" true
 pub trait FooSafe {
     fn foo(&self);
 }

--- a/tests/rustdoc-json/traits/private_supertrait.rs
+++ b/tests/rustdoc-json/traits/private_supertrait.rs
@@ -1,11 +1,11 @@
 // ignore-tidy-linelength
 
-// @!has "$.index[*][?(@.name == 'sealed')]"
+//@ !has "$.index[*][?(@.name == 'sealed')]"
 mod sealed {
-    // @set sealed_id = "$.index[*][?(@.name=='Sealed')].id"
+    //@ set sealed_id = "$.index[*][?(@.name=='Sealed')].id"
     pub trait Sealed {}
 }
 
-// @count "$.index[*][?(@.name=='Trait')].inner.trait.bounds[*]" 1
-// @is    "$.index[*][?(@.name=='Trait')].inner.trait.bounds[0].trait_bound.trait.id" $sealed_id
+//@ count "$.index[*][?(@.name=='Trait')].inner.trait.bounds[*]" 1
+//@ is    "$.index[*][?(@.name=='Trait')].inner.trait.bounds[0].trait_bound.trait.id" $sealed_id
 pub trait Trait: sealed::Sealed {}

--- a/tests/rustdoc-json/traits/supertrait.rs
+++ b/tests/rustdoc-json/traits/supertrait.rs
@@ -1,22 +1,22 @@
 // ignore-tidy-linelength
 
-// @set loud_id = "$.index[*][?(@.name=='Loud')].id"
+//@ set loud_id = "$.index[*][?(@.name=='Loud')].id"
 pub trait Loud {}
 
-// @set very_loud_id = "$.index[*][?(@.name=='VeryLoud')].id"
-// @count "$.index[*][?(@.name=='VeryLoud')].inner.trait.bounds[*]" 1
-// @is    "$.index[*][?(@.name=='VeryLoud')].inner.trait.bounds[0].trait_bound.trait.id" $loud_id
+//@ set very_loud_id = "$.index[*][?(@.name=='VeryLoud')].id"
+//@ count "$.index[*][?(@.name=='VeryLoud')].inner.trait.bounds[*]" 1
+//@ is    "$.index[*][?(@.name=='VeryLoud')].inner.trait.bounds[0].trait_bound.trait.id" $loud_id
 pub trait VeryLoud: Loud {}
 
-// @set sounds_good_id = "$.index[*][?(@.name=='SoundsGood')].id"
+//@ set sounds_good_id = "$.index[*][?(@.name=='SoundsGood')].id"
 pub trait SoundsGood {}
 
-// @count "$.index[*][?(@.name=='MetalBand')].inner.trait.bounds[*]" 2
-// @is    "$.index[*][?(@.name=='MetalBand')].inner.trait.bounds[0].trait_bound.trait.id" $very_loud_id
-// @is    "$.index[*][?(@.name=='MetalBand')].inner.trait.bounds[1].trait_bound.trait.id" $sounds_good_id
+//@ count "$.index[*][?(@.name=='MetalBand')].inner.trait.bounds[*]" 2
+//@ is    "$.index[*][?(@.name=='MetalBand')].inner.trait.bounds[0].trait_bound.trait.id" $very_loud_id
+//@ is    "$.index[*][?(@.name=='MetalBand')].inner.trait.bounds[1].trait_bound.trait.id" $sounds_good_id
 pub trait MetalBand: VeryLoud + SoundsGood {}
 
-// @count "$.index[*][?(@.name=='DnabLatem')].inner.trait.bounds[*]" 2
-// @is    "$.index[*][?(@.name=='DnabLatem')].inner.trait.bounds[1].trait_bound.trait.id" $very_loud_id
-// @is    "$.index[*][?(@.name=='DnabLatem')].inner.trait.bounds[0].trait_bound.trait.id" $sounds_good_id
+//@ count "$.index[*][?(@.name=='DnabLatem')].inner.trait.bounds[*]" 2
+//@ is    "$.index[*][?(@.name=='DnabLatem')].inner.trait.bounds[1].trait_bound.trait.id" $very_loud_id
+//@ is    "$.index[*][?(@.name=='DnabLatem')].inner.trait.bounds[0].trait_bound.trait.id" $sounds_good_id
 pub trait DnabLatem: SoundsGood + VeryLoud {}

--- a/tests/rustdoc-json/traits/trait_alias.rs
+++ b/tests/rustdoc-json/traits/trait_alias.rs
@@ -3,25 +3,25 @@
 
 #![feature(trait_alias)]
 
-// @set Orig = "$.index[*][?(@.name == 'Orig')].id"
-// @has "$.index[*][?(@.name == 'Orig')].inner.trait"
+//@ set Orig = "$.index[*][?(@.name == 'Orig')].id"
+//@ has "$.index[*][?(@.name == 'Orig')].inner.trait"
 pub trait Orig<T> {}
 
-// @set Alias = "$.index[*][?(@.name == 'Alias')].id"
-// @has "$.index[*][?(@.name == 'Alias')].inner.trait_alias"
-// @is "$.index[*][?(@.name == 'Alias')].inner.trait_alias.generics" '{"params": [], "where_predicates": []}'
-// @count "$.index[*][?(@.name == 'Alias')].inner.trait_alias.params[*]" 1
-// @is "$.index[*][?(@.name == 'Alias')].inner.trait_alias.params[0].trait_bound.trait.id" $Orig
-// @is "$.index[*][?(@.name == 'Alias')].inner.trait_alias.params[0].trait_bound.trait.args.angle_bracketed.args[0].type.primitive" '"i32"'
+//@ set Alias = "$.index[*][?(@.name == 'Alias')].id"
+//@ has "$.index[*][?(@.name == 'Alias')].inner.trait_alias"
+//@ is "$.index[*][?(@.name == 'Alias')].inner.trait_alias.generics" '{"params": [], "where_predicates": []}'
+//@ count "$.index[*][?(@.name == 'Alias')].inner.trait_alias.params[*]" 1
+//@ is "$.index[*][?(@.name == 'Alias')].inner.trait_alias.params[0].trait_bound.trait.id" $Orig
+//@ is "$.index[*][?(@.name == 'Alias')].inner.trait_alias.params[0].trait_bound.trait.args.angle_bracketed.args[0].type.primitive" '"i32"'
 pub trait Alias = Orig<i32>;
 
 pub struct Struct;
 
 impl Orig<i32> for Struct {}
 
-// @has "$.index[*][?(@.name=='takes_alias')].inner.function.decl.inputs[0][1].impl_trait"
-// @is "$.index[*][?(@.name=='takes_alias')].inner.function.decl.inputs[0][1].impl_trait[0].trait_bound.trait.id" $Alias
-// @is "$.index[*][?(@.name=='takes_alias')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $Alias
+//@ has "$.index[*][?(@.name=='takes_alias')].inner.function.decl.inputs[0][1].impl_trait"
+//@ is "$.index[*][?(@.name=='takes_alias')].inner.function.decl.inputs[0][1].impl_trait[0].trait_bound.trait.id" $Alias
+//@ is "$.index[*][?(@.name=='takes_alias')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $Alias
 pub fn takes_alias(_: impl Alias) {}
 // FIXME: Should the trait be mentioned in both the decl and generics?
 

--- a/tests/rustdoc-json/traits/uses_extern_trait.rs
+++ b/tests/rustdoc-json/traits/uses_extern_trait.rs
@@ -1,5 +1,5 @@
 #![no_std]
 pub fn drop_default<T: core::default::Default>(_x: T) {}
 
-// @!has "$.index[*][?(@.name=='Debug')]"
-// @!has "$.index[*][?(@.name=='Default')]"
+//@ !has "$.index[*][?(@.name=='Debug')]"
+//@ !has "$.index[*][?(@.name=='Default')]"

--- a/tests/rustdoc-json/type/dyn.rs
+++ b/tests/rustdoc-json/type/dyn.rs
@@ -1,46 +1,46 @@
 // ignore-tidy-linelength
 use std::fmt::Debug;
 
-// @count "$.index[*][?(@.name=='dyn')].inner.module.items[*]" 3
-// @set sync_int_gen = "$.index[*][?(@.name=='SyncIntGen')].id"
-// @set ref_fn       = "$.index[*][?(@.name=='RefFn')].id"
-// @set weird_order  = "$.index[*][?(@.name=='WeirdOrder')].id"
-// @ismany "$.index[*][?(@.name=='dyn')].inner.module.items[*]" $sync_int_gen $ref_fn $weird_order
+//@ count "$.index[*][?(@.name=='dyn')].inner.module.items[*]" 3
+//@ set sync_int_gen = "$.index[*][?(@.name=='SyncIntGen')].id"
+//@ set ref_fn       = "$.index[*][?(@.name=='RefFn')].id"
+//@ set weird_order  = "$.index[*][?(@.name=='WeirdOrder')].id"
+//@ ismany "$.index[*][?(@.name=='dyn')].inner.module.items[*]" $sync_int_gen $ref_fn $weird_order
 
-// @has    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias"
-// @is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.generics" '{"params": [], "where_predicates": []}'
-// @has    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path"
-// @is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.name" \"Box\"
-// @is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.bindings" []
-// @count "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args" 1
-// @has    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait"
-// @is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.lifetime" \"\'static\"
-// @count "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[*]" 3
-// @is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].generic_params" []
-// @is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[1].generic_params" []
-// @is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[2].generic_params" []
-// @is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].trait.name" '"Fn"'
-// @is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[1].trait.name" '"Send"'
-// @is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[2].trait.name" '"Sync"'
-// @is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].trait.args" '{"parenthesized": {"inputs": [],"output": {"primitive": "i32"}}}'
+//@ has    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias"
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.generics" '{"params": [], "where_predicates": []}'
+//@ has    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path"
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.name" \"Box\"
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.bindings" []
+//@ count "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args" 1
+//@ has    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait"
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.lifetime" \"\'static\"
+//@ count "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[*]" 3
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].generic_params" []
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[1].generic_params" []
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[2].generic_params" []
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].trait.name" '"Fn"'
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[1].trait.name" '"Send"'
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[2].trait.name" '"Sync"'
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].trait.args" '{"parenthesized": {"inputs": [],"output": {"primitive": "i32"}}}'
 pub type SyncIntGen = Box<dyn Fn() -> i32 + Send + Sync + 'static>;
 
-// @has "$.index[*][?(@.name=='RefFn')].inner.type_alias"
-// @is "$.index[*][?(@.name=='RefFn')].inner.type_alias.generics" '{"params": [{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"}],"where_predicates": []}'
-// @has "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref"
-// @is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.mutable" 'false'
-// @is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.lifetime" "\"'a\""
-// @has "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait"
-// @is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.lifetime" null
-// @count "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[*]" 1
-// @is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
-// @is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.name" '"Fn"'
-// @has "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.inputs[0].borrowed_ref"
-// @is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.inputs[0].borrowed_ref.lifetime" "\"'b\""
-// @has "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.output.borrowed_ref"
-// @is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.output.borrowed_ref.lifetime" "\"'b\""
+//@ has "$.index[*][?(@.name=='RefFn')].inner.type_alias"
+//@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.generics" '{"params": [{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"}],"where_predicates": []}'
+//@ has "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref"
+//@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.mutable" 'false'
+//@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.lifetime" "\"'a\""
+//@ has "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait"
+//@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.lifetime" null
+//@ count "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[*]" 1
+//@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
+//@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.name" '"Fn"'
+//@ has "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.inputs[0].borrowed_ref"
+//@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.inputs[0].borrowed_ref.lifetime" "\"'b\""
+//@ has "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.output.borrowed_ref"
+//@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.output.borrowed_ref.lifetime" "\"'b\""
 pub type RefFn<'a> = &'a dyn for<'b> Fn(&'b i32) -> &'b i32;
 
-// @is    "$.index[*][?(@.name=='WeirdOrder')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].trait.name" '"Send"'
-// @is    "$.index[*][?(@.name=='WeirdOrder')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[1].trait.name" '"Debug"'
+//@ is    "$.index[*][?(@.name=='WeirdOrder')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].trait.name" '"Send"'
+//@ is    "$.index[*][?(@.name=='WeirdOrder')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[1].trait.name" '"Debug"'
 pub type WeirdOrder = Box<dyn Send + Debug>;

--- a/tests/rustdoc-json/type/extern.rs
+++ b/tests/rustdoc-json/type/extern.rs
@@ -5,5 +5,5 @@ extern "C" {
     pub type Foo;
 }
 
-// @is "$.index[*][?(@.docs=='No inner information')].name" '"Foo"'
-// @is "$.index[*][?(@.docs=='No inner information')].inner" \"foreign_type\"
+//@ is "$.index[*][?(@.docs=='No inner information')].name" '"Foo"'
+//@ is "$.index[*][?(@.docs=='No inner information')].inner" \"foreign_type\"

--- a/tests/rustdoc-json/type/fn_lifetime.rs
+++ b/tests/rustdoc-json/type/fn_lifetime.rs
@@ -1,26 +1,26 @@
 // ignore-tidy-linelength
 
-// @has "$.index[*][?(@.name=='GenericFn')].inner.type_alias"
+//@ has "$.index[*][?(@.name=='GenericFn')].inner.type_alias"
 
-// @ismany "$.index[*][?(@.name=='GenericFn')].inner.type_alias.generics.params[*].name" \"\'a\"
-// @has    "$.index[*][?(@.name=='GenericFn')].inner.type_alias.generics.params[*].kind.lifetime"
-// @count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.generics.params[*].kind.lifetime.outlives[*]" 0
-// @count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.generics.where_predicates[*]" 0
-// @count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.generic_params[*]" 0
-// @count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.decl.inputs[*]" 1
-// @is     "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.decl.inputs[*][1].borrowed_ref.lifetime" \"\'a\"
-// @is     "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.decl.output.borrowed_ref.lifetime" \"\'a\"
+//@ ismany "$.index[*][?(@.name=='GenericFn')].inner.type_alias.generics.params[*].name" \"\'a\"
+//@ has    "$.index[*][?(@.name=='GenericFn')].inner.type_alias.generics.params[*].kind.lifetime"
+//@ count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.generics.params[*].kind.lifetime.outlives[*]" 0
+//@ count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.generics.where_predicates[*]" 0
+//@ count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.generic_params[*]" 0
+//@ count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.decl.inputs[*]" 1
+//@ is     "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.decl.inputs[*][1].borrowed_ref.lifetime" \"\'a\"
+//@ is     "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.decl.output.borrowed_ref.lifetime" \"\'a\"
 
 pub type GenericFn<'a> = fn(&'a i32) -> &'a i32;
 
-// @has    "$.index[*][?(@.name=='ForAll')].inner.type_alias"
-// @count "$.index[*][?(@.name=='ForAll')].inner.type_alias.generics.params[*]" 0
-// @count "$.index[*][?(@.name=='ForAll')].inner.type_alias.generics.where_predicates[*]" 0
-// @count "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*]" 1
-// @is    "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].name" \"\'a\"
-// @has   "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].kind.lifetime"
-// @count "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].kind.lifetime.outlives[*]" 0
-// @count "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.decl.inputs[*]" 1
-// @is    "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.decl.inputs[*][1].borrowed_ref.lifetime" \"\'a\"
-// @is    "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.decl.output.borrowed_ref.lifetime" \"\'a\"
+//@ has    "$.index[*][?(@.name=='ForAll')].inner.type_alias"
+//@ count "$.index[*][?(@.name=='ForAll')].inner.type_alias.generics.params[*]" 0
+//@ count "$.index[*][?(@.name=='ForAll')].inner.type_alias.generics.where_predicates[*]" 0
+//@ count "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*]" 1
+//@ is    "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].name" \"\'a\"
+//@ has   "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].kind.lifetime"
+//@ count "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].kind.lifetime.outlives[*]" 0
+//@ count "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.decl.inputs[*]" 1
+//@ is    "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.decl.inputs[*][1].borrowed_ref.lifetime" \"\'a\"
+//@ is    "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.decl.output.borrowed_ref.lifetime" \"\'a\"
 pub type ForAll = for<'a> fn(&'a i32) -> &'a i32;

--- a/tests/rustdoc-json/type/generic_default.rs
+++ b/tests/rustdoc-json/type/generic_default.rs
@@ -1,33 +1,33 @@
 // ignore-tidy-linelength
 
-// @set result = "$.index[*][?(@.name=='Result')].id"
+//@ set result = "$.index[*][?(@.name=='Result')].id"
 pub enum Result<T, E> {
     Ok(T),
     Err(E),
 }
 
-// @set my_error = "$.index[*][?(@.name=='MyError')].id"
+//@ set my_error = "$.index[*][?(@.name=='MyError')].id"
 pub struct MyError {}
 
-// @has    "$.index[*][?(@.name=='MyResult')].inner.type_alias"
-// @count "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.where_predicates[*]" 0
-// @count "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[*]" 2
-// @is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[0].name" \"T\"
-// @is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].name" \"E\"
-// @has   "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[0].kind.type"
-// @has   "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type"
-// @count "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[0].kind.type.bounds[*]" 0
-// @count "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.bounds[*]" 0
-// @is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[0].kind.type.default" null
-// @has    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.default.resolved_path"
-// @is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.default.resolved_path.id" $my_error
-// @is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.default.resolved_path.name" \"MyError\"
-// @has    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path"
-// @is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.id" $result
-// @is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.name" \"Result\"
-// @is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.bindings" []
-// @has    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.generic"
-// @has    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[1].type.generic"
-// @is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.generic" \"T\"
-// @is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[1].type.generic" \"E\"
+//@ has    "$.index[*][?(@.name=='MyResult')].inner.type_alias"
+//@ count "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.where_predicates[*]" 0
+//@ count "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[*]" 2
+//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[0].name" \"T\"
+//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].name" \"E\"
+//@ has   "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[0].kind.type"
+//@ has   "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type"
+//@ count "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[0].kind.type.bounds[*]" 0
+//@ count "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.bounds[*]" 0
+//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[0].kind.type.default" null
+//@ has    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.default.resolved_path"
+//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.default.resolved_path.id" $my_error
+//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.default.resolved_path.name" \"MyError\"
+//@ has    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path"
+//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.id" $result
+//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.name" \"Result\"
+//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.bindings" []
+//@ has    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.generic"
+//@ has    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[1].type.generic"
+//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.generic" \"T\"
+//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[1].type.generic" \"E\"
 pub type MyResult<T, E = MyError> = Result<T, E>;

--- a/tests/rustdoc-json/type/hrtb.rs
+++ b/tests/rustdoc-json/type/hrtb.rs
@@ -1,7 +1,7 @@
 // ignore-tidy-linelength
 
-// @is "$.index[*][?(@.name=='genfn')].inner.function.generics.where_predicates[0].bound_predicate.type" '{"generic": "F"}'
-// @is "$.index[*][?(@.name=='genfn')].inner.function.generics.where_predicates[0].bound_predicate.generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"},{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
+//@ is "$.index[*][?(@.name=='genfn')].inner.function.generics.where_predicates[0].bound_predicate.type" '{"generic": "F"}'
+//@ is "$.index[*][?(@.name=='genfn')].inner.function.generics.where_predicates[0].bound_predicate.generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"},{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
 pub fn genfn<F>(f: F)
 where
     for<'a, 'b> F: Fn(&'a i32, &'b i32),
@@ -10,12 +10,12 @@ where
     f(&zero, &zero);
 }
 
-// @is "$.index[*][?(@.name=='dynfn')].inner.function.generics" '{"params": [], "where_predicates": []}'
-// @is "$.index[*][?(@.name=='dynfn')].inner.function.generics" '{"params": [], "where_predicates": []}'
-// @is "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.lifetime" null
-// @count "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.traits[*]" 1
-// @is "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"},{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
-// @is "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.traits[0].trait.name" '"Fn"'
+//@ is "$.index[*][?(@.name=='dynfn')].inner.function.generics" '{"params": [], "where_predicates": []}'
+//@ is "$.index[*][?(@.name=='dynfn')].inner.function.generics" '{"params": [], "where_predicates": []}'
+//@ is "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.lifetime" null
+//@ count "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.traits[*]" 1
+//@ is "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"},{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
+//@ is "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.traits[0].trait.name" '"Fn"'
 pub fn dynfn(f: &dyn for<'a, 'b> Fn(&'a i32, &'b i32)) {
     let zero = 0;
     f(&zero, &zero);

--- a/tests/rustdoc-json/type/inherent_associated_type.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type.rs
@@ -2,23 +2,23 @@
 #![feature(inherent_associated_types)]
 #![allow(incomplete_features)]
 
-// @set OwnerMetadata = '$.index[*][?(@.name=="OwnerMetadata")].id'
+//@ set OwnerMetadata = '$.index[*][?(@.name=="OwnerMetadata")].id'
 pub struct OwnerMetadata;
-// @set Owner = '$.index[*][?(@.name=="Owner")].id'
+//@ set Owner = '$.index[*][?(@.name=="Owner")].id'
 pub struct Owner;
 
 pub fn create() -> Owner::Metadata {
     OwnerMetadata
 }
-// @is '$.index[*][?(@.name=="create")].inner.function.decl.output.qualified_path.name' '"Metadata"'
-// @is '$.index[*][?(@.name=="create")].inner.function.decl.output.qualified_path.trait' null
-// @is '$.index[*][?(@.name=="create")].inner.function.decl.output.qualified_path.self_type.resolved_path.id' $Owner
+//@ is '$.index[*][?(@.name=="create")].inner.function.decl.output.qualified_path.name' '"Metadata"'
+//@ is '$.index[*][?(@.name=="create")].inner.function.decl.output.qualified_path.trait' null
+//@ is '$.index[*][?(@.name=="create")].inner.function.decl.output.qualified_path.self_type.resolved_path.id' $Owner
 
 /// impl
 impl Owner {
     /// iat
     pub type Metadata = OwnerMetadata;
 }
-// @set iat = '$.index[*][?(@.docs=="iat")].id'
-// @is '$.index[*][?(@.docs=="impl")].inner.impl.items[*]' $iat
-// @is '$.index[*][?(@.docs=="iat")].inner.assoc_type.default.resolved_path.id' $OwnerMetadata
+//@ set iat = '$.index[*][?(@.docs=="iat")].id'
+//@ is '$.index[*][?(@.docs=="impl")].inner.impl.items[*]' $iat
+//@ is '$.index[*][?(@.docs=="iat")].inner.assoc_type.default.resolved_path.id' $OwnerMetadata

--- a/tests/rustdoc-json/type/inherent_associated_type_bound.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type_bound.rs
@@ -2,17 +2,17 @@
 #![feature(inherent_associated_types)]
 #![allow(incomplete_features)]
 
-// @set Carrier = '$.index[*][?(@.name=="Carrier")].id'
+//@ set Carrier = '$.index[*][?(@.name=="Carrier")].id'
 pub struct Carrier<'a>(&'a ());
 
-// @count "$.index[*][?(@.name=='user')].inner.function.decl.inputs[*]" 1
-// @is "$.index[*][?(@.name=='user')].inner.function.decl.inputs[0][0]" '"_"'
-// @is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.generic_params[*].name' \""'b"\"
-// @is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.self_type.resolved_path.id' $Carrier
-// @is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.self_type.resolved_path.args.angle_bracketed.args[0].lifetime' \""'b"\"
-// @is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.name' '"Focus"'
-// @is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.trait' null
-// @is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.args.angle_bracketed.args[0].type.primitive' '"i32"'
+//@ count "$.index[*][?(@.name=='user')].inner.function.decl.inputs[*]" 1
+//@ is "$.index[*][?(@.name=='user')].inner.function.decl.inputs[0][0]" '"_"'
+//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.generic_params[*].name' \""'b"\"
+//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.self_type.resolved_path.id' $Carrier
+//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.self_type.resolved_path.args.angle_bracketed.args[0].lifetime' \""'b"\"
+//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.name' '"Focus"'
+//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.trait' null
+//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.args.angle_bracketed.args[0].type.primitive' '"i32"'
 pub fn user(_: for<'b> fn(Carrier<'b>::Focus<i32>)) {}
 
 impl<'a> Carrier<'a> {

--- a/tests/rustdoc-json/type/inherent_associated_type_projections.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type_projections.rs
@@ -2,15 +2,15 @@
 #![feature(inherent_associated_types)]
 #![allow(incomplete_features)]
 
-// @set Parametrized = '$.index[*][?(@.name=="Parametrized")].id'
+//@ set Parametrized = '$.index[*][?(@.name=="Parametrized")].id'
 pub struct Parametrized<T>(T);
 
-// @count "$.index[*][?(@.name=='test')].inner.function.decl.inputs[*]" 1
-// @is "$.index[*][?(@.name=='test')].inner.function.decl.inputs[0][0]" '"_"'
-// @is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.self_type.resolved_path.id' $Parametrized
-// @is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.self_type.resolved_path.args.angle_bracketed.args[0].type.primitive' \"i32\"
-// @is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.name' '"Proj"'
-// @is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.trait' null
+//@ count "$.index[*][?(@.name=='test')].inner.function.decl.inputs[*]" 1
+//@ is "$.index[*][?(@.name=='test')].inner.function.decl.inputs[0][0]" '"_"'
+//@ is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.self_type.resolved_path.id' $Parametrized
+//@ is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.self_type.resolved_path.args.angle_bracketed.args[0].type.primitive' \"i32\"
+//@ is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.name' '"Proj"'
+//@ is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.trait' null
 pub fn test(_: Parametrized<i32>::Proj) {}
 
 /// param_bool
@@ -25,10 +25,10 @@ impl Parametrized<i32> {
     pub type Proj = String;
 }
 
-// @set param_bool = '$.index[*][?(@.docs=="param_bool")].id'
-// @set param_i32 = '$.index[*][?(@.docs=="param_i32")].id'
-// @set param_bool_proj = '$.index[*][?(@.docs=="param_bool_proj")].id'
-// @set param_i32_proj = '$.index[*][?(@.docs=="param_i32_proj")].id'
+//@ set param_bool = '$.index[*][?(@.docs=="param_bool")].id'
+//@ set param_i32 = '$.index[*][?(@.docs=="param_i32")].id'
+//@ set param_bool_proj = '$.index[*][?(@.docs=="param_bool_proj")].id'
+//@ set param_i32_proj = '$.index[*][?(@.docs=="param_i32_proj")].id'
 
-// @is '$.index[*][?(@.docs=="param_bool")].inner.impl.items[*]' $param_bool_proj
-// @is '$.index[*][?(@.docs=="param_i32")].inner.impl.items[*]' $param_i32_proj
+//@ is '$.index[*][?(@.docs=="param_bool")].inner.impl.items[*]' $param_bool_proj
+//@ is '$.index[*][?(@.docs=="param_i32")].inner.impl.items[*]' $param_i32_proj

--- a/tests/rustdoc-json/type_alias.rs
+++ b/tests/rustdoc-json/type_alias.rs
@@ -1,15 +1,15 @@
-// @set IntVec = "$.index[*][?(@.name=='IntVec')].id"
-// @is "$.index[*][?(@.name=='IntVec')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='IntVec')].inner.type_alias"
-// @is "$.index[*][?(@.name=='IntVec')].span.filename" $FILE
+//@ set IntVec = "$.index[*][?(@.name=='IntVec')].id"
+//@ is "$.index[*][?(@.name=='IntVec')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='IntVec')].inner.type_alias"
+//@ is "$.index[*][?(@.name=='IntVec')].span.filename" $FILE
 pub type IntVec = Vec<u32>;
 
-// @is "$.index[*][?(@.name=='f')].inner.function.decl.output.resolved_path.id" $IntVec
+//@ is "$.index[*][?(@.name=='f')].inner.function.decl.output.resolved_path.id" $IntVec
 pub fn f() -> IntVec {
     vec![0; 32]
 }
 
-// @!is "$.index[*][?(@.name=='g')].inner.function.decl.output.resolved_path.id" $IntVec
+//@ !is "$.index[*][?(@.name=='g')].inner.function.decl.output.resolved_path.id" $IntVec
 pub fn g() -> Vec<u32> {
     vec![0; 32]
 }

--- a/tests/rustdoc-json/unions/field_order.rs
+++ b/tests/rustdoc-json/unions/field_order.rs
@@ -15,24 +15,24 @@ pub union Foo {
     pub vll_9: i32,
 }
 
-// @set 0 = '$.index[*][?(@.name == "ews_0")].id'
-// @set 1 = '$.index[*][?(@.name == "dik_1")].id'
-// @set 2 = '$.index[*][?(@.name == "hsk_2")].id'
-// @set 3 = '$.index[*][?(@.name == "djt_3")].id'
-// @set 4 = '$.index[*][?(@.name == "jnr_4")].id'
-// @set 5 = '$.index[*][?(@.name == "dfs_5")].id'
-// @set 6 = '$.index[*][?(@.name == "bja_6")].id'
-// @set 7 = '$.index[*][?(@.name == "lyc_7")].id'
-// @set 8 = '$.index[*][?(@.name == "yqd_8")].id'
-// @set 9 = '$.index[*][?(@.name == "vll_9")].id'
+//@ set 0 = '$.index[*][?(@.name == "ews_0")].id'
+//@ set 1 = '$.index[*][?(@.name == "dik_1")].id'
+//@ set 2 = '$.index[*][?(@.name == "hsk_2")].id'
+//@ set 3 = '$.index[*][?(@.name == "djt_3")].id'
+//@ set 4 = '$.index[*][?(@.name == "jnr_4")].id'
+//@ set 5 = '$.index[*][?(@.name == "dfs_5")].id'
+//@ set 6 = '$.index[*][?(@.name == "bja_6")].id'
+//@ set 7 = '$.index[*][?(@.name == "lyc_7")].id'
+//@ set 8 = '$.index[*][?(@.name == "yqd_8")].id'
+//@ set 9 = '$.index[*][?(@.name == "vll_9")].id'
 
-// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[0]' $0
-// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[1]' $1
-// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[2]' $2
-// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[3]' $3
-// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[4]' $4
-// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[5]' $5
-// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[6]' $6
-// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[7]' $7
-// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[8]' $8
-// @is '$.index[*][?(@.name == "Foo")].inner.union.fields[9]' $9
+//@ is '$.index[*][?(@.name == "Foo")].inner.union.fields[0]' $0
+//@ is '$.index[*][?(@.name == "Foo")].inner.union.fields[1]' $1
+//@ is '$.index[*][?(@.name == "Foo")].inner.union.fields[2]' $2
+//@ is '$.index[*][?(@.name == "Foo")].inner.union.fields[3]' $3
+//@ is '$.index[*][?(@.name == "Foo")].inner.union.fields[4]' $4
+//@ is '$.index[*][?(@.name == "Foo")].inner.union.fields[5]' $5
+//@ is '$.index[*][?(@.name == "Foo")].inner.union.fields[6]' $6
+//@ is '$.index[*][?(@.name == "Foo")].inner.union.fields[7]' $7
+//@ is '$.index[*][?(@.name == "Foo")].inner.union.fields[8]' $8
+//@ is '$.index[*][?(@.name == "Foo")].inner.union.fields[9]' $9

--- a/tests/rustdoc-json/unions/impl.rs
+++ b/tests/rustdoc-json/unions/impl.rs
@@ -1,15 +1,15 @@
 #![no_std]
 
-// @is "$.index[*][?(@.name=='Ux')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='Ux')].inner.union"
+//@ is "$.index[*][?(@.name=='Ux')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='Ux')].inner.union"
 pub union Ux {
     a: u32,
     b: u64,
 }
 
-// @is "$.index[*][?(@.name=='Num')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='Num')].inner.trait"
+//@ is "$.index[*][?(@.name=='Num')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='Num')].inner.trait"
 pub trait Num {}
 
-// @count "$.index[*][?(@.name=='Ux')].inner.union.impls" 1
+//@ count "$.index[*][?(@.name=='Ux')].inner.union.impls" 1
 impl Num for Ux {}

--- a/tests/rustdoc-json/unions/union.rs
+++ b/tests/rustdoc-json/unions/union.rs
@@ -1,14 +1,14 @@
-// @has "$.index[*][?(@.name=='Union')].visibility" \"public\"
-// @has "$.index[*][?(@.name=='Union')].inner.union"
-// @!has "$.index[*][?(@.name=='Union')].inner.union.struct_type"
-// @set Union = "$.index[*][?(@.name=='Union')].id"
+//@ has "$.index[*][?(@.name=='Union')].visibility" \"public\"
+//@ has "$.index[*][?(@.name=='Union')].inner.union"
+//@ !has "$.index[*][?(@.name=='Union')].inner.union.struct_type"
+//@ set Union = "$.index[*][?(@.name=='Union')].id"
 pub union Union {
     int: i32,
     float: f32,
 }
 
-// @has "$.index[*][?(@.name=='make_int_union')].inner.function.decl.output.resolved_path"
-// @is "$.index[*][?(@.name=='make_int_union')].inner.function.decl.output.resolved_path.id" $Union
+//@ has "$.index[*][?(@.name=='make_int_union')].inner.function.decl.output.resolved_path"
+//@ is "$.index[*][?(@.name=='make_int_union')].inner.function.decl.output.resolved_path.id" $Union
 pub fn make_int_union(int: i32) -> Union {
     Union { int }
 }


### PR DESCRIPTION
Context: Comment chain in #125813.
Follow-up to #126788.
Use the same temporary approach of "double parsing" until we figure out how we want to support compiletest/ui_test directive "add-ons" for child test runners like HtmlDocCk and JsonDocCk.

I didn't touch much of jsondocck because I want to refactor it some other time (for robustness, maintainability and better diagnostics; basically by following a similar design of my WIP HtmlDocCk-next, cc #125780).

r? @GuillaumeGomez