### PR TITLE
Clean up warnings + `unsafe_op_in_unsafe_fn` when building std for armv6k-nintendo-3ds

### DIFF
--- a/library/std/src/os/horizon/mod.rs
+++ b/library/std/src/os/horizon/mod.rs
@@ -1,5 +1,6 @@
 //! Definitions for Horizon OS
 
+#![forbid(unsafe_op_in_unsafe_fn)]
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod fs;

--- a/library/std/src/os/horizon/raw.rs
+++ b/library/std/src/os/horizon/raw.rs
@@ -38,6 +38,7 @@ pub type time_t = libc::time_t;
 #[repr(C)]
 #[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
+#[allow(dead_code)] // This exists for parity with other `raw` modules, but isn't actually used.
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_dev: dev_t,

--- a/library/std/src/sys/pal/unix/alloc.rs
+++ b/library/std/src/sys/pal/unix/alloc.rs
@@ -67,7 +67,7 @@ cfg_if::cfg_if! {
     ))] {
         #[inline]
         unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
-            libc::memalign(layout.align(), layout.size()) as *mut u8
+            unsafe { libc::memalign(layout.align(), layout.size()) as *mut u8 }
         }
     } else {
         #[inline]

--- a/library/std/src/sys/pal/unix/process/process_unsupported.rs
+++ b/library/std/src/sys/pal/unix/process/process_unsupported.rs
@@ -1,4 +1,3 @@
-use crate::fmt;
 use crate::io;
 use crate::num::NonZero;
 use crate::sys::pal::unix::unsupported::*;


### PR DESCRIPTION
See #127747

ping @AzureMarker @Meziu 

I could only find one instance needing an extra `unsafe` that was not also shared with many other `unix` targets (presumably these will get covered in larger sweeping changes, I didn't want to introduce churn that would potentially conflict with those). The one codepath I found is shared with `vita` however, so also pinging @nikarh @pheki @zetanumbers just to make sure they're aware of this change.

Also removed one unused import from `process_unsupported` which should simply fix the warning for any target that uses it.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
