### PR TITLE
Fix stab display in doc blocks

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -831,6 +831,10 @@ pre, .rustdoc.src .example-wrap {
 	background: var(--table-alt-row-background-color);
 }
 
+.docblock .stab, .docblock-short .stab {
+	display: inline-block;
+}
+
 /* "where ..." clauses with block display are also smaller */
 div.where {
 	white-space: pre-wrap;

--- a/tests/rustdoc-gui/source-code-page-code-scroll.goml
+++ b/tests/rustdoc-gui/source-code-page-code-scroll.goml
@@ -2,7 +2,7 @@
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 set-window-size: (800, 1000)
 // "scrollWidth" should be superior than "clientWidth".
-assert-property: ("body", {"scrollWidth": 1047, "clientWidth": 800})
+assert-property: ("body", {"scrollWidth": 1114, "clientWidth": 800})
 
 // Both properties should be equal (ie, no scroll on the code block).
-assert-property: (".example-wrap .rust", {"scrollWidth": 933, "clientWidth": 933})
+assert-property: (".example-wrap .rust", {"scrollWidth": 1000, "clientWidth": 1000})

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -20,10 +20,10 @@ Also, stop using `bar` as it's <span class="stab deprecated" title="">deprecated
 Also, stop using `bar` as it's <span class="stab deprecated" title="">deprecated</span>.
 Also, stop using `bar` as it's <span class="stab deprecated" title="">deprecated</span>.
 
-Finally, you can use `quz` only on <span class="stab portability"><code>Unix or x86-64</code>
-</span>.
-Finally, you can use `quz` only on <span class="stab portability"><code>Unix or x86-64</code>
-</span>.
+Finally, you can use `quz` only on <span class="stab portability" data-span="1"><code>Unix or x86-64
+</code></span>.
+Finally, you can use `quz` only on <span class="stab portability" data-span="2"><code>Unix or x86-64
+</code></span>.
 */
 
 use std::convert::AsRef;

--- a/tests/rustdoc-gui/stab-in-doc.goml
+++ b/tests/rustdoc-gui/stab-in-doc.goml
@@ -1,0 +1,9 @@
+// This test ensure that `stab` elements if used in doc blocks are not breaking the text layout.
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+// We make the window wide enough for the two stabs who are looking into to be on the same line.
+set-window-size: (1100, 600)
+compare-elements-position: (
+    ".top-doc .docblock span[data-span='1']",
+    ".top-doc .docblock span[data-span='2']",
+    ["y"],
+)


### PR DESCRIPTION
Went across this bug randomly:

![Screenshot from 2024-07-20 22-09-49](https://github.com/user-attachments/assets/89fdf427-b00e-4fcb-9d57-078bcb1bacd9)

With the fixed CSS:

![Screenshot from 2024-07-20 22-10-14](https://github.com/user-attachments/assets/eda9a1a6-6a12-408f-bd3a-25bb3397d163)

r? @notriddle 