### PR TITLE
rustdoc: short descriptions cause word-breaks in tables

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -953,6 +953,7 @@ table,
 	display: table;
 	padding: 0;
 	margin: 0;
+	width: 100%;
 }
 .item-table > li {
 	display: table-row;


### PR DESCRIPTION
The `.item-table` class is used to display name+description lists, e.g. the exported functions, as a table. If the names are long and the descriptions are short, then the width of the table does not expand to the whole size, but only uses a fraction. This causes a some names to break inside a word.

This change makes the table always use 100% of its parent width. The `.width-limiter` wrapper already ensures that the used width still does not become excessive.

See e.g. <https://docs.rs/mathlab/0.3.0/mathlab/fun/vec_num/index.html> or <https://docs.rs/cw-events/0.0.9/cw_events/> (random choices out of the list of the recent releases).

[![](https://i.imgur.com/XnH4eeT.png)](https://imgur.com/XnH4eeT) [![](https://i.imgur.com/7iQ9xE2.png)](https://imgur.com/7iQ9xE2)

The problem occurs (at least) in Firefox 130, Falkon 24, and Konqueror 22. It does not occur in Chrome 126.