### PR TITLE
exhaustiveness: Explain why a given pattern is considered unreachable

### DIFF
--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -325,12 +325,16 @@ mir_build_union_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
 
 mir_build_union_pattern = cannot use unions in constant patterns
 
+mir_build_unreachable_making_this_unreachable = collectively making this unreachable
+
+mir_build_unreachable_matches_same_values = matches some of the same values
+
 mir_build_unreachable_pattern = unreachable pattern
     .label = unreachable pattern
     .unreachable_matches_no_values = this pattern matches no values because `{$ty}` is uninhabited
     .unreachable_covered_by_catchall = matches any value
     .unreachable_covered_by_one = matches all the values already
-    .unreachable_covered_by_many = matches some of the same values
+    .unreachable_covered_by_many = these patterns collectively make the last one unreachable
 
 mir_build_unsafe_fn_safe_body = an unsafe function restricts its caller, but its body is safe by default
 mir_build_unsafe_not_inherited = items do not inherit unsafety from separate enclosing items

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -327,7 +327,10 @@ mir_build_union_pattern = cannot use unions in constant patterns
 
 mir_build_unreachable_pattern = unreachable pattern
     .label = unreachable pattern
-    .catchall_label = matches any value
+    .unreachable_matches_no_values = this pattern matches no values because `{$ty}` is uninhabited
+    .unreachable_covered_by_catchall = matches any value
+    .unreachable_covered_by_one = matches all the values already
+    .unreachable_covered_by_many = matches some of the same values
 
 mir_build_unsafe_fn_safe_body = an unsafe function restricts its caller, but its body is safe by default
 mir_build_unsafe_not_inherited = items do not inherit unsafety from separate enclosing items

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -582,11 +582,37 @@ pub(crate) struct NonConstPath {
 
 #[derive(LintDiagnostic)]
 #[diag(mir_build_unreachable_pattern)]
-pub(crate) struct UnreachablePattern {
+pub(crate) struct UnreachablePattern<'tcx> {
     #[label]
     pub(crate) span: Option<Span>,
-    #[label(mir_build_catchall_label)]
-    pub(crate) catchall: Option<Span>,
+    #[subdiagnostic]
+    pub(crate) matches_no_values: Option<UnreachableMatchesNoValues<'tcx>>,
+    #[label(mir_build_unreachable_covered_by_catchall)]
+    pub(crate) covered_by_catchall: Option<Span>,
+    #[label(mir_build_unreachable_covered_by_one)]
+    pub(crate) covered_by_one: Option<Span>,
+    #[subdiagnostic]
+    pub(crate) covered_by_many: Option<UnreachableCoveredByMany>,
+}
+
+#[derive(Subdiagnostic)]
+#[note(mir_build_unreachable_matches_no_values)]
+pub(crate) struct UnreachableMatchesNoValues<'tcx> {
+    pub(crate) ty: Ty<'tcx>,
+}
+
+pub(crate) struct UnreachableCoveredByMany(pub(crate) Vec<Span>);
+
+impl Subdiagnostic for UnreachableCoveredByMany {
+    fn add_to_diag_with<G: EmissionGuarantee, F: SubdiagMessageOp<G>>(
+        self,
+        diag: &mut Diag<'_, G>,
+        _f: &F,
+    ) {
+        for span in self.0 {
+            diag.span_label(span, fluent::mir_build_unreachable_covered_by_many);
+        }
+    }
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -591,28 +591,14 @@ pub(crate) struct UnreachablePattern<'tcx> {
     pub(crate) covered_by_catchall: Option<Span>,
     #[label(mir_build_unreachable_covered_by_one)]
     pub(crate) covered_by_one: Option<Span>,
-    #[subdiagnostic]
-    pub(crate) covered_by_many: Option<UnreachableCoveredByMany>,
+    #[note(mir_build_unreachable_covered_by_many)]
+    pub(crate) covered_by_many: Option<MultiSpan>,
 }
 
 #[derive(Subdiagnostic)]
 #[note(mir_build_unreachable_matches_no_values)]
 pub(crate) struct UnreachableMatchesNoValues<'tcx> {
     pub(crate) ty: Ty<'tcx>,
-}
-
-pub(crate) struct UnreachableCoveredByMany(pub(crate) Vec<Span>);
-
-impl Subdiagnostic for UnreachableCoveredByMany {
-    fn add_to_diag_with<G: EmissionGuarantee, F: SubdiagMessageOp<G>>(
-        self,
-        diag: &mut Diag<'_, G>,
-        _f: &F,
-    ) {
-        for span in self.0 {
-            diag.span_label(span, fluent::mir_build_unreachable_covered_by_many);
-        }
-    }
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -391,12 +391,16 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
     ) -> Result<UsefulnessReport<'p, 'tcx>, ErrorGuaranteed> {
         let pattern_complexity_limit =
             get_limit_size(cx.tcx.hir().krate_attrs(), cx.tcx.sess, sym::pattern_complexity);
-        let report =
-            rustc_pattern_analysis::analyze_match(&cx, &arms, scrut_ty, pattern_complexity_limit)
-                .map_err(|err| {
-                self.error = Err(err);
-                err
-            })?;
+        let report = rustc_pattern_analysis::rustc::analyze_match(
+            &cx,
+            &arms,
+            scrut_ty,
+            pattern_complexity_limit,
+        )
+        .map_err(|err| {
+            self.error = Err(err);
+            err
+        })?;
 
         // Warn unreachable subpatterns.
         for (arm, is_useful) in report.arm_usefulness.iter() {

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -1,4 +1,6 @@
-//! Analysis of patterns, notably match exhaustiveness checking.
+//! Analysis of patterns, notably match exhaustiveness checking. The main entrypoint for this crate
+//! is [`usefulness::compute_match_usefulness`]. For rustc-specific types and entrypoints, see the
+//! [`rustc`] module.
 
 // tidy-alphabetical-start
 #![allow(rustc::diagnostic_outside_of_impl)]
@@ -23,14 +25,8 @@ use std::fmt;
 
 pub use rustc_index::{Idx, IndexVec}; // re-exported to avoid rustc_index version issues
 
-#[cfg(feature = "rustc")]
-use rustc_middle::ty::Ty;
-#[cfg(feature = "rustc")]
-use rustc_span::ErrorGuaranteed;
-
 use crate::constructor::{Constructor, ConstructorSet, IntRange};
 use crate::pat::DeconstructedPat;
-use crate::pat_column::PatternColumn;
 
 pub trait Captures<'a> {}
 impl<'a, T: ?Sized> Captures<'a> for T {}
@@ -128,30 +124,3 @@ impl<'p, Cx: PatCx> Clone for MatchArm<'p, Cx> {
 }
 
 impl<'p, Cx: PatCx> Copy for MatchArm<'p, Cx> {}
-
-/// The entrypoint for this crate. Computes whether a match is exhaustive and which of its arms are
-/// useful, and runs some lints.
-#[cfg(feature = "rustc")]
-pub fn analyze_match<'p, 'tcx>(
-    tycx: &rustc::RustcPatCtxt<'p, 'tcx>,
-    arms: &[rustc::MatchArm<'p, 'tcx>],
-    scrut_ty: Ty<'tcx>,
-    pattern_complexity_limit: Option<usize>,
-) -> Result<rustc::UsefulnessReport<'p, 'tcx>, ErrorGuaranteed> {
-    use lints::lint_nonexhaustive_missing_variants;
-    use usefulness::{compute_match_usefulness, PlaceValidity};
-
-    let scrut_ty = tycx.reveal_opaque_ty(scrut_ty);
-    let scrut_validity = PlaceValidity::from_bool(tycx.known_valid_scrutinee);
-    let report =
-        compute_match_usefulness(tycx, arms, scrut_ty, scrut_validity, pattern_complexity_limit)?;
-
-    // Run the non_exhaustive_omitted_patterns lint. Only run on refutable patterns to avoid hitting
-    // `if let`s. Only run if the match is exhaustive otherwise the error is redundant.
-    if tycx.refutable && report.non_exhaustiveness_witnesses.is_empty() {
-        let pat_column = PatternColumn::new(arms);
-        lint_nonexhaustive_missing_variants(tycx, arms, &pat_column, scrut_ty)?;
-    }
-
-    Ok(report)
-}

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -11,7 +11,7 @@ use crate::{PatCx, PrivateUninhabitedField};
 use self::Constructor::*;
 
 /// A globally unique id to distinguish patterns.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct PatId(u32);
 impl PatId {
     fn new() -> Self {
@@ -144,6 +144,21 @@ impl<Cx: PatCx> fmt::Debug for DeconstructedPat<Cx> {
             fields[ipat.idx] = PatOrWild::Pat(&ipat.pat);
         }
         self.ctor().fmt_fields(f, self.ty(), fields.into_iter())
+    }
+}
+
+/// Delegate to `uid`.
+impl<Cx: PatCx> PartialEq for DeconstructedPat<Cx> {
+    fn eq(&self, other: &Self) -> bool {
+        self.uid == other.uid
+    }
+}
+/// Delegate to `uid`.
+impl<Cx: PatCx> Eq for DeconstructedPat<Cx> {}
+/// Delegate to `uid`.
+impl<Cx: PatCx> std::hash::Hash for DeconstructedPat<Cx> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.uid.hash(state);
     }
 }
 

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -32,6 +32,8 @@ pub type Constructor<'p, 'tcx> = crate::constructor::Constructor<RustcPatCtxt<'p
 pub type ConstructorSet<'p, 'tcx> = crate::constructor::ConstructorSet<RustcPatCtxt<'p, 'tcx>>;
 pub type DeconstructedPat<'p, 'tcx> = crate::pat::DeconstructedPat<RustcPatCtxt<'p, 'tcx>>;
 pub type MatchArm<'p, 'tcx> = crate::MatchArm<'p, RustcPatCtxt<'p, 'tcx>>;
+pub type RedundancyExplanation<'p, 'tcx> =
+    crate::usefulness::RedundancyExplanation<'p, RustcPatCtxt<'p, 'tcx>>;
 pub type Usefulness<'p, 'tcx> = crate::usefulness::Usefulness<'p, RustcPatCtxt<'p, 'tcx>>;
 pub type UsefulnessReport<'p, 'tcx> =
     crate::usefulness::UsefulnessReport<'p, RustcPatCtxt<'p, 'tcx>>;

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -20,6 +20,9 @@ use rustc_target::abi::{FieldIdx, Integer, VariantIdx, FIRST_VARIANT};
 use crate::constructor::{
     IntRange, MaybeInfiniteInt, OpaqueId, RangeEnd, Slice, SliceKind, VariantVisibility,
 };
+use crate::lints::lint_nonexhaustive_missing_variants;
+use crate::pat_column::PatternColumn;
+use crate::usefulness::{compute_match_usefulness, PlaceValidity};
 use crate::{errors, Captures, PatCx, PrivateUninhabitedField};
 
 use crate::constructor::Constructor::*;
@@ -1057,4 +1060,27 @@ fn expand_or_pat<'p, 'tcx>(pat: &'p Pat<'tcx>) -> Vec<&'p Pat<'tcx>> {
     let mut pats = Vec::new();
     expand(pat, &mut pats);
     pats
+}
+
+/// The entrypoint for this crate. Computes whether a match is exhaustive and which of its arms are
+/// useful, and runs some lints.
+pub fn analyze_match<'p, 'tcx>(
+    tycx: &RustcPatCtxt<'p, 'tcx>,
+    arms: &[MatchArm<'p, 'tcx>],
+    scrut_ty: Ty<'tcx>,
+    pattern_complexity_limit: Option<usize>,
+) -> Result<UsefulnessReport<'p, 'tcx>, ErrorGuaranteed> {
+    let scrut_ty = tycx.reveal_opaque_ty(scrut_ty);
+    let scrut_validity = PlaceValidity::from_bool(tycx.known_valid_scrutinee);
+    let report =
+        compute_match_usefulness(tycx, arms, scrut_ty, scrut_validity, pattern_complexity_limit)?;
+
+    // Run the non_exhaustive_omitted_patterns lint. Only run on refutable patterns to avoid hitting
+    // `if let`s. Only run if the match is exhaustive otherwise the error is redundant.
+    if tycx.refutable && report.non_exhaustiveness_witnesses.is_empty() {
+        let pat_column = PatternColumn::new(arms);
+        lint_nonexhaustive_missing_variants(tycx, arms, &pat_column, scrut_ty)?;
+    }
+
+    Ok(report)
 }

--- a/compiler/rustc_pattern_analysis/tests/common/mod.rs
+++ b/compiler/rustc_pattern_analysis/tests/common/mod.rs
@@ -25,7 +25,7 @@ pub fn init_tracing() {
 
 /// A simple set of types.
 #[allow(dead_code)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Ty {
     /// Booleans
     Bool,
@@ -33,6 +33,8 @@ pub enum Ty {
     U8,
     /// Tuples.
     Tuple(&'static [Ty]),
+    /// Enum with one variant of each given type.
+    Enum(&'static [Ty]),
     /// A struct with `arity` fields of type `ty`.
     BigStruct { arity: usize, ty: &'static Ty },
     /// A enum with `arity` variants of type `ty`.
@@ -46,9 +48,20 @@ impl Ty {
         match (ctor, *self) {
             (Struct, Ty::Tuple(tys)) => tys.iter().copied().collect(),
             (Struct, Ty::BigStruct { arity, ty }) => (0..arity).map(|_| *ty).collect(),
+            (Variant(i), Ty::Enum(tys)) => vec![tys[*i]],
             (Variant(_), Ty::BigEnum { ty, .. }) => vec![*ty],
             (Bool(..) | IntRange(..) | NonExhaustive | Missing | Wildcard, _) => vec![],
             _ => panic!("Unexpected ctor {ctor:?} for type {self:?}"),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match *self {
+            Ty::Bool | Ty::U8 => false,
+            Ty::Tuple(tys) => tys.iter().any(|ty| ty.is_empty()),
+            Ty::Enum(tys) => tys.iter().all(|ty| ty.is_empty()),
+            Ty::BigStruct { arity, ty } => arity != 0 && ty.is_empty(),
+            Ty::BigEnum { arity, ty } => arity == 0 || ty.is_empty(),
         }
     }
 
@@ -64,10 +77,32 @@ impl Ty {
                 range_2: None,
             },
             Ty::Tuple(..) | Ty::BigStruct { .. } => ConstructorSet::Struct { empty: false },
-            Ty::BigEnum { arity, .. } => ConstructorSet::Variants {
-                variants: (0..arity).map(|_| VariantVisibility::Visible).collect(),
+            Ty::Enum(tys) if tys.is_empty() => ConstructorSet::NoConstructors,
+            Ty::Enum(tys) => ConstructorSet::Variants {
+                variants: tys
+                    .iter()
+                    .map(|ty| {
+                        if ty.is_empty() {
+                            VariantVisibility::Empty
+                        } else {
+                            VariantVisibility::Visible
+                        }
+                    })
+                    .collect(),
                 non_exhaustive: false,
             },
+            Ty::BigEnum { arity: 0, .. } => ConstructorSet::NoConstructors,
+            Ty::BigEnum { arity, ty } => {
+                let vis = if ty.is_empty() {
+                    VariantVisibility::Empty
+                } else {
+                    VariantVisibility::Visible
+                };
+                ConstructorSet::Variants {
+                    variants: (0..arity).map(|_| vis).collect(),
+                    non_exhaustive: false,
+                }
+            }
         }
     }
 
@@ -79,6 +114,7 @@ impl Ty {
         match (*self, ctor) {
             (Ty::Tuple(..), _) => Ok(()),
             (Ty::BigStruct { .. }, _) => write!(f, "BigStruct"),
+            (Ty::Enum(..), Constructor::Variant(i)) => write!(f, "Enum::Variant{i}"),
             (Ty::BigEnum { .. }, Constructor::Variant(i)) => write!(f, "BigEnum::Variant{i}"),
             _ => write!(f, "{:?}::{:?}", self, ctor),
         }
@@ -119,7 +155,7 @@ impl PatCx for Cx {
     }
 
     fn is_min_exhaustive_patterns_feature_on(&self) -> bool {
-        false
+        true
     }
 
     fn ctor_arity(&self, ctor: &Constructor<Self>, ty: &Self::Ty) -> usize {

--- a/compiler/rustc_pattern_analysis/tests/exhaustiveness.rs
+++ b/compiler/rustc_pattern_analysis/tests/exhaustiveness.rs
@@ -76,3 +76,17 @@ fn test_nested() {
         Struct(Variant.1, Variant.1),
     ));
 }
+
+#[test]
+fn test_empty() {
+    // `TY = Result<bool, !>`
+    const TY: Ty = Ty::Enum(&[Ty::Bool, Ty::Enum(&[])]);
+    assert_exhaustive(pats!(TY;
+        Variant.0,
+    ));
+    let ty = Ty::Tuple(&[Ty::Bool, TY]);
+    assert_exhaustive(pats!(ty;
+        (true, Variant.0),
+        (false, Variant.0),
+    ));
+}

--- a/compiler/rustc_pattern_analysis/tests/intersection.rs
+++ b/compiler/rustc_pattern_analysis/tests/intersection.rs
@@ -67,4 +67,24 @@ fn test_nested() {
         ),
         &[&[], &[]],
     );
+    let ty = Ty::Tuple(&[Ty::Bool; 3]);
+    assert_intersects(
+        pats!(ty;
+            (true, true, _),
+            (true, _, true),
+            (false, _, _),
+        ),
+        &[&[], &[], &[]],
+    );
+    let ty = Ty::Tuple(&[Ty::Bool, Ty::Bool, Ty::U8]);
+    assert_intersects(
+        pats!(ty;
+            (true, _, _),
+            (_, true, 0..10),
+            (_, true, 10..),
+            (_, true, 3),
+            _,
+        ),
+        &[&[], &[], &[], &[1], &[0, 1, 2, 3]],
+    );
 }

--- a/tests/ui/consts/packed_pattern.stderr
+++ b/tests/ui/consts/packed_pattern.stderr
@@ -1,8 +1,10 @@
 warning: unreachable pattern
   --> $DIR/packed_pattern.rs:16:9
    |
+LL |         Foo { field: (5, 6, 7, 8) } => {},
+   |         --------------------------- matches all the values already
 LL |         FOO => unreachable!(),
-   |         ^^^
+   |         ^^^ unreachable pattern
    |
    = note: `#[warn(unreachable_patterns)]` on by default
 

--- a/tests/ui/consts/packed_pattern2.stderr
+++ b/tests/ui/consts/packed_pattern2.stderr
@@ -1,8 +1,10 @@
 warning: unreachable pattern
   --> $DIR/packed_pattern2.rs:24:9
    |
+LL |         Bar { a: Foo { field: (5, 6) } } => {},
+   |         -------------------------------- matches all the values already
 LL |         FOO => unreachable!(),
-   |         ^^^
+   |         ^^^ unreachable pattern
    |
    = note: `#[warn(unreachable_patterns)]` on by default
 

--- a/tests/ui/error-codes/E0001.stderr
+++ b/tests/ui/error-codes/E0001.stderr
@@ -1,13 +1,18 @@
 error: unreachable pattern
   --> $DIR/E0001.rs:8:9
    |
+LL |         _ => {/* ... */}
+   |         ^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/E0001.rs:8:9
+   |
 LL |         Some(_) => {/* ... */}
    |         ------- matches some of the same values
 LL |         None => {/* ... */}
    |         ---- matches some of the same values
 LL |         _ => {/* ... */}
-   |         ^ unreachable pattern
-   |
+   |         ^ collectively making this unreachable
 note: the lint level is defined here
   --> $DIR/E0001.rs:1:9
    |

--- a/tests/ui/error-codes/E0001.stderr
+++ b/tests/ui/error-codes/E0001.stderr
@@ -1,8 +1,12 @@
 error: unreachable pattern
   --> $DIR/E0001.rs:8:9
    |
+LL |         Some(_) => {/* ... */}
+   |         ------- matches some of the same values
+LL |         None => {/* ... */}
+   |         ---- matches some of the same values
 LL |         _ => {/* ... */}
-   |         ^
+   |         ^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/E0001.rs:1:9

--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
@@ -29,6 +29,11 @@ fn main() {
         (1, 4 | 5) => {} //~ ERROR unreachable pattern
         _ => {}
     }
+    match (0u8, 0u8, 0u8) {
+        (0, 0, 0) => {}
+        (0, 0 | 1, 0) => {} //~ ERROR unreachable pattern
+        _ => {}
+    }
     match (true, true) {
         (false | true, false | true) => (),
     }

--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -23,12 +23,18 @@ LL |         (2,) => {}
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:19:9
    |
+LL |         (1 | 2,) => {}
+   |         ^^^^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:19:9
+   |
 LL |         (1,) => {}
    |         ---- matches some of the same values
 LL |         (2,) => {}
    |         ---- matches some of the same values
 LL |         (1 | 2,) => {}
-   |         ^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^ collectively making this unreachable
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:24:9
@@ -68,13 +74,19 @@ LL |         (2 | 1, 4) => {}
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:29:9
    |
+LL |         (1, 4 | 5) => {}
+   |         ^^^^^^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:29:9
+   |
 LL |         (1 | 2, 3 | 4) => {}
    |         -------------- matches some of the same values
 ...
 LL |         (1, 5 | 6) => {}
    |         ---------- matches some of the same values
 LL |         (1, 4 | 5) => {}
-   |         ^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^ collectively making this unreachable
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:34:13
@@ -177,10 +189,16 @@ LL |         (true, 0 | 0) => {}
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:84:17
    |
+LL |         (_, 0 | 0) => {}
+   |                 ^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:84:17
+   |
 LL |         (true, 0 | 0) => {}
    |                - matches some of the same values
 LL |         (_, 0 | 0) => {}
-   |             -   ^ unreachable pattern
+   |             -   ^ collectively making this unreachable
    |             |
    |             matches some of the same values
 
@@ -203,12 +221,18 @@ LL |         [true
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:111:36
    |
+LL |         (true | false, None | Some(true
+   |                                    ^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:111:36
+   |
 LL |         (true, Some(_)) => {}
    |                     - matches some of the same values
 LL |         (false, Some(true)) => {}
    |                      ---- matches some of the same values
 LL |         (true | false, None | Some(true
-   |                                    ^^^^ unreachable pattern
+   |                                    ^^^^ collectively making this unreachable
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:116:14
@@ -216,13 +240,21 @@ error: unreachable pattern
 LL |             (true
    |              ^^^^ unreachable pattern
 ...
+LL |         (true | false, None | Some(t_or_f!())) => {}
+   |                                    --------- in this macro invocation
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:116:14
+   |
+LL |             (true
+   |              ^^^^ collectively making this unreachable
+...
 LL |         (true, Some(_)) => {}
    |                     - matches some of the same values
 LL |         (false, Some(true)) => {}
    |                      ---- matches some of the same values
 LL |         (true | false, None | Some(t_or_f!())) => {}
    |                                    --------- in this macro invocation
-   |
    = note: this error originates in the macro `t_or_f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable pattern
@@ -245,15 +277,27 @@ LL |                 | false) => {}
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:154:15
    |
+LL |             | true) => {}
+   |               ^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:154:15
+   |
 LL |         (false, true) => {}
    |                 ---- matches some of the same values
 LL |         (true, true) => {}
    |                ---- matches some of the same values
 LL |         (false | true, false
 LL |             | true) => {}
-   |               ^^^^ unreachable pattern
+   |               ^^^^ collectively making this unreachable
 
 error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:160:15
+   |
+LL |             | true,
+   |               ^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
   --> $DIR/exhaustiveness-unreachable-pattern.rs:160:15
    |
 LL |         (true, false) => {}
@@ -262,7 +306,7 @@ LL |         (true, true) => {}
    |          ---- matches some of the same values
 LL |         (false
 LL |             | true,
-   |               ^^^^ unreachable pattern
+   |               ^^^^ collectively making this unreachable
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:165:15

--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -1,8 +1,10 @@
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:8:9
    |
+LL |         (1 | 2,) => {}
+   |         -------- matches all the values already
 LL |         (1,) => {}
-   |         ^^^^
+   |         ^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/exhaustiveness-unreachable-pattern.rs:1:9
@@ -13,212 +15,310 @@ LL | #![deny(unreachable_patterns)]
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:13:9
    |
+LL |         (1 | 2,) => {}
+   |         -------- matches all the values already
 LL |         (2,) => {}
-   |         ^^^^
+   |         ^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:19:9
    |
+LL |         (1,) => {}
+   |         ---- matches some of the same values
+LL |         (2,) => {}
+   |         ---- matches some of the same values
 LL |         (1 | 2,) => {}
-   |         ^^^^^^^^
+   |         ^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:24:9
    |
+LL |         (1 | 2, 3 | 4) => {}
+   |         -------------- matches all the values already
 LL |         (1, 3) => {}
-   |         ^^^^^^
+   |         ^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:25:9
    |
+LL |         (1 | 2, 3 | 4) => {}
+   |         -------------- matches all the values already
+LL |         (1, 3) => {}
 LL |         (1, 4) => {}
-   |         ^^^^^^
+   |         ^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:26:9
    |
+LL |         (1 | 2, 3 | 4) => {}
+   |         -------------- matches all the values already
+...
 LL |         (2, 4) => {}
-   |         ^^^^^^
+   |         ^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:27:9
    |
+LL |         (1 | 2, 3 | 4) => {}
+   |         -------------- matches all the values already
+...
 LL |         (2 | 1, 4) => {}
-   |         ^^^^^^^^^^
+   |         ^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:29:9
    |
+LL |         (1 | 2, 3 | 4) => {}
+   |         -------------- matches some of the same values
+...
+LL |         (1, 5 | 6) => {}
+   |         ---------- matches some of the same values
 LL |         (1, 4 | 5) => {}
-   |         ^^^^^^^^^^
+   |         ^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:37:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:34:13
    |
+LL |         (0, 0, 0) => {}
+   |             - matches all the values already
+LL |         (0, 0 | 1, 0) => {}
+   |             ^ unreachable pattern
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:42:9
+   |
+LL |         (None | Some(1 | 2),) => {}
+   |         --------------------- matches all the values already
 LL |         (Some(1),) => {}
-   |         ^^^^^^^^^^
-
-error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:38:9
-   |
-LL |         (None,) => {}
-   |         ^^^^^^^
+   |         ^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:43:9
    |
-LL |         ((1..=4,),) => {}
-   |         ^^^^^^^^^^^
+LL |         (None | Some(1 | 2),) => {}
+   |         --------------------- matches all the values already
+LL |         (Some(1),) => {}
+LL |         (None,) => {}
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:48:14
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:48:9
+   |
+LL |         ((1 | 2,) | (3 | 4,),) => {}
+   |         ---------------------- matches all the values already
+LL |         ((1..=4,),) => {}
+   |         ^^^^^^^^^^^ unreachable pattern
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:53:14
    |
 LL |         (1 | 1,) => {}
-   |              ^
+   |          -   ^ unreachable pattern
+   |          |
+   |          matches all the values already
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:52:19
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:57:19
    |
 LL |         (0 | 1) | 1 => {}
-   |                   ^
+   |              -    ^ unreachable pattern
+   |              |
+   |              matches all the values already
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:58:14
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:63:14
    |
 LL |         0 | (0 | 0) => {}
-   |              ^
+   |         -    ^ unreachable pattern
+   |         |
+   |         matches all the values already
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:58:18
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:63:18
    |
 LL |         0 | (0 | 0) => {}
-   |                  ^
+   |         -        ^ unreachable pattern
+   |         |
+   |         matches all the values already
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:66:13
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:71:13
    |
+LL |           Some(0) |
+   |           ------- matches all the values already
 LL | /             Some(
 LL | |                 0 | 0) => {}
-   | |______________________^
+   | |______________________^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:72:15
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:77:15
    |
+LL |         [0
+   |          - matches all the values already
 LL |             | 0
-   |               ^
+   |               ^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:74:15
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:79:15
    |
+LL |         , 0
+   |           - matches all the values already
 LL |             | 0] => {}
-   |               ^
+   |               ^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:78:20
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:83:20
    |
 LL |         (true, 0 | 0) => {}
-   |                    ^
+   |                -   ^ unreachable pattern
+   |                |
+   |                matches all the values already
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:79:17
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:84:17
    |
+LL |         (true, 0 | 0) => {}
+   |                - matches some of the same values
 LL |         (_, 0 | 0) => {}
-   |                 ^
+   |             -   ^ unreachable pattern
+   |             |
+   |             matches some of the same values
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:87:10
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:92:10
    |
+LL |         [1, ..] => {}
+   |          - matches all the values already
 LL |         [1
-   |          ^
+   |          ^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:99:10
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:104:10
    |
+LL |         [true, ..] => {}
+   |          ---- matches all the values already
 LL |         [true
-   |          ^^^^
+   |          ^^^^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:106:36
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:111:36
    |
+LL |         (true, Some(_)) => {}
+   |                     - matches some of the same values
+LL |         (false, Some(true)) => {}
+   |                      ---- matches some of the same values
 LL |         (true | false, None | Some(true
-   |                                    ^^^^
+   |                                    ^^^^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:111:14
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:116:14
    |
 LL |             (true
-   |              ^^^^
+   |              ^^^^ unreachable pattern
 ...
+LL |         (true, Some(_)) => {}
+   |                     - matches some of the same values
+LL |         (false, Some(true)) => {}
+   |                      ---- matches some of the same values
 LL |         (true | false, None | Some(t_or_f!())) => {}
    |                                    --------- in this macro invocation
    |
    = note: this error originates in the macro `t_or_f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:122:14
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:127:14
    |
+LL |         Some(0) => {}
+   |              - matches all the values already
 LL |         Some(0
-   |              ^
+   |              ^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:141:19
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:146:19
    |
+LL |         Some(false) => {}
+   |              ----- matches all the values already
+LL |         None | Some(true
 LL |                 | false) => {}
-   |                   ^^^^^
+   |                   ^^^^^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:149:15
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:154:15
    |
+LL |         (false, true) => {}
+   |                 ---- matches some of the same values
+LL |         (true, true) => {}
+   |                ---- matches some of the same values
+LL |         (false | true, false
 LL |             | true) => {}
-   |               ^^^^
-
-error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:155:15
-   |
-LL |             | true,
-   |               ^^^^
+   |               ^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:160:15
    |
-LL |             | (y, x) => {}
-   |               ^^^^^^
+LL |         (true, false) => {}
+   |          ---- matches some of the same values
+LL |         (true, true) => {}
+   |          ---- matches some of the same values
+LL |         (false
+LL |             | true,
+   |               ^^^^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:164:30
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:165:15
+   |
+LL |         (x, y)
+   |         ------ matches any value
+LL |             | (y, x) => {}
+   |               ^^^^^^ unreachable pattern
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:169:30
    |
 LL | fn unreachable_in_param((_ | (_, _)): (bool, bool)) {}
-   |                              ^^^^^^
+   |                          -   ^^^^^^ unreachable pattern
+   |                          |
+   |                          matches any value
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:171:14
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:176:14
    |
 LL |     let (_ | (_, _)) = bool_pair;
-   |              ^^^^^^
+   |          -   ^^^^^^ unreachable pattern
+   |          |
+   |          matches any value
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:173:14
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:178:14
    |
 LL |     for (_ | (_, _)) in [bool_pair] {}
-   |              ^^^^^^
+   |          -   ^^^^^^ unreachable pattern
+   |          |
+   |          matches any value
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:176:20
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:181:20
    |
 LL |     let (Some(_) | Some(true)) = bool_option else { return };
-   |                    ^^^^^^^^^^
+   |          -------   ^^^^^^^^^^ unreachable pattern
+   |          |
+   |          matches all the values already
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:178:22
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:183:22
    |
 LL |     if let Some(_) | Some(true) = bool_option {}
-   |                      ^^^^^^^^^^
+   |            -------   ^^^^^^^^^^ unreachable pattern
+   |            |
+   |            matches all the values already
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:180:25
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:185:25
    |
 LL |     while let Some(_) | Some(true) = bool_option {}
-   |                         ^^^^^^^^^^
+   |               -------   ^^^^^^^^^^ unreachable pattern
+   |               |
+   |               matches all the values already
 
-error: aborting due to 35 previous errors
+error: aborting due to 36 previous errors
 

--- a/tests/ui/pattern/usefulness/consts-opaque.stderr
+++ b/tests/ui/pattern/usefulness/consts-opaque.stderr
@@ -106,20 +106,28 @@ LL |         _ => {} // should not be emitting unreachable warning
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:72:9
    |
+LL |         BAZ => {}
+   |         --- matches all the values already
 LL |         Baz::Baz1 => {} // should not be emitting unreachable warning
-   |         ^^^^^^^^^
+   |         ^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:79:9
    |
+LL |         Baz::Baz1 => {}
+   |         --------- matches all the values already
 LL |         BAZ => {}
-   |         ^^^
+   |         ^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:87:9
    |
+LL |         BAZ => {}
+   |         --- matches some of the same values
+LL |         Baz::Baz2 => {}
+   |         --------- matches some of the same values
 LL |         _ => {} // should not be emitting unreachable warning
-   |         ^
+   |         ^ unreachable pattern
 
 error: aborting due to 17 previous errors
 

--- a/tests/ui/pattern/usefulness/consts-opaque.stderr
+++ b/tests/ui/pattern/usefulness/consts-opaque.stderr
@@ -122,12 +122,18 @@ LL |         BAZ => {}
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:87:9
    |
+LL |         _ => {} // should not be emitting unreachable warning
+   |         ^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/consts-opaque.rs:87:9
+   |
 LL |         BAZ => {}
    |         --- matches some of the same values
 LL |         Baz::Baz2 => {}
    |         --------- matches some of the same values
 LL |         _ => {} // should not be emitting unreachable warning
-   |         ^ unreachable pattern
+   |         ^ collectively making this unreachable
 
 error: aborting due to 17 previous errors
 

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
@@ -4,6 +4,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
+   = note: this pattern matches no values because `EmptyEnum` is uninhabited
 note: the lint level is defined here
   --> $DIR/empty-match-check-notes.rs:7:9
    |
@@ -11,25 +12,31 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:20:9
+  --> $DIR/empty-match-check-notes.rs:21:9
    |
 LL |         _ if false => {}
    |         ^
+   |
+   = note: this pattern matches no values because `EmptyEnum` is uninhabited
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:27:9
+  --> $DIR/empty-match-check-notes.rs:29:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `EmptyForeignEnum` is uninhabited
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:30:9
+  --> $DIR/empty-match-check-notes.rs:33:9
    |
 LL |         _ if false => {}
    |         ^
+   |
+   = note: this pattern matches no values because `EmptyForeignEnum` is uninhabited
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-match-check-notes.rs:35:9
+  --> $DIR/empty-match-check-notes.rs:39:9
    |
 LL |     let None = x;
    |         ^^^^ pattern `Some(_)` not covered
@@ -44,7 +51,7 @@ LL |     if let None = x { todo!() };
    |     ++              +++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u8..=u8::MAX` not covered
-  --> $DIR/empty-match-check-notes.rs:45:11
+  --> $DIR/empty-match-check-notes.rs:49:11
    |
 LL |     match 0u8 {
    |           ^^^ pattern `0_u8..=u8::MAX` not covered

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
@@ -4,6 +4,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
+   = note: this pattern matches no values because `EmptyEnum` is uninhabited
 note: the lint level is defined here
   --> $DIR/empty-match-check-notes.rs:7:9
    |
@@ -11,25 +12,31 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:20:9
+  --> $DIR/empty-match-check-notes.rs:21:9
    |
 LL |         _ if false => {}
    |         ^
+   |
+   = note: this pattern matches no values because `EmptyEnum` is uninhabited
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:27:9
+  --> $DIR/empty-match-check-notes.rs:29:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `EmptyForeignEnum` is uninhabited
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:30:9
+  --> $DIR/empty-match-check-notes.rs:33:9
    |
 LL |         _ if false => {}
    |         ^
+   |
+   = note: this pattern matches no values because `EmptyForeignEnum` is uninhabited
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-match-check-notes.rs:35:9
+  --> $DIR/empty-match-check-notes.rs:39:9
    |
 LL |     let None = x;
    |         ^^^^ pattern `Some(_)` not covered
@@ -43,7 +50,7 @@ LL |     if let None = x { todo!() };
    |     ++              +++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u8..=u8::MAX` not covered
-  --> $DIR/empty-match-check-notes.rs:45:11
+  --> $DIR/empty-match-check-notes.rs:49:11
    |
 LL |     match 0u8 {
    |           ^^^ pattern `0_u8..=u8::MAX` not covered

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.rs
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.rs
@@ -15,9 +15,11 @@ fn empty_enum(x: EmptyEnum) {
     match x {} // ok
     match x {
         _ => {} //~ ERROR unreachable pattern
+                //~^ NOTE matches no values
     }
     match x {
         _ if false => {} //~ ERROR unreachable pattern
+                         //~^ NOTE matches no values
     }
 }
 
@@ -25,9 +27,11 @@ fn empty_foreign_enum(x: empty::EmptyForeignEnum) {
     match x {} // ok
     match x {
         _ => {} //~ ERROR unreachable pattern
+                //~^ NOTE matches no values
     }
     match x {
         _ if false => {} //~ ERROR unreachable pattern
+                         //~^ NOTE matches no values
     }
 }
 

--- a/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
@@ -4,6 +4,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
+   = note: this pattern matches no values because `!` is uninhabited
 note: the lint level is defined here
   --> $DIR/empty-types.rs:17:9
    |
@@ -15,6 +16,8 @@ error: unreachable pattern
    |
 LL |         _x => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
   --> $DIR/empty-types.rs:58:11
@@ -36,24 +39,32 @@ error: unreachable pattern
    |
 LL |         (_, _) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `(u32, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:80:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:87:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
   --> $DIR/empty-types.rs:91:11
@@ -79,12 +90,16 @@ error: unreachable pattern
    |
 LL |         Err(_) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:104:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
   --> $DIR/empty-types.rs:101:11
@@ -123,114 +138,152 @@ error: unreachable pattern
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:123:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:126:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:127:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:130:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:131:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:140:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
    |
 LL |             _ if false => {}
    |             ^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:152:13
    |
 LL |             Some(_) => {}
    |             ^^^^^^^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:156:13
    |
+LL |             None => {}
+   |             ---- matches all the values already
 LL |             _ => {}
-   |             ^
+   |             ^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:208:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:213:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:218:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:223:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:229:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:291:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:294:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:295:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `&[!]` is non-empty
   --> $DIR/empty-types.rs:327:11
@@ -292,18 +345,24 @@ error: unreachable pattern
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `[!; 3]` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:372:9
    |
 LL |         [_, _, _] => {}
    |         ^^^^^^^^^
+   |
+   = note: this pattern matches no values because `[!; 3]` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:375:9
    |
 LL |         [_, ..] => {}
    |         ^^^^^^^
+   |
+   = note: this pattern matches no values because `[!; 3]` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
   --> $DIR/empty-types.rs:389:11
@@ -322,8 +381,10 @@ LL +     }
 error: unreachable pattern
   --> $DIR/empty-types.rs:396:9
    |
+LL |         [] => {}
+   |         -- matches all the values already
 LL |         _ => {}
-   |         ^
+   |         ^ unreachable pattern
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-types.rs:398:11
@@ -344,48 +405,66 @@ error: unreachable pattern
    |
 LL |         Some(_) => {}
    |         ^^^^^^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:422:9
    |
 LL |         Some(_a) => {}
    |         ^^^^^^^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:427:9
    |
+LL |         None => {}
+   |         ---- matches all the values already
+LL |         // !useful, !reachable
 LL |         _ => {}
-   |         ^
+   |         ^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:432:9
    |
+LL |         None => {}
+   |         ---- matches all the values already
+LL |         // !useful, !reachable
 LL |         _a => {}
-   |         ^^
+   |         ^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:604:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:607:9
    |
 LL |         _x => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:610:9
    |
 LL |         _ if false => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:613:9
    |
 LL |         _x if false => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: aborting due to 49 previous errors
 

--- a/tests/ui/pattern/usefulness/empty-types.min_exh_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.min_exh_pats.stderr
@@ -4,6 +4,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
+   = note: this pattern matches no values because `!` is uninhabited
 note: the lint level is defined here
   --> $DIR/empty-types.rs:17:9
    |
@@ -15,6 +16,8 @@ error: unreachable pattern
    |
 LL |         _x => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
   --> $DIR/empty-types.rs:58:11
@@ -36,24 +39,32 @@ error: unreachable pattern
    |
 LL |         (_, _) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `(u32, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:80:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:87:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
   --> $DIR/empty-types.rs:91:11
@@ -79,12 +90,16 @@ error: unreachable pattern
    |
 LL |         Err(_) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:104:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
   --> $DIR/empty-types.rs:101:11
@@ -137,60 +152,80 @@ error: unreachable pattern
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:123:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:126:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:127:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:130:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:131:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:140:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
    |
 LL |             _ if false => {}
    |             ^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:152:13
    |
 LL |             Some(_) => {}
    |             ^^^^^^^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:156:13
    |
+LL |             None => {}
+   |             ---- matches all the values already
 LL |             _ => {}
-   |             ^
+   |             ^ unreachable pattern
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
   --> $DIR/empty-types.rs:165:15
@@ -216,54 +251,72 @@ error: unreachable pattern
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:213:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:218:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:223:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:229:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:291:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:294:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:295:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
+   |
+   = note: this pattern matches no values because `Result<!, !>` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `(u32, !)` is non-empty
   --> $DIR/empty-types.rs:316:11
@@ -403,18 +456,24 @@ error: unreachable pattern
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `[!; 3]` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:372:9
    |
 LL |         [_, _, _] => {}
    |         ^^^^^^^^^
+   |
+   = note: this pattern matches no values because `[!; 3]` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:375:9
    |
 LL |         [_, ..] => {}
    |         ^^^^^^^
+   |
+   = note: this pattern matches no values because `[!; 3]` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
   --> $DIR/empty-types.rs:389:11
@@ -433,8 +492,10 @@ LL +     }
 error: unreachable pattern
   --> $DIR/empty-types.rs:396:9
    |
+LL |         [] => {}
+   |         -- matches all the values already
 LL |         _ => {}
-   |         ^
+   |         ^ unreachable pattern
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-types.rs:398:11
@@ -455,24 +516,34 @@ error: unreachable pattern
    |
 LL |         Some(_) => {}
    |         ^^^^^^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:422:9
    |
 LL |         Some(_a) => {}
    |         ^^^^^^^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:427:9
    |
+LL |         None => {}
+   |         ---- matches all the values already
+LL |         // !useful, !reachable
 LL |         _ => {}
-   |         ^
+   |         ^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:432:9
    |
+LL |         None => {}
+   |         ---- matches all the values already
+LL |         // !useful, !reachable
 LL |         _a => {}
-   |         ^^
+   |         ^^ unreachable pattern
 
 error[E0004]: non-exhaustive patterns: `&Some(_)` not covered
   --> $DIR/empty-types.rs:452:11
@@ -569,24 +640,32 @@ error: unreachable pattern
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:607:9
    |
 LL |         _x => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:610:9
    |
 LL |         _ if false => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:613:9
    |
 LL |         _x if false => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `&_` not covered
   --> $DIR/empty-types.rs:638:11

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -13,6 +13,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
+   = note: this pattern matches no values because `!` is uninhabited
 note: the lint level is defined here
   --> $DIR/empty-types.rs:17:9
    |
@@ -24,6 +25,8 @@ error: unreachable pattern
    |
 LL |         _x => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
   --> $DIR/empty-types.rs:58:11
@@ -73,6 +76,8 @@ error: unreachable pattern
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` and `Err(!)` not covered
   --> $DIR/empty-types.rs:91:11
@@ -218,12 +223,16 @@ error: unreachable pattern
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
    |
 LL |             _ if false => {}
    |             ^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Some(!)` not covered
   --> $DIR/empty-types.rs:146:15
@@ -266,36 +275,48 @@ error: unreachable pattern
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:213:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:218:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:223:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:229:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `(u32, !)` is non-empty
   --> $DIR/empty-types.rs:316:11
@@ -460,8 +481,10 @@ LL +     }
 error: unreachable pattern
   --> $DIR/empty-types.rs:396:9
    |
+LL |         [] => {}
+   |         -- matches all the values already
 LL |         _ => {}
-   |         ^
+   |         ^ unreachable pattern
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-types.rs:398:11
@@ -568,24 +591,32 @@ error: unreachable pattern
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:607:9
    |
 LL |         _x => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:610:9
    |
 LL |         _ if false => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:613:9
    |
 LL |         _x if false => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `&!` not covered
   --> $DIR/empty-types.rs:638:11

--- a/tests/ui/pattern/usefulness/empty-types.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.normal.stderr
@@ -4,6 +4,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
+   = note: this pattern matches no values because `!` is uninhabited
 note: the lint level is defined here
   --> $DIR/empty-types.rs:17:9
    |
@@ -15,6 +16,8 @@ error: unreachable pattern
    |
 LL |         _x => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
   --> $DIR/empty-types.rs:58:11
@@ -64,6 +67,8 @@ error: unreachable pattern
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` and `Err(_)` not covered
   --> $DIR/empty-types.rs:91:11
@@ -209,12 +214,16 @@ error: unreachable pattern
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
    |
 LL |             _ if false => {}
    |             ^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
   --> $DIR/empty-types.rs:146:15
@@ -257,36 +266,48 @@ error: unreachable pattern
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:213:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:218:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:223:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:229:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `(u32, !)` is non-empty
   --> $DIR/empty-types.rs:316:11
@@ -451,8 +472,10 @@ LL +     }
 error: unreachable pattern
   --> $DIR/empty-types.rs:396:9
    |
+LL |         [] => {}
+   |         -- matches all the values already
 LL |         _ => {}
-   |         ^
+   |         ^ unreachable pattern
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-types.rs:398:11
@@ -559,24 +582,32 @@ error: unreachable pattern
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:607:9
    |
 LL |         _x => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:610:9
    |
 LL |         _ if false => {}
    |         ^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:613:9
    |
 LL |         _x if false => {}
    |         ^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `&_` not covered
   --> $DIR/empty-types.rs:638:11

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
@@ -1,0 +1,97 @@
+#![feature(never_type)]
+#![feature(min_exhaustive_patterns)]
+#![deny(unreachable_patterns)]
+//~^ NOTE lint level is defined here
+
+#[rustfmt::skip]
+fn main() {
+    match (0u8,) {
+        (1 | 2,) => {}
+        //~^ NOTE matches all the values already
+        (2,) => {}
+        //~^ ERROR unreachable pattern
+        //~| NOTE unreachable pattern
+        _ => {}
+    }
+
+    match (0u8,) {
+        (1,) => {}
+        //~^ NOTE matches some of the same values
+        (2,) => {}
+        //~^ NOTE matches some of the same values
+        (1 | 2,) => {}
+        //~^ ERROR unreachable pattern
+        //~| NOTE unreachable pattern
+        _ => {}
+    }
+
+    let res: Result<(),!> = Ok(());
+    match res {
+        Ok(_) => {}
+        Err(_) => {}
+        //~^ ERROR unreachable pattern
+        //~| NOTE this pattern matches no values because `!` is uninhabited
+    }
+
+    #[derive(Copy, Clone)]
+    enum Void1 {}
+    #[derive(Copy, Clone)]
+    enum Void2 {}
+    // Only an empty type matched _by value_ can make an arm unreachable. We must get the right one.
+    let res1: Result<(), Void1> = Ok(());
+    let res2: Result<(), Void2> = Ok(());
+    match (&res1, res2) {
+        (Err(_), Err(_)) => {}
+        //~^ ERROR unreachable pattern
+        //~| NOTE this pattern matches no values because `Void2` is uninhabited
+        _ => {}
+    }
+    match (res1, &res2) {
+        (Err(_), Err(_)) => {}
+        //~^ ERROR unreachable pattern
+        //~| NOTE this pattern matches no values because `Void1` is uninhabited
+        _ => {}
+    }
+
+
+    if let (0
+        //~^ NOTE matches all the values already
+        | 0, _) = (0, 0) {}
+        //~^ ERROR unreachable pattern
+        //~| NOTE unreachable pattern
+
+    match (true, true) {
+        (_, true) if false => {} // Guarded patterns don't cover others
+        (true, _) => {}
+        //~^ NOTE matches some of the same values
+        (false, _) => {}
+        //~^ NOTE matches some of the same values
+        (_, true) => {}
+        //~^ ERROR unreachable pattern
+        //~| NOTE unreachable pattern
+    }
+
+    match (true, true) {
+        (true, _) => {}
+        //~^ NOTE matches all the values already
+        (false, _) => {}
+        #[allow(unreachable_patterns)]
+        (_, true) => {} // Doesn't cover below because it's already unreachable.
+        (true, true) => {}
+        //~^ ERROR unreachable pattern
+        //~| NOTE unreachable pattern
+    }
+
+    // Despite skipping some irrelevant cases, we still report a set of rows that covers the
+    // unreachable one.
+    match (true, true, 0) {
+        (true, _, _) => {}
+        (_, true, 0..10) => {}
+        //~^ NOTE matches all the values already
+        (_, true, 10..) => {}
+        (_, true, 3) => {}
+        //~^ ERROR unreachable pattern
+        //~| NOTE unreachable pattern
+        _ => {}
+    }
+}

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
@@ -22,6 +22,8 @@ fn main() {
         (1 | 2,) => {}
         //~^ ERROR unreachable pattern
         //~| NOTE unreachable pattern
+        //~| NOTE these patterns collectively make the last one unreachable
+        //~| NOTE collectively making this unreachable
         _ => {}
     }
 
@@ -69,6 +71,8 @@ fn main() {
         (_, true) => {}
         //~^ ERROR unreachable pattern
         //~| NOTE unreachable pattern
+        //~| NOTE these patterns collectively make the last one unreachable
+        //~| NOTE collectively making this unreachable
     }
 
     match (true, true) {

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
@@ -1,0 +1,92 @@
+error: unreachable pattern
+  --> $DIR/explain-unreachable-pats.rs:11:9
+   |
+LL |         (1 | 2,) => {}
+   |         -------- matches all the values already
+LL |
+LL |         (2,) => {}
+   |         ^^^^ unreachable pattern
+   |
+note: the lint level is defined here
+  --> $DIR/explain-unreachable-pats.rs:3:9
+   |
+LL | #![deny(unreachable_patterns)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/explain-unreachable-pats.rs:22:9
+   |
+LL |         (1,) => {}
+   |         ---- matches some of the same values
+LL |
+LL |         (2,) => {}
+   |         ---- matches some of the same values
+LL |
+LL |         (1 | 2,) => {}
+   |         ^^^^^^^^ unreachable pattern
+
+error: unreachable pattern
+  --> $DIR/explain-unreachable-pats.rs:31:9
+   |
+LL |         Err(_) => {}
+   |         ^^^^^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
+
+error: unreachable pattern
+  --> $DIR/explain-unreachable-pats.rs:44:9
+   |
+LL |         (Err(_), Err(_)) => {}
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern matches no values because `Void2` is uninhabited
+
+error: unreachable pattern
+  --> $DIR/explain-unreachable-pats.rs:50:9
+   |
+LL |         (Err(_), Err(_)) => {}
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern matches no values because `Void1` is uninhabited
+
+error: unreachable pattern
+  --> $DIR/explain-unreachable-pats.rs:59:11
+   |
+LL |     if let (0
+   |             - matches all the values already
+LL |
+LL |         | 0, _) = (0, 0) {}
+   |           ^ unreachable pattern
+
+error: unreachable pattern
+  --> $DIR/explain-unreachable-pats.rs:69:9
+   |
+LL |         (true, _) => {}
+   |         --------- matches some of the same values
+LL |
+LL |         (false, _) => {}
+   |         ---------- matches some of the same values
+LL |
+LL |         (_, true) => {}
+   |         ^^^^^^^^^ unreachable pattern
+
+error: unreachable pattern
+  --> $DIR/explain-unreachable-pats.rs:80:9
+   |
+LL |         (true, _) => {}
+   |         --------- matches all the values already
+...
+LL |         (true, true) => {}
+   |         ^^^^^^^^^^^^ unreachable pattern
+
+error: unreachable pattern
+  --> $DIR/explain-unreachable-pats.rs:92:9
+   |
+LL |         (_, true, 0..10) => {}
+   |         ---------------- matches all the values already
+...
+LL |         (_, true, 3) => {}
+   |         ^^^^^^^^^^^^ unreachable pattern
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
@@ -16,6 +16,12 @@ LL | #![deny(unreachable_patterns)]
 error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:22:9
    |
+LL |         (1 | 2,) => {}
+   |         ^^^^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/explain-unreachable-pats.rs:22:9
+   |
 LL |         (1,) => {}
    |         ---- matches some of the same values
 LL |
@@ -23,10 +29,10 @@ LL |         (2,) => {}
    |         ---- matches some of the same values
 LL |
 LL |         (1 | 2,) => {}
-   |         ^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^ collectively making this unreachable
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:31:9
+  --> $DIR/explain-unreachable-pats.rs:33:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
@@ -34,7 +40,7 @@ LL |         Err(_) => {}
    = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:44:9
+  --> $DIR/explain-unreachable-pats.rs:46:9
    |
 LL |         (Err(_), Err(_)) => {}
    |         ^^^^^^^^^^^^^^^^
@@ -42,7 +48,7 @@ LL |         (Err(_), Err(_)) => {}
    = note: this pattern matches no values because `Void2` is uninhabited
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:50:9
+  --> $DIR/explain-unreachable-pats.rs:52:9
    |
 LL |         (Err(_), Err(_)) => {}
    |         ^^^^^^^^^^^^^^^^
@@ -50,7 +56,7 @@ LL |         (Err(_), Err(_)) => {}
    = note: this pattern matches no values because `Void1` is uninhabited
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:59:11
+  --> $DIR/explain-unreachable-pats.rs:61:11
    |
 LL |     if let (0
    |             - matches all the values already
@@ -59,7 +65,13 @@ LL |         | 0, _) = (0, 0) {}
    |           ^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:69:9
+  --> $DIR/explain-unreachable-pats.rs:71:9
+   |
+LL |         (_, true) => {}
+   |         ^^^^^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/explain-unreachable-pats.rs:71:9
    |
 LL |         (true, _) => {}
    |         --------- matches some of the same values
@@ -68,10 +80,10 @@ LL |         (false, _) => {}
    |         ---------- matches some of the same values
 LL |
 LL |         (_, true) => {}
-   |         ^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^ collectively making this unreachable
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:80:9
+  --> $DIR/explain-unreachable-pats.rs:84:9
    |
 LL |         (true, _) => {}
    |         --------- matches all the values already
@@ -80,7 +92,7 @@ LL |         (true, true) => {}
    |         ^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:92:9
+  --> $DIR/explain-unreachable-pats.rs:96:9
    |
 LL |         (_, true, 0..10) => {}
    |         ---------------- matches all the values already

--- a/tests/ui/pattern/usefulness/floats.stderr
+++ b/tests/ui/pattern/usefulness/floats.stderr
@@ -14,8 +14,10 @@ LL +         _ => todo!()
 error: unreachable pattern
   --> $DIR/floats.rs:18:9
    |
+LL |         0.01f16..=6.5f16 => {}
+   |         ---------------- matches all the values already
 LL |         0.01f16 => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/floats.rs:1:9
@@ -26,80 +28,118 @@ LL | #![deny(unreachable_patterns)]
 error: unreachable pattern
   --> $DIR/floats.rs:19:9
    |
+LL |         0.01f16..=6.5f16 => {}
+   |         ---------------- matches all the values already
+LL |         0.01f16 => {}
 LL |         0.02f16 => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:20:9
    |
+LL |         0.01f16..=6.5f16 => {}
+   |         ---------------- matches all the values already
+...
 LL |         6.5f16 => {}
-   |         ^^^^^^
+   |         ^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:31:9
    |
+LL |         0.01f32..=6.5f32 => {}
+   |         ---------------- matches all the values already
 LL |         0.01f32 => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:32:9
    |
+LL |         0.01f32..=6.5f32 => {}
+   |         ---------------- matches all the values already
+LL |         0.01f32 => {}
 LL |         0.02f32 => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:33:9
    |
+LL |         0.01f32..=6.5f32 => {}
+   |         ---------------- matches all the values already
+...
 LL |         6.5f32 => {}
-   |         ^^^^^^
+   |         ^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:45:9
    |
+LL |         0.01f64..=6.5f64 => {}
+   |         ---------------- matches all the values already
+LL |         0.005f64 => {}
 LL |         0.01f64 => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:46:9
    |
+LL |         0.01f64..=6.5f64 => {}
+   |         ---------------- matches all the values already
+...
 LL |         0.02f64 => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:47:9
    |
+LL |         0.01f64..=6.5f64 => {}
+   |         ---------------- matches all the values already
+...
 LL |         6.5f64 => {}
-   |         ^^^^^^
+   |         ^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:49:9
    |
+LL |         0.01f64..=6.5f64 => {}
+   |         ---------------- matches all the values already
+...
 LL |         1.0f64..=4.0f64 => {}
-   |         ^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:62:9
    |
+LL |         0.01f128..=6.5f128 => {}
+   |         ------------------ matches all the values already
+LL |         0.005f128 => {}
 LL |         0.01f128 => {}
-   |         ^^^^^^^^
+   |         ^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:63:9
    |
+LL |         0.01f128..=6.5f128 => {}
+   |         ------------------ matches all the values already
+...
 LL |         0.02f128 => {}
-   |         ^^^^^^^^
+   |         ^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:64:9
    |
+LL |         0.01f128..=6.5f128 => {}
+   |         ------------------ matches all the values already
+...
 LL |         6.5f128 => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/floats.rs:66:9
    |
+LL |         0.01f128..=6.5f128 => {}
+   |         ------------------ matches all the values already
+...
 LL |         1.0f128..=4.0f128 => {}
-   |         ^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^ unreachable pattern
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/pattern/usefulness/impl-trait.stderr
+++ b/tests/ui/pattern/usefulness/impl-trait.stderr
@@ -4,6 +4,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
+   = note: this pattern matches no values because `Void` is uninhabited
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:5:9
    |
@@ -15,36 +16,48 @@ error: unreachable pattern
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:45:13
    |
 LL |             Some(_) => {}
    |             ^^^^^^^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:49:13
    |
+LL |             None => {}
+   |             ---- matches all the values already
 LL |             _ => {}
-   |             ^
+   |             ^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:59:13
    |
 LL |             Some(_) => {}
    |             ^^^^^^^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:63:13
    |
+LL |             None => {}
+   |             ---- matches all the values already
 LL |             _ => {}
-   |             ^
+   |             ^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:76:9
    |
 LL |         _ => {}
    |         ^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:86:9
@@ -59,12 +72,16 @@ error: unreachable pattern
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:105:9
    |
+LL |         Some((a, b)) => {}
+   |         ------------ matches all the values already
 LL |         Some((mut x, mut y)) => {
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:124:13
@@ -79,12 +96,16 @@ error: unreachable pattern
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `SecretelyVoid` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:151:13
    |
 LL |             _ => {}
    |             ^
+   |
+   = note: this pattern matches no values because `SecretelyDoubleVoid` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `impl Copy` is non-empty
   --> $DIR/impl-trait.rs:23:11

--- a/tests/ui/pattern/usefulness/integer-ranges/reachability.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/reachability.stderr
@@ -2,7 +2,9 @@ error: unreachable pattern
   --> $DIR/reachability.rs:18:17
    |
 LL |     m!(0u8, 42, 42);
-   |                 ^^
+   |             --  ^^ unreachable pattern
+   |             |
+   |             matches all the values already
    |
 note: the lint level is defined here
   --> $DIR/reachability.rs:3:9
@@ -14,121 +16,181 @@ error: unreachable pattern
   --> $DIR/reachability.rs:22:22
    |
 LL |     m!(0u8, 20..=30, 20);
-   |                      ^^
+   |             -------  ^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:23:22
    |
 LL |     m!(0u8, 20..=30, 21);
-   |                      ^^
+   |             -------  ^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:24:22
    |
 LL |     m!(0u8, 20..=30, 25);
-   |                      ^^
+   |             -------  ^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:25:22
    |
 LL |     m!(0u8, 20..=30, 29);
-   |                      ^^
+   |             -------  ^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:26:22
    |
 LL |     m!(0u8, 20..=30, 30);
-   |                      ^^
+   |             -------  ^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:29:21
    |
 LL |     m!(0u8, 20..30, 20);
-   |                     ^^
+   |             ------  ^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:30:21
    |
 LL |     m!(0u8, 20..30, 21);
-   |                     ^^
+   |             ------  ^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:31:21
    |
 LL |     m!(0u8, 20..30, 25);
-   |                     ^^
+   |             ------  ^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:32:21
    |
 LL |     m!(0u8, 20..30, 29);
-   |                     ^^
+   |             ------  ^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:36:22
    |
 LL |     m!(0u8, 20..=30, 20..=30);
-   |                      ^^^^^^^
+   |             -------  ^^^^^^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:37:22
    |
 LL |     m!(0u8, 20.. 30, 20.. 30);
-   |                      ^^^^^^^
+   |             -------  ^^^^^^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:38:22
    |
 LL |     m!(0u8, 20..=30, 20.. 30);
-   |                      ^^^^^^^
+   |             -------  ^^^^^^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:40:22
    |
 LL |     m!(0u8, 20..=30, 21..=30);
-   |                      ^^^^^^^
+   |             -------  ^^^^^^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:41:22
    |
 LL |     m!(0u8, 20..=30, 20..=29);
-   |                      ^^^^^^^
+   |             -------  ^^^^^^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:43:24
    |
 LL |     m!('a', 'A'..='z', 'a'..='z');
-   |                        ^^^^^^^^^
+   |             ---------  ^^^^^^^^^ unreachable pattern
+   |             |
+   |             matches all the values already
 
 error: unreachable pattern
   --> $DIR/reachability.rs:50:9
    |
+LL |         5 => {},
+   |         - matches some of the same values
+LL |         6 => {},
+   |         - matches some of the same values
+LL |         7 => {},
+   |         - matches some of the same values
+LL |         8 => {},
+   |         - matches some of the same values
 LL |         5..=8 => {},
-   |         ^^^^^
+   |         ^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/reachability.rs:56:9
    |
+LL |         0..10 => {},
+   |         ----- matches some of the same values
+LL |         10..20 => {},
+   |         ------ matches some of the same values
 LL |         5..15 => {},
-   |         ^^^^^
+   |         ^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/reachability.rs:63:9
    |
+LL |         0..10 => {},
+   |         ----- matches some of the same values
+LL |         10..20 => {},
+   |         ------ matches some of the same values
+LL |         20..30 => {},
+   |         ------ matches some of the same values
 LL |         5..25 => {},
-   |         ^^^^^
+   |         ^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/reachability.rs:71:9
    |
+LL |         0..10 => {},
+   |         ----- matches some of the same values
+LL |         10 => {},
+   |         -- matches some of the same values
+LL |         11..=23 => {},
+   |         ------- matches some of the same values
+LL |         19..30 => {},
+   |         ------ matches some of the same values
 LL |         5..25 => {},
-   |         ^^^^^
+   |         ^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/reachability.rs:77:9
    |
+LL |         0..10 => {},
+   |         ----- matches some of the same values
+LL |         10..20 => {},
+   |         ------ matches some of the same values
 LL |         5..15 => {},
-   |         ^^^^^
+   |         ^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/reachability.rs:84:9
@@ -141,20 +203,29 @@ LL |         '\u{D7FF}'..='\u{E000}' => {},
 error: unreachable pattern
   --> $DIR/reachability.rs:89:9
    |
+LL |         '\u{0}'..='\u{D7FF}' => {},
+   |         -------------------- matches some of the same values
+LL |         '\u{E000}'..='\u{10_FFFF}' => {},
+   |         -------------------------- matches some of the same values
 LL |         '\u{D7FF}'..='\u{E000}' => {},
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/reachability.rs:105:9
    |
+LL |         &42 => {}
+   |         --- matches all the values already
 LL |         &FOO => {}
-   |         ^^^^
+   |         ^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/reachability.rs:106:9
    |
+LL |         &42 => {}
+   |         --- matches all the values already
+LL |         &FOO => {}
 LL |         BAR => {}
-   |         ^^^
+   |         ^^^ unreachable pattern
 
 error: aborting due to 25 previous errors
 

--- a/tests/ui/pattern/usefulness/integer-ranges/reachability.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/reachability.stderr
@@ -135,6 +135,12 @@ LL |     m!('a', 'A'..='z', 'a'..='z');
 error: unreachable pattern
   --> $DIR/reachability.rs:50:9
    |
+LL |         5..=8 => {},
+   |         ^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/reachability.rs:50:9
+   |
 LL |         5 => {},
    |         - matches some of the same values
 LL |         6 => {},
@@ -144,9 +150,15 @@ LL |         7 => {},
 LL |         8 => {},
    |         - matches some of the same values
 LL |         5..=8 => {},
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ collectively making this unreachable
 
 error: unreachable pattern
+  --> $DIR/reachability.rs:56:9
+   |
+LL |         5..15 => {},
+   |         ^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
   --> $DIR/reachability.rs:56:9
    |
 LL |         0..10 => {},
@@ -154,9 +166,15 @@ LL |         0..10 => {},
 LL |         10..20 => {},
    |         ------ matches some of the same values
 LL |         5..15 => {},
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ collectively making this unreachable
 
 error: unreachable pattern
+  --> $DIR/reachability.rs:63:9
+   |
+LL |         5..25 => {},
+   |         ^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
   --> $DIR/reachability.rs:63:9
    |
 LL |         0..10 => {},
@@ -166,9 +184,15 @@ LL |         10..20 => {},
 LL |         20..30 => {},
    |         ------ matches some of the same values
 LL |         5..25 => {},
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ collectively making this unreachable
 
 error: unreachable pattern
+  --> $DIR/reachability.rs:71:9
+   |
+LL |         5..25 => {},
+   |         ^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
   --> $DIR/reachability.rs:71:9
    |
 LL |         0..10 => {},
@@ -180,9 +204,15 @@ LL |         11..=23 => {},
 LL |         19..30 => {},
    |         ------ matches some of the same values
 LL |         5..25 => {},
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ collectively making this unreachable
 
 error: unreachable pattern
+  --> $DIR/reachability.rs:77:9
+   |
+LL |         5..15 => {},
+   |         ^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
   --> $DIR/reachability.rs:77:9
    |
 LL |         0..10 => {},
@@ -190,7 +220,7 @@ LL |         0..10 => {},
 LL |         10..20 => {},
    |         ------ matches some of the same values
 LL |         5..15 => {},
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ collectively making this unreachable
 
 error: unreachable pattern
   --> $DIR/reachability.rs:84:9
@@ -203,12 +233,18 @@ LL |         '\u{D7FF}'..='\u{E000}' => {},
 error: unreachable pattern
   --> $DIR/reachability.rs:89:9
    |
+LL |         '\u{D7FF}'..='\u{E000}' => {},
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/reachability.rs:89:9
+   |
 LL |         '\u{0}'..='\u{D7FF}' => {},
    |         -------------------- matches some of the same values
 LL |         '\u{E000}'..='\u{10_FFFF}' => {},
    |         -------------------------- matches some of the same values
 LL |         '\u{D7FF}'..='\u{E000}' => {},
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ collectively making this unreachable
 
 error: unreachable pattern
   --> $DIR/reachability.rs:105:9

--- a/tests/ui/pattern/usefulness/issue-12116.stderr
+++ b/tests/ui/pattern/usefulness/issue-12116.stderr
@@ -1,8 +1,10 @@
 error: unreachable pattern
   --> $DIR/issue-12116.rs:15:9
    |
+LL |         &IntList::Cons(val, box ref next_list) => tail(next_list),
+   |         -------------------------------------- matches all the values already
 LL |         &IntList::Cons(val, box IntList::Nil)  => IntList::Cons(val, Box::new(IntList::Nil)),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/issue-12116.rs:4:9

--- a/tests/ui/pattern/usefulness/issue-12369.stderr
+++ b/tests/ui/pattern/usefulness/issue-12369.stderr
@@ -1,8 +1,12 @@
 error: unreachable pattern
   --> $DIR/issue-12369.rs:9:9
    |
+LL |         &[a,b,c] => 3,
+   |         -------- matches some of the same values
+LL |         &[a, ref rest @ ..] => a,
+   |         ------------------- matches some of the same values
 LL |         &[10,a, ref rest @ ..] => 10
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/issue-12369.rs:1:9

--- a/tests/ui/pattern/usefulness/issue-12369.stderr
+++ b/tests/ui/pattern/usefulness/issue-12369.stderr
@@ -1,13 +1,18 @@
 error: unreachable pattern
   --> $DIR/issue-12369.rs:9:9
    |
+LL |         &[10,a, ref rest @ ..] => 10
+   |         ^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/issue-12369.rs:9:9
+   |
 LL |         &[a,b,c] => 3,
    |         -------- matches some of the same values
 LL |         &[a, ref rest @ ..] => a,
    |         ------------------- matches some of the same values
 LL |         &[10,a, ref rest @ ..] => 10
-   |         ^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
-   |
+   |         ^^^^^^^^^^^^^^^^^^^^^^ collectively making this unreachable
 note: the lint level is defined here
   --> $DIR/issue-12369.rs:1:9
    |

--- a/tests/ui/pattern/usefulness/issue-13727.stderr
+++ b/tests/ui/pattern/usefulness/issue-13727.stderr
@@ -1,8 +1,10 @@
 error: unreachable pattern
   --> $DIR/issue-13727.rs:7:5
    |
+LL |     256 => print!("0b1110\n"),
+   |     --- matches all the values already
 LL |     512 => print!("0b1111\n"),
-   |     ^^^
+   |     ^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/issue-13727.rs:2:9

--- a/tests/ui/pattern/usefulness/issue-30240-b.stderr
+++ b/tests/ui/pattern/usefulness/issue-30240-b.stderr
@@ -2,7 +2,9 @@ error: unreachable pattern
   --> $DIR/issue-30240-b.rs:12:9
    |
 LL |         "hello" => {}
-   |         ^^^^^^^
+   |         ------- matches all the values already
+LL |         "hello" => {}
+   |         ^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/issue-30240-b.rs:1:9

--- a/tests/ui/pattern/usefulness/issue-31221.stderr
+++ b/tests/ui/pattern/usefulness/issue-31221.stderr
@@ -23,12 +23,18 @@ LL |         &Var2 => (),
 error: unreachable pattern
   --> $DIR/issue-31221.rs:31:9
    |
+LL |         anything => ()
+   |         ^^^^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/issue-31221.rs:31:9
+   |
 LL |         (Var1, b) => (),
    |         --------- matches some of the same values
 LL |         (c, d) => (),
    |         ------ matches some of the same values
 LL |         anything => ()
-   |         ^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^ collectively making this unreachable
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/pattern/usefulness/issue-31221.stderr
+++ b/tests/ui/pattern/usefulness/issue-31221.stderr
@@ -23,8 +23,10 @@ LL |         &Var2 => (),
 error: unreachable pattern
   --> $DIR/issue-31221.rs:31:9
    |
+LL |         (Var1, b) => (),
+   |         --------- matches some of the same values
 LL |         (c, d) => (),
-   |         ------ matches any value
+   |         ------ matches some of the same values
 LL |         anything => ()
    |         ^^^^^^^^ unreachable pattern
 

--- a/tests/ui/pattern/usefulness/issue-57472.stderr
+++ b/tests/ui/pattern/usefulness/issue-57472.stderr
@@ -1,8 +1,10 @@
 error: unreachable pattern
   --> $DIR/issue-57472.rs:15:13
    |
+LL |             Punned { foo: [_], .. } => println!("foo"),
+   |             ----------------------- matches all the values already
 LL |             Punned { bar: [_], .. } => println!("bar"),
-   |             ^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/issue-57472.rs:2:9
@@ -13,8 +15,10 @@ LL | #![deny(unreachable_patterns)]
 error: unreachable pattern
   --> $DIR/issue-57472.rs:32:17
    |
+LL |                 Punned { foo: [_] } => println!("foo"),
+   |                 ------------------- matches all the values already
 LL |                 Punned { bar: [_] } => println!("bar"),
-   |                 ^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^ unreachable pattern
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/pattern/usefulness/match-arm-statics.stderr
+++ b/tests/ui/pattern/usefulness/match-arm-statics.stderr
@@ -1,8 +1,11 @@
 error: unreachable pattern
   --> $DIR/match-arm-statics.rs:25:9
    |
+LL |         TRUE_TRUE => (),
+   |         --------- matches all the values already
+...
 LL |         (true, true) => ()
-   |         ^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/match-arm-statics.rs:2:9
@@ -13,14 +16,23 @@ LL | #![deny(unreachable_patterns)]
 error: unreachable pattern
   --> $DIR/match-arm-statics.rs:40:9
    |
+LL |         Some(Some(EAST)) => (),
+   |         ---------------- matches all the values already
+...
 LL |         Some(Some(East)) => (),
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/match-arm-statics.rs:60:9
    |
+LL |         Foo { bar: _, baz: NEW_FALSE } => (),
+   |         ------------------------------ matches some of the same values
+...
+LL |         Foo { bar: Some(EAST), .. } => (),
+   |         --------------------------- matches some of the same values
+LL |         Foo { bar: Some(North), baz: NewBool(true) } => (),
 LL |         Foo { bar: Some(EAST), baz: NewBool(false) } => ()
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/pattern/usefulness/match-arm-statics.stderr
+++ b/tests/ui/pattern/usefulness/match-arm-statics.stderr
@@ -25,6 +25,12 @@ LL |         Some(Some(East)) => (),
 error: unreachable pattern
   --> $DIR/match-arm-statics.rs:60:9
    |
+LL |         Foo { bar: Some(EAST), baz: NewBool(false) } => ()
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/match-arm-statics.rs:60:9
+   |
 LL |         Foo { bar: _, baz: NEW_FALSE } => (),
    |         ------------------------------ matches some of the same values
 ...
@@ -32,7 +38,7 @@ LL |         Foo { bar: Some(EAST), .. } => (),
    |         --------------------------- matches some of the same values
 LL |         Foo { bar: Some(North), baz: NewBool(true) } => (),
 LL |         Foo { bar: Some(EAST), baz: NewBool(false) } => ()
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ collectively making this unreachable
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/pattern/usefulness/match-byte-array-patterns.stderr
+++ b/tests/ui/pattern/usefulness/match-byte-array-patterns.stderr
@@ -1,8 +1,10 @@
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:8:9
    |
+LL |         b"AAAA" => {},
+   |         ------- matches all the values already
 LL |         &[0x41, 0x41, 0x41, 0x41] => {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/match-byte-array-patterns.rs:1:9
@@ -13,44 +15,58 @@ LL | #![deny(unreachable_patterns)]
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:14:9
    |
+LL |         &[0x41, 0x41, 0x41, 0x41] => {}
+   |         ------------------------- matches all the values already
 LL |         b"AAAA" => {},
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:20:9
    |
+LL |         &[_, 0x41, 0x41, 0x41] => {},
+   |         ---------------------- matches all the values already
 LL |         b"AAAA" => {},
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:26:9
    |
+LL |         &[0x41, .., 0x41] => {}
+   |         ----------------- matches all the values already
 LL |         b"AAAA" => {},
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:34:9
    |
+LL |         b"AAAA" => {},
+   |         ------- matches all the values already
 LL |         &[0x41, 0x41, 0x41, 0x41] => {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:40:9
    |
+LL |         &[0x41, 0x41, 0x41, 0x41] => {}
+   |         ------------------------- matches all the values already
 LL |         b"AAAA" => {},
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:46:9
    |
+LL |         &[_, 0x41, 0x41, 0x41] => {},
+   |         ---------------------- matches all the values already
 LL |         b"AAAA" => {},
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:52:9
    |
+LL |         &[0x41, .., 0x41] => {}
+   |         ----------------- matches all the values already
 LL |         b"AAAA" => {},
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/pattern/usefulness/match-ref-ice.stderr
+++ b/tests/ui/pattern/usefulness/match-ref-ice.stderr
@@ -1,8 +1,10 @@
 error: unreachable pattern
   --> $DIR/match-ref-ice.rs:13:9
    |
+LL |         [1, ref _madoka, 3] => (),
+   |         ------------------- matches all the values already
 LL |         [1, 2, 3] => (),
-   |         ^^^^^^^^^
+   |         ^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/match-ref-ice.rs:1:9

--- a/tests/ui/pattern/usefulness/match-vec-fixed.stderr
+++ b/tests/ui/pattern/usefulness/match-vec-fixed.stderr
@@ -2,7 +2,9 @@ error: unreachable pattern
   --> $DIR/match-vec-fixed.rs:7:9
    |
 LL |         [_, _, _] => {}
-   |         ^^^^^^^^^
+   |         --------- matches all the values already
+LL |         [_, _, _] => {}
+   |         ^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/match-vec-fixed.rs:1:9
@@ -14,7 +16,9 @@ error: unreachable pattern
   --> $DIR/match-vec-fixed.rs:11:9
    |
 LL |         [_, 1, _] => {}
-   |         ^^^^^^^^^
+   |         --------- matches all the values already
+LL |         [_, 1, _] => {}
+   |         ^^^^^^^^^ unreachable pattern
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/pattern/usefulness/match-vec-unreachable.stderr
+++ b/tests/ui/pattern/usefulness/match-vec-unreachable.stderr
@@ -1,8 +1,10 @@
 error: unreachable pattern
   --> $DIR/match-vec-unreachable.rs:8:9
    |
+LL |         [a, (2, 3), _] => (),
+   |         -------------- matches all the values already
 LL |         [(1, 2), (2, 3), b] => (),
-   |         ^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/match-vec-unreachable.rs:1:9
@@ -13,14 +15,18 @@ LL | #![deny(unreachable_patterns)]
 error: unreachable pattern
   --> $DIR/match-vec-unreachable.rs:18:9
    |
+LL |         [ref a, _, _, ..] => { println!("{}", a); }
+   |         ----------------- matches all the values already
 LL |         [_, _, _, _, _] => { }
-   |         ^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/match-vec-unreachable.rs:26:9
    |
+LL |         ['a', 'b', 'c', ref _tail @ ..] => {}
+   |         ------------------------------- matches all the values already
 LL |         ['a', 'b', 'c'] => {}
-   |         ^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^ unreachable pattern
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/pattern/usefulness/slice-pattern-const-2.stderr
+++ b/tests/ui/pattern/usefulness/slice-pattern-const-2.stderr
@@ -1,8 +1,11 @@
 error: unreachable pattern
   --> $DIR/slice-pattern-const-2.rs:9:9
    |
+LL |         MAGIC_TEST => (),
+   |         ---------- matches all the values already
+LL |         [0x00, 0x00, 0x00, 0x00] => (),
 LL |         [4, 5, 6, 7] => (),
-   |         ^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/slice-pattern-const-2.rs:1:9
@@ -13,20 +16,26 @@ LL | #![deny(unreachable_patterns)]
 error: unreachable pattern
   --> $DIR/slice-pattern-const-2.rs:15:9
    |
+LL |         MAGIC_TEST => (),
+   |         ---------- matches all the values already
 LL |         [4, 5, 6, 7] => (),
-   |         ^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const-2.rs:21:9
    |
+LL |         [4, 5, 6, 7] => (),
+   |         ------------ matches all the values already
 LL |         MAGIC_TEST => (),
-   |         ^^^^^^^^^^
+   |         ^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const-2.rs:28:9
    |
+LL |         [4] => (),
+   |         --- matches all the values already
 LL |         FOO => (),
-   |         ^^^
+   |         ^^^ unreachable pattern
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pattern/usefulness/slice-pattern-const-3.stderr
+++ b/tests/ui/pattern/usefulness/slice-pattern-const-3.stderr
@@ -1,8 +1,11 @@
 error: unreachable pattern
   --> $DIR/slice-pattern-const-3.rs:9:9
    |
+LL |         MAGIC_TEST => (),
+   |         ---------- matches all the values already
+LL |         ["0x00", "0x00", "0x00", "0x00"] => (),
 LL |         ["4", "5", "6", "7"] => (),
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/slice-pattern-const-3.rs:1:9
@@ -13,20 +16,26 @@ LL | #![deny(unreachable_patterns)]
 error: unreachable pattern
   --> $DIR/slice-pattern-const-3.rs:15:9
    |
+LL |         MAGIC_TEST => (),
+   |         ---------- matches all the values already
 LL |         ["4", "5", "6", "7"] => (),
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const-3.rs:21:9
    |
+LL |         ["4", "5", "6", "7"] => (),
+   |         -------------------- matches all the values already
 LL |         MAGIC_TEST => (),
-   |         ^^^^^^^^^^
+   |         ^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const-3.rs:28:9
    |
+LL |         ["boo"] => (),
+   |         ------- matches all the values already
 LL |         FOO => (),
-   |         ^^^
+   |         ^^^ unreachable pattern
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pattern/usefulness/slice-pattern-const.stderr
+++ b/tests/ui/pattern/usefulness/slice-pattern-const.stderr
@@ -1,8 +1,11 @@
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:9:9
    |
+LL |         MAGIC_TEST => (),
+   |         ---------- matches all the values already
+LL |         [0x00, 0x00, 0x00, 0x00] => (),
 LL |         [84, 69, 83, 84] => (),
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/slice-pattern-const.rs:1:9
@@ -13,50 +16,68 @@ LL | #![deny(unreachable_patterns)]
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:15:9
    |
+LL |         MAGIC_TEST => (),
+   |         ---------- matches all the values already
 LL |         [84, 69, 83, 84] => (),
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:21:9
    |
+LL |         [84, 69, 83, 84] => (),
+   |         ---------------- matches all the values already
 LL |         MAGIC_TEST => (),
-   |         ^^^^^^^^^^
+   |         ^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:28:9
    |
+LL |         [4] => (),
+   |         --- matches all the values already
 LL |         FOO => (),
-   |         ^^^
+   |         ^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:35:9
    |
+LL |         [4] => (),
+   |         --- matches all the values already
 LL |         BAR => (),
-   |         ^^^
+   |         ^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:43:9
    |
+LL |         [] => (),
+   |         -- matches all the values already
 LL |         BOO => (),
-   |         ^^^
+   |         ^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:44:9
    |
+LL |         [] => (),
+   |         -- matches all the values already
+LL |         BOO => (),
 LL |         b"" => (),
-   |         ^^^
+   |         ^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:45:9
    |
+LL |         [] => (),
+   |         -- matches all the values already
+...
 LL |         _ => (),
-   |         ^
+   |         ^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:51:9
    |
+LL |         CONST1 => {}
+   |         ------ matches all the values already
 LL |         [true] => {}
-   |         ^^^^^^
+   |         ^^^^^^ unreachable pattern
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/pattern/usefulness/slice-patterns-reachability.stderr
+++ b/tests/ui/pattern/usefulness/slice-patterns-reachability.stderr
@@ -2,7 +2,9 @@ error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:8:9
    |
 LL |         [true, ..] => {}
-   |         ^^^^^^^^^^
+   |         ---------- matches all the values already
+LL |         [true, ..] => {}
+   |         ^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/slice-patterns-reachability.rs:1:9
@@ -13,32 +15,45 @@ LL | #![deny(unreachable_patterns)]
 error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:9:9
    |
+LL |         [true, ..] => {}
+   |         ---------- matches all the values already
+LL |         [true, ..] => {}
 LL |         [true] => {}
-   |         ^^^^^^
+   |         ^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:14:9
    |
 LL |         [.., true] => {}
-   |         ^^^^^^^^^^
+   |         ---------- matches all the values already
+LL |         [.., true] => {}
+   |         ^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:15:9
    |
+LL |         [.., true] => {}
+   |         ---------- matches all the values already
+LL |         [.., true] => {}
 LL |         [true] => {}
-   |         ^^^^^^
+   |         ^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:20:9
    |
 LL |         [false, .., true] => {}
-   |         ^^^^^^^^^^^^^^^^^
+   |         ----------------- matches all the values already
+LL |         [false, .., true] => {}
+   |         ^^^^^^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:21:9
    |
+LL |         [false, .., true] => {}
+   |         ----------------- matches all the values already
+LL |         [false, .., true] => {}
 LL |         [false, true] => {}
-   |         ^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^ unreachable pattern
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/pattern/usefulness/top-level-alternation.stderr
+++ b/tests/ui/pattern/usefulness/top-level-alternation.stderr
@@ -2,7 +2,9 @@ error: unreachable pattern
   --> $DIR/top-level-alternation.rs:4:23
    |
 LL |     while let 0..=2 | 1 = 0 {}
-   |                       ^
+   |               -----   ^ unreachable pattern
+   |               |
+   |               matches all the values already
    |
 note: the lint level is defined here
   --> $DIR/top-level-alternation.rs:1:9
@@ -14,61 +16,84 @@ error: unreachable pattern
   --> $DIR/top-level-alternation.rs:5:20
    |
 LL |     if let 0..=2 | 1 = 0 {}
-   |                    ^
+   |            -----   ^ unreachable pattern
+   |            |
+   |            matches all the values already
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:9:15
    |
+LL |         0
+   |         - matches all the values already
 LL |             | 0 => {}
-   |               ^
+   |               ^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:14:15
    |
+LL |         Some(0)
+   |         ------- matches all the values already
 LL |             | Some(0) => {}
-   |               ^^^^^^^
+   |               ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:19:9
    |
+LL |         (0, _) | (_, 0) => {}
+   |         --------------- matches all the values already
 LL |         (0, 0) => {}
-   |         ^^^^^^
+   |         ^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:39:9
    |
+LL |         None | Some(_) => {}
+   |         -------------- matches all the values already
 LL |         _ => {}
-   |         ^
+   |         ^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:43:9
    |
+LL |         None | Some(_) => {}
+   |         -------------- matches all the values already
 LL |         Some(_) => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:44:9
    |
+LL |         None | Some(_) => {}
+   |         -------------- matches all the values already
+LL |         Some(_) => {}
 LL |         None => {}
-   |         ^^^^
+   |         ^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:49:9
    |
+LL |         Some(_) => {}
+   |         ------- matches some of the same values
+LL |         None => {}
+   |         ---- matches some of the same values
 LL |         None | Some(_) => {}
-   |         ^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:53:9
    |
+LL |         1 | 2 => {},
+   |         ----- matches all the values already
 LL |         1..=2 => {},
-   |         ^^^^^
+   |         ^^^^^ unreachable pattern
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:56:14
    |
 LL |     let (0 | 0) = 0 else { return };
-   |              ^
+   |          -   ^ unreachable pattern
+   |          |
+   |          matches all the values already
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/pattern/usefulness/top-level-alternation.stderr
+++ b/tests/ui/pattern/usefulness/top-level-alternation.stderr
@@ -72,12 +72,18 @@ LL |         None => {}
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:49:9
    |
+LL |         None | Some(_) => {}
+   |         ^^^^^^^^^^^^^^ unreachable pattern
+   |
+note: these patterns collectively make the last one unreachable
+  --> $DIR/top-level-alternation.rs:49:9
+   |
 LL |         Some(_) => {}
    |         ------- matches some of the same values
 LL |         None => {}
    |         ---- matches some of the same values
 LL |         None | Some(_) => {}
-   |         ^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^ collectively making this unreachable
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:53:9

--- a/tests/ui/reachable/unreachable-arm.stderr
+++ b/tests/ui/reachable/unreachable-arm.stderr
@@ -1,8 +1,10 @@
 error: unreachable pattern
   --> $DIR/unreachable-arm.rs:11:9
    |
+LL |         Foo::B(_) | Foo::A(box _, 1) => { }
+   |         ---------------------------- matches all the values already
 LL |         Foo::A(_, 1) => { }
-   |         ^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/unreachable-arm.rs:4:9

--- a/tests/ui/reachable/unreachable-loop-patterns.stderr
+++ b/tests/ui/reachable/unreachable-loop-patterns.stderr
@@ -4,6 +4,7 @@ error: unreachable pattern
 LL |     for _ in unimplemented!() as Void {}
    |         ^
    |
+   = note: this pattern matches no values because `Void` is uninhabited
 note: the lint level is defined here
   --> $DIR/unreachable-loop-patterns.rs:5:9
    |

--- a/tests/ui/reachable/unreachable-try-pattern.stderr
+++ b/tests/ui/reachable/unreachable-try-pattern.stderr
@@ -19,6 +19,7 @@ warning: unreachable pattern
 LL |     let y = (match x { Ok(n) => Ok(n as u32), Err(e) => Err(e) })?;
    |                        ^^^^^
    |
+   = note: this pattern matches no values because `!` is uninhabited
 note: the lint level is defined here
   --> $DIR/unreachable-try-pattern.rs:4:9
    |
@@ -30,6 +31,8 @@ warning: unreachable pattern
    |
 LL |     let y = (match x { Ok(n) => Ok(n), Err(e) => Err(e) })?;
    |                                        ^^^^^^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 warning: 3 warnings emitted
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.exh_pats.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.exh_pats.stderr
@@ -4,6 +4,7 @@ error: unreachable pattern
 LL |         Err(!),
    |         ^^^^^^
    |
+   = note: this pattern matches no values because `Void` is uninhabited
 note: the lint level is defined here
   --> $DIR/unreachable.rs:7:9
    |
@@ -15,30 +16,40 @@ error: unreachable pattern
    |
 LL |     let (Ok(_x) | Err(!)) = res_void;
    |                   ^^^^^^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:22:12
    |
 LL |     if let Err(!) = res_void {}
    |            ^^^^^^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:24:24
    |
 LL |     if let (Ok(true) | Err(!)) = res_void {}
    |                        ^^^^^^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:26:23
    |
 LL |     for (Ok(mut _x) | Err(!)) in [res_void] {}
    |                       ^^^^^^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:30:18
    |
 LL | fn foo((Ok(_x) | Err(!)): Result<bool, Void>) {}
    |                  ^^^^^^
+   |
+   = note: this pattern matches no values because `Void` is uninhabited
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
@@ -4,6 +4,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
+   = note: this pattern matches no values because `EmptyNonExhaustiveEnum` is uninhabited
 note: the lint level is defined here
   --> $DIR/enum_same_crate_empty_match.rs:1:9
    |

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/issue-65157-repeated-match-arm.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/issue-65157-repeated-match-arm.stderr
@@ -2,7 +2,9 @@ error: unreachable pattern
   --> $DIR/issue-65157-repeated-match-arm.rs:15:9
    |
 LL |         PartiallyInhabitedVariants::Struct { .. } => {},
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ----------------------------------------- matches all the values already
+LL |         PartiallyInhabitedVariants::Struct { .. } => {},
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
    |
 note: the lint level is defined here
   --> $DIR/issue-65157-repeated-match-arm.rs:2:9

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
@@ -4,6 +4,7 @@ error: unreachable pattern
 LL |         Some(_x) => (),
    |         ^^^^^^^^
    |
+   = note: this pattern matches no values because `UninhabitedEnum` is uninhabited
 note: the lint level is defined here
   --> $DIR/patterns_same_crate.rs:1:9
    |
@@ -15,24 +16,32 @@ error: unreachable pattern
    |
 LL |         Some(_x) => (),
    |         ^^^^^^^^
+   |
+   = note: this pattern matches no values because `UninhabitedVariants` is uninhabited
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:61:15
    |
 LL |     while let PartiallyInhabitedVariants::Struct { x } = partially_inhabited_variant() {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:65:15
    |
 LL |     while let Some(_x) = uninhabited_struct() {
    |               ^^^^^^^^
+   |
+   = note: this pattern matches no values because `UninhabitedStruct` is uninhabited
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:68:15
    |
 LL |     while let Some(_x) = uninhabited_tuple_struct() {
    |               ^^^^^^^^
+   |
+   = note: this pattern matches no values because `UninhabitedTupleStruct` is uninhabited
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/warns.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/warns.stderr
@@ -16,7 +16,9 @@ error: unreachable pattern
   --> $DIR/warns.rs:15:25
    |
 LL |         x if let None | None = x => {}
-   |                         ^^^^
+   |                  ----   ^^^^ unreachable pattern
+   |                  |
+   |                  matches all the values already
    |
 note: the lint level is defined here
   --> $DIR/warns.rs:12:8

--- a/tests/ui/uninhabited/uninhabited-patterns.stderr
+++ b/tests/ui/uninhabited/uninhabited-patterns.stderr
@@ -4,6 +4,7 @@ error: unreachable pattern
 LL |         Ok(box _) => (),
    |         ^^^^^^^^^
    |
+   = note: this pattern matches no values because `NotSoSecretlyEmpty` is uninhabited
 note: the lint level is defined here
   --> $DIR/uninhabited-patterns.rs:4:9
    |
@@ -15,12 +16,16 @@ error: unreachable pattern
    |
 LL |         Err(Ok(_y)) => (),
    |         ^^^^^^^^^^^
+   |
+   = note: this pattern matches no values because `NotSoSecretlyEmpty` is uninhabited
 
 error: unreachable pattern
   --> $DIR/uninhabited-patterns.rs:42:15
    |
 LL |     while let Some(_y) = foo() {
    |               ^^^^^^^^
+   |
+   = note: this pattern matches no values because `NotSoSecretlyEmpty` is uninhabited
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This PR tells the user why a given pattern is considered unreachable. I reused the intersection information we were already computing; even though it's incomplete I convinced myself that it is sufficient to always get a set of patterns that cover the unreachable one.

I'm not a fan of the diagnostic messages I came up with, I'm open to suggestions.

Fixes https://github.com/rust-lang/rust/issues/127870. This is also the other one of the two diagnostic improvements I wanted to do before https://github.com/rust-lang/rust/pull/122792.

Note: the first commit is an unrelated drive-by tweak.

r? @compiler-errors 