### PR TITLE
Don't output incremental test artifacts into working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ build/
 /target
 /src/bootstrap/target
 /src/tools/x/target
-/inc-fat/
 # Created by default with `src/ci/docker/run.sh`
 /obj/
 /rustc-ice*

--- a/tests/ui/lto/debuginfo-lto-alloc.rs
+++ b/tests/ui/lto/debuginfo-lto-alloc.rs
@@ -9,7 +9,8 @@
 // that compilation is successful.
 
 //@ check-pass
-//@ compile-flags: --test -C debuginfo=2 -C lto=fat -C incremental=inc-fat
+//@ compile-flags: --test -C debuginfo=2 -C lto=fat
+//@ incremental
 
 extern crate alloc;
 


### PR DESCRIPTION
Currently tests can ICE when the test spits out `inc-fat` incremental artifacts directly into the top of the git checkout, and then the compiler version changes, and it reads nonsense incremental artifacts on a subsequent test run.

r? @oli-obk 

cc @Oneirical, I think you added this -- I think the right flag to add when porting `-Cincremental` run-make tests is to use `//@ incremental` rather than manually specifying the `-Cincremental` rustflag.