### PR TITLE
rustdoc: revert spacing change in item-table

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2183,7 +2183,6 @@ in src-script.js and main.js
 		width: 33%;
 	}
 	.item-table > li > div {
-		padding-bottom: 5px;
 		word-break: break-all;
 	}
 }


### PR DESCRIPTION
It really wasn't necessary for the bug fix, and could reasonably be considered a functional regression.

In response to https://github.com/rust-lang/rust/pull/127418#discussion_r1685863628