### PR TITLE
Add regression test for items list size (#128023)

### DIFF
--- a/tests/rustdoc-gui/item-name-wrap.goml
+++ b/tests/rustdoc-gui/item-name-wrap.goml
@@ -1,0 +1,23 @@
+// This test ensures that the item name's width is not wrapped.
+go-to: "file://" + |DOC_PATH| + "/test_docs/short_docs/index.html"
+set-window-size: (1000, 600)
+
+// First we ensure that there is only one `item-table`...
+assert-count: ("ul.item-table", 1)
+// And only two items in it.
+assert-count: ("ul.item-table li", 2)
+
+// If they don't have the same height, then it means one of the two is on two lines whereas it
+// shouldn't!
+compare-elements-size: (
+    ".item-table .item-name a[href='fn.mult_vec_num.html']",
+    ".item-table .item-name a[href='fn.subt_vec_num.html']",
+    ["height"],
+)
+
+// We also check that the `item-table` is taking the full width.
+compare-elements-size: (
+    "#functions",
+    "ul.item-table",
+    ["width"],
+)

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -620,3 +620,11 @@ pub mod trait_bounds {
     pub trait TwoBounds: Sized + Copy {}
     pub trait ThreeBounds: Sized + Copy + Eq {}
 }
+
+pub mod short_docs {
+    /// mult_vec_num(x: &[f64], y: f64)
+    pub fn mult_vec_num() {}
+
+    /// subt_vec_num(x: &[f64], y: f64)
+    pub fn subt_vec_num() {}
+}


### PR DESCRIPTION
Add missing regression test for #128023.

cc @Kijewski (if you want more information about the framework used, documentation is available [here](https://github.com/GuillaumeGomez/browser-UI-test/blob/master/goml-script.md)).

r? @notriddle 