### PR TITLE
panic: Use local functions in `panic!` whenever possible

### DIFF
--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -23,6 +23,11 @@ pub use self::unwind_safe::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
 #[rustc_diagnostic_item = "core_panic_2015_macro"]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro panic_2015 {
+    // For all cases where it is possible, wrap the actual call to the
+    // internal panic implementation function with a local no-inline
+    // cold function. This moves the codegen for setting up the
+    // arguments to the panic implementation function to the
+    // presumably cold panic path.
     () => ({
         #[cold]
         #[track_caller]
@@ -78,6 +83,11 @@ pub macro panic_2015 {
 #[rustc_diagnostic_item = "core_panic_2021_macro"]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro panic_2021 {
+    // For all cases where it is possible, wrap the actual call to the
+    // internal panic implementation function with a local no-inline
+    // cold function. This moves the codegen for setting up the
+    // arguments to the panic implementation function to the
+    // presumably cold panic path.
     () => ({
         // Create a function so that the argument for `track_caller`
         // can be moved inside if possible.
@@ -114,6 +124,11 @@ pub macro panic_2021 {
 #[rustc_diagnostic_item = "unreachable_2015_macro"]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro unreachable_2015 {
+    // For all cases where it is possible, wrap the actual call to the
+    // internal panic implementation function with a local no-inline
+    // cold function. This moves the codegen for setting up the
+    // arguments to the panic implementation function to the
+    // presumably cold panic path.
     () => ({
         #[cold]
         #[track_caller]
@@ -147,6 +162,11 @@ pub macro unreachable_2015 {
 #[allow_internal_unstable(panic_internals)]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro unreachable_2021 {
+    // For all cases where it is possible, wrap the actual call to the
+    // internal panic implementation function with a local no-inline
+    // cold function. This moves the codegen for setting up the
+    // arguments to the panic implementation function to the
+    // presumably cold panic path.
     () => ({
         #[cold]
         #[track_caller]
@@ -164,7 +184,7 @@ pub macro unreachable_2021 {
         #[rustc_const_panic_str] // enforce a &&str argument in const-check and hook this by const-eval
         #[rustc_do_not_const_check] // hooked by const-eval
         const fn panic_cold_display<T: $crate::fmt::Display>(arg: &T) -> ! {
-            $crate::panicking::panic($crate::format_args!("internal error: entered unreachable code: {}", *arg));
+            $crate::panicking::panic_fmt("internal error: entered unreachable code: {}", *arg);
         }
         panic_cold_display(&$arg);
     }),

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -184,12 +184,12 @@ pub macro unreachable_2021 {
         #[rustc_const_panic_str] // enforce a &&str argument in const-check and hook this by const-eval
         #[rustc_do_not_const_check] // hooked by const-eval
         const fn panic_cold_display<T: $crate::fmt::Display>(arg: &T) -> ! {
-            $crate::panicking::panic_fmt("internal error: entered unreachable code: {}", *arg);
+            $crate::panicking::panic_fmt($crate::::format_args!("internal error: entered unreachable code: {}", *arg));
         }
         panic_cold_display(&$arg);
     }),
     ($($t:tt)+) => (
-        $crate::panic!("internal error: entered unreachable code: {}", $crate::format_args!($($t)+))
+        $crate::panic!("internal error: entered unreachable code: {}", $crate::const_format_args!($($t)+))
     ),
 }
 

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -36,13 +36,7 @@ pub macro panic_2015 {
     // arguments to the panic implementation function to the
     // presumably cold panic path.
     () => ({
-        #[cold]
-        #[track_caller]
-        #[inline(never)]
-        const fn panic_cold_explicit() -> ! {
-            $crate::panicking::panic("explicit panic");
-        }
-        panic_cold_explicit();
+        $crate::panicking::panic_cold_explicit();
     }),
     // Special-case for string literal.
     ($msg:literal $(,)?) => ({
@@ -98,15 +92,7 @@ pub macro panic_2021 {
     // It would be nice to handle literals here, but there are
     // some issues handling embedded format arguments.
     () => ({
-        // Create a function so that the argument for `track_caller`
-        // can be moved inside if possible.
-        #[cold]
-        #[track_caller]
-        #[inline(never)]
-        const fn panic_cold_explicit() -> ! {
-            $crate::panicking::panic_explicit()
-        }
-        panic_cold_explicit();
+        $crate::panicking::panic_cold_explicit();
     }),
     // Special-case the single-argument case for const_panic.
     ("{}", $arg:expr $(,)?) => ({
@@ -146,13 +132,7 @@ pub macro unreachable_2015 {
     // arguments to the panic implementation function to the
     // presumably cold panic path.
     () => ({
-        #[cold]
-        #[track_caller]
-        #[inline(never)]
-        const fn unreachable_cold_explicit() -> ! {
-            $crate::panicking::panic("internal error: entered unreachable code");
-        }
-        unreachable_cold_explicit();
+        $crate::panicking::unreachable_cold_explicit();
     }),
     ($msg:literal $(,)?) => ({
         #[cold]
@@ -186,13 +166,7 @@ pub macro unreachable_2015 {
 #[rustc_macro_transparency = "semitransparent"]
 pub macro unreachable_2021 {
     () => ({
-        #[cold]
-        #[track_caller]
-        #[inline(never)]
-        const fn unreachable_cold_explicit() -> ! {
-            $crate::panicking::panic("internal error: entered unreachable code");
-        }
-        unreachable_cold_explicit();
+        $crate::panicking::unreachable_cold_explicit();
     }),
     // Special-case the single-argument case for const_panic.
     ("{}", $arg:expr $(,)?) => ({

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -95,7 +95,7 @@ pub macro panic_2021 {
     // cold function. This moves the codegen for setting up the
     // arguments to the panic implementation function to the
     // presumably cold panic path.
-    // TODO: It would be nice to handle literals here, but there are
+    // It would be nice to handle literals here, but there are
     // some issues handling embedded format arguments.
     () => ({
         // Create a function so that the argument for `track_caller`

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -131,9 +131,9 @@ pub macro unreachable_2015 {
     // cold function. This moves the codegen for setting up the
     // arguments to the panic implementation function to the
     // presumably cold panic path.
-    () => ({
-        $crate::panicking::unreachable_cold_explicit();
-    }),
+    () => (
+        $crate::panicking::unreachable_cold_explicit()
+    ),
     ($msg:literal $(,)?) => ({
         #[cold]
         #[track_caller]
@@ -165,9 +165,9 @@ pub macro unreachable_2015 {
 )]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro unreachable_2021 {
-    () => ({
-        $crate::panicking::unreachable_cold_explicit();
-    }),
+    () => (
+        $crate::panicking::unreachable_cold_explicit()
+    ),
     // Special-case the single-argument case for const_panic.
     ("{}", $arg:expr $(,)?) => ({
         #[cold]

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -159,7 +159,7 @@ pub macro unreachable_2015 {
 
 #[doc(hidden)]
 #[unstable(feature = "edition_panic", issue = "none", reason = "use unreachable!() instead")]
-#[allow_internal_unstable(panic_internals)]
+#[allow_internal_unstable(panic_internals, const_format_args)]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro unreachable_2021 {
     // For all cases where it is possible, wrap the actual call to the

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -239,8 +239,12 @@ pub const fn panic_explicit() -> ! {
 
 #[inline]
 #[track_caller]
+#[rustc_do_not_const_check] // hooked by const-eval
+// enforce a &&str argument in const-check and hook this by const-eval
+#[rustc_const_panic_str]
+#[rustc_const_unstable(feature = "panic_internals", issue = "none")]
 #[rustc_diagnostic_item = "unreachable_display"] // needed for `non-fmt-panics` lint
-pub fn unreachable_display<T: fmt::Display>(x: &T) -> ! {
+pub const fn unreachable_display<T: fmt::Display>(x: &T) -> ! {
     panic_fmt(format_args!("internal error: entered unreachable code: {}", *x));
 }
 

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -258,6 +258,20 @@ pub const fn panic_str_2015(expr: &str) -> ! {
     panic_display(&expr);
 }
 
+#[cold]
+#[track_caller]
+#[inline(never)]
+pub const fn panic_cold_explicit() -> ! {
+    panic("explicit panic");
+}
+
+#[cold]
+#[track_caller]
+#[inline(never)]
+pub const fn unreachable_cold_explicit() -> ! {
+    panic("internal error: entered unreachable code");
+}
+
 #[inline]
 #[track_caller]
 #[rustc_do_not_const_check] // hooked by const-eval

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -261,6 +261,7 @@ pub const fn panic_str_2015(expr: &str) -> ! {
 #[cold]
 #[track_caller]
 #[inline(never)]
+#[rustc_const_unstable(feature = "panic_internals", issue = "none")]
 pub const fn panic_cold_explicit() -> ! {
     panic("explicit panic");
 }
@@ -268,6 +269,7 @@ pub const fn panic_cold_explicit() -> ! {
 #[cold]
 #[track_caller]
 #[inline(never)]
+#[rustc_const_unstable(feature = "panic_internals", issue = "none")]
 pub const fn unreachable_cold_explicit() -> ! {
     panic("internal error: entered unreachable code");
 }

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -248,8 +248,6 @@ pub macro panic_2015 {
         #[cold]
         #[track_caller]
         #[inline(never)]
-        #[rustc_const_panic_str] // enforce a &&str argument in const-check and hook this by const-eval
-        #[rustc_do_not_const_check] // hooked by const-eval
         const fn panic_cold_display<T: $crate::fmt::Display>(arg: &T) -> ! {
             $crate::rt::panic_display(arg)
         }

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -229,7 +229,7 @@ pub macro panic_2015 {
     // cold function. This moves the codegen for setting up the
     // arguments to the panic implementation function to the
     // presumably cold panic path.
-    // TODO: It would be nice to handle literals here specially with a
+    // It would be nice to handle literals here specially with a
     // wrapper function, but unfortunately it results in unclear error
     // messages when using panic(<non-str>).
     () => ({

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -248,7 +248,7 @@ pub macro panic_2015 {
         #[cold]
         #[track_caller]
         #[inline(never)]
-        const fn panic_cold_display<T: $crate::fmt::Display>(arg: &T) -> ! {
+        fn panic_cold_display<T: $crate::fmt::Display>(arg: &T) -> ! {
             $crate::rt::panic_display(arg)
         }
         panic_cold_display(&$arg);

--- a/src/tools/clippy/tests/ui/missing_const_for_thread_local.stderr
+++ b/src/tools/clippy/tests/ui/missing_const_for_thread_local.stderr
@@ -37,13 +37,5 @@ error: initializer for `thread_local` value can be made `const`
 LL |         static PEEL_ME_MANY: i32 = { let x = 1; x * x };
    |                                    ^^^^^^^^^^^^^^^^^^^^ help: replace with: `const { { let x = 1; x * x } }`
 
-error: initializer for `thread_local` value can be made `const`
-  --> tests/ui/missing_const_for_thread_local.rs:64:55
-   |
-LL |         static STATE_12637_UNREACHABLE: Cell<usize> = unreachable!();
-   |                                                       ^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 

--- a/src/tools/clippy/tests/ui/missing_const_for_thread_local.stderr
+++ b/src/tools/clippy/tests/ui/missing_const_for_thread_local.stderr
@@ -37,5 +37,13 @@ error: initializer for `thread_local` value can be made `const`
 LL |         static PEEL_ME_MANY: i32 = { let x = 1; x * x };
    |                                    ^^^^^^^^^^^^^^^^^^^^ help: replace with: `const { { let x = 1; x * x } }`
 
-error: aborting due to 6 previous errors
+error: initializer for `thread_local` value can be made `const`
+  --> tests/ui/missing_const_for_thread_local.rs:64:55
+   |
+LL |         static STATE_12637_UNREACHABLE: Cell<usize> = unreachable!();
+   |                                                       ^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 7 previous errors
 

--- a/tests/mir-opt/building/issue_101867.main.built.after.mir
+++ b/tests/mir-opt/building/issue_101867.main.built.after.mir
@@ -8,8 +8,8 @@ fn main() -> () {
     let mut _0: ();
     let _1: std::option::Option<u8> as UserTypeProjection { base: UserType(0), projs: [] };
     let mut _2: !;
-    let _3: ();
-    let mut _4: !;
+    let _3: !;
+    let _4: !;
     let mut _6: isize;
     scope 1 {
         debug x => _1;
@@ -31,14 +31,12 @@ fn main() -> () {
     }
 
     bb1: {
-        StorageLive(_3);
         StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> bb8;
+        _4 = panic_cold_explicit() -> bb8;
     }
 
     bb2: {
         StorageDead(_4);
-        StorageDead(_3);
         unreachable;
     }
 

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-abort.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-abort.diff
@@ -4,7 +4,7 @@
   fn hello() -> () {
       let mut _0: ();
       let mut _1: bool;
-      let mut _2: !;
+      let _2: !;
   
       bb0: {
           StorageLive(_1);
@@ -14,7 +14,7 @@
       }
   
       bb1: {
-          _2 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+          _2 = panic_cold_explicit() -> unwind unreachable;
       }
   
       bb2: {

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-unwind.diff
@@ -4,7 +4,7 @@
   fn hello() -> () {
       let mut _0: ();
       let mut _1: bool;
-      let mut _2: !;
+      let _2: !;
   
       bb0: {
           StorageLive(_1);
@@ -14,7 +14,7 @@
       }
   
       bb1: {
-          _2 = begin_panic::<&str>(const "explicit panic") -> unwind continue;
+          _2 = panic_cold_explicit() -> unwind continue;
       }
   
       bb2: {

--- a/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-abort.diff
@@ -9,6 +9,7 @@
       let mut _4: isize;
       let _5: T;
       let mut _6: !;
+      let _7: !;
       scope 1 {
           debug y => _5;
       }
@@ -31,8 +32,8 @@
       }
   
       bb2: {
-          StorageLive(_6);
-          _6 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+          StorageLive(_7);
+          _7 = panic_cold_explicit() -> unwind unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-abort.diff
@@ -33,7 +33,7 @@
   
       bb2: {
           StorageLive(_7);
-          _7 = panic_cold_explicit() -> unwind unreachable;
+          _7 = wrap_unwrap::panic_cold_explicit() -> unwind unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-unwind.diff
@@ -9,6 +9,7 @@
       let mut _4: isize;
       let _5: T;
       let mut _6: !;
+      let _7: !;
       scope 1 {
           debug y => _5;
       }
@@ -31,8 +32,8 @@
       }
   
       bb2: {
-          StorageLive(_6);
-          _6 = begin_panic::<&str>(const "explicit panic") -> unwind continue;
+          StorageLive(_7);
+          _7 = panic_cold_explicit() -> unwind continue;
       }
   
       bb3: {

--- a/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-unwind.diff
@@ -33,7 +33,7 @@
   
       bb2: {
           StorageLive(_7);
-          _7 = panic_cold_explicit() -> unwind continue;
+          _7 = wrap_unwrap::panic_cold_explicit() -> unwind continue;
       }
   
       bb3: {

--- a/tests/mir-opt/inline/inline_diverging.g.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_diverging.g.Inline.panic-abort.diff
@@ -10,7 +10,7 @@
       let mut _5: !;
       let _6: !;
 +     scope 1 (inlined panic) {
-+         let mut _7: !;
++         let _7: !;
 +     }
   
       bb0: {
@@ -36,7 +36,7 @@
           StorageLive(_6);
 -         _6 = panic() -> unwind unreachable;
 +         StorageLive(_7);
-+         _7 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
++         _7 = panic_cold_explicit() -> unwind unreachable;
       }
   }
   

--- a/tests/mir-opt/inline/inline_diverging.g.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_diverging.g.Inline.panic-unwind.diff
@@ -10,7 +10,7 @@
       let mut _5: !;
       let _6: !;
 +     scope 1 (inlined panic) {
-+         let mut _7: !;
++         let _7: !;
 +     }
   
       bb0: {
@@ -36,7 +36,7 @@
           StorageLive(_6);
 -         _6 = panic() -> unwind continue;
 +         StorageLive(_7);
-+         _7 = begin_panic::<&str>(const "explicit panic") -> unwind continue;
++         _7 = panic_cold_explicit() -> unwind continue;
       }
   }
   

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
@@ -35,7 +35,7 @@
       }
   
       bb1: {
-          _10 = unreachable_cold_explicit() -> unwind unreachable;
+          _10 = core::panicking::unreachable_cold_explicit() -> unwind unreachable;
       }
   
       bb2: {

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
@@ -9,7 +9,7 @@
       let _4: [T; 3];
       let mut _5: usize;
       let mut _6: bool;
-      let mut _10: !;
+      let _10: !;
       scope 1 {
           debug v => _2;
           let _7: &T;
@@ -35,7 +35,7 @@
       }
   
       bb1: {
-          _10 = core::panicking::panic(const "internal error: entered unreachable code") -> unwind unreachable;
+          _10 = unreachable_cold_explicit() -> unwind unreachable;
       }
   
       bb2: {

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
@@ -9,7 +9,7 @@
       let _4: [T; 3];
       let mut _5: usize;
       let mut _6: bool;
-      let _10: !;
+      let mut _10: !;
       scope 1 {
           debug v => _2;
           let _7: &T;

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
@@ -35,7 +35,7 @@
       }
   
       bb1: {
-          _10 = unreachable_cold_explicit() -> unwind continue;
+          _10 = core::panicking::unreachable_cold_explicit() -> unwind continue;
       }
   
       bb2: {

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
@@ -9,7 +9,7 @@
       let _4: [T; 3];
       let mut _5: usize;
       let mut _6: bool;
-      let _10: !;
+      let mut _10: !;
       scope 1 {
           debug v => _2;
           let _7: &T;

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
@@ -9,7 +9,7 @@
       let _4: [T; 3];
       let mut _5: usize;
       let mut _6: bool;
-      let mut _10: !;
+      let _10: !;
       scope 1 {
           debug v => _2;
           let _7: &T;
@@ -35,7 +35,7 @@
       }
   
       bb1: {
-          _10 = core::panicking::panic(const "internal error: entered unreachable code") -> unwind continue;
+          _10 = unreachable_cold_explicit() -> unwind continue;
       }
   
       bb2: {

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -6,9 +6,10 @@ fn unwrap(_1: Option<T>) -> T {
     let mut _2: isize;
     let _3: T;
     let mut _4: !;
-    let mut _5: isize;
+    let _5: !;
     let mut _6: isize;
     let mut _7: isize;
+    let mut _8: isize;
     scope 1 {
         debug x => _3;
     }
@@ -23,8 +24,8 @@ fn unwrap(_1: Option<T>) -> T {
     }
 
     bb2: {
-        StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+        StorageLive(_5);
+        _5 = panic_cold_explicit() -> unwind unreachable;
     }
 
     bb3: {
@@ -32,7 +33,7 @@ fn unwrap(_1: Option<T>) -> T {
         _3 = move ((_1 as Some).0: T);
         _0 = move _3;
         StorageDead(_3);
-        _5 = discriminant(_1);
+        _6 = discriminant(_1);
         return;
     }
 }

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -6,9 +6,10 @@ fn unwrap(_1: Option<T>) -> T {
     let mut _2: isize;
     let _3: T;
     let mut _4: !;
-    let mut _5: isize;
+    let _5: !;
     let mut _6: isize;
     let mut _7: isize;
+    let mut _8: isize;
     scope 1 {
         debug x => _3;
     }
@@ -23,8 +24,8 @@ fn unwrap(_1: Option<T>) -> T {
     }
 
     bb2: {
-        StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> bb4;
+        StorageLive(_5);
+        _5 = panic_cold_explicit() -> bb4;
     }
 
     bb3: {
@@ -32,12 +33,12 @@ fn unwrap(_1: Option<T>) -> T {
         _3 = move ((_1 as Some).0: T);
         _0 = move _3;
         StorageDead(_3);
-        _5 = discriminant(_1);
+        _6 = discriminant(_1);
         return;
     }
 
     bb4 (cleanup): {
-        _7 = discriminant(_1);
+        _8 = discriminant(_1);
         resume;
     }
 }

--- a/tests/ui/argument-suggestions/extra_arguments.stderr
+++ b/tests/ui/argument-suggestions/extra_arguments.stderr
@@ -329,7 +329,7 @@ error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/extra_arguments.rs:53:3
    |
 LL |   one_arg(1, panic!());
-   |   ^^^^^^^    -------- unexpected argument #2
+   |   ^^^^^^^    -------- unexpected argument #2 of type `!`
    |
 note: function defined here
   --> $DIR/extra_arguments.rs:2:4

--- a/tests/ui/block-result/issue-5500.rs
+++ b/tests/ui/block-result/issue-5500.rs
@@ -2,6 +2,6 @@ fn main() {
     &panic!()
     //~^ ERROR mismatched types
     //~| expected unit type `()`
-    //~| found reference `&_`
-    //~| expected `()`, found `&_`
+    //~| found reference `&!`
+    //~| expected `()`, found `&!`
 }

--- a/tests/ui/block-result/issue-5500.stderr
+++ b/tests/ui/block-result/issue-5500.stderr
@@ -4,15 +4,10 @@ error[E0308]: mismatched types
 LL | fn main() {
    |          - expected `()` because of default return type
 LL |     &panic!()
-   |     ^^^^^^^^^ expected `()`, found `&_`
+   |     ^^^^^^^^^ expected `()`, found `&!`
    |
    = note: expected unit type `()`
-              found reference `&_`
-help: consider removing the borrow
-   |
-LL -     &panic!()
-LL +     panic!()
-   |
+              found reference `&!`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/never_type/diverging-tuple-parts-39485.stderr
+++ b/tests/ui/never_type/diverging-tuple-parts-39485.stderr
@@ -1,20 +1,13 @@
 error[E0308]: mismatched types
   --> $DIR/diverging-tuple-parts-39485.rs:8:5
    |
+LL | fn g() {
+   |       - help: try adding a return type: `-> &!`
 LL |     &panic!()
-   |     ^^^^^^^^^ expected `()`, found `&_`
+   |     ^^^^^^^^^ expected `()`, found `&!`
    |
    = note: expected unit type `()`
-              found reference `&_`
-help: a return type might be missing here
-   |
-LL | fn g() -> _ {
-   |        ++++
-help: consider removing the borrow
-   |
-LL -     &panic!()
-LL +     panic!()
-   |
+              found reference `&!`
 
 error[E0308]: mismatched types
   --> $DIR/diverging-tuple-parts-39485.rs:12:5

--- a/tests/ui/never_type/issue-5500-1.rs
+++ b/tests/ui/never_type/issue-5500-1.rs
@@ -1,15 +1,15 @@
-// MIR doesn't generate an error because the assignment isn't reachable. This
-// is OK because the test is here to check that the compiler doesn't ICE (cf.
-// #5500).
-
-//@ check-pass
+// the test is here to check that the compiler doesn't ICE (cf. #5500).
 
 struct TrieMapIterator<'a> {
-    node: &'a usize
+    node: &'a usize,
 }
 
 fn main() {
     let a = 5;
-    let _iter = TrieMapIterator{node: &a};
+    let _iter = TrieMapIterator { node: &a };
     _iter.node = &panic!()
+    //~^ ERROR mismatched types
+    //~| expected `&usize`, found `&!`
+    //~| expected reference `&usize`
+    //~| found reference `&!`
 }

--- a/tests/ui/never_type/issue-5500-1.stderr
+++ b/tests/ui/never_type/issue-5500-1.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-5500-1.rs:10:18
+   |
+LL |     _iter.node = &panic!()
+   |     ----------   ^^^^^^^^^ expected `&usize`, found `&!`
+   |     |
+   |     expected due to the type of this binding
+   |
+   = note: expected reference `&usize`
+              found reference `&!`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/panics/issue-47429-short-backtraces.legacy.run.stderr
+++ b/tests/ui/panics/issue-47429-short-backtraces.legacy.run.stderr
@@ -2,5 +2,6 @@ thread 'main' panicked at $DIR/issue-47429-short-backtraces.rs:23:5:
 explicit panic
 stack backtrace:
    0: std::panicking::begin_panic
-   1: issue_47429_short_backtraces::main
+   1: issue_47429_short_backtraces::main::panic_cold_explicit
+   2: issue_47429_short_backtraces::main
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

--- a/tests/ui/panics/issue-47429-short-backtraces.v0.run.stderr
+++ b/tests/ui/panics/issue-47429-short-backtraces.v0.run.stderr
@@ -2,5 +2,6 @@ thread 'main' panicked at $DIR/issue-47429-short-backtraces.rs:23:5:
 explicit panic
 stack backtrace:
    0: std::panicking::begin_panic::<&str>
-   1: issue_47429_short_backtraces::main
+   1: issue_47429_short_backtraces::main::panic_cold_explicit
+   2: issue_47429_short_backtraces::main
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

--- a/tests/ui/panics/runtime-switch.legacy.run.stderr
+++ b/tests/ui/panics/runtime-switch.legacy.run.stderr
@@ -2,5 +2,6 @@ thread 'main' panicked at $DIR/runtime-switch.rs:26:5:
 explicit panic
 stack backtrace:
    0: std::panicking::begin_panic
-   1: runtime_switch::main
+   1: runtime_switch::main::panic_cold_explicit
+   2: runtime_switch::main
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

--- a/tests/ui/panics/runtime-switch.v0.run.stderr
+++ b/tests/ui/panics/runtime-switch.v0.run.stderr
@@ -2,5 +2,6 @@ thread 'main' panicked at $DIR/runtime-switch.rs:26:5:
 explicit panic
 stack backtrace:
    0: std::panicking::begin_panic::<&str>
-   1: runtime_switch::main
+   1: runtime_switch::main::panic_cold_explicit
+   2: runtime_switch::main
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

--- a/tests/ui/proc-macro/quote-debug.stdout
+++ b/tests/ui/proc-macro/quote-debug.stdout
@@ -33,7 +33,15 @@ fn main() {
                                             lit.set_span(crate::Span::recover_proc_macro_span(2));
                                             lit
                                         } else {
-                                           ::core::panicking::panic("internal error: entered unreachable code")
+                                           {
+                                               #[cold]
+                                               #[track_caller]
+                                               #[inline(never)]
+                                               const fn unreachable_cold_explicit() -> ! {
+                                                   ::core::panicking::panic("internal error: entered unreachable code");
+                                               }
+                                               unreachable_cold_explicit();
+                                           }
                                        }
                                 })),
                         crate::TokenStream::from(crate::TokenTree::Punct(crate::Punct::new(';',

--- a/tests/ui/proc-macro/quote-debug.stdout
+++ b/tests/ui/proc-macro/quote-debug.stdout
@@ -33,15 +33,7 @@ fn main() {
                                             lit.set_span(crate::Span::recover_proc_macro_span(2));
                                             lit
                                         } else {
-                                           {
-                                               #[cold]
-                                               #[track_caller]
-                                               #[inline(never)]
-                                               const fn unreachable_cold_explicit() -> ! {
-                                                   ::core::panicking::panic("internal error: entered unreachable code");
-                                               }
-                                               unreachable_cold_explicit();
-                                           }
+                                           { ::core::panicking::unreachable_cold_explicit(); }
                                        }
                                 })),
                         crate::TokenStream::from(crate::TokenTree::Punct(crate::Punct::new(';',

--- a/tests/ui/proc-macro/quote-debug.stdout
+++ b/tests/ui/proc-macro/quote-debug.stdout
@@ -32,9 +32,7 @@ fn main() {
                                                 (iter.next(), iter.next()) {
                                             lit.set_span(crate::Span::recover_proc_macro_span(2));
                                             lit
-                                        } else {
-                                           { ::core::panicking::unreachable_cold_explicit(); }
-                                       }
+                                        } else { ::core::panicking::unreachable_cold_explicit() }
                                 })),
                         crate::TokenStream::from(crate::TokenTree::Punct(crate::Punct::new(';',
                                     crate::Spacing::Alone)))].iter().cloned().collect::<crate::TokenStream>()

--- a/tests/ui/unpretty/let-else-hir.stdout
+++ b/tests/ui/unpretty/let-else-hir.stdout
@@ -12,7 +12,14 @@ fn foo(x:
     let Some(_) = x else
         {
 
-        { ::std::rt::begin_panic("explicit panic") }
+        {
+            #[cold]
+            #[track_caller]
+            #[inline(never)]
+            const fn panic_cold_explicit()
+                -> ! { ::std::rt::begin_panic("explicit panic"); }
+            panic_cold_explicit();
+        }
     };
 }
 fn main() { }


### PR DESCRIPTION
This is basically extending the idea implemented in `panic_2021!`.

By creating a cold/noinline function that wraps the setup for the call to the internal panic function moves more of the code-size cost of `panic!` to the cold path.

For example: https://godbolt.org/z/T1ndrcq4d

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
