### PR TITLE
Unify wording of "failed to resolve" errors with "cannot find" resolution errors

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -382,9 +382,15 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                     PathResult::NonModule(partial_res) => {
                         expected_found_error(partial_res.expect_full_res())
                     }
-                    PathResult::Failed { span, label, suggestion, .. } => {
-                        Err(VisResolutionError::FailedToResolve(span, label, suggestion))
-                    }
+                    PathResult::Failed {
+                        span, label, suggestion, segment_name, item_type, ..
+                    } => Err(VisResolutionError::FailedToResolve(
+                        span,
+                        segment_name,
+                        label,
+                        suggestion,
+                        item_type,
+                    )),
                     PathResult::Indeterminate => Err(VisResolutionError::Indeterminate(path.span)),
                 }
             }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -792,9 +792,30 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ResolutionError::SelfImportOnlyInImportListWithNonEmptyPrefix => {
                 self.dcx().create_err(errs::SelfImportOnlyInImportListWithNonEmptyPrefix { span })
             }
-            ResolutionError::FailedToResolve { segment, label, suggestion, module } => {
-                let mut err =
-                    struct_span_code_err!(self.dcx(), span, E0433, "failed to resolve: {label}");
+            ResolutionError::FailedToResolve { segment, label, suggestion, module, item_type } => {
+                let mut err = struct_span_code_err!(
+                    self.dcx(),
+                    span,
+                    E0433,
+                    "cannot find {item_type} `{segment}` in {}",
+                    match module {
+                        Some(ModuleOrUniformRoot::CurrentScope) | None => "this scope".to_string(),
+                        Some(ModuleOrUniformRoot::Module(module)) => {
+                            match module.kind {
+                                ModuleKind::Def(_, _, None) => "the crate root".to_string(),
+                                ModuleKind::Def(kind, def_id, Some(name)) => {
+                                    format!("{} `{name}`", kind.descr(def_id))
+                                }
+                                ModuleKind::Block => "this scope".to_string(),
+                            }
+                        }
+                        Some(ModuleOrUniformRoot::CrateRootAndExternPrelude) => {
+                            "the crate root or the list of imported crates".to_string()
+                        }
+                        Some(ModuleOrUniformRoot::ExternPrelude) =>
+                            "the list of imported crates".to_string(),
+                    },
+                );
                 err.span_label(span, label);
 
                 if let Some((suggestions, msg, applicability)) = suggestion {
@@ -806,7 +827,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
                 if let Some(ModuleOrUniformRoot::Module(module)) = module
                     && let Some(module) = module.opt_def_id()
-                    && let Some(segment) = segment
                 {
                     self.find_cfg_stripped(&mut err, &segment, module);
                 }
@@ -1003,10 +1023,18 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             VisResolutionError::AncestorOnly(span) => {
                 self.dcx().create_err(errs::AncestorOnly(span))
             }
-            VisResolutionError::FailedToResolve(span, label, suggestion) => self.into_struct_error(
-                span,
-                ResolutionError::FailedToResolve { segment: None, label, suggestion, module: None },
-            ),
+            VisResolutionError::FailedToResolve(span, segment, label, suggestion, item_type) => {
+                self.into_struct_error(
+                    span,
+                    ResolutionError::FailedToResolve {
+                        segment,
+                        label,
+                        suggestion,
+                        module: None,
+                        item_type,
+                    },
+                )
+            }
             VisResolutionError::ExpectedFound(span, path_str, res) => {
                 self.dcx().create_err(errs::ExpectedModuleFound { span, res, path_str })
             }

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -920,16 +920,18 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 suggestion,
                 module,
                 error_implied_by_parse_error: _,
+                item_type,
             } => {
                 if no_ambiguity {
                     assert!(import.imported_module.get().is_none());
                     self.report_error(
                         span,
                         ResolutionError::FailedToResolve {
-                            segment: Some(segment_name),
+                            segment: segment_name,
                             label,
                             suggestion,
                             module,
+                            item_type,
                         },
                     );
                 }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4696,14 +4696,16 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 module,
                 segment_name,
                 error_implied_by_parse_error: _,
+                item_type,
             } => {
                 return Err(respan(
                     span,
                     ResolutionError::FailedToResolve {
-                        segment: Some(segment_name),
+                        segment: segment_name,
                         label,
                         suggestion,
                         module,
+                        item_type,
                     },
                 ));
             }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -253,10 +253,11 @@ enum ResolutionError<'ra> {
     SelfImportOnlyInImportListWithNonEmptyPrefix,
     /// Error E0433: failed to resolve.
     FailedToResolve {
-        segment: Option<Symbol>,
+        segment: Symbol,
         label: String,
         suggestion: Option<Suggestion>,
         module: Option<ModuleOrUniformRoot<'ra>>,
+        item_type: &'static str,
     },
     /// Error E0434: can't capture dynamic environment in a fn item.
     CannotCaptureDynamicEnvironmentInFnItem,
@@ -315,7 +316,7 @@ enum ResolutionError<'ra> {
 enum VisResolutionError<'a> {
     Relative2018(Span, &'a ast::Path),
     AncestorOnly(Span),
-    FailedToResolve(Span, String, Option<Suggestion>),
+    FailedToResolve(Span, Symbol, String, Option<Suggestion>, &'static str),
     ExpectedFound(Span, String, Res),
     Indeterminate(Span),
     ModuleOnly(Span),
@@ -458,6 +459,7 @@ enum PathResult<'ra> {
         /// The segment name of target
         segment_name: Symbol,
         error_implied_by_parse_error: bool,
+        item_type: &'static str,
     },
 }
 
@@ -469,6 +471,7 @@ impl<'ra> PathResult<'ra> {
         error_implied_by_parse_error: bool,
         module: Option<ModuleOrUniformRoot<'ra>>,
         label_and_suggestion: impl FnOnce() -> (String, Option<Suggestion>),
+        item_type: &'static str,
     ) -> PathResult<'ra> {
         let (label, suggestion) =
             if finalize { label_and_suggestion() } else { (String::new(), None) };
@@ -480,6 +483,7 @@ impl<'ra> PathResult<'ra> {
             is_error_from_last_segment,
             module,
             error_implied_by_parse_error,
+            item_type,
         }
     }
 }

--- a/src/tools/clippy/tests/ui/crashes/unreachable-array-or-slice.stderr
+++ b/src/tools/clippy/tests/ui/crashes/unreachable-array-or-slice.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+error[E0433]: cannot find item `Self` in this scope
   --> tests/ui/crashes/unreachable-array-or-slice.rs:4:9
    |
 LL |     let Self::anything_here_kills_it(a, b, ..) = Foo(5, 5, 5, 5);

--- a/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.rs
+++ b/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.rs
@@ -1,6 +1,6 @@
 // Regression test for issue #95879.
 
-use unresolved_crate::module::Name; //~ ERROR failed to resolve
+use unresolved_crate::module::Name; //~ ERROR cannot find item
 
 /// [Name]
 pub struct S;

--- a/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
+++ b/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved_crate`
+error[E0433]: cannot find item `unresolved_crate` in the crate root
   --> $DIR/unresolved-import-recovery.rs:3:5
    |
 LL | use unresolved_crate::module::Name;

--- a/tests/rustdoc-ui/issues/issue-61732.rs
+++ b/tests/rustdoc-ui/issues/issue-61732.rs
@@ -1,4 +1,4 @@
 // This previously triggered an ICE.
 
 pub(in crate::r#mod) fn main() {}
-//~^ ERROR failed to resolve: use of unresolved module or unlinked crate `r#mod`
+//~^ ERROR cannot find item `mod`

--- a/tests/rustdoc-ui/issues/issue-61732.stderr
+++ b/tests/rustdoc-ui/issues/issue-61732.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `r#mod`
+error[E0433]: cannot find item `mod` in this scope
   --> $DIR/issue-61732.rs:3:15
    |
 LL | pub(in crate::r#mod) fn main() {}

--- a/tests/ui/asm/naked-invalid-attr.rs
+++ b/tests/ui/asm/naked-invalid-attr.rs
@@ -55,7 +55,7 @@ fn main() {
 // Check that the path of an attribute without a name is printed correctly (issue #140082)
 #[::a]
 //~^ ERROR attribute incompatible with `#[unsafe(naked)]`
-//~| ERROR failed to resolve: use of unresolved module or unlinked crate `a`
+//~| ERROR cannot find macro `a` in the crate root
 #[unsafe(naked)]
 extern "C" fn issue_140082() {
     naked_asm!("")

--- a/tests/ui/asm/naked-invalid-attr.stderr
+++ b/tests/ui/asm/naked-invalid-attr.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `a`
+error[E0433]: cannot find macro `a` in the crate root
   --> $DIR/naked-invalid-attr.rs:56:5
    |
 LL | #[::a]

--- a/tests/ui/attributes/check-builtin-attr-ice.rs
+++ b/tests/ui/attributes/check-builtin-attr-ice.rs
@@ -43,12 +43,12 @@
 
 struct Foo {
     #[should_panic::skip]
-    //~^ ERROR failed to resolve
+    //~^ ERROR cannot find
     //~| ERROR `#[should_panic::skip]` only has an effect on functions
     pub field: u8,
 
     #[should_panic::a::b::c]
-    //~^ ERROR failed to resolve
+    //~^ ERROR cannot find
     //~| ERROR `#[should_panic::a::b::c]` only has an effect on functions
     pub field2: u8,
 }
@@ -57,6 +57,6 @@ fn foo() {}
 
 fn main() {
     #[deny::skip]
-    //~^ ERROR failed to resolve
+    //~^ ERROR cannot find
     foo();
 }

--- a/tests/ui/attributes/check-builtin-attr-ice.stderr
+++ b/tests/ui/attributes/check-builtin-attr-ice.stderr
@@ -1,16 +1,16 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `should_panic`
+error[E0433]: cannot find item `should_panic` in this scope
   --> $DIR/check-builtin-attr-ice.rs:45:7
    |
 LL |     #[should_panic::skip]
    |       ^^^^^^^^^^^^ use of unresolved module or unlinked crate `should_panic`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `should_panic`
+error[E0433]: cannot find item `should_panic` in this scope
   --> $DIR/check-builtin-attr-ice.rs:50:7
    |
 LL |     #[should_panic::a::b::c]
    |       ^^^^^^^^^^^^ use of unresolved module or unlinked crate `should_panic`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `deny`
+error[E0433]: cannot find item `deny` in this scope
   --> $DIR/check-builtin-attr-ice.rs:59:7
    |
 LL |     #[deny::skip]

--- a/tests/ui/attributes/check-cfg_attr-ice.rs
+++ b/tests/ui/attributes/check-cfg_attr-ice.rs
@@ -10,27 +10,27 @@
 #![crate_type = "lib"]
 
 #[cfg_attr::no_such_thing]
-//~^ ERROR failed to resolve
+//~^ ERROR cannot find
 mod we_are_no_strangers_to_love {}
 
 #[cfg_attr::no_such_thing]
-//~^ ERROR failed to resolve
+//~^ ERROR cannot find
 struct YouKnowTheRules {
     #[cfg_attr::no_such_thing]
-    //~^ ERROR failed to resolve
+    //~^ ERROR cannot find
     and_so_do_i: u8,
 }
 
 #[cfg_attr::no_such_thing]
-//~^ ERROR failed to resolve
+//~^ ERROR cannot find
 fn a_full_commitment() {
     #[cfg_attr::no_such_thing]
-    //~^ ERROR failed to resolve
+    //~^ ERROR cannot find
     let is_what_i_am_thinking_of = ();
 }
 
 #[cfg_attr::no_such_thing]
-//~^ ERROR failed to resolve
+//~^ ERROR cannot find
 union AnyOtherGuy {
     owo: ()
 }
@@ -39,30 +39,30 @@ struct This;
 #[cfg_attr(FALSE, doc = "you wouldn't get this")]
 impl From<AnyOtherGuy> for This {
     #[cfg_attr::no_such_thing]
-    //~^ ERROR failed to resolve
+    //~^ ERROR cannot find
     fn from(#[cfg_attr::no_such_thing] any_other_guy: AnyOtherGuy) -> This {
-        //~^ ERROR failed to resolve
+        //~^ ERROR cannot find
         #[cfg_attr::no_such_thing]
         //~^ ERROR attributes on expressions are experimental
-        //~| ERROR failed to resolve
+        //~| ERROR cannot find
         unreachable!()
     }
 }
 
 #[cfg_attr::no_such_thing]
-//~^ ERROR failed to resolve
+//~^ ERROR cannot find
 enum NeverGonna {
     #[cfg_attr::no_such_thing]
-    //~^ ERROR failed to resolve
+    //~^ ERROR cannot find
     GiveYouUp(#[cfg_attr::no_such_thing] u8),
-    //~^ ERROR failed to resolve
+    //~^ ERROR cannot find
     LetYouDown {
         #![cfg_attr::no_such_thing]
         //~^ ERROR an inner attribute is not permitted in this context
         never_gonna: (),
         round_around: (),
         #[cfg_attr::no_such_thing]
-        //~^ ERROR failed to resolve
+        //~^ ERROR cannot find
         and_desert_you: (),
     },
 }

--- a/tests/ui/attributes/check-cfg_attr-ice.stderr
+++ b/tests/ui/attributes/check-cfg_attr-ice.stderr
@@ -17,79 +17,79 @@ LL |         #[cfg_attr::no_such_thing]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:52:3
    |
 LL | #[cfg_attr::no_such_thing]
    |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:55:7
    |
 LL |     #[cfg_attr::no_such_thing]
    |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:57:17
    |
 LL |     GiveYouUp(#[cfg_attr::no_such_thing] u8),
    |                 ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:64:11
    |
 LL |         #[cfg_attr::no_such_thing]
    |           ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:41:7
    |
 LL |     #[cfg_attr::no_such_thing]
    |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:43:15
    |
 LL |     fn from(#[cfg_attr::no_such_thing] any_other_guy: AnyOtherGuy) -> This {
    |               ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:45:11
    |
 LL |         #[cfg_attr::no_such_thing]
    |           ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:32:3
    |
 LL | #[cfg_attr::no_such_thing]
    |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:24:3
    |
 LL | #[cfg_attr::no_such_thing]
    |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:27:7
    |
 LL |     #[cfg_attr::no_such_thing]
    |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:16:3
    |
 LL | #[cfg_attr::no_such_thing]
    |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:19:7
    |
 LL |     #[cfg_attr::no_such_thing]
    |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
+error[E0433]: cannot find item `cfg_attr` in this scope
   --> $DIR/check-cfg_attr-ice.rs:12:3
    |
 LL | #[cfg_attr::no_such_thing]

--- a/tests/ui/attributes/field-attributes-vis-unresolved.rs
+++ b/tests/ui/attributes/field-attributes-vis-unresolved.rs
@@ -14,12 +14,12 @@ mod internal {
 
 struct S {
     #[rustfmt::skip]
-    pub(in nonexistent) field: u8 //~ ERROR failed to resolve
+    pub(in nonexistent) field: u8 //~ ERROR cannot find item `nonexistent` in this scope
 }
 
 struct Z(
     #[rustfmt::skip]
-    pub(in nonexistent) u8 //~ ERROR failed to resolve
+    pub(in nonexistent) u8 //~ ERROR cannot find item `nonexistent` in this scope
 );
 
 fn main() {}

--- a/tests/ui/attributes/field-attributes-vis-unresolved.stderr
+++ b/tests/ui/attributes/field-attributes-vis-unresolved.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistent`
+error[E0433]: cannot find item `nonexistent` in this scope
   --> $DIR/field-attributes-vis-unresolved.rs:17:12
    |
 LL |     pub(in nonexistent) field: u8
@@ -9,7 +9,7 @@ help: you might be missing a crate named `nonexistent`, add it to your project a
 LL + extern crate nonexistent;
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistent`
+error[E0433]: cannot find item `nonexistent` in this scope
   --> $DIR/field-attributes-vis-unresolved.rs:22:12
    |
 LL |     pub(in nonexistent) u8

--- a/tests/ui/attributes/use-doc-alias-name.rs
+++ b/tests/ui/attributes/use-doc-alias-name.rs
@@ -42,7 +42,7 @@ fn main() {
     //~| HELP: `S5` has a name defined in the doc alias attribute as `DocAliasS5`
 
     not_exist_module::DocAliasS1;
-    //~^ ERROR: use of unresolved module or unlinked crate `not_exist_module`
+    //~^ ERROR: cannot find item `not_exist_module` in this scope
     //~| HELP: you might be missing a crate named `not_exist_module`
 
     use_doc_alias_name_extern::DocAliasS1;
@@ -50,7 +50,7 @@ fn main() {
     //~| HELP: `S1` has a name defined in the doc alias attribute as `DocAliasS1`
 
     m::n::DocAliasX::y::S6;
-    //~^ ERROR: could not find `DocAliasX` in `n`
+    //~^ ERROR: cannot find item `DocAliasX` in module `n`
     //~| HELP: `x` has a name defined in the doc alias attribute as `DocAliasX`
 
     m::n::x::y::DocAliasS6;

--- a/tests/ui/attributes/use-doc-alias-name.stderr
+++ b/tests/ui/attributes/use-doc-alias-name.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: could not find `DocAliasX` in `n`
+error[E0433]: cannot find item `DocAliasX` in module `n`
   --> $DIR/use-doc-alias-name.rs:52:11
    |
 LL |     m::n::DocAliasX::y::S6;
@@ -136,7 +136,7 @@ LL -     doc_alias_f2();
 LL +     f();
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `not_exist_module`
+error[E0433]: cannot find item `not_exist_module` in this scope
   --> $DIR/use-doc-alias-name.rs:44:5
    |
 LL |     not_exist_module::DocAliasS1;

--- a/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.rs
+++ b/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.rs
@@ -4,9 +4,9 @@
 
 fn main() {
     let mut a = E::StructVar { boxed: Box::new(5_i32) };
-    //~^ ERROR failed to resolve: use of undeclared type `E`
+    //~^ ERROR cannot find item `E` in this scope
     match a {
         E::StructVar { box boxed } => { }
-        //~^ ERROR failed to resolve: use of undeclared type `E`
+        //~^ ERROR cannot find item `E` in this scope
     }
 }

--- a/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.stderr
+++ b/tests/ui/borrowck/non-ADT-struct-pattern-box-pattern-ice-121463.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `E`
+error[E0433]: cannot find item `E` in this scope
   --> $DIR/non-ADT-struct-pattern-box-pattern-ice-121463.rs:6:17
    |
 LL |     let mut a = E::StructVar { boxed: Box::new(5_i32) };
@@ -7,7 +7,7 @@ LL |     let mut a = E::StructVar { boxed: Box::new(5_i32) };
    |                 use of undeclared type `E`
    |                 help: a trait with a similar name exists: `Eq`
 
-error[E0433]: failed to resolve: use of undeclared type `E`
+error[E0433]: cannot find item `E` in this scope
   --> $DIR/non-ADT-struct-pattern-box-pattern-ice-121463.rs:9:9
    |
 LL |         E::StructVar { box boxed } => { }

--- a/tests/ui/cfg/diagnostics-cross-crate.rs
+++ b/tests/ui/cfg/diagnostics-cross-crate.rs
@@ -15,7 +15,7 @@ fn main() {
 
     // The module isn't found - we would like to get a diagnostic, but currently don't due to
     // the awkward way the resolver diagnostics are currently implemented.
-    cfged_out::inner::doesnt_exist::hello(); //~ ERROR failed to resolve
+    cfged_out::inner::doesnt_exist::hello(); //~ ERROR cannot find item `doesnt_exist`
     //~^ NOTE could not find `doesnt_exist` in `inner`
     //~| NOTE found an item that was configured out
     //~| NOTE the item is gated here

--- a/tests/ui/cfg/diagnostics-cross-crate.stderr
+++ b/tests/ui/cfg/diagnostics-cross-crate.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: could not find `doesnt_exist` in `inner`
+error[E0433]: cannot find item `doesnt_exist` in module `inner`
   --> $DIR/diagnostics-cross-crate.rs:18:23
    |
 LL |     cfged_out::inner::doesnt_exist::hello();

--- a/tests/ui/cfg/diagnostics-same-crate.rs
+++ b/tests/ui/cfg/diagnostics-same-crate.rs
@@ -51,7 +51,7 @@ fn main() {
 
     // The module isn't found - we would like to get a diagnostic, but currently don't due to
     // the awkward way the resolver diagnostics are currently implemented.
-    inner::doesnt_exist::hello(); //~ ERROR failed to resolve
+    inner::doesnt_exist::hello(); //~ ERROR cannot find item
     //~| NOTE could not find `doesnt_exist` in `inner`
 
     // It should find the one in the right module, not the wrong one.

--- a/tests/ui/cfg/diagnostics-same-crate.stderr
+++ b/tests/ui/cfg/diagnostics-same-crate.stderr
@@ -32,7 +32,7 @@ note: the item is gated here
 LL |     #[cfg(false)]
    |     ^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: could not find `doesnt_exist` in `inner`
+error[E0433]: cannot find item `doesnt_exist` in module `inner`
   --> $DIR/diagnostics-same-crate.rs:54:12
    |
 LL |     inner::doesnt_exist::hello();

--- a/tests/ui/coherence/conflicting-impl-with-err.rs
+++ b/tests/ui/coherence/conflicting-impl-with-err.rs
@@ -1,8 +1,8 @@
 struct ErrorKind;
 struct Error(ErrorKind);
 
-impl From<nope::Thing> for Error { //~ ERROR failed to resolve
-    fn from(_: nope::Thing) -> Self { //~ ERROR failed to resolve
+impl From<nope::Thing> for Error { //~ ERROR cannot find item
+    fn from(_: nope::Thing) -> Self { //~ ERROR cannot find item
         unimplemented!()
     }
 }

--- a/tests/ui/coherence/conflicting-impl-with-err.stderr
+++ b/tests/ui/coherence/conflicting-impl-with-err.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nope`
+error[E0433]: cannot find item `nope` in this scope
   --> $DIR/conflicting-impl-with-err.rs:4:11
    |
 LL | impl From<nope::Thing> for Error {
@@ -6,7 +6,7 @@ LL | impl From<nope::Thing> for Error {
    |
    = help: you might be missing a crate named `nope`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nope`
+error[E0433]: cannot find item `nope` in this scope
   --> $DIR/conflicting-impl-with-err.rs:5:16
    |
 LL |     fn from(_: nope::Thing) -> Self {

--- a/tests/ui/const-generics/generic_const_exprs/ice-predicates-of-no-entry-found-for-key-119275.rs
+++ b/tests/ui/const-generics/generic_const_exprs/ice-predicates-of-no-entry-found-for-key-119275.rs
@@ -11,7 +11,7 @@ where
     //~^ ERROR only lifetime parameters can be used in this context
     //~| ERROR defaults for generic parameters are not allowed in `for<...>` binders
     //~| ERROR defaults for generic parameters are not allowed in `for<...>` binders
-    //~| ERROR failed to resolve: use of undeclared type `COT`
+    //~| ERROR cannot find item `COT`
     //~| ERROR  the name `N` is already used for a generic parameter in this item's generic parameters
 {
 }

--- a/tests/ui/const-generics/generic_const_exprs/ice-predicates-of-no-entry-found-for-key-119275.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/ice-predicates-of-no-entry-found-for-key-119275.stderr
@@ -43,7 +43,7 @@ error: defaults for generic parameters are not allowed in `for<...>` binders
 LL |     for<const N: usize = 3, T = u32> [(); COT::BYTES]:,
    |                             ^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type `COT`
+error[E0433]: cannot find item `COT` in this scope
   --> $DIR/ice-predicates-of-no-entry-found-for-key-119275.rs:10:43
    |
 LL |     for<const N: usize = 3, T = u32> [(); COT::BYTES]:,

--- a/tests/ui/const-generics/issues/issue-82956.rs
+++ b/tests/ui/const-generics/issues/issue-82956.rs
@@ -23,7 +23,7 @@ where
 
     fn pop(self) -> (Self::Newlen, Self::Output) {
         let mut iter = IntoIter::new(self);
-        //~^ ERROR: failed to resolve: use of undeclared type `IntoIter`
+        //~^ ERROR cannot find item `IntoIter`
         let end = iter.next_back().unwrap();
         let new = [(); N - 1].map(move |()| iter.next().unwrap());
         (new, end)

--- a/tests/ui/const-generics/issues/issue-82956.stderr
+++ b/tests/ui/const-generics/issues/issue-82956.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `IntoIter`
+error[E0433]: cannot find item `IntoIter` in this scope
   --> $DIR/issue-82956.rs:25:24
    |
 LL |         let mut iter = IntoIter::new(self);

--- a/tests/ui/consts/const_refs_to_static-ice-121413.rs
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.rs
@@ -6,7 +6,7 @@
 const REF_INTERIOR_MUT: &usize = {
     //~^ HELP consider importing this struct
     static FOO: Sync = AtomicUsize::new(0);
-    //~^ ERROR failed to resolve: use of undeclared type `AtomicUsize`
+    //~^ ERROR cannot find item `AtomicUsize`
     //~| WARN trait objects without an explicit `dyn` are deprecated
     //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `AtomicUsize`
+error[E0433]: cannot find item `AtomicUsize` in this scope
   --> $DIR/const_refs_to_static-ice-121413.rs:8:24
    |
 LL |     static FOO: Sync = AtomicUsize::new(0);

--- a/tests/ui/custom-attribute-multisegment.rs
+++ b/tests/ui/custom-attribute-multisegment.rs
@@ -2,5 +2,5 @@
 
 mod existent {}
 
-#[existent::nonexistent] //~ ERROR failed to resolve: could not find `nonexistent` in `existent`
+#[existent::nonexistent] //~ ERROR cannot find macro `nonexistent` in module `existent`
 fn main() {}

--- a/tests/ui/custom-attribute-multisegment.stderr
+++ b/tests/ui/custom-attribute-multisegment.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: could not find `nonexistent` in `existent`
+error[E0433]: cannot find macro `nonexistent` in module `existent`
   --> $DIR/custom-attribute-multisegment.rs:5:13
    |
 LL | #[existent::nonexistent]

--- a/tests/ui/delegation/bad-resolve.rs
+++ b/tests/ui/delegation/bad-resolve.rs
@@ -40,7 +40,7 @@ impl Trait for S {
 }
 
 mod prefix {}
-reuse unresolved_prefix::{a, b, c}; //~ ERROR use of unresolved module or unlinked crate
-reuse prefix::{self, super, crate}; //~ ERROR `crate` in paths can only be used in start position
+reuse unresolved_prefix::{a, b, c}; //~ ERROR cannot find item `unresolved_prefix`
+reuse prefix::{self, super, crate}; //~ ERROR cannot find module `crate` in module `prefix`
 
 fn main() {}

--- a/tests/ui/delegation/bad-resolve.stderr
+++ b/tests/ui/delegation/bad-resolve.stderr
@@ -81,7 +81,7 @@ LL |     type Type;
 LL | impl Trait for S {
    | ^^^^^^^^^^^^^^^^ missing `Type` in implementation
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved_prefix`
+error[E0433]: cannot find item `unresolved_prefix` in this scope
   --> $DIR/bad-resolve.rs:43:7
    |
 LL | reuse unresolved_prefix::{a, b, c};
@@ -89,7 +89,7 @@ LL | reuse unresolved_prefix::{a, b, c};
    |
    = help: you might be missing a crate named `unresolved_prefix`
 
-error[E0433]: failed to resolve: `crate` in paths can only be used in start position
+error[E0433]: cannot find module `crate` in module `prefix`
   --> $DIR/bad-resolve.rs:44:29
    |
 LL | reuse prefix::{self, super, crate};

--- a/tests/ui/delegation/glob-bad-path.rs
+++ b/tests/ui/delegation/glob-bad-path.rs
@@ -5,7 +5,7 @@ trait Trait {}
 struct S;
 
 impl Trait for u8 {
-    reuse unresolved::*; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `unresolved`
+    reuse unresolved::*; //~ ERROR cannot find type `unresolved` in this scope
     reuse S::*; //~ ERROR expected trait, found struct `S`
 }
 

--- a/tests/ui/delegation/glob-bad-path.stderr
+++ b/tests/ui/delegation/glob-bad-path.stderr
@@ -4,7 +4,7 @@ error: expected trait, found struct `S`
 LL |     reuse S::*;
    |           ^ not a trait
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved`
+error[E0433]: cannot find type `unresolved` in this scope
   --> $DIR/glob-bad-path.rs:8:11
    |
 LL |     reuse unresolved::*;

--- a/tests/ui/derived-errors/issue-31997-1.stderr
+++ b/tests/ui/derived-errors/issue-31997-1.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `HashMap`
+error[E0433]: cannot find item `HashMap` in this scope
   --> $DIR/issue-31997-1.rs:20:19
    |
 LL |     let mut map = HashMap::new();

--- a/tests/ui/dollar-crate/dollar-crate-is-keyword-2.rs
+++ b/tests/ui/dollar-crate/dollar-crate-is-keyword-2.rs
@@ -3,11 +3,17 @@ mod a {}
 macro_rules! m {
     () => {
         use a::$crate; //~ ERROR unresolved import `a::$crate`
-        use a::$crate::b; //~ ERROR `$crate` in paths can only be used in start position
-        type A = a::$crate; //~ ERROR `$crate` in paths can only be used in start position
+        //~^ NOTE no `$crate` in `a`
+        use a::$crate::b; //~ ERROR cannot find module `$crate`
+        //~^ NOTE in paths can only be used in start position
+        type A = a::$crate; //~ ERROR cannot find module `$crate`
+        //~^ NOTE in paths can only be used in start position
     }
 }
 
 m!();
+//~^ NOTE in this expansion
+//~| NOTE in this expansion
+//~| NOTE in this expansion
 
 fn main() {}

--- a/tests/ui/dollar-crate/dollar-crate-is-keyword-2.stderr
+++ b/tests/ui/dollar-crate/dollar-crate-is-keyword-2.stderr
@@ -1,5 +1,5 @@
-error[E0433]: failed to resolve: `$crate` in paths can only be used in start position
-  --> $DIR/dollar-crate-is-keyword-2.rs:6:16
+error[E0433]: cannot find module `$crate` in module `a`
+  --> $DIR/dollar-crate-is-keyword-2.rs:7:16
    |
 LL |         use a::$crate::b;
    |                ^^^^^^ `$crate` in paths can only be used in start position
@@ -20,8 +20,8 @@ LL | m!();
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: `$crate` in paths can only be used in start position
-  --> $DIR/dollar-crate-is-keyword-2.rs:7:21
+error[E0433]: cannot find module `$crate` in module `a`
+  --> $DIR/dollar-crate-is-keyword-2.rs:9:21
    |
 LL |         type A = a::$crate;
    |                     ^^^^^^ `$crate` in paths can only be used in start position

--- a/tests/ui/enum/assoc-fn-call-on-variant.rs
+++ b/tests/ui/enum/assoc-fn-call-on-variant.rs
@@ -11,5 +11,5 @@ impl E {
 }
 
 fn main() {
-    E::A::f(); //~ ERROR failed to resolve: `A` is a variant, not a module
+    E::A::f(); //~ ERROR cannot find module `A` in enum `E`
 }

--- a/tests/ui/enum/assoc-fn-call-on-variant.stderr
+++ b/tests/ui/enum/assoc-fn-call-on-variant.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: `A` is a variant, not a module
+error[E0433]: cannot find module `A` in enum `E`
   --> $DIR/assoc-fn-call-on-variant.rs:14:8
    |
 LL |     E::A::f();

--- a/tests/ui/error-codes/E0433.stderr
+++ b/tests/ui/error-codes/E0433.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `NonExistingMap`
+error[E0433]: cannot find item `NonExistingMap` in this scope
   --> $DIR/E0433.rs:2:15
    |
 LL |     let map = NonExistingMap::new();

--- a/tests/ui/extern-flag/multiple-opts.rs
+++ b/tests/ui/extern-flag/multiple-opts.rs
@@ -16,5 +16,5 @@ pub mod m {
 }
 
 fn main() {
-    somedep::somefun();  //~ ERROR failed to resolve
+    somedep::somefun();  //~ ERROR cannot find item
 }

--- a/tests/ui/extern-flag/multiple-opts.stderr
+++ b/tests/ui/extern-flag/multiple-opts.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `somedep`
+error[E0433]: cannot find item `somedep` in this scope
   --> $DIR/multiple-opts.rs:19:5
    |
 LL |     somedep::somefun();

--- a/tests/ui/extern-flag/noprelude.rs
+++ b/tests/ui/extern-flag/noprelude.rs
@@ -3,5 +3,5 @@
 //@ edition:2018
 
 fn main() {
-    somedep::somefun();  //~ ERROR failed to resolve
+    somedep::somefun();  //~ ERROR cannot find item
 }

--- a/tests/ui/extern-flag/noprelude.stderr
+++ b/tests/ui/extern-flag/noprelude.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `somedep`
+error[E0433]: cannot find item `somedep` in this scope
   --> $DIR/noprelude.rs:6:5
    |
 LL |     somedep::somefun();

--- a/tests/ui/extern/extern-macro.rs
+++ b/tests/ui/extern/extern-macro.rs
@@ -2,5 +2,5 @@
 
 fn main() {
     enum Foo {}
-    let _ = Foo::bar!(); //~ ERROR failed to resolve: partially resolved path in a macro
+    let _ = Foo::bar!(); //~ ERROR cannot find macro `bar`
 }

--- a/tests/ui/extern/extern-macro.stderr
+++ b/tests/ui/extern/extern-macro.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: partially resolved path in a macro
+error[E0433]: cannot find macro `bar` in this scope
   --> $DIR/extern-macro.rs:5:13
    |
 LL |     let _ = Foo::bar!();

--- a/tests/ui/feature-gates/feature-gate-extern_absolute_paths.rs
+++ b/tests/ui/feature-gates/feature-gate-extern_absolute_paths.rs
@@ -1,5 +1,5 @@
 use core::default; //~ ERROR unresolved import `core`
 
 fn main() {
-    let _: u8 = ::core::default::Default(); //~ ERROR failed to resolve
+    let _: u8 = ::core::default::Default(); //~ ERROR cannot find item
 }

--- a/tests/ui/feature-gates/feature-gate-extern_absolute_paths.stderr
+++ b/tests/ui/feature-gates/feature-gate-extern_absolute_paths.stderr
@@ -7,7 +7,7 @@ LL | use core::default;
    |     you might be missing crate `core`
    |     help: try using `std` instead of `core`: `std`
 
-error[E0433]: failed to resolve: you might be missing crate `core`
+error[E0433]: cannot find item `core` in the crate root
   --> $DIR/feature-gate-extern_absolute_paths.rs:4:19
    |
 LL |     let _: u8 = ::core::default::Default();

--- a/tests/ui/foreign/stashed-issue-121451.rs
+++ b/tests/ui/foreign/stashed-issue-121451.rs
@@ -1,4 +1,4 @@
 extern "C" fn _f() -> libc::uintptr_t {}
-//~^ ERROR failed to resolve
+//~^ ERROR cannot find item `libc`
 
 fn main() {}

--- a/tests/ui/foreign/stashed-issue-121451.stderr
+++ b/tests/ui/foreign/stashed-issue-121451.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
+error[E0433]: cannot find item `libc` in this scope
   --> $DIR/stashed-issue-121451.rs:1:23
    |
 LL | extern "C" fn _f() -> libc::uintptr_t {}

--- a/tests/ui/generic-associated-types/equality-bound.rs
+++ b/tests/ui/generic-associated-types/equality-bound.rs
@@ -8,7 +8,7 @@ fn sum2<I: Iterator>(i: I) -> i32 where I::Item = i32 {
 }
 fn sum3<J: Iterator>(i: J) -> i32 where I::Item = i32 {
 //~^ ERROR equality constraints are not yet supported in `where` clauses
-//~| ERROR failed to resolve: use of undeclared type `I`
+//~| ERROR cannot find item `I`
     panic!()
 }
 

--- a/tests/ui/generic-associated-types/equality-bound.stderr
+++ b/tests/ui/generic-associated-types/equality-bound.stderr
@@ -164,7 +164,7 @@ LL | struct K {}
 LL |     fn from_iter<T>(_: T) -> Self where T::Item = A, T: IntoIterator,
    |                                                   ^ help: a struct with a similar name exists: `K`
 
-error[E0433]: failed to resolve: use of undeclared type `I`
+error[E0433]: cannot find item `I` in this scope
   --> $DIR/equality-bound.rs:9:41
    |
 LL | fn sum3<J: Iterator>(i: J) -> i32 where I::Item = i32 {

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.rs
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.rs
@@ -10,7 +10,7 @@ macro a() {
     mod u {
         // Late resolution.
         fn f() { my_core::mem::drop(0); }
-        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
+        //~^ ERROR cannot find item `my_core`
     }
 }
 
@@ -23,7 +23,7 @@ mod v {
 mod u {
     // Late resolution.
     fn f() { my_core::mem::drop(0); }
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
+    //~^ ERROR cannot find item `my_core`
 }
 
 fn main() {}

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.stderr
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.stderr
@@ -15,7 +15,7 @@ LL | a!();
    |
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
+error[E0433]: cannot find item `my_core` in this scope
   --> $DIR/extern-prelude-from-opaque-fail-2018.rs:12:18
    |
 LL |         fn f() { my_core::mem::drop(0); }
@@ -29,7 +29,7 @@ LL | a!();
            std::mem
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
+error[E0433]: cannot find item `my_core` in this scope
   --> $DIR/extern-prelude-from-opaque-fail-2018.rs:25:14
    |
 LL |     fn f() { my_core::mem::drop(0); }

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail.rs
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail.rs
@@ -10,7 +10,7 @@ macro a() {
     mod u {
         // Late resolution.
         fn f() { my_core::mem::drop(0); }
-        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
+        //~^ ERROR cannot find item `my_core`
     }
 }
 
@@ -23,7 +23,7 @@ mod v {
 mod u {
     // Late resolution.
     fn f() { my_core::mem::drop(0); }
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
+    //~^ ERROR cannot find item `my_core`
 }
 
 fn main() {}

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail.stderr
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail.stderr
@@ -15,7 +15,7 @@ LL | a!();
    |
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
+error[E0433]: cannot find item `my_core` in this scope
   --> $DIR/extern-prelude-from-opaque-fail.rs:12:18
    |
 LL |         fn f() { my_core::mem::drop(0); }
@@ -29,7 +29,7 @@ LL | a!();
            my_core::mem
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
+error[E0433]: cannot find item `my_core` in this scope
   --> $DIR/extern-prelude-from-opaque-fail.rs:25:14
    |
 LL |     fn f() { my_core::mem::drop(0); }

--- a/tests/ui/hygiene/no_implicit_prelude.rs
+++ b/tests/ui/hygiene/no_implicit_prelude.rs
@@ -8,7 +8,7 @@ mod foo {
 #[no_implicit_prelude]
 mod bar {
     pub macro m() {
-        Vec::new(); //~ ERROR failed to resolve
+        Vec::new(); //~ ERROR cannot find item
         ().clone() //~ ERROR no method named `clone` found
     }
     fn f() {

--- a/tests/ui/hygiene/no_implicit_prelude.stderr
+++ b/tests/ui/hygiene/no_implicit_prelude.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `Vec`
+error[E0433]: cannot find item `Vec` in this scope
   --> $DIR/no_implicit_prelude.rs:11:9
    |
 LL |     fn f() { ::bar::m!(); }

--- a/tests/ui/impl-trait/issues/issue-72911.rs
+++ b/tests/ui/impl-trait/issues/issue-72911.rs
@@ -9,12 +9,12 @@ pub fn gather_all() -> impl Iterator<Item = Lint> {
 }
 
 fn gather_from_file(dir_entry: &foo::MissingItem) -> impl Iterator<Item = Lint> {
-    //~^ ERROR: failed to resolve
+    //~^ ERROR cannot find item
     unimplemented!()
 }
 
 fn lint_files() -> impl Iterator<Item = foo::MissingItem> {
-    //~^ ERROR: failed to resolve
+    //~^ ERROR cannot find item
     unimplemented!()
 }
 

--- a/tests/ui/impl-trait/issues/issue-72911.stderr
+++ b/tests/ui/impl-trait/issues/issue-72911.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
+error[E0433]: cannot find item `foo` in this scope
   --> $DIR/issue-72911.rs:11:33
    |
 LL | fn gather_from_file(dir_entry: &foo::MissingItem) -> impl Iterator<Item = Lint> {
@@ -6,7 +6,7 @@ LL | fn gather_from_file(dir_entry: &foo::MissingItem) -> impl Iterator<Item = L
    |
    = help: you might be missing a crate named `foo`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
+error[E0433]: cannot find item `foo` in this scope
   --> $DIR/issue-72911.rs:16:41
    |
 LL | fn lint_files() -> impl Iterator<Item = foo::MissingItem> {

--- a/tests/ui/impl-trait/stashed-diag-issue-121504.rs
+++ b/tests/ui/impl-trait/stashed-diag-issue-121504.rs
@@ -4,7 +4,7 @@ trait MyTrait {
     async fn foo(self) -> (Self, i32);
 }
 
-impl MyTrait for xyz::T { //~ ERROR failed to resolve: use of unresolved module or unlinked crate `xyz`
+impl MyTrait for xyz::T { //~ ERROR cannot find item `xyz`
     async fn foo(self, key: i32) -> (u32, i32) {
         (self, key)
     }

--- a/tests/ui/impl-trait/stashed-diag-issue-121504.stderr
+++ b/tests/ui/impl-trait/stashed-diag-issue-121504.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `xyz`
+error[E0433]: cannot find item `xyz` in this scope
   --> $DIR/stashed-diag-issue-121504.rs:7:18
    |
 LL | impl MyTrait for xyz::T {

--- a/tests/ui/imports/absolute-paths-in-nested-use-groups.rs
+++ b/tests/ui/imports/absolute-paths-in-nested-use-groups.rs
@@ -3,9 +3,9 @@
 mod foo {}
 
 use foo::{
-    ::bar,       //~ ERROR crate root in paths can only be used in start position
-    super::bar,  //~ ERROR `super` in paths can only be used in start position
-    self::bar,   //~ ERROR `self` in paths can only be used in start position
+    ::bar,       //~ ERROR cannot find module
+    super::bar,  //~ ERROR cannot find module
+    self::bar,   //~ ERROR cannot find module
 };
 
 fn main() {}

--- a/tests/ui/imports/absolute-paths-in-nested-use-groups.stderr
+++ b/tests/ui/imports/absolute-paths-in-nested-use-groups.stderr
@@ -1,16 +1,16 @@
-error[E0433]: failed to resolve: crate root in paths can only be used in start position
+error[E0433]: cannot find module `{{root}}` in module `foo`
   --> $DIR/absolute-paths-in-nested-use-groups.rs:6:5
    |
 LL |     ::bar,
    |     ^ crate root in paths can only be used in start position
 
-error[E0433]: failed to resolve: `super` in paths can only be used in start position
+error[E0433]: cannot find module `super` in module `foo`
   --> $DIR/absolute-paths-in-nested-use-groups.rs:7:5
    |
 LL |     super::bar,
    |     ^^^^^ `super` in paths can only be used in start position
 
-error[E0433]: failed to resolve: `self` in paths can only be used in start position
+error[E0433]: cannot find module `self` in module `foo`
   --> $DIR/absolute-paths-in-nested-use-groups.rs:8:5
    |
 LL |     self::bar,

--- a/tests/ui/imports/extern-prelude-extern-crate-fail.rs
+++ b/tests/ui/imports/extern-prelude-extern-crate-fail.rs
@@ -7,7 +7,7 @@ mod n {
 
 mod m {
     fn check() {
-        two_macros::m!(); //~ ERROR failed to resolve: use of unresolved module or unlinked crate `two_macros`
+        two_macros::m!(); //~ ERROR cannot find item `two_macros`
     }
 }
 

--- a/tests/ui/imports/extern-prelude-extern-crate-fail.stderr
+++ b/tests/ui/imports/extern-prelude-extern-crate-fail.stderr
@@ -9,7 +9,7 @@ LL | define_std_as_non_existent!();
    |
    = note: this error originates in the macro `define_std_as_non_existent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `two_macros`
+error[E0433]: cannot find item `two_macros` in this scope
   --> $DIR/extern-prelude-extern-crate-fail.rs:10:9
    |
 LL |         two_macros::m!();

--- a/tests/ui/imports/suggest-import-issue-120074.edition2015.stderr
+++ b/tests/ui/imports/suggest-import-issue-120074.edition2015.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: unresolved import
+error[E0433]: cannot find item `bar` in the crate root
   --> $DIR/suggest-import-issue-120074.rs:12:35
    |
 LL |     println!("Hello, {}!", crate::bar::do_the_thing);

--- a/tests/ui/imports/suggest-import-issue-120074.edition2021.stderr
+++ b/tests/ui/imports/suggest-import-issue-120074.edition2021.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: unresolved import
+error[E0433]: cannot find item `bar` in the crate root
   --> $DIR/suggest-import-issue-120074.rs:12:35
    |
 LL |     println!("Hello, {}!", crate::bar::do_the_thing);

--- a/tests/ui/imports/suggest-import-issue-120074.rs
+++ b/tests/ui/imports/suggest-import-issue-120074.rs
@@ -9,5 +9,5 @@ pub mod foo {
 }
 
 fn main() {
-    println!("Hello, {}!", crate::bar::do_the_thing); //~ ERROR failed to resolve: unresolved import
+    println!("Hello, {}!", crate::bar::do_the_thing); //~ ERROR cannot find item `bar`
 }

--- a/tests/ui/imports/tool-mod-child.rs
+++ b/tests/ui/imports/tool-mod-child.rs
@@ -1,7 +1,7 @@
 use clippy::a; //~ ERROR unresolved import `clippy`
-use clippy::a::b; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `clippy`
+use clippy::a::b; //~ ERROR cannot find item `clippy`
 
 use rustdoc::a; //~ ERROR unresolved import `rustdoc`
-use rustdoc::a::b; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `rustdoc`
+use rustdoc::a::b; //~ ERROR cannot find item `rustdoc`
 
 fn main() {}

--- a/tests/ui/imports/tool-mod-child.stderr
+++ b/tests/ui/imports/tool-mod-child.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `clippy`
+error[E0433]: cannot find item `clippy` in the crate root
   --> $DIR/tool-mod-child.rs:2:5
    |
 LL | use clippy::a::b;
@@ -20,7 +20,7 @@ help: you might be missing a crate named `clippy`, add it to your project and im
 LL + extern crate clippy;
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rustdoc`
+error[E0433]: cannot find item `rustdoc` in the crate root
   --> $DIR/tool-mod-child.rs:5:5
    |
 LL | use rustdoc::a::b;

--- a/tests/ui/issues/issue-33293.rs
+++ b/tests/ui/issues/issue-33293.rs
@@ -1,6 +1,5 @@
 fn main() {
     match 0 {
-        aaa::bbb(_) => ()
-        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `aaa`
+        aaa::bbb(_) => () //~ ERROR cannot find item `aaa`
     };
 }

--- a/tests/ui/issues/issue-33293.stderr
+++ b/tests/ui/issues/issue-33293.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `aaa`
+error[E0433]: cannot find item `aaa` in this scope
   --> $DIR/issue-33293.rs:3:9
    |
 LL |         aaa::bbb(_) => ()

--- a/tests/ui/issues/issue-38857.rs
+++ b/tests/ui/issues/issue-38857.rs
@@ -1,5 +1,5 @@
 fn main() {
     let a = std::sys::imp::process::process_common::StdioPipes { ..panic!() };
-    //~^ ERROR failed to resolve: could not find `imp` in `sys` [E0433]
+    //~^ ERROR cannot find item `imp`
     //~^^ ERROR module `sys` is private [E0603]
 }

--- a/tests/ui/issues/issue-38857.stderr
+++ b/tests/ui/issues/issue-38857.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: could not find `imp` in `sys`
+error[E0433]: cannot find item `imp` in module `sys`
   --> $DIR/issue-38857.rs:2:23
    |
 LL |     let a = std::sys::imp::process::process_common::StdioPipes { ..panic!() };

--- a/tests/ui/issues/issue-46101.rs
+++ b/tests/ui/issues/issue-46101.rs
@@ -1,6 +1,6 @@
 trait Foo {}
-#[derive(Foo::Anything)] //~ ERROR failed to resolve: partially resolved path in a derive macro
-                         //~| ERROR failed to resolve: partially resolved path in a derive macro
+#[derive(Foo::Anything)] //~ ERROR cannot find macro `Anything`
+                         //~| ERROR cannot find macro `Anything`
 struct S;
 
 fn main() {}

--- a/tests/ui/issues/issue-46101.stderr
+++ b/tests/ui/issues/issue-46101.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: partially resolved path in a derive macro
+error[E0433]: cannot find macro `Anything` in this scope
   --> $DIR/issue-46101.rs:2:10
    |
 LL | #[derive(Foo::Anything)]
-   |          ^^^^^^^^^^^^^ partially resolved path in a derive macro
+   |          ^^^^^^^^^^^^^ partially resolved path in a macro
 
-error[E0433]: failed to resolve: partially resolved path in a derive macro
+error[E0433]: cannot find macro `Anything` in this scope
   --> $DIR/issue-46101.rs:2:10
    |
 LL | #[derive(Foo::Anything)]
-   |          ^^^^^^^^^^^^^ partially resolved path in a derive macro
+   |          ^^^^^^^^^^^^^ partially resolved path in a macro
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/issues/issue-71406.rs
+++ b/tests/ui/issues/issue-71406.rs
@@ -2,5 +2,5 @@ use std::sync::mpsc;
 
 fn main() {
     let (tx, rx) = mpsc::channel::new(1);
-    //~^ ERROR expected type, found function `channel` in `mpsc`
+    //~^ ERROR cannot find item `channel` in module `mpsc`
 }

--- a/tests/ui/issues/issue-71406.stderr
+++ b/tests/ui/issues/issue-71406.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: expected type, found function `channel` in `mpsc`
+error[E0433]: cannot find item `channel` in module `mpsc`
   --> $DIR/issue-71406.rs:4:26
    |
 LL |     let (tx, rx) = mpsc::channel::new(1);

--- a/tests/ui/keyword/keyword-super-as-identifier.rs
+++ b/tests/ui/keyword/keyword-super-as-identifier.rs
@@ -1,3 +1,5 @@
 fn main() {
-    let super = 22; //~ ERROR failed to resolve: there are too many leading `super` keywords
+    let super = 22; //~ ERROR cannot find item `super`
+    //~^ NOTE can't use `super` as an identifier
+    //~| HELP if you still want to call your identifier `super`, use the raw identifier format
 }

--- a/tests/ui/keyword/keyword-super-as-identifier.stderr
+++ b/tests/ui/keyword/keyword-super-as-identifier.stderr
@@ -1,8 +1,13 @@
-error[E0433]: failed to resolve: there are too many leading `super` keywords
+error[E0433]: cannot find item `super` in this scope
   --> $DIR/keyword-super-as-identifier.rs:2:9
    |
 LL |     let super = 22;
-   |         ^^^^^ there are too many leading `super` keywords
+   |         ^^^^^ can't use `super` as an identifier
+   |
+help: if you still want to call your identifier `super`, use the raw identifier format
+   |
+LL |     let r#super = 22;
+   |         ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/keyword/keyword-super.rs
+++ b/tests/ui/keyword/keyword-super.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let super: isize; //~ ERROR failed to resolve: there are too many leading `super` keywords
+    let super: isize; //~ ERROR cannot find item `super`
 }

--- a/tests/ui/keyword/keyword-super.stderr
+++ b/tests/ui/keyword/keyword-super.stderr
@@ -1,8 +1,13 @@
-error[E0433]: failed to resolve: there are too many leading `super` keywords
+error[E0433]: cannot find item `super` in this scope
   --> $DIR/keyword-super.rs:2:9
    |
 LL |     let super: isize;
-   |         ^^^^^ there are too many leading `super` keywords
+   |         ^^^^^ can't use `super` as an identifier
+   |
+help: if you still want to call your identifier `super`, use the raw identifier format
+   |
+LL |     let r#super: isize;
+   |         ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/issue-97194.rs
+++ b/tests/ui/lifetimes/issue-97194.rs
@@ -2,7 +2,7 @@ extern "C" {
     fn bget(&self, index: [usize; Self::DIM]) -> bool {
         //~^ ERROR incorrect function inside `extern` block
         //~| ERROR `self` parameter is only allowed in associated functions
-        //~| ERROR failed to resolve: `Self`
+        //~| ERROR cannot find item `Self` in this scope
         type T<'a> = &'a str;
     }
 }

--- a/tests/ui/lifetimes/issue-97194.stderr
+++ b/tests/ui/lifetimes/issue-97194.stderr
@@ -22,7 +22,7 @@ LL |     fn bget(&self, index: [usize; Self::DIM]) -> bool {
    |
    = note: associated functions are those in `impl` or `trait` definitions
 
-error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+error[E0433]: cannot find item `Self` in this scope
   --> $DIR/issue-97194.rs:2:35
    |
 LL |     fn bget(&self, index: [usize; Self::DIM]) -> bool {

--- a/tests/ui/lint/ice-array-into-iter-lint-issue-121532.rs
+++ b/tests/ui/lint/ice-array-into-iter-lint-issue-121532.rs
@@ -4,7 +4,7 @@
 
  // Typeck fails for the arg type as
  // `Self` makes no sense here
-fn func(a: Self::ItemsIterator) { //~ ERROR failed to resolve: `Self` is only available in impls, traits, and type definitions
+fn func(a: Self::ItemsIterator) { //~ ERROR cannot find item `Self` in this scope
     a.into_iter();
 }
 

--- a/tests/ui/lint/ice-array-into-iter-lint-issue-121532.stderr
+++ b/tests/ui/lint/ice-array-into-iter-lint-issue-121532.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+error[E0433]: cannot find item `Self` in this scope
   --> $DIR/ice-array-into-iter-lint-issue-121532.rs:7:12
    |
 LL | fn func(a: Self::ItemsIterator) {

--- a/tests/ui/macros/builtin-prelude-no-accidents.rs
+++ b/tests/ui/macros/builtin-prelude-no-accidents.rs
@@ -2,7 +2,7 @@
 // because macros with the same names are in prelude.
 
 fn main() {
-    env::current_dir; //~ ERROR use of unresolved module or unlinked crate `env`
-    type A = panic::PanicInfo; //~ ERROR use of unresolved module or unlinked crate `panic`
-    type B = vec::Vec<u8>; //~ ERROR use of unresolved module or unlinked crate `vec`
+    env::current_dir; //~ ERROR cannot find item `env`
+    type A = panic::PanicInfo; //~ ERROR cannot find item `panic`
+    type B = vec::Vec<u8>; //~ ERROR cannot find item `vec`
 }

--- a/tests/ui/macros/builtin-prelude-no-accidents.stderr
+++ b/tests/ui/macros/builtin-prelude-no-accidents.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `env`
+error[E0433]: cannot find item `env` in this scope
   --> $DIR/builtin-prelude-no-accidents.rs:5:5
    |
 LL |     env::current_dir;
@@ -10,7 +10,7 @@ help: consider importing this module
 LL + use std::env;
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `panic`
+error[E0433]: cannot find item `panic` in this scope
   --> $DIR/builtin-prelude-no-accidents.rs:6:14
    |
 LL |     type A = panic::PanicInfo;
@@ -22,7 +22,7 @@ help: consider importing this module
 LL + use std::panic;
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `vec`
+error[E0433]: cannot find item `vec` in this scope
   --> $DIR/builtin-prelude-no-accidents.rs:7:14
    |
 LL |     type B = vec::Vec<u8>;

--- a/tests/ui/macros/builtin-std-paths-fail.rs
+++ b/tests/ui/macros/builtin-std-paths-fail.rs
@@ -1,25 +1,25 @@
 #[derive(
-    core::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `core`
-                          //~| ERROR could not find `RustcDecodable` in `core`
-    core::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `core`
-                          //~| ERROR could not find `RustcDecodable` in `core`
+    core::RustcDecodable, //~ ERROR cannot find macro `RustcDecodable` in crate `core`
+                          //~| ERROR cannot find macro `RustcDecodable` in crate `core`
+    core::RustcDecodable, //~ ERROR cannot find macro `RustcDecodable` in crate `core`
+                          //~| ERROR cannot find macro `RustcDecodable` in crate `core`
 )]
-#[core::bench] //~ ERROR could not find `bench` in `core`
-#[core::global_allocator] //~ ERROR could not find `global_allocator` in `core`
-#[core::test_case] //~ ERROR could not find `test_case` in `core`
-#[core::test] //~ ERROR could not find `test` in `core`
+#[core::bench] //~ ERROR cannot find macro `bench` in crate `core`
+#[core::global_allocator] //~ ERROR cannot find macro `global_allocator` in crate `core`
+#[core::test_case] //~ ERROR cannot find macro `test_case` in crate `core`
+#[core::test] //~ ERROR cannot find macro `test` in crate `core`
 struct Core;
 
 #[derive(
-    std::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `std`
-                         //~| ERROR could not find `RustcDecodable` in `std`
-    std::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `std`
-                         //~| ERROR could not find `RustcDecodable` in `std`
+    std::RustcDecodable, //~ ERROR cannot find macro `RustcDecodable` in crate `std`
+                         //~| ERROR cannot find macro `RustcDecodable` in crate `std`
+    std::RustcDecodable, //~ ERROR cannot find macro `RustcDecodable` in crate `std`
+                         //~| ERROR cannot find macro `RustcDecodable` in crate `std`
 )]
-#[std::bench] //~ ERROR could not find `bench` in `std`
-#[std::global_allocator] //~ ERROR could not find `global_allocator` in `std`
-#[std::test_case] //~ ERROR could not find `test_case` in `std`
-#[std::test] //~ ERROR could not find `test` in `std`
+#[std::bench] //~ ERROR cannot find macro `bench` in crate `std`
+#[std::global_allocator] //~ ERROR cannot find macro `global_allocator` in crate `std`
+#[std::test_case] //~ ERROR cannot find macro `test_case` in crate `std`
+#[std::test] //~ ERROR cannot find macro `test` in crate `std`
 struct Std;
 
 fn main() {}

--- a/tests/ui/macros/builtin-std-paths-fail.stderr
+++ b/tests/ui/macros/builtin-std-paths-fail.stderr
@@ -1,16 +1,16 @@
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
+error[E0433]: cannot find macro `RustcDecodable` in crate `core`
   --> $DIR/builtin-std-paths-fail.rs:2:11
    |
 LL |     core::RustcDecodable,
    |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
 
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
+error[E0433]: cannot find macro `RustcDecodable` in crate `core`
   --> $DIR/builtin-std-paths-fail.rs:4:11
    |
 LL |     core::RustcDecodable,
    |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
 
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
+error[E0433]: cannot find macro `RustcDecodable` in crate `core`
   --> $DIR/builtin-std-paths-fail.rs:2:11
    |
 LL |     core::RustcDecodable,
@@ -18,7 +18,7 @@ LL |     core::RustcDecodable,
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
+error[E0433]: cannot find macro `RustcDecodable` in crate `core`
   --> $DIR/builtin-std-paths-fail.rs:4:11
    |
 LL |     core::RustcDecodable,
@@ -26,43 +26,43 @@ LL |     core::RustcDecodable,
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0433]: failed to resolve: could not find `bench` in `core`
+error[E0433]: cannot find macro `bench` in crate `core`
   --> $DIR/builtin-std-paths-fail.rs:7:9
    |
 LL | #[core::bench]
    |         ^^^^^ could not find `bench` in `core`
 
-error[E0433]: failed to resolve: could not find `global_allocator` in `core`
+error[E0433]: cannot find macro `global_allocator` in crate `core`
   --> $DIR/builtin-std-paths-fail.rs:8:9
    |
 LL | #[core::global_allocator]
    |         ^^^^^^^^^^^^^^^^ could not find `global_allocator` in `core`
 
-error[E0433]: failed to resolve: could not find `test_case` in `core`
+error[E0433]: cannot find macro `test_case` in crate `core`
   --> $DIR/builtin-std-paths-fail.rs:9:9
    |
 LL | #[core::test_case]
    |         ^^^^^^^^^ could not find `test_case` in `core`
 
-error[E0433]: failed to resolve: could not find `test` in `core`
+error[E0433]: cannot find macro `test` in crate `core`
   --> $DIR/builtin-std-paths-fail.rs:10:9
    |
 LL | #[core::test]
    |         ^^^^ could not find `test` in `core`
 
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
+error[E0433]: cannot find macro `RustcDecodable` in crate `std`
   --> $DIR/builtin-std-paths-fail.rs:14:10
    |
 LL |     std::RustcDecodable,
    |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
 
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
+error[E0433]: cannot find macro `RustcDecodable` in crate `std`
   --> $DIR/builtin-std-paths-fail.rs:16:10
    |
 LL |     std::RustcDecodable,
    |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
 
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
+error[E0433]: cannot find macro `RustcDecodable` in crate `std`
   --> $DIR/builtin-std-paths-fail.rs:14:10
    |
 LL |     std::RustcDecodable,
@@ -70,7 +70,7 @@ LL |     std::RustcDecodable,
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
+error[E0433]: cannot find macro `RustcDecodable` in crate `std`
   --> $DIR/builtin-std-paths-fail.rs:16:10
    |
 LL |     std::RustcDecodable,
@@ -78,25 +78,25 @@ LL |     std::RustcDecodable,
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0433]: failed to resolve: could not find `bench` in `std`
+error[E0433]: cannot find macro `bench` in crate `std`
   --> $DIR/builtin-std-paths-fail.rs:19:8
    |
 LL | #[std::bench]
    |        ^^^^^ could not find `bench` in `std`
 
-error[E0433]: failed to resolve: could not find `global_allocator` in `std`
+error[E0433]: cannot find macro `global_allocator` in crate `std`
   --> $DIR/builtin-std-paths-fail.rs:20:8
    |
 LL | #[std::global_allocator]
    |        ^^^^^^^^^^^^^^^^ could not find `global_allocator` in `std`
 
-error[E0433]: failed to resolve: could not find `test_case` in `std`
+error[E0433]: cannot find macro `test_case` in crate `std`
   --> $DIR/builtin-std-paths-fail.rs:21:8
    |
 LL | #[std::test_case]
    |        ^^^^^^^^^ could not find `test_case` in `std`
 
-error[E0433]: failed to resolve: could not find `test` in `std`
+error[E0433]: cannot find macro `test` in crate `std`
   --> $DIR/builtin-std-paths-fail.rs:22:8
    |
 LL | #[std::test]

--- a/tests/ui/macros/macro-inner-attributes.rs
+++ b/tests/ui/macros/macro-inner-attributes.rs
@@ -14,7 +14,6 @@ test!(b,
 
 #[rustc_dummy]
 fn main() {
-    a::bar();
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `a`
+    a::bar(); //~ ERROR cannot find item `a`
     b::bar();
 }

--- a/tests/ui/macros/macro-inner-attributes.stderr
+++ b/tests/ui/macros/macro-inner-attributes.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `a`
+error[E0433]: cannot find item `a` in this scope
   --> $DIR/macro-inner-attributes.rs:17:5
    |
 LL |     a::bar();

--- a/tests/ui/macros/macro-path-prelude-fail-1.rs
+++ b/tests/ui/macros/macro-path-prelude-fail-1.rs
@@ -1,7 +1,7 @@
 mod m {
     fn check() {
-        Vec::clone!(); //~ ERROR failed to resolve: `Vec` is a struct, not a module
-        u8::clone!(); //~ ERROR failed to resolve: `u8` is a builtin type, not a module
+        Vec::clone!(); //~ ERROR cannot find module `Vec`
+        u8::clone!(); //~ ERROR cannot find module `u8`
     }
 }
 

--- a/tests/ui/macros/macro-path-prelude-fail-1.stderr
+++ b/tests/ui/macros/macro-path-prelude-fail-1.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: `Vec` is a struct, not a module
+error[E0433]: cannot find module `Vec` in this scope
   --> $DIR/macro-path-prelude-fail-1.rs:3:9
    |
 LL |         Vec::clone!();
    |         ^^^ `Vec` is a struct, not a module
 
-error[E0433]: failed to resolve: `u8` is a builtin type, not a module
+error[E0433]: cannot find module `u8` in this scope
   --> $DIR/macro-path-prelude-fail-1.rs:4:9
    |
 LL |         u8::clone!();

--- a/tests/ui/macros/macro-path-prelude-fail-2.rs
+++ b/tests/ui/macros/macro-path-prelude-fail-2.rs
@@ -1,6 +1,6 @@
 mod m {
     fn check() {
-        Result::Ok!(); //~ ERROR failed to resolve: partially resolved path in a macro
+        Result::Ok!(); //~ ERROR cannot find macro `Ok`
     }
 }
 

--- a/tests/ui/macros/macro-path-prelude-fail-2.stderr
+++ b/tests/ui/macros/macro-path-prelude-fail-2.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: partially resolved path in a macro
+error[E0433]: cannot find macro `Ok` in this scope
   --> $DIR/macro-path-prelude-fail-2.rs:3:9
    |
 LL |         Result::Ok!();

--- a/tests/ui/macros/macro_path_as_generic_bound.rs
+++ b/tests/ui/macros/macro_path_as_generic_bound.rs
@@ -4,6 +4,6 @@ macro_rules! foo(($t:path) => {
     impl<T: $t> Foo for T {}
 });
 
-foo!(m::m2::A); //~ ERROR failed to resolve
+foo!(m::m2::A); //~ ERROR cannot find item
 
 fn main() {}

--- a/tests/ui/macros/macro_path_as_generic_bound.stderr
+++ b/tests/ui/macros/macro_path_as_generic_bound.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `m`
+error[E0433]: cannot find item `m` in this scope
   --> $DIR/macro_path_as_generic_bound.rs:7:6
    |
 LL | foo!(m::m2::A);

--- a/tests/ui/macros/meta-item-absolute-path.rs
+++ b/tests/ui/macros/meta-item-absolute-path.rs
@@ -1,5 +1,5 @@
-#[derive(::Absolute)] //~ ERROR failed to resolve
-                      //~| ERROR failed to resolve
+#[derive(::Absolute)] //~ ERROR cannot find macro
+                      //~| ERROR cannot find macro
 struct S;
 
 fn main() {}

--- a/tests/ui/macros/meta-item-absolute-path.stderr
+++ b/tests/ui/macros/meta-item-absolute-path.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `Absolute`
+error[E0433]: cannot find macro `Absolute` in the crate root
   --> $DIR/meta-item-absolute-path.rs:1:12
    |
 LL | #[derive(::Absolute)]
    |            ^^^^^^^^ use of unresolved module or unlinked crate `Absolute`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `Absolute`
+error[E0433]: cannot find macro `Absolute` in the crate root
   --> $DIR/meta-item-absolute-path.rs:1:12
    |
 LL | #[derive(::Absolute)]

--- a/tests/ui/mir/issue-121103.rs
+++ b/tests/ui/mir/issue-121103.rs
@@ -1,3 +1,3 @@
 fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
-//~^ ERROR failed to resolve: use of unresolved module or unlinked crate `lib2`
-//~| ERROR failed to resolve: use of unresolved module or unlinked crate `lib2`
+//~^ ERROR cannot find item `lib2`
+//~| ERROR cannot find item `lib2`

--- a/tests/ui/mir/issue-121103.stderr
+++ b/tests/ui/mir/issue-121103.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `lib2`
+error[E0433]: cannot find item `lib2` in this scope
   --> $DIR/issue-121103.rs:1:38
    |
 LL | fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
@@ -6,7 +6,7 @@ LL | fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
    |
    = help: you might be missing a crate named `lib2`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `lib2`
+error[E0433]: cannot find item `lib2` in this scope
   --> $DIR/issue-121103.rs:1:13
    |
 LL | fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}

--- a/tests/ui/modules_and_files_visibility/mod_file_disambig.rs
+++ b/tests/ui/modules_and_files_visibility/mod_file_disambig.rs
@@ -2,5 +2,5 @@ mod mod_file_disambig_aux; //~ ERROR file for module `mod_file_disambig_aux` fou
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
+    //~^ ERROR cannot find item `mod_file_aux`
 }

--- a/tests/ui/modules_and_files_visibility/mod_file_disambig.stderr
+++ b/tests/ui/modules_and_files_visibility/mod_file_disambig.stderr
@@ -6,7 +6,7 @@ LL | mod mod_file_disambig_aux;
    |
    = help: delete or rename one of them to remove the ambiguity
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
+error[E0433]: cannot find item `mod_file_aux` in this scope
   --> $DIR/mod_file_disambig.rs:4:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);

--- a/tests/ui/parser/const-param-decl-on-type-instead-of-impl.rs
+++ b/tests/ui/parser/const-param-decl-on-type-instead-of-impl.rs
@@ -11,5 +11,5 @@ fn banana(a: <T<const N: usize>>::BAR) {}
 fn chaenomeles() {
     path::path::Struct::<const N: usize>()
     //~^ ERROR unexpected `const` parameter declaration
-    //~| ERROR failed to resolve: use of unresolved module or unlinked crate `path`
+    //~| ERROR cannot find item `path`
 }

--- a/tests/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
+++ b/tests/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
@@ -22,7 +22,7 @@ error: unexpected `const` parameter declaration
 LL |     path::path::Struct::<const N: usize>()
    |                          ^^^^^^^^^^^^^^ expected a `const` expression, not a parameter declaration
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `path`
+error[E0433]: cannot find item `path` in this scope
   --> $DIR/const-param-decl-on-type-instead-of-impl.rs:12:5
    |
 LL |     path::path::Struct::<const N: usize>()

--- a/tests/ui/parser/dyn-trait-compatibility.rs
+++ b/tests/ui/parser/dyn-trait-compatibility.rs
@@ -1,7 +1,7 @@
 type A0 = dyn;
 //~^ ERROR cannot find type `dyn` in this scope
 type A1 = dyn::dyn;
-//~^ ERROR use of unresolved module or unlinked crate `dyn`
+//~^ ERROR cannot find item `dyn` in this scope
 type A2 = dyn<dyn, dyn>;
 //~^ ERROR cannot find type `dyn` in this scope
 //~| ERROR cannot find type `dyn` in this scope

--- a/tests/ui/parser/dyn-trait-compatibility.stderr
+++ b/tests/ui/parser/dyn-trait-compatibility.stderr
@@ -40,7 +40,7 @@ error[E0412]: cannot find type `dyn` in this scope
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                ^^^ not found in this scope
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `dyn`
+error[E0433]: cannot find item `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:3:11
    |
 LL | type A1 = dyn::dyn;

--- a/tests/ui/parser/mod_file_not_exist.rs
+++ b/tests/ui/parser/mod_file_not_exist.rs
@@ -3,6 +3,6 @@ mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
+    //~^ ERROR cannot find item `mod_file_aux`
     //~| HELP you might be missing a crate named `mod_file_aux`
 }

--- a/tests/ui/parser/mod_file_not_exist.stderr
+++ b/tests/ui/parser/mod_file_not_exist.stderr
@@ -7,7 +7,7 @@ LL | mod not_a_real_file;
    = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs" or "$DIR/not_a_real_file/mod.rs"
    = note: if there is a `mod not_a_real_file` elsewhere in the crate already, import it with `use crate::...` instead
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
+error[E0433]: cannot find item `mod_file_aux` in this scope
   --> $DIR/mod_file_not_exist.rs:5:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);

--- a/tests/ui/parser/mod_file_not_exist_windows.rs
+++ b/tests/ui/parser/mod_file_not_exist_windows.rs
@@ -5,6 +5,5 @@ mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
-    //~| HELP you might be missing a crate named `mod_file_aux`
+    //~^ ERROR cannot find item `mod_file_aux`
 }

--- a/tests/ui/pattern/pattern-error-continue.rs
+++ b/tests/ui/pattern/pattern-error-continue.rs
@@ -32,6 +32,6 @@ fn main() {
     //~| NOTE expected `char`, found `bool`
 
     match () {
-        E::V => {} //~ ERROR failed to resolve: use of undeclared type `E`
+        E::V => {} //~ ERROR cannot find item `E`
     }
 }

--- a/tests/ui/pattern/pattern-error-continue.stderr
+++ b/tests/ui/pattern/pattern-error-continue.stderr
@@ -52,7 +52,7 @@ note: function defined here
 LL | fn f(_c: char) {}
    |    ^ --------
 
-error[E0433]: failed to resolve: use of undeclared type `E`
+error[E0433]: cannot find item `E` in this scope
   --> $DIR/pattern-error-continue.rs:35:9
    |
 LL |         E::V => {}

--- a/tests/ui/privacy/restricted/test.rs
+++ b/tests/ui/privacy/restricted/test.rs
@@ -47,6 +47,6 @@ fn main() {
 }
 
 mod pathological {
-    pub(in bad::path) mod m1 {} //~ ERROR failed to resolve: use of unresolved module or unlinked crate `bad`
+    pub(in bad::path) mod m1 {} //~ ERROR cannot find item `bad`
     pub(in foo) mod m2 {} //~ ERROR visibilities can only be restricted to ancestor modules
 }

--- a/tests/ui/privacy/restricted/test.stderr
+++ b/tests/ui/privacy/restricted/test.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `bad`
+error[E0433]: cannot find item `bad` in this scope
   --> $DIR/test.rs:50:12
    |
 LL |     pub(in bad::path) mod m1 {}

--- a/tests/ui/privacy/unreachable-issue-121455.rs
+++ b/tests/ui/privacy/unreachable-issue-121455.rs
@@ -1,5 +1,6 @@
 fn test(s: &Self::Id) {
-//~^ ERROR failed to resolve: `Self` is only available in impls, traits, and type definitions
+//~^ ERROR cannot find item `Self` in this scope
+//~| NOTE `Self` is only available in impls, traits, and type definitions
     match &s[0..3] {}
 }
 

--- a/tests/ui/privacy/unreachable-issue-121455.stderr
+++ b/tests/ui/privacy/unreachable-issue-121455.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+error[E0433]: cannot find item `Self` in this scope
   --> $DIR/unreachable-issue-121455.rs:1:13
    |
 LL | fn test(s: &Self::Id) {

--- a/tests/ui/proc-macro/amputate-span.stderr
+++ b/tests/ui/proc-macro/amputate-span.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `Command`
+error[E0433]: cannot find item `Command` in this scope
   --> $DIR/amputate-span.rs:49:5
    |
 LL |     Command::new("git");
@@ -9,7 +9,7 @@ help: consider importing this struct
 LL + use std::process::Command;
    |
 
-error[E0433]: failed to resolve: use of undeclared type `Command`
+error[E0433]: cannot find item `Command` in this scope
   --> $DIR/amputate-span.rs:63:9
    |
 LL |         Command::new("git");

--- a/tests/ui/resolve/112590-2.fixed
+++ b/tests/ui/resolve/112590-2.fixed
@@ -15,7 +15,7 @@ mod u {
     use foo::bar::baz::MyVec;
 
 fn _a() {
-        let _: Vec<i32> = MyVec::new(); //~ ERROR failed to resolve
+        let _: Vec<i32> = MyVec::new(); //~ ERROR cannot find item
     }
 }
 
@@ -23,12 +23,12 @@ mod v {
     use foo::bar::baz::MyVec;
 
 fn _b() {
-        let _: Vec<i32> = MyVec::new(); //~ ERROR failed to resolve
+        let _: Vec<i32> = MyVec::new(); //~ ERROR cannot find item
     }
 }
 
 fn main() {
-    let _t: Vec<i32> = Vec::new(); //~ ERROR failed to resolve
-    type _B = vec::Vec::<u8>; //~ ERROR failed to resolve
-    let _t = AtomicBool::new(true); //~ ERROR failed to resolve
+    let _t: Vec<i32> = Vec::new(); //~ ERROR cannot find item
+    type _B = vec::Vec::<u8>; //~ ERROR cannot find item
+    let _t = AtomicBool::new(true); //~ ERROR cannot find item
 }

--- a/tests/ui/resolve/112590-2.rs
+++ b/tests/ui/resolve/112590-2.rs
@@ -9,18 +9,18 @@ mod foo {
 
 mod u {
     fn _a() {
-        let _: Vec<i32> = super::foo::baf::baz::MyVec::new(); //~ ERROR failed to resolve
+        let _: Vec<i32> = super::foo::baf::baz::MyVec::new(); //~ ERROR cannot find item
     }
 }
 
 mod v {
     fn _b() {
-        let _: Vec<i32> = fox::bar::baz::MyVec::new(); //~ ERROR failed to resolve
+        let _: Vec<i32> = fox::bar::baz::MyVec::new(); //~ ERROR cannot find item
     }
 }
 
 fn main() {
-    let _t: Vec<i32> = vec::new(); //~ ERROR failed to resolve
-    type _B = vec::Vec::<u8>; //~ ERROR failed to resolve
-    let _t = std::sync_error::atomic::AtomicBool::new(true); //~ ERROR failed to resolve
+    let _t: Vec<i32> = vec::new(); //~ ERROR cannot find item
+    type _B = vec::Vec::<u8>; //~ ERROR cannot find item
+    let _t = std::sync_error::atomic::AtomicBool::new(true); //~ ERROR cannot find item
 }

--- a/tests/ui/resolve/112590-2.stderr
+++ b/tests/ui/resolve/112590-2.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: could not find `baf` in `foo`
+error[E0433]: cannot find item `baf` in module `foo`
   --> $DIR/112590-2.rs:12:39
    |
 LL |         let _: Vec<i32> = super::foo::baf::baz::MyVec::new();
@@ -14,7 +14,7 @@ LL -         let _: Vec<i32> = super::foo::baf::baz::MyVec::new();
 LL +         let _: Vec<i32> = MyVec::new();
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fox`
+error[E0433]: cannot find item `fox` in this scope
   --> $DIR/112590-2.rs:18:27
    |
 LL |         let _: Vec<i32> = fox::bar::baz::MyVec::new();
@@ -31,7 +31,7 @@ LL -         let _: Vec<i32> = fox::bar::baz::MyVec::new();
 LL +         let _: Vec<i32> = MyVec::new();
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `vec`
+error[E0433]: cannot find item `vec` in this scope
   --> $DIR/112590-2.rs:24:15
    |
 LL |     type _B = vec::Vec::<u8>;
@@ -43,7 +43,7 @@ help: consider importing this module
 LL + use std::vec;
    |
 
-error[E0433]: failed to resolve: could not find `sync_error` in `std`
+error[E0433]: cannot find item `sync_error` in crate `std`
   --> $DIR/112590-2.rs:25:19
    |
 LL |     let _t = std::sync_error::atomic::AtomicBool::new(true);
@@ -59,7 +59,7 @@ LL -     let _t = std::sync_error::atomic::AtomicBool::new(true);
 LL +     let _t = AtomicBool::new(true);
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `vec`
+error[E0433]: cannot find item `vec` in this scope
   --> $DIR/112590-2.rs:23:24
    |
 LL |     let _t: Vec<i32> = vec::new();

--- a/tests/ui/resolve/bad-module.rs
+++ b/tests/ui/resolve/bad-module.rs
@@ -1,7 +1,7 @@
 fn main() {
     let foo = thing::len(Vec::new());
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `thing`
+    //~^ ERROR cannot find item `thing`
 
     let foo = foo::bar::baz();
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
+    //~^ ERROR cannot find item `foo`
 }

--- a/tests/ui/resolve/bad-module.stderr
+++ b/tests/ui/resolve/bad-module.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
+error[E0433]: cannot find item `foo` in this scope
   --> $DIR/bad-module.rs:5:15
    |
 LL |     let foo = foo::bar::baz();
@@ -6,7 +6,7 @@ LL |     let foo = foo::bar::baz();
    |
    = help: you might be missing a crate named `foo`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `thing`
+error[E0433]: cannot find item `thing` in this scope
   --> $DIR/bad-module.rs:2:15
    |
 LL |     let foo = thing::len(Vec::new());

--- a/tests/ui/resolve/editions-crate-root-2015.rs
+++ b/tests/ui/resolve/editions-crate-root-2015.rs
@@ -2,10 +2,10 @@
 
 mod inner {
     fn global_inner(_: ::nonexistant::Foo) {
-        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `nonexistant`
+        //~^ ERROR cannot find item `nonexistant`
     }
     fn crate_inner(_: crate::nonexistant::Foo) {
-        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `nonexistant`
+        //~^ ERROR cannot find item `nonexistant`
     }
 
     fn bare_global(_: ::nonexistant) {

--- a/tests/ui/resolve/editions-crate-root-2015.stderr
+++ b/tests/ui/resolve/editions-crate-root-2015.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistant`
+error[E0433]: cannot find item `nonexistant` in the crate root
   --> $DIR/editions-crate-root-2015.rs:4:26
    |
 LL |     fn global_inner(_: ::nonexistant::Foo) {
@@ -9,7 +9,7 @@ help: you might be missing a crate named `nonexistant`, add it to your project a
 LL + extern crate nonexistant;
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistant`
+error[E0433]: cannot find item `nonexistant` in the crate root
   --> $DIR/editions-crate-root-2015.rs:7:30
    |
 LL |     fn crate_inner(_: crate::nonexistant::Foo) {

--- a/tests/ui/resolve/editions-crate-root-2018.rs
+++ b/tests/ui/resolve/editions-crate-root-2018.rs
@@ -2,10 +2,10 @@
 
 mod inner {
     fn global_inner(_: ::nonexistant::Foo) {
-        //~^ ERROR failed to resolve: could not find `nonexistant` in the list of imported crates
+        //~^ ERROR cannot find item `nonexistant`
     }
     fn crate_inner(_: crate::nonexistant::Foo) {
-        //~^ ERROR failed to resolve: could not find `nonexistant` in the crate root
+        //~^ ERROR cannot find item `nonexistant`
     }
 
     fn bare_global(_: ::nonexistant) {

--- a/tests/ui/resolve/editions-crate-root-2018.stderr
+++ b/tests/ui/resolve/editions-crate-root-2018.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: could not find `nonexistant` in the list of imported crates
+error[E0433]: cannot find item `nonexistant` in the list of imported crates
   --> $DIR/editions-crate-root-2018.rs:4:26
    |
 LL |     fn global_inner(_: ::nonexistant::Foo) {
    |                          ^^^^^^^^^^^ could not find `nonexistant` in the list of imported crates
 
-error[E0433]: failed to resolve: could not find `nonexistant` in the crate root
+error[E0433]: cannot find item `nonexistant` in the crate root
   --> $DIR/editions-crate-root-2018.rs:7:30
    |
 LL |     fn crate_inner(_: crate::nonexistant::Foo) {

--- a/tests/ui/resolve/export-fully-qualified-2018.rs
+++ b/tests/ui/resolve/export-fully-qualified-2018.rs
@@ -5,7 +5,7 @@
 // want to change eventually.
 
 mod foo {
-    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
+    pub fn bar() { foo::baz(); } //~ ERROR cannot find item `foo`
 
     fn baz() { }
 }

--- a/tests/ui/resolve/export-fully-qualified-2018.stderr
+++ b/tests/ui/resolve/export-fully-qualified-2018.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
+error[E0433]: cannot find item `foo` in this scope
   --> $DIR/export-fully-qualified-2018.rs:8:20
    |
 LL |     pub fn bar() { foo::baz(); }

--- a/tests/ui/resolve/export-fully-qualified.rs
+++ b/tests/ui/resolve/export-fully-qualified.rs
@@ -5,7 +5,7 @@
 // want to change eventually.
 
 mod foo {
-    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
+    pub fn bar() { foo::baz(); } //~ ERROR cannot find item `foo`
 
     fn baz() { }
 }

--- a/tests/ui/resolve/export-fully-qualified.stderr
+++ b/tests/ui/resolve/export-fully-qualified.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
+error[E0433]: cannot find item `foo` in this scope
   --> $DIR/export-fully-qualified.rs:8:20
    |
 LL |     pub fn bar() { foo::baz(); }

--- a/tests/ui/resolve/extern-prelude-fail.rs
+++ b/tests/ui/resolve/extern-prelude-fail.rs
@@ -5,5 +5,5 @@
 
 fn main() {
     use extern_prelude::S; //~ ERROR unresolved import `extern_prelude`
-    let s = ::extern_prelude::S; //~ ERROR failed to resolve
+    let s = ::extern_prelude::S; //~ ERROR cannot find item
 }

--- a/tests/ui/resolve/extern-prelude-fail.stderr
+++ b/tests/ui/resolve/extern-prelude-fail.stderr
@@ -9,7 +9,7 @@ help: you might be missing a crate named `extern_prelude`, add it to your projec
 LL + extern crate extern_prelude;
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `extern_prelude`
+error[E0433]: cannot find item `extern_prelude` in the crate root
   --> $DIR/extern-prelude-fail.rs:8:15
    |
 LL |     let s = ::extern_prelude::S;

--- a/tests/ui/resolve/impl-items-vis-unresolved.rs
+++ b/tests/ui/resolve/impl-items-vis-unresolved.rs
@@ -19,7 +19,7 @@ pub struct RawFloatState;
 impl RawFloatState {
     perftools_inline! {
         pub(super) fn new() {}
-        //~^ ERROR failed to resolve: there are too many leading `super` keywords
+        //~^ ERROR cannot find module `super` in this scope
     }
 }
 

--- a/tests/ui/resolve/impl-items-vis-unresolved.stderr
+++ b/tests/ui/resolve/impl-items-vis-unresolved.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: there are too many leading `super` keywords
+error[E0433]: cannot find module `super` in this scope
   --> $DIR/impl-items-vis-unresolved.rs:21:13
    |
 LL |         pub(super) fn new() {}
-   |             ^^^^^ there are too many leading `super` keywords
+   |             ^^^^^ can't use `super` on the crate root, there are no further modules to go "up" to
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-101749-2.rs
+++ b/tests/ui/resolve/issue-101749-2.rs
@@ -12,5 +12,5 @@ fn main() {
     let rect = Rectangle::new(3, 4);
     // `area` is not implemented for `Rectangle`, so this should not suggest
     let _ = rect::area();
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `rect`
+    //~^ ERROR cannot find item `rect`
 }

--- a/tests/ui/resolve/issue-101749-2.stderr
+++ b/tests/ui/resolve/issue-101749-2.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rect`
+error[E0433]: cannot find item `rect` in this scope
   --> $DIR/issue-101749-2.rs:14:13
    |
 LL |     let _ = rect::area();

--- a/tests/ui/resolve/issue-101749.fixed
+++ b/tests/ui/resolve/issue-101749.fixed
@@ -15,5 +15,5 @@ impl Rectangle {
 fn main() {
     let rect = Rectangle::new(3, 4);
     let _ = rect.area();
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `rect`
+    //~^ ERROR cannot find item `rect`
 }

--- a/tests/ui/resolve/issue-101749.rs
+++ b/tests/ui/resolve/issue-101749.rs
@@ -15,5 +15,5 @@ impl Rectangle {
 fn main() {
     let rect = Rectangle::new(3, 4);
     let _ = rect::area();
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `rect`
+    //~^ ERROR cannot find item `rect`
 }

--- a/tests/ui/resolve/issue-101749.stderr
+++ b/tests/ui/resolve/issue-101749.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rect`
+error[E0433]: cannot find item `rect` in this scope
   --> $DIR/issue-101749.rs:17:13
    |
 LL |     let _ = rect::area();

--- a/tests/ui/resolve/issue-109250.rs
+++ b/tests/ui/resolve/issue-109250.rs
@@ -1,3 +1,3 @@
 fn main() {       //~ HELP consider importing
-    HashMap::new; //~ ERROR failed to resolve: use of undeclared type `HashMap`
+    HashMap::new; //~ ERROR cannot find item `HashMap`
 }

--- a/tests/ui/resolve/issue-109250.stderr
+++ b/tests/ui/resolve/issue-109250.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `HashMap`
+error[E0433]: cannot find item `HashMap` in this scope
   --> $DIR/issue-109250.rs:2:5
    |
 LL |     HashMap::new;

--- a/tests/ui/resolve/issue-117920.rs
+++ b/tests/ui/resolve/issue-117920.rs
@@ -1,6 +1,6 @@
 #![crate_type = "lib"]
 
-use super::A; //~ ERROR failed to resolve
+use super::A; //~ ERROR cannot find module
 
 mod b {
     pub trait A {}

--- a/tests/ui/resolve/issue-117920.stderr
+++ b/tests/ui/resolve/issue-117920.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: there are too many leading `super` keywords
+error[E0433]: cannot find module `super` in this scope
   --> $DIR/issue-117920.rs:3:5
    |
 LL | use super::A;
-   |     ^^^^^ there are too many leading `super` keywords
+   |     ^^^^^ can't use `super` on the crate root, there are no further modules to go "up" to
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-24968.rs
+++ b/tests/ui/resolve/issue-24968.rs
@@ -19,12 +19,12 @@ const FOO: Self = 0;
 //~^ ERROR cannot find type `Self`
 
 const FOO2: u32 = Self::bar();
-//~^ ERROR failed to resolve: `Self`
+//~^ ERROR cannot find item `Self` in this scope
 
 static FOO_S: Self = 0;
 //~^ ERROR cannot find type `Self`
 
 static FOO_S2: u32 = Self::bar();
-//~^ ERROR failed to resolve: `Self`
+//~^ ERROR cannot find item `Self` in this scope
 
 fn main() {}

--- a/tests/ui/resolve/issue-24968.stderr
+++ b/tests/ui/resolve/issue-24968.stderr
@@ -39,13 +39,13 @@ LL | static FOO_S: Self = 0;
    |        |
    |        `Self` not allowed in a static item
 
-error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+error[E0433]: cannot find item `Self` in this scope
   --> $DIR/issue-24968.rs:21:19
    |
 LL | const FOO2: u32 = Self::bar();
    |                   ^^^^ `Self` is only available in impls, traits, and type definitions
 
-error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+error[E0433]: cannot find item `Self` in this scope
   --> $DIR/issue-24968.rs:27:22
    |
 LL | static FOO_S2: u32 = Self::bar();

--- a/tests/ui/resolve/issue-81508.rs
+++ b/tests/ui/resolve/issue-81508.rs
@@ -8,7 +8,7 @@
 fn main() {
     let Baz: &str = "";
 
-    println!("{}", Baz::Bar); //~ ERROR: failed to resolve: use of undeclared type `Baz`
+    println!("{}", Baz::Bar); //~ ERROR cannot find item `Baz`
 }
 
 #[allow(non_upper_case_globals)]
@@ -17,6 +17,6 @@ pub const Foo: &str = "";
 mod submod {
     use super::Foo;
     fn function() {
-        println!("{}", Foo::Bar); //~ ERROR: failed to resolve: use of undeclared type `Foo`
+        println!("{}", Foo::Bar); //~ ERROR cannot find item `Foo`
     }
 }

--- a/tests/ui/resolve/issue-81508.stderr
+++ b/tests/ui/resolve/issue-81508.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `Baz`
+error[E0433]: cannot find item `Baz` in this scope
   --> $DIR/issue-81508.rs:11:20
    |
 LL |     let Baz: &str = "";
@@ -7,7 +7,7 @@ LL |
 LL |     println!("{}", Baz::Bar);
    |                    ^^^ use of undeclared type `Baz`
 
-error[E0433]: failed to resolve: use of undeclared type `Foo`
+error[E0433]: cannot find item `Foo` in this scope
   --> $DIR/issue-81508.rs:20:24
    |
 LL |     use super::Foo;

--- a/tests/ui/resolve/issue-82156.rs
+++ b/tests/ui/resolve/issue-82156.rs
@@ -1,3 +1,3 @@
 fn main() {
-    super(); //~ ERROR failed to resolve: there are too many leading `super` keywords
+    super(); //~ ERROR cannot find item `super`
 }

--- a/tests/ui/resolve/issue-82156.stderr
+++ b/tests/ui/resolve/issue-82156.stderr
@@ -1,8 +1,13 @@
-error[E0433]: failed to resolve: there are too many leading `super` keywords
+error[E0433]: cannot find item `super` in this scope
   --> $DIR/issue-82156.rs:2:5
    |
 LL |     super();
-   |     ^^^^^ there are too many leading `super` keywords
+   |     ^^^^^ can't use `super` as an identifier
+   |
+help: if you still want to call your identifier `super`, use the raw identifier format
+   |
+LL |     r#super();
+   |     ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-82865.rs
+++ b/tests/ui/resolve/issue-82865.rs
@@ -2,12 +2,14 @@
 
 #![feature(decl_macro)]
 
-use x::y::z; //~ ERROR: failed to resolve: use of unresolved module or unlinked crate `x`
+use x::y::z; //~ ERROR cannot find item `x`
+//~^ NOTE use of unresolved module or unlinked crate `x`
 
 macro mac () {
     Box::z //~ ERROR: no function or associated item
+    //~^ NOTE function or associated item not found in `Box<_, _>`
 }
 
 fn main() {
-    mac!();
+    mac!(); //~ NOTE in this expansion of mac!
 }

--- a/tests/ui/resolve/issue-82865.stderr
+++ b/tests/ui/resolve/issue-82865.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `x`
+error[E0433]: cannot find item `x` in the crate root
   --> $DIR/issue-82865.rs:5:5
    |
 LL | use x::y::z;
@@ -10,7 +10,7 @@ LL + extern crate x;
    |
 
 error[E0599]: no function or associated item named `z` found for struct `Box<_, _>` in the current scope
-  --> $DIR/issue-82865.rs:8:10
+  --> $DIR/issue-82865.rs:9:10
    |
 LL |     Box::z
    |          ^ function or associated item not found in `Box<_, _>`

--- a/tests/ui/resolve/missing-in-namespace.rs
+++ b/tests/ui/resolve/missing-in-namespace.rs
@@ -1,4 +1,4 @@
 fn main() {
     let _map = std::hahmap::HashMap::new();
-    //~^ ERROR failed to resolve: could not find `hahmap` in `std
+    //~^ ERROR cannot find item `hahmap`
 }

--- a/tests/ui/resolve/missing-in-namespace.stderr
+++ b/tests/ui/resolve/missing-in-namespace.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: could not find `hahmap` in `std`
+error[E0433]: cannot find item `hahmap` in crate `std`
   --> $DIR/missing-in-namespace.rs:2:21
    |
 LL |     let _map = std::hahmap::HashMap::new();

--- a/tests/ui/resolve/prelude-order.rs
+++ b/tests/ui/resolve/prelude-order.rs
@@ -58,7 +58,7 @@ extern crate macro_helpers as _;
 /* lang and libs implicitly in scope */
 
 // tool/extern -> extern
-#[type_ns::inner] //~ ERROR could not find `inner` in `type_ns`
+#[type_ns::inner] //~ ERROR cannot find macro `inner` in crate `macro_helpers`
 fn t1() {}
 
 // tool/lang -> tool
@@ -70,7 +70,7 @@ fn t2() {}
 fn t3() {}
 
 // extern/lang -> extern
-#[usize::inner] //~ ERROR could not find `inner` in `usize`
+#[usize::inner] //~ ERROR cannot find macro `inner` in crate `macro_helpers`
 fn e1() {} // NOTE: testing with `-> usize` isn't valid, crates aren't considered in that scope
            // (unless they have generic arguments, for some reason.)
 

--- a/tests/ui/resolve/prelude-order.stderr
+++ b/tests/ui/resolve/prelude-order.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: could not find `inner` in `type_ns`
+error[E0433]: cannot find macro `inner` in crate `macro_helpers`
   --> $DIR/prelude-order.rs:61:12
    |
 LL | #[type_ns::inner]
    |            ^^^^^ could not find `inner` in `type_ns`
 
-error[E0433]: failed to resolve: could not find `inner` in `usize`
+error[E0433]: cannot find macro `inner` in crate `macro_helpers`
   --> $DIR/prelude-order.rs:73:10
    |
 LL | #[usize::inner]

--- a/tests/ui/resolve/resolve-bad-visibility.rs
+++ b/tests/ui/resolve/resolve-bad-visibility.rs
@@ -4,8 +4,8 @@ trait Tr {}
 pub(in E) struct S; //~ ERROR expected module, found enum `E`
 pub(in Tr) struct Z; //~ ERROR expected module, found trait `Tr`
 pub(in std::vec) struct F; //~ ERROR visibilities can only be restricted to ancestor modules
-pub(in nonexistent) struct G; //~ ERROR failed to resolve
-pub(in too_soon) struct H; //~ ERROR failed to resolve
+pub(in nonexistent) struct G; //~ ERROR cannot find item
+pub(in too_soon) struct H; //~ ERROR cannot find item
 
 // Visibilities are resolved eagerly without waiting for modules becoming fully populated.
 // Visibilities can only use ancestor modules legally which are always available in time,

--- a/tests/ui/resolve/resolve-bad-visibility.stderr
+++ b/tests/ui/resolve/resolve-bad-visibility.stderr
@@ -16,7 +16,7 @@ error[E0742]: visibilities can only be restricted to ancestor modules
 LL | pub(in std::vec) struct F;
    |        ^^^^^^^^
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistent`
+error[E0433]: cannot find item `nonexistent` in this scope
   --> $DIR/resolve-bad-visibility.rs:7:8
    |
 LL | pub(in nonexistent) struct G;
@@ -27,7 +27,7 @@ help: you might be missing a crate named `nonexistent`, add it to your project a
 LL + extern crate nonexistent;
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `too_soon`
+error[E0433]: cannot find item `too_soon` in this scope
   --> $DIR/resolve-bad-visibility.rs:8:8
    |
 LL | pub(in too_soon) struct H;

--- a/tests/ui/resolve/resolve-variant-assoc-item.rs
+++ b/tests/ui/resolve/resolve-variant-assoc-item.rs
@@ -2,6 +2,6 @@ enum E { V }
 use E::V;
 
 fn main() {
-    E::V::associated_item; //~ ERROR failed to resolve: `V` is a variant, not a module
-    V::associated_item; //~ ERROR failed to resolve: `V` is a variant, not a module
+    E::V::associated_item; //~ ERROR cannot find module `V`
+    V::associated_item; //~ ERROR cannot find module `V`
 }

--- a/tests/ui/resolve/resolve-variant-assoc-item.stderr
+++ b/tests/ui/resolve/resolve-variant-assoc-item.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: `V` is a variant, not a module
+error[E0433]: cannot find module `V` in enum `E`
   --> $DIR/resolve-variant-assoc-item.rs:5:8
    |
 LL |     E::V::associated_item;
@@ -10,7 +10,7 @@ LL -     E::V::associated_item;
 LL +     E::associated_item;
    |
 
-error[E0433]: failed to resolve: `V` is a variant, not a module
+error[E0433]: cannot find module `V` in this scope
   --> $DIR/resolve-variant-assoc-item.rs:6:5
    |
 LL |     V::associated_item;

--- a/tests/ui/resolve/tool-import.rs
+++ b/tests/ui/resolve/tool-import.rs
@@ -1,7 +1,8 @@
 //@ edition: 2018
 
 use clippy::time::Instant;
-//~^ ERROR `clippy` is a tool module
+//~^ ERROR cannot find module `clippy`
+//~| NOTE `clippy` is a tool module
 
 fn main() {
     Instant::now();

--- a/tests/ui/resolve/tool-import.stderr
+++ b/tests/ui/resolve/tool-import.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: `clippy` is a tool module, not a module
+error[E0433]: cannot find module `clippy` in this scope
   --> $DIR/tool-import.rs:3:5
    |
 LL | use clippy::time::Instant;

--- a/tests/ui/resolve/typo-suggestion-mistyped-in-path.rs
+++ b/tests/ui/resolve/typo-suggestion-mistyped-in-path.rs
@@ -25,18 +25,18 @@ fn main() {
     //~| NOTE function or associated item not found in `Struct`
 
     Struc::foo();
-    //~^ ERROR failed to resolve: use of undeclared type `Struc`
+    //~^ ERROR cannot find item `Struc`
     //~| NOTE use of undeclared type `Struc`
 
     modul::foo();
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `modul`
+    //~^ ERROR cannot find item `modul`
     //~| NOTE use of unresolved module or unlinked crate `modul`
 
     module::Struc::foo();
-    //~^ ERROR failed to resolve: could not find `Struc` in `module`
+    //~^ ERROR cannot find item `Struc`
     //~| NOTE could not find `Struc` in `module`
 
     Trai::foo();
-    //~^ ERROR failed to resolve: use of undeclared type `Trai`
+    //~^ ERROR cannot find item `Trai`
     //~| NOTE use of undeclared type `Trai`
 }

--- a/tests/ui/resolve/typo-suggestion-mistyped-in-path.stderr
+++ b/tests/ui/resolve/typo-suggestion-mistyped-in-path.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: could not find `Struc` in `module`
+error[E0433]: cannot find item `Struc` in module `module`
   --> $DIR/typo-suggestion-mistyped-in-path.rs:35:13
    |
 LL |     module::Struc::foo();
@@ -22,7 +22,7 @@ LL -     Struct::fob();
 LL +     Struct::foo();
    |
 
-error[E0433]: failed to resolve: use of undeclared type `Struc`
+error[E0433]: cannot find item `Struc` in this scope
   --> $DIR/typo-suggestion-mistyped-in-path.rs:27:5
    |
 LL |     Struc::foo();
@@ -31,7 +31,7 @@ LL |     Struc::foo();
    |     use of undeclared type `Struc`
    |     help: a struct with a similar name exists: `Struct`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `modul`
+error[E0433]: cannot find item `modul` in this scope
   --> $DIR/typo-suggestion-mistyped-in-path.rs:31:5
    |
 LL |     modul::foo();
@@ -42,7 +42,7 @@ help: there is a crate or module with a similar name
 LL |     module::foo();
    |          +
 
-error[E0433]: failed to resolve: use of undeclared type `Trai`
+error[E0433]: cannot find item `Trai` in this scope
   --> $DIR/typo-suggestion-mistyped-in-path.rs:39:5
    |
 LL |     Trai::foo();

--- a/tests/ui/resolve/unresolved-segments-visibility.rs
+++ b/tests/ui/resolve/unresolved-segments-visibility.rs
@@ -6,6 +6,6 @@ extern crate alloc as b;
 mod foo {
     mod bar {
         pub(in b::string::String::newy) extern crate alloc as e;
-        //~^ ERROR failed to resolve: `String` is a struct, not a module [E0433]
+        //~^ ERROR cannot find module `String`
     }
 }

--- a/tests/ui/resolve/unresolved-segments-visibility.stderr
+++ b/tests/ui/resolve/unresolved-segments-visibility.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: `String` is a struct, not a module
+error[E0433]: cannot find module `String` in this scope
   --> $DIR/unresolved-segments-visibility.rs:8:27
    |
 LL |         pub(in b::string::String::newy) extern crate alloc as e;

--- a/tests/ui/resolve/use_suggestion.rs
+++ b/tests/ui/resolve/use_suggestion.rs
@@ -1,6 +1,6 @@
 fn main() {
-    let x1 = HashMap::new(); //~ ERROR failed to resolve
-    let x2 = GooMap::new(); //~ ERROR failed to resolve
+    let x1 = HashMap::new(); //~ ERROR cannot find item
+    let x2 = GooMap::new(); //~ ERROR cannot find item
 
     let y1: HashMap; //~ ERROR cannot find type
     let y2: GooMap; //~ ERROR cannot find type

--- a/tests/ui/resolve/use_suggestion.stderr
+++ b/tests/ui/resolve/use_suggestion.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `HashMap`
+error[E0433]: cannot find item `HashMap` in this scope
   --> $DIR/use_suggestion.rs:2:14
    |
 LL |     let x1 = HashMap::new();
@@ -26,7 +26,7 @@ error[E0412]: cannot find type `GooMap` in this scope
 LL |     let y2: GooMap;
    |             ^^^^^^ not found in this scope
 
-error[E0433]: failed to resolve: use of undeclared type `GooMap`
+error[E0433]: cannot find item `GooMap` in this scope
   --> $DIR/use_suggestion.rs:3:14
    |
 LL |     let x2 = GooMap::new();

--- a/tests/ui/rfcs/rfc-2126-crate-paths/crate-path-non-absolute.rs
+++ b/tests/ui/rfcs/rfc-2126-crate-paths/crate-path-non-absolute.rs
@@ -2,8 +2,8 @@ struct S;
 
 pub mod m {
     fn f() {
-        let s = ::m::crate::S; //~ ERROR failed to resolve
-        let s1 = ::crate::S; //~ ERROR failed to resolve
+        let s = ::m::crate::S; //~ ERROR cannot find module
+        let s1 = ::crate::S; //~ ERROR cannot find module
         let s2 = crate::S; // no error
     }
 }

--- a/tests/ui/rfcs/rfc-2126-crate-paths/crate-path-non-absolute.stderr
+++ b/tests/ui/rfcs/rfc-2126-crate-paths/crate-path-non-absolute.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: `crate` in paths can only be used in start position
+error[E0433]: cannot find module `crate` in module `m`
   --> $DIR/crate-path-non-absolute.rs:5:22
    |
 LL |         let s = ::m::crate::S;
    |                      ^^^^^ `crate` in paths can only be used in start position
 
-error[E0433]: failed to resolve: global paths cannot start with `crate`
+error[E0433]: cannot find module `crate` in the crate root
   --> $DIR/crate-path-non-absolute.rs:6:20
    |
 LL |         let s1 = ::crate::S;

--- a/tests/ui/rfcs/rfc-2126-extern-absolute-paths/non-existent-2.rs
+++ b/tests/ui/rfcs/rfc-2126-extern-absolute-paths/non-existent-2.rs
@@ -2,5 +2,5 @@
 
 fn main() {
     let s = ::xcrate::S;
-    //~^ ERROR failed to resolve: could not find `xcrate` in the list of imported crates
+    //~^ ERROR cannot find item `xcrate`
 }

--- a/tests/ui/rfcs/rfc-2126-extern-absolute-paths/non-existent-2.stderr
+++ b/tests/ui/rfcs/rfc-2126-extern-absolute-paths/non-existent-2.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: could not find `xcrate` in the list of imported crates
+error[E0433]: cannot find item `xcrate` in the list of imported crates
   --> $DIR/non-existent-2.rs:4:15
    |
 LL |     let s = ::xcrate::S;

--- a/tests/ui/simd/portable-intrinsics-arent-exposed.stderr
+++ b/tests/ui/simd/portable-intrinsics-arent-exposed.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: you might be missing crate `core`
+error[E0433]: cannot find item `core` in the crate root
   --> $DIR/portable-intrinsics-arent-exposed.rs:4:5
    |
 LL | use core::simd::intrinsics;

--- a/tests/ui/span/visibility-ty-params.rs
+++ b/tests/ui/span/visibility-ty-params.rs
@@ -4,7 +4,7 @@ macro_rules! m {
 
 struct S<T>(T);
 m!{ S<u8> } //~ ERROR unexpected generic arguments in path
-            //~| ERROR failed to resolve: `S` is a struct, not a module [E0433]
+            //~| ERROR cannot find module `S`
 
 mod m {
     m!{ m<> } //~ ERROR unexpected generic arguments in path

--- a/tests/ui/span/visibility-ty-params.stderr
+++ b/tests/ui/span/visibility-ty-params.stderr
@@ -4,7 +4,7 @@ error: unexpected generic arguments in path
 LL | m!{ S<u8> }
    |      ^^^^
 
-error[E0433]: failed to resolve: `S` is a struct, not a module
+error[E0433]: cannot find module `S` in this scope
   --> $DIR/visibility-ty-params.rs:6:5
    |
 LL | m!{ S<u8> }

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.no_std.fixed
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.no_std.fixed
@@ -12,7 +12,7 @@ use core::num::NonZero;
 fn main() {
     //~^ HELP consider importing this struct
     let _x = NonZero::new(5u32).unwrap();
-    //~^ ERROR failed to resolve: use of undeclared type `NonZero`
+    //~^ ERROR cannot find item `NonZero`
 }
 
 #[allow(dead_code)]

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.no_std.stderr
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.no_std.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `NonZero`
+error[E0433]: cannot find item `NonZero` in this scope
   --> $DIR/core-std-import-order-issue-83564.rs:12:14
    |
 LL |     let _x = NonZero::new(5u32).unwrap();

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.rs
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.rs
@@ -10,7 +10,7 @@
 fn main() {
     //~^ HELP consider importing this struct
     let _x = NonZero::new(5u32).unwrap();
-    //~^ ERROR failed to resolve: use of undeclared type `NonZero`
+    //~^ ERROR cannot find item `NonZero`
 }
 
 #[allow(dead_code)]

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.std.fixed
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.std.fixed
@@ -12,7 +12,7 @@ use std::num::NonZero;
 fn main() {
     //~^ HELP consider importing this struct
     let _x = NonZero::new(5u32).unwrap();
-    //~^ ERROR failed to resolve: use of undeclared type `NonZero`
+    //~^ ERROR cannot find item `NonZero`
 }
 
 #[allow(dead_code)]

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.std.stderr
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.std.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `NonZero`
+error[E0433]: cannot find item `NonZero` in this scope
   --> $DIR/core-std-import-order-issue-83564.rs:12:14
    |
 LL |     let _x = NonZero::new(5u32).unwrap();

--- a/tests/ui/suggestions/crate-or-module-typo.rs
+++ b/tests/ui/suggestions/crate-or-module-typo.rs
@@ -1,9 +1,9 @@
 //@ edition:2018
 
-use st::cell::Cell; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `st`
+use st::cell::Cell; //~ ERROR cannot find item `st`
 
 mod bar {
-    pub fn bar() { bar::baz(); } //~ ERROR failed to resolve: function `bar` is not a crate or module
+    pub fn bar() { bar::baz(); } //~ ERROR cannot find item `bar`
 
     fn baz() {}
 }
@@ -11,7 +11,7 @@ mod bar {
 use bas::bar; //~ ERROR unresolved import `bas`
 
 struct Foo {
-    bar: st::cell::Cell<bool> //~ ERROR failed to resolve: use of unresolved module or unlinked crate `st`
+    bar: st::cell::Cell<bool> //~ ERROR cannot find item `st`
 }
 
 fn main() {}

--- a/tests/ui/suggestions/crate-or-module-typo.stderr
+++ b/tests/ui/suggestions/crate-or-module-typo.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `st`
+error[E0433]: cannot find item `st` in this scope
   --> $DIR/crate-or-module-typo.rs:3:5
    |
 LL | use st::cell::Cell;
@@ -21,7 +21,7 @@ LL - use bas::bar;
 LL + use bar::bar;
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `st`
+error[E0433]: cannot find item `st` in this scope
   --> $DIR/crate-or-module-typo.rs:14:10
    |
 LL |     bar: st::cell::Cell<bool>
@@ -41,7 +41,7 @@ LL -     bar: st::cell::Cell<bool>
 LL +     bar: cell::Cell<bool>
    |
 
-error[E0433]: failed to resolve: function `bar` is not a crate or module
+error[E0433]: cannot find item `bar` in this scope
   --> $DIR/crate-or-module-typo.rs:6:20
    |
 LL |     pub fn bar() { bar::baz(); }

--- a/tests/ui/suggestions/issue-103112.rs
+++ b/tests/ui/suggestions/issue-103112.rs
@@ -1,4 +1,4 @@
 fn main() {
     std::process::abort!();
-    //~^ ERROR: failed to resolve
+    //~^ ERROR cannot find macro `abort`
 }

--- a/tests/ui/suggestions/issue-103112.stderr
+++ b/tests/ui/suggestions/issue-103112.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: could not find `abort` in `process`
+error[E0433]: cannot find macro `abort` in module `process`
   --> $DIR/issue-103112.rs:2:19
    |
 LL |     std::process::abort!();

--- a/tests/ui/suggestions/issue-112590-suggest-import.rs
+++ b/tests/ui/suggestions/issue-112590-suggest-import.rs
@@ -1,8 +1,8 @@
 pub struct S;
 
-impl fmt::Debug for S { //~ ERROR failed to resolve: use of unresolved module or unlinked crate `fmt`
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result { //~ ERROR failed to resolve: use of unresolved module or unlinked crate `fmt`
-        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `fmt`
+impl fmt::Debug for S { //~ ERROR cannot find item `fmt`
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result { //~ ERROR cannot find item `fmt`
+        //~^ ERROR cannot find item `fmt`
         Ok(())
     }
 }

--- a/tests/ui/suggestions/issue-112590-suggest-import.stderr
+++ b/tests/ui/suggestions/issue-112590-suggest-import.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fmt`
+error[E0433]: cannot find item `fmt` in this scope
   --> $DIR/issue-112590-suggest-import.rs:3:6
    |
 LL | impl fmt::Debug for S {
@@ -10,7 +10,7 @@ help: consider importing this module
 LL + use std::fmt;
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fmt`
+error[E0433]: cannot find item `fmt` in this scope
   --> $DIR/issue-112590-suggest-import.rs:4:28
    |
 LL |     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -22,7 +22,7 @@ help: consider importing this module
 LL + use std::fmt;
    |
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fmt`
+error[E0433]: cannot find item `fmt` in this scope
   --> $DIR/issue-112590-suggest-import.rs:4:51
    |
 LL |     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tests/ui/suggestions/suggest-tryinto-edition-change.rs
+++ b/tests/ui/suggestions/suggest-tryinto-edition-change.rs
@@ -8,17 +8,17 @@ fn test() {
     //~| NOTE 'std::convert::TryInto' is included in the prelude starting in Edition 2021
 
     let _i: i16 = TryFrom::try_from(0_i32).unwrap();
-    //~^ ERROR failed to resolve: use of undeclared type
+    //~^ ERROR cannot find item
     //~| NOTE use of undeclared type
     //~| NOTE 'std::convert::TryFrom' is included in the prelude starting in Edition 2021
 
     let _i: i16 = TryInto::try_into(0_i32).unwrap();
-    //~^ ERROR failed to resolve: use of undeclared type
+    //~^ ERROR cannot find item
     //~| NOTE use of undeclared type
     //~| NOTE 'std::convert::TryInto' is included in the prelude starting in Edition 2021
 
     let _v: Vec<_> = FromIterator::from_iter(&[1]);
-    //~^ ERROR failed to resolve: use of undeclared type
+    //~^ ERROR cannot find item
     //~| NOTE use of undeclared type
     //~| NOTE 'std::iter::FromIterator' is included in the prelude starting in Edition 2021
 }

--- a/tests/ui/suggestions/suggest-tryinto-edition-change.stderr
+++ b/tests/ui/suggestions/suggest-tryinto-edition-change.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type `TryFrom`
+error[E0433]: cannot find item `TryFrom` in this scope
   --> $DIR/suggest-tryinto-edition-change.rs:10:19
    |
 LL |     let _i: i16 = TryFrom::try_from(0_i32).unwrap();
@@ -10,7 +10,7 @@ help: consider importing this trait
 LL + use std::convert::TryFrom;
    |
 
-error[E0433]: failed to resolve: use of undeclared type `TryInto`
+error[E0433]: cannot find item `TryInto` in this scope
   --> $DIR/suggest-tryinto-edition-change.rs:15:19
    |
 LL |     let _i: i16 = TryInto::try_into(0_i32).unwrap();
@@ -22,7 +22,7 @@ help: consider importing this trait
 LL + use std::convert::TryInto;
    |
 
-error[E0433]: failed to resolve: use of undeclared type `FromIterator`
+error[E0433]: cannot find item `FromIterator` in this scope
   --> $DIR/suggest-tryinto-edition-change.rs:20:22
    |
 LL |     let _v: Vec<_> = FromIterator::from_iter(&[1]);

--- a/tests/ui/suggestions/undeclared-module-alloc.rs
+++ b/tests/ui/suggestions/undeclared-module-alloc.rs
@@ -1,5 +1,5 @@
 //@ edition:2018
 
-use alloc::rc::Rc; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `alloc`
+use alloc::rc::Rc; //~ ERROR cannot find item `alloc`
 
 fn main() {}

--- a/tests/ui/suggestions/undeclared-module-alloc.stderr
+++ b/tests/ui/suggestions/undeclared-module-alloc.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `alloc`
+error[E0433]: cannot find item `alloc` in this scope
   --> $DIR/undeclared-module-alloc.rs:3:5
    |
 LL | use alloc::rc::Rc;

--- a/tests/ui/super-at-top-level.rs
+++ b/tests/ui/super-at-top-level.rs
@@ -1,4 +1,5 @@
-use super::f; //~ ERROR there are too many leading `super` keywords
+use super::f; //~ ERROR cannot find module `super` in this scope
+//~^ NOTE can't use `super` on the crate root, there are no further modules to go "up" to
 
 fn main() {
 }

--- a/tests/ui/super-at-top-level.stderr
+++ b/tests/ui/super-at-top-level.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: there are too many leading `super` keywords
+error[E0433]: cannot find module `super` in this scope
   --> $DIR/super-at-top-level.rs:1:5
    |
 LL | use super::f;
-   |     ^^^^^ there are too many leading `super` keywords
+   |     ^^^^^ can't use `super` on the crate root, there are no further modules to go "up" to
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/tool-attributes/tool-attributes-shadowing.rs
+++ b/tests/ui/tool-attributes/tool-attributes-shadowing.rs
@@ -1,4 +1,4 @@
 mod rustfmt {}
 
-#[rustfmt::skip] //~ ERROR failed to resolve: could not find `skip` in `rustfmt`
+#[rustfmt::skip] //~ ERROR cannot find macro `skip`
 fn main() {}

--- a/tests/ui/tool-attributes/tool-attributes-shadowing.stderr
+++ b/tests/ui/tool-attributes/tool-attributes-shadowing.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: could not find `skip` in `rustfmt`
+error[E0433]: cannot find macro `skip` in module `rustfmt`
   --> $DIR/tool-attributes-shadowing.rs:3:12
    |
 LL | #[rustfmt::skip]

--- a/tests/ui/tool-attributes/unknown-tool-name.rs
+++ b/tests/ui/tool-attributes/unknown-tool-name.rs
@@ -1,2 +1,2 @@
-#[foo::bar] //~ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
+#[foo::bar] //~ ERROR cannot find item `foo`
 fn main() {}

--- a/tests/ui/tool-attributes/unknown-tool-name.stderr
+++ b/tests/ui/tool-attributes/unknown-tool-name.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
+error[E0433]: cannot find item `foo` in this scope
   --> $DIR/unknown-tool-name.rs:1:3
    |
 LL | #[foo::bar]

--- a/tests/ui/traits/bound/unknown-assoc-with-const-arg.rs
+++ b/tests/ui/traits/bound/unknown-assoc-with-const-arg.rs
@@ -7,7 +7,7 @@ trait X {
 
 trait Y {
     fn a() -> NOT_EXIST::unknown<{}> {}
-    //~^ ERROR: failed to resolve: use of undeclared type `NOT_EXIST`
+    //~^ ERROR: cannot find item `NOT_EXIST` in this scope
 }
 
 trait Z<T> {

--- a/tests/ui/traits/bound/unknown-assoc-with-const-arg.stderr
+++ b/tests/ui/traits/bound/unknown-assoc-with-const-arg.stderr
@@ -10,7 +10,7 @@ error[E0220]: associated type `unknown` not found for `T`
 LL |     fn a() -> T::unknown<{}> {}
    |                  ^^^^^^^ associated type `unknown` not found
 
-error[E0433]: failed to resolve: use of undeclared type `NOT_EXIST`
+error[E0433]: cannot find item `NOT_EXIST` in this scope
   --> $DIR/unknown-assoc-with-const-arg.rs:9:15
    |
 LL |     fn a() -> NOT_EXIST::unknown<{}> {}

--- a/tests/ui/traits/const-traits/issue-102156.stderr
+++ b/tests/ui/traits/const-traits/issue-102156.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: you might be missing crate `core`
+error[E0433]: cannot find item `core` in the crate root
   --> $DIR/issue-102156.rs:4:5
    |
 LL | use core::convert::{From, TryFrom};
@@ -7,7 +7,7 @@ LL | use core::convert::{From, TryFrom};
    |     you might be missing crate `core`
    |     help: try using `std` instead of `core`: `std`
 
-error[E0433]: failed to resolve: you might be missing crate `core`
+error[E0433]: cannot find item `core` in the crate root
   --> $DIR/issue-102156.rs:4:5
    |
 LL | use core::convert::{From, TryFrom};

--- a/tests/ui/type-alias/issue-62263-self-in-atb.rs
+++ b/tests/ui/type-alias/issue-62263-self-in-atb.rs
@@ -3,6 +3,6 @@ pub trait Trait {
 }
 
 pub type Alias = dyn Trait<A = Self::A>;
-//~^ ERROR failed to resolve: `Self`
+//~^ ERROR cannot find item `Self` in this scope
 
 fn main() {}

--- a/tests/ui/type-alias/issue-62263-self-in-atb.stderr
+++ b/tests/ui/type-alias/issue-62263-self-in-atb.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+error[E0433]: cannot find item `Self` in this scope
   --> $DIR/issue-62263-self-in-atb.rs:5:32
    |
 LL | pub type Alias = dyn Trait<A = Self::A>;

--- a/tests/ui/type-alias/issue-62305-self-assoc-ty.rs
+++ b/tests/ui/type-alias/issue-62305-self-assoc-ty.rs
@@ -1,4 +1,4 @@
 type Alias = Self::Target;
-//~^ ERROR failed to resolve: `Self`
+//~^ ERROR cannot find item `Self` in this scope
 
 fn main() {}

--- a/tests/ui/type-alias/issue-62305-self-assoc-ty.stderr
+++ b/tests/ui/type-alias/issue-62305-self-assoc-ty.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+error[E0433]: cannot find item `Self` in this scope
   --> $DIR/issue-62305-self-assoc-ty.rs:1:14
    |
 LL | type Alias = Self::Target;

--- a/tests/ui/type/type-path-err-node-types.rs
+++ b/tests/ui/type/type-path-err-node-types.rs
@@ -12,7 +12,7 @@ fn ufcs_trait() {
 }
 
 fn ufcs_item() {
-    NonExistent::Assoc::<u8>; //~ ERROR undeclared type `NonExistent`
+    NonExistent::Assoc::<u8>; //~ ERROR cannot find item `NonExistent` in this scope
 }
 
 fn method() {

--- a/tests/ui/type/type-path-err-node-types.stderr
+++ b/tests/ui/type/type-path-err-node-types.stderr
@@ -16,7 +16,7 @@ error[E0425]: cannot find value `nonexistent` in this scope
 LL |     nonexistent.nonexistent::<u8>();
    |     ^^^^^^^^^^^ not found in this scope
 
-error[E0433]: failed to resolve: use of undeclared type `NonExistent`
+error[E0433]: cannot find item `NonExistent` in this scope
   --> $DIR/type-path-err-node-types.rs:15:5
    |
 LL |     NonExistent::Assoc::<u8>;

--- a/tests/ui/typeck/issue-120856.rs
+++ b/tests/ui/typeck/issue-120856.rs
@@ -1,5 +1,5 @@
 pub type Archived<T> = <m::Alias as n::Trait>::Archived;
-//~^ ERROR failed to resolve: use of unresolved module or unlinked crate `m`
-//~| ERROR failed to resolve: use of unresolved module or unlinked crate `n`
+//~^ ERROR cannot find item `n` in this scope
+//~| ERROR cannot find item `m` in this scope
 
 fn main() {}

--- a/tests/ui/typeck/issue-120856.stderr
+++ b/tests/ui/typeck/issue-120856.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `n`
+error[E0433]: cannot find item `n` in this scope
   --> $DIR/issue-120856.rs:1:37
    |
 LL | pub type Archived<T> = <m::Alias as n::Trait>::Archived;
@@ -9,7 +9,7 @@ LL | pub type Archived<T> = <m::Alias as n::Trait>::Archived;
    |
    = help: you might be missing a crate named `n`
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `m`
+error[E0433]: cannot find item `m` in this scope
   --> $DIR/issue-120856.rs:1:25
    |
 LL | pub type Archived<T> = <m::Alias as n::Trait>::Archived;

--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.cargo-invoked.stderr
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.cargo-invoked.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `page_size`
+error[E0433]: cannot find item `page_size` in this scope
   --> $DIR/path-to-method-sugg-unresolved-expr.rs:5:21
    |
 LL |     let page_size = page_size::get();

--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.only-rustc.stderr
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.only-rustc.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `page_size`
+error[E0433]: cannot find item `page_size` in this scope
   --> $DIR/path-to-method-sugg-unresolved-expr.rs:5:21
    |
 LL |     let page_size = page_size::get();

--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.rs
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.rs
@@ -3,7 +3,7 @@
 //@[cargo-invoked] rustc-env:CARGO_CRATE_NAME=foo
 fn main() {
     let page_size = page_size::get();
-    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `page_size`
+    //~^ ERROR cannot find item `page_size`
     //~| NOTE use of unresolved module or unlinked crate `page_size`
     //[cargo-invoked]~^^^ HELP if you wanted to use a crate named `page_size`, use `cargo add
     //[only-rustc]~^^^^ HELP you might be missing a crate named `page_size`

--- a/tests/ui/use/use-self-type.rs
+++ b/tests/ui/use/use-self-type.rs
@@ -4,7 +4,7 @@ impl S {
     fn f() {}
     fn g() {
         use Self::f; //~ ERROR unresolved import
-        pub(in Self::f) struct Z; //~ ERROR failed to resolve: `Self`
+        pub(in Self::f) struct Z; //~ ERROR cannot find item `Self`
     }
 }
 

--- a/tests/ui/use/use-self-type.stderr
+++ b/tests/ui/use/use-self-type.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: `Self` cannot be used in imports
+error[E0433]: cannot find item `Self` in this scope
   --> $DIR/use-self-type.rs:7:16
    |
 LL |         pub(in Self::f) struct Z;

--- a/tests/ui/use/use-super-global-path.rs
+++ b/tests/ui/use/use-super-global-path.rs
@@ -4,11 +4,11 @@ struct S;
 struct Z;
 
 mod foo {
-    use ::super::{S, Z}; //~ ERROR global paths cannot start with `super`
-                         //~| ERROR global paths cannot start with `super`
+    use ::super::{S, Z}; //~ ERROR cannot find module `super`
+                         //~| ERROR cannot find module `super`
 
     pub fn g() {
-        use ::super::main; //~ ERROR global paths cannot start with `super`
+        use ::super::main; //~ ERROR cannot find module `super`
         main();
     }
 }

--- a/tests/ui/use/use-super-global-path.stderr
+++ b/tests/ui/use/use-super-global-path.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: global paths cannot start with `super`
+error[E0433]: cannot find module `super` in the crate root
   --> $DIR/use-super-global-path.rs:7:11
    |
 LL |     use ::super::{S, Z};
    |           ^^^^^ global paths cannot start with `super`
 
-error[E0433]: failed to resolve: global paths cannot start with `super`
+error[E0433]: cannot find module `super` in the crate root
   --> $DIR/use-super-global-path.rs:7:11
    |
 LL |     use ::super::{S, Z};
@@ -12,7 +12,7 @@ LL |     use ::super::{S, Z};
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0433]: failed to resolve: global paths cannot start with `super`
+error[E0433]: cannot find module `super` in the crate root
   --> $DIR/use-super-global-path.rs:11:15
    |
 LL |         use ::super::main;


### PR DESCRIPTION
* Use the same wording for all macro resolution errors
* specify the scope in which the resolution failure happened

Before

```
error[E0433]: failed to resolve: `crate` in paths can only be used in start position
  --> $DIR/crate-path-non-absolute.rs:5:22
   |
LL |         let s = ::m::crate::S;
   |                      ^^^^^ `crate` in paths can only be used in start position
```
after
```
error[E0433]: cannot find module `crate` in module `m`
  --> $DIR/crate-path-non-absolute.rs:5:22
   |
LL |         let s = ::m::crate::S;
   |                      ^^^^^ `crate` in paths can only be used in start position
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->


r? @petrochenkov 