### PR TITLE
add `is_multiple_of` for unsigned integer types

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2764,6 +2764,35 @@ macro_rules! uint_impl {
             }
         }
 
+        /// Returns `true` if `self` is an integer multiple of `rhs`, and false otherwise.
+        ///
+        /// This function is equivalent to `self % rhs == 0`, except that it will not panic
+        /// for `rhs == 0`. Instead, `0.is_multiple_of(0) == true`, and for any non-zero `n`,
+        /// `n.is_multiple_of(0) == false`.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(unsigned_is_multiple_of)]
+        #[doc = concat!("assert!(6_", stringify!($SelfT), ".is_multiple_of(2));")]
+        #[doc = concat!("assert!(!5_", stringify!($SelfT), ".is_multiple_of(2));")]
+        ///
+        #[doc = concat!("assert!(0_", stringify!($SelfT), ".is_multiple_of(0));")]
+        #[doc = concat!("assert!(!6_", stringify!($SelfT), ".is_multiple_of(0));")]
+        /// ```
+        #[unstable(feature = "unsigned_is_multiple_of", issue = "128101")]
+        #[must_use]
+        #[inline]
+        #[rustc_inherit_overflow_checks]
+        pub const fn is_multiple_of(self, rhs: Self) -> bool {
+            match rhs {
+                0 => self == 0,
+                _ => self % rhs == 0,
+            }
+        }
+
         /// Returns `true` if and only if `self == 2^k` for some `k`.
         ///
         /// # Examples

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -61,6 +61,7 @@
 #![feature(num_midpoint)]
 #![feature(offset_of_nested)]
 #![feature(isqrt)]
+#![feature(unsigned_is_multiple_of)]
 #![feature(step_trait)]
 #![feature(str_internals)]
 #![feature(std_internals)]

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -261,6 +261,14 @@ macro_rules! uint_module {
             }
 
             #[test]
+            fn test_is_next_multiple_of() {
+                assert!((12 as $T).is_multiple_of(4));
+                assert!(!(12 as $T).is_multiple_of(5));
+                assert!((0 as $T).is_multiple_of(0));
+                assert!(!(12 as $T).is_multiple_of(0));
+            }
+
+            #[test]
             fn test_carrying_add() {
                 assert_eq!($T::MAX.carrying_add(1, false), (0, true));
                 assert_eq!($T::MAX.carrying_add(0, true), (0, true));


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/128101

This adds the `.is_multiple_of` method on unsigned integers.

Returns `true` if `self` is an integer multiple of `rhs`, and false otherwise.

This function is equivalent to `self % rhs == 0`, except that it will not panic for `rhs == 0`. Instead, `0.is_multiple_of(0) == true`, and for any non-zero `n`, `n.is_multiple_of(0) == false`.