### PR TITLE
ensure std step before preparing sysroot

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1700,6 +1700,7 @@ impl Step for Assemble {
 
         // If we're downloading a compiler from CI, we can use the same compiler for all stages other than 0.
         if builder.download_rustc() {
+            builder.ensure(Std::new(target_compiler, target_compiler.host));
             let sysroot =
                 builder.ensure(Sysroot { compiler: target_compiler, force_recompile: false });
             // Ensure that `libLLVM.so` ends up in the newly created target directory,


### PR DESCRIPTION
When using download-rustc, any stage other than 0 or 1 (e.g., cargo +stage2 build/doc) will fail to find std while compiling on simple rust sources. Ensuring the std step fixes this issue.

r? Kobzol
