### PR TITLE
Do not use question as label

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2012,7 +2012,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 )
             } else if ident.name == sym::core {
                 (
-                    format!("maybe a missing crate `{ident}`?"),
+                    format!("you might be missing crate `{ident}`"),
                     Some((
                         vec![(ident.span, "std".to_string())],
                         "try using `std` instead of `core`".to_string(),
@@ -2021,7 +2021,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 )
             } else if self.tcx.sess.is_rust_2015() {
                 (
-                    format!("maybe a missing crate `{ident}`?"),
+                    format!("you might be missing crate `{ident}`"),
                     Some((
                         vec![],
                         format!(

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `inner`
   --> $DIR/ice-unresolved-import-100241.rs:9:13
    |
 LL |     pub use inner::S;
-   |             ^^^^^ maybe a missing crate `inner`?
+   |             ^^^^^ you might be missing crate `inner`
    |
    = help: consider adding `extern crate inner` to use the `inner` crate
 

--- a/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
+++ b/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: maybe a missing crate `unresolved_crate`?
+error[E0433]: failed to resolve: you might be missing crate `unresolved_crate`
   --> $DIR/unresolved-import-recovery.rs:3:5
    |
 LL | use unresolved_crate::module::Name;
-   |     ^^^^^^^^^^^^^^^^ maybe a missing crate `unresolved_crate`?
+   |     ^^^^^^^^^^^^^^^^ you might be missing crate `unresolved_crate`
    |
    = help: consider adding `extern crate unresolved_crate` to use the `unresolved_crate` crate
 

--- a/tests/rustdoc-ui/issues/issue-61732.rs
+++ b/tests/rustdoc-ui/issues/issue-61732.rs
@@ -1,4 +1,4 @@
 // This previously triggered an ICE.
 
 pub(in crate::r#mod) fn main() {}
-//~^ ERROR failed to resolve: maybe a missing crate `r#mod`
+//~^ ERROR failed to resolve: you might be missing crate `r#mod`

--- a/tests/rustdoc-ui/issues/issue-61732.stderr
+++ b/tests/rustdoc-ui/issues/issue-61732.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: maybe a missing crate `r#mod`?
+error[E0433]: failed to resolve: you might be missing crate `r#mod`
   --> $DIR/issue-61732.rs:3:15
    |
 LL | pub(in crate::r#mod) fn main() {}
-   |               ^^^^^ maybe a missing crate `r#mod`?
+   |               ^^^^^ you might be missing crate `r#mod`
    |
    = help: consider adding `extern crate r#mod` to use the `r#mod` crate
 

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -56,7 +56,7 @@ enum DiagnosticOnEnum {
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = E0123)]
 #[diag = "E0123"]
-//~^ ERROR failed to resolve: maybe a missing crate `core`
+//~^ ERROR failed to resolve: you might be missing crate `core`
 struct WrongStructAttrStyle {}
 
 #[derive(Diagnostic)]
@@ -801,7 +801,7 @@ struct SuggestionsNoItem {
 struct SuggestionsInvalidItem {
     #[suggestion(code(foo))]
     //~^ ERROR `code(...)` must contain only string literals
-    //~| ERROR failed to resolve: maybe a missing crate `core`
+    //~| ERROR failed to resolve: you might be missing crate `core`
     sub: Span,
 }
 
@@ -809,7 +809,7 @@ struct SuggestionsInvalidItem {
 #[diag(no_crate_example)]
 struct SuggestionsInvalidLiteral {
     #[suggestion(code = 3)]
-    //~^ ERROR failed to resolve: maybe a missing crate `core`
+    //~^ ERROR failed to resolve: you might be missing crate `core`
     sub: Span,
 }
 

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -524,23 +524,23 @@ LL |     #[suggestion(no_crate_suggestion, code = "")]
    = help: to show a suggestion consisting of multiple parts, use a `Subdiagnostic` annotated with `#[multipart_suggestion(...)]`
    = help: to show a variable set of suggestions, use a `Vec` of `Subdiagnostic`s annotated with `#[suggestion(...)]`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/diagnostic-derive.rs:58:8
    |
 LL | #[diag = "E0123"]
-   |        ^ maybe a missing crate `core`?
+   |        ^ you might be missing crate `core`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/diagnostic-derive.rs:802:23
    |
 LL |     #[suggestion(code(foo))]
-   |                       ^^^ maybe a missing crate `core`?
+   |                       ^^^ you might be missing crate `core`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/diagnostic-derive.rs:811:25
    |
 LL |     #[suggestion(code = 3)]
-   |                         ^ maybe a missing crate `core`?
+   |                         ^ you might be missing crate `core`
 
 error: cannot find attribute `nonsense` in this scope
   --> $DIR/diagnostic-derive.rs:63:3

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -94,8 +94,8 @@ struct G {
 
 #[derive(Subdiagnostic)]
 #[label("...")]
-//~^ ERROR failed to resolve: maybe a missing crate `core`?
-//~| NOTE maybe a missing crate `core`?
+//~^ ERROR failed to resolve: you might be missing crate `core`
+//~| NOTE you might be missing crate `core`
 struct H {
     #[primary_span]
     span: Span,
@@ -310,8 +310,8 @@ struct AB {
 
 #[derive(Subdiagnostic)]
 union AC {
-    //~^ ERROR failed to resolve: maybe a missing crate `core`?
-    //~| NOTE maybe a missing crate `core`?
+    //~^ ERROR failed to resolve: you might be missing crate `core`
+    //~| NOTE you might be missing crate `core`
     span: u32,
     b: u64,
 }
@@ -581,8 +581,8 @@ struct BD {
     span2: Span,
     #[suggestion_part(foo = "bar")]
     //~^ ERROR `code` is the only valid nested attribute
-    //~| ERROR failed to resolve: maybe a missing crate `core`?
-    //~| NOTE maybe a missing crate `core`?
+    //~| ERROR failed to resolve: you might be missing crate `core`
+    //~| NOTE you might be missing crate `core`
     span4: Span,
     #[suggestion_part(code = "...")]
     //~^ ERROR the `#[suggestion_part(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
@@ -674,8 +674,8 @@ enum BL {
 struct BM {
     #[suggestion_part(code("foo"))]
     //~^ ERROR expected exactly one string literal for `code = ...`
-    //~| ERROR failed to resolve: maybe a missing crate `core`?
-    //~| NOTE maybe a missing crate `core`?
+    //~| ERROR failed to resolve: you might be missing crate `core`
+    //~| NOTE you might be missing crate `core`
     span: Span,
     r#type: String,
 }
@@ -685,8 +685,8 @@ struct BM {
 struct BN {
     #[suggestion_part(code("foo", "bar"))]
     //~^ ERROR expected exactly one string literal for `code = ...`
-    //~| ERROR failed to resolve: maybe a missing crate `core`?
-    //~| NOTE maybe a missing crate `core`?
+    //~| ERROR failed to resolve: you might be missing crate `core`
+    //~| NOTE you might be missing crate `core`
     span: Span,
     r#type: String,
 }
@@ -696,8 +696,8 @@ struct BN {
 struct BO {
     #[suggestion_part(code(3))]
     //~^ ERROR expected exactly one string literal for `code = ...`
-    //~| ERROR failed to resolve: maybe a missing crate `core`?
-    //~| NOTE maybe a missing crate `core`?
+    //~| ERROR failed to resolve: you might be missing crate `core`
+    //~| NOTE you might be missing crate `core`
     span: Span,
     r#type: String,
 }
@@ -718,8 +718,8 @@ struct BP {
 #[multipart_suggestion(no_crate_example)]
 struct BQ {
     #[suggestion_part(code = 3)]
-    //~^ ERROR failed to resolve: maybe a missing crate `core`?
-    //~| NOTE maybe a missing crate `core`?
+    //~^ ERROR failed to resolve: you might be missing crate `core`
+    //~| NOTE you might be missing crate `core`
     span: Span,
     r#type: String,
 }
@@ -811,8 +811,8 @@ struct SuggestionStyleInvalid3 {
 #[derive(Subdiagnostic)]
 #[suggestion(no_crate_example, code = "", style("foo"))]
 //~^ ERROR expected `= "xxx"`
-//~| ERROR failed to resolve: maybe a missing crate `core`?
-//~| NOTE maybe a missing crate `core`?
+//~| ERROR failed to resolve: you might be missing crate `core`
+//~| NOTE you might be missing crate `core`
 struct SuggestionStyleInvalid4 {
     #[primary_span]
     sub: Span,

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
@@ -451,53 +451,53 @@ error: suggestion without `#[primary_span]` field
 LL | #[suggestion(no_crate_example, code = "")]
    | ^
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/subdiagnostic-derive.rs:96:9
    |
 LL | #[label("...")]
-   |         ^^^^^ maybe a missing crate `core`?
+   |         ^^^^^ you might be missing crate `core`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/subdiagnostic-derive.rs:312:1
    |
 LL | union AC {
-   | ^^^^^ maybe a missing crate `core`?
+   | ^^^^^ you might be missing crate `core`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/subdiagnostic-derive.rs:582:27
    |
 LL |     #[suggestion_part(foo = "bar")]
-   |                           ^ maybe a missing crate `core`?
+   |                           ^ you might be missing crate `core`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/subdiagnostic-derive.rs:675:28
    |
 LL |     #[suggestion_part(code("foo"))]
-   |                            ^^^^^ maybe a missing crate `core`?
+   |                            ^^^^^ you might be missing crate `core`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/subdiagnostic-derive.rs:686:28
    |
 LL |     #[suggestion_part(code("foo", "bar"))]
-   |                            ^^^^^ maybe a missing crate `core`?
+   |                            ^^^^^ you might be missing crate `core`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/subdiagnostic-derive.rs:697:28
    |
 LL |     #[suggestion_part(code(3))]
-   |                            ^ maybe a missing crate `core`?
+   |                            ^ you might be missing crate `core`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/subdiagnostic-derive.rs:720:30
    |
 LL |     #[suggestion_part(code = 3)]
-   |                              ^ maybe a missing crate `core`?
+   |                              ^ you might be missing crate `core`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/subdiagnostic-derive.rs:812:48
    |
 LL | #[suggestion(no_crate_example, code = "", style("foo"))]
-   |                                                ^ maybe a missing crate `core`?
+   |                                                ^ you might be missing crate `core`
 
 error: cannot find attribute `foo` in this scope
   --> $DIR/subdiagnostic-derive.rs:67:3

--- a/tests/ui/attributes/field-attributes-vis-unresolved.stderr
+++ b/tests/ui/attributes/field-attributes-vis-unresolved.stderr
@@ -1,16 +1,16 @@
-error[E0433]: failed to resolve: maybe a missing crate `nonexistent`?
+error[E0433]: failed to resolve: you might be missing crate `nonexistent`
   --> $DIR/field-attributes-vis-unresolved.rs:17:12
    |
 LL |     pub(in nonexistent) field: u8
-   |            ^^^^^^^^^^^ maybe a missing crate `nonexistent`?
+   |            ^^^^^^^^^^^ you might be missing crate `nonexistent`
    |
    = help: consider adding `extern crate nonexistent` to use the `nonexistent` crate
 
-error[E0433]: failed to resolve: maybe a missing crate `nonexistent`?
+error[E0433]: failed to resolve: you might be missing crate `nonexistent`
   --> $DIR/field-attributes-vis-unresolved.rs:22:12
    |
 LL |     pub(in nonexistent) u8
-   |            ^^^^^^^^^^^ maybe a missing crate `nonexistent`?
+   |            ^^^^^^^^^^^ you might be missing crate `nonexistent`
    |
    = help: consider adding `extern crate nonexistent` to use the `nonexistent` crate
 

--- a/tests/ui/error-codes/E0432.stderr
+++ b/tests/ui/error-codes/E0432.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `something`
   --> $DIR/E0432.rs:1:5
    |
 LL | use something::Foo;
-   |     ^^^^^^^^^ maybe a missing crate `something`?
+   |     ^^^^^^^^^ you might be missing crate `something`
    |
    = help: consider adding `extern crate something` to use the `something` crate
 

--- a/tests/ui/feature-gates/feature-gate-extern_absolute_paths.stderr
+++ b/tests/ui/feature-gates/feature-gate-extern_absolute_paths.stderr
@@ -4,14 +4,14 @@ error[E0432]: unresolved import `core`
 LL | use core::default;
    |     ^^^^
    |     |
-   |     maybe a missing crate `core`?
+   |     you might be missing crate `core`
    |     help: try using `std` instead of `core`: `std`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/feature-gate-extern_absolute_paths.rs:4:19
    |
 LL |     let _: u8 = ::core::default::Default();
-   |                   ^^^^ maybe a missing crate `core`?
+   |                   ^^^^ you might be missing crate `core`
    |
 help: try using `std` instead of `core`
    |

--- a/tests/ui/imports/import-from-missing-star-2.stderr
+++ b/tests/ui/imports/import-from-missing-star-2.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star-2.rs:2:9
    |
 LL |     use spam::*;
-   |         ^^^^ maybe a missing crate `spam`?
+   |         ^^^^ you might be missing crate `spam`
    |
    = help: consider adding `extern crate spam` to use the `spam` crate
 

--- a/tests/ui/imports/import-from-missing-star-3.stderr
+++ b/tests/ui/imports/import-from-missing-star-3.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star-3.rs:2:9
    |
 LL |     use spam::*;
-   |         ^^^^ maybe a missing crate `spam`?
+   |         ^^^^ you might be missing crate `spam`
    |
    = help: consider adding `extern crate spam` to use the `spam` crate
 
@@ -10,7 +10,7 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star-3.rs:27:13
    |
 LL |         use spam::*;
-   |             ^^^^ maybe a missing crate `spam`?
+   |             ^^^^ you might be missing crate `spam`
    |
    = help: consider adding `extern crate spam` to use the `spam` crate
 

--- a/tests/ui/imports/import-from-missing-star.stderr
+++ b/tests/ui/imports/import-from-missing-star.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star.rs:1:5
    |
 LL | use spam::*;
-   |     ^^^^ maybe a missing crate `spam`?
+   |     ^^^^ you might be missing crate `spam`
    |
    = help: consider adding `extern crate spam` to use the `spam` crate
 

--- a/tests/ui/imports/import3.stderr
+++ b/tests/ui/imports/import3.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `main`
   --> $DIR/import3.rs:2:5
    |
 LL | use main::bar;
-   |     ^^^^ maybe a missing crate `main`?
+   |     ^^^^ you might be missing crate `main`
    |
    = help: consider adding `extern crate main` to use the `main` crate
 

--- a/tests/ui/imports/issue-109343.stderr
+++ b/tests/ui/imports/issue-109343.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `unresolved`
   --> $DIR/issue-109343.rs:4:9
    |
 LL | pub use unresolved::f;
-   |         ^^^^^^^^^^ maybe a missing crate `unresolved`?
+   |         ^^^^^^^^^^ you might be missing crate `unresolved`
    |
    = help: consider adding `extern crate unresolved` to use the `unresolved` crate
 

--- a/tests/ui/imports/issue-1697.rs
+++ b/tests/ui/imports/issue-1697.rs
@@ -1,6 +1,8 @@
 // Testing that we don't fail abnormally after hitting the errors
 
-use unresolved::*; //~ ERROR unresolved import `unresolved` [E0432]
-                   //~^ maybe a missing crate `unresolved`?
+use unresolved::*;
+//~^ ERROR unresolved import `unresolved` [E0432]
+//~| NOTE you might be missing crate `unresolved`
+//~| HELP consider adding `extern crate unresolved` to use the `unresolved` crate
 
 fn main() {}

--- a/tests/ui/imports/issue-1697.stderr
+++ b/tests/ui/imports/issue-1697.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `unresolved`
   --> $DIR/issue-1697.rs:3:5
    |
 LL | use unresolved::*;
-   |     ^^^^^^^^^^ maybe a missing crate `unresolved`?
+   |     ^^^^^^^^^^ you might be missing crate `unresolved`
    |
    = help: consider adding `extern crate unresolved` to use the `unresolved` crate
 

--- a/tests/ui/imports/issue-33464.stderr
+++ b/tests/ui/imports/issue-33464.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `abc`
   --> $DIR/issue-33464.rs:3:5
    |
 LL | use abc::one_el;
-   |     ^^^ maybe a missing crate `abc`?
+   |     ^^^ you might be missing crate `abc`
    |
    = help: consider adding `extern crate abc` to use the `abc` crate
 
@@ -10,7 +10,7 @@ error[E0432]: unresolved import `abc`
   --> $DIR/issue-33464.rs:5:5
    |
 LL | use abc::{a, bbb, cccccc};
-   |     ^^^ maybe a missing crate `abc`?
+   |     ^^^ you might be missing crate `abc`
    |
    = help: consider adding `extern crate abc` to use the `abc` crate
 
@@ -18,7 +18,7 @@ error[E0432]: unresolved import `a_very_long_name`
   --> $DIR/issue-33464.rs:7:5
    |
 LL | use a_very_long_name::{el, el2};
-   |     ^^^^^^^^^^^^^^^^ maybe a missing crate `a_very_long_name`?
+   |     ^^^^^^^^^^^^^^^^ you might be missing crate `a_very_long_name`
    |
    = help: consider adding `extern crate a_very_long_name` to use the `a_very_long_name` crate
 

--- a/tests/ui/imports/issue-36881.stderr
+++ b/tests/ui/imports/issue-36881.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `issue_36881_aux`
   --> $DIR/issue-36881.rs:5:9
    |
 LL |     use issue_36881_aux::Foo;
-   |         ^^^^^^^^^^^^^^^ maybe a missing crate `issue_36881_aux`?
+   |         ^^^^^^^^^^^^^^^ you might be missing crate `issue_36881_aux`
    |
    = help: consider adding `extern crate issue_36881_aux` to use the `issue_36881_aux` crate
 

--- a/tests/ui/imports/issue-37887.stderr
+++ b/tests/ui/imports/issue-37887.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `test`
   --> $DIR/issue-37887.rs:3:9
    |
 LL |     use test::*;
-   |         ^^^^ maybe a missing crate `test`?
+   |         ^^^^ you might be missing crate `test`
    |
    = help: consider adding `extern crate test` to use the `test` crate
 

--- a/tests/ui/imports/issue-53269.stderr
+++ b/tests/ui/imports/issue-53269.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `nonexistent_module`
   --> $DIR/issue-53269.rs:6:9
    |
 LL |     use nonexistent_module::mac;
-   |         ^^^^^^^^^^^^^^^^^^ maybe a missing crate `nonexistent_module`?
+   |         ^^^^^^^^^^^^^^^^^^ you might be missing crate `nonexistent_module`
    |
    = help: consider adding `extern crate nonexistent_module` to use the `nonexistent_module` crate
 

--- a/tests/ui/imports/issue-55457.stderr
+++ b/tests/ui/imports/issue-55457.stderr
@@ -11,7 +11,7 @@ error[E0432]: unresolved import `non_existent`
   --> $DIR/issue-55457.rs:2:5
    |
 LL | use non_existent::non_existent;
-   |     ^^^^^^^^^^^^ maybe a missing crate `non_existent`?
+   |     ^^^^^^^^^^^^ you might be missing crate `non_existent`
    |
    = help: consider adding `extern crate non_existent` to use the `non_existent` crate
 

--- a/tests/ui/imports/issue-81413.stderr
+++ b/tests/ui/imports/issue-81413.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `doesnt_exist`
   --> $DIR/issue-81413.rs:7:9
    |
 LL | pub use doesnt_exist::*;
-   |         ^^^^^^^^^^^^ maybe a missing crate `doesnt_exist`?
+   |         ^^^^^^^^^^^^ you might be missing crate `doesnt_exist`
    |
    = help: consider adding `extern crate doesnt_exist` to use the `doesnt_exist` crate
 

--- a/tests/ui/imports/tool-mod-child.rs
+++ b/tests/ui/imports/tool-mod-child.rs
@@ -1,7 +1,7 @@
 use clippy::a; //~ ERROR unresolved import `clippy`
-use clippy::a::b; //~ ERROR failed to resolve: maybe a missing crate `clippy`?
+use clippy::a::b; //~ ERROR failed to resolve: you might be missing crate `clippy`
 
 use rustdoc::a; //~ ERROR unresolved import `rustdoc`
-use rustdoc::a::b; //~ ERROR failed to resolve: maybe a missing crate `rustdoc`?
+use rustdoc::a::b; //~ ERROR failed to resolve: you might be missing crate `rustdoc`
 
 fn main() {}

--- a/tests/ui/imports/tool-mod-child.stderr
+++ b/tests/ui/imports/tool-mod-child.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: maybe a missing crate `clippy`?
+error[E0433]: failed to resolve: you might be missing crate `clippy`
   --> $DIR/tool-mod-child.rs:2:5
    |
 LL | use clippy::a::b;
-   |     ^^^^^^ maybe a missing crate `clippy`?
+   |     ^^^^^^ you might be missing crate `clippy`
    |
    = help: consider adding `extern crate clippy` to use the `clippy` crate
 
@@ -10,15 +10,15 @@ error[E0432]: unresolved import `clippy`
   --> $DIR/tool-mod-child.rs:1:5
    |
 LL | use clippy::a;
-   |     ^^^^^^ maybe a missing crate `clippy`?
+   |     ^^^^^^ you might be missing crate `clippy`
    |
    = help: consider adding `extern crate clippy` to use the `clippy` crate
 
-error[E0433]: failed to resolve: maybe a missing crate `rustdoc`?
+error[E0433]: failed to resolve: you might be missing crate `rustdoc`
   --> $DIR/tool-mod-child.rs:5:5
    |
 LL | use rustdoc::a::b;
-   |     ^^^^^^^ maybe a missing crate `rustdoc`?
+   |     ^^^^^^^ you might be missing crate `rustdoc`
    |
    = help: consider adding `extern crate rustdoc` to use the `rustdoc` crate
 
@@ -26,7 +26,7 @@ error[E0432]: unresolved import `rustdoc`
   --> $DIR/tool-mod-child.rs:4:5
    |
 LL | use rustdoc::a;
-   |     ^^^^^^^ maybe a missing crate `rustdoc`?
+   |     ^^^^^^^ you might be missing crate `rustdoc`
    |
    = help: consider adding `extern crate rustdoc` to use the `rustdoc` crate
 

--- a/tests/ui/imports/unresolved-imports-used.stderr
+++ b/tests/ui/imports/unresolved-imports-used.stderr
@@ -14,7 +14,7 @@ error[E0432]: unresolved import `foo`
   --> $DIR/unresolved-imports-used.rs:11:5
    |
 LL | use foo::bar;
-   |     ^^^ maybe a missing crate `foo`?
+   |     ^^^ you might be missing crate `foo`
    |
    = help: consider adding `extern crate foo` to use the `foo` crate
 
@@ -22,7 +22,7 @@ error[E0432]: unresolved import `baz`
   --> $DIR/unresolved-imports-used.rs:12:5
    |
 LL | use baz::*;
-   |     ^^^ maybe a missing crate `baz`?
+   |     ^^^ you might be missing crate `baz`
    |
    = help: consider adding `extern crate baz` to use the `baz` crate
 
@@ -30,7 +30,7 @@ error[E0432]: unresolved import `foo2`
   --> $DIR/unresolved-imports-used.rs:14:5
    |
 LL | use foo2::bar2;
-   |     ^^^^ maybe a missing crate `foo2`?
+   |     ^^^^ you might be missing crate `foo2`
    |
    = help: consider adding `extern crate foo2` to use the `foo2` crate
 
@@ -38,7 +38,7 @@ error[E0432]: unresolved import `baz2`
   --> $DIR/unresolved-imports-used.rs:15:5
    |
 LL | use baz2::*;
-   |     ^^^^ maybe a missing crate `baz2`?
+   |     ^^^^ you might be missing crate `baz2`
    |
    = help: consider adding `extern crate baz2` to use the `baz2` crate
 

--- a/tests/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
+++ b/tests/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
@@ -13,7 +13,7 @@ error[E0432]: unresolved import `r#extern`
   --> $DIR/keyword-extern-as-identifier-use.rs:1:5
    |
 LL | use extern::foo;
-   |     ^^^^^^ maybe a missing crate `r#extern`?
+   |     ^^^^^^ you might be missing crate `r#extern`
    |
    = help: consider adding `extern crate r#extern` to use the `r#extern` crate
 

--- a/tests/ui/macros/meta-item-absolute-path.stderr
+++ b/tests/ui/macros/meta-item-absolute-path.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: maybe a missing crate `Absolute`?
+error[E0433]: failed to resolve: you might be missing crate `Absolute`
   --> $DIR/meta-item-absolute-path.rs:1:12
    |
 LL | #[derive(::Absolute)]
-   |            ^^^^^^^^ maybe a missing crate `Absolute`?
+   |            ^^^^^^^^ you might be missing crate `Absolute`
 
-error[E0433]: failed to resolve: maybe a missing crate `Absolute`?
+error[E0433]: failed to resolve: you might be missing crate `Absolute`
   --> $DIR/meta-item-absolute-path.rs:1:12
    |
 LL | #[derive(::Absolute)]
-   |            ^^^^^^^^ maybe a missing crate `Absolute`?
+   |            ^^^^^^^^ you might be missing crate `Absolute`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/privacy/restricted/test.rs
+++ b/tests/ui/privacy/restricted/test.rs
@@ -47,6 +47,6 @@ fn main() {
 }
 
 mod pathological {
-    pub(in bad::path) mod m1 {} //~ ERROR failed to resolve: maybe a missing crate `bad`?
+    pub(in bad::path) mod m1 {} //~ ERROR failed to resolve: you might be missing crate `bad`
     pub(in foo) mod m2 {} //~ ERROR visibilities can only be restricted to ancestor modules
 }

--- a/tests/ui/privacy/restricted/test.stderr
+++ b/tests/ui/privacy/restricted/test.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: maybe a missing crate `bad`?
+error[E0433]: failed to resolve: you might be missing crate `bad`
   --> $DIR/test.rs:50:12
    |
 LL |     pub(in bad::path) mod m1 {}
-   |            ^^^ maybe a missing crate `bad`?
+   |            ^^^ you might be missing crate `bad`
    |
    = help: consider adding `extern crate bad` to use the `bad` crate
 

--- a/tests/ui/resolve/editions-crate-root-2015.rs
+++ b/tests/ui/resolve/editions-crate-root-2015.rs
@@ -2,10 +2,10 @@
 
 mod inner {
     fn global_inner(_: ::nonexistant::Foo) {
-        //~^ ERROR failed to resolve: maybe a missing crate `nonexistant`?
+        //~^ ERROR failed to resolve: you might be missing crate `nonexistant`
     }
     fn crate_inner(_: crate::nonexistant::Foo) {
-        //~^ ERROR failed to resolve: maybe a missing crate `nonexistant`?
+        //~^ ERROR failed to resolve: you might be missing crate `nonexistant`
     }
 
     fn bare_global(_: ::nonexistant) {

--- a/tests/ui/resolve/editions-crate-root-2015.stderr
+++ b/tests/ui/resolve/editions-crate-root-2015.stderr
@@ -1,16 +1,16 @@
-error[E0433]: failed to resolve: maybe a missing crate `nonexistant`?
+error[E0433]: failed to resolve: you might be missing crate `nonexistant`
   --> $DIR/editions-crate-root-2015.rs:4:26
    |
 LL |     fn global_inner(_: ::nonexistant::Foo) {
-   |                          ^^^^^^^^^^^ maybe a missing crate `nonexistant`?
+   |                          ^^^^^^^^^^^ you might be missing crate `nonexistant`
    |
    = help: consider adding `extern crate nonexistant` to use the `nonexistant` crate
 
-error[E0433]: failed to resolve: maybe a missing crate `nonexistant`?
+error[E0433]: failed to resolve: you might be missing crate `nonexistant`
   --> $DIR/editions-crate-root-2015.rs:7:30
    |
 LL |     fn crate_inner(_: crate::nonexistant::Foo) {
-   |                              ^^^^^^^^^^^ maybe a missing crate `nonexistant`?
+   |                              ^^^^^^^^^^^ you might be missing crate `nonexistant`
    |
    = help: consider adding `extern crate nonexistant` to use the `nonexistant` crate
 

--- a/tests/ui/resolve/extern-prelude-fail.stderr
+++ b/tests/ui/resolve/extern-prelude-fail.stderr
@@ -2,15 +2,15 @@ error[E0432]: unresolved import `extern_prelude`
   --> $DIR/extern-prelude-fail.rs:7:9
    |
 LL |     use extern_prelude::S;
-   |         ^^^^^^^^^^^^^^ maybe a missing crate `extern_prelude`?
+   |         ^^^^^^^^^^^^^^ you might be missing crate `extern_prelude`
    |
    = help: consider adding `extern crate extern_prelude` to use the `extern_prelude` crate
 
-error[E0433]: failed to resolve: maybe a missing crate `extern_prelude`?
+error[E0433]: failed to resolve: you might be missing crate `extern_prelude`
   --> $DIR/extern-prelude-fail.rs:8:15
    |
 LL |     let s = ::extern_prelude::S;
-   |               ^^^^^^^^^^^^^^ maybe a missing crate `extern_prelude`?
+   |               ^^^^^^^^^^^^^^ you might be missing crate `extern_prelude`
    |
    = help: consider adding `extern crate extern_prelude` to use the `extern_prelude` crate
 

--- a/tests/ui/resolve/issue-82865.rs
+++ b/tests/ui/resolve/issue-82865.rs
@@ -2,7 +2,7 @@
 
 #![feature(decl_macro)]
 
-use x::y::z; //~ ERROR: failed to resolve: maybe a missing crate `x`?
+use x::y::z; //~ ERROR: failed to resolve: you might be missing crate `x`
 
 macro mac () {
     Box::z //~ ERROR: no function or associated item

--- a/tests/ui/resolve/issue-82865.stderr
+++ b/tests/ui/resolve/issue-82865.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: maybe a missing crate `x`?
+error[E0433]: failed to resolve: you might be missing crate `x`
   --> $DIR/issue-82865.rs:5:5
    |
 LL | use x::y::z;
-   |     ^ maybe a missing crate `x`?
+   |     ^ you might be missing crate `x`
    |
    = help: consider adding `extern crate x` to use the `x` crate
 

--- a/tests/ui/resolve/resolve-bad-visibility.stderr
+++ b/tests/ui/resolve/resolve-bad-visibility.stderr
@@ -16,19 +16,19 @@ error[E0742]: visibilities can only be restricted to ancestor modules
 LL | pub(in std::vec) struct F;
    |        ^^^^^^^^
 
-error[E0433]: failed to resolve: maybe a missing crate `nonexistent`?
+error[E0433]: failed to resolve: you might be missing crate `nonexistent`
   --> $DIR/resolve-bad-visibility.rs:7:8
    |
 LL | pub(in nonexistent) struct G;
-   |        ^^^^^^^^^^^ maybe a missing crate `nonexistent`?
+   |        ^^^^^^^^^^^ you might be missing crate `nonexistent`
    |
    = help: consider adding `extern crate nonexistent` to use the `nonexistent` crate
 
-error[E0433]: failed to resolve: maybe a missing crate `too_soon`?
+error[E0433]: failed to resolve: you might be missing crate `too_soon`
   --> $DIR/resolve-bad-visibility.rs:8:8
    |
 LL | pub(in too_soon) struct H;
-   |        ^^^^^^^^ maybe a missing crate `too_soon`?
+   |        ^^^^^^^^ you might be missing crate `too_soon`
    |
    = help: consider adding `extern crate too_soon` to use the `too_soon` crate
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/issue-102156.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/issue-102156.stderr
@@ -1,19 +1,19 @@
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/issue-102156.rs:4:5
    |
 LL | use core::convert::{From, TryFrom};
    |     ^^^^
    |     |
-   |     maybe a missing crate `core`?
+   |     you might be missing crate `core`
    |     help: try using `std` instead of `core`: `std`
 
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/issue-102156.rs:4:5
    |
 LL | use core::convert::{From, TryFrom};
    |     ^^^^
    |     |
-   |     maybe a missing crate `core`?
+   |     you might be missing crate `core`
    |     help: try using `std` instead of `core`: `std`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`

--- a/tests/ui/simd/portable-intrinsics-arent-exposed.stderr
+++ b/tests/ui/simd/portable-intrinsics-arent-exposed.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: maybe a missing crate `core`?
+error[E0433]: failed to resolve: you might be missing crate `core`
   --> $DIR/portable-intrinsics-arent-exposed.rs:4:5
    |
 LL | use core::simd::intrinsics;
    |     ^^^^
    |     |
-   |     maybe a missing crate `core`?
+   |     you might be missing crate `core`
    |     help: try using `std` instead of `core`: `std`
 
 error[E0432]: unresolved import `std::simd::intrinsics`

--- a/tests/ui/underscore-imports/issue-110164.stderr
+++ b/tests/ui/underscore-imports/issue-110164.stderr
@@ -38,7 +38,7 @@ error[E0432]: unresolved import `_`
   --> $DIR/issue-110164.rs:8:5
    |
 LL | use _::*;
-   |     ^ maybe a missing crate `_`?
+   |     ^ you might be missing crate `_`
    |
    = help: consider adding `extern crate _` to use the `_` crate
 
@@ -46,7 +46,7 @@ error[E0432]: unresolved import `_`
   --> $DIR/issue-110164.rs:5:5
    |
 LL | use _::a;
-   |     ^ maybe a missing crate `_`?
+   |     ^ you might be missing crate `_`
    |
    = help: consider adding `extern crate _` to use the `_` crate
 
@@ -54,7 +54,7 @@ error[E0432]: unresolved import `_`
   --> $DIR/issue-110164.rs:13:9
    |
 LL |     use _::a;
-   |         ^ maybe a missing crate `_`?
+   |         ^ you might be missing crate `_`
    |
    = help: consider adding `extern crate _` to use the `_` crate
 
@@ -62,7 +62,7 @@ error[E0432]: unresolved import `_`
   --> $DIR/issue-110164.rs:16:9
    |
 LL |     use _::*;
-   |         ^ maybe a missing crate `_`?
+   |         ^ you might be missing crate `_`
    |
    = help: consider adding `extern crate _` to use the `_` crate
 

--- a/tests/ui/unresolved/unresolved-asterisk-imports.stderr
+++ b/tests/ui/unresolved/unresolved-asterisk-imports.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `not_existing_crate`
   --> $DIR/unresolved-asterisk-imports.rs:1:5
    |
 LL | use not_existing_crate::*;
-   |     ^^^^^^^^^^^^^^^^^^ maybe a missing crate `not_existing_crate`?
+   |     ^^^^^^^^^^^^^^^^^^ you might be missing crate `not_existing_crate`
    |
    = help: consider adding `extern crate not_existing_crate` to use the `not_existing_crate` crate
 

--- a/tests/ui/unresolved/unresolved-import.rs
+++ b/tests/ui/unresolved/unresolved-import.rs
@@ -1,21 +1,25 @@
-use foo::bar; //~ ERROR unresolved import `foo` [E0432]
-              //~^ maybe a missing crate `foo`?
-              //~| HELP consider adding `extern crate foo` to use the `foo` crate
+use foo::bar;
+//~^ ERROR unresolved import `foo` [E0432]
+//~| NOTE you might be missing crate `foo`
+//~| HELP consider adding `extern crate foo` to use the `foo` crate
 
-use bar::Baz as x; //~ ERROR unresolved import `bar::Baz` [E0432]
-                   //~| no `Baz` in `bar`
-                   //~| HELP a similar name exists in the module
-                   //~| SUGGESTION Bar
+use bar::Baz as x;
+//~^ ERROR unresolved import `bar::Baz` [E0432]
+//~| NOTE no `Baz` in `bar`
+//~| HELP a similar name exists in the module
+//~| SUGGESTION Bar
 
-use food::baz; //~ ERROR unresolved import `food::baz`
-               //~| no `baz` in `food`
-               //~| HELP a similar name exists in the module
-               //~| SUGGESTION bag
+use food::baz;
+//~^ ERROR unresolved import `food::baz`
+//~| NOTE no `baz` in `food`
+//~| HELP a similar name exists in the module
+//~| SUGGESTION bag
 
-use food::{beens as Foo}; //~ ERROR unresolved import `food::beens` [E0432]
-                          //~| no `beens` in `food`
-                          //~| HELP a similar name exists in the module
-                          //~| SUGGESTION beans
+use food::{beens as Foo};
+//~^ ERROR unresolved import `food::beens` [E0432]
+//~| NOTE no `beens` in `food`
+//~| HELP a similar name exists in the module
+//~| SUGGESTION beans
 
 mod bar {
     pub struct Bar;
@@ -36,9 +40,10 @@ mod m {
         MyVariant
     }
 
-    use MyEnum::*; //~ ERROR unresolved import `MyEnum` [E0432]
-                   //~| HELP a similar path exists
-                   //~| SUGGESTION self::MyEnum
+    use MyEnum::*;
+    //~^ ERROR unresolved import `MyEnum` [E0432]
+    //~| HELP a similar path exists
+    //~| SUGGESTION self::MyEnum
 }
 
 mod items {
@@ -46,9 +51,10 @@ mod items {
         Variant
     }
 
-    use Enum::*; //~ ERROR unresolved import `Enum` [E0432]
-                 //~| HELP a similar path exists
-                 //~| SUGGESTION self::Enum
+    use Enum::*;
+    //~^ ERROR unresolved import `Enum` [E0432]
+    //~| HELP a similar path exists
+    //~| SUGGESTION self::Enum
 
     fn item() {}
 }

--- a/tests/ui/unresolved/unresolved-import.stderr
+++ b/tests/ui/unresolved/unresolved-import.stderr
@@ -2,12 +2,12 @@ error[E0432]: unresolved import `foo`
   --> $DIR/unresolved-import.rs:1:5
    |
 LL | use foo::bar;
-   |     ^^^ maybe a missing crate `foo`?
+   |     ^^^ you might be missing crate `foo`
    |
    = help: consider adding `extern crate foo` to use the `foo` crate
 
 error[E0432]: unresolved import `bar::Baz`
-  --> $DIR/unresolved-import.rs:5:5
+  --> $DIR/unresolved-import.rs:6:5
    |
 LL | use bar::Baz as x;
    |     ^^^^^---^^^^^
@@ -16,7 +16,7 @@ LL | use bar::Baz as x;
    |     no `Baz` in `bar`
 
 error[E0432]: unresolved import `food::baz`
-  --> $DIR/unresolved-import.rs:10:5
+  --> $DIR/unresolved-import.rs:12:5
    |
 LL | use food::baz;
    |     ^^^^^^---
@@ -25,7 +25,7 @@ LL | use food::baz;
    |     no `baz` in `food`
 
 error[E0432]: unresolved import `food::beens`
-  --> $DIR/unresolved-import.rs:15:12
+  --> $DIR/unresolved-import.rs:18:12
    |
 LL | use food::{beens as Foo};
    |            -----^^^^^^^
@@ -34,13 +34,13 @@ LL | use food::{beens as Foo};
    |            help: a similar name exists in the module: `beans`
 
 error[E0432]: unresolved import `MyEnum`
-  --> $DIR/unresolved-import.rs:39:9
+  --> $DIR/unresolved-import.rs:43:9
    |
 LL |     use MyEnum::*;
    |         ^^^^^^ help: a similar path exists: `self::MyEnum`
 
 error[E0432]: unresolved import `Enum`
-  --> $DIR/unresolved-import.rs:49:9
+  --> $DIR/unresolved-import.rs:54:9
    |
 LL |     use Enum::*;
    |         ^^^^ help: a similar path exists: `self::Enum`


### PR DESCRIPTION
We don't want to have questions in the diagnostic output. Instead, we use wording that communicates uncertainty, like "might":

```
error[E0432]: unresolved import `spam`
  --> $DIR/import-from-missing-star-3.rs:2:9
   |
LL |     use spam::*;
   |         ^^^^ you might be missing crate `spam`
   |
   = help: consider adding `extern crate spam` to use the `spam` crate
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
