### PR TITLE
Point at binding declaration on closure capture note

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -622,6 +622,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 for (sp, label) in spans_and_labels {
                     multi_span.push_span_label(sp, label);
                 }
+                for (sp, label) in upvars.iter().take(4).map(|(var_hir_id, _)| {
+                    let var_name = self.tcx.hir().name(*var_hir_id).to_string();
+                    let span = self.tcx.hir().span(*var_hir_id);
+                    let msg = format!("`{var_name}` declared here");
+                    (span, msg)
+                }) {
+                    multi_span.push_span_label(sp, label);
+                }
                 err.span_note(
                     multi_span,
                     "closures can only be coerced to `fn` types if they do not capture any variables"

--- a/tests/ui/closures/closure-no-fn-1.stderr
+++ b/tests/ui/closures/closure-no-fn-1.stderr
@@ -11,6 +11,8 @@ LL |     let foo: fn(u8) -> u8 = |v: u8| { a += v; a };
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-no-fn-1.rs:6:39
    |
+LL |     let mut a = 0u8;
+   |         ----- `a` declared here
 LL |     let foo: fn(u8) -> u8 = |v: u8| { a += v; a };
    |                                       ^ `a` captured here
 

--- a/tests/ui/closures/closure-no-fn-2.stderr
+++ b/tests/ui/closures/closure-no-fn-2.stderr
@@ -11,6 +11,8 @@ LL |     let bar: fn() -> u8 = || { b };
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-no-fn-2.rs:6:32
    |
+LL |     let b = 0u8;
+   |         - `b` declared here
 LL |     let bar: fn() -> u8 = || { b };
    |                                ^ `b` captured here
 

--- a/tests/ui/closures/closure-no-fn-4.stderr
+++ b/tests/ui/closures/closure-no-fn-4.stderr
@@ -16,6 +16,9 @@ LL | |     };
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-no-fn-4.rs:5:26
    |
+LL |     let b = 2;
+   |         - `b` declared here
+...
 LL |         false => |a| a - b,
    |                          ^ `b` captured here
 

--- a/tests/ui/closures/closure-no-fn-5.stderr
+++ b/tests/ui/closures/closure-no-fn-5.stderr
@@ -11,6 +11,15 @@ LL |     let bar: fn() -> u8 = || { a; b; c; d; e };
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-no-fn-5.rs:10:32
    |
+LL |     let a = 0u8;
+   |         - `a` declared here
+LL |     let b = 0u8;
+   |         - `b` declared here
+LL |     let c = 0u8;
+   |         - `c` declared here
+LL |     let d = 0u8;
+   |         - `d` declared here
+LL |     let e = 0u8;
 LL |     let bar: fn() -> u8 = || { a; b; c; d; e };
    |                                ^  ^  ^  ^ `d` captured here
    |                                |  |  |

--- a/tests/ui/closures/closure-reform-bad.stderr
+++ b/tests/ui/closures/closure-reform-bad.stderr
@@ -13,6 +13,8 @@ LL |     call_bare(f)
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-reform-bad.rs:10:43
    |
+LL |     let string = "world!";
+   |         ------ `string` declared here
 LL |     let f = |s: &str| println!("{}{}", s, string);
    |                                           ^^^^^^ `string` captured here
 note: function defined here

--- a/tests/ui/closures/print/closure-print-verbose.stderr
+++ b/tests/ui/closures/print/closure-print-verbose.stderr
@@ -11,6 +11,8 @@ LL |     let foo: fn(u8) -> u8 = |v: u8| { a += v; a };
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-print-verbose.rs:10:39
    |
+LL |     let mut a = 0u8;
+   |         ----- `a` declared here
 LL |     let foo: fn(u8) -> u8 = |v: u8| { a += v; a };
    |                                       ^ `a` captured here
 


### PR DESCRIPTION
```
error[E0308]: mismatched types
  --> $DIR/closure-no-fn-1.rs:6:29
   |
LL |     let foo: fn(u8) -> u8 = |v: u8| { a += v; a };
   |              ------------   ^^^^^^^^^^^^^^^^^^^^^ expected fn pointer, found closure
   |              |
   |              expected due to this
   |
   = note: expected fn pointer `fn(u8) -> u8`
                 found closure `{closure@$DIR/closure-no-fn-1.rs:6:29: 6:36}`
note: closures can only be coerced to `fn` types if they do not capture any variables
  --> $DIR/closure-no-fn-1.rs:6:39
   |
LL |     let mut a = 0u8;
   |         ----- `a` declared here
LL |     let foo: fn(u8) -> u8 = |v: u8| { a += v; a };
   |                                       ^ `a` captured here
```

"`a` declared here" is new.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @compiler-errors 