### PR TITLE
Improve spans on evaluated `cfg_attr`s.

### DIFF
--- a/tests/ui/proc-macro/cfg-eval-inner.stdout
+++ b/tests/ui/proc-macro/cfg-eval-inner.stdout
@@ -73,7 +73,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                                 span: $DIR/cfg-eval-inner.rs:19:40: 19:54 (#0),
                             },
                         ],
-                        span: $DIR/cfg-eval-inner.rs:19:5: 19:6 (#0),
+                        span: $DIR/cfg-eval-inner.rs:19:7: 19:56 (#0),
                     },
                     Punct {
                         ch: '#',
@@ -168,7 +168,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                                                         span: $DIR/cfg-eval-inner.rs:23:48: 23:70 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/cfg-eval-inner.rs:23:13: 23:14 (#0),
+                                                span: $DIR/cfg-eval-inner.rs:23:15: 23:72 (#0),
                                             },
                                             Literal {
                                                 kind: Integer,
@@ -233,7 +233,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                         span: $DIR/cfg-eval-inner.rs:32:40: 32:56 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval-inner.rs:32:5: 32:6 (#0),
+                span: $DIR/cfg-eval-inner.rs:32:7: 32:58 (#0),
             },
             Ident {
                 ident: "fn",

--- a/tests/ui/proc-macro/cfg-eval.stdout
+++ b/tests/ui/proc-macro/cfg-eval.stdout
@@ -60,7 +60,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                         span: $DIR/cfg-eval.rs:22:36: 22:38 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval.rs:22:5: 22:6 (#0),
+                span: $DIR/cfg-eval.rs:22:6: 22:40 (#0),
             },
             Ident {
                 ident: "field_true",
@@ -99,7 +99,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                 span: $DIR/cfg-eval.rs:35:62: 35:73 (#0),
             },
         ],
-        span: $DIR/cfg-eval.rs:35:39: 35:40 (#0),
+        span: $DIR/cfg-eval.rs:35:40: 35:75 (#0),
     },
     Group {
         delimiter: Parenthesis,

--- a/tests/ui/proc-macro/expand-to-derive.stdout
+++ b/tests/ui/proc-macro/expand-to-derive.stdout
@@ -57,7 +57,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                         span: $DIR/expand-to-derive.rs:27:28: 27:39 (#0),
                                     },
                                 ],
-                                span: $DIR/expand-to-derive.rs:27:5: 27:6 (#0),
+                                span: $DIR/expand-to-derive.rs:27:6: 27:41 (#0),
                             },
                             Ident {
                                 ident: "struct",

--- a/tests/ui/proc-macro/inner-attrs.stdout
+++ b/tests/ui/proc-macro/inner-attrs.stdout
@@ -674,7 +674,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                                         span: $DIR/inner-attrs.rs:41:52: 41:59 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/inner-attrs.rs:41:17: 41:18 (#0),
+                                                span: $DIR/inner-attrs.rs:41:19: 41:61 (#0),
                                             },
                                             Ident {
                                                 ident: "true",

--- a/tests/ui/proc-macro/issue-75930-derive-cfg.stdout
+++ b/tests/ui/proc-macro/issue-75930-derive-cfg.stdout
@@ -119,7 +119,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                 span: $DIR/issue-75930-derive-cfg.rs:50:29: 50:40 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:50:1: 50:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:50:2: 50:42 (#0),
     },
     Punct {
         ch: '#',
@@ -1395,7 +1395,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                 span: $DIR/issue-75930-derive-cfg.rs:50:29: 50:40 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:50:1: 50:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:50:2: 50:42 (#0),
     },
     Punct {
         ch: '#',
@@ -1571,7 +1571,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                                 span: $DIR/issue-75930-derive-cfg.rs:63:41: 63:51 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:63:13: 63:14 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:63:14: 63:53 (#0),
                                     },
                                     Ident {
                                         ident: "false",

--- a/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
+++ b/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
@@ -88,7 +88,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                         span: $DIR/macro-rules-derive-cfg.rs:19:59: 19:66 (#3),
                                     },
                                 ],
-                                span: $DIR/macro-rules-derive-cfg.rs:19:25: 19:26 (#3),
+                                span: $DIR/macro-rules-derive-cfg.rs:19:26: 19:68 (#3),
                             },
                             Punct {
                                 ch: '#',
@@ -113,7 +113,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                         span: $DIR/macro-rules-derive-cfg.rs:26:47: 26:55 (#0),
                                     },
                                 ],
-                                span: $DIR/macro-rules-derive-cfg.rs:26:13: 26:14 (#0),
+                                span: $DIR/macro-rules-derive-cfg.rs:26:14: 26:57 (#0),
                             },
                             Group {
                                 delimiter: Brace,
@@ -146,7 +146,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                                 span: $DIR/macro-rules-derive-cfg.rs:27:34: 27:42 (#0),
                                             },
                                         ],
-                                        span: $DIR/macro-rules-derive-cfg.rs:27:5: 27:6 (#0),
+                                        span: $DIR/macro-rules-derive-cfg.rs:27:7: 27:44 (#0),
                                     },
                                     Literal {
                                         kind: Integer,


### PR DESCRIPTION
When converting something like `#![cfg_attr(cond, attr)]` into `#![attr]`, we currently duplicate the `#` token and the `!` token. But weirdly, there is also this comment:

// We don't really have a good span to use for the synthesized `[]`
// in `#[attr]`, so just use the span of the `#` token.

Maybe that comment used to be true? But now it is false: we can duplicate the existing delimiters (and their spans and spacing), much like we do for the `#` and `!`.

This commit does that, thus removing the incorrect comment, and improving the spans on `Group`s in a few proc-macro tests.

@petrochenkov 